### PR TITLE
fallible scalar_at and validity

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -177,7 +177,7 @@ impl VTable for ALPVTable {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             ALPArray::new(
-                array.encoded().slice(range.clone()),
+                array.encoded().slice(range.clone())?,
                 array.exponents(),
                 array
                     .patches()
@@ -499,7 +499,7 @@ mod tests {
             encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
-        let expected = decompress_into_array(encoded);
+        let expected = decompress_into_array(encoded).unwrap();
 
         assert_arrays_eq!(result_canonical.into_array(), expected);
     }
@@ -523,7 +523,7 @@ mod tests {
             encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
-        let expected = decompress_into_array(encoded);
+        let expected = decompress_into_array(encoded).unwrap();
 
         assert_arrays_eq!(result_canonical.into_array(), expected);
     }
@@ -553,7 +553,7 @@ mod tests {
             encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
-        let expected = decompress_into_array(encoded);
+        let expected = decompress_into_array(encoded).unwrap();
 
         assert_arrays_eq!(result_canonical.into_array(), expected);
     }
@@ -581,7 +581,7 @@ mod tests {
             encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
-        let expected = decompress_into_array(encoded);
+        let expected = decompress_into_array(encoded).unwrap();
 
         assert_arrays_eq!(result_canonical.into_array(), expected);
     }
@@ -612,7 +612,7 @@ mod tests {
             encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
-        let expected = decompress_into_array(encoded);
+        let expected = decompress_into_array(encoded).unwrap();
 
         assert_arrays_eq!(result_canonical.into_array(), expected);
     }
@@ -639,7 +639,7 @@ mod tests {
 
         let slice_end = size - slice_start;
         let slice_len = slice_end - slice_start;
-        let sliced_encoded = encoded.slice(slice_start..slice_end);
+        let sliced_encoded = encoded.slice(slice_start..slice_end).unwrap();
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
@@ -686,7 +686,7 @@ mod tests {
 
         let slice_end = size - slice_start;
         let slice_len = slice_end - slice_start;
-        let sliced_encoded = encoded.slice(slice_start..slice_end);
+        let sliced_encoded = encoded.slice(slice_start..slice_end).unwrap();
 
         let result_primitive = sliced_encoded.to_primitive();
 
@@ -742,7 +742,8 @@ mod tests {
             original_patches.indices().clone(),
             original_patches.values().clone(),
             None, // NO chunk_offsets - this triggers the bug!
-        );
+        )
+        .unwrap();
 
         // Build a new ALPArray with the same encoded data but patches without chunk_offsets.
         let alp_without_chunk_offsets = ALPArray::new(
@@ -752,7 +753,7 @@ mod tests {
         );
 
         // The legacy decompress_into_array path should work correctly.
-        let result_legacy = decompress_into_array(alp_without_chunk_offsets.clone());
+        let result_legacy = decompress_into_array(alp_without_chunk_offsets.clone()).unwrap();
         let legacy_slice = result_legacy.as_slice::<f64>();
 
         // Verify the legacy path produces correct values.

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -34,7 +34,6 @@ use vortex_array::vtable::ValidityVTableFromChild;
 use vortex_array::vtable::VisitorVTable;
 use vortex_dtype::DType;
 use vortex_dtype::PType;
-use vortex_error::VortexError;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -101,20 +100,14 @@ impl VTable for ALPVTable {
         let patches = metadata
             .patches
             .map(|p| {
-                let indices = children.get(1, &p.indices_dtype(), p.len())?;
-                let values = children.get(2, dtype, p.len())?;
+                let indices = children.get(1, &p.indices_dtype()?, p.len()?)?;
+                let values = children.get(2, dtype, p.len()?)?;
                 let chunk_offsets = p
-                    .chunk_offsets_dtype()
+                    .chunk_offsets_dtype()?
                     .map(|dtype| children.get(3, &dtype, usize::try_from(p.chunk_offsets_len())?))
                     .transpose()?;
 
-                Ok::<_, VortexError>(Patches::new(
-                    len,
-                    p.offset(),
-                    indices,
-                    values,
-                    chunk_offsets,
-                ))
+                Patches::new(len, p.offset()?, indices, values, chunk_offsets)
             })
             .transpose()?;
 
@@ -167,7 +160,7 @@ impl VTable for ALPVTable {
                 indices,
                 values,
                 chunk_offsets,
-            ));
+            )?);
         }
 
         Ok(())
@@ -657,7 +650,7 @@ mod tests {
         for idx in 0..slice_len {
             let expected_value = values[slice_start + idx];
 
-            let result_valid = result_primitive.validity().is_valid(idx);
+            let result_valid = result_primitive.validity().is_valid(idx).unwrap();
             assert_eq!(
                 result_valid,
                 expected_value.is_some(),

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -120,7 +120,7 @@ where
             valid_exceptional_positions.into_array(),
             valid_exceptional_values,
             Some(chunk_offsets.into_array()),
-        ))
+        )?)
     };
     Ok((exponents, encoded_array, patches))
 }

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -150,7 +150,7 @@ mod tests {
         assert_arrays_eq!(encoded.encoded(), expected_encoded);
         assert_eq!(encoded.exponents(), Exponents { e: 9, f: 6 });
 
-        let decoded = decompress_into_array(encoded);
+        let decoded = decompress_into_array(encoded).unwrap();
         assert_arrays_eq!(decoded, array);
     }
 
@@ -163,7 +163,7 @@ mod tests {
         assert_arrays_eq!(encoded.encoded(), expected_encoded);
         assert_eq!(encoded.exponents(), Exponents { e: 9, f: 6 });
 
-        let decoded = decompress_into_array(encoded);
+        let decoded = decompress_into_array(encoded).unwrap();
         let expected = PrimitiveArray::from_option_iter(vec![None, Some(1.234f32), None]);
         assert_arrays_eq!(decoded, expected);
     }
@@ -179,7 +179,7 @@ mod tests {
         assert_arrays_eq!(encoded.encoded(), expected_encoded);
         assert_eq!(encoded.exponents(), Exponents { e: 16, f: 13 });
 
-        let decoded = decompress_into_array(encoded);
+        let decoded = decompress_into_array(encoded).unwrap();
         let expected_decoded = PrimitiveArray::new(values, Validity::NonNullable);
         assert_arrays_eq!(decoded, expected_decoded);
     }
@@ -196,7 +196,7 @@ mod tests {
         assert_arrays_eq!(encoded.encoded(), expected_encoded);
         assert_eq!(encoded.exponents(), Exponents { e: 16, f: 13 });
 
-        let decoded = decompress_into_array(encoded);
+        let decoded = decompress_into_array(encoded).unwrap();
         assert_arrays_eq!(decoded, array);
     }
 
@@ -217,7 +217,7 @@ mod tests {
 
         assert_arrays_eq!(encoded, array);
 
-        let _decoded = decompress_into_array(encoded);
+        let _decoded = decompress_into_array(encoded).unwrap();
     }
 
     #[test]
@@ -361,9 +361,9 @@ mod tests {
         let original = PrimitiveArray::new(Buffer::from(values), Validity::NonNullable);
         let encoded = alp_encode(&original, None).unwrap();
 
-        let sliced_alp = encoded.slice(512..1024);
+        let sliced_alp = encoded.slice(512..1024).unwrap();
 
-        let expected_slice = original.slice(512..1024);
+        let expected_slice = original.slice(512..1024).unwrap();
         assert_arrays_eq!(sliced_alp, expected_slice);
     }
 
@@ -373,9 +373,9 @@ mod tests {
         let original = PrimitiveArray::new(Buffer::from(values), Validity::NonNullable);
         let encoded = alp_encode(&original, None).unwrap();
 
-        let sliced_alp = encoded.slice(512..1024);
+        let sliced_alp = encoded.slice(512..1024).unwrap();
 
-        let expected_slice = original.slice(512..1024);
+        let expected_slice = original.slice(512..1024).unwrap();
         assert_arrays_eq!(sliced_alp, expected_slice);
     }
 
@@ -389,9 +389,9 @@ mod tests {
         let original = PrimitiveArray::new(Buffer::from(values), Validity::NonNullable);
         let encoded = alp_encode(&original, None).unwrap();
 
-        let sliced_alp = encoded.slice(512..1024);
+        let sliced_alp = encoded.slice(512..1024).unwrap();
 
-        let expected_slice = original.slice(512..1024);
+        let expected_slice = original.slice(512..1024).unwrap();
         assert_arrays_eq!(sliced_alp, expected_slice);
         assert!(encoded.patches().is_some());
     }
@@ -409,9 +409,9 @@ mod tests {
         let original = PrimitiveArray::new(Buffer::from(values), Validity::NonNullable);
         let encoded = alp_encode(&original, None).unwrap();
 
-        let sliced_alp = encoded.slice(1023..1025);
+        let sliced_alp = encoded.slice(1023..1025).unwrap();
 
-        let expected_slice = original.slice(1023..1025);
+        let expected_slice = original.slice(1023..1025).unwrap();
         assert_arrays_eq!(sliced_alp, expected_slice);
         assert!(encoded.patches().is_some());
     }
@@ -425,10 +425,10 @@ mod tests {
         let original = PrimitiveArray::from_option_iter(values);
         let encoded = alp_encode(&original, None).unwrap();
 
-        let sliced_alp = encoded.slice(512..1024);
+        let sliced_alp = encoded.slice(512..1024).unwrap();
         let decoded = sliced_alp.to_primitive();
 
-        let expected_slice = original.slice(512..1024);
+        let expected_slice = original.slice(512..1024).unwrap();
         assert_arrays_eq!(decoded, expected_slice);
     }
 
@@ -439,7 +439,7 @@ mod tests {
         let encoded = alp_encode(&array, None).unwrap();
 
         assert!(encoded.patches().is_none());
-        let decoded = decompress_into_array(encoded);
+        let decoded = decompress_into_array(encoded).unwrap();
         assert_arrays_eq!(decoded, array);
     }
 
@@ -450,7 +450,7 @@ mod tests {
         let encoded = alp_encode(&array, None).unwrap();
 
         assert!(encoded.patches().is_none());
-        let decoded = decompress_into_array(encoded);
+        let decoded = decompress_into_array(encoded).unwrap();
         assert_arrays_eq!(decoded, array);
     }
 
@@ -467,7 +467,7 @@ mod tests {
         let encoded = alp_encode(&array, None).unwrap();
 
         assert!(encoded.patches().is_some());
-        let decoded = decompress_into_array(encoded);
+        let decoded = decompress_into_array(encoded).unwrap();
         assert_arrays_eq!(decoded, array);
     }
 
@@ -488,7 +488,7 @@ mod tests {
         let encoded = alp_encode(&array, None).unwrap();
 
         assert!(encoded.patches().is_some());
-        let decoded = decompress_into_array(encoded);
+        let decoded = decompress_into_array(encoded).unwrap();
 
         for idx in 0..size {
             let decoded_val = decoded.as_slice::<f64>()[idx];
@@ -515,7 +515,7 @@ mod tests {
 
         let array = PrimitiveArray::from_option_iter(values);
         let encoded = alp_encode(&array, None).unwrap();
-        let decoded = decompress_into_array(encoded);
+        let decoded = decompress_into_array(encoded).unwrap();
 
         assert_arrays_eq!(decoded, array);
     }
@@ -535,7 +535,7 @@ mod tests {
 
         let array = PrimitiveArray::new(Buffer::from(values), validity);
         let encoded = alp_encode(&array, None).unwrap();
-        let decoded = decompress_into_array(encoded);
+        let decoded = decompress_into_array(encoded).unwrap();
 
         assert_arrays_eq!(decoded, array);
     }

--- a/encodings/alp/src/alp/decompress.rs
+++ b/encodings/alp/src/alp/decompress.rs
@@ -25,7 +25,7 @@ use crate::match_each_alp_float_ptype;
 /// # Returns
 ///
 /// A `PrimitiveArray` containing the decompressed floating-point values with all patches applied.
-pub fn decompress_into_array(array: ALPArray) -> PrimitiveArray {
+pub fn decompress_into_array(array: ALPArray) -> VortexResult<PrimitiveArray> {
     let (encoded, exponents, patches, dtype) = array.into_parts();
     if let Some(ref patches) = patches
         && let Some(chunk_offsets) = patches.chunk_offsets()
@@ -38,7 +38,7 @@ pub fn decompress_into_array(array: ALPArray) -> PrimitiveArray {
         let patches_chunk_offsets = chunk_offsets.as_ref().to_primitive();
         let patches_indices = patches.indices().to_primitive();
         let patches_values = patches.values().to_primitive();
-        decompress_chunked_core(
+        Ok(decompress_chunked_core(
             prim_encoded,
             exponents,
             &patches_indices,
@@ -46,7 +46,7 @@ pub fn decompress_into_array(array: ALPArray) -> PrimitiveArray {
             &patches_chunk_offsets,
             patches,
             dtype,
-        )
+        ))
     } else {
         let encoded_prim = encoded.to_primitive();
         // We need to drop ALPArray here in case converting encoded buffer into
@@ -86,9 +86,7 @@ pub fn execute_decompress(array: ALPArray, ctx: &mut ExecutionCtx) -> VortexResu
         ))
     } else {
         let encoded = encoded.execute::<PrimitiveArray>(ctx)?;
-        Ok(decompress_unchunked_core(
-            encoded, exponents, patches, dtype,
-        ))
+        decompress_unchunked_core(encoded, exponents, patches, dtype)
     }
 }
 
@@ -157,7 +155,7 @@ fn decompress_unchunked_core(
     exponents: Exponents,
     patches: Option<Patches>,
     dtype: DType,
-) -> PrimitiveArray {
+) -> VortexResult<PrimitiveArray> {
     let validity = encoded.validity().clone();
     let ptype = dtype.as_ptype();
 
@@ -171,6 +169,6 @@ fn decompress_unchunked_core(
     if let Some(patches) = patches {
         decoded.patch(&patches)
     } else {
-        decoded
+        Ok(decoded)
     }
 }

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -38,7 +38,6 @@ use vortex_buffer::Buffer;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
-use vortex_error::VortexError;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -170,17 +169,17 @@ impl VTable for ALPRDVTable {
             .0
             .patches
             .map(|p| {
-                let indices = children.get(2, &p.indices_dtype(), p.len())?;
-                let values = children.get(3, &left_parts_dtype, p.len())?;
+                let indices = children.get(2, &p.indices_dtype()?, p.len()?)?;
+                let values = children.get(3, &left_parts_dtype, p.len()?)?;
 
-                Ok::<_, VortexError>(Patches::new(
+                Patches::new(
                     len,
-                    p.offset(),
+                    p.offset()?,
                     indices,
                     values,
                     // TODO(0ax1): handle chunk offsets
                     None,
-                ))
+                )
             })
             .transpose()?;
 
@@ -234,7 +233,7 @@ impl VTable for ALPRDVTable {
             array.left_parts_patches = Some(Patches::new(
                 array_len, offset, indices, values,
                 None, // chunk_offsets not currently supported for ALPRD
-            ));
+            )?);
         }
 
         Ok(())

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -89,9 +89,9 @@ impl VTable for ALPRDVTable {
         Ok(Some(unsafe {
             ALPRDArray::new_unchecked(
                 array.dtype().clone(),
-                array.left_parts().slice(range.clone()),
+                array.left_parts().slice(range.clone())?,
                 array.left_parts_dictionary().clone(),
-                array.right_parts().slice(range),
+                array.right_parts().slice(range)?,
                 array.right_bit_width(),
                 left_parts_exceptions,
             )

--- a/encodings/alp/src/alp_rd/mod.rs
+++ b/encodings/alp/src/alp_rd/mod.rs
@@ -178,6 +178,7 @@ impl RDEncoder {
     /// Encode a set of floating point values with ALP-RD.
     ///
     /// Each value will be split into a left and right component, which are compressed individually.
+    // TODO(joe): make fallible
     pub fn encode(&self, array: &PrimitiveArray) -> ALPRDArray {
         match_each_alp_float_ptype!(array.ptype(), |P| { self.encode_generic::<P>(array) })
     }

--- a/encodings/alp/src/alp_rd/mod.rs
+++ b/encodings/alp/src/alp_rd/mod.rs
@@ -266,6 +266,7 @@ impl RDEncoder {
                 // TODO(0ax1): handle chunk offsets
                 None,
             )
+            .vortex_expect("Patches construction in encode")
         });
 
         ALPRDArray::try_new(

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -113,7 +113,7 @@ impl VTable for ByteBoolVTable {
         Ok(Some(
             ByteBoolArray::new(
                 array.buffer().slice(range.clone()),
-                array.validity().slice(range),
+                array.validity().slice(range)?,
             )
             .into_array(),
         ))

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -97,7 +97,7 @@ mod tests {
         let original = vec![Some(true), Some(true), None, Some(false), None];
         let vortex_arr = ByteBoolArray::from(original);
 
-        let sliced_arr = vortex_arr.slice(1..4);
+        let sliced_arr = vortex_arr.slice(1..4).unwrap();
 
         let expected = ByteBoolArray::from(vec![Some(true), None, Some(false)]);
         assert_arrays_eq!(sliced_arr, expected.to_array());

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -172,9 +172,9 @@ impl VTable for DateTimePartsVTable {
         Ok(Some(unsafe {
             DateTimePartsArray::new_unchecked(
                 array.dtype().clone(),
-                array.days().slice(range.clone()),
-                array.seconds().slice(range.clone()),
-                array.subseconds().slice(range),
+                array.days().slice(range.clone())?,
+                array.seconds().slice(range.clone())?,
+                array.subseconds().slice(range)?,
             )
             .into_array()
         }))

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -133,7 +133,7 @@ impl VTable for DecimalBytePartsVTable {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         // SAFETY: slicing encoded MSP does not change the encoded values
         Ok(Some(unsafe {
-            DecimalBytePartsArray::new_unchecked(array.msp.slice(range), *array.decimal_dtype())
+            DecimalBytePartsArray::new_unchecked(array.msp.slice(range)?, *array.decimal_dtype())
                 .into_array()
         }))
     }

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -220,7 +220,7 @@ pub fn gather_patches(
                 num_exceptions_hint,
                 patch_validity,
                 validity_mask,
-            )
+            )?
         })
     } else if array_len < u16::MAX as usize {
         match_each_integer_ptype!(parray.ptype(), |T| {
@@ -230,7 +230,7 @@ pub fn gather_patches(
                 num_exceptions_hint,
                 patch_validity,
                 validity_mask,
-            )
+            )?
         })
     } else if array_len < u32::MAX as usize {
         match_each_integer_ptype!(parray.ptype(), |T| {
@@ -240,7 +240,7 @@ pub fn gather_patches(
                 num_exceptions_hint,
                 patch_validity,
                 validity_mask,
-            )
+            )?
         })
     } else {
         match_each_integer_ptype!(parray.ptype(), |T| {
@@ -250,7 +250,7 @@ pub fn gather_patches(
                 num_exceptions_hint,
                 patch_validity,
                 validity_mask,
-            )
+            )?
         })
     };
 
@@ -263,7 +263,7 @@ fn gather_patches_impl<T, P>(
     num_exceptions_hint: usize,
     patch_validity: Validity,
     validity_mask: Mask,
-) -> Option<Patches>
+) -> VortexResult<Option<Patches>>
 where
     T: PrimInt + NativePType,
     P: IntegerPType,
@@ -288,15 +288,17 @@ where
         }
     }
 
-    (!indices.is_empty()).then(|| {
-        Patches::new(
+    if indices.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(Patches::new(
             data.len(),
             0,
             indices.into_array(),
             PrimitiveArray::new(values, patch_validity).into_array(),
             Some(chunk_offsets.into_array()),
-        )
-    })
+        )?))
+    }
 }
 
 pub fn bit_width_histogram(array: &PrimitiveArray) -> VortexResult<Vec<usize>> {

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -345,7 +345,7 @@ mod tests {
         let bitpacked = bitpack_encode(&zeros, 10, None).unwrap();
         assert_eq!(bitpacked.len(), 1025);
         assert!(bitpacked.patches().is_some());
-        let bitpacked = bitpacked.slice(1023..1025);
+        let bitpacked = bitpacked.slice(1023..1025).unwrap();
         let actual = unpack_array(
             bitpacked.as_::<BitPackedVTable>(),
             &mut SESSION.create_execution_ctx(),
@@ -362,7 +362,7 @@ mod tests {
         let bitpacked = bitpack_encode(&zeros, 10, None).unwrap();
         assert_eq!(bitpacked.len(), 2229);
         assert!(bitpacked.patches().is_some());
-        let bitpacked = bitpacked.slice(1023..2049);
+        let bitpacked = bitpacked.slice(1023..2049).unwrap();
         let actual = unpack_array(
             bitpacked.as_::<BitPackedVTable>(),
             &mut SESSION.create_execution_ctx(),
@@ -648,7 +648,7 @@ mod tests {
         // Test with sliced array (offset > 0).
         let values = PrimitiveArray::from_iter(0u32..2048);
         let bitpacked = bitpack_encode(&values, 11, None).unwrap();
-        let sliced = bitpacked.slice(500..1500);
+        let sliced = bitpacked.slice(500..1500).unwrap();
 
         // Test all three methods on the sliced array.
         let sliced_bp = sliced.as_::<BitPackedVTable>();

--- a/encodings/fastlanes/src/bitpacking/compute/cast.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/cast.rs
@@ -31,13 +31,13 @@ impl CastKernel for BitPackedVTable {
                         .patches()
                         .map(|patches| {
                             let new_values = cast(patches.values(), dtype)?;
-                            VortexResult::Ok(Patches::new(
+                            Patches::new(
                                 patches.array_len(),
                                 patches.offset(),
                                 patches.indices().clone(),
                                 new_values,
                                 patches.chunk_offsets().clone(),
-                            ))
+                            )
                         })
                         .transpose()?,
                     array.bit_width(),

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -104,7 +104,7 @@ fn filter_primitive_no_decompression<T: NativePType + BitPacking>(
 
     let mut values = PrimitiveArray::new(values, validity).reinterpret_cast(array.ptype());
     if let Some(patches) = patches {
-        values = values.patch(&patches);
+        values = values.patch(&patches)?;
     }
     Ok(values)
 }

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -198,7 +198,7 @@ mod test {
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
         let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 6).unwrap();
-        let sliced = bitpacked.slice(128..2050);
+        let sliced = bitpacked.slice(128..2050).unwrap();
 
         let mask = Mask::from_indices(sliced.len(), vec![1919, 1921]);
 

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -137,7 +137,7 @@ fn take_primitive<T: NativePType + BitPacking, I: IntegerPType>(
         && let Some(patches) = patches.take(indices.as_ref())?
     {
         let cast_patches = patches.cast_values(unpatched_taken.dtype())?;
-        return Ok(unpatched_taken.patch(&cast_patches)?);
+        return unpatched_taken.patch(&cast_patches);
     }
 
     Ok(unpatched_taken)
@@ -196,7 +196,7 @@ mod test {
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
         let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 6).unwrap();
-        let sliced = bitpacked.slice(128..2050);
+        let sliced = bitpacked.slice(128..2050).unwrap();
 
         let primitive_result = take(&sliced, &indices).unwrap();
         assert_arrays_eq!(primitive_result, PrimitiveArray::from_iter([31u8, 33]));

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -137,7 +137,7 @@ fn take_primitive<T: NativePType + BitPacking, I: IntegerPType>(
         && let Some(patches) = patches.take(indices.as_ref())?
     {
         let cast_patches = patches.cast_values(unpatched_taken.dtype())?;
-        return Ok(unpatched_taken.patch(&cast_patches));
+        return Ok(unpatched_taken.patch(&cast_patches)?);
     }
 
     Ok(unpatched_taken)

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -26,7 +26,6 @@ use vortex_array::vtable::ValidityVTableFromValidityHelper;
 use vortex_dtype::DType;
 use vortex_dtype::PType;
 use vortex_dtype::match_each_integer_ptype;
-use vortex_error::VortexError;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -111,7 +110,7 @@ impl VTable for BitPackedVTable {
                 patch_indices,
                 patch_values,
                 patch_chunk_offsets,
-            ))
+            )?)
         } else {
             None
         };
@@ -196,7 +195,7 @@ impl VTable for BitPackedVTable {
 
         let validity_idx = match &metadata.patches {
             None => 0,
-            Some(patches_meta) if patches_meta.chunk_offsets_dtype().is_some() => 3,
+            Some(patches_meta) if patches_meta.chunk_offsets_dtype()?.is_some() => 3,
             Some(_) => 2,
         };
 
@@ -205,20 +204,14 @@ impl VTable for BitPackedVTable {
         let patches = metadata
             .patches
             .map(|p| {
-                let indices = children.get(0, &p.indices_dtype(), p.len())?;
-                let values = children.get(1, dtype, p.len())?;
+                let indices = children.get(0, &p.indices_dtype()?, p.len()?)?;
+                let values = children.get(1, dtype, p.len()?)?;
                 let chunk_offsets = p
-                    .chunk_offsets_dtype()
+                    .chunk_offsets_dtype()?
                     .map(|dtype| children.get(2, &dtype, p.chunk_offsets_len() as usize))
                     .transpose()?;
 
-                Ok::<_, VortexError>(Patches::new(
-                    len,
-                    p.offset(),
-                    indices,
-                    values,
-                    chunk_offsets,
-                ))
+                Patches::new(len, p.offset()?, indices, values, chunk_offsets)
             })
             .transpose()?;
 

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -291,7 +291,7 @@ impl VTable for BitPackedVTable {
             BitPackedArray::new_unchecked(
                 array.packed().slice(encoded_start..encoded_stop),
                 array.dtype.clone(),
-                array.validity().slice(range.clone()),
+                array.validity().slice(range.clone())?,
                 array
                     .patches()
                     .map(|p| p.slice(range.clone()))

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -52,7 +52,11 @@ mod test {
             6,
         )
         .unwrap();
-        let sliced = arr.slice(1024..2048).as_::<BitPackedVTable>().clone();
+        let sliced = arr
+            .slice(1024..2048)
+            .unwrap()
+            .as_::<BitPackedVTable>()
+            .clone();
         assert_nth_scalar!(sliced, 0, 1024u32 % 64);
         assert_nth_scalar!(sliced, 1023, 2047u32 % 64);
         assert_eq!(sliced.offset(), 0);
@@ -67,7 +71,11 @@ mod test {
         )
         .unwrap()
         .into_array();
-        let sliced = arr.slice(512..1434).as_::<BitPackedVTable>().clone();
+        let sliced = arr
+            .slice(512..1434)
+            .unwrap()
+            .as_::<BitPackedVTable>()
+            .clone();
         assert_nth_scalar!(sliced, 0, 512u32 % 64);
         assert_nth_scalar!(sliced, 921, 1433u32 % 64);
         assert_eq!(sliced.offset(), 512);
@@ -82,7 +90,7 @@ mod test {
         )
         .unwrap();
 
-        let compressed = packed.slice(768..9999);
+        let compressed = packed.slice(768..9999).unwrap();
         assert_nth_scalar!(compressed, 0, (768 % 63) as u8);
         assert_nth_scalar!(compressed, compressed.len() - 1, (9998 % 63) as u8);
     }
@@ -95,7 +103,7 @@ mod test {
         )
         .unwrap();
 
-        let compressed = packed.slice(7168..9216);
+        let compressed = packed.slice(7168..9216).unwrap();
         assert_nth_scalar!(compressed, 0, (7168 % 63) as u8);
         assert_nth_scalar!(compressed, compressed.len() - 1, (9215 % 63) as u8);
     }
@@ -108,12 +116,20 @@ mod test {
         )
         .unwrap()
         .into_array();
-        let sliced = arr.slice(512..1434).as_::<BitPackedVTable>().clone();
+        let sliced = arr
+            .slice(512..1434)
+            .unwrap()
+            .as_::<BitPackedVTable>()
+            .clone();
         assert_nth_scalar!(sliced, 0, 512u32 % 64);
         assert_nth_scalar!(sliced, 921, 1433u32 % 64);
         assert_eq!(sliced.offset(), 512);
         assert_eq!(sliced.len(), 922);
-        let doubly_sliced = sliced.slice(127..911).as_::<BitPackedVTable>().clone();
+        let doubly_sliced = sliced
+            .slice(127..911)
+            .unwrap()
+            .as_::<BitPackedVTable>()
+            .clone();
         assert_nth_scalar!(doubly_sliced, 0, (512u32 + 127) % 64);
         assert_nth_scalar!(doubly_sliced, 783, (512u32 + 910) % 64);
         assert_eq!(doubly_sliced.offset(), 639);
@@ -131,7 +147,7 @@ mod test {
         assert_eq!(patch_indices.len(), 1);
 
         // Slicing drops the empty patches array.
-        let sliced = array.slice(0..64);
+        let sliced = array.slice(0..64).unwrap();
         let sliced_bp = sliced.as_::<BitPackedVTable>();
         assert!(sliced_bp.patches().is_none());
     }
@@ -146,7 +162,7 @@ mod test {
 
         // Slice the array.
         // The resulting array will still have 3 1024-element chunks.
-        let sliced = array.slice(922..2061);
+        let sliced = array.slice(922..2061).unwrap();
 
         // Take one element from each chunk.
         // Chunk 1: physical indices  922-1023, logical indices    0-101

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -164,13 +164,16 @@ mod test {
                 ByteBuffer::copy_from_aligned([0u8; 128], Alignment::of::<u32>()),
                 DType::Primitive(PType::U32, true.into()),
                 Validity::AllInvalid,
-                Some(Patches::new(
-                    8,
-                    0,
-                    buffer![1u32].into_array(),
-                    PrimitiveArray::new(buffer![999u32], Validity::AllValid).to_array(),
-                    None,
-                )),
+                Some(
+                    Patches::new(
+                        8,
+                        0,
+                        buffer![1u32].into_array(),
+                        PrimitiveArray::new(buffer![999u32], Validity::AllValid).to_array(),
+                        None,
+                    )
+                    .unwrap(),
+                ),
                 1,
                 8,
                 0,

--- a/encodings/fastlanes/src/delta/array/delta_decompress.rs
+++ b/encodings/fastlanes/src/delta/array/delta_decompress.rs
@@ -32,7 +32,7 @@ pub fn delta_decompress(
 
     let validity =
         Validity::from_mask(array.deltas().validity_mask()?, array.dtype().nullability());
-    let validity = validity.slice(start..end);
+    let validity = validity.slice(start..end)?;
 
     Ok(match_each_unsigned_integer_ptype!(deltas.ptype(), |T| {
         const LANES: usize = T::LANES;

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -72,11 +72,11 @@ impl VTable for DeltaVTable {
 
         let new_bases = bases.slice(
             min(start_chunk * lanes, array.bases_len())..min(stop_chunk * lanes, array.bases_len()),
-        );
+        )?;
 
         let new_deltas = deltas.slice(
             min(start_chunk * 1024, array.deltas_len())..min(stop_chunk * 1024, array.deltas_len()),
-        );
+        )?;
 
         // SAFETY: slicing valid bases/deltas preserves correctness
         Ok(Some(unsafe {

--- a/encodings/fastlanes/src/delta/vtable/operations.rs
+++ b/encodings/fastlanes/src/delta/vtable/operations.rs
@@ -11,7 +11,7 @@ use crate::DeltaArray;
 
 impl OperationsVTable<DeltaVTable> for DeltaVTable {
     fn scalar_at(array: &DeltaArray, index: usize) -> VortexResult<Scalar> {
-        let decompressed = array.slice(index..index + 1).to_primitive();
+        let decompressed = array.slice(index..index + 1)?.to_primitive();
         decompressed.scalar_at(0)
     }
 }
@@ -31,7 +31,7 @@ mod tests {
     fn test_slice_non_jagged_array_first_chunk_of_two() {
         let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
 
-        let actual = delta.slice(10..250);
+        let actual = delta.slice(10..250).unwrap();
         let expected = PrimitiveArray::from_iter(10u32..250).into_array();
         assert_arrays_eq!(actual, expected);
     }
@@ -40,7 +40,7 @@ mod tests {
     fn test_slice_non_jagged_array_second_chunk_of_two() {
         let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
 
-        let actual = delta.slice(1024 + 10..1024 + 250);
+        let actual = delta.slice(1024 + 10..1024 + 250).unwrap();
         let expected = PrimitiveArray::from_iter((1024 + 10u32)..(1024 + 250)).into_array();
         assert_arrays_eq!(actual, expected);
     }
@@ -49,7 +49,7 @@ mod tests {
     fn test_slice_non_jagged_array_span_two_chunks_chunk_of_two() {
         let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
 
-        let actual = delta.slice(1000..1048);
+        let actual = delta.slice(1000..1048).unwrap();
         let expected = PrimitiveArray::from_iter(1000u32..1048).into_array();
         assert_arrays_eq!(actual, expected);
     }
@@ -58,7 +58,7 @@ mod tests {
     fn test_slice_non_jagged_array_span_two_chunks_chunk_of_four() {
         let delta = DeltaArray::try_from_vec((0u32..4096).collect()).unwrap();
 
-        let actual = delta.slice(2040..2050);
+        let actual = delta.slice(2040..2050).unwrap();
         let expected = PrimitiveArray::from_iter(2040u32..2050).into_array();
         assert_arrays_eq!(actual, expected);
     }
@@ -67,7 +67,7 @@ mod tests {
     fn test_slice_non_jagged_array_whole() {
         let delta = DeltaArray::try_from_vec((0u32..4096).collect()).unwrap();
 
-        let actual = delta.slice(0..4096);
+        let actual = delta.slice(0..4096).unwrap();
         let expected = PrimitiveArray::from_iter(0u32..4096).into_array();
         assert_arrays_eq!(actual, expected);
     }
@@ -76,15 +76,15 @@ mod tests {
     fn test_slice_non_jagged_array_empty() {
         let delta = DeltaArray::try_from_vec((0u32..4096).collect()).unwrap();
 
-        let actual = delta.slice(0..0);
+        let actual = delta.slice(0..0).unwrap();
         let expected = PrimitiveArray::from_iter(Vec::<u32>::new()).into_array();
         assert_arrays_eq!(actual, expected);
 
-        let actual = delta.slice(4096..4096);
+        let actual = delta.slice(4096..4096).unwrap();
         let expected = PrimitiveArray::from_iter(Vec::<u32>::new()).into_array();
         assert_arrays_eq!(actual, expected);
 
-        let actual = delta.slice(1024..1024);
+        let actual = delta.slice(1024..1024).unwrap();
         let expected = PrimitiveArray::from_iter(Vec::<u32>::new()).into_array();
         assert_arrays_eq!(actual, expected);
     }
@@ -93,7 +93,7 @@ mod tests {
     fn test_slice_jagged_array_second_chunk_of_two() {
         let delta = DeltaArray::try_from_vec((0u32..2000).collect()).unwrap();
 
-        let actual = delta.slice(1024 + 10..1024 + 250);
+        let actual = delta.slice(1024 + 10..1024 + 250).unwrap();
         let expected = PrimitiveArray::from_iter((1024 + 10u32)..(1024 + 250)).into_array();
         assert_arrays_eq!(actual, expected);
     }
@@ -102,15 +102,15 @@ mod tests {
     fn test_slice_jagged_array_empty() {
         let delta = DeltaArray::try_from_vec((0u32..4000).collect()).unwrap();
 
-        let actual = delta.slice(0..0);
+        let actual = delta.slice(0..0).unwrap();
         let expected = PrimitiveArray::from_iter(Vec::<u32>::new()).into_array();
         assert_arrays_eq!(actual, expected);
 
-        let actual = delta.slice(4000..4000);
+        let actual = delta.slice(4000..4000).unwrap();
         let expected = PrimitiveArray::from_iter(Vec::<u32>::new()).into_array();
         assert_arrays_eq!(actual, expected);
 
-        let actual = delta.slice(1024..1024);
+        let actual = delta.slice(1024..1024).unwrap();
         let expected = PrimitiveArray::from_iter(Vec::<u32>::new()).into_array();
         assert_arrays_eq!(actual, expected);
     }
@@ -119,8 +119,8 @@ mod tests {
     fn test_slice_of_slice_of_non_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
 
-        let sliced = delta.slice(10..1013);
-        let sliced_again = sliced.slice(0..2);
+        let sliced = delta.slice(10..1013).unwrap();
+        let sliced_again = sliced.slice(0..2).unwrap();
 
         let expected = PrimitiveArray::from_iter(vec![10u32, 11]).into_array();
         assert_arrays_eq!(sliced_again, expected);
@@ -130,8 +130,8 @@ mod tests {
     fn test_slice_of_slice_of_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2000).collect()).unwrap();
 
-        let sliced = delta.slice(10..1013);
-        let sliced_again = sliced.slice(0..2);
+        let sliced = delta.slice(10..1013).unwrap();
+        let sliced_again = sliced.slice(0..2).unwrap();
 
         let expected = PrimitiveArray::from_iter(vec![10u32, 11]).into_array();
         assert_arrays_eq!(sliced_again, expected);
@@ -141,8 +141,8 @@ mod tests {
     fn test_slice_of_slice_second_chunk_of_non_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
 
-        let sliced = delta.slice(1034..1050);
-        let sliced_again = sliced.slice(0..2);
+        let sliced = delta.slice(1034..1050).unwrap();
+        let sliced_again = sliced.slice(0..2).unwrap();
 
         let expected = PrimitiveArray::from_iter(vec![1034u32, 1035]).into_array();
         assert_arrays_eq!(sliced_again, expected);
@@ -152,8 +152,8 @@ mod tests {
     fn test_slice_of_slice_second_chunk_of_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2000).collect()).unwrap();
 
-        let sliced = delta.slice(1034..1050);
-        let sliced_again = sliced.slice(0..2);
+        let sliced = delta.slice(1034..1050).unwrap();
+        let sliced_again = sliced.slice(0..2).unwrap();
 
         let expected = PrimitiveArray::from_iter(vec![1034u32, 1035]).into_array();
         assert_arrays_eq!(sliced_again, expected);
@@ -163,8 +163,8 @@ mod tests {
     fn test_slice_of_slice_spanning_two_chunks_of_non_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2048).collect()).unwrap();
 
-        let sliced = delta.slice(1010..1050);
-        let sliced_again = sliced.slice(5..20);
+        let sliced = delta.slice(1010..1050).unwrap();
+        let sliced_again = sliced.slice(5..20).unwrap();
 
         let expected = PrimitiveArray::from_iter(1015u32..1030).into_array();
         assert_arrays_eq!(sliced_again, expected);
@@ -174,8 +174,8 @@ mod tests {
     fn test_slice_of_slice_spanning_two_chunks_of_jagged() {
         let delta = DeltaArray::try_from_vec((0u32..2000).collect()).unwrap();
 
-        let sliced = delta.slice(1010..1050);
-        let sliced_again = sliced.slice(5..20);
+        let sliced = delta.slice(1010..1050).unwrap();
+        let sliced_again = sliced.slice(5..20).unwrap();
 
         let expected = PrimitiveArray::from_iter(1015u32..1030).into_array();
         assert_arrays_eq!(sliced_again, expected);

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -113,7 +113,7 @@ impl VTable for FoRVTable {
         // SAFETY: Just slicing encoded data does not affect FOR.
         Ok(Some(unsafe {
             FoRArray::new_unchecked(
-                array.encoded().slice(range),
+                array.encoded().slice(range)?,
                 array.reference_scalar().clone(),
             )
             .into_array()

--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -315,11 +315,11 @@ mod tests {
         )
         .unwrap();
 
-        let valid_slice = rle_array.slice(0..3).to_primitive();
+        let valid_slice = rle_array.slice(0..3).unwrap().to_primitive();
         // TODO(joe): replace with compute null count
         assert!(valid_slice.all_valid().unwrap());
 
-        let mixed_slice = rle_array.slice(1..5);
+        let mixed_slice = rle_array.slice(1..5).unwrap();
         assert!(!mixed_slice.all_valid().unwrap());
     }
 
@@ -355,12 +355,13 @@ mod tests {
         // TODO(joe): replace with compute null count
         let invalid_slice = rle_array
             .slice(2..5)
+            .unwrap()
             .to_canonical()
             .unwrap()
             .into_primitive();
         assert!(invalid_slice.all_invalid().unwrap());
 
-        let mixed_slice = rle_array.slice(1..4);
+        let mixed_slice = rle_array.slice(1..4).unwrap();
         assert!(!mixed_slice.all_invalid().unwrap());
     }
 
@@ -393,7 +394,7 @@ mod tests {
         )
         .unwrap();
 
-        let sliced_array = rle_array.slice(1..4);
+        let sliced_array = rle_array.slice(1..4).unwrap();
         let validity_mask = sliced_array.validity_mask().unwrap();
 
         let expected_mask = Validity::from_iter([false, true, false]).to_mask(3);
@@ -476,7 +477,7 @@ mod tests {
     fn test_rle_serialization_slice() {
         let primitive = PrimitiveArray::from_iter((0..2048).map(|i| (i / 100) as u32));
         let rle_array = RLEArray::encode(&primitive).unwrap();
-        let sliced = rle_array.slice(100..200);
+        let sliced = rle_array.slice(100..200).unwrap();
         assert_eq!(sliced.len(), 100);
 
         let ctx = ArrayContext::empty();

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -78,15 +78,15 @@ impl VTable for RLEVTable {
             array.values().len()
         };
 
-        let sliced_values = array.values().slice(values_start_idx..values_end_idx);
+        let sliced_values = array.values().slice(values_start_idx..values_end_idx)?;
 
         let sliced_values_idx_offsets = array
             .values_idx_offsets()
-            .slice(chunk_start_idx..chunk_end_idx);
+            .slice(chunk_start_idx..chunk_end_idx)?;
 
         let sliced_indices = array
             .indices()
-            .slice(chunk_start_idx * FL_CHUNK_SIZE..chunk_end_idx * FL_CHUNK_SIZE);
+            .slice(chunk_start_idx * FL_CHUNK_SIZE..chunk_end_idx * FL_CHUNK_SIZE)?;
 
         // SAFETY: Slicing preserves all invariants.
         Ok(Some(unsafe {

--- a/encodings/fastlanes/src/rle/vtable/operations.rs
+++ b/encodings/fastlanes/src/rle/vtable/operations.rs
@@ -111,7 +111,7 @@ mod tests {
 
         let array = fixture::rle_array();
         let expected = PrimitiveArray::from_iter([10u32, 10, 20, 20, 20, 30, 10]);
-        assert_arrays_eq!(array.slice(0..7), expected);
+        assert_arrays_eq!(array.slice(0..7).unwrap(), expected);
     }
 
     #[test]
@@ -128,7 +128,7 @@ mod tests {
             Some(30),
             Some(10),
         ]);
-        assert_arrays_eq!(array.slice(0..7), expected);
+        assert_arrays_eq!(array.slice(0..7).unwrap(), expected);
     }
 
     #[test]
@@ -136,7 +136,7 @@ mod tests {
         use vortex_array::assert_arrays_eq;
 
         let array = fixture::rle_array();
-        let sliced = array.slice(2..6); // [20, 20, 20, 30]
+        let sliced = array.slice(2..6).unwrap(); // [20, 20, 20, 30]
 
         assert_eq!(sliced.len(), 4);
         let expected = PrimitiveArray::from_iter([20u32, 20, 20, 30]);
@@ -148,7 +148,7 @@ mod tests {
         use vortex_array::assert_arrays_eq;
 
         let array = fixture::rle_array_with_nulls();
-        let sliced = array.slice(2..6); // [20, 20, null, 30]
+        let sliced = array.slice(2..6).unwrap(); // [20, 20, null, 30]
 
         assert_eq!(sliced.len(), 4);
         let expected = PrimitiveArray::from_option_iter([Some(20u32), Some(20), None, Some(30)]);
@@ -189,14 +189,14 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_scalar_at_slice_out_of_bounds() {
-        let array = fixture::rle_array().slice(0..1);
+        let array = fixture::rle_array().slice(0..1).unwrap();
         array.scalar_at(1).unwrap();
     }
 
     #[test]
     fn test_slice_full_range() {
         let array = fixture::rle_array_with_nulls();
-        let sliced = array.slice(0..7);
+        let sliced = array.slice(0..7).unwrap();
 
         let expected = PrimitiveArray::from_option_iter([
             Some(10u32),
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     fn test_slice_partial_range() {
         let array = fixture::rle_array();
-        let sliced = array.slice(4..6); // [20, 30]
+        let sliced = array.slice(4..6).unwrap(); // [20, 30]
 
         let expected = buffer![20u32, 30].into_array();
         assert_arrays_eq!(sliced.to_array(), expected);
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn test_slice_single_element() {
         let array = fixture::rle_array();
-        let sliced = array.slice(5..6); // [30]
+        let sliced = array.slice(5..6).unwrap(); // [30]
 
         let expected = buffer![30u32].into_array();
         assert_arrays_eq!(sliced.to_array(), expected);
@@ -231,7 +231,7 @@ mod tests {
     #[test]
     fn test_slice_empty_range() {
         let array = fixture::rle_array();
-        let sliced = array.slice(3..3);
+        let sliced = array.slice(3..3).unwrap();
 
         assert_eq!(sliced.len(), 0);
     }
@@ -239,7 +239,7 @@ mod tests {
     #[test]
     fn test_slice_with_nulls() {
         let array = fixture::rle_array_with_nulls();
-        let sliced = array.slice(1..4); // [null, 20, 20]
+        let sliced = array.slice(1..4).unwrap(); // [null, 20, 20]
 
         let expected = PrimitiveArray::from_option_iter([Option::<u32>::None, Some(20), Some(20)]);
         assert_arrays_eq!(sliced.to_array(), expected.to_array());
@@ -248,7 +248,7 @@ mod tests {
     #[test]
     fn test_slice_decode_with_nulls() {
         let array = fixture::rle_array_with_nulls();
-        let sliced = array.slice(1..4).to_array().to_primitive(); // [null, 20, 20]
+        let sliced = array.slice(1..4).unwrap().to_array().to_primitive(); // [null, 20, 20]
 
         let expected = PrimitiveArray::from_option_iter([Option::<u32>::None, Some(20), Some(20)]);
         assert_arrays_eq!(sliced.to_array(), expected.to_array());
@@ -257,7 +257,7 @@ mod tests {
     #[test]
     fn test_slice_preserves_dtype() {
         let array = fixture::rle_array();
-        let sliced = array.slice(1..4);
+        let sliced = array.slice(1..4).unwrap();
 
         assert_eq!(array.dtype(), sliced.dtype());
     }
@@ -271,14 +271,14 @@ mod tests {
         let encoded = RLEArray::encode(&array.to_primitive()).unwrap();
 
         // Slice across first and second chunk.
-        let slice = encoded.slice(500..1500);
+        let slice = encoded.slice(500..1500).unwrap();
         assert_arrays_eq!(
             slice,
             PrimitiveArray::from_iter(expected[500..1500].iter().copied())
         );
 
         // Slice across second and third chunk.
-        let slice = encoded.slice(1000..2000);
+        let slice = encoded.slice(1000..2000).unwrap();
         assert_arrays_eq!(
             slice,
             PrimitiveArray::from_iter(expected[1000..2000].iter().copied())

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -219,7 +219,7 @@ impl VTable for FSSTVTable {
                         .vortex_expect("varbin slice cannot fail")
                         .as_::<VarBinVTable>()
                         .clone(),
-                    array.uncompressed_lengths().slice(range),
+                    array.uncompressed_lengths().slice(range)?,
                 )
             }
             .into_array(),

--- a/encodings/fsst/src/tests.rs
+++ b/encodings/fsst/src/tests.rs
@@ -54,7 +54,7 @@ fn test_fsst_array_ops() {
     );
 
     // test slice
-    let fsst_sliced = fsst_array.slice(1..3);
+    let fsst_sliced = fsst_array.slice(1..3).unwrap();
     assert!(fsst_sliced.is::<FSSTVTable>());
     assert_eq!(fsst_sliced.len(), 2);
     assert_nth_scalar!(

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -178,7 +178,7 @@ impl VTable for PcoVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        Ok(Canonical::Primitive(array.decompress()))
+        Ok(Canonical::Primitive(array.decompress()?))
     }
 }
 
@@ -343,7 +343,7 @@ impl PcoArray {
         }
     }
 
-    pub fn decompress(&self) -> PrimitiveArray {
+    pub fn decompress(&self) -> VortexResult<PrimitiveArray> {
         // To start, we figure out which chunks and pages we need to decompress, and with
         // what value offset into the first such page.
         let number_type = number_type_from_dtype(&self.dtype);
@@ -354,13 +354,13 @@ impl PcoArray {
             }
         );
 
-        PrimitiveArray::from_values_byte_buffer(
+        Ok(PrimitiveArray::from_values_byte_buffer(
             values_byte_buffer,
             self.dtype.as_ptype(),
             self.unsliced_validity
-                .slice(self.slice_start..self.slice_stop),
+                .slice(self.slice_start..self.slice_stop)?,
             self.slice_stop - self.slice_start,
-        )
+        ))
     }
 
     #[allow(clippy::unwrap_in_result, clippy::unwrap_used)]
@@ -527,7 +527,7 @@ impl BaseArrayVTable<PcoVTable> for PcoVTable {
 
 impl OperationsVTable<PcoVTable> for PcoVTable {
     fn scalar_at(array: &PcoArray, index: usize) -> VortexResult<Scalar> {
-        array._slice(index, index + 1).decompress().scalar_at(0)
+        array._slice(index, index + 1).decompress()?.scalar_at(0)
     }
 }
 
@@ -577,7 +577,7 @@ mod tests {
         );
 
         // Slice to get only the non-null values in the middle
-        let sliced = pco.slice(1..5);
+        let sliced = pco.slice(1..5).unwrap();
         let expected =
             PrimitiveArray::from_option_iter([Some(20u32), Some(30), Some(40), Some(50)])
                 .into_array();

--- a/encodings/pco/src/compute/cast.rs
+++ b/encodings/pco/src/compute/cast.rs
@@ -118,7 +118,7 @@ mod tests {
             Validity::from_iter([true, true, true, true, true, true]),
         );
         let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
-        let sliced = pco.slice(1..5);
+        let sliced = pco.slice(1..5).unwrap();
         let casted = cast(
             sliced.as_ref(),
             &DType::Primitive(PType::U32, Nullability::NonNullable),
@@ -143,7 +143,7 @@ mod tests {
             Some(60),
         ]);
         let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
-        let sliced = pco.slice(1..5);
+        let sliced = pco.slice(1..5).unwrap();
         let casted = cast(
             sliced.as_ref(),
             &DType::Primitive(PType::U32, Nullability::NonNullable),

--- a/encodings/pco/src/test.rs
+++ b/encodings/pco/src/test.rs
@@ -42,17 +42,17 @@ fn test_compress_decompress() {
     assert!(compressed.pages.len() < array.nbytes() as usize);
 
     // check full decompression works
-    let decompressed = compressed.decompress();
+    let decompressed = compressed.decompress().unwrap();
     assert_arrays_eq!(decompressed, PrimitiveArray::from_iter(data));
 
     // check slicing works
-    let slice = compressed.slice(100..105);
+    let slice = compressed.slice(100..105).unwrap();
     for i in 0_i32..5 {
         assert_nth_scalar!(slice, i as usize, 100 + i);
     }
     assert_arrays_eq!(slice, PrimitiveArray::from_iter([100, 101, 102, 103, 104]));
 
-    let slice = compressed.slice(200..200);
+    let slice = compressed.slice(200..200).unwrap();
     assert_arrays_eq!(slice, PrimitiveArray::from_iter(Vec::<i32>::new()));
 }
 
@@ -64,7 +64,7 @@ fn test_compress_decompress_small() {
     let expected = array.into_array();
     assert_arrays_eq!(compressed, expected);
 
-    let decompressed = compressed.decompress();
+    let decompressed = compressed.decompress().unwrap();
     assert_arrays_eq!(decompressed, expected);
 }
 
@@ -73,7 +73,7 @@ fn test_empty() {
     let data: Vec<i32> = vec![];
     let array = PrimitiveArray::from_iter(data.clone());
     let compressed = PcoArray::from_primitive(&array, 3, 100).unwrap();
-    let primitive = compressed.decompress();
+    let primitive = compressed.decompress().unwrap();
     assert_arrays_eq!(primitive, PrimitiveArray::from_iter(data));
 }
 
@@ -109,7 +109,7 @@ fn test_validity_and_multiple_chunks_and_pages() {
     assert_nth_scalar!(compressed, 199, 199);
 
     // check slicing works
-    let slice = compressed.slice(100..103);
+    let slice = compressed.slice(100..103).unwrap();
     assert_nth_scalar!(slice, 0, 100);
     assert_nth_scalar!(slice, 2, 102);
     let primitive = slice.to_primitive();
@@ -133,7 +133,7 @@ fn test_validity_vtable() {
         Mask::from_iter(mask_bools)
     );
     assert_eq!(
-        compressed.slice(1..4).validity_mask().unwrap(),
+        compressed.slice(1..4).unwrap().validity_mask().unwrap(),
         Mask::from_iter(vec![true, true, false])
     );
 }

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -491,7 +491,7 @@ pub(super) fn run_end_canonicalize(
                 bools,
                 array.offset(),
                 array.len(),
-            ))
+            )?)
         }
         DType::Primitive(..) => {
             let pvalues = array.values().clone().execute(ctx)?;
@@ -500,7 +500,7 @@ pub(super) fn run_end_canonicalize(
                 pvalues,
                 array.offset(),
                 array.len(),
-            ))
+            )?)
         }
         _ => vortex_panic!("Only Primitive and Bool values are supported"),
     })

--- a/encodings/runend/src/arrow.rs
+++ b/encodings/runend/src/arrow.rs
@@ -41,8 +41,8 @@ where
             let slice_end = find_slice_end_index(ends.as_ref(), offset + len)?;
 
             (
-                ends.slice(slice_begin..slice_end),
-                values.slice(slice_begin..slice_end),
+                ends.slice(slice_begin..slice_end)?,
+                values.slice(slice_begin..slice_end)?,
             )
         };
 

--- a/encodings/runend/src/arrow.rs
+++ b/encodings/runend/src/arrow.rs
@@ -12,7 +12,7 @@ use vortex_array::search_sorted::SearchSortedSide;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_dtype::NativePType;
-use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 use vortex_scalar::PValue;
 
 use crate::RunEndArray;
@@ -22,25 +22,23 @@ impl<R: RunEndIndexType> FromArrowArray<&RunArray<R>> for RunEndArray
 where
     R::Native: NativePType,
 {
-    fn from_arrow(array: &RunArray<R>, nullable: bool) -> Self {
+    fn from_arrow(array: &RunArray<R>, nullable: bool) -> VortexResult<Self> {
         let offset = array.run_ends().offset();
         let len = array.run_ends().len();
         let ends_buf =
             Buffer::<R::Native>::from_arrow_scalar_buffer(array.run_ends().inner().clone());
         let ends = PrimitiveArray::new(ends_buf, Validity::NonNullable)
             .reinterpret_cast(R::Native::PTYPE.to_unsigned());
-        let values = ArrayRef::from_arrow(array.values().as_ref(), nullable);
+        let values = ArrayRef::from_arrow(array.values().as_ref(), nullable)?;
 
         let (ends_slice, values_slice) = if offset == 0 && len == array.run_ends().max_value() {
             (ends.into_array(), values)
         } else {
             let slice_begin = ends
                 .as_primitive_typed()
-                .search_sorted(&PValue::from(offset), SearchSortedSide::Right)
-                .vortex_expect("search_sorted on primitive ends")
+                .search_sorted(&PValue::from(offset), SearchSortedSide::Right)?
                 .to_ends_index(ends.len());
-            let slice_end = find_slice_end_index(ends.as_ref(), offset + len)
-                .vortex_expect("find_slice_end_index on primitive ends");
+            let slice_end = find_slice_end_index(ends.as_ref(), offset + len)?;
 
             (
                 ends.slice(slice_begin..slice_end),
@@ -49,7 +47,7 @@ where
         };
 
         // SAFETY: arrow-rs enforces the RunEndArray invariants, we inherit their guarantees
-        unsafe { RunEndArray::new_unchecked(ends_slice, values_slice, offset, len) }
+        Ok(unsafe { RunEndArray::new_unchecked(ends_slice, values_slice, offset, len) })
     }
 }
 
@@ -69,11 +67,12 @@ mod tests {
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;
     use vortex_dtype::PType;
+    use vortex_error::VortexResult;
 
     use crate::RunEndArray;
 
     #[test]
-    fn test_arrow_run_array_to_vortex() {
+    fn test_arrow_run_array_to_vortex() -> VortexResult<()> {
         // Create an Arrow RunArray with UInt32 run ends and Int32 values
         // Run ends: [3, 5, 8] means runs of length 3, 2, 3
         // Values: [10, 20, 30] means values 10, 10, 10, 20, 20, 30, 30, 30
@@ -82,23 +81,24 @@ mod tests {
         let arrow_run_array = RunArray::<Int32Type>::try_new(&run_ends, &values).unwrap();
 
         // Convert to Vortex
-        let vortex_array = RunEndArray::from_arrow(&arrow_run_array, false);
+        let vortex_array = RunEndArray::from_arrow(&arrow_run_array, false)?;
 
         assert_arrays_eq!(
             vortex_array.as_ref(),
             buffer![10i32, 10, 10, 20, 20, 30, 30, 30].into_array()
         );
+        Ok(())
     }
 
     #[test]
-    fn test_arrow_run_array_with_nulls_to_vortex() {
+    fn test_arrow_run_array_with_nulls_to_vortex() -> VortexResult<()> {
         // Create an Arrow RunArray with nullable values
         let run_ends = Int32Array::from(vec![2i32, 4, 6]);
         let values = Int32Array::from(vec![Some(100), None, Some(300)]);
         let arrow_run_array = RunArray::<Int32Type>::try_new(&run_ends, &values).unwrap();
 
         // Convert to Vortex with nullable=true
-        let vortex_array = RunEndArray::from_arrow(&arrow_run_array, true);
+        let vortex_array = RunEndArray::from_arrow(&arrow_run_array, true)?;
 
         assert_arrays_eq!(
             vortex_array.as_ref(),
@@ -111,23 +111,25 @@ mod tests {
                 Some(300i32)
             ])
         );
+        Ok(())
     }
 
     #[test]
-    fn test_arrow_run_array_with_different_types() {
+    fn test_arrow_run_array_with_different_types() -> VortexResult<()> {
         // Test with UInt64 run ends and Float64 values
         let run_ends = Int64Array::from(vec![1i64, 3, 4]);
         let values = Float64Array::from(vec![1.5, 2.5, 3.5]);
         let arrow_run_array = RunArray::<Int64Type>::try_new(&run_ends, &values).unwrap();
 
         // Convert to Vortex
-        let vortex_array = RunEndArray::from_arrow(&arrow_run_array, false);
+        let vortex_array = RunEndArray::from_arrow(&arrow_run_array, false)?;
 
         assert_arrays_eq!(vortex_array, buffer![1.5f64, 2.5, 2.5, 3.5].into_array());
+        Ok(())
     }
 
     #[test]
-    fn test_sliced_arrow_run_array_to_vortex() {
+    fn test_sliced_arrow_run_array_to_vortex() -> VortexResult<()> {
         // Create an Arrow RunArray with run ends and values
         // Run ends: [2, 5, 8, 10] means runs of length 2, 3, 3, 2
         // Values: [100, 200, 300, 400] means: 100, 100, 200, 200, 200, 300, 300, 300, 400, 400
@@ -140,15 +142,16 @@ mod tests {
         let sliced_array = arrow_run_array.slice(1, 6);
 
         // Convert the sliced array to Vortex
-        let vortex_array = RunEndArray::from_arrow(&sliced_array, false);
+        let vortex_array = RunEndArray::from_arrow(&sliced_array, false)?;
         assert_arrays_eq!(
             vortex_array,
             buffer![100, 200, 200, 200, 300, 300].into_array()
         );
+        Ok(())
     }
 
     #[test]
-    fn test_sliced_arrow_run_array_with_nulls_to_vortex() {
+    fn test_sliced_arrow_run_array_with_nulls_to_vortex() -> VortexResult<()> {
         // Create an Arrow RunArray with nullable values
         // Run ends: [3, 6, 9, 12] means runs of length 3, 3, 3, 3
         // Values: [Some(10), None, Some(30), Some(40)]
@@ -162,7 +165,7 @@ mod tests {
         let sliced_array = arrow_run_array.slice(4, 6);
 
         // Convert to Vortex with nullable=true
-        let vortex_array = RunEndArray::from_arrow(&sliced_array, true);
+        let vortex_array = RunEndArray::from_arrow(&sliced_array, true)?;
 
         assert_arrays_eq!(
             vortex_array,
@@ -175,10 +178,11 @@ mod tests {
                 Some(40),
             ])
         );
+        Ok(())
     }
 
     #[test]
-    fn test_sliced_to_0_arrow_run_array_with_nulls_to_vortex() {
+    fn test_sliced_to_0_arrow_run_array_with_nulls_to_vortex() -> VortexResult<()> {
         // Create an Arrow RunArray with nullable values
         // Run ends: [3, 6, 9, 12] means runs of length 3, 3, 3, 3
         // Values: [Some(10), None, Some(30), Some(40)]
@@ -192,7 +196,7 @@ mod tests {
         let sliced_array = arrow_run_array.slice(4, 0);
 
         // Convert to Vortex with nullable=true
-        let vortex_array = RunEndArray::from_arrow(&sliced_array, true);
+        let vortex_array = RunEndArray::from_arrow(&sliced_array, true)?;
 
         // Verify properties
         assert_eq!(vortex_array.len(), 0);
@@ -200,5 +204,6 @@ mod tests {
             vortex_array.dtype(),
             &DType::Primitive(PType::I64, Nullability::Nullable)
         );
+        Ok(())
     }
 }

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -178,7 +178,7 @@ pub fn runend_decode_primitive(
             runend_decode_typed_primitive(
                 trimmed_ends_iter(ends.as_slice::<E>(), offset, length),
                 values.as_slice::<P>(),
-                validity_mask.clone(),
+                validity_mask,
                 values.dtype().nullability(),
                 length,
             )
@@ -197,7 +197,7 @@ pub fn runend_decode_bools(
         runend_decode_typed_bool(
             trimmed_ends_iter(ends.as_slice::<E>(), offset, length),
             values.bit_buffer(),
-            validity_mask.clone(),
+            validity_mask,
             values.dtype().nullability(),
             length,
         )

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -22,6 +22,7 @@ use vortex_dtype::Nullability;
 use vortex_dtype::match_each_native_ptype;
 use vortex_dtype::match_each_unsigned_integer_ptype;
 use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 use vortex_mask::Mask;
 use vortex_scalar::Scalar;
 
@@ -170,18 +171,19 @@ pub fn runend_decode_primitive(
     values: PrimitiveArray,
     offset: usize,
     length: usize,
-) -> PrimitiveArray {
-    match_each_native_ptype!(values.ptype(), |P| {
+) -> VortexResult<PrimitiveArray> {
+    let validity_mask = values.validity_mask()?;
+    Ok(match_each_native_ptype!(values.ptype(), |P| {
         match_each_unsigned_integer_ptype!(ends.ptype(), |E| {
             runend_decode_typed_primitive(
                 trimmed_ends_iter(ends.as_slice::<E>(), offset, length),
                 values.as_slice::<P>(),
-                values.validity_mask().vortex_expect("validity_mask"),
+                validity_mask.clone(),
                 values.dtype().nullability(),
                 length,
             )
         })
-    })
+    }))
 }
 
 pub fn runend_decode_bools(
@@ -189,16 +191,17 @@ pub fn runend_decode_bools(
     values: BoolArray,
     offset: usize,
     length: usize,
-) -> BoolArray {
-    match_each_unsigned_integer_ptype!(ends.ptype(), |E| {
+) -> VortexResult<BoolArray> {
+    let validity_mask = values.validity_mask()?;
+    Ok(match_each_unsigned_integer_ptype!(ends.ptype(), |E| {
         runend_decode_typed_bool(
             trimmed_ends_iter(ends.as_slice::<E>(), offset, length),
             values.bit_buffer(),
-            values.validity_mask().vortex_expect("validity_mask"),
+            validity_mask.clone(),
             values.dtype().nullability(),
             length,
         )
-    })
+    }))
 }
 
 pub fn runend_decode_typed_primitive<T: NativePType>(
@@ -311,6 +314,7 @@ mod test {
     use vortex_array::validity::Validity;
     use vortex_buffer::BitBuffer;
     use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
 
     use crate::compress::runend_decode_primitive;
     use crate::compress::runend_encode;
@@ -361,12 +365,13 @@ mod test {
     }
 
     #[test]
-    fn decode() {
+    fn decode() -> VortexResult<()> {
         let ends = PrimitiveArray::from_iter([2u32, 5, 10]);
         let values = PrimitiveArray::from_iter([1i32, 2, 3]);
-        let decoded = runend_decode_primitive(ends, values, 0, 10);
+        let decoded = runend_decode_primitive(ends, values, 0, 10)?;
 
         let expected = PrimitiveArray::from_iter(vec![1i32, 1, 2, 2, 2, 3, 3, 3, 3, 3]);
         assert_arrays_eq!(decoded, expected);
+        Ok(())
     }
 }

--- a/encodings/runend/src/compute/cast.rs
+++ b/encodings/runend/src/compute/cast.rs
@@ -130,7 +130,7 @@ mod tests {
         .unwrap();
 
         // Slice it to get offset 3, length 5: [200, 200, 300, 300, 300]
-        let sliced = runend.slice(3..8);
+        let sliced = runend.slice(3..8).unwrap();
 
         // Verify the slice is correct before casting
         assert_arrays_eq!(sliced, PrimitiveArray::from_iter([200, 200, 300, 300, 300]));

--- a/encodings/runend/src/compute/compare.rs
+++ b/encodings/runend/src/compute/compare.rs
@@ -26,21 +26,18 @@ impl CompareKernel for RunEndVTable {
     ) -> VortexResult<Option<ArrayRef>> {
         // If the RHS is constant, then we just need to compare against our encoded values.
         if let Some(const_scalar) = rhs.as_constant() {
-            return compare(
+            let values = compare(
                 lhs.values(),
                 ConstantArray::new(const_scalar, lhs.values().len()).as_ref(),
                 operator,
-            )
-            .map(|values| {
-                runend_decode_bools(
-                    lhs.ends().to_primitive(),
-                    values.to_bool(),
-                    lhs.offset(),
-                    lhs.len(),
-                )
-            })
-            .map(|a| a.into_array())
-            .map(Some);
+            )?;
+            let decoded = runend_decode_bools(
+                lhs.ends().to_primitive(),
+                values.to_bool(),
+                lhs.offset(),
+                lhs.len(),
+            )?;
+            return Ok(Some(decoded.into_array()));
         }
 
         // Otherwise, fall back

--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn filter_sliced_run_end() -> VortexResult<()> {
-        let arr = ree_array().slice(2..7);
+        let arr = ree_array().slice(2..7).unwrap();
         let filtered = arr.filter(Mask::from_iter([true, false, false, true, true]))?;
 
         assert_arrays_eq!(

--- a/encodings/runend/src/compute/take.rs
+++ b/encodings/runend/src/compute/take.rs
@@ -131,7 +131,7 @@ mod test {
 
     #[test]
     fn sliced_take() {
-        let sliced = ree_array().slice(4..9);
+        let sliced = ree_array().slice(4..9).unwrap();
         let taken = take(sliced.as_ref(), buffer![1, 3, 4].into_array().as_ref()).unwrap();
 
         let expected = PrimitiveArray::from_iter(vec![4i32, 2, 5]).into_array();
@@ -186,13 +186,13 @@ mod test {
     }
 
     #[rstest]
-    #[case(ree_array().slice(3..6))]
+    #[case(ree_array().slice(3..6).unwrap())]
     #[case({
         let array = RunEndArray::encode(
             buffer![1i32, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3].into_array(),
         )
         .unwrap();
-        array.slice(2..8)
+        array.slice(2..8).unwrap()
     })]
     fn test_take_sliced_runend_conformance(#[case] sliced: ArrayRef) {
         test_take_conformance(sliced.as_ref());

--- a/encodings/runend/src/kernel.rs
+++ b/encodings/runend/src/kernel.rs
@@ -63,8 +63,8 @@ fn slice(array: &RunEndArray, range: Range<usize>) -> VortexResult<ArrayRef> {
     // SAFETY: we maintain the ends invariant in our slice implementation
     Ok(unsafe {
         RunEndArray::new_unchecked(
-            array.ends().slice(slice_begin..slice_end),
-            array.values().slice(slice_begin..slice_end),
+            array.ends().slice(slice_begin..slice_end)?,
+            array.values().slice(slice_begin..slice_end)?,
             range.start + array.offset(),
             new_length,
         )

--- a/encodings/runend/src/ops.rs
+++ b/encodings/runend/src/ops.rs
@@ -63,7 +63,8 @@ mod tests {
             buffer![1i32, 2, 3].into_array(),
         )
         .unwrap()
-        .slice(3..8);
+        .slice(3..8)
+        .unwrap();
         assert_eq!(
             arr.dtype(),
             &DType::Primitive(PType::I32, Nullability::NonNullable)
@@ -81,10 +82,11 @@ mod tests {
             buffer![1i32, 2, 3].into_array(),
         )
         .unwrap()
-        .slice(3..8);
+        .slice(3..8)
+        .unwrap();
         assert_eq!(arr.len(), 5);
 
-        let doubly_sliced = arr.slice(0..3);
+        let doubly_sliced = arr.slice(0..3).unwrap();
 
         let expected = PrimitiveArray::from_iter(vec![2i32, 2, 3]).into_array();
         assert_arrays_eq!(doubly_sliced, expected);
@@ -97,7 +99,8 @@ mod tests {
             buffer![1i32, 2, 3].into_array(),
         )
         .unwrap()
-        .slice(4..10);
+        .slice(4..10)
+        .unwrap();
         assert_eq!(
             arr.dtype(),
             &DType::Primitive(PType::I32, Nullability::NonNullable)
@@ -118,7 +121,7 @@ mod tests {
 
         assert_eq!(re_array.len(), 10);
 
-        let sliced_array = re_array.slice(re_array.len()..re_array.len());
+        let sliced_array = re_array.slice(re_array.len()..re_array.len()).unwrap();
         assert!(sliced_array.is_empty());
     }
 
@@ -132,7 +135,7 @@ mod tests {
 
         assert_eq!(re_array.len(), 10);
 
-        let sliced_array = re_array.slice(2..5);
+        let sliced_array = re_array.slice(2..5).unwrap();
 
         assert!(
             is_constant_opts(
@@ -167,43 +170,43 @@ mod tests {
         .unwrap();
 
         // Slice from start of first run to end of first run (indices 0..3)
-        let slice1 = arr.slice(0..3);
+        let slice1 = arr.slice(0..3).unwrap();
         assert_eq!(slice1.len(), 3);
         let expected = PrimitiveArray::from_iter(vec![1i32, 1, 1]).into_array();
         assert_arrays_eq!(slice1, expected);
 
         // Slice from start of second run to end of second run (indices 3..6)
-        let slice2 = arr.slice(3..6);
+        let slice2 = arr.slice(3..6).unwrap();
         assert_eq!(slice2.len(), 3);
         let expected = PrimitiveArray::from_iter(vec![4i32, 4, 4]).into_array();
         assert_arrays_eq!(slice2, expected);
 
         // Slice from start of third run to end of third run (indices 6..8)
-        let slice3 = arr.slice(6..8);
+        let slice3 = arr.slice(6..8).unwrap();
         assert_eq!(slice3.len(), 2);
         let expected = PrimitiveArray::from_iter(vec![2i32, 2]).into_array();
         assert_arrays_eq!(slice3, expected);
 
         // Slice from start of last run to end of last run (indices 8..12)
-        let slice4 = arr.slice(8..12);
+        let slice4 = arr.slice(8..12).unwrap();
         assert_eq!(slice4.len(), 4);
         let expected = PrimitiveArray::from_iter(vec![5i32, 5, 5, 5]).into_array();
         assert_arrays_eq!(slice4, expected);
 
         // Slice spanning exactly two runs (indices 3..8)
-        let slice5 = arr.slice(3..8);
+        let slice5 = arr.slice(3..8).unwrap();
         assert_eq!(slice5.len(), 5);
         let expected = PrimitiveArray::from_iter(vec![4i32, 4, 4, 2, 2]).into_array();
         assert_arrays_eq!(slice5, expected);
 
         // Slice from middle of first run to end of second run (indices 1..6)
-        let slice6 = arr.slice(1..6);
+        let slice6 = arr.slice(1..6).unwrap();
         assert_eq!(slice6.len(), 5);
         let expected = PrimitiveArray::from_iter(vec![1i32, 1, 4, 4, 4]).into_array();
         assert_arrays_eq!(slice6, expected);
 
         // Slice from start of second run to middle of third run (indices 3..7)
-        let slice7 = arr.slice(3..7);
+        let slice7 = arr.slice(3..7).unwrap();
         assert_eq!(slice7.len(), 4);
         let expected = PrimitiveArray::from_iter(vec![4i32, 4, 4, 2]).into_array();
         assert_arrays_eq!(slice7, expected);

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -444,7 +444,8 @@ mod tests {
     fn test_sequence_slice_canonical() {
         let arr = SequenceArray::typed_new(2i64, 3, Nullability::NonNullable, 4)
             .unwrap()
-            .slice(2..3);
+            .slice(2..3)
+            .unwrap();
 
         let canon = PrimitiveArray::from_iter((2..3).map(|i| 2i64 + i * 3));
 

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -64,13 +64,13 @@ pub(super) fn canonicalize_sparse(array: &SparseArray) -> VortexResult<Canonical
             Canonical::Null(NullArray::new(array.len()))
         }
         DType::Bool(..) => {
-            let resolved_patches = array.resolved_patches();
-            canonicalize_sparse_bools(&resolved_patches, array.fill_scalar())
+            let resolved_patches = array.resolved_patches()?;
+            canonicalize_sparse_bools(&resolved_patches, array.fill_scalar())?
         }
         DType::Primitive(ptype, ..) => {
-            let resolved_patches = array.resolved_patches();
+            let resolved_patches = array.resolved_patches()?;
             match_each_native_ptype!(ptype, |P| {
-                canonicalize_sparse_primitives::<P>(&resolved_patches, array.fill_scalar())
+                canonicalize_sparse_primitives::<P>(&resolved_patches, array.fill_scalar())?
             })
         }
         DType::Struct(struct_fields, ..) => canonicalize_sparse_struct(
@@ -79,7 +79,7 @@ pub(super) fn canonicalize_sparse(array: &SparseArray) -> VortexResult<Canonical
             array.dtype(),
             array.patches(),
             array.len(),
-        ),
+        )?,
         DType::Decimal(decimal_dtype, nullability) => {
             let canonical_decimal_value_type =
                 DecimalType::smallest_decimal_value_type(decimal_dtype);
@@ -91,23 +91,23 @@ pub(super) fn canonicalize_sparse(array: &SparseArray) -> VortexResult<Canonical
                     fill_value,
                     array.patches(),
                     array.len(),
-                )
+                )?
             })
         }
         dtype @ DType::Utf8(..) => {
             let fill_value = array.fill_scalar().as_utf8().value();
             let fill_value = fill_value.map(BufferString::into_inner);
-            canonicalize_varbin(array, dtype.clone(), fill_value)
+            canonicalize_varbin(array, dtype.clone(), fill_value)?
         }
         dtype @ DType::Binary(..) => {
             let fill_value = array.fill_scalar().as_binary().value();
-            canonicalize_varbin(array, dtype.clone(), fill_value)
+            canonicalize_varbin(array, dtype.clone(), fill_value)?
         }
         DType::List(values_dtype, nullability) => {
-            canonicalize_sparse_lists(array, values_dtype.clone(), *nullability)
+            canonicalize_sparse_lists(array, values_dtype.clone(), *nullability)?
         }
         DType::FixedSizeList(.., nullability) => {
-            canonicalize_sparse_fixed_size_list(array, *nullability)
+            canonicalize_sparse_fixed_size_list(array, *nullability)?
         }
         DType::Extension(_ext_dtype) => todo!(),
     })
@@ -121,8 +121,8 @@ fn canonicalize_sparse_lists(
     array: &SparseArray,
     values_dtype: Arc<DType>,
     nullability: Nullability,
-) -> Canonical {
-    let resolved_patches = array.resolved_patches();
+) -> VortexResult<Canonical> {
+    let resolved_patches = array.resolved_patches()?;
 
     let indices = resolved_patches.indices().to_primitive();
     let values = resolved_patches.values().to_listview();
@@ -131,12 +131,9 @@ fn canonicalize_sparse_lists(
     let n_filled = array.len() - resolved_patches.num_patches();
     let total_canonical_values = values.elements().len() + fill_value.len() * n_filled;
 
-    let validity = Validity::from_mask(
-        array.validity_mask().vortex_expect("validity_mask"),
-        nullability,
-    );
+    let validity = Validity::from_mask(array.validity_mask()?, nullability);
 
-    match_each_integer_ptype!(indices.ptype(), |I| {
+    Ok(match_each_integer_ptype!(indices.ptype(), |I| {
         match_smallest_offset_type!(total_canonical_values, |O| {
             canonicalize_sparse_lists_inner::<I, O>(
                 indices.as_slice(),
@@ -148,7 +145,7 @@ fn canonicalize_sparse_lists(
                 validity,
             )
         })
-    })
+    }))
 }
 
 fn canonicalize_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
@@ -203,18 +200,18 @@ fn canonicalize_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
 }
 
 /// Canonicalize a sparse [`FixedSizeListArray`] by expanding it into a dense representation.
-fn canonicalize_sparse_fixed_size_list(array: &SparseArray, nullability: Nullability) -> Canonical {
-    let resolved_patches = array.resolved_patches();
+fn canonicalize_sparse_fixed_size_list(
+    array: &SparseArray,
+    nullability: Nullability,
+) -> VortexResult<Canonical> {
+    let resolved_patches = array.resolved_patches()?;
     let indices = resolved_patches.indices().to_primitive();
     let values = resolved_patches.values().to_fixed_size_list();
     let fill_value = array.fill_scalar().as_list();
 
-    let validity = Validity::from_mask(
-        array.validity_mask().vortex_expect("validity_mask"),
-        nullability,
-    );
+    let validity = Validity::from_mask(array.validity_mask()?, nullability);
 
-    match_each_integer_ptype!(indices.ptype(), |I| {
+    Ok(match_each_integer_ptype!(indices.ptype(), |I| {
         canonicalize_sparse_fixed_size_list_inner::<I>(
             indices.as_slice(),
             values,
@@ -222,7 +219,7 @@ fn canonicalize_sparse_fixed_size_list(array: &SparseArray, nullability: Nullabi
             array.len(),
             validity,
         )
-    })
+    }))
 }
 
 /// Build a canonical [`FixedSizeListArray`] from sparse patches by interleaving patch values with
@@ -312,7 +309,7 @@ fn append_n_lists(
     }
 }
 
-fn canonicalize_sparse_bools(patches: &Patches, fill_value: &Scalar) -> Canonical {
+fn canonicalize_sparse_bools(patches: &Patches, fill_value: &Scalar) -> VortexResult<Canonical> {
     let (fill_bool, validity) = if fill_value.is_null() {
         (false, Validity::AllInvalid)
     } else {
@@ -331,7 +328,7 @@ fn canonicalize_sparse_bools(patches: &Patches, fill_value: &Scalar) -> Canonica
     let bools =
         BoolArray::from_bit_buffer(BitBuffer::full(fill_bool, patches.array_len()), validity);
 
-    Canonical::Bool(bools.patch(patches))
+    Ok(Canonical::Bool(bools.patch(patches)?))
 }
 
 fn canonicalize_sparse_primitives<
@@ -339,7 +336,7 @@ fn canonicalize_sparse_primitives<
 >(
     patches: &Patches,
     fill_value: &Scalar,
-) -> Canonical {
+) -> VortexResult<Canonical> {
     let (primitive_fill, validity) = if fill_value.is_null() {
         (T::default(), Validity::AllInvalid)
     } else {
@@ -357,7 +354,7 @@ fn canonicalize_sparse_primitives<
 
     let parray = PrimitiveArray::new(buffer![primitive_fill; patches.array_len()], validity);
 
-    Canonical::Primitive(parray.patch(patches))
+    Ok(Canonical::Primitive(parray.patch(patches)?))
 }
 
 fn canonicalize_sparse_struct(
@@ -367,7 +364,7 @@ fn canonicalize_sparse_struct(
     // Resolution is unnecessary b/c we're just pushing the patches into the fields.
     unresolved_patches: &Patches,
     len: usize,
-) -> Canonical {
+) -> VortexResult<Canonical> {
     let (fill_values, top_level_fill_validity) = match fill_struct.fields() {
         Some(fill_values) => (fill_values.collect::<Vec<_>>(), Validity::AllValid),
         None => (
@@ -393,7 +390,7 @@ fn canonicalize_sparse_struct(
                     .vortex_expect("validity_mask"),
                 Nullability::Nullable,
             ),
-        )
+        )?
     } else {
         top_level_fill_validity
             .into_non_nullable(len)
@@ -419,7 +416,6 @@ fn canonicalize_sparse_struct(
         validity,
     )
     .map(Canonical::Struct)
-    .vortex_expect("Creating struct array")
 }
 
 fn canonicalize_sparse_decimal<D: NativeDecimalType>(
@@ -428,7 +424,7 @@ fn canonicalize_sparse_decimal<D: NativeDecimalType>(
     fill_value: DecimalScalar,
     patches: &Patches,
     len: usize,
-) -> Canonical {
+) -> VortexResult<Canonical> {
     let mut builder = DecimalBuilder::with_capacity::<D>(len, decimal_dtype, nullability);
     match fill_value.decimal_value() {
         Some(fill_value) => {
@@ -444,28 +440,25 @@ fn canonicalize_sparse_decimal<D: NativeDecimalType>(
         }
     }
     let filled_array = builder.finish_into_decimal();
-    let array = filled_array.patch(patches);
-    Canonical::Decimal(array)
+    let array = filled_array.patch(patches)?;
+    Ok(Canonical::Decimal(array))
 }
 
 fn canonicalize_varbin(
     array: &SparseArray,
     dtype: DType,
     fill_value: Option<ByteBuffer>,
-) -> Canonical {
-    let patches = array.resolved_patches();
+) -> VortexResult<Canonical> {
+    let patches = array.resolved_patches()?;
     let indices = patches.indices().to_primitive();
     let values = patches.values().to_varbinview();
-    let validity = Validity::from_mask(
-        array.validity_mask().vortex_expect("validity_mask"),
-        dtype.nullability(),
-    );
+    let validity = Validity::from_mask(array.validity_mask()?, dtype.nullability());
     let len = array.len();
 
-    match_each_integer_ptype!(indices.ptype(), |I| {
+    Ok(match_each_integer_ptype!(indices.ptype(), |I| {
         let indices = indices.to_buffer::<I>();
         canonicalize_varbin_inner::<I>(fill_value, indices, values, dtype, validity, len)
-    })
+    }))
 }
 
 fn canonicalize_varbin_inner<I: IntegerPType>(

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -256,8 +256,14 @@ fn canonicalize_sparse_fixed_size_list_inner<I: IntegerPType>(
         );
 
         // Append the patch value, handling null patches by appending defaults.
-        if values.validity().is_valid(patch_idx) {
-            let patch_list = values.fixed_size_list_elements_at(patch_idx);
+        if values
+            .validity()
+            .is_valid(patch_idx)
+            .vortex_expect("is_valid")
+        {
+            let patch_list = values
+                .fixed_size_list_elements_at(patch_idx)
+                .vortex_expect("fixed_size_list_elements_at");
             for i in 0..list_size as usize {
                 builder
                     .append_scalar(&patch_list.scalar_at(i).vortex_expect("scalar_at"))
@@ -1020,7 +1026,7 @@ mod test {
         .into_array();
 
         // Slice to get lists 2..6, which are: [1], [2], [1], [2]
-        let lists = lists.slice(2..6);
+        let lists = lists.slice(2..6).unwrap();
 
         let indices = buffer![0u8, 3u8, 4u8, 5u8].into_array();
         let fill_value = Scalar::null(lists.dtype().clone());
@@ -1520,7 +1526,7 @@ mod test {
         // - Index 0: [2, 3, 4] (original list 1)
         // - Index 1: [5] (original list 2)
         // - Index 2: [6, 7] (original list 3)
-        let sliced = full_listview.slice(1..4);
+        let sliced = full_listview.slice(1..4).unwrap();
 
         // Create sparse array with indices [0, 1] and length 5
         // Expected result:
@@ -1531,7 +1537,7 @@ mod test {
         // - Index 4: null
         let indices = buffer![0u8, 1].into_array();
         // Extract only the values we need from the sliced array
-        let values = sliced.slice(0..2);
+        let values = sliced.slice(0..2).unwrap();
         let sparse =
             SparseArray::try_new(indices, values, 5, Scalar::null(sliced.dtype().clone())).unwrap();
 

--- a/encodings/sparse/src/compute/take.rs
+++ b/encodings/sparse/src/compute/take.rs
@@ -87,7 +87,7 @@ mod test {
     #[test]
     fn take_with_non_zero_offset() {
         let sparse = sparse_array();
-        let sparse = sparse.slice(30..40);
+        let sparse = sparse.slice(30..40).unwrap();
         let taken = take(&sparse, &buffer![6, 7, 8].into_array()).unwrap();
         let expected = PrimitiveArray::from_option_iter([Option::<f64>::None, Some(0.47), None]);
         assert_arrays_eq!(taken, expected.to_array());

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -572,13 +572,13 @@ mod test {
 
     #[test]
     pub fn scalar_at_sliced() {
-        let sliced = sparse_array(nullable_fill()).slice(2..7);
+        let sliced = sparse_array(nullable_fill()).slice(2..7).unwrap();
         assert_eq!(usize::try_from(&sliced.scalar_at(0).unwrap()).unwrap(), 100);
     }
 
     #[test]
     pub fn validity_mask_sliced_null_fill() {
-        let sliced = sparse_array(nullable_fill()).slice(2..7);
+        let sliced = sparse_array(nullable_fill()).slice(2..7).unwrap();
         assert_eq!(
             sliced.validity_mask().unwrap(),
             Mask::from_iter(vec![true, false, false, true, false])
@@ -598,7 +598,8 @@ mod test {
             Scalar::primitive(1.0f32, Nullability::Nullable),
         )
         .unwrap()
-        .slice(2..7);
+        .slice(2..7)
+        .unwrap();
 
         assert_eq!(
             sliced.validity_mask().unwrap(),
@@ -608,13 +609,13 @@ mod test {
 
     #[test]
     pub fn scalar_at_sliced_twice() {
-        let sliced_once = sparse_array(nullable_fill()).slice(1..8);
+        let sliced_once = sparse_array(nullable_fill()).slice(1..8).unwrap();
         assert_eq!(
             usize::try_from(&sliced_once.scalar_at(1).unwrap()).unwrap(),
             100
         );
 
-        let sliced_twice = sliced_once.slice(1..6);
+        let sliced_twice = sliced_once.slice(1..6).unwrap();
         assert_eq!(
             usize::try_from(&sliced_twice.scalar_at(3).unwrap()).unwrap(),
             200

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -113,18 +113,17 @@ impl VTable for SparseVTable {
                 children.len()
             )
         }
-        assert_eq!(
-            metadata.0.patches.offset(),
-            0,
+        vortex_ensure!(
+            metadata.0.patches.offset()? == 0,
             "Patches must start at offset 0"
         );
 
         let patch_indices = children.get(
             0,
-            &metadata.0.patches.indices_dtype(),
-            metadata.0.patches.len(),
+            &metadata.0.patches.indices_dtype()?,
+            metadata.0.patches.len()?,
         )?;
-        let patch_values = children.get(1, dtype, metadata.0.patches.len())?;
+        let patch_values = children.get(1, dtype, metadata.0.patches.len()?)?;
 
         if buffers.len() != 1 {
             vortex_bail!("Expected 1 buffer, got {}", buffers.len());
@@ -154,7 +153,7 @@ impl VTable for SparseVTable {
             patch_indices,
             patch_values,
             array.patches.chunk_offsets().clone(),
-        );
+        )?;
 
         Ok(())
     }
@@ -231,7 +230,7 @@ impl SparseArray {
 
         Ok(Self {
             // TODO(0ax1): handle chunk offsets
-            patches: Patches::new(len, 0, indices, values, None),
+            patches: Patches::new(len, 0, indices, values, None)?,
             fill_value,
             stats_set: Default::default(),
         })
@@ -268,13 +267,10 @@ impl SparseArray {
     }
 
     #[inline]
-    pub fn resolved_patches(&self) -> Patches {
+    pub fn resolved_patches(&self) -> VortexResult<Patches> {
         let patches = self.patches();
-        let indices_offset = Scalar::from(patches.offset())
-            .cast(patches.indices().dtype())
-            .vortex_expect("Patches offset must cast to the indices dtype");
-        let indices = sub_scalar(patches.indices(), indices_offset)
-            .vortex_expect("must be able to subtract offset from indices");
+        let indices_offset = Scalar::from(patches.offset()).cast(patches.indices().dtype())?;
+        let indices = sub_scalar(patches.indices(), indices_offset)?;
 
         Patches::new(
             patches.array_len(),

--- a/encodings/sparse/src/ops.rs
+++ b/encodings/sparse/src/ops.rs
@@ -33,7 +33,7 @@ mod tests {
         let indices = buffer![0u8].into_array();
 
         let sparse = SparseArray::try_new(indices, values, 1000, 999u64.into()).unwrap();
-        let sliced = sparse.slice(0..1000);
+        let sliced = sparse.slice(0..1000).unwrap();
         let mut expected = vec![999u64; 1000];
         expected[0] = 0;
 

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -100,7 +100,7 @@ impl VTable for ZigZagVTable {
 
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
-            ZigZagArray::new(array.encoded().slice(range)).into_array(),
+            ZigZagArray::new(array.encoded().slice(range)?).into_array(),
         ))
     }
 
@@ -243,7 +243,7 @@ mod test {
             array.statistics().compute_is_constant()
         );
 
-        let sliced = zigzag.slice(0..2);
+        let sliced = zigzag.slice(0..2).unwrap();
         let sliced = sliced.as_::<ZigZagVTable>();
         assert_eq!(
             sliced.scalar_at(sliced.len() - 1).unwrap(),

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -173,7 +173,7 @@ impl VTable for ZstdVTable {
     }
 
     fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        array.decompress().execute(ctx)
+        array.decompress()?.execute(ctx)
     }
 
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
@@ -493,7 +493,7 @@ impl ZstdArray {
         }
     }
 
-    pub fn decompress(&self) -> ArrayRef {
+    pub fn decompress(&self) -> VortexResult<ArrayRef> {
         // To start, we figure out which frames we need to decompress, and with
         // what row offset into the first such frame.
         let byte_width = self.byte_width();
@@ -570,7 +570,7 @@ impl ZstdArray {
         // Last, we slice the exact values requested out of the decompressed data.
         let mut slice_validity = self
             .unsliced_validity
-            .slice(self.slice_start..self.slice_stop);
+            .slice(self.slice_start..self.slice_stop)?;
 
         // NOTE: this block handles setting the output type when the validity and DType disagree.
         //
@@ -582,7 +582,7 @@ impl ZstdArray {
         // implied by the DType.
         if !self.dtype().is_nullable() && slice_validity != Validity::NonNullable {
             assert!(
-                slice_validity.all_valid(slice_n_rows),
+                slice_validity.all_valid(slice_n_rows)?,
                 "ZSTD array expects to be non-nullable but there are nulls after decompression"
             );
 
@@ -607,7 +607,7 @@ impl ZstdArray {
                     slice_n_rows,
                 );
 
-                primitive.into_array()
+                Ok(primitive.into_array())
             }
             DType::Binary(_) | DType::Utf8(_) => {
                 match slice_validity.to_mask(slice_n_rows).indices() {
@@ -621,7 +621,7 @@ impl ZstdArray {
                         );
 
                         // SAFETY: we properly construct the views inside `reconstruct_views`
-                        unsafe {
+                        Ok(unsafe {
                             VarBinViewArray::new_unchecked(
                                 valid_views,
                                 Arc::from([decompressed]),
@@ -629,12 +629,13 @@ impl ZstdArray {
                                 slice_validity,
                             )
                         }
-                        .into_array()
+                        .into_array())
                     }
-                    AllOr::None => {
-                        ConstantArray::new(Scalar::null(self.dtype.clone()), slice_n_rows)
-                            .into_array()
-                    }
+                    AllOr::None => Ok(ConstantArray::new(
+                        Scalar::null(self.dtype.clone()),
+                        slice_n_rows,
+                    )
+                    .into_array()),
                     AllOr::Some(valid_indices) => {
                         // the decompressed buffer is a bunch of interleaved u32 lengths
                         // and strings of those lengths, we need to reconstruct the
@@ -650,7 +651,7 @@ impl ZstdArray {
                         }
 
                         // SAFETY: we properly construct the views inside `reconstruct_views`
-                        unsafe {
+                        Ok(unsafe {
                             VarBinViewArray::new_unchecked(
                                 views.freeze(),
                                 Arc::from([decompressed]),
@@ -658,7 +659,7 @@ impl ZstdArray {
                                 slice_validity,
                             )
                         }
-                        .into_array()
+                        .into_array())
                     }
                 }
             }
@@ -774,7 +775,7 @@ impl BaseArrayVTable<ZstdVTable> for ZstdVTable {
 
 impl OperationsVTable<ZstdVTable> for ZstdVTable {
     fn scalar_at(array: &ZstdArray, index: usize) -> VortexResult<Scalar> {
-        array._slice(index, index + 1).decompress().scalar_at(0)
+        array._slice(index, index + 1).decompress()?.scalar_at(0)
     }
 }
 

--- a/encodings/zstd/src/compute/cast.rs
+++ b/encodings/zstd/src/compute/cast.rs
@@ -28,25 +28,27 @@ impl CastKernel for ZstdVTable {
             // completeness of the match arms we also handle it here.
             (Nullability::Nullable, Nullability::Nullable)
             | (Nullability::NonNullable, Nullability::NonNullable) => Ok(Some(array.to_array())),
-            (Nullability::NonNullable, Nullability::Nullable) => Ok(Some(
+            (Nullability::NonNullable, Nullability::Nullable) => {
                 // nonnull => null, trivial cast by altering the validity
-                ZstdArray::new(
-                    array.dictionary.clone(),
-                    array.frames.clone(),
-                    dtype.clone(),
-                    array.metadata.clone(),
-                    array.unsliced_n_rows(),
-                    array.unsliced_validity.clone(),
-                )
-                .slice(array.slice_start()..array.slice_stop()),
-            )),
+                Ok(Some(
+                    ZstdArray::new(
+                        array.dictionary.clone(),
+                        array.frames.clone(),
+                        dtype.clone(),
+                        array.metadata.clone(),
+                        array.unsliced_n_rows(),
+                        array.unsliced_validity.clone(),
+                    )
+                    .slice(array.slice_start()..array.slice_stop())?,
+                ))
+            }
             (Nullability::Nullable, Nullability::NonNullable) => {
                 // null => non-null works if there are no nulls in the sliced range
                 let sliced_len = array.slice_stop() - array.slice_start();
                 let has_nulls = !array
                     .unsliced_validity
-                    .slice(array.slice_start()..array.slice_stop())
-                    .all_valid(sliced_len);
+                    .slice(array.slice_start()..array.slice_stop())?
+                    .all_valid(sliced_len)?;
 
                 // We don't attempt to handle casting when there are nulls.
                 if has_nulls {
@@ -63,7 +65,7 @@ impl CastKernel for ZstdVTable {
                         array.unsliced_n_rows(),
                         array.unsliced_validity.clone(),
                     )
-                    .slice(array.slice_start()..array.slice_stop()),
+                    .slice(array.slice_start()..array.slice_stop())?,
                 ))
             }
         }
@@ -136,7 +138,7 @@ mod tests {
             Validity::from_iter([true, true, true, true, true, true]),
         );
         let zstd = ZstdArray::from_primitive(&values, 0, 128).unwrap();
-        let sliced = zstd.slice(1..5);
+        let sliced = zstd.slice(1..5).unwrap();
         let casted = cast(
             sliced.as_ref(),
             &DType::Primitive(PType::U32, Nullability::NonNullable),
@@ -162,7 +164,7 @@ mod tests {
             Some(60),
         ]);
         let zstd = ZstdArray::from_primitive(&values, 0, 128).unwrap();
-        let sliced = zstd.slice(1..5);
+        let sliced = zstd.slice(1..5).unwrap();
         let casted = cast(
             sliced.as_ref(),
             &DType::Primitive(PType::U32, Nullability::NonNullable),

--- a/encodings/zstd/src/test.rs
+++ b/encodings/zstd/src/test.rs
@@ -29,17 +29,17 @@ fn test_zstd_compress_decompress() {
     assert!(compressed.dictionary.is_none());
 
     // check full decompression works
-    let decompressed = compressed.decompress();
+    let decompressed = compressed.decompress().unwrap();
     assert_arrays_eq!(decompressed, PrimitiveArray::from_iter(data));
 
     // check slicing works
-    let slice = compressed.slice(100..105);
+    let slice = compressed.slice(100..105).unwrap();
     for i in 0_i32..5 {
         assert_nth_scalar!(slice, i as usize, 100 + i);
     }
     assert_arrays_eq!(slice, PrimitiveArray::from_iter([100, 101, 102, 103, 104]));
 
-    let slice = compressed.slice(200..200);
+    let slice = compressed.slice(200..200).unwrap();
     assert_arrays_eq!(slice, PrimitiveArray::from_iter(Vec::<i32>::new()));
 }
 
@@ -74,14 +74,14 @@ fn test_zstd_with_validity_and_multi_frame() {
     assert_nth_scalar!(compressed, 10, None::<i32>);
     assert_nth_scalar!(compressed, 177, 177);
 
-    let decompressed = compressed.decompress().to_primitive();
+    let decompressed = compressed.decompress().unwrap().to_primitive();
     let decompressed_values = decompressed.as_slice::<i32>();
     assert_eq!(decompressed_values[3], 3);
     assert_eq!(decompressed_values[177], 177);
     assert_eq!(decompressed.validity(), array.validity());
 
     // check slicing works
-    let slice = compressed.slice(176..179);
+    let slice = compressed.slice(176..179).unwrap();
     let primitive = slice.to_primitive();
     assert_eq!(
         TryInto::<i32>::try_into(primitive.scalar_at(1).unwrap().as_ref())
@@ -108,11 +108,11 @@ fn test_zstd_with_dict() {
     assert_nth_scalar!(compressed, 0, 0);
     assert_nth_scalar!(compressed, 199, 199);
 
-    let decompressed = compressed.decompress().to_primitive();
+    let decompressed = compressed.decompress().unwrap().to_primitive();
     assert_arrays_eq!(decompressed, PrimitiveArray::from_iter(data));
 
     // check slicing works
-    let slice = compressed.slice(176..179);
+    let slice = compressed.slice(176..179).unwrap();
     let primitive = slice.to_primitive();
     assert_arrays_eq!(primitive, PrimitiveArray::from_iter([176, 177, 178]));
 }
@@ -130,7 +130,7 @@ fn test_validity_vtable() {
         Mask::from_iter(mask_bools)
     );
     assert_eq!(
-        compressed.slice(1..4).validity_mask().unwrap(),
+        compressed.slice(1..4).unwrap().validity_mask().unwrap(),
         Mask::from_iter(vec![true, true, false])
     );
 }
@@ -154,7 +154,7 @@ fn test_zstd_var_bin_view() {
     assert_nth_scalar!(compressed, 3, "Lorem ipsum dolor sit amet");
     assert_nth_scalar!(compressed, 4, "baz");
 
-    let sliced = compressed.slice(1..4);
+    let sliced = compressed.slice(1..4).unwrap();
     assert_nth_scalar!(sliced, 0, "bar");
     assert_nth_scalar!(sliced, 1, None::<String>);
     assert_nth_scalar!(sliced, 2, "Lorem ipsum dolor sit amet");
@@ -178,7 +178,7 @@ fn test_zstd_decompress_var_bin_view() {
     assert_nth_scalar!(compressed, 2, None::<String>);
     assert_nth_scalar!(compressed, 3, "Lorem ipsum dolor sit amet");
     assert_nth_scalar!(compressed, 4, "baz");
-    let decompressed = compressed.decompress().to_varbinview();
+    let decompressed = compressed.decompress().unwrap().to_varbinview();
     assert_nth_scalar!(decompressed, 0, "foo");
     assert_nth_scalar!(decompressed, 1, "bar");
     assert_nth_scalar!(decompressed, 2, None::<String>);
@@ -191,7 +191,7 @@ fn test_sliced_array_children() {
     let data: Vec<Option<i32>> = (0..10).map(|v| (v != 5).then_some(v)).collect();
     let compressed =
         ZstdArray::from_primitive(&PrimitiveArray::from_option_iter(data), 0, 100).unwrap();
-    let sliced = compressed.slice(0..4);
+    let sliced = compressed.slice(0..4).unwrap();
     sliced.children();
 }
 

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -568,7 +568,9 @@ pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> crate::error::VortexFuzz
                 assert_array_eq(&expected.array(), &current_array, i)?;
             }
             Action::Slice(range) => {
-                current_array = current_array.slice(range);
+                current_array = current_array
+                    .slice(range)
+                    .vortex_expect("slice operation should succeed in fuzz test");
                 assert_array_eq(&expected.array(), &current_array, i)?;
             }
             Action::Take(indices) => {

--- a/fuzz/src/array/scalar_at.rs
+++ b/fuzz/src/array/scalar_at.rs
@@ -42,7 +42,9 @@ pub fn scalar_at_canonical_array(canonical: Canonical, index: usize) -> VortexRe
         }
         Canonical::VarBinView(array) => varbin_scalar(array.bytes_at(index), array.dtype()),
         Canonical::List(array) => {
-            let list = array.list_elements_at(index);
+            let list = array
+                .list_elements_at(index)
+                .vortex_expect("list_elements_at should succeed in fuzz test");
             let children: Vec<Scalar> = (0..list.len())
                 .map(|i| {
                     scalar_at_canonical_array(

--- a/fuzz/src/array/scalar_at.rs
+++ b/fuzz/src/array/scalar_at.rs
@@ -42,9 +42,7 @@ pub fn scalar_at_canonical_array(canonical: Canonical, index: usize) -> VortexRe
         }
         Canonical::VarBinView(array) => varbin_scalar(array.bytes_at(index), array.dtype()),
         Canonical::List(array) => {
-            let list = array
-                .list_elements_at(index)
-                .vortex_expect("list_elements_at should succeed in fuzz test");
+            let list = array.list_elements_at(index)?;
             let children: Vec<Scalar> = (0..list.len())
                 .map(|i| {
                     scalar_at_canonical_array(
@@ -62,7 +60,7 @@ pub fn scalar_at_canonical_array(canonical: Canonical, index: usize) -> VortexRe
             )
         }
         Canonical::FixedSizeList(array) => {
-            let list = array.fixed_size_list_elements_at(index);
+            let list = array.fixed_size_list_elements_at(index)?;
             let children: Vec<Scalar> = (0..list.len())
                 .map(|i| {
                     scalar_at_canonical_array(

--- a/vortex-array/benches/dict_compare.rs
+++ b/vortex-array/benches/dict_compare.rs
@@ -113,7 +113,7 @@ fn bench_compare_sliced_dict_primitive(
 ) {
     let primitive_arr = gen_primitive_for_dict::<i32>(codes_len.max(values_len), values_len);
     let dict = dict_encode(primitive_arr.as_ref()).unwrap();
-    let dict = dict.slice(0..codes_len);
+    let dict = dict.slice(0..codes_len).unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
     let session = VortexSession::empty();
 
@@ -133,7 +133,7 @@ fn bench_compare_sliced_dict_varbinview(
 ) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(codes_len.max(values_len), values_len));
     let dict = dict_encode(varbin_arr.as_ref()).unwrap();
-    let dict = dict.slice(0..codes_len);
+    let dict = dict.slice(0..codes_len).unwrap();
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
     let session = VortexSession::empty();

--- a/vortex-array/benches/take_patches.rs
+++ b/vortex-array/benches/take_patches.rs
@@ -98,6 +98,7 @@ fn fixture(len: usize, sparsity: f64, rng: &mut StdRng) -> Patches {
         // TODO(0ax1): handle chunk offsets
         None,
     )
+    .unwrap()
 }
 
 fn fixture_with_chunk_offsets(len: usize, sparsity: f64, rng: &mut StdRng) -> Patches {
@@ -124,6 +125,7 @@ fn fixture_with_chunk_offsets(len: usize, sparsity: f64, rng: &mut StdRng) -> Pa
         values,
         Some(Buffer::from(chunk_offsets).into_array()),
     )
+    .unwrap()
 }
 
 fn indices(array_len: usize, n_indices: usize, rng: &mut StdRng) -> ArrayRef {

--- a/vortex-array/benches/varbinview_compact.rs
+++ b/vortex-array/benches/varbinview_compact.rs
@@ -56,7 +56,10 @@ fn compact_impl(bencher: Bencher, (output_size, utilization_pct): (usize, usize)
 fn compact_sliced_impl(bencher: Bencher, (output_size, utilization_pct): (usize, usize)) {
     let base_size = (output_size * 100) / utilization_pct;
     let base_array = build_varbinview_fixture(base_size);
-    let sliced = base_array.as_ref().slice(0..output_size);
+    let sliced = base_array
+        .as_ref()
+        .slice(0..output_size)
+        .vortex_expect("slice should succeed");
     let array = sliced.to_varbinview();
 
     bencher.with_inputs(|| &array).bench_refs(|array| {

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -99,7 +99,7 @@ pub trait Array:
     fn encoding_id(&self) -> ArrayId;
 
     /// Performs a constant-time slice of the array.
-    fn slice(&self, range: Range<usize>) -> ArrayRef;
+    fn slice(&self, range: Range<usize>) -> VortexResult<ArrayRef>;
 
     /// Wraps the array in a [`FilterArray`] such that it is logically filtered by the given mask.
     fn filter(&self, mask: Mask) -> VortexResult<ArrayRef>;
@@ -216,7 +216,7 @@ impl Array for Arc<dyn Array> {
     }
 
     #[inline]
-    fn slice(&self, range: Range<usize>) -> ArrayRef {
+    fn slice(&self, range: Range<usize>) -> VortexResult<ArrayRef> {
         self.as_ref().slice(range)
     }
 
@@ -458,12 +458,12 @@ impl<V: VTable> Array for ArrayAdapter<V> {
         V::id(&self.0)
     }
 
-    fn slice(&self, range: Range<usize>) -> ArrayRef {
+    fn slice(&self, range: Range<usize>) -> VortexResult<ArrayRef> {
         let start = range.start;
         let stop = range.end;
 
         if start == 0 && stop == self.len() {
-            return self.to_array();
+            return Ok(self.to_array());
         }
 
         assert!(
@@ -480,7 +480,7 @@ impl<V: VTable> Array for ArrayAdapter<V> {
         assert!(start <= stop, "start ({start}) must be <= stop ({stop})");
 
         if start == stop {
-            return Canonical::empty(self.dtype()).into_array();
+            return Ok(Canonical::empty(self.dtype()).into_array());
         }
 
         let sliced = V::slice(&self.0, range.clone())
@@ -521,7 +521,7 @@ impl<V: VTable> Array for ArrayAdapter<V> {
             });
         }
 
-        sliced
+        Ok(sliced)
     }
 
     fn filter(&self, mask: Mask) -> VortexResult<ArrayRef> {

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -483,11 +483,9 @@ impl<V: VTable> Array for ArrayAdapter<V> {
             return Ok(Canonical::empty(self.dtype()).into_array());
         }
 
-        let sliced = V::slice(&self.0, range.clone())
-            .vortex_expect("cannot fail")
+        let sliced = V::slice(&self.0, range.clone())?
             .unwrap_or_else(|| SliceArray::new(self.to_array(), range).to_array())
-            .optimize()
-            .vortex_expect("cannot fail for now");
+            .optimize()?;
 
         assert_eq!(
             sliced.len(),
@@ -552,11 +550,7 @@ impl<V: VTable> Array for ArrayAdapter<V> {
         match self.validity()? {
             Validity::NonNullable | Validity::AllValid => Ok(true),
             Validity::AllInvalid => Ok(false),
-            Validity::Array(a) => Ok(a
-                .scalar_at(index)?
-                .as_bool()
-                .value()
-                .vortex_expect("validity must be non-nullable")),
+            Validity::Array(a) => a.scalar_at(index)?.as_bool().value(),
         }
     }
 
@@ -592,9 +586,7 @@ impl<V: VTable> Array for ArrayAdapter<V> {
             Validity::AllInvalid => 0,
             Validity::Array(a) => {
                 let sum = compute::sum(&a)?;
-                sum.as_primitive()
-                    .as_::<usize>()
-                    .vortex_expect("Sum must be non-nullable")
+                sum.as_primitive().as_::<usize>()?
             }
         };
         vortex_ensure!(count <= self.len(), "Valid count exceeds array length");

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -550,7 +550,11 @@ impl<V: VTable> Array for ArrayAdapter<V> {
         match self.validity()? {
             Validity::NonNullable | Validity::AllValid => Ok(true),
             Validity::AllInvalid => Ok(false),
-            Validity::Array(a) => a.scalar_at(index)?.as_bool().value(),
+            Validity::Array(a) => a
+                .scalar_at(index)?
+                .as_bool()
+                .value()
+                .ok_or_else(|| vortex_err!("validity value at index {} is null", index)),
         }
     }
 
@@ -586,7 +590,9 @@ impl<V: VTable> Array for ArrayAdapter<V> {
             Validity::AllInvalid => 0,
             Validity::Array(a) => {
                 let sum = compute::sum(&a)?;
-                sum.as_primitive().as_::<usize>()?
+                sum.as_primitive()
+                    .as_::<usize>()
+                    .ok_or_else(|| vortex_err!("sum of validity array is null"))?
             }
         };
         vortex_ensure!(count <= self.len(), "Valid count exceeds array length");

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -31,6 +31,7 @@ use crate::validity::Validity;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> vortex_error::VortexResult<()> {
 /// use vortex_array::arrays::BoolArray;
 /// use vortex_array::IntoArray;
 ///
@@ -38,12 +39,14 @@ use crate::validity::Validity;
 /// let array: BoolArray = [true, false, true, false].into_iter().collect();
 ///
 /// // Slice the array
-/// let sliced = array.slice(1..3);
+/// let sliced = array.slice(1..3)?;
 /// assert_eq!(sliced.len(), 2);
 ///
 /// // Access individual values
 /// let value = array.scalar_at(0).unwrap();
 /// assert_eq!(value, true.into());
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug)]
 pub struct BoolArray {

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -314,7 +314,7 @@ mod tests {
     #[test]
     fn patch_sliced_bools() {
         let arr = BoolArray::from(BitBuffer::new_set(12));
-        let sliced = arr.slice(4..12);
+        let sliced = arr.slice(4..12).unwrap();
         assert_eq!(sliced.len(), 8);
         let values = sliced.to_bool().into_bit_buffer().into_mut();
         assert_eq!(values.len(), 8);
@@ -325,7 +325,7 @@ mod tests {
             (1..12).for_each(|i| builder.set(i));
             BoolArray::from(builder.freeze())
         };
-        let sliced = arr.slice(4..12);
+        let sliced = arr.slice(4..12).unwrap();
         let sliced_len = sliced.len();
         let values = sliced.to_bool().into_bit_buffer().into_mut();
         assert_eq!(values.as_slice(), &[254, 15]);
@@ -337,15 +337,17 @@ mod tests {
             buffer![4u32].into_array(), // This creates a non-nullable array
             BoolArray::from(BitBuffer::new_unset(1)).into_array(),
             None,
-        );
-        let arr = arr.patch(&patches);
+        )
+        .unwrap();
+        let arr = arr.patch(&patches).unwrap();
         let arr_len = arr.len();
         let values = arr.to_bool().into_bit_buffer().into_mut();
         assert_eq!(values.len(), arr_len);
         assert_eq!(values.as_slice(), &[238, 15]);
 
         // the slice should be unchanged
-        let values = sliced.to_bool().into_bit_buffer().into_mut();
+        let sliced = sliced.to_bool();
+        let values = sliced.into_bit_buffer().into_mut();
         assert_eq!(values.len(), sliced_len);
         assert_eq!(values.as_slice(), &[254, 15]); // unchanged
     }
@@ -353,7 +355,7 @@ mod tests {
     #[test]
     fn slice_array_in_middle() {
         let arr = BoolArray::from(BitBuffer::new_set(16));
-        let sliced = arr.slice(4..12);
+        let sliced = arr.slice(4..12).unwrap();
         let sliced_len = sliced.len();
         let values = sliced.to_bool().into_bit_buffer().into_mut();
         assert_eq!(values.len(), sliced_len);
@@ -371,8 +373,9 @@ mod tests {
             PrimitiveArray::new(buffer![0u32], Validity::NonNullable).into_array(),
             BoolArray::from(BitBuffer::new_unset(1)).into_array(),
             None,
-        );
-        let arr = arr.patch(&patches);
+        )
+        .unwrap();
+        let arr = arr.patch(&patches).unwrap();
         assert_eq!(arr.bit_buffer().inner().as_ptr(), buf_ptr);
 
         let values = arr.into_bit_buffer();
@@ -382,7 +385,7 @@ mod tests {
     #[test]
     fn patch_sliced_bools_offset() {
         let arr = BoolArray::from(BitBuffer::new_set(15));
-        let sliced = arr.slice(4..15);
+        let sliced = arr.slice(4..15).unwrap();
         let values = sliced.to_bool().into_bit_buffer().into_mut();
         assert_eq!(values.as_slice(), &[255, 255]);
     }

--- a/vortex-array/src/arrays/bool/patch.rs
+++ b/vortex-array/src/arrays/bool/patch.rs
@@ -48,7 +48,7 @@ mod tests {
     #[test]
     fn patch_sliced_bools() {
         let arr = BoolArray::from(BitBuffer::new_set(12));
-        let sliced = arr.slice(4..12);
+        let sliced = arr.slice(4..12).unwrap();
         let values = sliced.to_bool().into_bit_buffer().into_mut();
         assert_eq!(values.len(), 8);
         assert_eq!(values.as_slice(), &[255, 255]);
@@ -57,7 +57,7 @@ mod tests {
     #[test]
     fn patch_sliced_bools_offset() {
         let arr = BoolArray::from(BitBuffer::new_set(15));
-        let sliced = arr.slice(4..15);
+        let sliced = arr.slice(4..15).unwrap();
         let values = sliced.to_bool().into_bit_buffer().into_mut();
         assert_eq!(values.len(), 11);
         assert_eq!(values.as_slice(), &[255, 255]);

--- a/vortex-array/src/arrays/bool/patch.rs
+++ b/vortex-array/src/arrays/bool/patch.rs
@@ -3,6 +3,7 @@
 
 use itertools::Itertools;
 use vortex_dtype::match_each_unsigned_integer_ptype;
+use vortex_error::VortexResult;
 
 use crate::ToCanonical;
 use crate::arrays::BoolArray;
@@ -10,7 +11,7 @@ use crate::patches::Patches;
 use crate::vtable::ValidityHelper;
 
 impl BoolArray {
-    pub fn patch(self, patches: &Patches) -> Self {
+    pub fn patch(self, patches: &Patches) -> VortexResult<Self> {
         let len = self.len();
         let offset = patches.offset();
         let indices = patches.indices().to_primitive();
@@ -19,7 +20,7 @@ impl BoolArray {
         let patched_validity =
             self.validity()
                 .clone()
-                .patch(len, offset, indices.as_ref(), values.validity());
+                .patch(len, offset, indices.as_ref(), values.validity())?;
 
         let mut own_values = self.into_bit_buffer().into_mut();
         match_each_unsigned_integer_ptype!(indices.ptype(), |I| {
@@ -33,7 +34,7 @@ impl BoolArray {
             }
         });
 
-        Self::from_bit_buffer(own_values.freeze(), patched_validity)
+        Ok(Self::from_bit_buffer(own_values.freeze(), patched_validity))
     }
 }
 

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -138,7 +138,7 @@ impl VTable for BoolVTable {
         Ok(Some(
             BoolArray::from_bit_buffer(
                 array.bit_buffer().slice(range.clone()),
-                array.validity().slice(range),
+                array.validity().slice(range)?,
             )
             .into_array(),
         ))

--- a/vortex-array/src/arrays/bool/vtable/operations.rs
+++ b/vortex-array/src/arrays/bool/vtable/operations.rs
@@ -28,7 +28,7 @@ mod tests {
     #[test]
     fn test_slice_hundred_elements() {
         let arr = BoolArray::from_iter(iter::repeat_n(Some(true), 100));
-        let sliced_arr = arr.slice(8..16).to_bool();
+        let sliced_arr = arr.slice(8..16).unwrap().to_bool();
         assert_eq!(sliced_arr.len(), 8);
         assert_eq!(sliced_arr.bit_buffer().len(), 8);
         assert_eq!(sliced_arr.bit_buffer().offset(), 0);
@@ -37,7 +37,7 @@ mod tests {
     #[test]
     fn test_slice() {
         let arr = BoolArray::from_iter([Some(true), Some(true), None, Some(false), None]);
-        let sliced_arr = arr.slice(1..4).to_bool();
+        let sliced_arr = arr.slice(1..4).unwrap().to_bool();
 
         assert_arrays_eq!(
             sliced_arr,

--- a/vortex-array/src/arrays/chunked/compute/compare.rs
+++ b/vortex-array/src/arrays/chunked/compute/compare.rs
@@ -31,7 +31,7 @@ impl CompareKernel for ChunkedVTable {
         );
 
         for chunk in lhs.non_empty_chunks() {
-            let sliced = rhs.slice(idx..idx + chunk.len());
+            let sliced = rhs.slice(idx..idx + chunk.len())?;
             let cmp_result = compare(chunk, &sliced, operator)?;
 
             bool_builder.extend_from_array(&cmp_result);

--- a/vortex-array/src/arrays/chunked/compute/zip.rs
+++ b/vortex-array/src/arrays/chunked/compute/zip.rs
@@ -47,8 +47,8 @@ impl ZipKernel for ChunkedVTable {
             let take_until = lhs_rem.min(rhs_rem);
 
             let mask_slice = mask.slice(pos..pos + take_until);
-            let lhs_slice = lhs_chunk.slice(lhs_offset..lhs_offset + take_until);
-            let rhs_slice = rhs_chunk.slice(rhs_offset..rhs_offset + take_until);
+            let lhs_slice = lhs_chunk.slice(lhs_offset..lhs_offset + take_until)?;
+            let rhs_slice = rhs_chunk.slice(rhs_offset..rhs_offset + take_until)?;
 
             out_chunks.push(zip(lhs_slice.as_ref(), rhs_slice.as_ref(), &mask_slice)?);
 

--- a/vortex-array/src/arrays/chunked/tests.rs
+++ b/vortex-array/src/arrays/chunked/tests.rs
@@ -36,7 +36,7 @@ fn chunked_array() -> ChunkedArray {
 #[test]
 fn slice_middle() {
     assert_arrays_eq!(
-        chunked_array().slice(2..5),
+        chunked_array().slice(2..5).unwrap(),
         PrimitiveArray::from_iter([3u64, 4, 5])
     );
 }
@@ -44,7 +44,7 @@ fn slice_middle() {
 #[test]
 fn slice_begin() {
     assert_arrays_eq!(
-        chunked_array().slice(1..3),
+        chunked_array().slice(1..3).unwrap(),
         PrimitiveArray::from_iter([2u64, 3])
     );
 }
@@ -52,7 +52,7 @@ fn slice_begin() {
 #[test]
 fn slice_aligned() {
     assert_arrays_eq!(
-        chunked_array().slice(3..6),
+        chunked_array().slice(3..6).unwrap(),
         PrimitiveArray::from_iter([4u64, 5, 6])
     );
 }
@@ -60,7 +60,7 @@ fn slice_aligned() {
 #[test]
 fn slice_many_aligned() {
     assert_arrays_eq!(
-        chunked_array().slice(0..6),
+        chunked_array().slice(0..6).unwrap(),
         PrimitiveArray::from_iter([1u64, 2, 3, 4, 5, 6])
     );
 }
@@ -68,7 +68,7 @@ fn slice_many_aligned() {
 #[test]
 fn slice_end() {
     assert_arrays_eq!(
-        chunked_array().slice(7..8),
+        chunked_array().slice(7..8).unwrap(),
         PrimitiveArray::from_iter([8u64])
     );
 }
@@ -76,7 +76,7 @@ fn slice_end() {
 #[test]
 fn slice_exactly_end() {
     assert_arrays_eq!(
-        chunked_array().slice(6..9),
+        chunked_array().slice(6..9).unwrap(),
         PrimitiveArray::from_iter([7u64, 8, 9])
     );
 }
@@ -84,7 +84,7 @@ fn slice_exactly_end() {
 #[test]
 fn slice_empty() {
     let chunked = ChunkedArray::try_new(vec![], PType::U32.into()).unwrap();
-    let sliced = chunked.slice(0..0);
+    let sliced = chunked.slice(0..0).unwrap();
 
     assert!(sliced.is_empty());
 }

--- a/vortex-array/src/arrays/chunked/vtable/compute.rs
+++ b/vortex-array/src/arrays/chunked/vtable/compute.rs
@@ -55,7 +55,7 @@ fn invoke_elementwise(
         inputs.push(chunk.clone());
         for i in 1..args.inputs.len() {
             let input = args.inputs[i].array().vortex_expect("checked already");
-            let sliced = input.slice(idx..idx + chunk.len());
+            let sliced = input.slice(idx..idx + chunk.len())?;
             inputs.push(sliced);
         }
 

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -214,7 +214,7 @@ impl VTable for ChunkedVTable {
         if length_chunk == offset_chunk {
             let chunk = array.chunk(offset_chunk);
             return Ok(Some(
-                chunk.slice(offset_in_first_chunk..length_in_last_chunk),
+                chunk.slice(offset_in_first_chunk..length_in_last_chunk)?,
             ));
         }
 
@@ -222,13 +222,13 @@ impl VTable for ChunkedVTable {
             .map(|i| array.chunk(i).clone())
             .collect_vec();
         if let Some(c) = chunks.first_mut() {
-            *c = c.slice(offset_in_first_chunk..c.len());
+            *c = c.slice(offset_in_first_chunk..c.len())?;
         }
 
         if length_in_last_chunk == 0 {
             chunks.pop();
         } else if let Some(c) = chunks.last_mut() {
-            *c = c.slice(0..length_in_last_chunk);
+            *c = c.slice(0..length_in_last_chunk)?;
         }
 
         // SAFETY: chunks are slices of the original valid chunks, preserving their dtype.

--- a/vortex-array/src/arrays/chunked/vtable/operations.rs
+++ b/vortex-array/src/arrays/chunked/vtable/operations.rs
@@ -58,38 +58,41 @@ mod tests {
 
     #[test]
     fn slice_middle() {
-        assert_equal_slices(&chunked_array().slice(2..5), &[3u64, 4, 5])
+        assert_equal_slices(chunked_array().slice(2..5).unwrap().as_ref(), &[3u64, 4, 5])
     }
 
     #[test]
     fn slice_begin() {
-        assert_equal_slices(&chunked_array().slice(1..3), &[2u64, 3]);
+        assert_equal_slices(chunked_array().slice(1..3).unwrap().as_ref(), &[2u64, 3]);
     }
 
     #[test]
     fn slice_aligned() {
-        assert_equal_slices(&chunked_array().slice(3..6), &[4u64, 5, 6]);
+        assert_equal_slices(chunked_array().slice(3..6).unwrap().as_ref(), &[4u64, 5, 6]);
     }
 
     #[test]
     fn slice_many_aligned() {
-        assert_equal_slices(&chunked_array().slice(0..6), &[1u64, 2, 3, 4, 5, 6]);
+        assert_equal_slices(
+            chunked_array().slice(0..6).unwrap().as_ref(),
+            &[1u64, 2, 3, 4, 5, 6],
+        );
     }
 
     #[test]
     fn slice_end() {
-        assert_equal_slices(&chunked_array().slice(7..8), &[8u64]);
+        assert_equal_slices(chunked_array().slice(7..8).unwrap().as_ref(), &[8u64]);
     }
 
     #[test]
     fn slice_exactly_end() {
-        assert_equal_slices(&chunked_array().slice(6..9), &[7u64, 8, 9]);
+        assert_equal_slices(chunked_array().slice(6..9).unwrap().as_ref(), &[7u64, 8, 9]);
     }
 
     #[test]
     fn slice_empty() {
         let chunked = ChunkedArray::try_new(vec![], PType::U32.into()).unwrap();
-        let sliced = chunked.slice(0..0);
+        let sliced = chunked.slice(0..0).unwrap();
 
         assert!(sliced.is_empty());
     }

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -140,7 +140,7 @@ pub(super) fn constant_canonicalize(array: &ConstantArray) -> VortexResult<Canon
                     .map(|s| ConstantArray::new(s, array.len()).into_array())
                     .collect(),
                 None => {
-                    assert!(validity.all_invalid(array.len()));
+                    assert!(validity.all_invalid(array.len())?);
                     struct_dtype
                         .fields()
                         .map(|dt| {
@@ -514,7 +514,7 @@ mod tests {
 
         // Check that each list is [10, 20, 30].
         for i in 0..4 {
-            let list = canonical.fixed_size_list_elements_at(i);
+            let list = canonical.fixed_size_list_elements_at(i).unwrap();
             let list_primitive = list.to_primitive();
             assert_arrays_eq!(list_primitive, PrimitiveArray::from_iter([10i32, 20, 30]));
         }
@@ -662,14 +662,14 @@ mod tests {
 
         // Check element validity.
         let element_validity = elements.validity();
-        assert!(element_validity.is_valid(0));
-        assert!(!element_validity.is_valid(1));
-        assert!(element_validity.is_valid(2));
+        assert!(element_validity.is_valid(0).unwrap());
+        assert!(!element_validity.is_valid(1).unwrap());
+        assert!(element_validity.is_valid(2).unwrap());
 
         // Pattern should repeat.
-        assert!(element_validity.is_valid(3));
-        assert!(!element_validity.is_valid(4));
-        assert!(element_validity.is_valid(5));
+        assert!(element_validity.is_valid(3).unwrap());
+        assert!(!element_validity.is_valid(4).unwrap());
+        assert!(element_validity.is_valid(5).unwrap());
     }
 
     #[test]

--- a/vortex-array/src/arrays/decimal/array.rs
+++ b/vortex-array/src/arrays/decimal/array.rs
@@ -324,7 +324,7 @@ impl DecimalArray {
         clippy::cognitive_complexity,
         reason = "complexity from nested match_each_* macros"
     )]
-    pub fn patch(self, patches: &Patches) -> Self {
+    pub fn patch(self, patches: &Patches) -> VortexResult<Self> {
         let offset = patches.offset();
         let patch_indices = patches.indices().to_primitive();
         let patch_values = patches.values().to_decimal();
@@ -334,10 +334,10 @@ impl DecimalArray {
             offset,
             patch_indices.as_ref(),
             patch_values.validity(),
-        );
+        )?;
         assert_eq!(self.decimal_dtype(), patch_values.decimal_dtype());
 
-        match_each_integer_ptype!(patch_indices.ptype(), |I| {
+        Ok(match_each_integer_ptype!(patch_indices.ptype(), |I| {
             let patch_indices = patch_indices.as_slice::<I>();
             match_each_decimal_value_type!(patch_values.values_type(), |PatchDVT| {
                 let patch_values = patch_values.buffer::<PatchDVT>();
@@ -353,7 +353,7 @@ impl DecimalArray {
                     )
                 })
             })
-        })
+        }))
     }
 }
 

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -153,7 +153,7 @@ impl VTable for DecimalVTable {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let result = match_each_decimal_value_type!(array.values_type(), |D| {
             let sliced = array.buffer::<D>().slice(range.clone());
-            let validity = array.validity().clone().slice(range);
+            let validity = array.validity().clone().slice(range)?;
             // SAFETY: Slicing preserves all DecimalArray invariants
             unsafe { DecimalArray::new_unchecked(sliced, array.decimal_dtype(), validity) }
                 .into_array()

--- a/vortex-array/src/arrays/decimal/vtable/operations.rs
+++ b/vortex-array/src/arrays/decimal/vtable/operations.rs
@@ -44,7 +44,7 @@ mod tests {
         )
         .to_array();
 
-        let sliced = array.slice(1..3);
+        let sliced = array.slice(1..3).unwrap();
         assert_eq!(sliced.len(), 2);
 
         let decimal = sliced.as_::<DecimalVTable>();
@@ -60,7 +60,7 @@ mod tests {
         )
         .to_array();
 
-        let sliced = array.slice(1..3);
+        let sliced = array.slice(1..3).unwrap();
         assert_eq!(sliced.len(), 2);
     }
 

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -109,8 +109,8 @@ mod tests {
     fn test_sliced_dict() {
         let reference = PrimitiveArray::from_iter([1, 5, 10, 50, 100]);
         let dict = dict_encode(reference.as_ref()).unwrap();
-        let sliced = dict.slice(1..3);
-        assert_min_max(&sliced, Some((5, 10)));
+        let sliced = dict.slice(1..3).unwrap();
+        assert_min_max(sliced.as_ref(), Some((5, 10)));
     }
 
     #[rstest]

--- a/vortex-array/src/arrays/dict/compute/mod.rs
+++ b/vortex-array/src/arrays/dict/compute/mod.rs
@@ -146,7 +146,7 @@ mod test {
             Some(5),
         ]);
         let dict = dict_encode(reference.as_ref()).unwrap();
-        dict.slice(1..4)
+        dict.slice(1..4).unwrap()
     }
 
     #[test]

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -64,7 +64,7 @@ impl VTable for DictVTable {
     }
 
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
-        let sliced_code = array.codes().slice(range);
+        let sliced_code = array.codes().slice(range)?;
         if sliced_code.is::<ConstantVTable>() {
             let code = &sliced_code.scalar_at(0)?.as_primitive().as_::<usize>();
             return if let Some(code) = code {

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -104,7 +104,7 @@ impl VTable for ExtensionVTable {
 
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
-            ExtensionArray::new(array.ext_dtype().clone(), array.storage().slice(range))
+            ExtensionArray::new(array.ext_dtype().clone(), array.storage().slice(range)?)
                 .into_array(),
         ))
     }

--- a/vortex-array/src/arrays/fixed_size_list/array.rs
+++ b/vortex-array/src/arrays/fixed_size_list/array.rs
@@ -218,16 +218,16 @@ impl FixedSizeListArray {
 
     /// Returns the elements of the fixed-size list scalar at the given index of the list array.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the index is out of bounds.
-    pub fn fixed_size_list_elements_at(&self, index: usize) -> ArrayRef {
+    /// Returns an error if the index is out of bounds or the slice operation fails.
+    pub fn fixed_size_list_elements_at(&self, index: usize) -> VortexResult<ArrayRef> {
         debug_assert!(
             index < self.len,
             "index out of bounds: the len is {} but the index is {index}",
             self.len
         );
-        debug_assert!(self.validity.is_valid(index));
+        debug_assert!(self.validity.is_valid(index).unwrap_or(false));
 
         let start = self.list_size as usize * index;
         let end = self.list_size as usize * (index + 1);

--- a/vortex-array/src/arrays/fixed_size_list/array.rs
+++ b/vortex-array/src/arrays/fixed_size_list/array.rs
@@ -34,6 +34,7 @@ use crate::validity::Validity;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> vortex_error::VortexResult<()> {
 /// use vortex_array::arrays::{FixedSizeListArray, PrimitiveArray};
 /// use vortex_array::validity::Validity;
 /// use vortex_array::IntoArray;
@@ -54,8 +55,10 @@ use crate::validity::Validity;
 /// assert_eq!(fixed_list_array.list_size(), 2);
 ///
 /// // Access individual lists
-/// let first_list = fixed_list_array.fixed_size_list_elements_at(0);
+/// let first_list = fixed_list_array.fixed_size_list_elements_at(0)?;
 /// assert_eq!(first_list.len(), 2);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug)]
 pub struct FixedSizeListArray {

--- a/vortex-array/src/arrays/fixed_size_list/tests/basic.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/basic.rs
@@ -35,22 +35,22 @@ fn test_basic_fixed_size_list() {
     ));
 
     // Check the actual values in each list.
-    let first_list = fsl.fixed_size_list_elements_at(0);
+    let first_list = fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(first_list.scalar_at(0).unwrap(), 1i32.into());
     assert_eq!(first_list.scalar_at(1).unwrap(), 2i32.into());
     assert_eq!(first_list.scalar_at(2).unwrap(), 3i32.into());
 
-    let second_list = fsl.fixed_size_list_elements_at(1);
+    let second_list = fsl.fixed_size_list_elements_at(1).unwrap();
     assert_eq!(second_list.scalar_at(0).unwrap(), 4i32.into());
     assert_eq!(second_list.scalar_at(1).unwrap(), 5i32.into());
     assert_eq!(second_list.scalar_at(2).unwrap(), 6i32.into());
 
-    let third_list = fsl.fixed_size_list_elements_at(2);
+    let third_list = fsl.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(third_list.scalar_at(0).unwrap(), 7i32.into());
     assert_eq!(third_list.scalar_at(1).unwrap(), 8i32.into());
     assert_eq!(third_list.scalar_at(2).unwrap(), 9i32.into());
 
-    let fourth_list = fsl.fixed_size_list_elements_at(3);
+    let fourth_list = fsl.fixed_size_list_elements_at(3).unwrap();
     assert_eq!(fourth_list.scalar_at(0).unwrap(), 10i32.into());
     assert_eq!(fourth_list.scalar_at(1).unwrap(), 11i32.into());
     assert_eq!(fourth_list.scalar_at(2).unwrap(), 12i32.into());
@@ -76,7 +76,7 @@ fn test_scalar_at() {
     );
 
     // Additionally check individual elements via fixed_size_list_at.
-    let first_list = fsl.fixed_size_list_elements_at(0);
+    let first_list = fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(first_list.scalar_at(0).unwrap(), 1i32.into());
     assert_eq!(first_list.scalar_at(1).unwrap(), 2i32.into());
     assert_eq!(first_list.scalar_at(2).unwrap(), 3i32.into());
@@ -93,7 +93,7 @@ fn test_scalar_at() {
     );
 
     // Additionally check individual elements via fixed_size_list_at.
-    let second_list = fsl.fixed_size_list_elements_at(1);
+    let second_list = fsl.fixed_size_list_elements_at(1).unwrap();
     assert_eq!(second_list.scalar_at(0).unwrap(), 4i32.into());
     assert_eq!(second_list.scalar_at(1).unwrap(), 5i32.into());
     assert_eq!(second_list.scalar_at(2).unwrap(), 6i32.into());
@@ -108,13 +108,13 @@ fn test_fixed_size_list_at() {
     let fsl = FixedSizeListArray::new(elements, list_size, Validity::AllValid, len);
 
     // Get the first list [1.0, 2.0].
-    let first_list = fsl.fixed_size_list_elements_at(0);
+    let first_list = fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(first_list.len(), list_size as usize);
     assert_eq!(first_list.scalar_at(0).unwrap(), 1.0f64.into());
     assert_eq!(first_list.scalar_at(1).unwrap(), 2.0f64.into());
 
     // Get the third list [5.0, 6.0].
-    let third_list = fsl.fixed_size_list_elements_at(2);
+    let third_list = fsl.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(third_list.len(), list_size as usize);
     assert_eq!(third_list.scalar_at(0).unwrap(), 5.0f64.into());
     assert_eq!(third_list.scalar_at(1).unwrap(), 6.0f64.into());

--- a/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
@@ -110,12 +110,12 @@ fn test_filter_with_nulls() {
     assert_eq!(filtered_fsl.list_size(), 2, "list_size should be preserved");
 
     // First list should be [1, 2] and valid.
-    let first = filtered_fsl.fixed_size_list_elements_at(0);
+    let first = filtered_fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(first.scalar_at(0).unwrap(), 1i32.into());
     assert_eq!(first.scalar_at(1).unwrap(), 2i32.into());
 
     // Second list should be [5, 6] and valid.
-    let second = filtered_fsl.fixed_size_list_elements_at(1);
+    let second = filtered_fsl.fixed_size_list_elements_at(1).unwrap();
     assert_eq!(second.scalar_at(0).unwrap(), 5i32.into());
     assert_eq!(second.scalar_at(1).unwrap(), 6i32.into());
 }
@@ -190,15 +190,15 @@ fn test_filter_nested_fixed_size_lists() {
     assert_eq!(filtered_inner.list_size(), 2);
 
     // Check the actual values.
-    let inner_list_0 = filtered_inner.fixed_size_list_elements_at(0);
+    let inner_list_0 = filtered_inner.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(inner_list_0.scalar_at(0).unwrap(), 7i32.into());
     assert_eq!(inner_list_0.scalar_at(1).unwrap(), 8i32.into());
 
-    let inner_list_1 = filtered_inner.fixed_size_list_elements_at(1);
+    let inner_list_1 = filtered_inner.fixed_size_list_elements_at(1).unwrap();
     assert_eq!(inner_list_1.scalar_at(0).unwrap(), 9i32.into());
     assert_eq!(inner_list_1.scalar_at(1).unwrap(), 10i32.into());
 
-    let inner_list_2 = filtered_inner.fixed_size_list_elements_at(2);
+    let inner_list_2 = filtered_inner.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(inner_list_2.scalar_at(0).unwrap(), 11i32.into());
     assert_eq!(inner_list_2.scalar_at(1).unwrap(), 12i32.into());
 }
@@ -354,19 +354,19 @@ fn test_mask_expansion_threshold_boundary() {
     assert_eq!(filtered_fsl.elements().len(), 3 * list_size as usize);
 
     // Verify correct elements were kept.
-    let first = filtered_fsl.fixed_size_list_elements_at(0);
+    let first = filtered_fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(
         first.scalar_at(0).unwrap(),
         (5i32 * list_size as i32).into()
     );
 
-    let second = filtered_fsl.fixed_size_list_elements_at(1);
+    let second = filtered_fsl.fixed_size_list_elements_at(1).unwrap();
     assert_eq!(
         second.scalar_at(0).unwrap(),
         (25i32 * list_size as i32).into()
     );
 
-    let third = filtered_fsl.fixed_size_list_elements_at(2);
+    let third = filtered_fsl.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(
         third.scalar_at(0).unwrap(),
         (75i32 * list_size as i32).into()
@@ -419,15 +419,15 @@ fn test_filter_large_list_size() {
     assert_eq!(filtered_fsl.elements().len(), 3 * list_size as usize);
 
     // Check that the correct lists were kept (indices 1, 3, 4 from original).
-    let list_0 = filtered_fsl.fixed_size_list_elements_at(0);
+    let list_0 = filtered_fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(list_0.scalar_at(0).unwrap(), 100i64.into()); // Start of original list 1.
     assert_eq!(list_0.scalar_at(99).unwrap(), 199i64.into()); // End of original list 1.
 
-    let list_1 = filtered_fsl.fixed_size_list_elements_at(1);
+    let list_1 = filtered_fsl.fixed_size_list_elements_at(1).unwrap();
     assert_eq!(list_1.scalar_at(0).unwrap(), 300i64.into()); // Start of original list 3.
     assert_eq!(list_1.scalar_at(99).unwrap(), 399i64.into()); // End of original list 3.
 
-    let list_2 = filtered_fsl.fixed_size_list_elements_at(2);
+    let list_2 = filtered_fsl.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(list_2.scalar_at(0).unwrap(), 400i64.into()); // Start of original list 4.
     assert_eq!(list_2.scalar_at(99).unwrap(), 499i64.into()); // End of original list 4.
 
@@ -441,7 +441,7 @@ fn test_filter_large_list_size() {
     assert_eq!(filtered_single_fsl.elements().len(), list_size as usize);
 
     // Verify it's the correct list (original list 2).
-    let single_list = filtered_single_fsl.fixed_size_list_elements_at(0);
+    let single_list = filtered_single_fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(single_list.scalar_at(0).unwrap(), 200i64.into());
     assert_eq!(single_list.scalar_at(50).unwrap(), 250i64.into());
     assert_eq!(single_list.scalar_at(99).unwrap(), 299i64.into());

--- a/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
@@ -67,7 +67,7 @@ fn test_fsl_of_fsl_basic() {
     ));
 
     // Get the first outer list.
-    let first_outer = outer_fsl.fixed_size_list_elements_at(0);
+    let first_outer = outer_fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(first_outer.len(), outer_list_size as usize);
 
     // The first outer list should contain 3 inner lists.
@@ -77,50 +77,56 @@ fn test_fsl_of_fsl_basic() {
 
     // Check the actual values in the nested structure.
     // First outer list contains: [[1,2], [3,4], [5,6]].
-    let first_outer_list = outer_fsl.fixed_size_list_elements_at(0);
+    let first_outer_list = outer_fsl.fixed_size_list_elements_at(0).unwrap();
 
     // Check first inner list [1,2].
     let inner_list_0 = first_outer_list
         .to_fixed_size_list()
-        .fixed_size_list_elements_at(0);
+        .fixed_size_list_elements_at(0)
+        .unwrap();
     assert_eq!(inner_list_0.scalar_at(0).unwrap(), 1i32.into());
     assert_eq!(inner_list_0.scalar_at(1).unwrap(), 2i32.into());
 
     // Check second inner list [3,4].
     let inner_list_1 = first_outer_list
         .to_fixed_size_list()
-        .fixed_size_list_elements_at(1);
+        .fixed_size_list_elements_at(1)
+        .unwrap();
     assert_eq!(inner_list_1.scalar_at(0).unwrap(), 3i32.into());
     assert_eq!(inner_list_1.scalar_at(1).unwrap(), 4i32.into());
 
     // Check third inner list [5,6].
     let inner_list_2 = first_outer_list
         .to_fixed_size_list()
-        .fixed_size_list_elements_at(2);
+        .fixed_size_list_elements_at(2)
+        .unwrap();
     assert_eq!(inner_list_2.scalar_at(0).unwrap(), 5i32.into());
     assert_eq!(inner_list_2.scalar_at(1).unwrap(), 6i32.into());
 
     // Second outer list contains: [[7,8], [9,10], [11,12]].
-    let second_outer_list = outer_fsl.fixed_size_list_elements_at(1);
+    let second_outer_list = outer_fsl.fixed_size_list_elements_at(1).unwrap();
 
     // Check first inner list [7,8].
     let inner_list_0 = second_outer_list
         .to_fixed_size_list()
-        .fixed_size_list_elements_at(0);
+        .fixed_size_list_elements_at(0)
+        .unwrap();
     assert_eq!(inner_list_0.scalar_at(0).unwrap(), 7i32.into());
     assert_eq!(inner_list_0.scalar_at(1).unwrap(), 8i32.into());
 
     // Check second inner list [9,10].
     let inner_list_1 = second_outer_list
         .to_fixed_size_list()
-        .fixed_size_list_elements_at(1);
+        .fixed_size_list_elements_at(1)
+        .unwrap();
     assert_eq!(inner_list_1.scalar_at(0).unwrap(), 9i32.into());
     assert_eq!(inner_list_1.scalar_at(1).unwrap(), 10i32.into());
 
     // Check third inner list [11,12].
     let inner_list_2 = second_outer_list
         .to_fixed_size_list()
-        .fixed_size_list_elements_at(2);
+        .fixed_size_list_elements_at(2)
+        .unwrap();
     assert_eq!(inner_list_2.scalar_at(0).unwrap(), 11i32.into());
     assert_eq!(inner_list_2.scalar_at(1).unwrap(), 12i32.into());
 }
@@ -215,29 +221,43 @@ fn test_deeply_nested_fsl() {
 
     // Check the actual deeply nested values.
     // Structure: [[[1,2],[3,4]],[[5,6],[7,8]]].
-    let top_level = level3.fixed_size_list_elements_at(0);
+    let top_level = level3.fixed_size_list_elements_at(0).unwrap();
     let level2_0 = top_level
         .to_fixed_size_list()
-        .fixed_size_list_elements_at(0);
+        .fixed_size_list_elements_at(0)
+        .unwrap();
     let level2_1 = top_level
         .to_fixed_size_list()
-        .fixed_size_list_elements_at(1);
+        .fixed_size_list_elements_at(1)
+        .unwrap();
 
     // First level-2 list: [[1,2],[3,4]].
-    let level1_0_0 = level2_0.to_fixed_size_list().fixed_size_list_elements_at(0);
+    let level1_0_0 = level2_0
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(0)
+        .unwrap();
     assert_eq!(level1_0_0.scalar_at(0).unwrap(), 1i32.into());
     assert_eq!(level1_0_0.scalar_at(1).unwrap(), 2i32.into());
 
-    let level1_0_1 = level2_0.to_fixed_size_list().fixed_size_list_elements_at(1);
+    let level1_0_1 = level2_0
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(1)
+        .unwrap();
     assert_eq!(level1_0_1.scalar_at(0).unwrap(), 3i32.into());
     assert_eq!(level1_0_1.scalar_at(1).unwrap(), 4i32.into());
 
     // Second level-2 list: [[5,6],[7,8]].
-    let level1_1_0 = level2_1.to_fixed_size_list().fixed_size_list_elements_at(0);
+    let level1_1_0 = level2_1
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(0)
+        .unwrap();
     assert_eq!(level1_1_0.scalar_at(0).unwrap(), 5i32.into());
     assert_eq!(level1_1_0.scalar_at(1).unwrap(), 6i32.into());
 
-    let level1_1_1 = level2_1.to_fixed_size_list().fixed_size_list_elements_at(1);
+    let level1_1_1 = level2_1
+        .to_fixed_size_list()
+        .fixed_size_list_elements_at(1)
+        .unwrap();
     assert_eq!(level1_1_1.scalar_at(0).unwrap(), 7i32.into());
     assert_eq!(level1_1_1.scalar_at(1).unwrap(), 8i32.into());
 }

--- a/vortex-array/src/arrays/fixed_size_list/tests/nullability.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/nullability.rs
@@ -41,7 +41,7 @@ fn test_nullable_fsl_with_nulls() {
     );
 
     // Check individual elements of the first list.
-    let first_list = fsl.fixed_size_list_elements_at(0);
+    let first_list = fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(first_list.scalar_at(0).unwrap(), 1i32.into());
     assert_eq!(first_list.scalar_at(1).unwrap(), 2i32.into());
 
@@ -62,7 +62,7 @@ fn test_nullable_fsl_with_nulls() {
     );
 
     // Check individual elements of the third list.
-    let third_list = fsl.fixed_size_list_elements_at(2);
+    let third_list = fsl.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(third_list.scalar_at(0).unwrap(), 5i32.into());
     assert_eq!(third_list.scalar_at(1).unwrap(), 6i32.into());
 
@@ -141,7 +141,7 @@ fn test_nullable_elements_and_nullable_lists() {
     );
 
     // Check individual elements of the first list.
-    let first_list = fsl.fixed_size_list_elements_at(0);
+    let first_list = fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(first_list.scalar_at(0).unwrap(), Some(10u16).into());
     assert_eq!(first_list.scalar_at(1).unwrap(), None::<u16>.into());
 
@@ -162,7 +162,7 @@ fn test_nullable_elements_and_nullable_lists() {
     );
 
     // Check individual elements of the third list.
-    let third_list = fsl.fixed_size_list_elements_at(2);
+    let third_list = fsl.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(third_list.scalar_at(0).unwrap(), None::<u16>.into());
     assert_eq!(third_list.scalar_at(1).unwrap(), None::<u16>.into());
 }

--- a/vortex-array/src/arrays/fixed_size_list/tests/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/take.rs
@@ -51,7 +51,7 @@ fn test_take_basic_smoke_test() {
     assert_eq!(result_fsl.list_size(), 2, "list_size should be preserved");
 
     // First list should be the original third list [5, 6].
-    let first = result_fsl.fixed_size_list_elements_at(0);
+    let first = result_fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(
         first.scalar_at(0).unwrap(),
         5i32.into(),
@@ -64,12 +64,12 @@ fn test_take_basic_smoke_test() {
     );
 
     // Second list should be the original first list [1, 2].
-    let second = result_fsl.fixed_size_list_elements_at(1);
+    let second = result_fsl.fixed_size_list_elements_at(1).unwrap();
     assert_eq!(second.scalar_at(0).unwrap(), 1i32.into());
     assert_eq!(second.scalar_at(1).unwrap(), 2i32.into());
 
     // Third list should be the original second list [3, 4].
-    let third = result_fsl.fixed_size_list_elements_at(2);
+    let third = result_fsl.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(third.scalar_at(0).unwrap(), 3i32.into());
     assert_eq!(third.scalar_at(1).unwrap(), 4i32.into());
 }
@@ -137,13 +137,13 @@ fn test_take_large_list_size() {
     assert_eq!(result_fsl.list_size(), 100);
 
     // First list should be [200..300].
-    let first = result_fsl.fixed_size_list_elements_at(0);
+    let first = result_fsl.fixed_size_list_elements_at(0).unwrap();
     for i in 0..100i32 {
         assert_eq!(first.scalar_at(i as usize).unwrap(), (200 + i).into());
     }
 
     // Second list should be [0..100].
-    let second = result_fsl.fixed_size_list_elements_at(1);
+    let second = result_fsl.fixed_size_list_elements_at(1).unwrap();
     for i in 0..100i32 {
         assert_eq!(second.scalar_at(i as usize).unwrap(), i.into());
     }
@@ -165,7 +165,7 @@ fn test_take_fsl_with_null_indices_preserves_elements() {
 
     // First list should be [3, 4].
     assert!(!result_fsl.scalar_at(0).unwrap().is_null());
-    let first = result_fsl.fixed_size_list_elements_at(0);
+    let first = result_fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(first.scalar_at(0).unwrap(), 3i32.into());
     assert_eq!(first.scalar_at(1).unwrap(), 4i32.into());
 
@@ -174,7 +174,7 @@ fn test_take_fsl_with_null_indices_preserves_elements() {
 
     // Third list should be [1, 2].
     assert!(!result_fsl.scalar_at(2).unwrap().is_null());
-    let third = result_fsl.fixed_size_list_elements_at(2);
+    let third = result_fsl.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(third.scalar_at(0).unwrap(), 1i32.into());
     assert_eq!(third.scalar_at(1).unwrap(), 2i32.into());
 }

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -64,9 +64,9 @@ impl VTable for FixedSizeListVTable {
                 FixedSizeListArray::new_unchecked(
                     array
                         .elements()
-                        .slice(range.start * list_size..range.end * list_size),
+                        .slice(range.start * list_size..range.end * list_size)?,
                     array.list_size(),
-                    array.validity().slice(range),
+                    array.validity().slice(range)?,
                     new_len,
                 )
             }

--- a/vortex-array/src/arrays/fixed_size_list/vtable/operations.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/operations.rs
@@ -11,7 +11,7 @@ use crate::vtable::OperationsVTable;
 impl OperationsVTable<FixedSizeListVTable> for FixedSizeListVTable {
     fn scalar_at(array: &FixedSizeListArray, index: usize) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
-        let list = array.fixed_size_list_elements_at(index);
+        let list = array.fixed_size_list_elements_at(index)?;
         let children_elements: Vec<Scalar> = (0..list.len())
             .map(|i| list.scalar_at(i))
             .collect::<VortexResult<_>>()?;

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -273,7 +273,7 @@ impl ListArray {
     pub fn list_elements_at(&self, index: usize) -> VortexResult<ArrayRef> {
         let start = self.offset_at(index)?;
         let end = self.offset_at(index + 1)?;
-        Ok(self.elements().slice(start..end))
+        self.elements().slice(start..end)
     }
 
     /// Returns elements of the list array referenced by the offsets array.
@@ -283,7 +283,7 @@ impl ListArray {
     pub fn sliced_elements(&self) -> VortexResult<ArrayRef> {
         let start = self.offset_at(0)?;
         let end = self.offset_at(self.len())?;
-        Ok(self.elements().slice(start..end))
+        self.elements().slice(start..end)
     }
 
     /// Returns the offsets array.

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -70,10 +70,10 @@ use crate::validity::Validity;
 /// assert_eq!(list_array.len(), 3);
 ///
 /// // Access individual lists
-/// let first_list = list_array.list_elements_at(0);
+/// let first_list = list_array.list_elements_at(0).unwrap();
 /// assert_eq!(first_list.len(), 2); // [1, 2]
 ///
-/// let third_list = list_array.list_elements_at(2);
+/// let third_list = list_array.list_elements_at(2).unwrap();
 /// assert!(third_list.is_empty()); // []
 /// ```
 #[derive(Clone, Debug)]
@@ -248,42 +248,42 @@ impl ListArray {
 
     /// Returns the offset at the given index from the list array.
     ///
-    /// Panics if the index is out of bounds.
-    pub fn offset_at(&self, index: usize) -> usize {
-        assert!(
+    /// Returns an error if the index is out of bounds or scalar_at fails.
+    pub fn offset_at(&self, index: usize) -> VortexResult<usize> {
+        vortex_ensure!(
             index <= self.len(),
             "Index {index} out of bounds 0..={}",
             self.len()
         );
 
-        self.offsets()
-            .as_opt::<PrimitiveVTable>()
-            .map(|p| match_each_native_ptype!(p.ptype(), |P| { p.as_slice::<P>()[index].as_() }))
-            .unwrap_or_else(|| {
-                self.offsets()
-                    .scalar_at(index)
-                    .vortex_expect("offsets must support scalar_at")
-                    .as_primitive()
-                    .as_::<usize>()
-                    .vortex_expect("index must fit in usize")
-            })
+        if let Some(p) = self.offsets().as_opt::<PrimitiveVTable>() {
+            Ok(match_each_native_ptype!(p.ptype(), |P| {
+                p.as_slice::<P>()[index].as_()
+            }))
+        } else {
+            self.offsets()
+                .scalar_at(index)?
+                .as_primitive()
+                .as_::<usize>()
+                .ok_or_else(|| vortex_error::vortex_err!("offset value does not fit in usize"))
+        }
     }
 
     /// Returns the elements of the list scalar at the given index of the list array.
-    pub fn list_elements_at(&self, index: usize) -> ArrayRef {
-        let start = self.offset_at(index);
-        let end = self.offset_at(index + 1);
-        self.elements().slice(start..end)
+    pub fn list_elements_at(&self, index: usize) -> VortexResult<ArrayRef> {
+        let start = self.offset_at(index)?;
+        let end = self.offset_at(index + 1)?;
+        Ok(self.elements().slice(start..end))
     }
 
     /// Returns elements of the list array referenced by the offsets array.
     ///
     /// This is useful for discarding any potentially unused parts of the underlying `elements`
     /// child array.
-    pub fn sliced_elements(&self) -> ArrayRef {
-        let start = self.offset_at(0);
-        let end = self.offset_at(self.len());
-        self.elements().slice(start..end)
+    pub fn sliced_elements(&self) -> VortexResult<ArrayRef> {
+        let start = self.offset_at(0)?;
+        let end = self.offset_at(self.len())?;
+        Ok(self.elements().slice(start..end))
     }
 
     /// Returns the offsets array.
@@ -304,7 +304,7 @@ impl ListArray {
     /// Create a copy of this array by adjusting `offsets` to start at `0` and removing elements not
     /// referenced by the `offsets`.
     pub fn reset_offsets(&self, recurse: bool) -> VortexResult<Self> {
-        let mut elements = self.sliced_elements();
+        let mut elements = self.sliced_elements()?;
         if recurse && elements.is_canonical() {
             elements = elements.to_canonical()?.compact()?.into_array();
         } else if recurse && let Some(child_list_array) = elements.as_opt::<ListVTable>() {

--- a/vortex-array/src/arrays/list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/list/compute/is_constant.rs
@@ -25,9 +25,9 @@ impl IsConstantKernel for ListVTable {
 
         // We can first quickly check if all of the list lengths are equal. If not, then we know the
         // array cannot be constant.
-        let first_list_len = array.offset_at(1) - array.offset_at(0);
+        let first_list_len = array.offset_at(1)? - array.offset_at(0)?;
         for i in 1..manual_check_until {
-            let current_list_len = array.offset_at(i + 1) - array.offset_at(i);
+            let current_list_len = array.offset_at(i + 1)? - array.offset_at(i)?;
             if current_list_len != first_list_len {
                 return Ok(Some(false));
             }

--- a/vortex-array/src/arrays/list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/list/compute/is_constant.rs
@@ -42,10 +42,10 @@ impl IsConstantKernel for ListVTable {
         // If the array is long, do an optimistic check on the remainder of the list lengths.
         if array.len() > SMALL_ARRAY_THRESHOLD {
             // check the rest of the element lengths
-            let start_offsets = array.offsets().slice(SMALL_ARRAY_THRESHOLD..array.len());
+            let start_offsets = array.offsets().slice(SMALL_ARRAY_THRESHOLD..array.len())?;
             let end_offsets = array
                 .offsets()
-                .slice(SMALL_ARRAY_THRESHOLD + 1..array.len() + 1);
+                .slice(SMALL_ARRAY_THRESHOLD + 1..array.len() + 1)?;
             let list_lengths = numeric(&end_offsets, &start_offsets, NumericOperator::Sub)?;
 
             if !is_constant(&list_lengths)?.unwrap_or_default() {

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -123,7 +123,7 @@ fn test_list_filter_dense_mask() {
 
     // Verify first remaining list (originally index 1) has correct elements [10..25].
     assert_arrays_eq!(
-        filtered_list.list_elements_at(0),
+        filtered_list.list_elements_at(0).unwrap(),
         PrimitiveArray::from_iter(10..25)
     );
 }
@@ -152,13 +152,13 @@ fn test_list_filter_sparse_mask() {
 
     // Verify first list (originally index 0) has elements [0..10].
     assert_arrays_eq!(
-        filtered_list.list_elements_at(0),
+        filtered_list.list_elements_at(0).unwrap(),
         PrimitiveArray::from_iter(0..10)
     );
 
     // Verify second list (originally index 5) has elements [85..100].
     assert_arrays_eq!(
-        filtered_list.list_elements_at(1),
+        filtered_list.list_elements_at(1).unwrap(),
         PrimitiveArray::from_iter(85..100)
     );
 }
@@ -182,19 +182,19 @@ fn test_list_filter_empty_lists() {
     assert_eq!(filtered_list.len(), 4);
 
     // First list is empty.
-    assert_eq!(filtered_list.list_elements_at(0).len(), 0);
+    assert_eq!(filtered_list.list_elements_at(0).unwrap().len(), 0);
 
     // Second list has elements [0..3].
     assert_arrays_eq!(
-        filtered_list.list_elements_at(1),
+        filtered_list.list_elements_at(1).unwrap(),
         PrimitiveArray::from_iter(0..3)
     );
 
     // Third list is empty.
-    assert_eq!(filtered_list.list_elements_at(2).len(), 0);
+    assert_eq!(filtered_list.list_elements_at(2).unwrap().len(), 0);
 
     // Fourth list is empty.
-    assert_eq!(filtered_list.list_elements_at(3).len(), 0);
+    assert_eq!(filtered_list.list_elements_at(3).unwrap().len(), 0);
 }
 
 #[test]
@@ -248,7 +248,7 @@ fn test_list_filter_all_true() {
     for i in 0..4 {
         let ii32 = i32::try_from(i).vortex_expect("must fit");
         assert_arrays_eq!(
-            filtered_list.list_elements_at(i),
+            filtered_list.list_elements_at(i).unwrap(),
             PrimitiveArray::from_iter((ii32 * 5)..(ii32 + 1) * 5)
         );
     }
@@ -294,7 +294,7 @@ fn test_list_filter_single_element() {
 
     // The single remaining list has elements [20..30].
     assert_arrays_eq!(
-        filtered_list.list_elements_at(0),
+        filtered_list.list_elements_at(0).unwrap(),
         PrimitiveArray::from_iter(20..30)
     );
 }
@@ -323,7 +323,7 @@ fn test_list_filter_alternating_pattern() {
     // Verify we have the correct lists: [0..5], [10..15], [20..25], [30..35], [40..45], [50..55].
     for (i, expected_start) in [0, 10, 20, 30, 40, 50].iter().enumerate() {
         assert_arrays_eq!(
-            filtered_list.list_elements_at(i),
+            filtered_list.list_elements_at(i).unwrap(),
             PrimitiveArray::from_iter(*expected_start..*expected_start + 5)
         );
     }
@@ -350,12 +350,12 @@ fn test_list_filter_variable_sizes() {
     assert_eq!(filtered_list.len(), 6);
 
     // Verify sizes of filtered lists.
-    assert_eq!(filtered_list.list_elements_at(0).len(), 1); // Size 1
-    assert_eq!(filtered_list.list_elements_at(1).len(), 3); // Size 3
-    assert_eq!(filtered_list.list_elements_at(2).len(), 5); // Size 5
-    assert_eq!(filtered_list.list_elements_at(3).len(), 15); // Size 15
-    assert_eq!(filtered_list.list_elements_at(4).len(), 25); // Size 25
-    assert_eq!(filtered_list.list_elements_at(5).len(), 40); // Size 40
+    assert_eq!(filtered_list.list_elements_at(0).unwrap().len(), 1); // Size 1
+    assert_eq!(filtered_list.list_elements_at(1).unwrap().len(), 3); // Size 3
+    assert_eq!(filtered_list.list_elements_at(2).unwrap().len(), 5); // Size 5
+    assert_eq!(filtered_list.list_elements_at(3).unwrap().len(), 15); // Size 15
+    assert_eq!(filtered_list.list_elements_at(4).unwrap().len(), 25); // Size 25
+    assert_eq!(filtered_list.list_elements_at(5).unwrap().len(), 40); // Size 40
 }
 
 #[test]
@@ -425,8 +425,8 @@ fn test_offset_to_0() {
     assert_eq!(list_array.offsets().len(), 3);
 
     // Each list has 3 elements
-    assert_eq!(list_array.list_elements_at(0).len(), 3);
-    assert_eq!(list_array.list_elements_at(1).len(), 3);
+    assert_eq!(list_array.list_elements_at(0).unwrap().len(), 3);
+    assert_eq!(list_array.list_elements_at(1).unwrap().len(), 3);
 }
 
 type OptVec<T> = Vec<Option<T>>;
@@ -580,37 +580,37 @@ fn test_list_of_lists() {
     ));
 
     // Access the first list of lists and verify its contents.
-    let first_outer = list_of_lists.list_elements_at(0);
+    let first_outer = list_of_lists.list_elements_at(0).unwrap();
     let first_outer_list = first_outer.as_::<ListVTable>();
     assert_eq!(first_outer_list.len(), 2);
 
     // Check first inner list [1, 2].
-    let first_inner = first_outer_list.list_elements_at(0);
+    let first_inner = first_outer_list.list_elements_at(0).unwrap();
     assert_arrays_eq!(first_inner, PrimitiveArray::from_iter([1, 2]));
 
     // Check second inner list [3].
-    let second_inner = first_outer_list.list_elements_at(1);
+    let second_inner = first_outer_list.list_elements_at(1).unwrap();
     assert_arrays_eq!(second_inner, PrimitiveArray::from_iter([3]));
 
     // Check the second list of lists [[4, 5, 6]].
-    let second_outer = list_of_lists.list_elements_at(1);
+    let second_outer = list_of_lists.list_elements_at(1).unwrap();
     let second_outer_list = second_outer.as_::<ListVTable>();
     assert_eq!(second_outer_list.len(), 1);
 
-    let inner = second_outer_list.list_elements_at(0);
+    let inner = second_outer_list.list_elements_at(0).unwrap();
     assert_arrays_eq!(inner, PrimitiveArray::from_iter([4, 5, 6]));
 
     // Check the third list of lists (empty).
-    let third_outer = list_of_lists.list_elements_at(2);
+    let third_outer = list_of_lists.list_elements_at(2).unwrap();
     // Empty slices return canonical form (`ListViewArray`), so we check length directly.
     assert_eq!(third_outer.len(), 0);
 
     // Check the fourth list of lists [[7]].
-    let fourth_outer = list_of_lists.list_elements_at(3);
+    let fourth_outer = list_of_lists.list_elements_at(3).unwrap();
     let fourth_outer_list = fourth_outer.as_::<ListVTable>();
     assert_eq!(fourth_outer_list.len(), 1);
 
-    let inner = fourth_outer_list.list_elements_at(0);
+    let inner = fourth_outer_list.list_elements_at(0).unwrap();
     assert_arrays_eq!(inner, PrimitiveArray::from_iter([7]));
 
     // Test scalar conversion.
@@ -625,12 +625,12 @@ fn test_list_of_lists() {
     assert_eq!(sliced_list.len(), 2);
 
     // First element of slice should be [[4, 5, 6]].
-    let first_sliced = sliced_list.list_elements_at(0);
+    let first_sliced = sliced_list.list_elements_at(0).unwrap();
     let first_sliced_list = first_sliced.as_::<ListVTable>();
     assert_eq!(first_sliced_list.len(), 1);
 
     // Second element of slice should be empty [].
-    let second_sliced = sliced_list.list_elements_at(1);
+    let second_sliced = sliced_list.list_elements_at(1).unwrap();
     // Empty slices return canonical form (`ListViewArray`), so we check length directly
     assert_eq!(second_sliced.len(), 0);
 }
@@ -667,14 +667,14 @@ fn test_list_of_lists_nullable_outer() {
     assert!(second.is_null());
 
     // Third element should be [[4, 5, 6]].
-    let third = list_of_lists.list_elements_at(2);
+    let third = list_of_lists.list_elements_at(2).unwrap();
     let third_list = third.as_::<ListVTable>();
     assert_eq!(third_list.len(), 1);
-    let inner = third_list.list_elements_at(0);
+    let inner = third_list.list_elements_at(0).unwrap();
     assert_eq!(inner.len(), 3);
 
     // Fourth element should be [[7]].
-    let fourth = list_of_lists.list_elements_at(3);
+    let fourth = list_of_lists.list_elements_at(3).unwrap();
     let fourth_list = fourth.as_::<ListVTable>();
     assert_eq!(fourth_list.len(), 1);
 }
@@ -711,7 +711,7 @@ fn test_list_of_lists_nullable_inner() {
     ));
 
     // First outer list should have 3 inner lists with the second being null.
-    let first_outer = list_of_lists.list_elements_at(0);
+    let first_outer = list_of_lists.list_elements_at(0).unwrap();
     let first_list = first_outer.as_::<ListVTable>();
     assert_eq!(first_list.len(), 3);
 
@@ -746,12 +746,12 @@ fn test_list_of_lists_both_nullable() {
     // First outer list should have 2 elements, second is null inner list.
     let first_outer = list_of_lists.scalar_at(0).unwrap();
     assert!(!first_outer.is_null());
-    let first_outer_array = list_of_lists.list_elements_at(0);
+    let first_outer_array = list_of_lists.list_elements_at(0).unwrap();
     let first_list = first_outer_array.as_::<ListVTable>();
     assert_eq!(first_list.len(), 2);
 
     // First inner list should be [1, 2].
-    let first_inner = first_list.list_elements_at(0);
+    let first_inner = first_list.list_elements_at(0).unwrap();
     assert_eq!(first_inner.len(), 2);
 
     // Second inner list should be null.
@@ -763,14 +763,14 @@ fn test_list_of_lists_both_nullable() {
     assert!(second_outer.is_null());
 
     // Third outer list should have [3].
-    let third_outer = list_of_lists.list_elements_at(2);
+    let third_outer = list_of_lists.list_elements_at(2).unwrap();
     let third_list = third_outer.as_::<ListVTable>();
     assert_eq!(third_list.len(), 1);
-    let inner = third_list.list_elements_at(0);
+    let inner = third_list.list_elements_at(0).unwrap();
     assert_arrays_eq!(inner, PrimitiveArray::from_iter([3]));
 
     // Fourth outer list should have a null inner list.
-    let fourth_outer = list_of_lists.list_elements_at(3);
+    let fourth_outer = list_of_lists.list_elements_at(3).unwrap();
     let fourth_list = fourth_outer.as_::<ListVTable>();
     assert_eq!(fourth_list.len(), 1);
     let inner = fourth_list.scalar_at(0).unwrap();
@@ -859,9 +859,9 @@ fn test_offsets_constant() {
     // This should succeed as it represents empty lists
     let list = ListArray::try_new(elements, offsets, validity).unwrap();
     assert_eq!(list.len(), 3);
-    assert_eq!(list.list_elements_at(0).len(), 0);
-    assert_eq!(list.list_elements_at(1).len(), 0);
-    assert_eq!(list.list_elements_at(2).len(), 0);
+    assert_eq!(list.list_elements_at(0).unwrap().len(), 0);
+    assert_eq!(list.list_elements_at(1).unwrap().len(), 0);
+    assert_eq!(list.list_elements_at(2).unwrap().len(), 0);
 }
 
 #[test]

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -412,7 +412,7 @@ fn test_offset_to_0() {
             .as_list(),
         )
         .vortex_expect("operation should succeed in test");
-    let list = builder.finish().slice(2..4);
+    let list = builder.finish().slice(2..4).unwrap();
 
     // The sliced list should be a ListArray since we built it with ListBuilder
     // and slice doesn't change the encoding
@@ -620,7 +620,7 @@ fn test_list_of_lists() {
     assert_eq!(list_scalar.len(), 2);
 
     // Test slicing.
-    let sliced = list_of_lists.slice(1..3);
+    let sliced = list_of_lists.slice(1..3).unwrap();
     let sliced_list = sliced.as_::<ListVTable>();
     assert_eq!(sliced_list.len(), 2);
 
@@ -878,7 +878,7 @@ fn test_recursive_compact_list_of_lists() {
 
     let original = create_list_of_lists_nullable(nested_data);
     // Slice to remove prefix - creates wasted space since offsets no longer reference early elements
-    let sliced = original.slice(1..3);
+    let sliced = original.slice(1..3).unwrap();
     let sliced_list = sliced.as_::<ListVTable>();
 
     // Test non-recursive compaction: only resets outer list offsets

--- a/vortex-array/src/arrays/list/vtable/kernel/filter.rs
+++ b/vortex-array/src/arrays/list/vtable/kernel/filter.rs
@@ -115,7 +115,7 @@ impl ExecuteParentKernel<ListVTable> for ListFilterKernel {
         });
 
         let new_elements = array
-            .sliced_elements()
+            .sliced_elements()?
             .filter(element_mask)?
             .execute::<Vector>(ctx)?;
 

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -67,8 +67,8 @@ impl VTable for ListVTable {
         Ok(Some(
             ListArray::new(
                 array.elements().clone(),
-                array.offsets().slice(range.start..range.end + 1),
-                array.validity().slice(range),
+                array.offsets().slice(range.start..range.end + 1)?,
+                array.validity().slice(range)?,
             )
             .into_array(),
         ))

--- a/vortex-array/src/arrays/list/vtable/operations.rs
+++ b/vortex-array/src/arrays/list/vtable/operations.rs
@@ -13,7 +13,7 @@ use crate::vtable::OperationsVTable;
 impl OperationsVTable<ListVTable> for ListVTable {
     fn scalar_at(array: &ListArray, index: usize) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
-        let elems = array.list_elements_at(index);
+        let elems = array.list_elements_at(index)?;
         let scalars: Vec<Scalar> = (0..elems.len())
             .map(|i| elems.scalar_at(i))
             .collect::<VortexResult<_>>()?;

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -407,7 +407,11 @@ impl ListViewArray {
     }
 
     /// Returns the elements at the given index from the list array.
-    pub fn list_elements_at(&self, index: usize) -> ArrayRef {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the slice operation fails.
+    pub fn list_elements_at(&self, index: usize) -> VortexResult<ArrayRef> {
         let offset = self.offset_at(index);
         let size = self.size_at(index);
         self.elements().slice(offset..offset + size)

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -48,6 +48,7 @@ use crate::validity::Validity;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> vortex_error::VortexResult<()> {
 /// # use vortex_array::arrays::{ListViewArray, PrimitiveArray};
 /// # use vortex_array::validity::Validity;
 /// # use vortex_array::IntoArray;
@@ -71,7 +72,7 @@ use crate::validity::Validity;
 /// assert_eq!(list_view.len(), 3);
 ///
 /// // Access individual lists
-/// let first_list = list_view.list_elements_at(0);
+/// let first_list = list_view.list_elements_at(0)?;
 /// assert_eq!(first_list.len(), 2);
 /// // First list contains elements[2..4] = [3, 4]
 ///
@@ -79,6 +80,8 @@ use crate::validity::Validity;
 /// let first_size = list_view.size_at(0);
 /// assert_eq!(first_offset, 2);
 /// assert_eq!(first_size, 2);
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// [`ListArray`]: crate::arrays::ListArray

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -53,7 +53,7 @@ pub fn list_view_from_list(list: ListArray, ctx: &mut ExecutionCtx) -> VortexRes
 
     // We need to slice the `offsets` to remove the last element (`ListArray` has `n + 1` offsets).
     debug_assert_eq!(list_offsets.len(), list.len() + 1);
-    let adjusted_offsets = list_offsets.slice(0..list.len());
+    let adjusted_offsets = list_offsets.slice(0..list.len())?;
 
     // SAFETY: Since everything came from an existing valid `ListArray`, and the `sizes` were
     // derived from valid and in-order `offsets`, we know these fields are valid.
@@ -342,7 +342,7 @@ mod tests {
 
         // ListArray offsets should have n+1 elements for n lists (add the final offset).
         // Check that the first n offsets match.
-        let list_array_offsets_without_last = list_array.offsets().slice(0..list_view.len());
+        let list_array_offsets_without_last = list_array.offsets().slice(0..list_view.len())?;
         assert_arrays_eq!(list_view.offsets().clone(), list_array_offsets_without_last);
 
         // Verify data integrity.

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -404,8 +404,8 @@ mod tests {
 
         // The resulting ListArray should have monotonic offsets.
         for i in 0..list_array.len() {
-            let start = list_array.offset_at(i);
-            let end = list_array.offset_at(i + 1);
+            let start = list_array.offset_at(i)?;
+            let end = list_array.offset_at(i + 1)?;
             assert!(end >= start, "Offsets should be monotonic after conversion");
         }
 
@@ -424,7 +424,7 @@ mod tests {
 
         // All sublists should be empty.
         for i in 0..list_array.len() {
-            assert_eq!(list_array.list_elements_at(i).len(), 0);
+            assert_eq!(list_array.list_elements_at(i)?.len(), 0);
         }
 
         // Round-trip.

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -59,7 +59,7 @@ impl ListViewArray {
 
         match mode {
             ListViewRebuildMode::MakeZeroCopyToList => self.rebuild_zero_copy_to_list(),
-            ListViewRebuildMode::TrimElements => Ok(self.rebuild_trim_elements()),
+            ListViewRebuildMode::TrimElements => self.rebuild_trim_elements(),
             ListViewRebuildMode::MakeExact => self.rebuild_make_exact(),
             ListViewRebuildMode::OverlapCompression => unimplemented!("Does P=NP?"),
         }
@@ -159,7 +159,7 @@ impl ListViewArray {
 
             new_offsets.push(n_elements);
             new_sizes.push(size);
-            new_elements_builder.extend_from_array(&elements_canonical.slice(start..stop));
+            new_elements_builder.extend_from_array(&elements_canonical.slice(start..stop)?);
 
             n_elements += num_traits::cast(size).vortex_expect("Cast failed");
         }
@@ -191,7 +191,7 @@ impl ListViewArray {
     /// Rebuilds a [`ListViewArray`] by trimming any unused / unreferenced leading and trailing
     /// elements, which is defined as a contiguous run of values in the `elements` array that are
     /// not referecened by any views in the corresponding [`ListViewArray`].
-    fn rebuild_trim_elements(&self) -> ListViewArray {
+    fn rebuild_trim_elements(&self) -> VortexResult<ListViewArray> {
         let start = if self.is_zero_copy_to_list() {
             // If offsets are sorted, then the minimum offset is the first offset.
             // Note that even if the first view is null, offsets must always be valid, so it is
@@ -233,13 +233,13 @@ impl ListViewArray {
                 .vortex_expect("was somehow unable to adjust offsets down by their minimum")
         });
 
-        let sliced_elements = self.elements().slice(start..end);
+        let sliced_elements = self.elements().slice(start..end)?;
 
         // SAFETY: The only thing we changed was the elements (which we verify through mins and
         // maxes that all adjusted offsets + sizes are within the correct bounds), so the parameters
         // are valid. And if the original array was zero-copyable to list, trimming elements doesn't
         // change that property.
-        unsafe {
+        Ok(unsafe {
             ListViewArray::new_unchecked(
                 sliced_elements,
                 adjusted_offsets,
@@ -247,12 +247,12 @@ impl ListViewArray {
                 self.validity().clone(),
             )
             .with_zero_copy_to_list(self.is_zero_copy_to_list())
-        }
+        })
     }
 
     fn rebuild_make_exact(&self) -> VortexResult<ListViewArray> {
         if self.is_zero_copy_to_list() {
-            Ok(self.rebuild_trim_elements())
+            self.rebuild_trim_elements()
         } else {
             // When we completely rebuild the `ListViewArray`, we get the benefit that we also trim
             // any leading and trailing garbage data.
@@ -301,12 +301,12 @@ mod tests {
 
         // Verify the data is correct
         assert_arrays_eq!(
-            flattened.list_elements_at(0),
+            flattened.list_elements_at(0).unwrap(),
             PrimitiveArray::from_iter([1i32, 2, 3])
         );
 
         assert_arrays_eq!(
-            flattened.list_elements_at(1),
+            flattened.list_elements_at(1).unwrap(),
             PrimitiveArray::from_iter([2i32, 3])
         );
         Ok(())
@@ -334,18 +334,18 @@ mod tests {
 
         // Verify nullability is preserved
         assert_eq!(flattened.dtype().nullability(), Nullability::Nullable);
-        assert!(flattened.validity().is_valid(0)?);
-        assert!(!flattened.validity().is_valid(1)?);
-        assert!(flattened.validity().is_valid(2)?);
+        assert!(flattened.validity().is_valid(0).unwrap());
+        assert!(!flattened.validity().is_valid(1).unwrap());
+        assert!(flattened.validity().is_valid(2).unwrap());
 
         // Verify valid lists contain correct data
         assert_arrays_eq!(
-            flattened.list_elements_at(0),
+            flattened.list_elements_at(0).unwrap(),
             PrimitiveArray::from_iter([1i32, 2])
         );
 
         assert_arrays_eq!(
-            flattened.list_elements_at(2),
+            flattened.list_elements_at(2).unwrap(),
             PrimitiveArray::from_iter([3i32])
         );
         Ok(())
@@ -380,12 +380,12 @@ mod tests {
 
         // Verify the data is correct.
         assert_arrays_eq!(
-            trimmed.list_elements_at(0),
+            trimmed.list_elements_at(0).unwrap(),
             PrimitiveArray::from_iter([1i32, 2])
         );
 
         assert_arrays_eq!(
-            trimmed.list_elements_at(1),
+            trimmed.list_elements_at(1).unwrap(),
             PrimitiveArray::from_iter([3i32, 4])
         );
 
@@ -438,12 +438,12 @@ mod tests {
 
         // Verify data is preserved
         assert_arrays_eq!(
-            exact.list_elements_at(0),
+            exact.list_elements_at(0).unwrap(),
             PrimitiveArray::from_iter([1i32, 2])
         );
 
         assert_arrays_eq!(
-            exact.list_elements_at(1),
+            exact.list_elements_at(1).unwrap(),
             PrimitiveArray::from_iter([3i32, 4])
         );
         Ok(())

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -334,9 +334,9 @@ mod tests {
 
         // Verify nullability is preserved
         assert_eq!(flattened.dtype().nullability(), Nullability::Nullable);
-        assert!(flattened.validity().is_valid(0));
-        assert!(!flattened.validity().is_valid(1));
-        assert!(flattened.validity().is_valid(2));
+        assert!(flattened.validity().is_valid(0)?);
+        assert!(!flattened.validity().is_valid(1)?);
+        assert!(flattened.validity().is_valid(2)?);
 
         // Verify valid lists contain correct data
         assert_arrays_eq!(

--- a/vortex-array/src/arrays/listview/tests/basic.rs
+++ b/vortex-array/src/arrays/listview/tests/basic.rs
@@ -49,7 +49,7 @@ fn test_basic_listview_comprehensive() {
 
     // Check individual list elements.
     assert_arrays_eq!(
-        listview.list_elements_at(0),
+        listview.list_elements_at(0).unwrap(),
         PrimitiveArray::from_iter([1i32, 2, 3])
     );
 
@@ -65,12 +65,12 @@ fn test_basic_listview_comprehensive() {
     );
 
     assert_arrays_eq!(
-        listview.list_elements_at(1),
+        listview.list_elements_at(1).unwrap(),
         PrimitiveArray::from_iter([4i32, 5])
     );
 
     assert_arrays_eq!(
-        listview.list_elements_at(2),
+        listview.list_elements_at(2).unwrap(),
         PrimitiveArray::from_iter([6i32, 7, 8, 9])
     );
 }
@@ -89,13 +89,13 @@ fn test_out_of_order_offsets() {
 
     // First list starts at offset 6: [7, 8, 9].
     assert_arrays_eq!(
-        listview.list_elements_at(0),
+        listview.list_elements_at(0).unwrap(),
         PrimitiveArray::from_iter([7i32, 8, 9])
     );
 
     // Second list starts at offset 0: [1, 2, 3].
     assert_arrays_eq!(
-        listview.list_elements_at(1),
+        listview.list_elements_at(1).unwrap(),
         PrimitiveArray::from_iter([1i32, 2, 3])
     );
 }
@@ -133,7 +133,7 @@ fn test_from_list_array() -> VortexResult<()> {
 
     // Check first list.
     assert_arrays_eq!(
-        list_view.list_elements_at(0),
+        list_view.list_elements_at(0).unwrap(),
         PrimitiveArray::from_iter([1i32, 2])
     );
 
@@ -144,7 +144,7 @@ fn test_from_list_array() -> VortexResult<()> {
 
     // Check third list.
     assert_arrays_eq!(
-        list_view.list_elements_at(2),
+        list_view.list_elements_at(2)?,
         PrimitiveArray::from_iter([5i32, 6, 7])
     );
     Ok(())
@@ -188,25 +188,25 @@ fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_o
         // All lists are identical [1, 2, 3] (overlapping).
         let expected = PrimitiveArray::from_iter([1i32, 2, 3]);
         for i in 0..3 {
-            assert_arrays_eq!(listview.list_elements_at(i), expected);
+            assert_arrays_eq!(listview.list_elements_at(i).unwrap(), expected);
         }
     } else if const_sizes {
         // All lists have size 3, different offsets (no overlap).
-        assert_eq!(listview.list_elements_at(0).len(), 3);
-        assert_eq!(listview.list_elements_at(1).len(), 3);
-        assert_eq!(listview.list_elements_at(2).len(), 3);
+        assert_eq!(listview.list_elements_at(0).unwrap().len(), 3);
+        assert_eq!(listview.list_elements_at(1).unwrap().len(), 3);
+        assert_eq!(listview.list_elements_at(2).unwrap().len(), 3);
     } else if const_offsets {
         // All lists start at offset 0, different sizes (overlapping).
         assert_eq!(
-            listview.list_elements_at(0).scalar_at(0).unwrap(),
+            listview.list_elements_at(0).unwrap().scalar_at(0).unwrap(),
             1i32.into()
         );
         assert_eq!(
-            listview.list_elements_at(1).scalar_at(0).unwrap(),
+            listview.list_elements_at(1).unwrap().scalar_at(0).unwrap(),
             1i32.into()
         );
         assert_eq!(
-            listview.list_elements_at(2).scalar_at(0).unwrap(),
+            listview.list_elements_at(2).unwrap().scalar_at(0).unwrap(),
             1i32.into()
         );
     }

--- a/vortex-array/src/arrays/listview/tests/filter.rs
+++ b/vortex-array/src/arrays/listview/tests/filter.rs
@@ -97,7 +97,7 @@ fn test_filter_with_gaps() {
 
     // Verify the lists still read correctly.
     assert_arrays_eq!(
-        result_list.list_elements_at(0),
+        result_list.list_elements_at(0).unwrap(),
         PrimitiveArray::from_iter([7i32, 8, 9])
     );
 }
@@ -184,7 +184,7 @@ fn test_filter_extreme_offsets() {
     assert_eq!(result_list.elements().len(), 10000);
 
     // Verify we can still read the correct values.
-    let list0 = result_list.list_elements_at(0);
+    let list0 = result_list.list_elements_at(0).unwrap();
     assert_eq!(
         list0
             .scalar_at(0)

--- a/vortex-array/src/arrays/listview/tests/nested.rs
+++ b/vortex-array/src/arrays/listview/tests/nested.rs
@@ -60,14 +60,14 @@ fn test_listview_of_listview_with_overlapping() {
     assert_eq!(outer_listview.len(), 2);
 
     // Verify the outer structure.
-    let first_outer = outer_listview.list_elements_at(0);
+    let first_outer = outer_listview.list_elements_at(0).unwrap();
     let first_outer_lv = first_outer.as_::<ListViewVTable>();
     assert_eq!(first_outer_lv.len(), 3);
 
     // Verify overlapping data is preserved correctly.
     // inner[0] and inner[1] both contain element 3.
-    let inner0 = first_outer_lv.list_elements_at(0);
-    let inner1 = first_outer_lv.list_elements_at(1);
+    let inner0 = first_outer_lv.list_elements_at(0).unwrap();
+    let inner1 = first_outer_lv.list_elements_at(1).unwrap();
 
     // inner[0] should be [1, 2, 3].
     assert_eq!(
@@ -110,10 +110,10 @@ fn test_listview_of_listview_with_overlapping() {
     );
 
     // Test slicing the outer ListView.
-    let sliced = outer_listview.slice(1..2);
+    let sliced = outer_listview.slice(1..2).unwrap();
     assert_eq!(sliced.len(), 1);
     let sliced_lv = sliced.as_::<ListViewVTable>();
-    let inner_after_slice = sliced_lv.list_elements_at(0);
+    let inner_after_slice = sliced_lv.list_elements_at(0).unwrap();
     assert_eq!(inner_after_slice.len(), 3);
 }
 
@@ -163,22 +163,22 @@ fn test_deeply_nested_out_of_order() {
     assert_eq!(level3.len(), 2);
 
     // Navigate through the scrambled structure.
-    let top0 = level3.list_elements_at(0);
+    let top0 = level3.list_elements_at(0).unwrap();
     let top0_lv = top0.as_::<ListViewVTable>();
     assert_eq!(top0_lv.len(), 2);
 
     // Due to out-of-order at level3, top0 actually contains level2[2] and level2[3].
-    let mid0 = top0_lv.list_elements_at(0);
+    let mid0 = top0_lv.list_elements_at(0).unwrap();
     let mid0_lv = mid0.as_::<ListViewVTable>();
     assert_eq!(mid0_lv.len(), 2);
 
     // Verify data integrity through the scrambled offsets.
     // This should access the original elements correctly despite the scrambling.
-    let inner = mid0_lv.list_elements_at(0);
+    let inner = mid0_lv.list_elements_at(0).unwrap();
     assert_eq!(inner.len(), 2);
 
     // Test that operations work correctly with out-of-order offsets.
-    let sliced = level3.slice(0..1);
+    let sliced = level3.slice(0..1).unwrap();
     assert_eq!(sliced.len(), 1);
 }
 
@@ -223,16 +223,16 @@ fn test_mixed_offset_size_types() {
     assert_eq!(outer_listview.len(), 3);
 
     // Verify that different integer types work correctly.
-    let first_outer = outer_listview.list_elements_at(0);
+    let first_outer = outer_listview.list_elements_at(0).unwrap();
     assert_eq!(first_outer.len(), 3);
 
     // Test slicing with mixed types.
-    let sliced = outer_listview.slice(1..3);
+    let sliced = outer_listview.slice(1..3).unwrap();
     assert_eq!(sliced.len(), 2);
     let sliced_lv = sliced.as_::<ListViewVTable>();
 
     // Verify the sliced data maintains correct offsets despite type differences.
-    let sliced_first = sliced_lv.list_elements_at(0);
+    let sliced_first = sliced_lv.list_elements_at(0).unwrap();
     assert_eq!(sliced_first.len(), 3);
 }
 
@@ -279,13 +279,13 @@ fn test_listview_zero_and_overlapping() {
     assert_eq!(outer_listview.len(), 3);
 
     // Test first outer list with mixed empty/non-empty.
-    let first_outer = outer_listview.list_elements_at(0);
+    let first_outer = outer_listview.list_elements_at(0).unwrap();
     let first_outer_lv = first_outer.as_::<ListViewVTable>();
 
-    let inner0 = first_outer_lv.list_elements_at(0);
+    let inner0 = first_outer_lv.list_elements_at(0).unwrap();
     assert_eq!(inner0.len(), 0); // Empty
 
-    let inner1 = first_outer_lv.list_elements_at(1);
+    let inner1 = first_outer_lv.list_elements_at(1).unwrap();
     assert_eq!(inner1.len(), 3); // [1, 2, 3]
     assert_eq!(
         inner1
@@ -297,14 +297,14 @@ fn test_listview_zero_and_overlapping() {
         1
     );
 
-    let inner2 = first_outer_lv.list_elements_at(2);
+    let inner2 = first_outer_lv.list_elements_at(2).unwrap();
     assert_eq!(inner2.len(), 0); // Empty
 
     // Test second outer list with overlapping data.
-    let second_outer = outer_listview.list_elements_at(1);
+    let second_outer = outer_listview.list_elements_at(1).unwrap();
     let second_outer_lv = second_outer.as_::<ListViewVTable>();
 
-    let inner3 = second_outer_lv.list_elements_at(0);
+    let inner3 = second_outer_lv.list_elements_at(0).unwrap();
     assert_eq!(inner3.len(), 3); // [2, 3, 4]
     assert_eq!(
         inner3
@@ -317,7 +317,7 @@ fn test_listview_zero_and_overlapping() {
     );
 
     // Verify slicing works with empty lists.
-    let sliced = outer_listview.slice(0..2);
+    let sliced = outer_listview.slice(0..2).unwrap();
     assert_eq!(sliced.len(), 2);
 }
 
@@ -377,17 +377,17 @@ fn test_listview_of_struct_with_nulls() {
     assert_eq!(listview.len(), 3);
 
     // Verify first list.
-    let list0 = listview.list_elements_at(0);
+    let list0 = listview.list_elements_at(0).unwrap();
     assert_eq!(list0.len(), 2);
 
     // Verify overlapping list with null struct.
-    let list1 = listview.list_elements_at(1);
+    let list1 = listview.list_elements_at(1).unwrap();
     assert_eq!(list1.len(), 3);
 
     // The middle element (struct[2]) should be null.
     assert!(list1.scalar_at(1).unwrap().is_null());
 
     // Test slicing preserves null handling.
-    let sliced = listview.slice(1..3);
+    let sliced = listview.slice(1..3).unwrap();
     assert_eq!(sliced.len(), 2);
 }

--- a/vortex-array/src/arrays/listview/tests/nullability.rs
+++ b/vortex-array/src/arrays/listview/tests/nullability.rs
@@ -70,7 +70,7 @@ fn test_nullable_listview_comprehensive() {
     );
 
     // list_elements_at still returns data even for null lists.
-    let null_list_data = listview.list_elements_at(1);
+    let null_list_data = listview.list_elements_at(1).unwrap();
     assert_eq!(null_list_data.len(), 2);
     assert_eq!(null_list_data.scalar_at(0).unwrap(), 3i32.into());
     assert_eq!(null_list_data.scalar_at(1).unwrap(), 4i32.into());
@@ -110,20 +110,20 @@ fn test_nullable_elements() {
     };
 
     // First list: [Some(1), None].
-    let first_list = listview.list_elements_at(0);
+    let first_list = listview.list_elements_at(0).unwrap();
     assert_eq!(first_list.len(), 2);
     assert!(!first_list.scalar_at(0).unwrap().is_null());
     assert_eq!(first_list.scalar_at(0).unwrap(), 1i32.into());
     assert!(first_list.scalar_at(1).unwrap().is_null());
 
     // Second list: [Some(3), None].
-    let second_list = listview.list_elements_at(1);
+    let second_list = listview.list_elements_at(1).unwrap();
     assert!(!second_list.scalar_at(0).unwrap().is_null());
     assert_eq!(second_list.scalar_at(0).unwrap(), 3i32.into());
     assert!(second_list.scalar_at(1).unwrap().is_null());
 
     // Third list: [Some(5), Some(6)].
-    let third_list = listview.list_elements_at(2);
+    let third_list = listview.list_elements_at(2).unwrap();
     assert!(!third_list.scalar_at(0).unwrap().is_null());
     assert_eq!(third_list.scalar_at(0).unwrap(), 5i32.into());
     assert!(!third_list.scalar_at(1).unwrap().is_null());

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -43,7 +43,7 @@ fn test_slice_comprehensive() {
     let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
 
     // Test basic slice [1..3] - middle portion.
-    let sliced = listview.slice(1..3);
+    let sliced = listview.slice(1..3).unwrap();
     let sliced_list = sliced.as_::<ListViewVTable>();
     assert_eq!(sliced_list.len(), 2, "Wrong slice length");
     assert_eq!(sliced_list.offset_at(0), 3, "Wrong offset for list[1]");
@@ -52,7 +52,7 @@ fn test_slice_comprehensive() {
     assert_eq!(sliced_list.size_at(1), 3, "Wrong size for list[2]");
 
     // Test full array slice [0..4].
-    let full = listview.slice(0..4);
+    let full = listview.slice(0..4).unwrap();
     let full_list = full.as_::<ListViewVTable>();
     assert_eq!(full_list.len(), 4, "Full slice should preserve length");
     for i in 0..4 {
@@ -66,7 +66,7 @@ fn test_slice_comprehensive() {
     }
 
     // Test single element slice [2..3].
-    let single = listview.slice(2..3);
+    let single = listview.slice(2..3).unwrap();
     let single_list = single.as_::<ListViewVTable>();
     assert_eq!(single_list.len(), 1, "Single element slice failed");
     assert_eq!(single_list.offset_at(0), 5, "Wrong offset for single slice");
@@ -84,7 +84,7 @@ fn test_slice_out_of_order() {
     let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
 
     // Slice [1..4] should maintain the out-of-order offsets.
-    let sliced = listview.slice(1..4);
+    let sliced = listview.slice(1..4).unwrap();
     let sliced_list = sliced.as_::<ListViewVTable>();
 
     assert_eq!(
@@ -113,15 +113,15 @@ fn test_slice_out_of_order() {
 
     // Verify the actual list contents are correct.
     assert_arrays_eq!(
-        sliced_list.list_elements_at(0),
+        sliced_list.list_elements_at(0).unwrap(),
         PrimitiveArray::from_iter([10i32, 20, 30])
     );
     assert_arrays_eq!(
-        sliced_list.list_elements_at(1),
+        sliced_list.list_elements_at(1).unwrap(),
         PrimitiveArray::from_iter([40i32, 50, 60])
     );
     assert_arrays_eq!(
-        sliced_list.list_elements_at(2),
+        sliced_list.list_elements_at(2).unwrap(),
         PrimitiveArray::from_iter([90i32])
     );
 }
@@ -143,7 +143,7 @@ fn test_slice_with_nulls() {
     .into_array();
 
     // Slice [1..3] should preserve nulls.
-    let sliced = listview.slice(1..3);
+    let sliced = listview.slice(1..3).unwrap();
     let sliced_list = sliced.as_::<ListViewVTable>();
 
     assert_eq!(sliced_list.len(), 2);
@@ -179,13 +179,13 @@ fn test_slice_edge_cases(
 
     match expected_len {
         Some(len) => {
-            let sliced = listview.slice(start..stop);
+            let sliced = listview.slice(start..stop).unwrap();
             assert_eq!(sliced.len(), len);
         }
         None => {
             // slice will panic or return empty for invalid ranges
             if start < stop && stop <= listview.len() {
-                let sliced = listview.slice(start..stop);
+                let sliced = listview.slice(start..stop).unwrap();
                 assert_eq!(sliced.len(), 0);
             }
         }

--- a/vortex-array/src/arrays/listview/tests/take.rs
+++ b/vortex-array/src/arrays/listview/tests/take.rs
@@ -87,7 +87,7 @@ fn test_take_with_gaps() {
 
     // Verify the lists still read correctly despite gaps.
     assert_arrays_eq!(
-        result_list.list_elements_at(0),
+        result_list.list_elements_at(0).unwrap(),
         PrimitiveArray::from_iter([7i32, 8, 9])
     );
 }
@@ -174,7 +174,7 @@ fn test_take_extreme_offsets() {
     assert_eq!(result_list.elements().len(), 10000);
 
     // Verify we can still read the correct values.
-    let list0 = result_list.list_elements_at(0);
+    let list0 = result_list.list_elements_at(0).unwrap();
     assert_eq!(
         list0
             .scalar_at(0)

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -76,9 +76,9 @@ impl VTable for ListViewVTable {
             unsafe {
                 ListViewArray::new_unchecked(
                     array.elements().clone(),
-                    array.offsets().slice(range.clone()),
-                    array.sizes().slice(range.clone()),
-                    array.validity().slice(range),
+                    array.offsets().slice(range.clone())?,
+                    array.sizes().slice(range.clone())?,
+                    array.validity().slice(range)?,
                 )
                 .with_zero_copy_to_list(array.is_zero_copy_to_list())
             }

--- a/vortex-array/src/arrays/listview/vtable/operations.rs
+++ b/vortex-array/src/arrays/listview/vtable/operations.rs
@@ -13,7 +13,7 @@ use crate::vtable::OperationsVTable;
 impl OperationsVTable<ListViewVTable> for ListViewVTable {
     fn scalar_at(array: &ListViewArray, index: usize) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
-        let list = array.list_elements_at(index);
+        let list = array.list_elements_at(index)?;
         let children: Vec<Scalar> = (0..list.len())
             .map(|i| list.scalar_at(i))
             .collect::<VortexResult<_>>()?;

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -70,8 +70,8 @@ impl VTable for MaskedVTable {
     }
 
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
-        let child = array.child.slice(range.clone());
-        let validity = array.validity.slice(range);
+        let child = array.child.slice(range.clone())?;
+        let validity = array.validity.slice(range)?;
 
         Ok(Some(
             MaskedArray {

--- a/vortex-array/src/arrays/null/compute/mod.rs
+++ b/vortex-array/src/arrays/null/compute/mod.rs
@@ -26,7 +26,7 @@ mod test {
     #[test]
     fn test_slice_nulls() {
         let nulls = NullArray::new(10);
-        let sliced = nulls.slice(0..4).to_null();
+        let sliced = nulls.slice(0..4).unwrap().to_null();
 
         assert_eq!(sliced.len(), 4);
         assert!(matches!(sliced.validity_mask().unwrap(), Mask::AllFalse(4)));

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -101,6 +101,7 @@ impl VTable for NullVTable {
 /// # Examples
 ///
 /// ```
+/// # fn main() -> vortex_error::VortexResult<()> {
 /// use vortex_array::arrays::NullArray;
 /// use vortex_array::IntoArray;
 ///
@@ -108,12 +109,14 @@ impl VTable for NullVTable {
 /// let array = NullArray::new(5);
 ///
 /// // Slice the array - still contains nulls
-/// let sliced = array.slice(1..3);
+/// let sliced = array.slice(1..3)?;
 /// assert_eq!(sliced.len(), 2);
 ///
 /// // All elements are null
 /// let scalar = array.scalar_at(0).unwrap();
 /// assert!(scalar.is_null());
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug)]
 pub struct NullArray {

--- a/vortex-array/src/arrays/primitive/array/mod.rs
+++ b/vortex-array/src/arrays/primitive/array/mod.rs
@@ -47,14 +47,15 @@ use crate::buffer::BufferHandle;
 /// # Examples
 ///
 /// ```
+/// # fn main() -> vortex_error::VortexResult<()> {
 /// use vortex_array::arrays::PrimitiveArray;
 /// use vortex_array::compute::sum;
-/// ///
+///
 /// // Create from iterator using FromIterator impl
 /// let array: PrimitiveArray = [1i32, 2, 3, 4, 5].into_iter().collect();
 ///
 /// // Slice the array
-/// let sliced = array.slice(1..3);
+/// let sliced = array.slice(1..3)?;
 ///
 /// // Access individual values
 /// let value = sliced.scalar_at(0).unwrap();
@@ -63,6 +64,8 @@ use crate::buffer::BufferHandle;
 /// // Convert into a type-erased array that can be passed to compute functions.
 /// let summed = sum(sliced.as_ref()).unwrap().as_primitive().typed_value::<i64>().unwrap();
 /// assert_eq!(summed, 5i64);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug)]
 pub struct PrimitiveArray {

--- a/vortex-array/src/arrays/primitive/array/patch.rs
+++ b/vortex-array/src/arrays/primitive/array/patch.rs
@@ -137,7 +137,7 @@ mod tests {
     #[test]
     fn patch_sliced() {
         let input = PrimitiveArray::new(buffer![2u32; 10], Validity::AllValid);
-        let sliced = input.slice(2..8);
+        let sliced = input.slice(2..8).unwrap();
         assert_arrays_eq!(
             sliced.to_primitive(),
             PrimitiveArray::new(buffer![2u32; 6], Validity::AllValid)

--- a/vortex-array/src/arrays/primitive/array/patch.rs
+++ b/vortex-array/src/arrays/primitive/array/patch.rs
@@ -8,6 +8,7 @@ use vortex_dtype::NativePType;
 use vortex_dtype::UnsignedPType;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_dtype::match_each_native_ptype;
+use vortex_error::VortexResult;
 
 use crate::ToCanonical;
 use crate::arrays::PrimitiveArray;
@@ -17,7 +18,7 @@ use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
 impl PrimitiveArray {
-    pub fn patch(self, patches: &Patches) -> Self {
+    pub fn patch(self, patches: &Patches) -> VortexResult<Self> {
         let patch_indices = patches.indices().to_primitive();
         let patch_values = patches.values().to_primitive();
 
@@ -26,8 +27,8 @@ impl PrimitiveArray {
             patches.offset(),
             patch_indices.as_ref(),
             patch_values.validity(),
-        );
-        match_each_integer_ptype!(patch_indices.ptype(), |I| {
+        )?;
+        Ok(match_each_integer_ptype!(patch_indices.ptype(), |I| {
             match_each_native_ptype!(self.ptype(), |T| {
                 self.patch_typed::<T, I>(
                     patch_indices,
@@ -36,7 +37,7 @@ impl PrimitiveArray {
                     patched_validity,
                 )
             })
-        })
+        }))
     }
 
     fn patch_typed<T, I>(

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -153,7 +153,7 @@ impl VTable for PrimitiveVTable {
             PrimitiveArray::from_buffer_handle(
                 array.buffer_handle().slice_typed::<T>(range.clone()),
                 T::PTYPE,
-                array.validity().slice(range),
+                array.validity().slice(range)?,
             )
             .into_array()
         });

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -177,7 +177,7 @@ impl VTable for ScalarFnVTable {
             .children()
             .iter()
             .map(|c| c.slice(range.clone()))
-            .collect();
+            .collect::<VortexResult<_>>()?;
 
         Ok(Some(
             ScalarFnArray {

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -106,7 +106,7 @@ impl VTable for SliceVTable {
     fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
         // Execute the child to get canonical form, then slice it
         let canonical = array.child.clone().execute::<Canonical>(ctx)?;
-        let result = canonical.as_ref().slice(array.range.clone());
+        let result = canonical.as_ref().slice(array.range.clone())?;
         assert!(
             result.is_canonical(),
             "this must be canonical fix the slice impl for the dtype {} showing this error",
@@ -164,7 +164,7 @@ impl OperationsVTable<SliceVTable> for SliceVTable {
 
 impl ValidityVTable<SliceVTable> for SliceVTable {
     fn validity(array: &SliceArray) -> VortexResult<Validity> {
-        Ok(array.child.validity()?.slice(array.range.clone()))
+        array.child.validity()?.slice(array.range.clone())
     }
 
     fn validity_mask(array: &SliceArray) -> VortexResult<Mask> {
@@ -203,7 +203,7 @@ mod tests {
         // Slice(1..4, Slice(2..8, base)) combines to Slice(3..6, base)
         let arr = PrimitiveArray::from_iter(0i32..10).into_array();
         let inner_slice = SliceArray::new(arr, 2..8).into_array();
-        let slice = inner_slice.slice(1..4);
+        let slice = inner_slice.slice(1..4)?;
 
         assert_arrays_eq!(slice, PrimitiveArray::from_iter([3i32, 4, 5]));
 

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -147,11 +147,11 @@ impl VTable for StructVTable {
     }
 
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
-        let fields = array
+        let fields: Vec<_> = array
             .fields()
             .iter()
             .map(|field| field.slice(range.clone()))
-            .collect_vec();
+            .try_collect()?;
 
         // SAFETY: Slicing preserves all StructArray invariants
         Ok(Some(
@@ -160,7 +160,7 @@ impl VTable for StructVTable {
                     fields,
                     array.struct_fields().clone(),
                     range.len(),
-                    array.validity().slice(range),
+                    array.validity().slice(range)?,
                 )
             }
             .into_array(),

--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -317,12 +317,13 @@ impl VarBinArray {
     /// # Example
     ///
     /// ```
+    /// # fn main() -> vortex_error::VortexResult<()> {
     /// # use vortex_array::arrays::VarBinArray;
     /// # use vortex_array::arrays::VarBinVTable;
     /// # use vortex_dtype::DType;
     /// # use vortex_dtype::Nullability::NonNullable;
     /// let items = VarBinArray::from_iter_nonnull(["abc", "def", "ghi"], DType::Utf8(NonNullable));
-    /// let sliced = items.slice(1..3).as_::<VarBinVTable>().clone();
+    /// let sliced = items.slice(1..3)?.as_::<VarBinVTable>().clone();
     ///
     /// // After slicing, there is some unused data at the front of the bytes.
     /// assert_eq!(sliced.offset_at(0), 3);
@@ -331,6 +332,8 @@ impl VarBinArray {
     /// let truncated = sliced.zero_offsets();
     /// assert_eq!(truncated.offset_at(0), 0);
     /// assert_eq!(truncated.len(), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     #[doc(hidden)]
     pub fn zero_offsets(self) -> Self {

--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -180,7 +180,7 @@ impl VarBinArray {
                     .map(|o| (o[0].as_(), o[1].as_()))
                     .enumerate()
                 {
-                    if validity.is_null(i) {
+                    if validity.is_null(i)? {
                         continue;
                     }
 

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -110,7 +110,7 @@ impl CompareKernel for VarBinVTable {
             }
             .map_err(|err| vortex_err!("Failed to compare VarBin array: {}", err))?;
 
-            Ok(Some(from_arrow_array_with_len(&array, len, nullable)))
+            Ok(Some(from_arrow_array_with_len(&array, len, nullable)?))
         } else if !rhs.is::<VarBinVTable>() {
             // NOTE: If the rhs is not a VarBin array it will be canonicalized to a VarBinView
             // Arrow doesn't support comparing VarBin to VarBinView arrays, so we convert ourselves

--- a/vortex-array/src/arrays/varbin/compute/filter.rs
+++ b/vortex-array/src/arrays/varbin/compute/filter.rs
@@ -174,7 +174,7 @@ fn filter_select_var_bin_by_index_primitive_offset<O: IntegerPType>(
 ) -> VortexResult<VarBinArray> {
     let mut builder = VarBinBuilder::<O>::with_capacity(selection_count);
     for idx in mask_indices.iter().copied() {
-        if validity.is_valid(idx) {
+        if validity.is_valid(idx)? {
             let (start, end) = (
                 offsets[idx].to_usize().ok_or_else(|| {
                     vortex_err!("Failed to convert offset to usize: {}", offsets[idx])

--- a/vortex-array/src/arrays/varbin/tests.rs
+++ b/vortex-array/src/arrays/varbin/tests.rs
@@ -41,7 +41,7 @@ pub fn test_scalar_at(binary_array: ArrayRef) {
 
 #[rstest]
 pub fn slice_array(binary_array: ArrayRef) {
-    let binary_arr = binary_array.slice(1..2);
+    let binary_arr = binary_array.slice(1..2).unwrap();
     assert_arrays_eq!(
         binary_arr,
         VarBinViewArray::from_iter_str(["hello world this is a long string"])

--- a/vortex-array/src/arrays/varbin/vtable/canonical.rs
+++ b/vortex-array/src/arrays/varbin/vtable/canonical.rs
@@ -65,7 +65,7 @@ mod tests {
         varbin.append_value("1234567890123".as_bytes());
         let varbin = varbin.finish(dtype.clone());
 
-        let varbin = varbin.slice(1..4);
+        let varbin = varbin.slice(1..4).unwrap();
 
         let canonical = varbin.to_varbinview();
         assert_eq!(canonical.dtype(), &dtype);

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -133,10 +133,10 @@ impl VTable for VarBinVTable {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(unsafe {
             VarBinArray::new_unchecked(
-                array.offsets().slice(range.start..range.end + 1),
+                array.offsets().slice(range.start..range.end + 1)?,
                 array.bytes().clone(),
                 array.dtype().clone(),
-                array.validity().slice(range),
+                array.validity().slice(range)?,
             )
             .into_array()
         }))

--- a/vortex-array/src/arrays/varbinview/array.rs
+++ b/vortex-array/src/arrays/varbinview/array.rs
@@ -217,7 +217,7 @@ impl VarBinViewArray {
         F: Fn(&[u8]) -> bool,
     {
         for (idx, &view) in views.iter().enumerate() {
-            if validity.is_null(idx) {
+            if validity.is_null(idx)? {
                 continue;
             }
 

--- a/vortex-array/src/arrays/varbinview/tests.rs
+++ b/vortex-array/src/arrays/varbinview/tests.rs
@@ -21,7 +21,8 @@ pub fn varbin_view() {
 pub fn slice_array() {
     let binary_arr =
         VarBinViewArray::from_iter_str(["hello world", "hello world this is a long string"])
-            .slice(1..2);
+            .slice(1..2)
+            .unwrap();
     assert_arrays_eq!(
         binary_arr,
         VarBinViewArray::from_iter_str(["hello world this is a long string"])

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -127,7 +127,7 @@ impl VTable for VarBinViewVTable {
                 array.views().slice(range.clone()),
                 array.buffers().clone(),
                 array.dtype().clone(),
-                array.validity().slice(range),
+                array.validity().slice(range)?,
             )
             .into_array(),
         ))

--- a/vortex-array/src/arrow/array.rs
+++ b/vortex-array/src/arrow/array.rs
@@ -88,7 +88,7 @@ impl VTable for ArrowVTable {
     }
 
     fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        ArrayRef::from_arrow(array.inner.as_ref(), array.dtype.is_nullable())
+        ArrayRef::from_arrow(array.inner.as_ref(), array.dtype.is_nullable())?
             .execute::<Canonical>(ctx)
     }
 }

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -69,6 +69,7 @@ use vortex_dtype::NativePType;
 use vortex_dtype::PType;
 use vortex_dtype::datetime::TimeUnit;
 use vortex_error::VortexExpect as _;
+use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_scalar::i256;
 
@@ -136,10 +137,10 @@ where
 macro_rules! impl_from_arrow_primitive {
     ($T:path) => {
         impl FromArrowArray<&ArrowPrimitiveArray<$T>> for ArrayRef {
-            fn from_arrow(value: &ArrowPrimitiveArray<$T>, nullable: bool) -> Self {
+            fn from_arrow(value: &ArrowPrimitiveArray<$T>, nullable: bool) -> VortexResult<Self> {
                 let buffer = Buffer::from_arrow_scalar_buffer(value.values().clone());
                 let validity = nulls(value.nulls(), nullable);
-                PrimitiveArray::new(buffer, validity).into_array()
+                Ok(PrimitiveArray::new(buffer, validity).into_array())
             }
         }
     };
@@ -158,34 +159,34 @@ impl_from_arrow_primitive!(Float32Type);
 impl_from_arrow_primitive!(Float64Type);
 
 impl FromArrowArray<&ArrowPrimitiveArray<Decimal32Type>> for ArrayRef {
-    fn from_arrow(array: &ArrowPrimitiveArray<Decimal32Type>, nullable: bool) -> Self {
+    fn from_arrow(array: &ArrowPrimitiveArray<Decimal32Type>, nullable: bool) -> VortexResult<Self> {
         let decimal_type = DecimalDType::new(array.precision(), array.scale());
         let buffer = Buffer::from_arrow_scalar_buffer(array.values().clone());
         let validity = nulls(array.nulls(), nullable);
-        DecimalArray::new(buffer, decimal_type, validity).into_array()
+        Ok(DecimalArray::new(buffer, decimal_type, validity).into_array())
     }
 }
 
 impl FromArrowArray<&ArrowPrimitiveArray<Decimal64Type>> for ArrayRef {
-    fn from_arrow(array: &ArrowPrimitiveArray<Decimal64Type>, nullable: bool) -> Self {
+    fn from_arrow(array: &ArrowPrimitiveArray<Decimal64Type>, nullable: bool) -> VortexResult<Self> {
         let decimal_type = DecimalDType::new(array.precision(), array.scale());
         let buffer = Buffer::from_arrow_scalar_buffer(array.values().clone());
         let validity = nulls(array.nulls(), nullable);
-        DecimalArray::new(buffer, decimal_type, validity).into_array()
+        Ok(DecimalArray::new(buffer, decimal_type, validity).into_array())
     }
 }
 
 impl FromArrowArray<&ArrowPrimitiveArray<Decimal128Type>> for ArrayRef {
-    fn from_arrow(array: &ArrowPrimitiveArray<Decimal128Type>, nullable: bool) -> Self {
+    fn from_arrow(array: &ArrowPrimitiveArray<Decimal128Type>, nullable: bool) -> VortexResult<Self> {
         let decimal_type = DecimalDType::new(array.precision(), array.scale());
         let buffer = Buffer::from_arrow_scalar_buffer(array.values().clone());
         let validity = nulls(array.nulls(), nullable);
-        DecimalArray::new(buffer, decimal_type, validity).into_array()
+        Ok(DecimalArray::new(buffer, decimal_type, validity).into_array())
     }
 }
 
 impl FromArrowArray<&ArrowPrimitiveArray<Decimal256Type>> for ArrayRef {
-    fn from_arrow(array: &ArrowPrimitiveArray<Decimal256Type>, nullable: bool) -> Self {
+    fn from_arrow(array: &ArrowPrimitiveArray<Decimal256Type>, nullable: bool) -> VortexResult<Self> {
         let decimal_type = DecimalDType::new(array.precision(), array.scale());
         let buffer = Buffer::from_arrow_scalar_buffer(array.values().clone());
         // SAFETY: Our i256 implementation has the same bit-pattern representation of the
@@ -194,15 +195,15 @@ impl FromArrowArray<&ArrowPrimitiveArray<Decimal256Type>> for ArrayRef {
         let buffer =
             unsafe { std::mem::transmute::<Buffer<arrow_buffer::i256>, Buffer<i256>>(buffer) };
         let validity = nulls(array.nulls(), nullable);
-        DecimalArray::new(buffer, decimal_type, validity).into_array()
+        Ok(DecimalArray::new(buffer, decimal_type, validity).into_array())
     }
 }
 
 macro_rules! impl_from_arrow_temporal {
     ($T:path) => {
         impl FromArrowArray<&ArrowPrimitiveArray<$T>> for ArrayRef {
-            fn from_arrow(value: &ArrowPrimitiveArray<$T>, nullable: bool) -> Self {
-                temporal_array(value, nullable)
+            fn from_arrow(value: &ArrowPrimitiveArray<$T>, nullable: bool) -> vortex_error::VortexResult<Self> {
+                Ok(temporal_array(value, nullable))
             }
         }
     };
@@ -253,25 +254,24 @@ impl<T: ByteArrayType> FromArrowArray<&GenericByteArray<T>> for ArrayRef
 where
     <T as ByteArrayType>::Offset: IntegerPType,
 {
-    fn from_arrow(value: &GenericByteArray<T>, nullable: bool) -> Self {
+    fn from_arrow(value: &GenericByteArray<T>, nullable: bool) -> VortexResult<Self> {
         let dtype = match T::DATA_TYPE {
             DataType::Binary | DataType::LargeBinary => DType::Binary(nullable.into()),
             DataType::Utf8 | DataType::LargeUtf8 => DType::Utf8(nullable.into()),
             dt => vortex_panic!("Invalid data type for ByteArray: {dt}"),
         };
-        VarBinArray::try_new(
+        Ok(VarBinArray::try_new(
             value.offsets().clone().into_array(),
             ByteBuffer::from_arrow_buffer(value.values().clone(), Alignment::of::<u8>()),
             dtype,
             nulls(value.nulls(), nullable),
-        )
-        .vortex_expect("Failed to convert Arrow GenericByteArray to Vortex VarBinArray")
-        .into_array()
+        )?
+        .into_array())
     }
 }
 
 impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayRef {
-    fn from_arrow(value: &GenericByteViewArray<T>, nullable: bool) -> Self {
+    fn from_arrow(value: &GenericByteViewArray<T>, nullable: bool) -> VortexResult<Self> {
         let dtype = match T::DATA_TYPE {
             DataType::BinaryView => DType::Binary(nullable.into()),
             DataType::Utf8View => DType::Utf8(nullable.into()),
@@ -284,7 +284,7 @@ impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayRef {
 
         // SAFETY: arrow-rs ByteViewArray already checks the same invariants, we inherit those
         //  guarantees by zero-copy constructing from one.
-        unsafe {
+        Ok(unsafe {
             VarBinViewArray::new_unchecked(
                 views_buffer,
                 Arc::from(
@@ -298,17 +298,17 @@ impl<T: ByteViewType> FromArrowArray<&GenericByteViewArray<T>> for ArrayRef {
                 nulls(value.nulls(), nullable),
             )
             .into_array()
-        }
+        })
     }
 }
 
 impl FromArrowArray<&ArrowBooleanArray> for ArrayRef {
-    fn from_arrow(value: &ArrowBooleanArray, nullable: bool) -> Self {
-        BoolArray::from_bit_buffer(
+    fn from_arrow(value: &ArrowBooleanArray, nullable: bool) -> VortexResult<Self> {
+        Ok(BoolArray::from_bit_buffer(
             value.values().clone().into(),
             nulls(value.nulls(), nullable),
         )
-        .into_array()
+        .into_array())
     }
 }
 
@@ -361,8 +361,8 @@ fn remove_nulls(data: arrow_data::ArrayData) -> arrow_data::ArrayData {
 }
 
 impl FromArrowArray<&ArrowStructArray> for ArrayRef {
-    fn from_arrow(value: &ArrowStructArray, nullable: bool) -> Self {
-        StructArray::try_new(
+    fn from_arrow(value: &ArrowStructArray, nullable: bool) -> VortexResult<Self> {
+        Ok(StructArray::try_new(
             value.column_names().iter().copied().collect(),
             value
                 .columns()
@@ -378,17 +378,16 @@ impl FromArrowArray<&ArrowStructArray> for ArrayRef {
                         Self::from_arrow(c.as_ref(), field.is_nullable())
                     }
                 })
-                .collect::<Vec<_>>(),
+                .collect::<VortexResult<Vec<_>>>()?,
             value.len(),
             nulls(value.nulls(), nullable),
-        )
-        .vortex_expect("Failed to convert Arrow StructArray to Vortex StructArray")
-        .into_array()
+        )?
+        .into_array())
     }
 }
 
 impl<O: IntegerPType + OffsetSizeTrait> FromArrowArray<&GenericListArray<O>> for ArrayRef {
-    fn from_arrow(value: &GenericListArray<O>, nullable: bool) -> Self {
+    fn from_arrow(value: &GenericListArray<O>, nullable: bool) -> VortexResult<Self> {
         // Extract the validity of the underlying element array.
         let elements_are_nullable = match value.data_type() {
             DataType::List(field) => field.is_nullable(),
@@ -396,20 +395,18 @@ impl<O: IntegerPType + OffsetSizeTrait> FromArrowArray<&GenericListArray<O>> for
             dt => vortex_panic!("Invalid data type for ListArray: {dt}"),
         };
 
-        let elements = Self::from_arrow(value.values().as_ref(), elements_are_nullable);
+        let elements = Self::from_arrow(value.values().as_ref(), elements_are_nullable)?;
 
         // `offsets` are always non-nullable.
         let offsets = value.offsets().clone().into_array();
         let nulls = nulls(value.nulls(), nullable);
 
-        ListArray::try_new(elements, offsets, nulls)
-            .vortex_expect("Failed to convert Arrow ListArray to Vortex ListArray")
-            .into_array()
+        Ok(ListArray::try_new(elements, offsets, nulls)?.into_array())
     }
 }
 
 impl<O: OffsetSizeTrait + NativePType> FromArrowArray<&GenericListViewArray<O>> for ArrayRef {
-    fn from_arrow(array: &GenericListViewArray<O>, nullable: bool) -> Self {
+    fn from_arrow(array: &GenericListViewArray<O>, nullable: bool) -> VortexResult<Self> {
         // Extract the validity of the underlying element array.
         let elements_are_nullable = match array.data_type() {
             DataType::ListView(field) => field.is_nullable(),
@@ -417,50 +414,47 @@ impl<O: OffsetSizeTrait + NativePType> FromArrowArray<&GenericListViewArray<O>> 
             dt => vortex_panic!("Invalid data type for ListViewArray: {dt}"),
         };
 
-        let elements = Self::from_arrow(array.values().as_ref(), elements_are_nullable);
+        let elements = Self::from_arrow(array.values().as_ref(), elements_are_nullable)?;
 
         // `offsets` and `sizes` are always non-nullable.
         let offsets = array.offsets().clone().into_array();
         let sizes = array.sizes().clone().into_array();
         let nulls = nulls(array.nulls(), nullable);
 
-        ListViewArray::try_new(elements, offsets, sizes, nulls)
-            .vortex_expect("Failed to convert Arrow ListViewArray to Vortex ListViewArray")
-            .into_array()
+        Ok(ListViewArray::try_new(elements, offsets, sizes, nulls)?.into_array())
     }
 }
 
 impl FromArrowArray<&ArrowFixedSizeListArray> for ArrayRef {
-    fn from_arrow(array: &ArrowFixedSizeListArray, nullable: bool) -> Self {
+    fn from_arrow(array: &ArrowFixedSizeListArray, nullable: bool) -> VortexResult<Self> {
         let DataType::FixedSizeList(field, list_size) = array.data_type() else {
             vortex_panic!("Invalid data type for ListArray: {}", array.data_type());
         };
 
-        FixedSizeListArray::try_new(
-            Self::from_arrow(array.values().as_ref(), field.is_nullable()),
+        Ok(FixedSizeListArray::try_new(
+            Self::from_arrow(array.values().as_ref(), field.is_nullable())?,
             *list_size as u32,
             nulls(array.nulls(), nullable),
             array.len(),
-        )
-        .vortex_expect("Failed to convert Arrow FixedSizeListArray to Vortex FixedSizeListArray")
-        .into_array()
+        )?
+        .into_array())
     }
 }
 
 impl FromArrowArray<&ArrowNullArray> for ArrayRef {
-    fn from_arrow(value: &ArrowNullArray, nullable: bool) -> Self {
+    fn from_arrow(value: &ArrowNullArray, nullable: bool) -> VortexResult<Self> {
         assert!(nullable);
-        NullArray::new(value.len()).into_array()
+        Ok(NullArray::new(value.len()).into_array())
     }
 }
 
 impl<K: ArrowDictionaryKeyType> FromArrowArray<&DictionaryArray<K>> for DictArray {
-    fn from_arrow(array: &DictionaryArray<K>, nullable: bool) -> Self {
+    fn from_arrow(array: &DictionaryArray<K>, nullable: bool) -> VortexResult<Self> {
         let keys = AnyDictionaryArray::keys(array);
-        let keys = ArrayRef::from_arrow(keys, keys.is_nullable());
-        let values = ArrayRef::from_arrow(array.values().as_ref(), nullable);
+        let keys = ArrayRef::from_arrow(keys, keys.is_nullable())?;
+        let values = ArrayRef::from_arrow(array.values().as_ref(), nullable)?;
         // SAFETY: we assume that Arrow has checked the invariants on construction.
-        unsafe { DictArray::new_unchecked(keys, values) }
+        Ok(unsafe { DictArray::new_unchecked(keys, values) })
     }
 }
 
@@ -482,7 +476,7 @@ fn nulls(nulls: Option<&NullBuffer>, nullable: bool) -> Validity {
 }
 
 impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
-    fn from_arrow(array: &dyn ArrowArray, nullable: bool) -> Self {
+    fn from_arrow(array: &dyn ArrowArray, nullable: bool) -> VortexResult<Self> {
         match array.data_type() {
             DataType::Boolean => Self::from_arrow(array.as_boolean(), nullable),
             DataType::UInt8 => Self::from_arrow(array.as_primitive::<UInt8Type>(), nullable),
@@ -556,33 +550,46 @@ impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
                 Self::from_arrow(array.as_primitive::<Decimal256Type>(), nullable)
             }
             DataType::Dictionary(key_type, _) => match key_type.as_ref() {
-                DataType::Int8 => {
-                    DictArray::from_arrow(array.as_dictionary::<Int8Type>(), nullable).into_array()
-                }
-                DataType::Int16 => {
-                    DictArray::from_arrow(array.as_dictionary::<Int16Type>(), nullable).into_array()
-                }
-                DataType::Int32 => {
-                    DictArray::from_arrow(array.as_dictionary::<Int32Type>(), nullable).into_array()
-                }
-                DataType::Int64 => {
-                    DictArray::from_arrow(array.as_dictionary::<Int64Type>(), nullable).into_array()
-                }
-                DataType::UInt8 => {
-                    DictArray::from_arrow(array.as_dictionary::<UInt8Type>(), nullable).into_array()
-                }
-                DataType::UInt16 => {
-                    DictArray::from_arrow(array.as_dictionary::<UInt16Type>(), nullable)
-                        .into_array()
-                }
-                DataType::UInt32 => {
-                    DictArray::from_arrow(array.as_dictionary::<UInt32Type>(), nullable)
-                        .into_array()
-                }
-                DataType::UInt64 => {
-                    DictArray::from_arrow(array.as_dictionary::<UInt64Type>(), nullable)
-                        .into_array()
-                }
+                DataType::Int8 => Ok(DictArray::from_arrow(
+                    array.as_dictionary::<Int8Type>(),
+                    nullable,
+                )?
+                .into_array()),
+                DataType::Int16 => Ok(DictArray::from_arrow(
+                    array.as_dictionary::<Int16Type>(),
+                    nullable,
+                )?
+                .into_array()),
+                DataType::Int32 => Ok(DictArray::from_arrow(
+                    array.as_dictionary::<Int32Type>(),
+                    nullable,
+                )?
+                .into_array()),
+                DataType::Int64 => Ok(DictArray::from_arrow(
+                    array.as_dictionary::<Int64Type>(),
+                    nullable,
+                )?
+                .into_array()),
+                DataType::UInt8 => Ok(DictArray::from_arrow(
+                    array.as_dictionary::<UInt8Type>(),
+                    nullable,
+                )?
+                .into_array()),
+                DataType::UInt16 => Ok(DictArray::from_arrow(
+                    array.as_dictionary::<UInt16Type>(),
+                    nullable,
+                )?
+                .into_array()),
+                DataType::UInt32 => Ok(DictArray::from_arrow(
+                    array.as_dictionary::<UInt32Type>(),
+                    nullable,
+                )?
+                .into_array()),
+                DataType::UInt64 => Ok(DictArray::from_arrow(
+                    array.as_dictionary::<UInt64Type>(),
+                    nullable,
+                )?
+                .into_array()),
                 key_dt => vortex_panic!("Unsupported dictionary key type: {key_dt}"),
             },
             dt => vortex_panic!("Array encoding not implemented for Arrow data type {dt}"),
@@ -591,13 +598,13 @@ impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
 }
 
 impl FromArrowArray<RecordBatch> for ArrayRef {
-    fn from_arrow(array: RecordBatch, nullable: bool) -> Self {
+    fn from_arrow(array: RecordBatch, nullable: bool) -> VortexResult<Self> {
         ArrayRef::from_arrow(&arrow_array::StructArray::from(array), nullable)
     }
 }
 
 impl FromArrowArray<&RecordBatch> for ArrayRef {
-    fn from_arrow(array: &RecordBatch, nullable: bool) -> Self {
+    fn from_arrow(array: &RecordBatch, nullable: bool) -> VortexResult<Self> {
         Self::from_arrow(array.clone(), nullable)
     }
 }
@@ -680,10 +687,10 @@ mod tests {
     #[test]
     fn test_int8_array_conversion() {
         let arrow_array = Int8Array::from(vec![Some(1), None, Some(3), Some(4)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Int8Array::from(vec![1, 2, 3, 4]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -699,10 +706,10 @@ mod tests {
     #[test]
     fn test_int16_array_conversion() {
         let arrow_array = Int16Array::from(vec![Some(100), None, Some(300), Some(400)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Int16Array::from(vec![100, 200, 300, 400]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -718,10 +725,10 @@ mod tests {
     #[test]
     fn test_int32_array_conversion() {
         let arrow_array = Int32Array::from(vec![Some(1000), None, Some(3000), Some(4000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Int32Array::from(vec![1000, 2000, 3000, 4000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -737,10 +744,10 @@ mod tests {
     #[test]
     fn test_int64_array_conversion() {
         let arrow_array = Int64Array::from(vec![Some(10000), None, Some(30000), Some(40000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Int64Array::from(vec![10000_i64, 20000, 30000, 40000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -756,10 +763,10 @@ mod tests {
     #[test]
     fn test_uint8_array_conversion() {
         let arrow_array = UInt8Array::from(vec![Some(1), None, Some(3), Some(4)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = UInt8Array::from(vec![1_u8, 2, 3, 4]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -775,10 +782,10 @@ mod tests {
     #[test]
     fn test_uint16_array_conversion() {
         let arrow_array = UInt16Array::from(vec![Some(100), None, Some(300), Some(400)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = UInt16Array::from(vec![100_u16, 200, 300, 400]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -794,10 +801,10 @@ mod tests {
     #[test]
     fn test_uint32_array_conversion() {
         let arrow_array = UInt32Array::from(vec![Some(1000), None, Some(3000), Some(4000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = UInt32Array::from(vec![1000_u32, 2000, 3000, 4000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -813,10 +820,10 @@ mod tests {
     #[test]
     fn test_uint64_array_conversion() {
         let arrow_array = UInt64Array::from(vec![Some(10000), None, Some(30000), Some(40000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = UInt64Array::from(vec![10000_u64, 20000, 30000, 40000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -837,7 +844,7 @@ mod tests {
             Some(<Float16Type as ArrowPrimitiveType>::Native::from_f32(3.5)),
         ];
         let arrow_array = arrow_array::PrimitiveArray::<Float16Type>::from(values);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let non_null_values = vec![
             <Float16Type as ArrowPrimitiveType>::Native::from_f32(1.5),
@@ -845,7 +852,7 @@ mod tests {
         ];
         let arrow_array_non_null =
             arrow_array::PrimitiveArray::<Float16Type>::from(non_null_values);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 3);
         assert_eq!(vortex_array_non_null.len(), 2);
@@ -861,10 +868,10 @@ mod tests {
     #[test]
     fn test_float32_array_conversion() {
         let arrow_array = Float32Array::from(vec![Some(1.5), None, Some(3.5), Some(4.5)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Float32Array::from(vec![1.5_f32, 2.5, 3.5, 4.5]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -880,10 +887,10 @@ mod tests {
     #[test]
     fn test_float64_array_conversion() {
         let arrow_array = Float64Array::from(vec![Some(1.5), None, Some(3.5), Some(4.5)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Float64Array::from(vec![1.5_f64, 2.5, 3.5, 4.5]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -906,7 +913,7 @@ mod tests {
         builder.append_value(11111);
         let decimal_array = builder.finish().with_precision_and_scale(10, 2).unwrap();
 
-        let vortex_array = ArrayRef::from_arrow(&decimal_array, true);
+        let vortex_array = ArrayRef::from_arrow(&decimal_array, true).unwrap();
         assert_eq!(vortex_array.len(), 4);
 
         let mut builder_non_null = Decimal128Builder::with_capacity(3);
@@ -918,7 +925,7 @@ mod tests {
             .with_precision_and_scale(10, 2)
             .unwrap();
 
-        let vortex_array_non_null = ArrayRef::from_arrow(&decimal_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&decimal_array_non_null, false).unwrap();
         assert_eq!(vortex_array_non_null.len(), 3);
 
         // Verify metadata - should be DecimalArray with correct precision and scale
@@ -943,7 +950,7 @@ mod tests {
         builder.append_value(arrow_buffer::i256::from_i128(11111));
         let decimal_array = builder.finish().with_precision_and_scale(38, 10).unwrap();
 
-        let vortex_array = ArrayRef::from_arrow(&decimal_array, true);
+        let vortex_array = ArrayRef::from_arrow(&decimal_array, true).unwrap();
         assert_eq!(vortex_array.len(), 4);
 
         let mut builder_non_null = Decimal256Builder::with_capacity(3);
@@ -955,7 +962,7 @@ mod tests {
             .with_precision_and_scale(38, 10)
             .unwrap();
 
-        let vortex_array_non_null = ArrayRef::from_arrow(&decimal_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&decimal_array_non_null, false).unwrap();
         assert_eq!(vortex_array_non_null.len(), 3);
 
         // Verify metadata - should be DecimalArray with correct precision and scale
@@ -976,10 +983,10 @@ mod tests {
     fn test_timestamp_second_array_conversion() {
         let arrow_array =
             TimestampSecondArray::from(vec![Some(1000), None, Some(3000), Some(4000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = TimestampSecondArray::from(vec![1000_i64, 2000, 3000, 4000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1003,11 +1010,11 @@ mod tests {
     fn test_timestamp_millisecond_array_conversion() {
         let arrow_array =
             TimestampMillisecondArray::from(vec![Some(1000), None, Some(3000), Some(4000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null =
             TimestampMillisecondArray::from(vec![1000_i64, 2000, 3000, 4000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1017,11 +1024,11 @@ mod tests {
     fn test_timestamp_microsecond_array_conversion() {
         let arrow_array =
             TimestampMicrosecondArray::from(vec![Some(1000), None, Some(3000), Some(4000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null =
             TimestampMicrosecondArray::from(vec![1000_i64, 2000, 3000, 4000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1032,11 +1039,11 @@ mod tests {
         let arrow_array =
             TimestampMicrosecondArray::from(vec![Some(1000), None, Some(3000), Some(4000)])
                 .with_timezone("UTC");
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null =
             TimestampMicrosecondArray::from(vec![1000_i64, 2000, 3000, 4000]).with_timezone("UTC");
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(
@@ -1068,10 +1075,10 @@ mod tests {
     fn test_timestamp_nanosecond_array_conversion() {
         let arrow_array =
             TimestampNanosecondArray::from(vec![Some(1000), None, Some(3000), Some(4000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = TimestampNanosecondArray::from(vec![1000_i64, 2000, 3000, 4000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1080,10 +1087,10 @@ mod tests {
     #[test]
     fn test_time32_second_array_conversion() {
         let arrow_array = Time32SecondArray::from(vec![Some(1000), None, Some(3000), Some(4000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Time32SecondArray::from(vec![1000_i32, 2000, 3000, 4000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1107,10 +1114,10 @@ mod tests {
     fn test_time32_millisecond_array_conversion() {
         let arrow_array =
             Time32MillisecondArray::from(vec![Some(1000), None, Some(3000), Some(4000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Time32MillisecondArray::from(vec![1000_i32, 2000, 3000, 4000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1120,10 +1127,10 @@ mod tests {
     fn test_time64_microsecond_array_conversion() {
         let arrow_array =
             Time64MicrosecondArray::from(vec![Some(1000), None, Some(3000), Some(4000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Time64MicrosecondArray::from(vec![1000_i64, 2000, 3000, 4000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1133,10 +1140,10 @@ mod tests {
     fn test_time64_nanosecond_array_conversion() {
         let arrow_array =
             Time64NanosecondArray::from(vec![Some(1000), None, Some(3000), Some(4000)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Time64NanosecondArray::from(vec![1000_i64, 2000, 3000, 4000]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1145,10 +1152,10 @@ mod tests {
     #[test]
     fn test_date32_array_conversion() {
         let arrow_array = Date32Array::from(vec![Some(18000), None, Some(18002), Some(18003)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Date32Array::from(vec![18000_i32, 18001, 18002, 18003]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1162,7 +1169,7 @@ mod tests {
             Some(1555286400000),
             Some(1555372800000),
         ]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = Date64Array::from(vec![
             1555200000000_i64,
@@ -1170,7 +1177,7 @@ mod tests {
             1555286400000,
             1555372800000,
         ]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1180,10 +1187,10 @@ mod tests {
     #[test]
     fn test_utf8_array_conversion() {
         let arrow_array = StringArray::from(vec![Some("hello"), None, Some("world"), Some("test")]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = StringArray::from(vec!["hello", "world", "test", "vortex"]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1200,10 +1207,10 @@ mod tests {
     fn test_large_utf8_array_conversion() {
         let arrow_array =
             LargeStringArray::from(vec![Some("hello"), None, Some("world"), Some("test")]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = LargeStringArray::from(vec!["hello", "world", "test", "vortex"]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1217,7 +1224,7 @@ mod tests {
             Some("world".as_bytes()),
             Some("test".as_bytes()),
         ]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = BinaryArray::from(vec![
             "hello".as_bytes(),
@@ -1225,7 +1232,7 @@ mod tests {
             "test".as_bytes(),
             "vortex".as_bytes(),
         ]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1239,7 +1246,7 @@ mod tests {
             Some("world".as_bytes()),
             Some("test".as_bytes()),
         ]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = LargeBinaryArray::from(vec![
             "hello".as_bytes(),
@@ -1247,7 +1254,7 @@ mod tests {
             "test".as_bytes(),
             "vortex".as_bytes(),
         ]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1261,7 +1268,7 @@ mod tests {
         builder.append_value("world");
         builder.append_value("test");
         let arrow_array = builder.finish();
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let mut builder_non_null = StringViewBuilder::new();
         builder_non_null.append_value("hello");
@@ -1269,7 +1276,7 @@ mod tests {
         builder_non_null.append_value("test");
         builder_non_null.append_value("vortex");
         let arrow_array_non_null = builder_non_null.finish();
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1301,7 +1308,7 @@ mod tests {
         builder.append_value(b"world");
         builder.append_value(b"test");
         let arrow_array = builder.finish();
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let mut builder_non_null = BinaryViewBuilder::new();
         builder_non_null.append_value(b"hello");
@@ -1309,7 +1316,7 @@ mod tests {
         builder_non_null.append_value(b"test");
         builder_non_null.append_value(b"vortex");
         let arrow_array_non_null = builder_non_null.finish();
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1337,10 +1344,10 @@ mod tests {
     #[test]
     fn test_boolean_array_conversion() {
         let arrow_array = BooleanArray::from(vec![Some(true), None, Some(false), Some(true)]);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
 
         let arrow_array_non_null = BooleanArray::from(vec![true, false, true, false]);
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
         assert_eq!(vortex_array_non_null.len(), 4);
@@ -1364,7 +1371,7 @@ mod tests {
             None,
         );
 
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, false);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, false).unwrap();
         assert_eq!(vortex_array.len(), 3);
 
         // Verify metadata - should be StructArray with correct field names
@@ -1385,7 +1392,7 @@ mod tests {
             ]))),
         );
 
-        let vortex_nullable_array = ArrayRef::from_arrow(&nullable_array, true);
+        let vortex_nullable_array = ArrayRef::from_arrow(&nullable_array, true).unwrap();
         assert_eq!(vortex_nullable_array.len(), 3);
 
         // Verify metadata for nullable struct
@@ -1404,7 +1411,7 @@ mod tests {
         builder.append_value([Some(4), Some(5)]);
         let arrow_array = builder.finish();
 
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
         assert_eq!(vortex_array.len(), 3);
 
         // Verify metadata - should be ListArray with correct offsets
@@ -1419,7 +1426,7 @@ mod tests {
         builder_non_null.append_value([Some(4), Some(5)]);
         let arrow_array_non_null = builder_non_null.finish();
 
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
         assert_eq!(vortex_array_non_null.len(), 2);
 
         // Verify metadata for non-nullable list
@@ -1439,7 +1446,7 @@ mod tests {
         builder.append_value([Some(4), Some(5)]);
         let arrow_array = builder.finish();
 
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
         assert_eq!(vortex_array.len(), 3);
 
         // Verify metadata - should be ListArray with correct offsets (I64 for large lists)
@@ -1454,7 +1461,7 @@ mod tests {
         builder_non_null.append_value([Some(4), Some(5)]);
         let arrow_array_non_null = builder_non_null.finish();
 
-        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false);
+        let vortex_array_non_null = ArrayRef::from_arrow(&arrow_array_non_null, false).unwrap();
         assert_eq!(vortex_array_non_null.len(), 2);
 
         // Verify metadata for non-nullable large list
@@ -1488,7 +1495,7 @@ mod tests {
         let field = Arc::new(Field::new("item", DataType::Int32, true));
         let arrow_array =
             ArrowFixedSizeListArray::try_new(field.clone(), 3, Arc::new(values), None).unwrap();
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, false);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, false).unwrap();
 
         assert_eq!(vortex_array.len(), 4);
 
@@ -1521,7 +1528,7 @@ mod tests {
             Some(null_buffer),
         )
         .unwrap();
-        let vortex_array_nullable = ArrayRef::from_arrow(&arrow_array_nullable, true);
+        let vortex_array_nullable = ArrayRef::from_arrow(&arrow_array_nullable, true).unwrap();
 
         assert_eq!(vortex_array_nullable.len(), 3);
 
@@ -1561,7 +1568,7 @@ mod tests {
         )
         .unwrap();
 
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, false);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, false).unwrap();
         assert_eq!(vortex_array.len(), 4);
 
         // Verify metadata - should be ListViewArray with correct offsets and sizes
@@ -1587,7 +1594,7 @@ mod tests {
         )
         .unwrap();
 
-        let vortex_array_nullable = ArrayRef::from_arrow(&arrow_array_nullable, true);
+        let vortex_array_nullable = ArrayRef::from_arrow(&arrow_array_nullable, true).unwrap();
         assert_eq!(vortex_array_nullable.len(), 4);
 
         // Test LargeListView (i64 offsets and sizes)
@@ -1603,7 +1610,7 @@ mod tests {
         )
         .unwrap();
 
-        let large_vortex_array = ArrayRef::from_arrow(&large_arrow_array, false);
+        let large_vortex_array = ArrayRef::from_arrow(&large_arrow_array, false).unwrap();
         assert_eq!(large_vortex_array.len(), 4);
 
         // Verify metadata for large ListView
@@ -1625,7 +1632,7 @@ mod tests {
     #[test]
     fn test_null_array_conversion() {
         let arrow_array = NullArray::new(5);
-        let vortex_array = ArrayRef::from_arrow(&arrow_array, true);
+        let vortex_array = ArrayRef::from_arrow(&arrow_array, true).unwrap();
         assert_eq!(vortex_array.len(), 5);
     }
 
@@ -1675,7 +1682,7 @@ mod tests {
 
         let record_batch = RecordBatch::try_new(schema, vec![field1_data, field2_data]).unwrap();
 
-        let vortex_array = ArrayRef::from_arrow(record_batch, false);
+        let vortex_array = ArrayRef::from_arrow(record_batch, false).unwrap();
         assert_eq!(vortex_array.len(), 4);
 
         // Test with reference
@@ -1689,7 +1696,7 @@ mod tests {
 
         let record_batch = RecordBatch::try_new(schema, vec![field1_data, field2_data]).unwrap();
 
-        let vortex_array = ArrayRef::from_arrow(&record_batch, false);
+        let vortex_array = ArrayRef::from_arrow(&record_batch, false).unwrap();
         assert_eq!(vortex_array.len(), 4);
     }
 
@@ -1698,17 +1705,17 @@ mod tests {
     fn test_dyn_array_conversion() {
         let int_array = Int32Array::from(vec![1, 2, 3, 4]);
         let dyn_array: &dyn ArrowArray = &int_array;
-        let vortex_array = ArrayRef::from_arrow(dyn_array, false);
+        let vortex_array = ArrayRef::from_arrow(dyn_array, false).unwrap();
         assert_eq!(vortex_array.len(), 4);
 
         let string_array = StringArray::from(vec!["a", "b", "c"]);
         let dyn_array: &dyn ArrowArray = &string_array;
-        let vortex_array = ArrayRef::from_arrow(dyn_array, false);
+        let vortex_array = ArrayRef::from_arrow(dyn_array, false).unwrap();
         assert_eq!(vortex_array.len(), 3);
 
         let bool_array = BooleanArray::from(vec![true, false, true]);
         let dyn_array: &dyn ArrowArray = &bool_array;
-        let vortex_array = ArrayRef::from_arrow(dyn_array, false);
+        let vortex_array = ArrayRef::from_arrow(dyn_array, false).unwrap();
         assert_eq!(vortex_array.len(), 3);
     }
 
@@ -1723,7 +1730,7 @@ mod tests {
             )])),
             1,
         );
-        ArrayRef::from_arrow(null_struct_array_with_non_nullable_field.as_ref(), true);
+        ArrayRef::from_arrow(null_struct_array_with_non_nullable_field.as_ref(), true).unwrap();
     }
 
     #[test]
@@ -1740,7 +1747,7 @@ mod tests {
             )])),
             1,
         );
-        ArrayRef::from_arrow(null_struct_array_with_non_nullable_field.as_ref(), true);
+        ArrayRef::from_arrow(null_struct_array_with_non_nullable_field.as_ref(), true).unwrap();
     }
 
     #[test]
@@ -1755,6 +1762,6 @@ mod tests {
             1,
         );
 
-        ArrayRef::from_arrow(null_struct_array_with_non_nullable_field.as_ref(), true);
+        ArrayRef::from_arrow(null_struct_array_with_non_nullable_field.as_ref(), true).unwrap();
     }
 }

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -159,7 +159,10 @@ impl_from_arrow_primitive!(Float32Type);
 impl_from_arrow_primitive!(Float64Type);
 
 impl FromArrowArray<&ArrowPrimitiveArray<Decimal32Type>> for ArrayRef {
-    fn from_arrow(array: &ArrowPrimitiveArray<Decimal32Type>, nullable: bool) -> VortexResult<Self> {
+    fn from_arrow(
+        array: &ArrowPrimitiveArray<Decimal32Type>,
+        nullable: bool,
+    ) -> VortexResult<Self> {
         let decimal_type = DecimalDType::new(array.precision(), array.scale());
         let buffer = Buffer::from_arrow_scalar_buffer(array.values().clone());
         let validity = nulls(array.nulls(), nullable);
@@ -168,7 +171,10 @@ impl FromArrowArray<&ArrowPrimitiveArray<Decimal32Type>> for ArrayRef {
 }
 
 impl FromArrowArray<&ArrowPrimitiveArray<Decimal64Type>> for ArrayRef {
-    fn from_arrow(array: &ArrowPrimitiveArray<Decimal64Type>, nullable: bool) -> VortexResult<Self> {
+    fn from_arrow(
+        array: &ArrowPrimitiveArray<Decimal64Type>,
+        nullable: bool,
+    ) -> VortexResult<Self> {
         let decimal_type = DecimalDType::new(array.precision(), array.scale());
         let buffer = Buffer::from_arrow_scalar_buffer(array.values().clone());
         let validity = nulls(array.nulls(), nullable);
@@ -177,7 +183,10 @@ impl FromArrowArray<&ArrowPrimitiveArray<Decimal64Type>> for ArrayRef {
 }
 
 impl FromArrowArray<&ArrowPrimitiveArray<Decimal128Type>> for ArrayRef {
-    fn from_arrow(array: &ArrowPrimitiveArray<Decimal128Type>, nullable: bool) -> VortexResult<Self> {
+    fn from_arrow(
+        array: &ArrowPrimitiveArray<Decimal128Type>,
+        nullable: bool,
+    ) -> VortexResult<Self> {
         let decimal_type = DecimalDType::new(array.precision(), array.scale());
         let buffer = Buffer::from_arrow_scalar_buffer(array.values().clone());
         let validity = nulls(array.nulls(), nullable);
@@ -186,7 +195,10 @@ impl FromArrowArray<&ArrowPrimitiveArray<Decimal128Type>> for ArrayRef {
 }
 
 impl FromArrowArray<&ArrowPrimitiveArray<Decimal256Type>> for ArrayRef {
-    fn from_arrow(array: &ArrowPrimitiveArray<Decimal256Type>, nullable: bool) -> VortexResult<Self> {
+    fn from_arrow(
+        array: &ArrowPrimitiveArray<Decimal256Type>,
+        nullable: bool,
+    ) -> VortexResult<Self> {
         let decimal_type = DecimalDType::new(array.precision(), array.scale());
         let buffer = Buffer::from_arrow_scalar_buffer(array.values().clone());
         // SAFETY: Our i256 implementation has the same bit-pattern representation of the
@@ -202,7 +214,10 @@ impl FromArrowArray<&ArrowPrimitiveArray<Decimal256Type>> for ArrayRef {
 macro_rules! impl_from_arrow_temporal {
     ($T:path) => {
         impl FromArrowArray<&ArrowPrimitiveArray<$T>> for ArrayRef {
-            fn from_arrow(value: &ArrowPrimitiveArray<$T>, nullable: bool) -> vortex_error::VortexResult<Self> {
+            fn from_arrow(
+                value: &ArrowPrimitiveArray<$T>,
+                nullable: bool,
+            ) -> vortex_error::VortexResult<Self> {
                 Ok(temporal_array(value, nullable))
             }
         }

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -70,6 +70,7 @@ use vortex_dtype::PType;
 use vortex_dtype::datetime::TimeUnit;
 use vortex_error::VortexExpect as _;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
 use vortex_scalar::i256;
 
@@ -605,9 +606,9 @@ impl FromArrowArray<&dyn ArrowArray> for ArrayRef {
                     nullable,
                 )?
                 .into_array()),
-                key_dt => vortex_panic!("Unsupported dictionary key type: {key_dt}"),
+                key_dt => vortex_bail!("Unsupported dictionary key type: {key_dt}"),
             },
-            dt => vortex_panic!("Array encoding not implemented for Arrow data type {dt}"),
+            dt => vortex_bail!("Array encoding not implemented for Arrow data type {dt}"),
         }
     }
 }

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -29,7 +29,7 @@ impl Datum {
     pub fn try_new(array: &dyn Array) -> VortexResult<Self> {
         if array.is::<ConstantVTable>() {
             Ok(Self {
-                array: array.slice(0..1).into_arrow_preferred()?,
+                array: array.slice(0..1)?.into_arrow_preferred()?,
                 is_scalar: true,
             })
         } else {
@@ -55,7 +55,7 @@ impl Datum {
     ) -> VortexResult<Self> {
         if array.is::<ConstantVTable>() {
             Ok(Self {
-                array: array.slice(0..1).into_arrow(target_datatype)?,
+                array: array.slice(0..1)?.into_arrow(target_datatype)?,
                 is_scalar: true,
             })
         } else {

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -84,13 +84,13 @@ impl ArrowDatum for Datum {
 /// # Error
 ///
 /// The provided array must have length
-pub fn from_arrow_array_with_len<A>(array: A, len: usize, nullable: bool) -> ArrayRef
+pub fn from_arrow_array_with_len<A>(array: A, len: usize, nullable: bool) -> VortexResult<ArrayRef>
 where
     ArrayRef: FromArrowArray<A>,
 {
-    let array = ArrayRef::from_arrow(array, nullable);
+    let array = ArrayRef::from_arrow(array, nullable)?;
     if array.len() == len {
-        return array;
+        return Ok(array);
     }
 
     if array.len() != 1 {
@@ -102,11 +102,11 @@ where
         );
     }
 
-    ConstantArray::new(
+    Ok(ConstantArray::new(
         array
             .scalar_at(0)
             .vortex_expect("array of length 1 must support scalar_at(0)"),
         len,
     )
-    .into_array()
+    .into_array())
 }

--- a/vortex-array/src/arrow/iter.rs
+++ b/vortex-array/src/arrow/iter.rs
@@ -35,7 +35,7 @@ impl Iterator for ArrowArrayStreamAdapter {
     fn next(&mut self) -> Option<Self::Item> {
         let batch = self.stream.next()?;
 
-        Some(batch.map_err(VortexError::from).map(|b| {
+        Some(batch.map_err(VortexError::from).and_then(|b| {
             debug_assert_eq!(&self.dtype, &DType::from_arrow(b.schema()));
             ArrayRef::from_arrow(b, false)
         }))

--- a/vortex-array/src/arrow/mod.rs
+++ b/vortex-array/src/arrow/mod.rs
@@ -25,7 +25,9 @@ use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 
 pub trait FromArrowArray<A> {
-    fn from_arrow(array: A, nullable: bool) -> Self;
+    fn from_arrow(array: A, nullable: bool) -> VortexResult<Self>
+    where
+        Self: Sized;
 }
 
 pub trait IntoArrowArray {

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -447,9 +447,9 @@ mod tests {
         assert_eq!(fsl.len(), 3);
 
         let fsl_array = fsl.to_fixed_size_list();
-        assert!(fsl_array.validity().is_valid(0));
-        assert!(!fsl_array.validity().is_valid(1));
-        assert!(fsl_array.validity().is_valid(2));
+        assert!(fsl_array.validity().is_valid(0).unwrap());
+        assert!(!fsl_array.validity().is_valid(1).unwrap());
+        assert!(fsl_array.validity().is_valid(2).unwrap());
     }
 
     #[test]
@@ -532,7 +532,7 @@ mod tests {
 
         // Check that all lists are null.
         for i in 0..3 {
-            assert!(!fsl_array.validity().is_valid(i));
+            assert!(!fsl_array.validity().is_valid(i).unwrap());
         }
     }
 
@@ -555,7 +555,7 @@ mod tests {
         assert_eq!(fsl_array.list_size(), 2);
 
         // Check that all lists are null.
-        assert!(!fsl_array.validity().is_valid(0));
+        assert!(!fsl_array.validity().is_valid(0).unwrap());
     }
 
     #[test]
@@ -624,12 +624,12 @@ mod tests {
         assert_eq!(fsl_array.elements().len(), 12);
 
         // Check validity pattern is repeated.
-        assert!(fsl_array.validity().is_valid(0));
-        assert!(!fsl_array.validity().is_valid(1));
-        assert!(fsl_array.validity().is_valid(2));
-        assert!(fsl_array.validity().is_valid(3));
-        assert!(!fsl_array.validity().is_valid(4));
-        assert!(fsl_array.validity().is_valid(5));
+        assert!(fsl_array.validity().is_valid(0).unwrap());
+        assert!(!fsl_array.validity().is_valid(1).unwrap());
+        assert!(fsl_array.validity().is_valid(2).unwrap());
+        assert!(fsl_array.validity().is_valid(3).unwrap());
+        assert!(!fsl_array.validity().is_valid(4).unwrap());
+        assert!(fsl_array.validity().is_valid(5).unwrap());
     }
 
     #[test]
@@ -664,11 +664,11 @@ mod tests {
         assert_eq!(fsl_array.elements().len(), 0);
 
         // Check validity pattern.
-        assert!(fsl_array.validity().is_valid(0));
-        assert!(!fsl_array.validity().is_valid(1));
-        assert!(fsl_array.validity().is_valid(2));
-        assert!(!fsl_array.validity().is_valid(3));
-        assert!(fsl_array.validity().is_valid(4));
+        assert!(fsl_array.validity().is_valid(0).unwrap());
+        assert!(!fsl_array.validity().is_valid(1).unwrap());
+        assert!(fsl_array.validity().is_valid(2).unwrap());
+        assert!(!fsl_array.validity().is_valid(3).unwrap());
+        assert!(fsl_array.validity().is_valid(4).unwrap());
     }
 
     #[test]
@@ -744,12 +744,12 @@ mod tests {
         assert_eq!(fsl_array.elements().len(), 12);
 
         // Check validity.
-        assert!(fsl_array.validity().is_valid(0)); // append_value
-        assert!(!fsl_array.validity().is_valid(1)); // append_null
-        assert!(fsl_array.validity().is_valid(2)); // append_zeros
-        assert!(fsl_array.validity().is_valid(3)); // append_zeros
-        assert!(!fsl_array.validity().is_valid(4)); // append_nulls
-        assert!(fsl_array.validity().is_valid(5)); // extend_from_array
+        assert!(fsl_array.validity().is_valid(0).unwrap()); // append_value
+        assert!(!fsl_array.validity().is_valid(1).unwrap()); // append_null
+        assert!(fsl_array.validity().is_valid(2).unwrap()); // append_zeros
+        assert!(fsl_array.validity().is_valid(3).unwrap()); // append_zeros
+        assert!(!fsl_array.validity().is_valid(4).unwrap()); // append_nulls
+        assert!(fsl_array.validity().is_valid(5).unwrap()); // extend_from_array
     }
 
     #[test]
@@ -792,9 +792,9 @@ mod tests {
         }
 
         // Check validity - first two should be valid, third should be null.
-        assert!(array.validity().is_valid(0));
-        assert!(array.validity().is_valid(1));
-        assert!(!array.validity().is_valid(2));
+        assert!(array.validity().is_valid(0).unwrap());
+        assert!(array.validity().is_valid(1).unwrap());
+        assert!(!array.validity().is_valid(2).unwrap());
 
         // Test wrong dtype error.
         let mut builder = FixedSizeListBuilder::with_capacity(dtype, 2, NonNullable, 10);

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -255,7 +255,9 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
                 let size: usize = new_sizes[i].as_();
 
                 if size > 0 {
-                    let list_elements = new_elements.slice(offset..offset + size);
+                    let list_elements = new_elements
+                        .slice(offset..offset + size)
+                        .vortex_expect("list builder slice");
                     builder.elements_builder.extend_from_array(&list_elements);
                     curr_offset += size;
                 }
@@ -365,8 +367,8 @@ mod tests {
 
         let list_array = list.to_listview();
 
-        assert_eq!(list_array.list_elements_at(0).len(), 3);
-        assert_eq!(list_array.list_elements_at(1).len(), 3);
+        assert_eq!(list_array.list_elements_at(0).unwrap().len(), 3);
+        assert_eq!(list_array.list_elements_at(1).unwrap().len(), 3);
     }
 
     #[test]
@@ -417,9 +419,9 @@ mod tests {
 
         let list_array = list.to_listview();
 
-        assert_eq!(list_array.list_elements_at(0).len(), 3);
-        assert_eq!(list_array.list_elements_at(1).len(), 0);
-        assert_eq!(list_array.list_elements_at(2).len(), 3);
+        assert_eq!(list_array.list_elements_at(0).unwrap().len(), 3);
+        assert_eq!(list_array.list_elements_at(1).unwrap().len(), 0);
+        assert_eq!(list_array.list_elements_at(2).unwrap().len(), 3);
     }
 
     fn test_extend_builder_gen<O: IntegerPType>() {
@@ -434,8 +436,8 @@ mod tests {
 
         builder.extend_from_array(&list);
         builder.extend_from_array(&list);
-        builder.extend_from_array(&list.slice(0..0));
-        builder.extend_from_array(&list.slice(1..3));
+        builder.extend_from_array(&list.slice(0..0).unwrap());
+        builder.extend_from_array(&list.slice(1..3).unwrap());
 
         let expected = ListArray::from_iter_opt_slow::<O, _, _>(
             [

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -559,9 +559,9 @@ mod tests {
         assert!(list2.is_null()); // This should be null.
 
         // Check validity.
-        assert!(array.validity().is_valid(0));
-        assert!(array.validity().is_valid(1));
-        assert!(!array.validity().is_valid(2));
+        assert!(array.validity().is_valid(0).unwrap());
+        assert!(array.validity().is_valid(1).unwrap());
+        assert!(!array.validity().is_valid(2).unwrap());
 
         // Test wrong dtype error.
         let mut builder = ListBuilder::<u64>::with_capacity(dtype, NonNullable, 20, 10);

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -486,19 +486,19 @@ mod tests {
 
         // Check first list: [1, 2, 3].
         assert_arrays_eq!(
-            listview.list_elements_at(0),
+            listview.list_elements_at(0).unwrap(),
             PrimitiveArray::from_iter([1i32, 2, 3])
         );
 
         // Check empty list.
-        assert_eq!(listview.list_elements_at(1).len(), 0);
+        assert_eq!(listview.list_elements_at(1).unwrap().len(), 0);
 
         // Check null list.
         assert!(!listview.validity().is_valid(2).unwrap());
 
         // Check last list: [4, 5].
         assert_arrays_eq!(
-            listview.list_elements_at(3),
+            listview.list_elements_at(3).unwrap(),
             PrimitiveArray::from_iter([4i32, 5])
         );
     }
@@ -532,13 +532,13 @@ mod tests {
 
         // Verify first list: [1, 2].
         assert_arrays_eq!(
-            listview.list_elements_at(0),
+            listview.list_elements_at(0).unwrap(),
             PrimitiveArray::from_iter([1i32, 2])
         );
 
         // Verify second list: [3, 4, 5].
         assert_arrays_eq!(
-            listview.list_elements_at(1),
+            listview.list_elements_at(1).unwrap(),
             PrimitiveArray::from_iter([3i32, 4, 5])
         );
 
@@ -561,7 +561,7 @@ mod tests {
         // Verify the values: [0], [10], [20], [30], [40].
         for i in 0..5i32 {
             assert_arrays_eq!(
-                listview2.list_elements_at(i as usize),
+                listview2.list_elements_at(i as usize).unwrap(),
                 PrimitiveArray::from_iter([i * 10])
             );
         }
@@ -591,8 +591,8 @@ mod tests {
         assert_eq!(listview.len(), 5);
 
         // First two are empty lists (from append_zeros).
-        assert_eq!(listview.list_elements_at(0).len(), 0);
-        assert_eq!(listview.list_elements_at(1).len(), 0);
+        assert_eq!(listview.list_elements_at(0).unwrap().len(), 0);
+        assert_eq!(listview.list_elements_at(1).unwrap().len(), 0);
 
         // Next two are nulls.
         assert!(!listview.validity().is_valid(2).unwrap());
@@ -600,7 +600,7 @@ mod tests {
 
         // Last is the regular list: [10, 20].
         assert_arrays_eq!(
-            listview.list_elements_at(4),
+            listview.list_elements_at(4).unwrap(),
             PrimitiveArray::from_iter([10i32, 20])
         );
     }
@@ -640,13 +640,13 @@ mod tests {
         // Check the extended data.
         // First list: [0] (initial data).
         assert_arrays_eq!(
-            listview.list_elements_at(0),
+            listview.list_elements_at(0).unwrap(),
             PrimitiveArray::from_iter([0i32])
         );
 
         // Second list: [1, 2, 3] (from source).
         assert_arrays_eq!(
-            listview.list_elements_at(1),
+            listview.list_elements_at(1).unwrap(),
             PrimitiveArray::from_iter([1i32, 2, 3])
         );
 
@@ -655,7 +655,7 @@ mod tests {
 
         // Fourth list: [4, 5] (from source).
         assert_arrays_eq!(
-            listview.list_elements_at(3),
+            listview.list_elements_at(3).unwrap(),
             PrimitiveArray::from_iter([4i32, 5])
         );
     }

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -494,7 +494,7 @@ mod tests {
         assert_eq!(listview.list_elements_at(1).len(), 0);
 
         // Check null list.
-        assert!(!listview.validity().is_valid(2));
+        assert!(!listview.validity().is_valid(2).unwrap());
 
         // Check last list: [4, 5].
         assert_arrays_eq!(
@@ -595,8 +595,8 @@ mod tests {
         assert_eq!(listview.list_elements_at(1).len(), 0);
 
         // Next two are nulls.
-        assert!(!listview.validity().is_valid(2));
-        assert!(!listview.validity().is_valid(3));
+        assert!(!listview.validity().is_valid(2).unwrap());
+        assert!(!listview.validity().is_valid(3).unwrap());
 
         // Last is the regular list: [10, 20].
         assert_arrays_eq!(
@@ -651,7 +651,7 @@ mod tests {
         );
 
         // Third list: null (from source).
-        assert!(!listview.validity().is_valid(2));
+        assert!(!listview.validity().is_valid(2).unwrap());
 
         // Fourth list: [4, 5] (from source).
         assert_arrays_eq!(

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -611,9 +611,9 @@ mod tests {
 
         // Check validity - first two should be valid, third should be null.
         use crate::vtable::ValidityHelper;
-        assert!(array.validity().is_valid(0));
-        assert!(array.validity().is_valid(1));
-        assert!(!array.validity().is_valid(2));
+        assert!(array.validity().is_valid(0).unwrap());
+        assert!(array.validity().is_valid(1).unwrap());
+        assert!(!array.validity().is_valid(2).unwrap());
 
         // Test wrong dtype error.
         let mut builder = PrimitiveBuilder::<i32>::with_capacity(Nullability::NonNullable, 10);

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -899,10 +899,10 @@ mod tests {
         assert_eq!(builder.completed_block_count(), 1);
 
         array
-            .slice(1..2)
+            .slice(1..2)?
             .append_to_builder(&mut builder, &mut ctx)?;
         array
-            .slice(0..1)
+            .slice(0..1)?
             .append_to_builder(&mut builder, &mut ctx)?;
         assert_eq!(builder.completed_block_count(), 1);
 
@@ -917,10 +917,10 @@ mod tests {
         assert_eq!(builder.completed_block_count(), 2);
 
         array
-            .slice(0..1)
+            .slice(0..1)?
             .append_to_builder(&mut builder, &mut ctx)?;
         array2
-            .slice(0..1)
+            .slice(0..1)?
             .append_to_builder(&mut builder, &mut ctx)?;
         assert_eq!(builder.completed_block_count(), 2);
         Ok(())

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -575,7 +575,7 @@ mod test {
             nulls.finish(),
         );
 
-        let vortex_struct = ArrayRef::from_arrow(&arrow_struct, true);
+        let vortex_struct = ArrayRef::from_arrow(&arrow_struct, true).unwrap();
 
         assert_eq!(
             &arrow_struct,
@@ -599,7 +599,7 @@ mod test {
         );
         let list_data_type = arrow_list.data_type();
 
-        let vortex_list = ArrayRef::from_arrow(&arrow_list, true);
+        let vortex_list = ArrayRef::from_arrow(&arrow_list, true).unwrap();
 
         let rt_arrow_list = vortex_list.into_arrow(list_data_type).unwrap();
 

--- a/vortex-array/src/compute/boolean.rs
+++ b/vortex-array/src/compute/boolean.rs
@@ -317,7 +317,7 @@ pub(crate) fn arrow_boolean(
         BooleanOperator::OrKleene => arrow_arith::boolean::or_kleene(&lhs, &rhs)?,
     };
 
-    Ok(ArrayRef::from_arrow(&array, nullable))
+    ArrayRef::from_arrow(&array, nullable)
 }
 
 #[cfg(test)]

--- a/vortex-array/src/compute/compare.rs
+++ b/vortex-array/src/compute/compare.rs
@@ -392,7 +392,7 @@ fn arrow_compare(
             Operator::Lte => cmp::lt_eq(&lhs, &rhs)?,
         }
     };
-    Ok(from_arrow_array_with_len(&array, left.len(), nullable))
+    from_arrow_array_with_len(&array, left.len(), nullable)
 }
 
 pub fn scalar_cmp(lhs: &Scalar, rhs: &Scalar, operator: Operator) -> Scalar {

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -302,7 +302,9 @@ fn test_slice_filter_consistency(array: &dyn Array) {
     let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
 
     // Slice should produce the same result
-    let sliced = array.slice(1..4.min(len));
+    let sliced = array
+        .slice(1..4.min(len))
+        .vortex_expect("slice should succeed in conformance test");
 
     assert_eq!(
         filtered.len(),
@@ -353,7 +355,9 @@ fn test_take_slice_consistency(array: &dyn Array) {
     let taken = take(array, &indices).vortex_expect("take should succeed in conformance test");
 
     // Slice from 1 to end
-    let sliced = array.slice(1..end);
+    let sliced = array
+        .slice(1..end)
+        .vortex_expect("slice should succeed in conformance test");
 
     assert_eq!(
         taken.len(),
@@ -500,7 +504,9 @@ fn test_empty_operations_consistency(array: &dyn Array) {
 
     // Empty slice (if array is non-empty)
     if len > 0 {
-        let empty_slice = array.slice(0..0);
+        let empty_slice = array
+            .slice(0..0)
+            .vortex_expect("slice should succeed in conformance test");
         assert_eq!(empty_slice.len(), 0);
         assert_eq!(empty_slice.dtype(), array.dtype());
     }
@@ -953,9 +959,14 @@ fn test_slice_aggregate_consistency(array: &dyn Array) {
     let end = (len - 1).min(start + 10); // Take up to 10 elements
 
     // Get sliced array and canonical slice
-    let sliced = array.slice(start..end);
+    let sliced = array
+        .slice(start..end)
+        .vortex_expect("slice should succeed in conformance test");
     let canonical = array.to_canonical().vortex_expect("to_canonical failed");
-    let canonical_sliced = canonical.as_ref().slice(start..end);
+    let canonical_sliced = canonical
+        .as_ref()
+        .slice(start..end)
+        .vortex_expect("slice should succeed in conformance test");
 
     // Test null count through invalid_count
     let sliced_invalid_count = sliced
@@ -1164,7 +1175,9 @@ fn test_cast_slice_consistency(array: &dyn Array) {
     // Test each target dtype
     for target_dtype in target_dtypes {
         // Slice the array
-        let sliced = array.slice(start..end);
+        let sliced = array
+            .slice(start..end)
+            .vortex_expect("slice should succeed in conformance test");
 
         // Try to cast the sliced array
         let slice_then_cast = match cast(&sliced, &target_dtype) {
@@ -1219,7 +1232,9 @@ fn test_cast_slice_consistency(array: &dyn Array) {
             Ok(result) => result,
             Err(_) => continue, // Skip if cast fails
         };
-        let cast_then_slice = casted.slice(start..end);
+        let cast_then_slice = casted
+            .slice(start..end)
+            .vortex_expect("slice should succeed in conformance test");
 
         // Verify the two approaches produce identical results
         assert_eq!(

--- a/vortex-array/src/compute/conformance/search_sorted.rs
+++ b/vortex-array/src/compute/conformance/search_sorted.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#![allow(clippy::unwrap_used)]
+
 pub use rstest::rstest;
 pub use rstest_reuse;
 use rstest_reuse::template;

--- a/vortex-array/src/compute/conformance/search_sorted.rs
+++ b/vortex-array/src/compute/conformance/search_sorted.rs
@@ -19,73 +19,97 @@ pub fn all_null() -> ArrayRef {
 
 pub fn sparse_high_null_fill() -> ArrayRef {
     PrimitiveArray::new(buffer![0; 20], Validity::AllInvalid)
-        .patch(&Patches::new(
-            20,
-            0,
-            buffer![17u64, 18, 19].into_array(),
-            PrimitiveArray::new(buffer![33_i32, 44, 55], Validity::AllValid).into_array(),
-            None,
-        ))
+        .patch(
+            &Patches::new(
+                20,
+                0,
+                buffer![17u64, 18, 19].into_array(),
+                PrimitiveArray::new(buffer![33_i32, 44, 55], Validity::AllValid).into_array(),
+                None,
+            )
+            .unwrap(),
+        )
+        .unwrap()
         .into_array()
 }
 
 pub fn sparse_high_non_null_fill() -> ArrayRef {
     PrimitiveArray::new(buffer![22; 20], Validity::NonNullable)
-        .patch(&Patches::new(
-            20,
-            0,
-            buffer![17u64, 18, 19].into_array(),
-            buffer![33_i32, 44, 55].into_array(),
-            None,
-        ))
+        .patch(
+            &Patches::new(
+                20,
+                0,
+                buffer![17u64, 18, 19].into_array(),
+                buffer![33_i32, 44, 55].into_array(),
+                None,
+            )
+            .unwrap(),
+        )
+        .unwrap()
         .into_array()
 }
 
 pub fn sparse_low() -> ArrayRef {
     PrimitiveArray::new(buffer![60; 20], Validity::NonNullable)
-        .patch(&Patches::new(
-            20,
-            0,
-            buffer![0u64, 1, 2].into_array(),
-            buffer![33i32, 44, 55].into_array(),
-            None,
-        ))
+        .patch(
+            &Patches::new(
+                20,
+                0,
+                buffer![0u64, 1, 2].into_array(),
+                buffer![33i32, 44, 55].into_array(),
+                None,
+            )
+            .unwrap(),
+        )
+        .unwrap()
         .into_array()
 }
 
 pub fn sparse_low_high() -> ArrayRef {
     PrimitiveArray::new(buffer![30; 20], Validity::NonNullable)
-        .patch(&Patches::new(
-            20,
-            0,
-            buffer![0u64, 1, 17, 18, 19].into_array(),
-            buffer![11i32, 22, 33, 44, 55].into_array(),
-            None,
-        ))
+        .patch(
+            &Patches::new(
+                20,
+                0,
+                buffer![0u64, 1, 17, 18, 19].into_array(),
+                buffer![11i32, 22, 33, 44, 55].into_array(),
+                None,
+            )
+            .unwrap(),
+        )
+        .unwrap()
         .into_array()
 }
 
 pub fn sparse_edge_patch_high() -> ArrayRef {
     PrimitiveArray::new(buffer![33; 20], Validity::NonNullable)
-        .patch(&Patches::new(
-            20,
-            0,
-            buffer![0u64, 1, 2, 19].into_array(),
-            buffer![11i32, 22, 23, 55].into_array(),
-            None,
-        ))
+        .patch(
+            &Patches::new(
+                20,
+                0,
+                buffer![0u64, 1, 2, 19].into_array(),
+                buffer![11i32, 22, 23, 55].into_array(),
+                None,
+            )
+            .unwrap(),
+        )
+        .unwrap()
         .into_array()
 }
 
 pub fn sparse_edge_patch_low() -> ArrayRef {
     PrimitiveArray::new(buffer![22; 20], Validity::NonNullable)
-        .patch(&Patches::new(
-            20,
-            0,
-            buffer![0u64, 17, 18, 19].into_array(),
-            buffer![11i32, 33, 44, 55].into_array(),
-            None,
-        ))
+        .patch(
+            &Patches::new(
+                20,
+                0,
+                buffer![0u64, 17, 18, 19].into_array(),
+                buffer![11i32, 33, 44, 55].into_array(),
+                None,
+            )
+            .unwrap(),
+        )
+        .unwrap()
         .into_array()
 }
 

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -255,10 +255,7 @@ pub fn arrow_filter_fn(array: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef>
     let mask_array = BooleanArray::new(values.bit_buffer().clone().into(), None);
     let filtered = arrow_select::filter::filter(array_ref.as_ref(), &mask_array)?;
 
-    ArrayRef::from_arrow(
-        filtered.as_ref(),
-        array.dtype().is_nullable(),
-    )
+    ArrayRef::from_arrow(filtered.as_ref(), array.dtype().is_nullable())
 }
 
 #[cfg(test)]

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -255,10 +255,10 @@ pub fn arrow_filter_fn(array: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef>
     let mask_array = BooleanArray::new(values.bit_buffer().clone().into(), None);
     let filtered = arrow_select::filter::filter(array_ref.as_ref(), &mask_array)?;
 
-    Ok(ArrayRef::from_arrow(
+    ArrayRef::from_arrow(
         filtered.as_ref(),
         array.dtype().is_nullable(),
-    ))
+    )
 }
 
 #[cfg(test)]

--- a/vortex-array/src/compute/like.rs
+++ b/vortex-array/src/compute/like.rs
@@ -230,5 +230,5 @@ pub(crate) fn arrow_like(
         (true, true) => arrow_string::like::nilike(&lhs, &rhs)?,
     };
 
-    Ok(from_arrow_array_with_len(&result, len, nullable))
+    from_arrow_array_with_len(&result, len, nullable)
 }

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -259,7 +259,7 @@ fn list_contains_scalar(
 ) -> VortexResult<ArrayRef> {
     // If the list array is constant, we perform a single comparison.
     if array.len() > 1 && array.is::<ConstantVTable>() {
-        let contains = list_contains_scalar(&array.slice(0..1), value, nullability)?;
+        let contains = list_contains_scalar(&array.slice(0..1)?, value, nullability)?;
         return Ok(ConstantArray::new(contains.scalar_at(0)?, array.len()).into_array());
     }
 

--- a/vortex-array/src/compute/mask.rs
+++ b/vortex-array/src/compute/mask.rs
@@ -151,7 +151,7 @@ impl ComputeFnVTable for MaskFn {
 
         let masked = arrow_select::nullif::nullif(array_ref.as_ref(), &mask)?;
 
-        Ok(ArrayRef::from_arrow(masked.as_ref(), true).into())
+        Ok(ArrayRef::from_arrow(masked.as_ref(), true)?.into())
     }
 
     fn return_dtype(&self, args: &InvocationArgs) -> VortexResult<DType> {

--- a/vortex-array/src/compute/mask.rs
+++ b/vortex-array/src/compute/mask.rs
@@ -60,11 +60,11 @@ pub(crate) fn warm_up_vtable() -> usize {
 ///
 /// let masked = mask(array.as_ref(), &mask_array)?;
 /// assert_eq!(masked.len(), 5);
-/// assert!(!masked.is_valid(0)?);
-/// assert!(!masked.is_valid(1)?);
+/// assert!(!masked.is_valid(0).unwrap());
+/// assert!(!masked.is_valid(1).unwrap());
 /// assert_eq!(masked.scalar_at(2)?, Scalar::from(Some(1)));
-/// assert!(!masked.is_valid(3)?);
-/// assert!(!masked.is_valid(4)?);
+/// assert!(!masked.is_valid(3).unwrap());
+/// assert!(!masked.is_valid(4).unwrap());
 /// # Ok(())
 /// # }
 /// ```

--- a/vortex-array/src/compute/numeric.rs
+++ b/vortex-array/src/compute/numeric.rs
@@ -277,7 +277,7 @@ fn arrow_numeric(
         NumericOperator::RDiv => arrow_arith::numeric::div(&right, &left)?,
     };
 
-    Ok(from_arrow_array_with_len(array.as_ref(), len, nullable))
+    from_arrow_array_with_len(array.as_ref(), len, nullable)
 }
 
 #[cfg(test)]

--- a/vortex-array/src/compute/zip.rs
+++ b/vortex-array/src/compute/zip.rs
@@ -228,11 +228,11 @@ fn zip_impl_with_builder(
         AllOr::None => Ok(if_false.to_array()),
         AllOr::Some(slices) => {
             for (start, end) in slices {
-                builder.extend_from_array(&if_false.slice(builder.len()..*start));
-                builder.extend_from_array(&if_true.slice(*start..*end));
+                builder.extend_from_array(&if_false.slice(builder.len()..*start)?);
+                builder.extend_from_array(&if_true.slice(*start..*end)?);
             }
             if builder.len() < if_false.len() {
-                builder.extend_from_array(&if_false.slice(builder.len()..if_false.len()));
+                builder.extend_from_array(&if_false.slice(builder.len()..if_false.len())?);
             }
             Ok(builder.finish())
         }

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -21,11 +21,10 @@ use vortex_dtype::match_each_integer_ptype;
 use vortex_dtype::match_each_native_ptype;
 use vortex_dtype::match_each_unsigned_integer_ptype;
 use vortex_error::VortexError;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
-use vortex_error::vortex_panic;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
 use vortex_mask::MaskMut;
@@ -91,8 +90,8 @@ impl PatchesMetadata {
     }
 
     #[inline]
-    pub fn len(&self) -> usize {
-        usize::try_from(self.len).vortex_expect("len is a valid usize")
+    pub fn len(&self) -> VortexResult<usize> {
+        usize::try_from(self.len).map_err(|_| vortex_err!("len does not fit in usize"))
     }
 
     #[inline]
@@ -101,28 +100,31 @@ impl PatchesMetadata {
     }
 
     #[inline]
-    pub fn offset(&self) -> usize {
-        usize::try_from(self.offset).vortex_expect("offset is a valid usize")
+    pub fn offset(&self) -> VortexResult<usize> {
+        usize::try_from(self.offset).map_err(|_| vortex_err!("offset does not fit in usize"))
     }
 
     #[inline]
-    pub fn chunk_offsets_dtype(&self) -> Option<DType> {
+    pub fn chunk_offsets_dtype(&self) -> VortexResult<Option<DType>> {
         self.chunk_offsets_ptype
             .map(|t| {
                 PType::try_from(t)
                     .map_err(|e| vortex_err!("invalid i32 value {t} for PType: {}", e))
-                    .vortex_expect("invalid i32 value for PType")
+                    .map(|ptype| DType::Primitive(ptype, NonNullable))
             })
-            .map(|ptype| DType::Primitive(ptype, NonNullable))
+            .transpose()
     }
 
     #[inline]
-    pub fn indices_dtype(&self) -> DType {
-        assert!(
-            self.indices_ptype().is_unsigned_int(),
+    pub fn indices_dtype(&self) -> VortexResult<DType> {
+        let ptype = PType::try_from(self.indices_ptype).map_err(|e| {
+            vortex_err!("invalid i32 value {} for PType: {}", self.indices_ptype, e)
+        })?;
+        vortex_ensure!(
+            ptype.is_unsigned_int(),
             "Patch indices must be unsigned integers"
         );
-        DType::Primitive(self.indices_ptype(), NonNullable)
+        Ok(DType::Primitive(ptype, NonNullable))
     }
 }
 
@@ -159,29 +161,25 @@ impl Patches {
         indices: ArrayRef,
         values: ArrayRef,
         chunk_offsets: Option<ArrayRef>,
-    ) -> Self {
-        assert_eq!(
-            indices.len(),
-            values.len(),
+    ) -> VortexResult<Self> {
+        vortex_ensure!(
+            indices.len() == values.len(),
             "Patch indices and values must have the same length"
         );
-        assert!(
+        vortex_ensure!(
             indices.dtype().is_unsigned_int() && !indices.dtype().is_nullable(),
             "Patch indices must be non-nullable unsigned integers, got {:?}",
             indices.dtype()
         );
-        assert!(
+        vortex_ensure!(
             indices.len() <= array_len,
             "Patch indices must be shorter than the array length"
         );
-        assert!(!indices.is_empty(), "Patch indices must not be empty");
-        let max = usize::try_from(
-            &indices
-                .scalar_at(indices.len() - 1)
-                .vortex_expect("indices must support scalar_at"),
-        )
-        .vortex_expect("indices must be a number");
-        assert!(
+        vortex_ensure!(!indices.is_empty(), "Patch indices must not be empty");
+
+        let max = usize::try_from(&indices.scalar_at(indices.len() - 1)?)
+            .map_err(|_| vortex_err!("indices must be a number"))?;
+        vortex_ensure!(
             max - offset < array_len,
             "Patch indices {max:?}, offset {offset} are longer than the array length {array_len}"
         );
@@ -193,7 +191,7 @@ impl Patches {
             "Patch indices must be sorted"
         );
 
-        Self {
+        Ok(Self {
             array_len,
             offset,
             indices,
@@ -201,7 +199,7 @@ impl Patches {
             chunk_offsets: chunk_offsets.clone(),
             // Initialize with `Some(0)` only if `chunk_offsets` are set.
             offset_within_chunk: chunk_offsets.map(|_| 0),
-        }
+        })
     }
 
     /// Construct new patches without validating any of the arguments
@@ -288,17 +286,16 @@ impl Patches {
     }
 
     #[inline]
-    pub fn chunk_offset_at(&self, idx: usize) -> usize {
+    pub fn chunk_offset_at(&self, idx: usize) -> VortexResult<usize> {
         let Some(chunk_offsets) = &self.chunk_offsets else {
-            vortex_panic!("chunk_offsets must be set to retrieve offset at index")
+            vortex_bail!("chunk_offsets must be set to retrieve offset at index")
         };
 
         chunk_offsets
-            .scalar_at(idx)
-            .vortex_expect("chunk_offsets must support scalar_at")
+            .scalar_at(idx)?
             .as_primitive()
             .as_::<usize>()
-            .vortex_expect("chunk offset must be usize")
+            .ok_or_else(|| vortex_err!("chunk offset does not fit in usize"))
     }
 
     /// Returns the number of patches sliced off from the current first chunk.
@@ -315,8 +312,9 @@ impl Patches {
     }
 
     #[inline]
-    pub fn indices_ptype(&self) -> PType {
-        PType::try_from(self.indices.dtype()).vortex_expect("primitive indices")
+    pub fn indices_ptype(&self) -> VortexResult<PType> {
+        PType::try_from(self.indices.dtype())
+            .map_err(|_| vortex_err!("indices dtype is not primitive"))
     }
 
     pub fn to_metadata(&self, len: usize, dtype: &DType) -> VortexResult<PatchesMetadata> {
@@ -431,15 +429,14 @@ impl Patches {
     /// Returns a [`SearchResult`] indicating either the exact patch index if found,
     /// or the insertion point if not found.
     ///
-    /// # Panics
-    /// Panics if `chunk_offsets` or `offset_within_chunk` are not set.
+    /// Returns an error if `chunk_offsets` or `offset_within_chunk` are not set.
     fn search_index_chunked(&self, index: usize) -> VortexResult<SearchResult> {
         let Some(chunk_offsets) = &self.chunk_offsets else {
-            vortex_panic!("chunk_offsets is required to be set")
+            vortex_bail!("chunk_offsets is required to be set")
         };
 
         let Some(offset_within_chunk) = self.offset_within_chunk else {
-            vortex_panic!("offset_within_chunk is required to be set")
+            vortex_bail!("offset_within_chunk is required to be set")
         };
 
         if index >= self.array_len() {
@@ -449,9 +446,9 @@ impl Patches {
         let chunk_idx = (index + self.offset % PATCH_CHUNK_SIZE) / PATCH_CHUNK_SIZE;
 
         // Patch index offsets are absolute and need to be offset by the first chunk of the current slice.
-        let base_offset = self.chunk_offset_at(0);
+        let base_offset = self.chunk_offset_at(0)?;
 
-        let patches_start_idx = (self.chunk_offset_at(chunk_idx) - base_offset)
+        let patches_start_idx = (self.chunk_offset_at(chunk_idx)? - base_offset)
             // Chunk offsets are only sliced off in case the slice is fully
             // outside of the chunk range.
             //
@@ -461,7 +458,7 @@ impl Patches {
             .saturating_sub(offset_within_chunk);
 
         let patches_end_idx = if chunk_idx < chunk_offsets.len() - 1 {
-            self.chunk_offset_at(chunk_idx + 1) - base_offset - offset_within_chunk
+            self.chunk_offset_at(chunk_idx + 1)? - base_offset - offset_within_chunk
         } else {
             self.indices.len()
         };
@@ -493,7 +490,7 @@ impl Patches {
         usize: TryFrom<O>,
     {
         let Some(offset_within_chunk) = self.offset_within_chunk else {
-            vortex_panic!("offset_within_chunk is required to be set")
+            vortex_bail!("offset_within_chunk is required to be set")
         };
 
         let chunk_idx = {
@@ -510,9 +507,8 @@ impl Patches {
         };
 
         // Patch index offsets are absolute and need to be offset by the first chunk of the current slice.
-        let Ok(chunk_offset) = usize::try_from(chunk_offsets[chunk_idx] - chunk_offsets[0]) else {
-            vortex_panic!("chunk_offset failed to convert to usize")
-        };
+        let chunk_offset = usize::try_from(chunk_offsets[chunk_idx] - chunk_offsets[0])
+            .map_err(|_| vortex_err!("chunk_offset failed to convert to usize"))?;
 
         let patches_start_idx = chunk_offset
             // Chunk offsets are only sliced off in case the slice is fully
@@ -526,17 +522,11 @@ impl Patches {
         let patches_end_idx = if chunk_idx < chunk_offsets.len() - 1 {
             let base_offset_end = chunk_offsets[chunk_idx + 1];
 
-            let Some(offset_within_chunk) = O::from(offset_within_chunk) else {
-                vortex_panic!("offset_within_chunk failed to convert to O");
-            };
+            let offset_within_chunk = O::from(offset_within_chunk)
+                .ok_or_else(|| vortex_err!("offset_within_chunk failed to convert to O"))?;
 
-            let Ok(patches_end_idx) =
-                usize::try_from(base_offset_end - chunk_offsets[0] - offset_within_chunk)
-            else {
-                vortex_panic!("patches_end_idx failed to convert to usize")
-            };
-
-            patches_end_idx
+            usize::try_from(base_offset_end - chunk_offsets[0] - offset_within_chunk)
+                .map_err(|_| vortex_err!("patches_end_idx failed to convert to usize"))?
         } else {
             self.indices.len()
         };
@@ -556,27 +546,25 @@ impl Patches {
     }
 
     /// Returns the minimum patch index
-    pub fn min_index(&self) -> usize {
+    pub fn min_index(&self) -> VortexResult<usize> {
         let first = self
             .indices
-            .scalar_at(0)
-            .vortex_expect("indices must support scalar_at")
+            .scalar_at(0)?
             .as_primitive()
             .as_::<usize>()
-            .vortex_expect("non-null");
-        first - self.offset
+            .ok_or_else(|| vortex_err!("index does not fit in usize"))?;
+        Ok(first - self.offset)
     }
 
     /// Returns the maximum patch index
-    pub fn max_index(&self) -> usize {
+    pub fn max_index(&self) -> VortexResult<usize> {
         let last = self
             .indices
-            .scalar_at(self.indices.len() - 1)
-            .vortex_expect("indices must support scalar_at")
+            .scalar_at(self.indices.len() - 1)?
             .as_primitive()
             .as_::<usize>()
-            .vortex_expect("non-null");
-        last - self.offset
+            .ok_or_else(|| vortex_err!("index does not fit in usize"))?;
+        Ok(last - self.offset)
     }
 
     /// Filter the patches by a mask, resulting in new patches for the filtered array.
@@ -672,15 +660,17 @@ impl Patches {
             chunk_offsets.slice(chunk_start_idx..chunk_end_idx)
         });
 
-        let offset_within_chunk = chunk_offsets.as_ref().map(|chunk_offsets| {
-            let base_offset = chunk_offsets
-                .scalar_at(0)
-                .vortex_expect("chunk_offsets must support scalar_at")
-                .as_primitive()
-                .as_::<usize>()
-                .vortex_expect("chunk offset must be usize");
-            slice_start_idx - base_offset
-        });
+        let offset_within_chunk = chunk_offsets
+            .as_ref()
+            .map(|chunk_offsets| -> VortexResult<usize> {
+                let base_offset = chunk_offsets
+                    .scalar_at(0)?
+                    .as_primitive()
+                    .as_::<usize>()
+                    .ok_or_else(|| vortex_err!("chunk offset does not fit in usize"))?;
+                Ok(slice_start_idx - base_offset)
+            })
+            .transpose()?;
 
         Ok(Some(Self {
             array_len: range.len(),
@@ -817,6 +807,9 @@ impl Patches {
         let indices = self.indices.to_primitive();
         let new_length = take_indices.len();
 
+        let min_index = self.min_index()?;
+        let max_index = self.max_index()?;
+
         let Some((new_sparse_indices, value_indices)) =
             match_each_unsigned_integer_ptype!(indices.ptype(), |Indices| {
                 match_each_integer_ptype!(take_indices.ptype(), |TakeIndices| {
@@ -824,8 +817,8 @@ impl Patches {
                         indices.as_slice::<Indices>(),
                         take_indices,
                         self.offset(),
-                        self.min_index(),
-                        self.max_index(),
+                        min_index,
+                        max_index,
                         include_nulls,
                     )?
                 })
@@ -1014,7 +1007,9 @@ where
     usize: TryFrom<T>,
     VortexError: From<<I as TryFrom<usize>>::Error>,
 {
+    let take_indices_len = take_indices.len();
     let take_indices_validity = take_indices.validity();
+    let take_indices_validity_mask = take_indices_validity.to_mask(take_indices_len);
     let take_indices = take_indices.as_slice::<T>();
     let offset_i = I::try_from(indices_offset)?;
 
@@ -1026,30 +1021,31 @@ where
         .map(|(value_index, sparse_index)| (sparse_index, value_index))
         .collect();
 
-    let (new_sparse_indices, value_indices): (BufferMut<u64>, BufferMut<u64>) = take_indices
-        .iter()
-        .copied()
-        .map(usize::try_from)
-        .process_results(|iter| {
-            iter.enumerate()
-                .filter_map(|(idx_in_take, ti)| {
-                    // If we have to take nulls the take index doesn't matter, make it 0 for consistency
-                    if include_nulls && take_indices_validity.is_null(idx_in_take) {
-                        Some((idx_in_take as u64, 0))
-                    } else if ti < min_index || ti > max_index {
-                        None
-                    } else {
-                        sparse_index_to_value_index
-                            .get(
-                                &I::try_from(ti)
-                                    .vortex_expect("take index is between min and max index"),
-                            )
-                            .map(|value_index| (idx_in_take as u64, *value_index as u64))
-                    }
-                })
-                .unzip()
-        })
-        .map_err(|_| vortex_err!("Failed to convert index to usize"))?;
+    let mut new_sparse_indices = BufferMut::<u64>::with_capacity(take_indices.len());
+    let mut value_indices = BufferMut::<u64>::with_capacity(take_indices.len());
+
+    for (idx_in_take, &take_idx) in take_indices.iter().enumerate() {
+        let ti = usize::try_from(take_idx)
+            .map_err(|_| vortex_err!("Failed to convert index to usize"))?;
+
+        // If we have to take nulls the take index doesn't matter, make it 0 for consistency
+        let is_null = match take_indices_validity_mask.bit_buffer() {
+            AllOr::All => false,
+            AllOr::None => true,
+            AllOr::Some(buf) => !buf.value(idx_in_take),
+        };
+        if include_nulls && is_null {
+            new_sparse_indices.push(idx_in_take as u64);
+            value_indices.push(0);
+        } else if ti >= min_index && ti <= max_index {
+            let ti_as_i = I::try_from(ti)
+                .map_err(|_| vortex_err!("take index does not fit in index type"))?;
+            if let Some(&value_index) = sparse_index_to_value_index.get(&ti_as_i) {
+                new_sparse_indices.push(idx_in_take as u64);
+                value_indices.push(value_index as u64);
+            }
+        }
+    }
 
     if new_sparse_indices.is_empty() {
         return Ok(None);
@@ -1095,10 +1091,13 @@ fn filter_patches_with_mask<T: IntegerPType>(
         //  fallback to performing a two-way iterator merge.
         if (mask_idx + STRIDE) < patch_indices.len() && (true_idx + STRIDE) < mask_indices.len() {
             // Load a vector of each into our registers.
-            let left_min = patch_indices[mask_idx].to_usize().vortex_expect("left_min") - offset;
+            let left_min = patch_indices[mask_idx]
+                .to_usize()
+                .ok_or_else(|| vortex_err!("patch index does not fit in usize"))?
+                - offset;
             let left_max = patch_indices[mask_idx + STRIDE]
                 .to_usize()
-                .vortex_expect("left_max")
+                .ok_or_else(|| vortex_err!("patch index does not fit in usize"))?
                 - offset;
             let right_min = mask_indices[true_idx];
             let right_max = mask_indices[true_idx + STRIDE];
@@ -1117,7 +1116,10 @@ fn filter_patches_with_mask<T: IntegerPType>(
 
         // Two-way sorted iterator merge:
 
-        let left = patch_indices[mask_idx].to_usize().vortex_expect("left") - offset;
+        let left = patch_indices[mask_idx]
+            .to_usize()
+            .ok_or_else(|| vortex_err!("patch index does not fit in usize"))?
+            - offset;
         let right = mask_indices[true_idx];
 
         match left.cmp(&right) {
@@ -1155,7 +1157,7 @@ fn filter_patches_with_mask<T: IntegerPType>(
         new_patch_values,
         // TODO(0ax1): Chunk offsets are invalid after a filter is applied.
         None,
-    )))
+    )?))
 }
 
 fn take_indices_with_search_fn<

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -463,7 +463,7 @@ impl Patches {
             self.indices.len()
         };
 
-        let chunk_indices = self.indices.slice(patches_start_idx..patches_end_idx);
+        let chunk_indices = self.indices.slice(patches_start_idx..patches_end_idx)?;
         let result = Self::search_index_binary_search(&chunk_indices, index + self.offset)?;
 
         Ok(match result {
@@ -650,15 +650,19 @@ impl Patches {
             return Ok(None);
         }
 
-        let values = self.values().slice(slice_start_idx..slice_end_idx);
-        let indices = self.indices().slice(slice_start_idx..slice_end_idx);
+        let values = self.values().slice(slice_start_idx..slice_end_idx)?;
+        let indices = self.indices().slice(slice_start_idx..slice_end_idx)?;
 
-        let chunk_offsets = self.chunk_offsets.as_ref().map(|chunk_offsets| {
-            let chunk_relative_offset = self.offset % PATCH_CHUNK_SIZE;
-            let chunk_start_idx = (chunk_relative_offset + range.start) / PATCH_CHUNK_SIZE;
-            let chunk_end_idx = (chunk_relative_offset + range.end).div_ceil(PATCH_CHUNK_SIZE);
-            chunk_offsets.slice(chunk_start_idx..chunk_end_idx)
-        });
+        let chunk_offsets = self
+            .chunk_offsets
+            .as_ref()
+            .map(|chunk_offsets| -> VortexResult<ArrayRef> {
+                let chunk_relative_offset = self.offset % PATCH_CHUNK_SIZE;
+                let chunk_start_idx = (chunk_relative_offset + range.start) / PATCH_CHUNK_SIZE;
+                let chunk_end_idx = (chunk_relative_offset + range.end).div_ceil(PATCH_CHUNK_SIZE);
+                chunk_offsets.slice(chunk_start_idx..chunk_end_idx)
+            })
+            .transpose()?;
 
         let offset_within_chunk = chunk_offsets
             .as_ref()
@@ -1217,7 +1221,8 @@ mod test {
             buffer![10u32, 11, 20].into_array(),
             buffer![100, 110, 200].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         let filtered = patches
             .filter(&Mask::from_indices(100, vec![10, 20, 30]))
@@ -1236,7 +1241,8 @@ mod test {
             buffer![2u64, 9, 15].into_array(),
             PrimitiveArray::new(buffer![33_i32, 44, 55], Validity::AllValid).into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         let taken = patches
             .take(
@@ -1267,7 +1273,8 @@ mod test {
             buffer![2u64, 9, 15].into_array(),
             buffer![33_i32, 44, 55].into_array(),
             Some(buffer![0u64].into_array()),
-        );
+        )
+        .unwrap();
 
         let taken = patches
             .take_search(
@@ -1299,7 +1306,8 @@ mod test {
             buffer![100u64, 500, 1200, 1800].into_array(),
             buffer![10_i32, 20, 30, 40].into_array(),
             Some(buffer![0u64, 2].into_array()),
-        );
+        )
+        .unwrap();
 
         let taken = patches
             .take_search(
@@ -1324,7 +1332,8 @@ mod test {
             buffer![2u64, 9, 15].into_array(),
             buffer![33_i32, 44, 55].into_array(),
             Some(buffer![0u64].into_array()),
-        );
+        )
+        .unwrap();
 
         let taken = patches
             .take_search(
@@ -1344,7 +1353,8 @@ mod test {
             buffer![5u64, 10, 20, 25].into_array(),
             buffer![100_i32, 200, 300, 400].into_array(),
             Some(buffer![0u64].into_array()),
-        );
+        )
+        .unwrap();
 
         let taken = patches
             .take_search(
@@ -1369,7 +1379,8 @@ mod test {
             BufferMut::from_iter(0..1500u64).into_array(),
             BufferMut::from_iter(0..1500i32).into_array(),
             Some(buffer![0u64, 1024u64].into_array()),
-        );
+        )
+        .unwrap();
 
         let taken = patches
             .take_search(
@@ -1387,7 +1398,7 @@ mod test {
         let values = buffer![15_u32, 135, 13531, 42].into_array();
         let indices = buffer![10_u64, 11, 50, 100].into_array();
 
-        let patches = Patches::new(101, 0, indices, values, None);
+        let patches = Patches::new(101, 0, indices, values, None).unwrap();
 
         let sliced = patches.slice(15..100).unwrap().unwrap();
         assert_eq!(sliced.array_len(), 100 - 15);
@@ -1399,7 +1410,7 @@ mod test {
         let values = buffer![15_u32, 135, 13531, 42].into_array();
         let indices = buffer![10_u64, 11, 50, 100].into_array();
 
-        let patches = Patches::new(101, 0, indices, values, None);
+        let patches = Patches::new(101, 0, indices, values, None).unwrap();
 
         let sliced = patches.slice(15..100).unwrap().unwrap();
         assert_eq!(sliced.array_len(), 100 - 15);
@@ -1420,7 +1431,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         let mask = Mask::new_true(10);
         let masked = patches.mask(&mask).unwrap();
@@ -1435,7 +1447,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         let mask = Mask::new_false(10);
         let masked = patches.mask(&mask).unwrap().unwrap();
@@ -1461,7 +1474,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Mask that removes patches at indices 2 and 8 (but not 5)
         let mask = Mask::from_iter([
@@ -1485,7 +1499,8 @@ mod test {
             buffer![7u64, 10, 13].into_array(), // actual indices are 2, 5, 8
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Mask that sets actual index 2 to null
         let mask = Mask::from_iter([
@@ -1507,7 +1522,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             PrimitiveArray::from_option_iter([Some(100i32), None, Some(300)]).into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Test masking removes patch at index 2
         let mask = Mask::from_iter([
@@ -1537,7 +1553,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Keep all indices (mask with indices 0-9)
         let mask = Mask::from_indices(10, (0..10).collect());
@@ -1558,7 +1575,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Filter out all (empty mask means keep nothing)
         let mask = Mask::from_indices(10, vec![]);
@@ -1574,7 +1592,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Keep indices 2, 5, 9 (so patches at 2 and 5 remain)
         let mask = Mask::from_indices(10, vec![2, 5, 9]);
@@ -1592,7 +1611,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         let sliced = patches.slice(0..10).unwrap().unwrap();
 
@@ -1611,7 +1631,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Slice from 3 to 8 (includes patch at 5)
         let sliced = patches.slice(3..8).unwrap().unwrap();
@@ -1630,7 +1651,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Slice from 6 to 7 (no patches in this range)
         let sliced = patches.slice(6..7).unwrap();
@@ -1645,7 +1667,8 @@ mod test {
             buffer![7u64, 10, 13].into_array(), // actual indices are 2, 5, 8
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Slice from 3 to 8 (includes patch at actual index 5)
         let sliced = patches.slice(3..8).unwrap().unwrap();
@@ -1663,7 +1686,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         let values = patches.values().to_primitive();
         assert_eq!(
@@ -1688,10 +1712,11 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
-        assert_eq!(patches.min_index(), 2);
-        assert_eq!(patches.max_index(), 8);
+        assert_eq!(patches.min_index().unwrap(), 2);
+        assert_eq!(patches.max_index().unwrap(), 8);
     }
 
     #[test]
@@ -1702,7 +1727,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Search for exact indices
         assert_eq!(patches.search_index(2).unwrap(), SearchResult::Found(0));
@@ -1725,7 +1751,8 @@ mod test {
             buffer![0u64, 9].into_array(),
             buffer![100i32, 200].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         let mask = Mask::from_iter([
             true, false, false, false, false, false, false, false, false, false,
@@ -1746,7 +1773,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Mask that removes all patches
         let mask = Mask::from_iter([
@@ -1765,7 +1793,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Mask that doesn't affect any patches
         let mask = Mask::from_iter([
@@ -1789,7 +1818,8 @@ mod test {
             buffer![2u64].into_array(),
             buffer![42i32].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Mask that removes the single patch
         let mask = Mask::from_iter([false, false, true, false, false]);
@@ -1811,7 +1841,8 @@ mod test {
             buffer![3u64, 4, 5, 6].into_array(),
             buffer![100i32, 200, 300, 400].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Mask that removes middle patches
         let mask = Mask::from_iter([
@@ -1832,7 +1863,8 @@ mod test {
             buffer![16u64, 17, 19].into_array(), // actual indices are 1, 2, 4
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Mask that removes the patch at actual index 2
         let mask = Mask::from_iter([
@@ -1854,7 +1886,8 @@ mod test {
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
             None,
-        );
+        )
+        .unwrap();
 
         // Mask with wrong length
         let mask = Mask::from_iter([false, false, true, false, false]);
@@ -1866,7 +1899,7 @@ mod test {
         let indices = buffer![100u64, 200, 3000, 3100].into_array();
         let values = buffer![10i32, 20, 30, 40].into_array();
         let chunk_offsets = buffer![0u64, 2, 2, 3].into_array();
-        let patches = Patches::new(4096, 0, indices, values, Some(chunk_offsets));
+        let patches = Patches::new(4096, 0, indices, values, Some(chunk_offsets)).unwrap();
 
         assert!(patches.chunk_offsets.is_some());
 
@@ -1899,7 +1932,7 @@ mod test {
         let indices = buffer![100u64, 500, 1200, 1300, 1500, 1800, 2100, 2500].into_array();
         let values = buffer![10i32, 20, 30, 35, 40, 45, 50, 60].into_array();
         let chunk_offsets = buffer![0u64, 2, 6].into_array();
-        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets));
+        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets)).unwrap();
 
         let sliced = patches.slice(1000..2200).unwrap().unwrap();
 
@@ -1918,7 +1951,7 @@ mod test {
         let indices = buffer![100u64, 500, 1200, 1300, 1500, 1800, 2100, 2500].into_array();
         let values = buffer![10i32, 20, 30, 35, 40, 45, 50, 60].into_array();
         let chunk_offsets = buffer![0u64, 2, 6].into_array();
-        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets));
+        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets)).unwrap();
 
         let sliced = patches.slice(1300..2200).unwrap().unwrap();
 
@@ -1937,7 +1970,7 @@ mod test {
         let indices = buffer![100u64, 200, 3000, 3100].into_array();
         let values = buffer![10i32, 20, 30, 40].into_array();
         let chunk_offsets = buffer![0u64, 2].into_array();
-        let patches = Patches::new(4000, 0, indices, values, Some(chunk_offsets));
+        let patches = Patches::new(4000, 0, indices, values, Some(chunk_offsets)).unwrap();
 
         let sliced = patches.slice(1000..2000).unwrap();
         assert!(sliced.is_none());
@@ -1948,7 +1981,7 @@ mod test {
         let indices = buffer![100u64, 1200, 1300, 2500].into_array();
         let values = buffer![10i32, 20, 30, 40].into_array();
         let chunk_offsets = buffer![0u64, 1, 3].into_array();
-        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets));
+        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets)).unwrap();
 
         let sliced = patches.slice(1100..1250).unwrap().unwrap();
 
@@ -1964,7 +1997,7 @@ mod test {
         let indices = buffer![100u64, 200, 1100, 1200, 2100, 2200].into_array();
         let values = buffer![10i32, 20, 30, 40, 50, 60].into_array();
         let chunk_offsets = buffer![0u64, 2, 4].into_array();
-        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets));
+        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets)).unwrap();
 
         let sliced = patches.slice(150..2150).unwrap().unwrap();
 
@@ -1982,7 +2015,7 @@ mod test {
         let indices = buffer![1023u64, 1024, 1025, 2047, 2048].into_array();
         let values = buffer![10i32, 20, 30, 40, 50].into_array();
         let chunk_offsets = buffer![0u64, 1, 4].into_array();
-        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets));
+        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets)).unwrap();
 
         assert_eq!(patches.search_index(1023).unwrap(), SearchResult::Found(0));
         assert_eq!(patches.search_index(1024).unwrap(), SearchResult::Found(1));
@@ -2005,7 +2038,7 @@ mod test {
         let indices = buffer![0u64, 1, 1023, 1024, 2047, 2048].into_array();
         let values = buffer![10i32, 20, 30, 40, 50, 60].into_array();
         let chunk_offsets = buffer![0u64, 3, 5].into_array();
-        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets));
+        let patches = Patches::new(3000, 0, indices, values, Some(chunk_offsets)).unwrap();
 
         // Slice at the very beginning
         let sliced = patches.slice(0..10).unwrap().unwrap();
@@ -2025,7 +2058,7 @@ mod test {
         let indices = buffer![100u64, 200, 300, 400, 500, 600].into_array();
         let values = buffer![10i32, 20, 30, 40, 50, 60].into_array();
         let chunk_offsets = buffer![0u64].into_array();
-        let patches = Patches::new(1000, 0, indices, values, Some(chunk_offsets));
+        let patches = Patches::new(1000, 0, indices, values, Some(chunk_offsets)).unwrap();
 
         let sliced1 = patches.slice(150..550).unwrap().unwrap();
         assert_eq!(sliced1.num_patches(), 4); // 200, 300, 400, 500
@@ -2046,7 +2079,7 @@ mod test {
         let chunk_offsets = buffer![0u64].into_array();
         let indices = buffer![1023u64].into_array();
         let values = buffer![42i32].into_array();
-        let patches = Patches::new(1024, 0, indices, values, Some(chunk_offsets));
+        let patches = Patches::new(1024, 0, indices, values, Some(chunk_offsets)).unwrap();
         assert_eq!(
             patches.search_index(2048).unwrap(),
             SearchResult::NotFound(1)

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -12,6 +12,7 @@ use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_error::VortexExpect as _;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_mask::AllOr;
@@ -270,17 +271,17 @@ impl Validity {
         indices_offset: usize,
         indices: &dyn Array,
         patches: &Validity,
-    ) -> Self {
+    ) -> VortexResult<Self> {
         match (&self, patches) {
-            (Validity::NonNullable, Validity::NonNullable) => return Validity::NonNullable,
+            (Validity::NonNullable, Validity::NonNullable) => return Ok(Validity::NonNullable),
             (Validity::NonNullable, _) => {
-                vortex_panic!("Can't patch a non-nullable validity with nullable validity")
+                vortex_bail!("Can't patch a non-nullable validity with nullable validity")
             }
             (_, Validity::NonNullable) => {
-                vortex_panic!("Can't patch a nullable validity with non-nullable validity")
+                vortex_bail!("Can't patch a nullable validity with non-nullable validity")
             }
-            (Validity::AllValid, Validity::AllValid) => return Validity::AllValid,
-            (Validity::AllInvalid, Validity::AllInvalid) => return Validity::AllInvalid,
+            (Validity::AllValid, Validity::AllValid) => return Ok(Validity::AllValid),
+            (Validity::AllInvalid, Validity::AllInvalid) => return Ok(Validity::AllInvalid),
             _ => {}
         };
 
@@ -311,9 +312,12 @@ impl Validity {
             patch_values.into_array(),
             // TODO(0ax1): chunk offsets
             None,
-        );
+        )?;
 
-        Self::from_array(source.patch(&patches).into_array(), own_nullability)
+        Ok(Self::from_array(
+            source.patch(&patches)?.into_array(),
+            own_nullability,
+        ))
     }
 
     /// Convert into a nullable variant

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -99,8 +99,8 @@ impl Validity {
     }
 
     #[inline]
-    pub fn all_valid(&self, len: usize) -> bool {
-        match self {
+    pub fn all_valid(&self, len: usize) -> VortexResult<bool> {
+        Ok(match self {
             _ if len == 0 => true,
             Validity::NonNullable | Validity::AllValid => true,
             Validity::AllInvalid => false,
@@ -109,12 +109,12 @@ impl Validity {
                     .vortex_expect("sum must be a usize")
                     == array.len()
             }
-        }
+        })
     }
 
     #[inline]
-    pub fn all_invalid(&self, len: usize) -> bool {
-        match self {
+    pub fn all_invalid(&self, len: usize) -> VortexResult<bool> {
+        Ok(match self {
             _ if len == 0 => true,
             Validity::NonNullable | Validity::AllValid => false,
             Validity::AllInvalid => true,
@@ -123,13 +123,13 @@ impl Validity {
                     .vortex_expect("sum must be a usize")
                     == 0
             }
-        }
+        })
     }
 
     /// Returns whether the `index` item is valid.
     #[inline]
-    pub fn is_valid(&self, index: usize) -> bool {
-        match self {
+    pub fn is_valid(&self, index: usize) -> VortexResult<bool> {
+        Ok(match self {
             Self::NonNullable | Self::AllValid => true,
             Self::AllInvalid => false,
             Self::Array(a) => a
@@ -138,19 +138,19 @@ impl Validity {
                 .as_bool()
                 .value()
                 .vortex_expect("Validity must be non-nullable"),
-        }
+        })
     }
 
     #[inline]
-    pub fn is_null(&self, index: usize) -> bool {
-        !self.is_valid(index)
+    pub fn is_null(&self, index: usize) -> VortexResult<bool> {
+        Ok(!self.is_valid(index)?)
     }
 
     #[inline]
-    pub fn slice(&self, range: Range<usize>) -> Self {
+    pub fn slice(&self, range: Range<usize>) -> VortexResult<Self> {
         match self {
-            Self::Array(a) => Self::Array(a.slice(range)),
-            Self::NonNullable | Self::AllValid | Self::AllInvalid => self.clone(),
+            Self::Array(a) => Ok(Self::Array(a.slice(range)?)),
+            Self::NonNullable | Self::AllValid | Self::AllInvalid => Ok(self.clone()),
         }
     }
 
@@ -544,13 +544,18 @@ mod tests {
     ) {
         let indices =
             PrimitiveArray::new(Buffer::copy_from(positions), Validity::NonNullable).into_array();
-        assert_eq!(validity.patch(len, 0, &indices, &patches), expected);
+        assert_eq!(
+            validity.patch(len, 0, &indices, &patches).unwrap(),
+            expected
+        );
     }
 
     #[test]
     #[should_panic]
     fn out_of_bounds_patch() {
-        Validity::NonNullable.patch(2, 0, &buffer![4].into_array(), &Validity::AllInvalid);
+        Validity::NonNullable
+            .patch(2, 0, &buffer![4].into_array(), &Validity::AllInvalid)
+            .unwrap();
     }
 
     #[test]

--- a/vortex-array/src/vtable/validity.rs
+++ b/vortex-array/src/vtable/validity.rs
@@ -57,7 +57,7 @@ pub struct ValidityVTableFromValiditySliceHelper;
 pub trait ValiditySliceHelper {
     fn unsliced_validity_and_slice(&self) -> (&Validity, usize, usize);
 
-    fn sliced_validity(&self) -> Validity {
+    fn sliced_validity(&self) -> VortexResult<Validity> {
         let (unsliced_validity, start, stop) = self.unsliced_validity_and_slice();
         unsliced_validity.slice(start..stop)
     }
@@ -68,7 +68,7 @@ where
     V::Array: ValiditySliceHelper,
 {
     fn validity(array: &V::Array) -> VortexResult<Validity> {
-        Ok(array.sliced_validity())
+        array.sliced_validity()
     }
 }
 
@@ -100,7 +100,7 @@ pub struct ValidityVTableFromChildSliceHelper;
 pub trait ValidityChildSliceHelper {
     fn unsliced_child_and_slice(&self) -> (&ArrayRef, usize, usize);
 
-    fn sliced_child_array(&self) -> ArrayRef {
+    fn sliced_child_array(&self) -> VortexResult<ArrayRef> {
         let (unsliced_validity, start, stop) = self.unsliced_child_and_slice();
         unsliced_validity.slice(start..stop)
     }
@@ -111,6 +111,6 @@ where
     V::Array: ValidityChildSliceHelper,
 {
     fn validity(array: &V::Array) -> VortexResult<Validity> {
-        array.sliced_child_array().validity()
+        array.sliced_child_array()?.validity()
     }
 }

--- a/vortex-bench/src/conversions.rs
+++ b/vortex-bench/src/conversions.rs
@@ -36,7 +36,7 @@ pub async fn parquet_to_vortex(parquet_path: PathBuf) -> anyhow::Result<ChunkedA
 
     while let Some(rb) = reader.next().await {
         let rb = rb?;
-        let chunk = ArrayRef::from_arrow(rb, false);
+        let chunk = ArrayRef::from_arrow(rb, false)?;
 
         // Make sure data is uncompressed and canonicalized
         let mut builder = builder_with_capacity(chunk.dtype(), chunk.len());

--- a/vortex-bench/src/tpch/tpchgen.rs
+++ b/vortex-bench/src/tpch/tpchgen.rs
@@ -428,7 +428,7 @@ impl VortexWriter {
 #[async_trait::async_trait]
 impl FileWriter for VortexWriter {
     async fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
-        let array = ArrayRef::from_arrow(batch, false);
+        let array = ArrayRef::from_arrow(batch, false)?;
         self.sender
             .as_ref()
             .vortex_expect("sender closed early")

--- a/vortex-btrblocks/src/float.rs
+++ b/vortex-btrblocks/src/float.rs
@@ -17,7 +17,6 @@ use vortex_array::arrays::MaskedArray;
 use vortex_array::arrays::PrimitiveVTable;
 use vortex_array::vtable::ValidityHelper;
 use vortex_dtype::PType;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_scalar::Scalar;
@@ -240,8 +239,7 @@ impl Scheme for ALPScheme {
         allowed_cascading: usize,
         excludes: &[FloatCode],
     ) -> VortexResult<ArrayRef> {
-        let alp_encoded = alp_encode(&stats.source().to_primitive(), None)
-            .vortex_expect("Input is a supported floating point array");
+        let alp_encoded = alp_encode(&stats.source().to_primitive(), None)?;
         let alp = alp_encoded.as_::<ALPVTable>();
         let alp_ints = alp.encoded().to_primitive();
 

--- a/vortex-btrblocks/src/float.rs
+++ b/vortex-btrblocks/src/float.rs
@@ -486,6 +486,7 @@ mod tests {
     use vortex_buffer::Buffer;
     use vortex_buffer::buffer_mut;
     use vortex_dtype::Nullability;
+    use vortex_error::VortexResult;
     use vortex_sparse::SparseVTable;
 
     use crate::Compressor;
@@ -496,21 +497,21 @@ mod tests {
     use crate::float::RLE_FLOAT_SCHEME;
 
     #[test]
-    fn test_empty() {
+    fn test_empty() -> VortexResult<()> {
         // Make sure empty array compression does not fail
         let result = FloatCompressor::compress(
             &PrimitiveArray::new(Buffer::<f32>::empty(), Validity::NonNullable),
             false,
             3,
             &[],
-        )
-        .unwrap();
+        )?;
 
         assert!(result.is_empty());
+        Ok(())
     }
 
     #[test]
-    fn test_compress() {
+    fn test_compress() -> VortexResult<()> {
         let mut values = buffer_mut![1.0f32; 1024];
         // Sprinkle some other values in.
         for i in 0..1024 {
@@ -521,12 +522,13 @@ mod tests {
         }
 
         let floats = values.into_array().to_primitive();
-        let compressed = FloatCompressor::compress(&floats, false, MAX_CASCADE, &[]).unwrap();
-        println!("compressed: {}", compressed.display_tree())
+        let compressed = FloatCompressor::compress(&floats, false, MAX_CASCADE, &[])?;
+        println!("compressed: {}", compressed.display_tree());
+        Ok(())
     }
 
     #[test]
-    fn test_rle_compression() {
+    fn test_rle_compression() -> VortexResult<()> {
         let mut values = Vec::new();
         values.extend(iter::repeat_n(1.5f32, 100));
         values.extend(iter::repeat_n(2.7f32, 200));
@@ -534,15 +536,16 @@ mod tests {
 
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
         let stats = crate::float::FloatStats::generate(&array);
-        let compressed = RLE_FLOAT_SCHEME.compress(&stats, false, 3, &[]).unwrap();
+        let compressed = RLE_FLOAT_SCHEME.compress(&stats, false, 3, &[])?;
 
         let decoded = compressed;
         let expected = Buffer::copy_from(&values).into_array();
         assert_arrays_eq!(decoded.as_ref(), expected.as_ref());
+        Ok(())
     }
 
     #[test]
-    fn test_sparse_compression() {
+    fn test_sparse_compression() -> VortexResult<()> {
         let mut array = PrimitiveBuilder::<f32>::with_capacity(Nullability::Nullable, 100);
         array.append_value(f32::NAN);
         array.append_value(-f32::NAN);
@@ -554,9 +557,10 @@ mod tests {
 
         let floats = array.finish_into_primitive();
 
-        let compressed = FloatCompressor::compress(&floats, false, MAX_CASCADE, &[]).unwrap();
+        let compressed = FloatCompressor::compress(&floats, false, MAX_CASCADE, &[])?;
 
         assert!(compressed.is::<SparseVTable>());
+        Ok(())
     }
 }
 
@@ -573,47 +577,52 @@ mod scheme_selection_tests {
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_dtype::Nullability;
+    use vortex_error::VortexResult;
     use vortex_sparse::SparseVTable;
 
     use crate::Compressor;
     use crate::float::FloatCompressor;
 
     #[test]
-    fn test_constant_compressed() {
+    fn test_constant_compressed() -> VortexResult<()> {
         let values: Vec<f64> = vec![42.5; 100];
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
-        let compressed = FloatCompressor::compress(&array, false, 3, &[]).unwrap();
+        let compressed = FloatCompressor::compress(&array, false, 3, &[])?;
         assert!(compressed.is::<ConstantVTable>());
+        Ok(())
     }
 
     #[test]
-    fn test_alp_compressed() {
+    fn test_alp_compressed() -> VortexResult<()> {
         let values: Vec<f64> = (0..1000).map(|i| (i as f64) * 0.01).collect();
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
-        let compressed = FloatCompressor::compress(&array, false, 3, &[]).unwrap();
+        let compressed = FloatCompressor::compress(&array, false, 3, &[])?;
         assert!(compressed.is::<ALPVTable>());
+        Ok(())
     }
 
     #[test]
-    fn test_dict_compressed() {
+    fn test_dict_compressed() -> VortexResult<()> {
         let distinct_values = [1.1, 2.2, 3.3, 4.4, 5.5];
         let values: Vec<f64> = (0..1000)
             .map(|i| distinct_values[i % distinct_values.len()])
             .collect();
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
-        let compressed = FloatCompressor::compress(&array, false, 3, &[]).unwrap();
+        let compressed = FloatCompressor::compress(&array, false, 3, &[])?;
         assert!(compressed.is::<DictVTable>());
+        Ok(())
     }
 
     #[test]
-    fn test_null_dominated_compressed() {
+    fn test_null_dominated_compressed() -> VortexResult<()> {
         let mut builder = PrimitiveBuilder::<f64>::with_capacity(Nullability::Nullable, 100);
         for i in 0..5 {
             builder.append_value(i as f64);
         }
         builder.append_nulls(95);
         let array = builder.finish_into_primitive();
-        let compressed = FloatCompressor::compress(&array, false, 3, &[]).unwrap();
+        let compressed = FloatCompressor::compress(&array, false, 3, &[])?;
         assert!(compressed.is::<SparseVTable>());
+        Ok(())
     }
 }

--- a/vortex-btrblocks/src/float/stats.rs
+++ b/vortex-btrblocks/src/float/stats.rs
@@ -13,6 +13,7 @@ use vortex_array::arrays::PrimitiveVTable;
 use vortex_dtype::NativePType;
 use vortex_dtype::PType;
 use vortex_dtype::half::f16;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
@@ -83,7 +84,7 @@ impl CompressorStats for FloatStats {
 
     fn generate_opts(input: &PrimitiveArray, opts: GenerateStatsOptions) -> Self {
         Self::generate_opts_fallible(input, opts)
-            .expect("FloatStats::generate_opts should not fail")
+            .vortex_expect("FloatStats::generate_opts should not fail")
     }
 
     fn source(&self) -> &PrimitiveArray {
@@ -165,7 +166,7 @@ where
     let mut runs = 1;
     let head_idx = validity
         .first()
-        .expect("All null masks have been handled before");
+        .vortex_expect("All null masks have been handled before");
     let buff = array.to_buffer::<T>();
     let mut prev = buff[head_idx];
 

--- a/vortex-btrblocks/src/float/stats.rs
+++ b/vortex-btrblocks/src/float/stats.rs
@@ -13,7 +13,8 @@ use vortex_array::arrays::PrimitiveVTable;
 use vortex_dtype::NativePType;
 use vortex_dtype::PType;
 use vortex_dtype::half::f16;
-use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_mask::AllOr;
 use vortex_utils::aliases::hash_set::HashSet;
@@ -63,16 +64,26 @@ pub struct FloatStats {
     pub(super) distinct_values_count: u32,
 }
 
-impl CompressorStats for FloatStats {
-    type ArrayVTable = PrimitiveVTable;
-
-    fn generate_opts(input: &PrimitiveArray, opts: GenerateStatsOptions) -> Self {
+impl FloatStats {
+    fn generate_opts_fallible(
+        input: &PrimitiveArray,
+        opts: GenerateStatsOptions,
+    ) -> VortexResult<Self> {
         match input.ptype() {
             PType::F16 => typed_float_stats::<f16>(input, opts.count_distinct_values),
             PType::F32 => typed_float_stats::<f32>(input, opts.count_distinct_values),
             PType::F64 => typed_float_stats::<f64>(input, opts.count_distinct_values),
             _ => vortex_panic!("cannot generate FloatStats from ptype {}", input.ptype()),
         }
+    }
+}
+
+impl CompressorStats for FloatStats {
+    type ArrayVTable = PrimitiveVTable;
+
+    fn generate_opts(input: &PrimitiveArray, opts: GenerateStatsOptions) -> Self {
+        Self::generate_opts_fallible(input, opts)
+            .expect("FloatStats::generate_opts should not fail")
     }
 
     fn source(&self) -> &PrimitiveArray {
@@ -103,14 +114,14 @@ impl RLEStats for FloatStats {
 fn typed_float_stats<T: NativePType + Float>(
     array: &PrimitiveArray,
     count_distinct_values: bool,
-) -> FloatStats
+) -> VortexResult<FloatStats>
 where
     DistinctValues<T>: Into<ErasedDistinctValues>,
     NativeValue<T>: Hash + Eq,
 {
     // Special case: empty array
     if array.is_empty() {
-        return FloatStats {
+        return Ok(FloatStats {
             src: array.clone(),
             null_count: 0,
             value_count: 0,
@@ -120,11 +131,11 @@ where
                 values: HashSet::<NativeValue<T>, FxBuildHasher>::with_hasher(FxBuildHasher),
             }
             .into(),
-        };
-    } else if array.all_invalid().vortex_expect("all_invalid") {
-        return FloatStats {
+        });
+    } else if array.all_invalid()? {
+        return Ok(FloatStats {
             src: array.clone(),
-            null_count: array.len().try_into().vortex_expect("null_count"),
+            null_count: u32::try_from(array.len())?,
             value_count: 0,
             average_run_length: 0,
             distinct_values_count: 0,
@@ -132,13 +143,13 @@ where
                 values: HashSet::<NativeValue<T>, FxBuildHasher>::with_hasher(FxBuildHasher),
             }
             .into(),
-        };
+        });
     }
 
     let null_count = array
         .statistics()
         .compute_null_count()
-        .vortex_expect("null count");
+        .ok_or_else(|| vortex_err!("Failed to compute null_count"))?;
     let value_count = array.len() - null_count;
 
     // Keep a HashMap of T, then convert the keys into PValue afterward since value is
@@ -149,12 +160,12 @@ where
         HashSet::with_hasher(FxBuildHasher)
     };
 
-    let validity = array.validity_mask().vortex_expect("validity_mask");
+    let validity = array.validity_mask()?;
 
     let mut runs = 1;
     let head_idx = validity
         .first()
-        .vortex_expect("All null masks have been handled before");
+        .expect("All null masks have been handled before");
     let buff = array.to_buffer::<T>();
     let mut prev = buff[head_idx];
 
@@ -192,22 +203,15 @@ where
         }
     }
 
-    let null_count = null_count
-        .try_into()
-        .vortex_expect("null_count must fit in u32");
-    let value_count = value_count
-        .try_into()
-        .vortex_expect("null_count must fit in u32");
+    let null_count = u32::try_from(null_count)?;
+    let value_count = u32::try_from(value_count)?;
     let distinct_values_count = if count_distinct_values {
-        distinct_values
-            .len()
-            .try_into()
-            .vortex_expect("distinct values count must fit in u32")
+        u32::try_from(distinct_values.len())?
     } else {
         u32::MAX
     };
 
-    FloatStats {
+    Ok(FloatStats {
         null_count,
         value_count,
         distinct_values_count,
@@ -217,7 +221,7 @@ where
             values: distinct_values,
         }
         .into(),
-    }
+    })
 }
 
 #[cfg(test)]

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -822,7 +822,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dict_encodable() {
+    fn test_dict_encodable() -> VortexResult<()> {
         let mut codes = BufferMut::<i32>::with_capacity(65_535);
         // Write some runs of length 3 of a handful of different values. Interrupted by some
         // one-off values.
@@ -842,38 +842,36 @@ mod tests {
         }
 
         let primitive = codes.freeze().into_array().to_primitive();
-        let compressed = IntCompressor::compress(&primitive, false, 3, &[]).unwrap();
+        let compressed = IntCompressor::compress(&primitive, false, 3, &[])?;
         assert!(compressed.is::<DictVTable>());
+        Ok(())
     }
 
     #[test]
-    fn sparse_with_nulls() {
+    fn sparse_with_nulls() -> VortexResult<()> {
         let array = PrimitiveArray::new(
             buffer![189u8, 189, 189, 0, 46],
             Validity::from_iter(vec![true, true, true, true, false]),
         );
-        let compressed = SparseScheme
-            .compress(&IntegerStats::generate(&array), false, 3, &[])
-            .unwrap();
+        let compressed = SparseScheme.compress(&IntegerStats::generate(&array), false, 3, &[])?;
         assert!(compressed.is::<SparseVTable>());
         let decoded = compressed.clone();
         let expected =
             PrimitiveArray::new(buffer![189u8, 189, 189, 0, 0], array.validity().clone())
                 .into_array();
         assert_arrays_eq!(decoded.as_ref(), expected.as_ref());
+        Ok(())
     }
 
     #[test]
-    fn sparse_mostly_nulls() {
+    fn sparse_mostly_nulls() -> VortexResult<()> {
         let array = PrimitiveArray::new(
             buffer![189u8, 189, 189, 189, 189, 189, 189, 189, 189, 0, 46],
             Validity::from_iter(vec![
                 false, false, false, false, false, false, false, false, false, false, true,
             ]),
         );
-        let compressed = SparseScheme
-            .compress(&IntegerStats::generate(&array), false, 3, &[])
-            .unwrap();
+        let compressed = SparseScheme.compress(&IntegerStats::generate(&array), false, 3, &[])?;
         assert!(compressed.is::<SparseVTable>());
         let decoded = compressed.clone();
         let expected = PrimitiveArray::new(
@@ -882,36 +880,36 @@ mod tests {
         )
         .into_array();
         assert_arrays_eq!(decoded.as_ref(), expected.as_ref());
+        Ok(())
     }
 
     #[test]
-    fn nullable_sequence() {
+    fn nullable_sequence() -> VortexResult<()> {
         let values = (0i32..20).step_by(7).collect_vec();
         let array = PrimitiveArray::from_option_iter(values.clone().into_iter().map(Some));
-        let compressed = SequenceScheme
-            .compress(&IntegerStats::generate(&array), false, 3, &[])
-            .unwrap();
+        let compressed = SequenceScheme.compress(&IntegerStats::generate(&array), false, 3, &[])?;
         assert!(compressed.is::<SequenceVTable>());
         let decoded = compressed;
         let expected = PrimitiveArray::from_option_iter(values.into_iter().map(Some)).into_array();
         assert_arrays_eq!(decoded.as_ref(), expected.as_ref());
+        Ok(())
     }
 
     #[test]
-    fn test_rle_compression() {
+    fn test_rle_compression() -> VortexResult<()> {
         let mut values = Vec::new();
         values.extend(iter::repeat_n(42i32, 100));
         values.extend(iter::repeat_n(123i32, 200));
         values.extend(iter::repeat_n(987i32, 150));
 
         let array = PrimitiveArray::new(Buffer::copy_from(&values), Validity::NonNullable);
-        let compressed = RLE_INTEGER_SCHEME
-            .compress(&IntegerStats::generate(&array), false, 3, &[])
-            .unwrap();
+        let compressed =
+            RLE_INTEGER_SCHEME.compress(&IntegerStats::generate(&array), false, 3, &[])?;
 
         let decoded = compressed;
         let expected = Buffer::copy_from(&values).into_array();
         assert_arrays_eq!(decoded.as_ref(), expected.as_ref());
+        Ok(())
     }
 
     #[test_with::env(CI)]

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -17,7 +17,6 @@ use vortex_array::arrays::MaskedArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::PrimitiveVTable;
 use vortex_array::vtable::ValidityHelper;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
@@ -283,7 +282,7 @@ impl Scheme for FORScheme {
             .ptype()
             .bit_width()
             .try_into()
-            .vortex_expect("bit width must fit in u32");
+            .expect("bit width must fit in u32");
         let bw = match stats.typed.max_minus_min().checked_ilog2() {
             Some(l) => l + 1,
             // If max-min == 0, it we should use a different compression scheme

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -17,6 +17,7 @@ use vortex_array::arrays::MaskedArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::PrimitiveVTable;
 use vortex_array::vtable::ValidityHelper;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
@@ -282,7 +283,7 @@ impl Scheme for FORScheme {
             .ptype()
             .bit_width()
             .try_into()
-            .expect("bit width must fit in u32");
+            .vortex_expect("bit width must fit in u32");
         let bw = match stats.typed.max_minus_min().checked_ilog2() {
             Some(l) => l + 1,
             // If max-min == 0, it we should use a different compression scheme

--- a/vortex-btrblocks/src/integer/stats.rs
+++ b/vortex-btrblocks/src/integer/stats.rs
@@ -14,6 +14,7 @@ use vortex_buffer::BitBuffer;
 use vortex_dtype::IntegerPType;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexError;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::AllOr;
 use vortex_scalar::PValue;
@@ -88,7 +89,7 @@ impl ErasedStats {
             ErasedStats::I16(x) => (x.max as i32 - x.min as i32) as u64,
             ErasedStats::I32(x) => (x.max as i64 - x.min as i64) as u64,
             ErasedStats::I64(x) => u64::try_from(x.max as i128 - x.min as i128)
-                .expect("max minus min result bigger than u64"),
+                .vortex_expect("max minus min result bigger than u64"),
         }
     }
 
@@ -155,7 +156,7 @@ impl CompressorStats for IntegerStats {
 
     fn generate_opts(input: &PrimitiveArray, opts: GenerateStatsOptions) -> Self {
         Self::generate_opts_fallible(input, opts)
-            .expect("IntegerStats::generate_opts should not fail")
+            .vortex_expect("IntegerStats::generate_opts should not fail")
     }
 
     fn source(&self) -> &PrimitiveArray {
@@ -234,7 +235,7 @@ where
     // Initialize loop state
     let head_idx = validity
         .first()
-        .expect("All null masks have been handled before");
+        .vortex_expect("All null masks have been handled before");
     let buffer = array.to_buffer::<T>();
     let head = buffer[head_idx];
 
@@ -254,7 +255,7 @@ where
         AllOr::All => {
             for chunk in &mut chunks {
                 inner_loop_nonnull(
-                    chunk.try_into().expect("chunk size must be 64"),
+                    chunk.try_into().vortex_expect("chunk size must be 64"),
                     count_distinct_values,
                     &mut loop_state,
                 )
@@ -280,13 +281,13 @@ where
                     0 => continue,
                     // Inner loop for when validity check can be elided
                     64 => inner_loop_nonnull(
-                        chunk.try_into().expect("chunk size must be 64"),
+                        chunk.try_into().vortex_expect("chunk size must be 64"),
                         count_distinct_values,
                         &mut loop_state,
                     ),
                     // Inner loop for when we need to check validity
                     _ => inner_loop_nullable(
-                        chunk.try_into().expect("chunk size must be 64"),
+                        chunk.try_into().vortex_expect("chunk size must be 64"),
                         count_distinct_values,
                         &validity,
                         &mut loop_state,
@@ -309,7 +310,7 @@ where
             .distinct_values
             .iter()
             .max_by_key(|&(_, &count)| count)
-            .expect("non-empty");
+            .vortex_expect("non-empty");
         (top_value.0, top_count)
     } else {
         (T::default(), 0)
@@ -325,12 +326,12 @@ where
     let min = array
         .statistics()
         .compute_as::<T>(Stat::Min)
-        .expect("min should be computed");
+        .vortex_expect("min should be computed");
 
     let max = array
         .statistics()
         .compute_as::<T>(Stat::Max)
-        .expect("max should be computed");
+        .vortex_expect("max should be computed");
 
     let typed = TypedStats {
         min,

--- a/vortex-btrblocks/src/integer/stats.rs
+++ b/vortex-btrblocks/src/integer/stats.rs
@@ -14,7 +14,7 @@ use vortex_buffer::BitBuffer;
 use vortex_dtype::IntegerPType;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexError;
-use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
 use vortex_mask::AllOr;
 use vortex_scalar::PValue;
 use vortex_scalar::Scalar;
@@ -88,7 +88,7 @@ impl ErasedStats {
             ErasedStats::I16(x) => (x.max as i32 - x.min as i32) as u64,
             ErasedStats::I32(x) => (x.max as i64 - x.min as i64) as u64,
             ErasedStats::I64(x) => u64::try_from(x.max as i128 - x.min as i128)
-                .vortex_expect("max minus min result bigger than u64"),
+                .expect("max minus min result bigger than u64"),
         }
     }
 
@@ -139,13 +139,23 @@ pub struct IntegerStats {
     pub(crate) typed: ErasedStats,
 }
 
+impl IntegerStats {
+    fn generate_opts_fallible(
+        input: &PrimitiveArray,
+        opts: GenerateStatsOptions,
+    ) -> VortexResult<Self> {
+        match_each_integer_ptype!(input.ptype(), |T| {
+            typed_int_stats::<T>(input, opts.count_distinct_values)
+        })
+    }
+}
+
 impl CompressorStats for IntegerStats {
     type ArrayVTable = PrimitiveVTable;
 
     fn generate_opts(input: &PrimitiveArray, opts: GenerateStatsOptions) -> Self {
-        match_each_integer_ptype!(input.ptype(), |T| {
-            typed_int_stats::<T>(input, opts.count_distinct_values)
-        })
+        Self::generate_opts_fallible(input, opts)
+            .expect("IntegerStats::generate_opts should not fail")
     }
 
     fn source(&self) -> &PrimitiveArray {
@@ -173,7 +183,10 @@ impl RLEStats for IntegerStats {
     }
 }
 
-fn typed_int_stats<T>(array: &PrimitiveArray, count_distinct_values: bool) -> IntegerStats
+fn typed_int_stats<T>(
+    array: &PrimitiveArray,
+    count_distinct_values: bool,
+) -> VortexResult<IntegerStats>
 where
     T: IntegerPType + PrimInt + for<'a> TryFrom<&'a Scalar, Error = VortexError>,
     TypedStats<T>: Into<ErasedStats>,
@@ -181,7 +194,7 @@ where
 {
     // Special case: empty array
     if array.is_empty() {
-        return IntegerStats {
+        return Ok(IntegerStats {
             src: array.clone(),
             null_count: 0,
             value_count: 0,
@@ -195,11 +208,11 @@ where
                 distinct_values: HashMap::with_hasher(FxBuildHasher),
             }
             .into(),
-        };
-    } else if array.all_invalid().vortex_expect("all_invalid") {
-        return IntegerStats {
+        });
+    } else if array.all_invalid()? {
+        return Ok(IntegerStats {
             src: array.clone(),
-            null_count: array.len().try_into().vortex_expect("null_count"),
+            null_count: u32::try_from(array.len())?,
             value_count: 0,
             average_run_length: 0,
             distinct_values_count: 0,
@@ -211,17 +224,17 @@ where
                 distinct_values: HashMap::with_hasher(FxBuildHasher),
             }
             .into(),
-        };
+        });
     }
 
-    let validity = array.validity_mask().vortex_expect("validity_mask");
+    let validity = array.validity_mask()?;
     let null_count = validity.false_count();
     let value_count = validity.true_count();
 
     // Initialize loop state
     let head_idx = validity
         .first()
-        .vortex_expect("All null masks have been handled before");
+        .expect("All null masks have been handled before");
     let buffer = array.to_buffer::<T>();
     let head = buffer[head_idx];
 
@@ -241,7 +254,7 @@ where
         AllOr::All => {
             for chunk in &mut chunks {
                 inner_loop_nonnull(
-                    chunk.try_into().vortex_expect("chunk size must be 64"),
+                    chunk.try_into().expect("chunk size must be 64"),
                     count_distinct_values,
                     &mut loop_state,
                 )
@@ -267,13 +280,13 @@ where
                     0 => continue,
                     // Inner loop for when validity check can be elided
                     64 => inner_loop_nonnull(
-                        chunk.try_into().vortex_expect("chunk size must be 64"),
+                        chunk.try_into().expect("chunk size must be 64"),
                         count_distinct_values,
                         &mut loop_state,
                     ),
                     // Inner loop for when we need to check validity
                     _ => inner_loop_nullable(
-                        chunk.try_into().vortex_expect("chunk size must be 64"),
+                        chunk.try_into().expect("chunk size must be 64"),
                         count_distinct_values,
                         &validity,
                         &mut loop_state,
@@ -296,7 +309,7 @@ where
             .distinct_values
             .iter()
             .max_by_key(|&(_, &count)| count)
-            .vortex_expect("non-empty");
+            .expect("non-empty");
         (top_value.0, top_count)
     } else {
         (T::default(), 0)
@@ -304,11 +317,7 @@ where
 
     let runs = loop_state.runs;
     let distinct_values_count = if count_distinct_values {
-        loop_state
-            .distinct_values
-            .len()
-            .try_into()
-            .vortex_expect("distinct values count must fit in u32")
+        u32::try_from(loop_state.distinct_values.len())?
     } else {
         u32::MAX
     };
@@ -316,12 +325,12 @@ where
     let min = array
         .statistics()
         .compute_as::<T>(Stat::Min)
-        .vortex_expect("min should be computed");
+        .expect("min should be computed");
 
     let max = array
         .statistics()
         .compute_as::<T>(Stat::Max)
-        .vortex_expect("max should be computed");
+        .expect("max should be computed");
 
     let typed = TypedStats {
         min,
@@ -331,21 +340,17 @@ where
         top_count,
     };
 
-    let null_count = null_count
-        .try_into()
-        .vortex_expect("null_count must fit in u32");
-    let value_count = value_count
-        .try_into()
-        .vortex_expect("value_count must fit in u32");
+    let null_count = u32::try_from(null_count)?;
+    let value_count = u32::try_from(value_count)?;
 
-    IntegerStats {
+    Ok(IntegerStats {
         src: array.clone(),
         null_count,
         value_count,
         average_run_length: value_count / runs,
         distinct_values_count,
         typed: typed.into(),
-    }
+    })
 }
 
 struct LoopState<T> {
@@ -429,45 +434,50 @@ mod tests {
     use vortex_buffer::BitBuffer;
     use vortex_buffer::Buffer;
     use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
 
     use crate::CompressorStats;
     use crate::integer::IntegerStats;
     use crate::integer::stats::typed_int_stats;
 
     #[test]
-    fn test_naive_count_distinct_values() {
+    fn test_naive_count_distinct_values() -> VortexResult<()> {
         let array = PrimitiveArray::new(buffer![217u8, 0], Validity::NonNullable);
-        let stats = typed_int_stats::<u8>(&array, true);
+        let stats = typed_int_stats::<u8>(&array, true)?;
         assert_eq!(stats.distinct_values_count, 2);
+        Ok(())
     }
 
     #[test]
-    fn test_naive_count_distinct_values_nullable() {
+    fn test_naive_count_distinct_values_nullable() -> VortexResult<()> {
         let array = PrimitiveArray::new(
             buffer![217u8, 0],
             Validity::from(BitBuffer::from(vec![true, false])),
         );
-        let stats = typed_int_stats::<u8>(&array, true);
+        let stats = typed_int_stats::<u8>(&array, true)?;
         assert_eq!(stats.distinct_values_count, 1);
+        Ok(())
     }
 
     #[test]
-    fn test_count_distinct_values() {
+    fn test_count_distinct_values() -> VortexResult<()> {
         let array = PrimitiveArray::new((0..128u8).collect::<Buffer<u8>>(), Validity::NonNullable);
-        let stats = typed_int_stats::<u8>(&array, true);
+        let stats = typed_int_stats::<u8>(&array, true)?;
         assert_eq!(stats.distinct_values_count, 128);
+        Ok(())
     }
 
     #[test]
-    fn test_count_distinct_values_nullable() {
+    fn test_count_distinct_values_nullable() -> VortexResult<()> {
         let array = PrimitiveArray::new(
             (0..128u8).collect::<Buffer<u8>>(),
             Validity::from(BitBuffer::from_iter(
                 iter::repeat_n(vec![true, false], 64).flatten(),
             )),
         );
-        let stats = typed_int_stats::<u8>(&array, true);
+        let stats = typed_int_stats::<u8>(&array, true)?;
         assert_eq!(stats.distinct_values_count, 64);
+        Ok(())
     }
 
     #[test]

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -53,6 +53,7 @@ use vortex_array::vtable::ValidityHelper;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::datetime::TemporalMetadata;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::decimal::compress_decimal;
@@ -188,7 +189,7 @@ fn estimate_compression_ratio_with_sampling<T: Scheme + ?Sized>(
         // We want to sample about 1% of data, while keeping a minimal sample of 640 values.
         let sample_count = usize::max(
             (source_len / 100)
-                / usize::try_from(SAMPLE_SIZE).expect("SAMPLE_SIZE must fit in usize"),
+                / usize::try_from(SAMPLE_SIZE).vortex_expect("SAMPLE_SIZE must fit in usize"),
             10,
         );
 
@@ -202,7 +203,7 @@ fn estimate_compression_ratio_with_sampling<T: Scheme + ?Sized>(
             SAMPLE_SIZE,
             sample_count
                 .try_into()
-                .expect("sample count must fit in u32"),
+                .vortex_expect("sample count must fit in u32"),
         )
     };
 

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -53,7 +53,6 @@ use vortex_array::vtable::ValidityHelper;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::datetime::TemporalMetadata;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::decimal::compress_decimal;
@@ -189,7 +188,7 @@ fn estimate_compression_ratio_with_sampling<T: Scheme + ?Sized>(
         // We want to sample about 1% of data, while keeping a minimal sample of 640 values.
         let sample_count = usize::max(
             (source_len / 100)
-                / usize::try_from(SAMPLE_SIZE).vortex_expect("SAMPLE_SIZE must fit in usize"),
+                / usize::try_from(SAMPLE_SIZE).expect("SAMPLE_SIZE must fit in usize"),
             10,
         );
 
@@ -203,7 +202,7 @@ fn estimate_compression_ratio_with_sampling<T: Scheme + ?Sized>(
             SAMPLE_SIZE,
             sample_count
                 .try_into()
-                .vortex_expect("sample count must fit in u32"),
+                .expect("sample count must fit in u32"),
         )
     };
 

--- a/vortex-btrblocks/src/patches.rs
+++ b/vortex-btrblocks/src/patches.rs
@@ -25,12 +25,12 @@ pub fn compress_patches(patches: &Patches) -> VortexResult<Patches> {
         values.clone()
     };
 
-    Ok(Patches::new(
+    Patches::new(
         patches.array_len(),
         patches.offset(),
         indices,
         values,
         // TODO(0ax1): chunk offsets
         None,
-    ))
+    )
 }

--- a/vortex-btrblocks/src/sample.rs
+++ b/vortex-btrblocks/src/sample.rs
@@ -8,6 +8,7 @@ use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::arrays::ChunkedArray;
+use vortex_error::VortexExpect;
 
 pub(crate) fn sample(input: &dyn Array, sample_size: u32, sample_count: u32) -> ArrayRef {
     if input.len() <= (sample_size as usize) * (sample_count as usize) {
@@ -22,15 +23,17 @@ pub(crate) fn sample(input: &dyn Array, sample_size: u32, sample_count: u32) -> 
     );
 
     // For every slice, grab the relevant slice and repack into a new PrimitiveArray.
-    ChunkedArray::try_new(
-        slices
-            .into_iter()
-            .map(|(start, end)| input.slice(start..end))
-            .collect(),
-        input.dtype().clone(),
-    )
-    .expect("sample slices should form valid chunked array")
-    .into_array()
+    let chunks: Vec<_> = slices
+        .into_iter()
+        .map(|(start, end)| {
+            input
+                .slice(start..end)
+                .vortex_expect("slice should succeed")
+        })
+        .collect();
+    ChunkedArray::try_new(chunks, input.dtype().clone())
+        .vortex_expect("sample slices should form valid chunked array")
+        .into_array()
 }
 
 pub fn stratified_slices(

--- a/vortex-btrblocks/src/sample.rs
+++ b/vortex-btrblocks/src/sample.rs
@@ -8,7 +8,6 @@ use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::arrays::ChunkedArray;
-use vortex_error::VortexExpect;
 
 pub(crate) fn sample(input: &dyn Array, sample_size: u32, sample_count: u32) -> ArrayRef {
     if input.len() <= (sample_size as usize) * (sample_count as usize) {
@@ -30,7 +29,7 @@ pub(crate) fn sample(input: &dyn Array, sample_size: u32, sample_count: u32) -> 
             .collect(),
         input.dtype().clone(),
     )
-    .vortex_expect("sample")
+    .expect("sample slices should form valid chunked array")
     .into_array()
 }
 

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -13,6 +13,7 @@ use vortex_array::arrays::VarBinViewVTable;
 use vortex_array::builders::dict::dict_encode;
 use vortex_array::compute::is_constant;
 use vortex_array::vtable::ValidityHelper;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 use vortex_fsst::FSSTArray;
@@ -90,7 +91,7 @@ impl CompressorStats for StringStats {
 
     fn generate_opts(input: &VarBinViewArray, opts: GenerateStatsOptions) -> Self {
         Self::generate_opts_fallible(input, opts)
-            .expect("StringStats::generate_opts should not fail")
+            .vortex_expect("StringStats::generate_opts should not fail")
     }
 
     fn source(&self) -> &VarBinViewArray {

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -456,6 +456,7 @@ mod tests {
     use vortex_array::builders::VarBinViewBuilder;
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;
+    use vortex_error::VortexResult;
     use vortex_sparse::SparseVTable;
 
     use crate::Compressor;
@@ -463,7 +464,7 @@ mod tests {
     use crate::string::StringCompressor;
 
     #[test]
-    fn test_strings() {
+    fn test_strings() -> VortexResult<()> {
         let mut strings = Vec::new();
         for _ in 0..1024 {
             strings.push(Some("hello-world-1234"));
@@ -475,13 +476,15 @@ mod tests {
 
         println!("original array: {}", strings.as_ref().display_tree());
 
-        let compressed = StringCompressor::compress(&strings, false, 3, &[]).unwrap();
+        let compressed = StringCompressor::compress(&strings, false, 3, &[])?;
 
         println!("compression tree: {}", compressed.display_tree());
+
+        Ok(())
     }
 
     #[test]
-    fn test_sparse_nulls() {
+    fn test_sparse_nulls() -> VortexResult<()> {
         let mut strings = VarBinViewBuilder::with_capacity(DType::Utf8(Nullability::Nullable), 100);
         strings.append_nulls(99);
 
@@ -489,8 +492,10 @@ mod tests {
 
         let strings = strings.finish_into_varbinview();
 
-        let compressed = StringCompressor::compress(&strings, false, MAX_CASCADE, &[]).unwrap();
+        let compressed = StringCompressor::compress(&strings, false, MAX_CASCADE, &[])?;
         assert!(compressed.is::<SparseVTable>());
+
+        Ok(())
     }
 }
 
@@ -502,33 +507,36 @@ mod scheme_selection_tests {
     use vortex_array::arrays::VarBinViewArray;
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;
+    use vortex_error::VortexResult;
     use vortex_fsst::FSSTVTable;
 
     use crate::Compressor;
     use crate::string::StringCompressor;
 
     #[test]
-    fn test_constant_compressed() {
+    fn test_constant_compressed() -> VortexResult<()> {
         let strings: Vec<Option<&str>> = vec![Some("constant_value"); 100];
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
-        let compressed = StringCompressor::compress(&array, false, 3, &[]).unwrap();
+        let compressed = StringCompressor::compress(&array, false, 3, &[])?;
         assert!(compressed.is::<ConstantVTable>());
+        Ok(())
     }
 
     #[test]
-    fn test_dict_compressed() {
+    fn test_dict_compressed() -> VortexResult<()> {
         let distinct_values = ["apple", "banana", "cherry"];
         let mut strings = Vec::with_capacity(1000);
         for i in 0..1000 {
             strings.push(Some(distinct_values[i % 3]));
         }
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
-        let compressed = StringCompressor::compress(&array, false, 3, &[]).unwrap();
+        let compressed = StringCompressor::compress(&array, false, 3, &[])?;
         assert!(compressed.is::<DictVTable>());
+        Ok(())
     }
 
     #[test]
-    fn test_fsst_compressed() {
+    fn test_fsst_compressed() -> VortexResult<()> {
         let mut strings = Vec::with_capacity(1000);
         for i in 0..1000 {
             strings.push(Some(format!(
@@ -536,7 +544,8 @@ mod scheme_selection_tests {
             )));
         }
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
-        let compressed = StringCompressor::compress(&array, false, 3, &[]).unwrap();
+        let compressed = StringCompressor::compress(&array, false, 3, &[])?;
         assert!(compressed.is::<FSSTVTable>());
+        Ok(())
     }
 }

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -13,8 +13,8 @@ use vortex_array::arrays::VarBinViewVTable;
 use vortex_array::builders::dict::dict_encode;
 use vortex_array::compute::is_constant;
 use vortex_array::vtable::ValidityHelper;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_err;
 use vortex_fsst::FSSTArray;
 use vortex_fsst::fsst_compress;
 use vortex_fsst::fsst_train_compressor;
@@ -42,7 +42,7 @@ pub struct StringStats {
 }
 
 /// Estimate the number of distinct strings in the var bin view array.
-fn estimate_distinct_count(strings: &VarBinViewArray) -> u32 {
+fn estimate_distinct_count(strings: &VarBinViewArray) -> VortexResult<u32> {
     let views = strings.views();
     // Iterate the views. Two strings which are equal must have the same first 8-bytes.
     // NOTE: there are cases where this performs pessimally, e.g. when we have strings that all
@@ -57,33 +57,40 @@ fn estimate_distinct_count(strings: &VarBinViewArray) -> u32 {
         distinct.insert(len_and_prefix);
     });
 
-    distinct
-        .len()
-        .try_into()
-        .vortex_expect("distinct count must fit in u32")
+    Ok(u32::try_from(distinct.len())?)
+}
+
+impl StringStats {
+    fn generate_opts_fallible(
+        input: &VarBinViewArray,
+        opts: GenerateStatsOptions,
+    ) -> VortexResult<Self> {
+        let null_count = input
+            .statistics()
+            .compute_null_count()
+            .ok_or_else(|| vortex_err!("Failed to compute null_count"))?;
+        let value_count = input.len() - null_count;
+        let estimated_distinct = if opts.count_distinct_values {
+            estimate_distinct_count(input)?
+        } else {
+            u32::MAX
+        };
+
+        Ok(Self {
+            src: input.clone(),
+            value_count: u32::try_from(value_count)?,
+            null_count: u32::try_from(null_count)?,
+            estimated_distinct_count: estimated_distinct,
+        })
+    }
 }
 
 impl CompressorStats for StringStats {
     type ArrayVTable = VarBinViewVTable;
 
     fn generate_opts(input: &VarBinViewArray, opts: GenerateStatsOptions) -> Self {
-        let null_count = input
-            .statistics()
-            .compute_null_count()
-            .vortex_expect("null count");
-        let value_count = input.len() - null_count;
-        let estimated_distinct = if opts.count_distinct_values {
-            estimate_distinct_count(input)
-        } else {
-            u32::MAX
-        };
-
-        Self {
-            src: input.clone(),
-            value_count: value_count.try_into().vortex_expect("value_count"),
-            null_count: null_count.try_into().vortex_expect("null_count"),
-            estimated_distinct_count: estimated_distinct,
-        }
+        Self::generate_opts_fallible(input, opts)
+            .expect("StringStats::generate_opts should not fail")
     }
 
     fn source(&self) -> &VarBinViewArray {

--- a/vortex-cxx/src/write.rs
+++ b/vortex-cxx/src/write.rs
@@ -37,8 +37,8 @@ fn arrow_stream_to_vortex_stream(reader: ArrowArrayStreamReader) -> Result<impl 
         DType::from_arrow(reader.schema()),
         reader.map(|result| {
             result
-                .map(|record_batch| ArrayRef::from_arrow(record_batch, false))
                 .map_err(VortexError::from)
+                .and_then(|record_batch| ArrayRef::from_arrow(record_batch, false))
         }),
     );
 

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -477,7 +477,7 @@ mod tests {
         path: &str,
         rb: RecordBatch,
     ) -> anyhow::Result<u64> {
-        let array = ArrayRef::from_arrow(rb, false);
+        let array = ArrayRef::from_arrow(rb, false)?;
         let path = Path::parse(path)?;
 
         let mut write = ObjectStoreWriter::new(object_store, &path).await?;

--- a/vortex-datafusion/src/persistent/sink.rs
+++ b/vortex-datafusion/src/persistent/sink.rs
@@ -30,7 +30,6 @@ use vortex::array::arrow::FromArrowArray;
 use vortex::array::stream::ArrayStreamAdapter;
 use vortex::dtype::DType;
 use vortex::dtype::arrow::FromArrowType;
-use vortex::error::VortexResult;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::file::WriteSummary;
 use vortex::io::ObjectStoreWriter;
@@ -121,8 +120,7 @@ impl FileSink for VortexSink {
             // We need to spawn work because there's a dependency between the different files. If one file has too many batches buffered,
             // the demux task might deadlock itself.
             file_write_tasks.spawn(async move {
-                let stream = ReceiverStream::new(rx)
-                    .map(move |rb| VortexResult::Ok(ArrayRef::from_arrow(rb, false)));
+                let stream = ReceiverStream::new(rx).map(move |rb| ArrayRef::from_arrow(rb, false));
 
                 let stream_adapter = ArrayStreamAdapter::new(dtype, stream);
 

--- a/vortex-datafusion/tests/schema_evolution.rs
+++ b/vortex-datafusion/tests/schema_evolution.rs
@@ -80,7 +80,7 @@ fn make_session_ctx() -> (SessionContext, Arc<dyn ObjectStore>) {
 }
 
 async fn write_file(store: &Arc<dyn ObjectStore>, path: &str, records: &RecordBatch) {
-    let array = ArrayRef::from_arrow(records, false);
+    let array = ArrayRef::from_arrow(records, false).unwrap();
     let path = Path::from_url_path(path).unwrap();
     let mut write = ObjectStoreWriter::new(store.clone(), &path).await.unwrap();
     SESSION

--- a/vortex-duckdb/src/convert/vector.rs
+++ b/vortex-duckdb/src/convert/vector.rs
@@ -642,7 +642,7 @@ mod tests {
 
         assert_eq!(vortex_array.len(), len);
         assert_arrays_eq!(
-            vortex_array.list_elements_at(0),
+            vortex_array.list_elements_at(0).unwrap(),
             PrimitiveArray::from_option_iter([Some(1i32), Some(2), Some(3), Some(4)])
         );
     }
@@ -670,7 +670,7 @@ mod tests {
 
         assert_eq!(vortex_array.len(), len);
         assert_arrays_eq!(
-            vortex_array.fixed_size_list_elements_at(0),
+            vortex_array.fixed_size_list_elements_at(0).unwrap(),
             PrimitiveArray::from_option_iter([Some(1i32), Some(2), Some(3), Some(4)])
         );
     }
@@ -772,7 +772,7 @@ mod tests {
 
         assert_eq!(vortex_array.len(), len);
         assert_arrays_eq!(
-            vortex_array.list_elements_at(0),
+            vortex_array.list_elements_at(0).unwrap(),
             PrimitiveArray::from_option_iter([Some(1i32), Some(2), Some(3), Some(4)])
         );
         assert_eq!(
@@ -817,11 +817,11 @@ mod tests {
 
         assert_eq!(vortex_array.len(), len);
         assert_arrays_eq!(
-            vortex_array.list_elements_at(0),
+            vortex_array.list_elements_at(0).unwrap(),
             PrimitiveArray::from_option_iter([Some(3i32), Some(4)])
         );
         assert_arrays_eq!(
-            vortex_array.list_elements_at(1),
+            vortex_array.list_elements_at(1).unwrap(),
             PrimitiveArray::from_option_iter([Some(1i32), Some(2)])
         );
     }
@@ -874,11 +874,11 @@ mod tests {
 
         // Valid entries should work correctly.
         assert_arrays_eq!(
-            vortex_array.list_elements_at(0),
+            vortex_array.list_elements_at(0).unwrap(),
             PrimitiveArray::from_option_iter([Some(1i32), Some(2)])
         );
         assert_arrays_eq!(
-            vortex_array.list_elements_at(2),
+            vortex_array.list_elements_at(2).unwrap(),
             PrimitiveArray::from_option_iter([Some(3i32), Some(4)])
         );
 

--- a/vortex-duckdb/src/duckdb/vector.rs
+++ b/vortex-duckdb/src/duckdb/vector.rs
@@ -390,7 +390,7 @@ mod tests {
 
         let validity = vector.validity_ref(len);
         let validity = validity.to_validity();
-        assert!(validity.is_null(0));
+        assert!(validity.is_null(0).unwrap());
     }
 
     #[test]
@@ -406,7 +406,7 @@ mod tests {
 
         let validity = vector.validity_ref(len);
         let validity = validity.to_validity();
-        assert!(validity.is_valid(0));
+        assert!(validity.is_valid(0).unwrap());
     }
 
     #[test]

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -56,7 +56,8 @@ impl ArrayExporter {
         cache: &ConversionCache,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
-        assert!(array.validity().all_valid(array.len()));
+        let all_valid = array.validity().all_valid(array.len())?;
+        assert!(all_valid);
         let fields = array
             .fields()
             .iter()

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -15,6 +15,56 @@
 #include <stdlib.h>
 
 /**
+ * Variant enum for Vortex primitive types.
+ */
+typedef enum {
+  /**
+   * Unsigned 8-bit integer
+   */
+  PTYPE_U8 = 0,
+  /**
+   * Unsigned 16-bit integer
+   */
+  PTYPE_U16 = 1,
+  /**
+   * Unsigned 32-bit integer
+   */
+  PTYPE_U32 = 2,
+  /**
+   * Unsigned 64-bit integer
+   */
+  PTYPE_U64 = 3,
+  /**
+   * Signed 8-bit integer
+   */
+  PTYPE_I8 = 4,
+  /**
+   * Signed 16-bit integer
+   */
+  PTYPE_I16 = 5,
+  /**
+   * Signed 32-bit integer
+   */
+  PTYPE_I32 = 6,
+  /**
+   * Signed 64-bit integer
+   */
+  PTYPE_I64 = 7,
+  /**
+   * 16-bit floating point number
+   */
+  PTYPE_F16 = 8,
+  /**
+   * 32-bit floating point number
+   */
+  PTYPE_F32 = 9,
+  /**
+   * 64-bit floating point number
+   */
+  PTYPE_F64 = 10,
+} vx_ptype;
+
+/**
  * The variant tag for a Vortex data type.
  */
 typedef enum {
@@ -91,54 +141,61 @@ typedef enum {
 } vx_log_level;
 
 /**
- * Variant enum for Vortex primitive types.
+ * Physical type enum, represents the in-memory physical layout but might represent a different logical type.
  */
-typedef enum {
+enum PType
+#ifdef __cplusplus
+  : uint8_t
+#endif // __cplusplus
+ {
   /**
-   * Unsigned 8-bit integer
+   * An 8-bit unsigned integer
    */
-  PTYPE_U8 = 0,
+  U8 = 0,
   /**
-   * Unsigned 16-bit integer
+   * A 16-bit unsigned integer
    */
-  PTYPE_U16 = 1,
+  U16 = 1,
   /**
-   * Unsigned 32-bit integer
+   * A 32-bit unsigned integer
    */
-  PTYPE_U32 = 2,
+  U32 = 2,
   /**
-   * Unsigned 64-bit integer
+   * A 64-bit unsigned integer
    */
-  PTYPE_U64 = 3,
+  U64 = 3,
   /**
-   * Signed 8-bit integer
+   * An 8-bit signed integer
    */
-  PTYPE_I8 = 4,
+  I8 = 4,
   /**
-   * Signed 16-bit integer
+   * A 16-bit signed integer
    */
-  PTYPE_I16 = 5,
+  I16 = 5,
   /**
-   * Signed 32-bit integer
+   * A 32-bit signed integer
    */
-  PTYPE_I32 = 6,
+  I32 = 6,
   /**
-   * Signed 64-bit integer
+   * A 64-bit signed integer
    */
-  PTYPE_I64 = 7,
+  I64 = 7,
   /**
-   * 16-bit floating point number
+   * A 16-bit floating point number
    */
-  PTYPE_F16 = 8,
+  F16 = 8,
   /**
-   * 32-bit floating point number
+   * A 32-bit floating point number
    */
-  PTYPE_F32 = 9,
+  F32 = 9,
   /**
-   * 64-bit floating point number
+   * A 64-bit floating point number
    */
-  PTYPE_F64 = 10,
-} vx_ptype;
+  F64 = 10,
+};
+#ifndef __cplusplus
+typedef uint8_t PType;
+#endif // __cplusplus
 
 /**
  * The logical types of elements in Vortex arrays.
@@ -166,6 +223,11 @@ typedef enum {
  * [`NonNullable`]: Nullability::NonNullable
  */
 typedef struct DType DType;
+
+/**
+ * Whether an instance of a DType can be `null or not
+ */
+typedef struct Nullability Nullability;
 
 /**
  * Base type for all Vortex arrays.

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -15,56 +15,6 @@
 #include <stdlib.h>
 
 /**
- * Variant enum for Vortex primitive types.
- */
-typedef enum {
-  /**
-   * Unsigned 8-bit integer
-   */
-  PTYPE_U8 = 0,
-  /**
-   * Unsigned 16-bit integer
-   */
-  PTYPE_U16 = 1,
-  /**
-   * Unsigned 32-bit integer
-   */
-  PTYPE_U32 = 2,
-  /**
-   * Unsigned 64-bit integer
-   */
-  PTYPE_U64 = 3,
-  /**
-   * Signed 8-bit integer
-   */
-  PTYPE_I8 = 4,
-  /**
-   * Signed 16-bit integer
-   */
-  PTYPE_I16 = 5,
-  /**
-   * Signed 32-bit integer
-   */
-  PTYPE_I32 = 6,
-  /**
-   * Signed 64-bit integer
-   */
-  PTYPE_I64 = 7,
-  /**
-   * 16-bit floating point number
-   */
-  PTYPE_F16 = 8,
-  /**
-   * 32-bit floating point number
-   */
-  PTYPE_F32 = 9,
-  /**
-   * 64-bit floating point number
-   */
-  PTYPE_F64 = 10,
-} vx_ptype;
-
-/**
  * The variant tag for a Vortex data type.
  */
 typedef enum {
@@ -141,61 +91,54 @@ typedef enum {
 } vx_log_level;
 
 /**
- * Physical type enum, represents the in-memory physical layout but might represent a different logical type.
+ * Variant enum for Vortex primitive types.
  */
-enum PType
-#ifdef __cplusplus
-  : uint8_t
-#endif // __cplusplus
- {
+typedef enum {
   /**
-   * An 8-bit unsigned integer
+   * Unsigned 8-bit integer
    */
-  U8 = 0,
+  PTYPE_U8 = 0,
   /**
-   * A 16-bit unsigned integer
+   * Unsigned 16-bit integer
    */
-  U16 = 1,
+  PTYPE_U16 = 1,
   /**
-   * A 32-bit unsigned integer
+   * Unsigned 32-bit integer
    */
-  U32 = 2,
+  PTYPE_U32 = 2,
   /**
-   * A 64-bit unsigned integer
+   * Unsigned 64-bit integer
    */
-  U64 = 3,
+  PTYPE_U64 = 3,
   /**
-   * An 8-bit signed integer
+   * Signed 8-bit integer
    */
-  I8 = 4,
+  PTYPE_I8 = 4,
   /**
-   * A 16-bit signed integer
+   * Signed 16-bit integer
    */
-  I16 = 5,
+  PTYPE_I16 = 5,
   /**
-   * A 32-bit signed integer
+   * Signed 32-bit integer
    */
-  I32 = 6,
+  PTYPE_I32 = 6,
   /**
-   * A 64-bit signed integer
+   * Signed 64-bit integer
    */
-  I64 = 7,
+  PTYPE_I64 = 7,
   /**
-   * A 16-bit floating point number
+   * 16-bit floating point number
    */
-  F16 = 8,
+  PTYPE_F16 = 8,
   /**
-   * A 32-bit floating point number
+   * 32-bit floating point number
    */
-  F32 = 9,
+  PTYPE_F32 = 9,
   /**
-   * A 64-bit floating point number
+   * 64-bit floating point number
    */
-  F64 = 10,
-};
-#ifndef __cplusplus
-typedef uint8_t PType;
-#endif // __cplusplus
+  PTYPE_F64 = 10,
+} vx_ptype;
 
 /**
  * The logical types of elements in Vortex arrays.
@@ -223,11 +166,6 @@ typedef uint8_t PType;
  * [`NonNullable`]: Nullability::NonNullable
  */
 typedef struct DType DType;
-
-/**
- * Whether an instance of a DType can be `null or not
- */
-typedef struct Nullability Nullability;
 
 /**
  * Base type for all Vortex arrays.
@@ -415,7 +353,7 @@ const vx_array *vx_array_get_field(const vx_array *array, uint32_t index, vx_err
 const vx_array *vx_array_slice(const vx_array *array,
                                uint32_t start,
                                uint32_t stop,
-                               vx_error **_error_out);
+                               vx_error **error_out);
 
 bool vx_array_is_null(const vx_array *array, uint32_t index, vx_error **_error_out);
 

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -72,12 +72,13 @@ pub unsafe extern "C-unwind" fn vx_array_slice(
     array: *const vx_array,
     start: u32,
     stop: u32,
-    // TODO(aduffy): deprecate this from the FFI API.
-    _error_out: *mut *mut vx_error,
+    error_out: *mut *mut vx_error,
 ) -> *const vx_array {
-    let array = vx_array::as_ref(array);
-    let sliced = array.slice(start as usize..stop as usize);
-    vx_array::new(sliced)
+    try_or_default(error_out, || {
+        let array = vx_array::as_ref(array);
+        let sliced = array.slice(start as usize..stop as usize)?;
+        Ok(vx_array::new(sliced))
+    })
 }
 
 #[unsafe(no_mangle)]
@@ -87,7 +88,7 @@ pub unsafe extern "C-unwind" fn vx_array_is_null(
     _error_out: *mut *mut vx_error,
 ) -> bool {
     let array = vx_array::as_ref(array);
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     array
         .is_invalid(index as usize)
         .vortex_expect("is_invalid failed")
@@ -109,9 +110,9 @@ macro_rules! ffiarray_get_ptype {
             #[unsafe(no_mangle)]
             pub unsafe extern "C-unwind" fn [<vx_array_get_ $ptype>](array: *const vx_array, index: u32) -> $ptype {
                 let array = vx_array::as_ref(array);
-                // TODO: propagate this error up instead of expecting
+                // TODO(joe): propagate this error up instead of expecting
                 let value = array.scalar_at(index as usize).vortex_expect("scalar_at failed");
-                // TODO: propagate this error up instead of expecting
+                // TODO(joe): propagate this error up instead of expecting
                 value.as_primitive()
                     .as_::<$ptype>()
                     .vortex_expect("null value")
@@ -120,9 +121,9 @@ macro_rules! ffiarray_get_ptype {
             #[unsafe(no_mangle)]
             pub unsafe extern "C-unwind" fn [<vx_array_get_storage_ $ptype>](array: *const vx_array, index: u32) -> $ptype {
                 let array = vx_array::as_ref(array);
-                // TODO: propagate this error up instead of expecting
+                // TODO(joe): propagate this error up instead of expecting
                 let value = array.scalar_at(index as usize).vortex_expect("scalar_at failed");
-                // TODO: propagate this error up instead of expecting
+                // TODO(joe): propagate this error up instead of expecting
                 value.as_extension()
                     .storage()
                     .as_primitive()
@@ -153,7 +154,7 @@ pub unsafe extern "C-unwind" fn vx_array_get_utf8(
     index: u32,
 ) -> *const vx_string {
     let array = vx_array::as_ref(array);
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let value = array
         .scalar_at(index as usize)
         .vortex_expect("scalar_at failed");
@@ -173,7 +174,7 @@ pub unsafe extern "C-unwind" fn vx_array_get_binary(
     index: u32,
 ) -> *const vx_binary {
     let array = vx_array::as_ref(array);
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let value = array
         .scalar_at(index as usize)
         .vortex_expect("scalar_at failed");

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -87,6 +87,7 @@ pub unsafe extern "C-unwind" fn vx_array_is_null(
     _error_out: *mut *mut vx_error,
 ) -> bool {
     let array = vx_array::as_ref(array);
+    // TODO: propagate this error up instead of expecting
     array
         .is_invalid(index as usize)
         .vortex_expect("is_invalid failed")
@@ -108,7 +109,9 @@ macro_rules! ffiarray_get_ptype {
             #[unsafe(no_mangle)]
             pub unsafe extern "C-unwind" fn [<vx_array_get_ $ptype>](array: *const vx_array, index: u32) -> $ptype {
                 let array = vx_array::as_ref(array);
+                // TODO: propagate this error up instead of expecting
                 let value = array.scalar_at(index as usize).vortex_expect("scalar_at failed");
+                // TODO: propagate this error up instead of expecting
                 value.as_primitive()
                     .as_::<$ptype>()
                     .vortex_expect("null value")
@@ -117,7 +120,9 @@ macro_rules! ffiarray_get_ptype {
             #[unsafe(no_mangle)]
             pub unsafe extern "C-unwind" fn [<vx_array_get_storage_ $ptype>](array: *const vx_array, index: u32) -> $ptype {
                 let array = vx_array::as_ref(array);
+                // TODO: propagate this error up instead of expecting
                 let value = array.scalar_at(index as usize).vortex_expect("scalar_at failed");
+                // TODO: propagate this error up instead of expecting
                 value.as_extension()
                     .storage()
                     .as_primitive()
@@ -148,6 +153,7 @@ pub unsafe extern "C-unwind" fn vx_array_get_utf8(
     index: u32,
 ) -> *const vx_string {
     let array = vx_array::as_ref(array);
+    // TODO: propagate this error up instead of expecting
     let value = array
         .scalar_at(index as usize)
         .vortex_expect("scalar_at failed");
@@ -167,6 +173,7 @@ pub unsafe extern "C-unwind" fn vx_array_get_binary(
     index: u32,
 ) -> *const vx_binary {
     let array = vx_array::as_ref(array);
+    // TODO: propagate this error up instead of expecting
     let value = array
         .scalar_at(index as usize)
         .vortex_expect("scalar_at failed");

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -180,6 +180,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_primitive_ptype(dtype: *const vx_dtype)
 /// Returns the precision of a decimal.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_decimal_precision(dtype: *const vx_dtype) -> u8 {
+    // TODO: propagate this error up instead of expecting
     vx_dtype::as_ref(dtype)
         .as_decimal_opt()
         .vortex_expect("not a decimal dtype")
@@ -189,6 +190,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_decimal_precision(dtype: *const vx_dtyp
 /// Returns the scale of a decimal.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_decimal_scale(dtype: *const vx_dtype) -> i8 {
+    // TODO: propagate this error up instead of expecting
     vx_dtype::as_ref(dtype)
         .as_decimal_opt()
         .vortex_expect("not a decimal dtype")
@@ -203,6 +205,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_decimal_scale(dtype: *const vx_dtype) -
 pub unsafe extern "C-unwind" fn vx_dtype_struct_dtype(
     dtype: *const vx_dtype,
 ) -> *const vx_struct_fields {
+    // TODO: propagate this error up instead of expecting
     let struct_dtype = vx_dtype::as_ref(dtype)
         .as_struct_fields_opt()
         .vortex_expect("not a struct dtype");
@@ -215,6 +218,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_struct_dtype(
 /// Do NOT free the returned dtype pointer - it shares the lifetime of the list dtype.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_list_element(dtype: *const vx_dtype) -> *const vx_dtype {
+    // TODO: propagate this error up instead of expecting
     let element_dtype = vx_dtype::as_ref(dtype)
         .as_list_element_opt()
         .vortex_expect("not a list dtype");
@@ -229,6 +233,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_list_element(dtype: *const vx_dtype) ->
 pub unsafe extern "C-unwind" fn vx_dtype_fixed_size_list_element(
     dtype: *const vx_dtype,
 ) -> *const vx_dtype {
+    // TODO: propagate this error up instead of expecting
     let element_dtype = vx_dtype::as_ref(dtype)
         .as_fixed_size_list_element_opt()
         .vortex_expect("not a fixed-size list dtype");
@@ -248,6 +253,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_fixed_size_list_size(dtype: *const vx_d
 /// Checks if the type is time.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_is_time(dtype: *const DType) -> bool {
+    // TODO: propagate this error up instead of expecting
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
     match dtype {
@@ -259,6 +265,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_time(dtype: *const DType) -> bool {
 /// Checks if the type is a date.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_is_date(dtype: *const DType) -> bool {
+    // TODO: propagate this error up instead of expecting
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
     match dtype {
@@ -270,6 +277,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_date(dtype: *const DType) -> bool {
 /// Checks if the type is a timestamp.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_is_timestamp(dtype: *const DType) -> bool {
+    // TODO: propagate this error up instead of expecting
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
     match dtype {
@@ -281,12 +289,14 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_timestamp(dtype: *const DType) -> bo
 /// Returns the time unit, assuming the type is time.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_time_unit(dtype: *const DType) -> u8 {
+    // TODO: propagate this error up instead of expecting
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
     let DType::Extension(ext_dtype) = dtype else {
         vortex_panic!("DType_time_unit: not a time dtype")
     };
 
+    // TODO: propagate this error up instead of expecting
     let metadata = ext_dtype.metadata().vortex_expect("time unit metadata");
 
     metadata.as_ref()[0]
@@ -295,12 +305,14 @@ pub unsafe extern "C-unwind" fn vx_dtype_time_unit(dtype: *const DType) -> u8 {
 /// Returns the time zone, assuming the type is time. Caller is responsible for freeing the returned pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_time_zone(dtype: *const DType) -> *const vx_string {
+    // TODO: propagate this error up instead of expecting
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
     let DType::Extension(ext_dtype) = dtype else {
         vortex_panic!("vx_dtype_time_unit: not a time dtype")
     };
 
+    // TODO: propagate this error up instead of expecting
     match TemporalMetadata::try_from(ext_dtype).vortex_expect("timestamp") {
         TemporalMetadata::Timestamp(_, zone) => {
             if let Some(zone) = zone {

--- a/vortex-ffi/src/dtype.rs
+++ b/vortex-ffi/src/dtype.rs
@@ -180,7 +180,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_primitive_ptype(dtype: *const vx_dtype)
 /// Returns the precision of a decimal.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_decimal_precision(dtype: *const vx_dtype) -> u8 {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     vx_dtype::as_ref(dtype)
         .as_decimal_opt()
         .vortex_expect("not a decimal dtype")
@@ -190,7 +190,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_decimal_precision(dtype: *const vx_dtyp
 /// Returns the scale of a decimal.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_decimal_scale(dtype: *const vx_dtype) -> i8 {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     vx_dtype::as_ref(dtype)
         .as_decimal_opt()
         .vortex_expect("not a decimal dtype")
@@ -205,7 +205,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_decimal_scale(dtype: *const vx_dtype) -
 pub unsafe extern "C-unwind" fn vx_dtype_struct_dtype(
     dtype: *const vx_dtype,
 ) -> *const vx_struct_fields {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let struct_dtype = vx_dtype::as_ref(dtype)
         .as_struct_fields_opt()
         .vortex_expect("not a struct dtype");
@@ -218,7 +218,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_struct_dtype(
 /// Do NOT free the returned dtype pointer - it shares the lifetime of the list dtype.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_list_element(dtype: *const vx_dtype) -> *const vx_dtype {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let element_dtype = vx_dtype::as_ref(dtype)
         .as_list_element_opt()
         .vortex_expect("not a list dtype");
@@ -233,7 +233,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_list_element(dtype: *const vx_dtype) ->
 pub unsafe extern "C-unwind" fn vx_dtype_fixed_size_list_element(
     dtype: *const vx_dtype,
 ) -> *const vx_dtype {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let element_dtype = vx_dtype::as_ref(dtype)
         .as_fixed_size_list_element_opt()
         .vortex_expect("not a fixed-size list dtype");
@@ -253,7 +253,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_fixed_size_list_size(dtype: *const vx_d
 /// Checks if the type is time.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_is_time(dtype: *const DType) -> bool {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
     match dtype {
@@ -265,7 +265,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_time(dtype: *const DType) -> bool {
 /// Checks if the type is a date.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_is_date(dtype: *const DType) -> bool {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
     match dtype {
@@ -277,7 +277,7 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_date(dtype: *const DType) -> bool {
 /// Checks if the type is a timestamp.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_is_timestamp(dtype: *const DType) -> bool {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
     match dtype {
@@ -289,14 +289,14 @@ pub unsafe extern "C-unwind" fn vx_dtype_is_timestamp(dtype: *const DType) -> bo
 /// Returns the time unit, assuming the type is time.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_time_unit(dtype: *const DType) -> u8 {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
     let DType::Extension(ext_dtype) = dtype else {
         vortex_panic!("DType_time_unit: not a time dtype")
     };
 
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let metadata = ext_dtype.metadata().vortex_expect("time unit metadata");
 
     metadata.as_ref()[0]
@@ -305,14 +305,14 @@ pub unsafe extern "C-unwind" fn vx_dtype_time_unit(dtype: *const DType) -> u8 {
 /// Returns the time zone, assuming the type is time. Caller is responsible for freeing the returned pointer.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_dtype_time_zone(dtype: *const DType) -> *const vx_string {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let dtype = unsafe { dtype.as_ref() }.vortex_expect("dtype null");
 
     let DType::Extension(ext_dtype) = dtype else {
         vortex_panic!("vx_dtype_time_unit: not a time dtype")
     };
 
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     match TemporalMetadata::try_from(ext_dtype).vortex_expect("timestamp") {
         TemporalMetadata::Timestamp(_, zone) => {
             if let Some(zone) = zone {

--- a/vortex-ffi/src/macros.rs
+++ b/vortex-ffi/src/macros.rs
@@ -68,6 +68,7 @@ macro_rules! arc_dyn_wrapper {
                 /// Extract a borrowed reference from a const pointer.
                 pub(crate) fn as_ref<'a>(ptr: *const $ffi_ident) -> &'a std::sync::Arc<$T> {
                     use vortex::error::VortexExpect;
+                    // TODO: propagate this error up instead of expecting
                     &unsafe { ptr.as_ref() }
                         .vortex_expect("null pointer")
                         .0
@@ -129,6 +130,7 @@ macro_rules! arc_wrapper {
                 /// Extract a borrowed reference from a const pointer.
                 pub(crate) fn as_ref(ptr: *const $ffi_ident) -> &'static $T {
                     use vortex::error::VortexExpect;
+                    // TODO: propagate this error up instead of expecting
                     &unsafe { ptr.as_ref() }
                         .vortex_expect("null pointer")
                         .0
@@ -193,6 +195,7 @@ macro_rules! box_dyn_wrapper {
                 /// Extract a borrowed reference from a const pointer.
                 pub(crate) fn as_ref<'a>(ptr: *const $ffi_ident) -> &'a $T {
                     use vortex::error::VortexExpect;
+                    // TODO: propagate this error up instead of expecting
                     unsafe { ptr.as_ref() }
                         .vortex_expect("null pointer")
                         .0
@@ -202,6 +205,7 @@ macro_rules! box_dyn_wrapper {
                 /// Extract a borrowed mutable reference from a mut pointer.
                 pub(crate) fn as_mut<'a>(ptr: *mut $ffi_ident) -> &'a mut $T {
                     use vortex::error::VortexExpect;
+                    // TODO: propagate this error up instead of expecting
                     unsafe { ptr.as_mut() }
                         .vortex_expect("null pointer")
                         .0
@@ -253,6 +257,7 @@ macro_rules! box_wrapper {
                 /// Extract a borrowed reference from a const pointer.
                 pub(crate) fn as_ref<'a>(ptr: *const $ffi_ident) -> &'a $T {
                     use vortex::error::VortexExpect;
+                    // TODO: propagate this error up instead of expecting
                     &unsafe { ptr.as_ref() }
                         .vortex_expect("null pointer")
                         .0
@@ -261,6 +266,7 @@ macro_rules! box_wrapper {
                 /// Extract a borrowed mutable reference from a mut pointer.
                 pub(crate) fn as_mut<'a>(ptr: *mut $ffi_ident) -> &'a mut $T {
                     use vortex::error::VortexExpect;
+                    // TODO: propagate this error up instead of expecting
                     &mut unsafe { ptr.as_mut() }
                         .vortex_expect("null pointer")
                         .0

--- a/vortex-ffi/src/macros.rs
+++ b/vortex-ffi/src/macros.rs
@@ -68,7 +68,7 @@ macro_rules! arc_dyn_wrapper {
                 /// Extract a borrowed reference from a const pointer.
                 pub(crate) fn as_ref<'a>(ptr: *const $ffi_ident) -> &'a std::sync::Arc<$T> {
                     use vortex::error::VortexExpect;
-                    // TODO: propagate this error up instead of expecting
+                    // TODO(joe): propagate this error up instead of expecting
                     &unsafe { ptr.as_ref() }
                         .vortex_expect("null pointer")
                         .0
@@ -130,7 +130,7 @@ macro_rules! arc_wrapper {
                 /// Extract a borrowed reference from a const pointer.
                 pub(crate) fn as_ref(ptr: *const $ffi_ident) -> &'static $T {
                     use vortex::error::VortexExpect;
-                    // TODO: propagate this error up instead of expecting
+                    // TODO(joe): propagate this error up instead of expecting
                     &unsafe { ptr.as_ref() }
                         .vortex_expect("null pointer")
                         .0
@@ -195,7 +195,7 @@ macro_rules! box_dyn_wrapper {
                 /// Extract a borrowed reference from a const pointer.
                 pub(crate) fn as_ref<'a>(ptr: *const $ffi_ident) -> &'a $T {
                     use vortex::error::VortexExpect;
-                    // TODO: propagate this error up instead of expecting
+                    // TODO(joe): propagate this error up instead of expecting
                     unsafe { ptr.as_ref() }
                         .vortex_expect("null pointer")
                         .0
@@ -205,7 +205,7 @@ macro_rules! box_dyn_wrapper {
                 /// Extract a borrowed mutable reference from a mut pointer.
                 pub(crate) fn as_mut<'a>(ptr: *mut $ffi_ident) -> &'a mut $T {
                     use vortex::error::VortexExpect;
-                    // TODO: propagate this error up instead of expecting
+                    // TODO(joe): propagate this error up instead of expecting
                     unsafe { ptr.as_mut() }
                         .vortex_expect("null pointer")
                         .0
@@ -257,7 +257,7 @@ macro_rules! box_wrapper {
                 /// Extract a borrowed reference from a const pointer.
                 pub(crate) fn as_ref<'a>(ptr: *const $ffi_ident) -> &'a $T {
                     use vortex::error::VortexExpect;
-                    // TODO: propagate this error up instead of expecting
+                    // TODO(joe): propagate this error up instead of expecting
                     &unsafe { ptr.as_ref() }
                         .vortex_expect("null pointer")
                         .0
@@ -266,7 +266,7 @@ macro_rules! box_wrapper {
                 /// Extract a borrowed mutable reference from a mut pointer.
                 pub(crate) fn as_mut<'a>(ptr: *mut $ffi_ident) -> &'a mut $T {
                     use vortex::error::VortexExpect;
-                    // TODO: propagate this error up instead of expecting
+                    // TODO(joe): propagate this error up instead of expecting
                     &mut unsafe { ptr.as_mut() }
                         .vortex_expect("null pointer")
                         .0

--- a/vortex-ffi/src/sink.rs
+++ b/vortex-ffi/src/sink.rs
@@ -87,7 +87,7 @@ pub unsafe extern "C-unwind" fn vx_array_sink_push(
     error_out: *mut *mut vx_error,
 ) {
     let array = vx_array::as_ref(array);
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let sink = unsafe { sink.as_mut().vortex_expect("null array stream") };
     try_or_default(error_out, || {
         RUNTIME

--- a/vortex-ffi/src/sink.rs
+++ b/vortex-ffi/src/sink.rs
@@ -87,6 +87,7 @@ pub unsafe extern "C-unwind" fn vx_array_sink_push(
     error_out: *mut *mut vx_error,
 ) {
     let array = vx_array::as_ref(array);
+    // TODO: propagate this error up instead of expecting
     let sink = unsafe { sink.as_mut().vortex_expect("null array stream") };
     try_or_default(error_out, || {
         RUNTIME

--- a/vortex-ffi/src/string.rs
+++ b/vortex-ffi/src/string.rs
@@ -32,6 +32,7 @@ impl vx_string {
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_string_new(ptr: *const c_char, len: usize) -> *const vx_string {
     let slice = unsafe { slice::from_raw_parts(ptr.cast(), len) };
+    // TODO: propagate this error up instead of expecting
     let string = String::from_utf8(slice.to_vec())
         .map_err(|e| vortex_err!("invalid utf-8: {e}"))
         .vortex_expect("CString creation should succeed");
@@ -41,6 +42,7 @@ pub unsafe extern "C-unwind" fn vx_string_new(ptr: *const c_char, len: usize) ->
 /// Create a new Vortex UTF-8 string by copying from a null-terminated C-style string.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_string_new_from_cstr(ptr: *const c_char) -> *const vx_string {
+    // TODO: propagate this error up instead of expecting
     let string = unsafe { CStr::from_ptr(ptr) }
         .to_str()
         .map_err(|e| vortex_err!("invalid utf-8: {e}"))

--- a/vortex-ffi/src/string.rs
+++ b/vortex-ffi/src/string.rs
@@ -32,7 +32,7 @@ impl vx_string {
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_string_new(ptr: *const c_char, len: usize) -> *const vx_string {
     let slice = unsafe { slice::from_raw_parts(ptr.cast(), len) };
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let string = String::from_utf8(slice.to_vec())
         .map_err(|e| vortex_err!("invalid utf-8: {e}"))
         .vortex_expect("CString creation should succeed");
@@ -42,7 +42,7 @@ pub unsafe extern "C-unwind" fn vx_string_new(ptr: *const c_char, len: usize) ->
 /// Create a new Vortex UTF-8 string by copying from a null-terminated C-style string.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_string_new_from_cstr(ptr: *const c_char) -> *const vx_string {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let string = unsafe { CStr::from_ptr(ptr) }
         .to_str()
         .map_err(|e| vortex_err!("invalid utf-8: {e}"))

--- a/vortex-ffi/src/struct_fields.rs
+++ b/vortex-ffi/src/struct_fields.rs
@@ -23,6 +23,7 @@ arc_wrapper!(
 /// Return the number of fields in the struct dtype.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_struct_fields_nfields(dtype: *const vx_struct_fields) -> u64 {
+    // TODO: propagate this error up instead of expecting
     unsafe { dtype.as_ref() }
         .vortex_expect("null ptr")
         .0
@@ -39,6 +40,7 @@ pub unsafe extern "C-unwind" fn vx_struct_fields_field_name(
     dtype: *const vx_struct_fields,
     idx: usize,
 ) -> *const vx_string {
+    // TODO: propagate this error up instead of expecting
     let ptr = unsafe { dtype.as_ref() }.vortex_expect("null ptr");
     let struct_dtype = &ptr.0;
     if idx >= struct_dtype.nfields() {
@@ -60,6 +62,7 @@ pub unsafe extern "C-unwind" fn vx_struct_fields_field_dtype(
     dtype: *const vx_struct_fields,
     idx: usize,
 ) -> *const vx_dtype {
+    // TODO: propagate this error up instead of expecting
     let ptr = unsafe { dtype.as_ref() }.vortex_expect("null ptr");
     let struct_dtype = &ptr.0;
 

--- a/vortex-ffi/src/struct_fields.rs
+++ b/vortex-ffi/src/struct_fields.rs
@@ -23,7 +23,7 @@ arc_wrapper!(
 /// Return the number of fields in the struct dtype.
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_struct_fields_nfields(dtype: *const vx_struct_fields) -> u64 {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     unsafe { dtype.as_ref() }
         .vortex_expect("null ptr")
         .0
@@ -40,7 +40,7 @@ pub unsafe extern "C-unwind" fn vx_struct_fields_field_name(
     dtype: *const vx_struct_fields,
     idx: usize,
 ) -> *const vx_string {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let ptr = unsafe { dtype.as_ref() }.vortex_expect("null ptr");
     let struct_dtype = &ptr.0;
     if idx >= struct_dtype.nfields() {
@@ -62,7 +62,7 @@ pub unsafe extern "C-unwind" fn vx_struct_fields_field_dtype(
     dtype: *const vx_struct_fields,
     idx: usize,
 ) -> *const vx_dtype {
-    // TODO: propagate this error up instead of expecting
+    // TODO(joe): propagate this error up instead of expecting
     let ptr = unsafe { dtype.as_ref() }.vortex_expect("null ptr");
     let struct_dtype = &ptr.0;
 

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -479,18 +479,22 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getBinary<'local>(
 ///
 /// Panics if the index is out of bounds.
 fn get_ptr_len_varbin(index: jint, array: &VarBinArray) -> (*const u8, u32) {
+    // TODO: propagate this error up instead of expecting
     let bytes = array.bytes_at(usize::try_from(index).vortex_expect("index must fit in usize"));
     (
         bytes.as_ptr(),
+        // TODO: propagate this error up instead of expecting
         u32::try_from(bytes.len()).vortex_expect("string length must fit in u32"),
     )
 }
 
 /// Get a raw pointer + len to pass back to Java to avoid copying across the boundary.
 fn get_ptr_len_view(index: jint, array: &VarBinViewArray) -> (*const u8, u32) {
+    // TODO: propagate this error up instead of expecting
     let bytes = array.bytes_at(usize::try_from(index).vortex_expect("index must fit in usize"));
     (
         bytes.as_ptr(),
+        // TODO: propagate this error up instead of expecting
         u32::try_from(bytes.len()).vortex_expect("string length must fit in u32"),
     )
 }

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -244,7 +244,10 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_slice(
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
 
     try_or_throw(&mut env, |_| {
-        let sliced_array = array_ref.inner.as_ref().slice(start as usize..end as usize);
+        let sliced_array = array_ref
+            .inner
+            .as_ref()
+            .slice(start as usize..end as usize)?;
         Ok(NativeArray::new(sliced_array).into_raw())
     })
 }

--- a/vortex-jni/src/file.rs
+++ b/vortex-jni/src/file.rs
@@ -278,6 +278,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeFileMethods_scan(
 ) -> jlong {
     // Return a new pointer to some native memory for the scan.
     let file = unsafe { NativeFile::from_ptr(pointer) };
+    // TODO: propagate this error up instead of expecting
     let mut scan_builder = file.inner.scan().vortex_expect("scan builder");
 
     try_or_throw(&mut env, |env| {

--- a/vortex-jni/src/lib.rs
+++ b/vortex-jni/src/lib.rs
@@ -30,6 +30,7 @@ mod writer;
 
 // Shared Tokio runtime for all the async operations in this package.
 static TOKIO_RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
+    // TODO: propagate this error up instead of expecting
     Builder::new_multi_thread()
         .enable_all()
         .build()

--- a/vortex-jni/src/writer.rs
+++ b/vortex-jni/src/writer.rs
@@ -88,7 +88,7 @@ impl NativeWriter {
     /// Write an Arrow record batch to the writer stream.
     pub fn write_record_batch(&self, batch: RecordBatch) -> VortexResult<()> {
         // We do not allow top-level nulls
-        let vortex_batch = ArrayRef::from_arrow(batch, false);
+        let vortex_batch = ArrayRef::from_arrow(batch, false)?;
 
         // Validate schema conforms
         if !vortex_batch.dtype().eq(&self.write_schema) {

--- a/vortex-layout/src/layouts/dict/writer.rs
+++ b/vortex-layout/src/layouts/dict/writer.rs
@@ -271,7 +271,7 @@ fn dict_encode_stream(
             match input.as_mut().peek().await {
                 Some(_) => {
                     let mut labeler = DictChunkLabeler::new(sequence_id);
-                    let chunks = state.encode(&mut labeler, chunk);
+                    let chunks = state.encode(&mut labeler, chunk)?;
                     drop(labeler);
                     for dict_chunk in chunks {
                         yield dict_chunk;
@@ -280,7 +280,7 @@ fn dict_encode_stream(
                 None => {
                     // this is the last element, encode and drain chunks
                     let mut labeler = DictChunkLabeler::new(sequence_id);
-                    let encoded = state.encode(&mut labeler, chunk);
+                    let encoded = state.encode(&mut labeler, chunk)?;
                     let drained = state.drain_values(&mut labeler);
                     drop(labeler);
                     for dict_chunk in encoded.into_iter().chain(drained.into_iter()) {
@@ -298,12 +298,16 @@ struct DictStreamState {
 }
 
 impl DictStreamState {
-    fn encode(&mut self, labeler: &mut DictChunkLabeler, chunk: ArrayRef) -> Vec<DictionaryChunk> {
+    fn encode(
+        &mut self,
+        labeler: &mut DictChunkLabeler,
+        chunk: ArrayRef,
+    ) -> VortexResult<Vec<DictionaryChunk>> {
         let mut res = Vec::new();
         let mut to_be_encoded = Some(chunk);
         while let Some(remaining) = to_be_encoded.take() {
             match self.encoder.take() {
-                None => match start_encoding(&self.constraints, &remaining) {
+                None => match start_encoding(&self.constraints, &remaining)? {
                     EncodingState::Continue((encoder, encoded)) => {
                         let ptype = encoder.codes_ptype();
                         res.push(labeler.codes(encoded, ptype));
@@ -320,7 +324,7 @@ impl DictStreamState {
                 },
                 Some(encoder) => {
                     let ptype = encoder.codes_ptype();
-                    match encode_chunk(encoder, &remaining) {
+                    match encode_chunk(encoder, &remaining)? {
                         EncodingState::Continue((encoder, encoded)) => {
                             res.push(labeler.codes(encoded, ptype));
                             self.encoder = Some(encoder);
@@ -334,7 +338,7 @@ impl DictStreamState {
                 }
             }
         }
-        res
+        Ok(res)
     }
 
     fn drain_values(&mut self, labeler: &mut DictChunkLabeler) -> Vec<DictionaryChunk> {
@@ -535,21 +539,28 @@ enum EncodingState {
     Done((ArrayRef, ArrayRef, ArrayRef)),
 }
 
-fn start_encoding(constraints: &DictConstraints, chunk: &dyn Array) -> EncodingState {
+fn start_encoding(constraints: &DictConstraints, chunk: &dyn Array) -> VortexResult<EncodingState> {
     let encoder = dict_encoder(chunk, constraints);
     encode_chunk(encoder, chunk)
 }
 
-fn encode_chunk(mut encoder: Box<dyn DictEncoder>, chunk: &dyn Array) -> EncodingState {
+fn encode_chunk(
+    mut encoder: Box<dyn DictEncoder>,
+    chunk: &dyn Array,
+) -> VortexResult<EncodingState> {
     let encoded = encoder.encode(chunk);
-    match remainder(chunk, encoded.len()) {
-        None => EncodingState::Continue((encoder, encoded)),
-        Some(unencoded) => EncodingState::Done((encoder.reset(), encoded, unencoded)),
+    match remainder(chunk, encoded.len())? {
+        None => Ok(EncodingState::Continue((encoder, encoded))),
+        Some(unencoded) => Ok(EncodingState::Done((encoder.reset(), encoded, unencoded))),
     }
 }
 
-fn remainder(array: &dyn Array, encoded_len: usize) -> Option<ArrayRef> {
-    (encoded_len < array.len()).then(|| array.slice(encoded_len..array.len()))
+fn remainder(array: &dyn Array, encoded_len: usize) -> VortexResult<Option<ArrayRef>> {
+    if encoded_len < array.len() {
+        Ok(Some(array.slice(encoded_len..array.len())?))
+    } else {
+        Ok(None)
+    }
 }
 
 #[cfg(test)]

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -144,7 +144,7 @@ impl LayoutReader for FlatReader {
 
             // Slice the array based on the row mask.
             if row_range.start > 0 || row_range.end < array.len() {
-                array = array.slice(row_range.clone());
+                array = array.slice(row_range.clone())?;
             }
 
             let array_mask = if mask.density() < EXPR_EVAL_THRESHOLD {
@@ -200,7 +200,7 @@ impl LayoutReader for FlatReader {
 
             // Slice the array based on the row mask.
             if row_range.start > 0 || row_range.end < array.len() {
-                array = array.slice(row_range.clone());
+                array = array.slice(row_range.clone())?;
             }
 
             // First apply the filter to the array.

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -92,7 +92,7 @@ impl LayoutStrategy for RepartitionStrategy {
                 let mut offset = 0;
                 while offset < chunk.len() {
                     let end = (offset + options.block_len_multiple).min(chunk.len());
-                    let sliced = chunk.slice(offset..end);
+                    let sliced = chunk.slice(offset..end)?;
                     chunks.push_back(sliced);
                     offset = end;
 
@@ -177,8 +177,8 @@ impl ChunksBuffer {
             let len = chunk.len();
 
             if len > remaining {
-                let left = chunk.slice(0..remaining);
-                let right = chunk.slice(remaining..len);
+                let left = chunk.slice(0..remaining)?;
+                let right = chunk.slice(remaining..len)?;
                 self.push_front(right);
                 res.push(left);
                 remaining = 0;

--- a/vortex-python/src/arrays/from_arrow.rs
+++ b/vortex-python/src/arrays/from_arrow.rs
@@ -31,16 +31,15 @@ pub(super) fn from_arrow(obj: &Borrowed<'_, '_, PyAny>) -> PyVortexResult<PyArra
     if obj.is_instance(&pa_array)? {
         let arrow_array = ArrowArrayData::from_pyarrow(&obj.as_borrowed()).map(make_array)?;
         let is_nullable = arrow_array.is_nullable();
-        let enc_array = ArrayRef::from_arrow(arrow_array.as_ref(), is_nullable);
+        let enc_array = ArrayRef::from_arrow(arrow_array.as_ref(), is_nullable)?;
         Ok(PyArrayRef::from(enc_array))
     } else if obj.is_instance(&chunked_array)? {
         let chunks: Vec<Bound<PyAny>> = obj.getattr("chunks")?.extract()?;
         let encoded_chunks = chunks
             .iter()
             .map(|a| {
-                ArrowArrayData::from_pyarrow(&a.as_borrowed())
-                    .map(make_array)
-                    .map(|a| ArrayRef::from_arrow(a.as_ref(), false))
+                let arrow_array = ArrowArrayData::from_pyarrow(&a.as_borrowed()).map(make_array)?;
+                ArrayRef::from_arrow(arrow_array.as_ref(), false).map_err(|e| e.into())
             })
             .collect::<PyResult<Vec<_>>>()?;
         let dtype: DType = obj
@@ -55,10 +54,11 @@ pub(super) fn from_arrow(obj: &Borrowed<'_, '_, PyAny>) -> PyVortexResult<PyArra
         let dtype = DType::from_arrow(array_stream.schema());
         let chunks = array_stream
             .into_iter()
-            .map(|b| -> PyVortexResult<_> {
-                Ok(ArrayRef::from_arrow(b.map_err(VortexError::from)?, false))
+            .map(|b| {
+                b.map_err(VortexError::from)
+                    .and_then(|b| ArrayRef::from_arrow(b, false))
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<VortexResult<Vec<_>>>()?;
         Ok(PyArrayRef::from(
             ChunkedArray::try_new(chunks, dtype)?.into_array(),
         ))

--- a/vortex-python/src/arrays/from_arrow.rs
+++ b/vortex-python/src/arrays/from_arrow.rs
@@ -16,9 +16,11 @@ use vortex::array::arrow::FromArrowArray;
 use vortex::dtype::DType;
 use vortex::dtype::arrow::FromArrowType;
 use vortex::error::VortexError;
+use vortex::error::VortexResult;
 
 use crate::arrays::PyArrayRef;
 use crate::arrow::FromPyArrow;
+use crate::error::PyVortexError;
 use crate::error::PyVortexResult;
 
 /// Convert an Arrow object to a Vortex array.
@@ -39,9 +41,9 @@ pub(super) fn from_arrow(obj: &Borrowed<'_, '_, PyAny>) -> PyVortexResult<PyArra
             .iter()
             .map(|a| {
                 let arrow_array = ArrowArrayData::from_pyarrow(&a.as_borrowed()).map(make_array)?;
-                ArrayRef::from_arrow(arrow_array.as_ref(), false).map_err(|e| e.into())
+                ArrayRef::from_arrow(arrow_array.as_ref(), false).map_err(PyVortexError::from)
             })
-            .collect::<PyResult<Vec<_>>>()?;
+            .collect::<PyVortexResult<Vec<_>>>()?;
         let dtype: DType = obj
             .getattr("type")
             .and_then(|v| DataType::from_pyarrow(&v.as_borrowed()))

--- a/vortex-python/src/arrays/into_array.rs
+++ b/vortex-python/src/arrays/into_array.rs
@@ -57,7 +57,7 @@ impl<'py> FromPyObject<'_, 'py> for PyIntoArray {
             return Ok(PyIntoArray(PyVortex(ArrayRef::from_arrow(
                 make_array(arrow_array_data).as_ref(),
                 false,
-            ))));
+            )?)));
         }
 
         if ob.is_instance(&pa.getattr("Table")?)? {

--- a/vortex-python/src/arrays/into_array.rs
+++ b/vortex-python/src/arrays/into_array.rs
@@ -19,7 +19,6 @@ use vortex::array::iter::ArrayIteratorExt;
 use vortex::dtype::DType;
 use vortex::dtype::arrow::FromArrowType as _;
 use vortex::error::VortexError;
-use vortex::error::VortexResult;
 
 use crate::PyVortex;
 use crate::arrays::PyArrayRef;
@@ -54,23 +53,19 @@ impl<'py> FromPyObject<'_, 'py> for PyIntoArray {
 
         if ob.is_instance(&pa.getattr("Array")?)? {
             let arrow_array_data = ArrayData::from_pyarrow(&ob.as_borrowed())?;
-            return Ok(PyIntoArray(PyVortex(ArrayRef::from_arrow(
-                make_array(arrow_array_data).as_ref(),
-                false,
-            )?)));
+            let array = ArrayRef::from_arrow(make_array(arrow_array_data).as_ref(), false)
+                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+            return Ok(PyIntoArray(PyVortex(array)));
         }
 
         if ob.is_instance(&pa.getattr("Table")?)? {
             let arrow_stream = ArrowArrayStreamReader::from_pyarrow(&ob.as_borrowed())?;
             let dtype = DType::from_arrow(arrow_stream.schema());
-            let vortex_iter = arrow_stream
-                .into_iter()
-                .map(|batch_result| -> VortexResult<_> {
-                    Ok(ArrayRef::from_arrow(
-                        batch_result.map_err(VortexError::from)?,
-                        false,
-                    ))
-                });
+            let vortex_iter = arrow_stream.into_iter().map(|batch_result| {
+                batch_result
+                    .map_err(VortexError::from)
+                    .and_then(|b| ArrayRef::from_arrow(b, false))
+            });
             let array = ArrayIteratorAdapter::new(dtype, vortex_iter)
                 .read_all()
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -643,7 +643,7 @@ impl PyArray {
     #[pyo3(signature = (start, end))]
     fn slice(slf: Bound<Self>, start: usize, end: usize) -> PyResult<PyArrayRef> {
         let slf = PyArrayRef::extract(slf.as_any().as_borrowed())?.into_inner();
-        let inner = slf.slice(start..end);
+        let inner = slf.slice(start..end)?;
         Ok(PyArrayRef::from(inner))
     }
 

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -641,7 +641,7 @@ impl PyArray {
     }
 
     #[pyo3(signature = (start, end))]
-    fn slice(slf: Bound<Self>, start: usize, end: usize) -> PyResult<PyArrayRef> {
+    fn slice(slf: Bound<Self>, start: usize, end: usize) -> PyVortexResult<PyArrayRef> {
         let slf = PyArrayRef::extract(slf.as_any().as_borrowed())?.into_inner();
         let inner = slf.slice(start..end)?;
         Ok(PyArrayRef::from(inner))

--- a/vortex-python/src/io.rs
+++ b/vortex-python/src/io.rs
@@ -366,7 +366,7 @@ fn try_arrow_stream_to_iterator(
             .into_iter()
             .map(|batch_result| -> VortexResult<ArrayRef> {
                 let batch = batch_result.map_err(VortexError::from)?;
-                Ok(ArrayRef::from_arrow(batch, false)?)
+                ArrayRef::from_arrow(batch, false)
             });
 
         Ok(Box::new(ArrayIteratorAdapter::new(dtype, vortex_iter)))

--- a/vortex-python/src/io.rs
+++ b/vortex-python/src/io.rs
@@ -366,7 +366,7 @@ fn try_arrow_stream_to_iterator(
             .into_iter()
             .map(|batch_result| -> VortexResult<ArrayRef> {
                 let batch = batch_result.map_err(VortexError::from)?;
-                Ok(ArrayRef::from_arrow(batch, false))
+                Ok(ArrayRef::from_arrow(batch, false)?)
             });
 
         Ok(Box::new(ArrayIteratorAdapter::new(dtype, vortex_iter)))

--- a/vortex-scan/src/arrow.rs
+++ b/vortex-scan/src/arrow.rs
@@ -151,7 +151,7 @@ mod tests {
         );
 
         // Convert to Vortex
-        Ok(ArrayRef::from_arrow(&struct_array, true))
+        Ok(ArrayRef::from_arrow(&struct_array, true)?)
     }
 
     fn create_arrow_schema() -> Arc<Schema> {

--- a/vortex-scan/src/arrow.rs
+++ b/vortex-scan/src/arrow.rs
@@ -151,7 +151,7 @@ mod tests {
         );
 
         // Convert to Vortex
-        Ok(ArrayRef::from_arrow(&struct_array, true)?)
+        ArrayRef::from_arrow(&struct_array, true)
     }
 
     fn create_arrow_schema() -> Arc<Schema> {

--- a/vortex-tui/src/convert.rs
+++ b/vortex-tui/src/convert.rs
@@ -77,7 +77,7 @@ pub async fn exec_convert(session: &VortexSession, flags: ConvertArgs) -> anyhow
         .map(|record_batch| {
             record_batch
                 .map_err(|e| VortexError::generic(e.into()))
-                .map(|rb| ArrayRef::from_arrow(rb, false))
+                .and_then(|rb| ArrayRef::from_arrow(rb, false))
         })
         .boxed();
 

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -177,7 +177,6 @@ impl VortexSessionDefault for VortexSession {
 mod test {
     use std::path::PathBuf;
 
-    use itertools::Itertools;
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
     use vortex_array::ToCanonical;
@@ -221,9 +220,12 @@ mod test {
         .build()?;
 
         let dtype = DType::from_arrow(reader.schema());
-        let chunks = reader
-            .map_ok(|record_batch| ArrayRef::from_arrow(record_batch, false))
-            .try_collect()?;
+        let chunks: Vec<_> = reader
+            .map(|record_batch| {
+                let batch = record_batch?;
+                Ok(ArrayRef::from_arrow(batch, false)?)
+            })
+            .collect::<VortexResult<_>>()?;
         let vortex_array = ChunkedArray::try_new(chunks, dtype)?.into_array();
         // [convert]
 

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -223,7 +223,7 @@ mod test {
         let chunks: Vec<_> = reader
             .map(|record_batch| {
                 let batch = record_batch?;
-                Ok(ArrayRef::from_arrow(batch, false)?)
+                ArrayRef::from_arrow(batch, false)
             })
             .collect::<VortexResult<_>>()?;
         let vortex_array = ChunkedArray::try_new(chunks, dtype)?.into_array();


### PR DESCRIPTION
  This PR makes several validity and scalar-related methods fallible (returning VortexResult<T> instead of T).                                                                       
                                                                                                                                                                                     
  ---                                                                                                                                                                                
  Breaking Changes                                                                                                                                                                   
                                                                                                                                                                                     
  Validity methods (in vortex-array)                                                                                                                                                 
```  ┌──────────────────────────────────────┬─────────┬───────────────────────┐                                                                                                         
  │                Method                │ Before  │         After         │                                                                                                         
  ├──────────────────────────────────────┼─────────┼───────────────────────┤                                                                                                         
  │ is_valid(index)                      │ -> bool │ -> VortexResult<bool> │                                                                                                         
  ├──────────────────────────────────────┼─────────┼───────────────────────┤                                                                                                         
  │ all_valid(len)                       │ -> bool │ -> VortexResult<bool> │                                                                                                         
  ├──────────────────────────────────────┼─────────┼───────────────────────┤                                                                                                         
  │ all_invalid(len)                     │ -> bool │ -> VortexResult<bool> │                                                                                                         
  ├──────────────────────────────────────┼─────────┼───────────────────────┤                                                                                                         
  │ slice(range)                         │ -> Self │ -> VortexResult<Self> │                                                                                                         
  ├──────────────────────────────────────┼─────────┼───────────────────────┤                                                                                                         
  │ patch(len, offset, indices, patches) │ -> Self │ -> VortexResult<Self> │                                                                                                         
  └──────────────────────────────────────┴─────────┴───────────────────────┘                                                                                                         
  Array patch methods                                                                                                                                                                
  ┌─────────────────────────┬─────────┬───────────────────────┐                                                                                                                      
  │          Type           │ Before  │         After         │                                                                                                                      
  ├─────────────────────────┼─────────┼───────────────────────┤                                                                                                                      
  │ BoolArray::patch()      │ -> Self │ -> VortexResult<Self> │                                                                                                                      
  ├─────────────────────────┼─────────┼───────────────────────┤                                                                                                                      
  │ PrimitiveArray::patch() │ -> Self │ -> VortexResult<Self> │                                                                                                                      
  ├─────────────────────────┼─────────┼───────────────────────┤                                                                                                                      
  │ DecimalArray::patch()   │ -> Self │ -> VortexResult<Self> │   
  ```