### PR TITLE
chore: Remove redundant move from replacement_scan function

### DIFF
--- a/vortex-duckdb/cpp/replacement_scan.cpp
+++ b/vortex-duckdb/cpp/replacement_scan.cpp
@@ -28,7 +28,7 @@ VortexScanReplacement(duckdb::ClientContext &context, duckdb::ReplacementScanInp
         table_function->alias = fs.ExtractBaseName(table_name);
     }
 
-    return std::move(table_function);
+    return table_function;
 }
 
 } // namespace vortex


### PR DESCRIPTION
Signed-off-by: Robert Kruszewski <github@robertk.io>
