### PR TITLE
chore: clean up cond cuda compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "vortex-datafusion",
     "vortex-duckdb",
     "vortex-cuda",
+    "vortex-cuda/nvcomp",
     "vortex-cxx",
     "vortex-ffi",
     "fuzz",

--- a/vortex-cuda/Cargo.toml
+++ b/vortex-cuda/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [features]
 default = []
-nvcomp = ["dep:vortex-nvcomp"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -33,7 +32,7 @@ vortex-decimal-byte-parts = { workspace = true }
 vortex-dtype = { workspace = true }
 vortex-error = { workspace = true }
 vortex-fastlanes = { workspace = true }
-vortex-nvcomp = { path = "nvcomp", optional = true }
+vortex-nvcomp = { path = "nvcomp" }
 vortex-session = { workspace = true }
 vortex-utils = { workspace = true }
 vortex-zigzag = { workspace = true }

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -1,397 +1,412 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-#![allow(clippy::unwrap_used)]
-#![allow(clippy::cast_possible_truncation)]
+//! CUDA benchmarks for FoR decompression.
+//!
+//! This module is only compiled when CUDA/nvcc is available.
+//! The `cuda_available` cfg is automatically set by build.rs.
 
-use std::mem::size_of;
-use std::time::Duration;
+// When CUDA is not available, provide a stub main.
+#[cfg(not(cuda_available))]
+fn main() {}
 
-use criterion::BenchmarkId;
-use criterion::Criterion;
-use criterion::Throughput;
+#[cfg(cuda_available)]
+mod cuda_benchmarks {
+    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::cast_possible_truncation)]
+
+    use std::mem::size_of;
+    use std::time::Duration;
+
+    use criterion::BenchmarkId;
+    use criterion::Criterion;
+    use criterion::Throughput;
+    use cudarc::driver::CudaView;
+    use cudarc::driver::PushKernelArg;
+    use cudarc::driver::sys::CUevent_flags::CU_EVENT_BLOCKING_SYNC;
+    use vortex_array::IntoArray;
+    use vortex_array::ToCanonical;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_buffer::Buffer;
+    use vortex_cuda::CudaExecutionCtx;
+    use vortex_cuda::CudaSession;
+    use vortex_error::VortexExpect;
+    use vortex_fastlanes::FoRArray;
+    use vortex_session::VortexSession;
+
+    const BENCH_ARGS: &[(usize, &str)] = &[
+        (1_000, "1K"),
+        (10_000, "10K"),
+        (100_000, "100K"),
+        (1_000_000, "1M"),
+        (10_000_000, "10M"),
+    ];
+
+    /// Creates a FoR array of u8 for the given size.
+    fn make_for_array_u8(len: usize) -> FoRArray {
+        let data: Vec<u8> = (0..len as u8).map(|i| i.wrapping_add(10)).collect();
+        let primitive_array = PrimitiveArray::new(
+            Buffer::from(data),
+            vortex_array::validity::Validity::NonNullable,
+        )
+        .into_array();
+
+        FoRArray::try_new(primitive_array, 10u8.into()).vortex_expect("failed to create FoR array")
+    }
+
+    /// Creates a FoR array of u16 for the given size.
+    fn make_for_array_u16(len: usize) -> FoRArray {
+        let data: Vec<u16> = (0..len as u16).map(|i| i.wrapping_add(10)).collect();
+        let primitive_array = PrimitiveArray::new(
+            Buffer::from(data),
+            vortex_array::validity::Validity::NonNullable,
+        )
+        .into_array();
+
+        FoRArray::try_new(primitive_array, 10u16.into()).vortex_expect("failed to create FoR array")
+    }
+
+    /// Creates a FoR array of u32 for the given size.
+    fn make_for_array_u32(len: usize) -> FoRArray {
+        let primitive_array = PrimitiveArray::new(
+            Buffer::from((0u32..len as u32).collect::<Vec<u32>>()),
+            vortex_array::validity::Validity::NonNullable,
+        )
+        .into_array();
+
+        FoRArray::try_new(primitive_array, 10u32.into()).vortex_expect("failed to create FoR array")
+    }
+
+    /// Creates a FoR array of u64 for the given size.
+    fn make_for_array_u64(len: usize) -> FoRArray {
+        let data: Vec<u64> = (0..len as u64).map(|i| i.wrapping_add(10)).collect();
+        let primitive_array = PrimitiveArray::new(
+            Buffer::from(data),
+            vortex_array::validity::Validity::NonNullable,
+        )
+        .into_array();
+
+        FoRArray::try_new(primitive_array, 10u64.into()).vortex_expect("failed to create FoR array")
+    }
+
+    /// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
+    fn launch_for_kernel_timed_u8(
+        for_array: &FoRArray,
+        device_data: CudaView<'_, u8>,
+        reference: u8,
+        cuda_ctx: &mut CudaExecutionCtx,
+    ) -> vortex_error::VortexResult<Duration> {
+        let array_len_u64 = for_array.len() as u64;
+
+        let events = vortex_cuda::launch_cuda_kernel!(
+            execution_ctx: cuda_ctx,
+            module: "for",
+            ptypes: &[for_array.ptype()],
+            launch_args: [device_data, reference, array_len_u64],
+            event_recording: CU_EVENT_BLOCKING_SYNC,
+            array_len: for_array.len()
+        );
+
+        let elapsed_ms = events
+            .before_launch
+            .elapsed_ms(&events.after_launch) // synchronizes
+            .map_err(|e| vortex_error::vortex_err!("failed to get elapsed time: {}", e))?;
+
+        Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
+    }
+
+    /// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
+    fn launch_for_kernel_timed_u16(
+        for_array: &FoRArray,
+        device_data: CudaView<'_, u16>,
+        reference: u16,
+        cuda_ctx: &mut CudaExecutionCtx,
+    ) -> vortex_error::VortexResult<Duration> {
+        let array_len_u64 = for_array.len() as u64;
+
+        let events = vortex_cuda::launch_cuda_kernel!(
+            execution_ctx: cuda_ctx,
+            module: "for",
+            ptypes: &[for_array.ptype()],
+            launch_args: [device_data, reference, array_len_u64],
+            event_recording: CU_EVENT_BLOCKING_SYNC,
+            array_len: for_array.len()
+        );
+
+        let elapsed_ms = events
+            .before_launch
+            .elapsed_ms(&events.after_launch) // synchronizes
+            .map_err(|e| vortex_error::vortex_err!("failed to get elapsed time: {}", e))?;
+
+        Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
+    }
+
+    /// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
+    fn launch_for_kernel_timed_u32(
+        for_array: &FoRArray,
+        device_data: CudaView<'_, u32>,
+        reference: u32,
+        cuda_ctx: &mut CudaExecutionCtx,
+    ) -> vortex_error::VortexResult<Duration> {
+        let array_len_u64 = for_array.len() as u64;
+
+        let events = vortex_cuda::launch_cuda_kernel!(
+            execution_ctx: cuda_ctx,
+            module: "for",
+            ptypes: &[for_array.ptype()],
+            launch_args: [device_data, reference, array_len_u64],
+            event_recording: CU_EVENT_BLOCKING_SYNC,
+            array_len: for_array.len()
+        );
+
+        let elapsed_ms = events
+            .before_launch
+            .elapsed_ms(&events.after_launch) // synchronizes
+            .map_err(|e| vortex_error::vortex_err!("failed to get elapsed time: {}", e))?;
+
+        Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
+    }
+
+    /// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
+    fn launch_for_kernel_timed_u64(
+        for_array: &FoRArray,
+        device_data: CudaView<'_, u64>,
+        reference: u64,
+        cuda_ctx: &mut CudaExecutionCtx,
+    ) -> vortex_error::VortexResult<Duration> {
+        let array_len_u64 = for_array.len() as u64;
+
+        let events = vortex_cuda::launch_cuda_kernel!(
+            execution_ctx: cuda_ctx,
+            module: "for",
+            ptypes: &[for_array.ptype()],
+            launch_args: [device_data, reference, array_len_u64],
+            event_recording: CU_EVENT_BLOCKING_SYNC,
+            array_len: for_array.len()
+        );
+
+        let elapsed_ms = events
+            .before_launch
+            .elapsed_ms(&events.after_launch) // synchronizes
+            .map_err(|e| vortex_error::vortex_err!("failed to get elapsed time: {}", e))?;
+
+        Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
+    }
+
+    /// Benchmark u8 FoR decompression
+    fn benchmark_for_u8(c: &mut Criterion) {
+        let mut group = c.benchmark_group("FoR_cuda_u8");
+        group.sample_size(10);
+
+        for (len, label) in BENCH_ARGS {
+            let for_array = make_for_array_u8(*len);
+
+            group.throughput(Throughput::Bytes((len * size_of::<u8>()) as u64));
+            group.bench_with_input(
+                BenchmarkId::new("u8_FoR", label),
+                &for_array,
+                |b, for_array| {
+                    b.iter_custom(|iters| {
+                        let mut cuda_ctx =
+                            CudaSession::create_execution_ctx(VortexSession::empty())
+                                .vortex_expect("failed to create execution context");
+
+                        let encoded = for_array.encoded();
+                        let unpacked_array = encoded.to_primitive();
+                        let unpacked_slice = unpacked_array.as_slice::<u8>();
+
+                        let reference = 10u8;
+                        let mut total_time = Duration::ZERO;
+
+                        for _ in 0..iters {
+                            let device_data = cuda_ctx
+                                .copy_buffer_to_device(unpacked_slice)
+                                .vortex_expect("failed to copy to device");
+
+                            let kernel_time = launch_for_kernel_timed_u8(
+                                for_array,
+                                device_data.as_view(),
+                                reference,
+                                &mut cuda_ctx,
+                            )
+                            .vortex_expect("kernel launch failed");
+
+                            total_time += kernel_time;
+                        }
+
+                        total_time
+                    });
+                },
+            );
+        }
+
+        group.finish();
+    }
+
+    /// Benchmark u16 FoR decompression
+    fn benchmark_for_u16(c: &mut Criterion) {
+        let mut group = c.benchmark_group("FoR_cuda_u16");
+        group.sample_size(10);
+
+        for (len, label) in BENCH_ARGS {
+            let for_array = make_for_array_u16(*len);
+
+            group.throughput(Throughput::Bytes((len * size_of::<u16>()) as u64));
+            group.bench_with_input(
+                BenchmarkId::new("u16_FoR", label),
+                &for_array,
+                |b, for_array| {
+                    b.iter_custom(|iters| {
+                        let mut cuda_ctx =
+                            CudaSession::create_execution_ctx(VortexSession::empty())
+                                .vortex_expect("failed to create execution context");
+
+                        let encoded = for_array.encoded();
+                        let unpacked_array = encoded.to_primitive();
+                        let unpacked_slice = unpacked_array.as_slice::<u16>();
+
+                        let reference = 10u16;
+                        let mut total_time = Duration::ZERO;
+
+                        for _ in 0..iters {
+                            let device_data = cuda_ctx
+                                .copy_buffer_to_device(unpacked_slice)
+                                .vortex_expect("failed to copy to device");
+
+                            let kernel_time = launch_for_kernel_timed_u16(
+                                for_array,
+                                device_data.as_view(),
+                                reference,
+                                &mut cuda_ctx,
+                            )
+                            .vortex_expect("kernel launch failed");
+
+                            total_time += kernel_time;
+                        }
+
+                        total_time
+                    });
+                },
+            );
+        }
+
+        group.finish();
+    }
+
+    /// Benchmark u32 FoR decompression
+    fn benchmark_for_u32(c: &mut Criterion) {
+        let mut group = c.benchmark_group("FoR_cuda_u32");
+        group.sample_size(10);
+
+        for (len, label) in BENCH_ARGS {
+            let for_array = make_for_array_u32(*len);
+
+            group.throughput(Throughput::Bytes((len * size_of::<u32>()) as u64));
+            group.bench_with_input(
+                BenchmarkId::new("u32_FoR", label),
+                &for_array,
+                |b, for_array| {
+                    b.iter_custom(|iters| {
+                        let mut cuda_ctx =
+                            CudaSession::create_execution_ctx(VortexSession::empty())
+                                .vortex_expect("failed to create execution context");
+
+                        let encoded = for_array.encoded();
+                        let unpacked_array = encoded.to_primitive();
+                        let unpacked_slice = unpacked_array.as_slice::<u32>();
+
+                        let reference = 10u32;
+                        let mut total_time = Duration::ZERO;
+
+                        for _ in 0..iters {
+                            let device_data = cuda_ctx
+                                .copy_buffer_to_device(unpacked_slice)
+                                .vortex_expect("failed to copy to device");
+
+                            let kernel_time = launch_for_kernel_timed_u32(
+                                for_array,
+                                device_data.as_view(),
+                                reference,
+                                &mut cuda_ctx,
+                            )
+                            .vortex_expect("kernel launch failed");
+
+                            total_time += kernel_time;
+                        }
+
+                        total_time
+                    });
+                },
+            );
+        }
+
+        group.finish();
+    }
+
+    /// Benchmark u64 FoR decompression
+    fn benchmark_for_u64(c: &mut Criterion) {
+        let mut group = c.benchmark_group("FoR_cuda_u64");
+        group.sample_size(10);
+
+        for (len, label) in BENCH_ARGS {
+            let for_array = make_for_array_u64(*len);
+
+            group.throughput(Throughput::Bytes((len * size_of::<u64>()) as u64));
+            group.bench_with_input(
+                BenchmarkId::new("u64_FoR", label),
+                &for_array,
+                |b, for_array| {
+                    b.iter_custom(|iters| {
+                        let mut cuda_ctx =
+                            CudaSession::create_execution_ctx(VortexSession::empty())
+                                .vortex_expect("failed to create execution context");
+
+                        let encoded = for_array.encoded();
+                        let unpacked_array = encoded.to_primitive();
+                        let unpacked_slice = unpacked_array.as_slice::<u64>();
+
+                        let reference = 10u64;
+                        let mut total_time = Duration::ZERO;
+
+                        for _ in 0..iters {
+                            let device_data = cuda_ctx
+                                .copy_buffer_to_device(unpacked_slice)
+                                .vortex_expect("failed to copy to device");
+
+                            let kernel_time = launch_for_kernel_timed_u64(
+                                for_array,
+                                device_data.as_view(),
+                                reference,
+                                &mut cuda_ctx,
+                            )
+                            .vortex_expect("kernel launch failed");
+
+                            total_time += kernel_time;
+                        }
+
+                        total_time
+                    });
+                },
+            );
+        }
+
+        group.finish();
+    }
+
+    pub fn benchmark_for_cuda(c: &mut Criterion) {
+        benchmark_for_u8(c);
+        benchmark_for_u16(c);
+        benchmark_for_u32(c);
+        benchmark_for_u64(c);
+    }
+}
+
+#[cfg(cuda_available)]
 use criterion::criterion_group;
+#[cfg(cuda_available)]
 use criterion::criterion_main;
-use cudarc::driver::CudaView;
-use cudarc::driver::PushKernelArg;
-use cudarc::driver::sys::CUevent_flags::CU_EVENT_BLOCKING_SYNC;
-use vortex_array::IntoArray;
-use vortex_array::ToCanonical;
-use vortex_array::arrays::PrimitiveArray;
-use vortex_buffer::Buffer;
-use vortex_cuda::CudaExecutionCtx;
-use vortex_cuda::CudaSession;
-use vortex_cuda::has_nvcc;
-use vortex_error::VortexExpect;
-use vortex_fastlanes::FoRArray;
-use vortex_session::VortexSession;
 
-const BENCH_ARGS: &[(usize, &str)] = &[
-    (1_000, "1K"),
-    (10_000, "10K"),
-    (100_000, "100K"),
-    (1_000_000, "1M"),
-    (10_000_000, "10M"),
-];
-
-/// Creates a FoR array of u8 for the given size.
-fn make_for_array_u8(len: usize) -> FoRArray {
-    let data: Vec<u8> = (0..len as u8).map(|i| i.wrapping_add(10)).collect();
-    let primitive_array = PrimitiveArray::new(
-        Buffer::from(data),
-        vortex_array::validity::Validity::NonNullable,
-    )
-    .into_array();
-
-    FoRArray::try_new(primitive_array, 10u8.into()).vortex_expect("failed to create FoR array")
-}
-
-/// Creates a FoR array of u16 for the given size.
-fn make_for_array_u16(len: usize) -> FoRArray {
-    let data: Vec<u16> = (0..len as u16).map(|i| i.wrapping_add(10)).collect();
-    let primitive_array = PrimitiveArray::new(
-        Buffer::from(data),
-        vortex_array::validity::Validity::NonNullable,
-    )
-    .into_array();
-
-    FoRArray::try_new(primitive_array, 10u16.into()).vortex_expect("failed to create FoR array")
-}
-
-/// Creates a FoR array of u32 for the given size.
-fn make_for_array_u32(len: usize) -> FoRArray {
-    let primitive_array = PrimitiveArray::new(
-        Buffer::from((0u32..len as u32).collect::<Vec<u32>>()),
-        vortex_array::validity::Validity::NonNullable,
-    )
-    .into_array();
-
-    FoRArray::try_new(primitive_array, 10u32.into()).vortex_expect("failed to create FoR array")
-}
-
-/// Creates a FoR array of u64 for the given size.
-fn make_for_array_u64(len: usize) -> FoRArray {
-    let data: Vec<u64> = (0..len as u64).map(|i| i.wrapping_add(10)).collect();
-    let primitive_array = PrimitiveArray::new(
-        Buffer::from(data),
-        vortex_array::validity::Validity::NonNullable,
-    )
-    .into_array();
-
-    FoRArray::try_new(primitive_array, 10u64.into()).vortex_expect("failed to create FoR array")
-}
-
-/// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
-fn launch_for_kernel_timed_u8(
-    for_array: &FoRArray,
-    device_data: CudaView<'_, u8>,
-    reference: u8,
-    cuda_ctx: &mut CudaExecutionCtx,
-) -> vortex_error::VortexResult<Duration> {
-    let array_len_u64 = for_array.len() as u64;
-
-    let events = vortex_cuda::launch_cuda_kernel!(
-        execution_ctx: cuda_ctx,
-        module: "for",
-        ptypes: &[for_array.ptype()],
-        launch_args: [device_data, reference, array_len_u64],
-        event_recording: CU_EVENT_BLOCKING_SYNC,
-        array_len: for_array.len()
-    );
-
-    let elapsed_ms = events
-        .before_launch
-        .elapsed_ms(&events.after_launch) // synchronizes
-        .map_err(|e| vortex_error::vortex_err!("failed to get elapsed time: {}", e))?;
-
-    Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
-}
-
-/// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
-fn launch_for_kernel_timed_u16(
-    for_array: &FoRArray,
-    device_data: CudaView<'_, u16>,
-    reference: u16,
-    cuda_ctx: &mut CudaExecutionCtx,
-) -> vortex_error::VortexResult<Duration> {
-    let array_len_u64 = for_array.len() as u64;
-
-    let events = vortex_cuda::launch_cuda_kernel!(
-        execution_ctx: cuda_ctx,
-        module: "for",
-        ptypes: &[for_array.ptype()],
-        launch_args: [device_data, reference, array_len_u64],
-        event_recording: CU_EVENT_BLOCKING_SYNC,
-        array_len: for_array.len()
-    );
-
-    let elapsed_ms = events
-        .before_launch
-        .elapsed_ms(&events.after_launch) // synchronizes
-        .map_err(|e| vortex_error::vortex_err!("failed to get elapsed time: {}", e))?;
-
-    Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
-}
-
-/// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
-fn launch_for_kernel_timed_u32(
-    for_array: &FoRArray,
-    device_data: CudaView<'_, u32>,
-    reference: u32,
-    cuda_ctx: &mut CudaExecutionCtx,
-) -> vortex_error::VortexResult<Duration> {
-    let array_len_u64 = for_array.len() as u64;
-
-    let events = vortex_cuda::launch_cuda_kernel!(
-        execution_ctx: cuda_ctx,
-        module: "for",
-        ptypes: &[for_array.ptype()],
-        launch_args: [device_data, reference, array_len_u64],
-        event_recording: CU_EVENT_BLOCKING_SYNC,
-        array_len: for_array.len()
-    );
-
-    let elapsed_ms = events
-        .before_launch
-        .elapsed_ms(&events.after_launch) // synchronizes
-        .map_err(|e| vortex_error::vortex_err!("failed to get elapsed time: {}", e))?;
-
-    Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
-}
-
-/// Launches FoR decompression kernel and returns elapsed GPU time in seconds.
-fn launch_for_kernel_timed_u64(
-    for_array: &FoRArray,
-    device_data: CudaView<'_, u64>,
-    reference: u64,
-    cuda_ctx: &mut CudaExecutionCtx,
-) -> vortex_error::VortexResult<Duration> {
-    let array_len_u64 = for_array.len() as u64;
-
-    let events = vortex_cuda::launch_cuda_kernel!(
-        execution_ctx: cuda_ctx,
-        module: "for",
-        ptypes: &[for_array.ptype()],
-        launch_args: [device_data, reference, array_len_u64],
-        event_recording: CU_EVENT_BLOCKING_SYNC,
-        array_len: for_array.len()
-    );
-
-    let elapsed_ms = events
-        .before_launch
-        .elapsed_ms(&events.after_launch) // synchronizes
-        .map_err(|e| vortex_error::vortex_err!("failed to get elapsed time: {}", e))?;
-
-    Ok(Duration::from_secs_f32(elapsed_ms / 1000.0))
-}
-
-/// Benchmark u8 FoR decompression
-fn benchmark_for_u8(c: &mut Criterion) {
-    let mut group = c.benchmark_group("FoR_cuda_u8");
-    group.sample_size(10);
-
-    for (len, label) in BENCH_ARGS {
-        let for_array = make_for_array_u8(*len);
-
-        group.throughput(Throughput::Bytes((len * size_of::<u8>()) as u64));
-        group.bench_with_input(
-            BenchmarkId::new("u8_FoR", label),
-            &for_array,
-            |b, for_array| {
-                b.iter_custom(|iters| {
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(VortexSession::empty())
-                        .vortex_expect("failed to create execution context");
-
-                    let encoded = for_array.encoded();
-                    let unpacked_array = encoded.to_primitive();
-                    let unpacked_slice = unpacked_array.as_slice::<u8>();
-
-                    let reference = 10u8;
-                    let mut total_time = Duration::ZERO;
-
-                    for _ in 0..iters {
-                        let device_data = cuda_ctx
-                            .copy_buffer_to_device(unpacked_slice)
-                            .vortex_expect("failed to copy to device");
-
-                        let kernel_time = launch_for_kernel_timed_u8(
-                            for_array,
-                            device_data.as_view(),
-                            reference,
-                            &mut cuda_ctx,
-                        )
-                        .vortex_expect("kernel launch failed");
-
-                        total_time += kernel_time;
-                    }
-
-                    total_time
-                });
-            },
-        );
-    }
-
-    group.finish();
-}
-
-/// Benchmark u16 FoR decompression
-fn benchmark_for_u16(c: &mut Criterion) {
-    let mut group = c.benchmark_group("FoR_cuda_u16");
-    group.sample_size(10);
-
-    for (len, label) in BENCH_ARGS {
-        let for_array = make_for_array_u16(*len);
-
-        group.throughput(Throughput::Bytes((len * size_of::<u16>()) as u64));
-        group.bench_with_input(
-            BenchmarkId::new("u16_FoR", label),
-            &for_array,
-            |b, for_array| {
-                b.iter_custom(|iters| {
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(VortexSession::empty())
-                        .vortex_expect("failed to create execution context");
-
-                    let encoded = for_array.encoded();
-                    let unpacked_array = encoded.to_primitive();
-                    let unpacked_slice = unpacked_array.as_slice::<u16>();
-
-                    let reference = 10u16;
-                    let mut total_time = Duration::ZERO;
-
-                    for _ in 0..iters {
-                        let device_data = cuda_ctx
-                            .copy_buffer_to_device(unpacked_slice)
-                            .vortex_expect("failed to copy to device");
-
-                        let kernel_time = launch_for_kernel_timed_u16(
-                            for_array,
-                            device_data.as_view(),
-                            reference,
-                            &mut cuda_ctx,
-                        )
-                        .vortex_expect("kernel launch failed");
-
-                        total_time += kernel_time;
-                    }
-
-                    total_time
-                });
-            },
-        );
-    }
-
-    group.finish();
-}
-
-/// Benchmark u32 FoR decompression
-fn benchmark_for_u32(c: &mut Criterion) {
-    let mut group = c.benchmark_group("FoR_cuda_u32");
-    group.sample_size(10);
-
-    for (len, label) in BENCH_ARGS {
-        let for_array = make_for_array_u32(*len);
-
-        group.throughput(Throughput::Bytes((len * size_of::<u32>()) as u64));
-        group.bench_with_input(
-            BenchmarkId::new("u32_FoR", label),
-            &for_array,
-            |b, for_array| {
-                b.iter_custom(|iters| {
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(VortexSession::empty())
-                        .vortex_expect("failed to create execution context");
-
-                    let encoded = for_array.encoded();
-                    let unpacked_array = encoded.to_primitive();
-                    let unpacked_slice = unpacked_array.as_slice::<u32>();
-
-                    let reference = 10u32;
-                    let mut total_time = Duration::ZERO;
-
-                    for _ in 0..iters {
-                        let device_data = cuda_ctx
-                            .copy_buffer_to_device(unpacked_slice)
-                            .vortex_expect("failed to copy to device");
-
-                        let kernel_time = launch_for_kernel_timed_u32(
-                            for_array,
-                            device_data.as_view(),
-                            reference,
-                            &mut cuda_ctx,
-                        )
-                        .vortex_expect("kernel launch failed");
-
-                        total_time += kernel_time;
-                    }
-
-                    total_time
-                });
-            },
-        );
-    }
-
-    group.finish();
-}
-
-/// Benchmark u64 FoR decompression
-fn benchmark_for_u64(c: &mut Criterion) {
-    let mut group = c.benchmark_group("FoR_cuda_u64");
-    group.sample_size(10);
-
-    for (len, label) in BENCH_ARGS {
-        let for_array = make_for_array_u64(*len);
-
-        group.throughput(Throughput::Bytes((len * size_of::<u64>()) as u64));
-        group.bench_with_input(
-            BenchmarkId::new("u64_FoR", label),
-            &for_array,
-            |b, for_array| {
-                b.iter_custom(|iters| {
-                    let mut cuda_ctx = CudaSession::create_execution_ctx(VortexSession::empty())
-                        .vortex_expect("failed to create execution context");
-
-                    let encoded = for_array.encoded();
-                    let unpacked_array = encoded.to_primitive();
-                    let unpacked_slice = unpacked_array.as_slice::<u64>();
-
-                    let reference = 10u64;
-                    let mut total_time = Duration::ZERO;
-
-                    for _ in 0..iters {
-                        let device_data = cuda_ctx
-                            .copy_buffer_to_device(unpacked_slice)
-                            .vortex_expect("failed to copy to device");
-
-                        let kernel_time = launch_for_kernel_timed_u64(
-                            for_array,
-                            device_data.as_view(),
-                            reference,
-                            &mut cuda_ctx,
-                        )
-                        .vortex_expect("kernel launch failed");
-
-                        total_time += kernel_time;
-                    }
-
-                    total_time
-                });
-            },
-        );
-    }
-
-    group.finish();
-}
-
-fn benchmark_for_cuda(c: &mut Criterion) {
-    if !has_nvcc() {
-        eprintln!("nvcc not found, skipping CUDA benchmarks");
-        return;
-    }
-
-    benchmark_for_u8(c);
-    benchmark_for_u16(c);
-    benchmark_for_u32(c);
-    benchmark_for_u64(c);
-}
-
-criterion_group!(benches, benchmark_for_cuda);
+#[cfg(cuda_available)]
+criterion_group!(benches, cuda_benchmarks::benchmark_for_cuda);
+#[cfg(cuda_available)]
 criterion_main!(benches);

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -2,9 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 //! CUDA benchmarks for FoR decompression.
-//!
-//! This module is only compiled when CUDA/nvcc is available.
-//! The `cuda_available` cfg is automatically set by build.rs.
 
 // When CUDA is not available, provide a stub main.
 #[cfg(not(cuda_available))]

--- a/vortex-cuda/build.rs
+++ b/vortex-cuda/build.rs
@@ -9,6 +9,9 @@ use std::path::Path;
 use std::process::Command;
 
 fn main() {
+    // Declare the cfg so rustc doesn't warn about unexpected cfg.
+    println!("cargo::rustc-check-cfg=cfg(cuda_available)");
+
     if cfg!(not(target_os = "linux")) {
         // cuda is only support on linux right now
         return;
@@ -18,8 +21,6 @@ fn main() {
     let kernels_dir = Path::new(&manifest_dir).join("kernels");
 
     if !has_nvcc() {
-        // Only warn on Linux where we expect CUDA to be available.
-        println!("cargo:warning=nvcc not found, skipping CUDA kernel compilation");
         return;
     }
 
@@ -29,12 +30,15 @@ fn main() {
         for path in entries.flatten().map(|entry| entry.path()) {
             if path.extension().is_some_and(|ext| ext == "cu") {
                 println!("cargo:rerun-if-changed={}", path.display());
-                if let Err(e) = nvcc_compile_ptx(&kernels_dir, &path) {
-                    println!("cargo:warning=Failed to compile CUDA kernel: {}", e);
-                }
+                nvcc_compile_ptx(&kernels_dir, &path)
+                    .map_err(|e| format!("Failed to compile CUDA kernel {}: {}", path.display(), e))
+                    .unwrap();
             }
         }
     }
+
+    // Signal that CUDA kernels are available for conditional compilation.
+    println!("cargo:rustc-cfg=cuda_available");
 }
 
 fn nvcc_compile_ptx(kernel_dir: &Path, cu_path: &Path) -> std::io::Result<()> {
@@ -62,7 +66,7 @@ fn nvcc_compile_ptx(kernel_dir: &Path, cu_path: &Path) -> std::io::Result<()> {
         // CUDA Sanitizers
         // - memory: https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html#using-memcheck
         // - thread: https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html#using-racecheck
-        // - init: // https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html#using-initcheck
+        // - init: https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html#using-initcheck
         // - synchronize : https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html#using-synccheck
     } else {
         cmd.arg("-O3");

--- a/vortex-cuda/nvcomp/build.rs
+++ b/vortex-cuda/nvcomp/build.rs
@@ -34,7 +34,7 @@ fn generate_stub(reason: &str) {
 
 fn main() {
     // Declare the cfg so rustc doesn't warn about unexpected cfg.
-    println!("cargo::rustc-check-cfg=cfg(nvcomp_available)");
+    println!("cargo::rustc-check-cfg=cfg(cuda_available)");
     println!("cargo:rerun-if-env-changed=CUDA_PATH");
 
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
@@ -144,6 +144,6 @@ fn main() {
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
     bindings.write_to_file(out_dir.join("sys.rs")).unwrap();
 
-    // Signal that nvCOMP bindings are available for conditional compilation.
-    println!("cargo:rustc-cfg=nvcomp_available");
+    // Signal that CUDA/nvCOMP bindings are available for conditional compilation.
+    println!("cargo:rustc-cfg=cuda_available");
 }

--- a/vortex-cuda/nvcomp/src/lib.rs
+++ b/vortex-cuda/nvcomp/src/lib.rs
@@ -12,7 +12,7 @@
 //! nvCOMP is only available on Linux x86_64 and ARM64. On other platforms,
 //! this crate compiles but provides no functionality.
 
-#[cfg(nvcomp_available)]
+#[cfg(cuda_available)]
 #[allow(
     non_upper_case_globals,
     non_camel_case_types,
@@ -22,7 +22,8 @@
 )]
 pub mod sys;
 
-#[cfg(all(test, nvcomp_available))]
+#[cfg(test)]
+#[cfg(cuda_available)]
 mod tests {
     use super::sys;
 

--- a/vortex-cuda/src/kernel/encodings/alp.rs
+++ b/vortex-cuda/src/kernel/encodings/alp.rs
@@ -115,6 +115,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg(cuda_available)]
 mod tests {
     use vortex_alp::ALPArray;
     use vortex_alp::Exponents;
@@ -126,15 +127,10 @@ mod tests {
     use vortex_session::VortexSession;
 
     use super::*;
-    use crate::has_nvcc;
     use crate::session::CudaSession;
 
     #[tokio::test]
     async fn test_cuda_alp_decompression_f32() {
-        if !has_nvcc() {
-            return;
-        }
-
         let mut cuda_ctx = CudaSession::create_execution_ctx(VortexSession::empty())
             .vortex_expect("failed to create execution context");
 

--- a/vortex-cuda/src/kernel/encodings/decimal_byte_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/decimal_byte_parts.rs
@@ -50,6 +50,7 @@ impl CudaExecute for DecimalBytePartsExecutor {
 }
 
 #[cfg(test)]
+#[cfg(cuda_available)]
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
@@ -63,7 +64,6 @@ mod tests {
     use vortex_session::VortexSession;
 
     use super::*;
-    use crate::has_nvcc;
     use crate::session::CudaSession;
 
     #[rstest]
@@ -77,10 +77,6 @@ mod tests {
         #[case] precision: u8,
         #[case] scale: i8,
     ) {
-        if !has_nvcc() {
-            return;
-        }
-
         let mut cuda_ctx = CudaSession::create_execution_ctx(VortexSession::empty())
             .vortex_expect("create execution context");
 

--- a/vortex-cuda/src/kernel/encodings/for_.rs
+++ b/vortex-cuda/src/kernel/encodings/for_.rs
@@ -102,6 +102,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg(cuda_available)]
 mod tests {
     use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
@@ -113,15 +114,10 @@ mod tests {
     use vortex_session::VortexSession;
 
     use super::*;
-    use crate::has_nvcc;
     use crate::session::CudaSession;
 
     #[tokio::test]
     async fn test_cuda_for_decompression_u8() {
-        if !has_nvcc() {
-            return;
-        }
-
         let mut cuda_ctx = CudaSession::create_execution_ctx(VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
@@ -156,10 +152,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_cuda_for_decompression_u16() {
-        if !has_nvcc() {
-            return;
-        }
-
         let mut cuda_ctx = CudaSession::create_execution_ctx(VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
@@ -193,10 +185,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_cuda_for_decompression_u32() {
-        if !has_nvcc() {
-            return;
-        }
-
         let mut cuda_ctx = CudaSession::create_execution_ctx(VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
@@ -230,10 +218,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_cuda_for_decompression_u64() {
-        if !has_nvcc() {
-            return;
-        }
-
         let mut cuda_ctx = CudaSession::create_execution_ctx(VortexSession::empty())
             .vortex_expect("failed to create execution context");
 

--- a/vortex-cuda/src/kernel/encodings/zigzag.rs
+++ b/vortex-cuda/src/kernel/encodings/zigzag.rs
@@ -106,6 +106,7 @@ where
 }
 
 #[cfg(test)]
+#[cfg(cuda_available)]
 mod tests {
     use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
@@ -117,15 +118,10 @@ mod tests {
     use vortex_zigzag::ZigZagArray;
 
     use super::*;
-    use crate::has_nvcc;
     use crate::session::CudaSession;
 
     #[tokio::test]
     async fn test_cuda_zigzag_decompression_u32() {
-        if !has_nvcc() {
-            return;
-        }
-
         let mut cuda_ctx = CudaSession::create_execution_ctx(VortexSession::empty())
             .vortex_expect("failed to create execution context");
 

--- a/vortex-cuda/src/lib.rs
+++ b/vortex-cuda/src/lib.rs
@@ -9,8 +9,6 @@ mod kernel;
 mod session;
 mod stream;
 
-use std::process::Command;
-
 pub use device_buffer::CudaBufferExt;
 pub use device_buffer::CudaDeviceBuffer;
 pub use executor::CudaExecutionCtx;
@@ -25,19 +23,10 @@ use vortex_alp::ALPVTable;
 use vortex_array::arrays::DictVTable;
 use vortex_decimal_byte_parts::DecimalBytePartsVTable;
 use vortex_fastlanes::FoRVTable;
-#[cfg(feature = "nvcomp")]
 pub use vortex_nvcomp as nvcomp;
 use vortex_zigzag::ZigZagVTable;
 
 use crate::kernel::DecimalBytePartsExecutor;
-
-/// Check if the NVIDIA CUDA Compiler is available.
-pub fn has_nvcc() -> bool {
-    Command::new("nvcc")
-        .arg("--version")
-        .output()
-        .is_ok_and(|o| o.status.success())
-}
 
 /// Registers CUDA kernels.
 pub fn initialize_cuda(session: &CudaSession) {


### PR DESCRIPTION
Always include CUDA code in tests and benchmarks if the environment has a CUDA installation. This does not require the user to pass a feature flag but is determined at build.rs time.