### PR TITLE
Chore: Replace `filter(array)` with `array.filter()` in most places

### DIFF
--- a/encodings/alp/src/alp/compute/filter.rs
+++ b/encodings/alp/src/alp/compute/filter.rs
@@ -4,7 +4,6 @@
 use vortex_array::ArrayRef;
 use vortex_array::compute::FilterKernel;
 use vortex_array::compute::FilterKernelAdapter;
-use vortex_array::compute::filter;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
@@ -23,7 +22,7 @@ impl FilterKernel for ALPVTable {
         // SAFETY: filtering the values does not change correctness
         unsafe {
             Ok(ALPArray::new_unchecked(
-                filter(array.encoded(), mask)?,
+                array.encoded().filter(mask.clone())?,
                 array.exponents(),
                 patches,
                 array.dtype().clone(),

--- a/encodings/alp/src/alp_rd/compute/filter.rs
+++ b/encodings/alp/src/alp_rd/compute/filter.rs
@@ -5,7 +5,6 @@ use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::compute::FilterKernel;
 use vortex_array::compute::FilterKernelAdapter;
-use vortex_array::compute::filter;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
@@ -23,9 +22,9 @@ impl FilterKernel for ALPRDVTable {
 
         Ok(ALPRDArray::try_new(
             array.dtype().clone(),
-            filter(array.left_parts(), mask)?,
+            array.left_parts().filter(mask.clone())?,
             array.left_parts_dictionary().clone(),
-            filter(array.right_parts(), mask)?,
+            array.right_parts().filter(mask.clone())?,
             array.right_bit_width(),
             left_parts_exceptions,
         )?
@@ -42,7 +41,6 @@ mod test {
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::compute::conformance::filter::test_filter_conformance;
-    use vortex_array::compute::filter;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_mask::Mask;
@@ -61,7 +59,9 @@ mod test {
         assert!(encoded.left_parts_patches().is_some());
 
         // The first two values need no patching
-        let filtered = filter(encoded.as_ref(), &Mask::from_iter([true, false, true])).unwrap();
+        let filtered = encoded
+            .filter(Mask::from_iter([true, false, true]))
+            .unwrap();
         assert_arrays_eq!(filtered, PrimitiveArray::from_iter([a, outlier]));
     }
 

--- a/encodings/datetime-parts/src/compute/filter.rs
+++ b/encodings/datetime-parts/src/compute/filter.rs
@@ -5,7 +5,6 @@ use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::compute::FilterKernel;
 use vortex_array::compute::FilterKernelAdapter;
-use vortex_array::compute::filter;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
@@ -17,9 +16,9 @@ impl FilterKernel for DateTimePartsVTable {
     fn filter(&self, array: &DateTimePartsArray, mask: &Mask) -> VortexResult<ArrayRef> {
         Ok(DateTimePartsArray::try_new(
             array.dtype().clone(),
-            filter(array.days().as_ref(), mask)?,
-            filter(array.seconds().as_ref(), mask)?,
-            filter(array.subseconds().as_ref(), mask)?,
+            array.days().filter(mask.clone())?,
+            array.seconds().filter(mask.clone())?,
+            array.subseconds().filter(mask.clone())?,
         )?
         .into_array())
     }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
@@ -4,7 +4,6 @@
 use vortex_array::ArrayRef;
 use vortex_array::compute::FilterKernel;
 use vortex_array::compute::FilterKernelAdapter;
-use vortex_array::compute::filter;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
@@ -14,7 +13,7 @@ use crate::DecimalBytePartsVTable;
 
 impl FilterKernel for DecimalBytePartsVTable {
     fn filter(&self, array: &Self::Array, mask: &Mask) -> VortexResult<ArrayRef> {
-        DecimalBytePartsArray::try_new(filter(&array.msp, mask)?, *array.decimal_dtype())
+        DecimalBytePartsArray::try_new(array.msp.filter(mask.clone())?, *array.decimal_dtype())
             .map(|d| d.to_array())
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -11,7 +11,6 @@ use vortex_array::ToCanonical;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::compute::FilterKernel;
 use vortex_array::compute::FilterKernelAdapter;
-use vortex_array::compute::filter;
 use vortex_array::register_kernel;
 use vortex_array::vtable::ValidityHelper;
 use vortex_buffer::Buffer;
@@ -71,7 +70,7 @@ fn filter_primitive<T: NativePType + BitPacking>(
     };
     if mask.density() >= full_decompression_threshold {
         let decompressed_array = array.to_primitive();
-        Ok(filter(decompressed_array.as_ref(), mask)?.to_primitive())
+        Ok(decompressed_array.filter(mask.clone())?.to_primitive())
     } else {
         filter_primitive_no_decompression::<T>(array, mask)
     }
@@ -170,7 +169,6 @@ mod test {
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::compute::conformance::filter::test_filter_conformance;
-    use vortex_array::compute::filter;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_buffer::buffer;
@@ -186,7 +184,7 @@ mod test {
 
         let mask = Mask::from_indices(bitpacked.len(), vec![0, 125, 2047, 2049, 2151, 2790]);
 
-        let primitive_result = filter(bitpacked.as_ref(), &mask).unwrap();
+        let primitive_result = bitpacked.filter(mask).unwrap();
         assert_arrays_eq!(
             primitive_result,
             PrimitiveArray::from_iter([0u8, 62, 31, 33, 9, 18])
@@ -202,7 +200,7 @@ mod test {
 
         let mask = Mask::from_indices(sliced.len(), vec![1919, 1921]);
 
-        let primitive_result = filter(&sliced, &mask).unwrap();
+        let primitive_result = sliced.filter(mask).unwrap();
         assert_arrays_eq!(primitive_result, PrimitiveArray::from_iter([31u8, 33]));
     }
 
@@ -210,11 +208,9 @@ mod test {
     fn filter_bitpacked() {
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
         let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 6).unwrap();
-        let filtered = filter(
-            bitpacked.as_ref(),
-            &Mask::from_indices(4096, (0..1024).collect()),
-        )
-        .unwrap();
+        let filtered = bitpacked
+            .filter(Mask::from_indices(4096, (0..1024).collect()))
+            .unwrap();
         assert_arrays_eq!(
             filtered.to_primitive(),
             PrimitiveArray::from_iter((0..1024).map(|i| (i % 63) as u8))
@@ -226,12 +222,10 @@ mod test {
         let values: Buffer<i64> = (0..500).collect();
         let unpacked = PrimitiveArray::new(values.clone(), Validity::NonNullable);
         let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 9).unwrap();
-        let filtered = filter(
-            bitpacked.as_ref(),
-            &Mask::from_indices(values.len(), (0..250).collect()),
-        )
-        .unwrap()
-        .to_primitive();
+        let filtered = bitpacked
+            .filter(Mask::from_indices(values.len(), (0..250).collect()))
+            .unwrap()
+            .to_primitive();
 
         assert_arrays_eq!(
             filtered,
@@ -275,12 +269,10 @@ mod test {
         );
 
         // Filter to include some patched and some non-patched values.
-        let filtered = filter(
-            bitpacked.as_ref(),
-            &Mask::from_indices(values.len(), vec![0, 2, 5, 9]),
-        )
-        .unwrap()
-        .to_primitive();
+        let filtered = bitpacked
+            .filter(Mask::from_indices(values.len(), vec![0, 2, 5, 9]))
+            .unwrap()
+            .to_primitive();
 
         assert_arrays_eq!(filtered, PrimitiveArray::from_iter([0i32, 1000, 2000, 70]));
     }
@@ -310,12 +302,10 @@ mod test {
 
         // Use low selectivity (only select 2% of values) to avoid full decompression.
         let indices: Vec<usize> = (0..20).collect();
-        let filtered = filter(
-            bitpacked.as_ref(),
-            &Mask::from_indices(values.len(), indices),
-        )
-        .unwrap()
-        .to_primitive();
+        let filtered = bitpacked
+            .filter(Mask::from_indices(values.len(), indices))
+            .unwrap()
+            .to_primitive();
 
         let expected: Vec<i32> = values[0..20].to_vec();
         assert_arrays_eq!(filtered, PrimitiveArray::from_iter(expected));

--- a/encodings/fastlanes/src/for/compute/mod.rs
+++ b/encodings/fastlanes/src/for/compute/mod.rs
@@ -13,7 +13,6 @@ use vortex_array::compute::FilterKernel;
 use vortex_array::compute::FilterKernelAdapter;
 use vortex_array::compute::TakeKernel;
 use vortex_array::compute::TakeKernelAdapter;
-use vortex_array::compute::filter;
 use vortex_array::compute::take;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
@@ -37,7 +36,7 @@ register_kernel!(TakeKernelAdapter(FoRVTable).lift());
 impl FilterKernel for FoRVTable {
     fn filter(&self, array: &FoRArray, mask: &Mask) -> VortexResult<ArrayRef> {
         FoRArray::try_new(
-            filter(array.encoded(), mask)?,
+            array.encoded().filter(mask.clone())?,
             array.reference_scalar().clone(),
         )
         .map(|a| a.into_array())

--- a/encodings/fsst/src/compute/filter.rs
+++ b/encodings/fsst/src/compute/filter.rs
@@ -6,7 +6,6 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::VarBinVTable;
 use vortex_array::compute::FilterKernel;
 use vortex_array::compute::FilterKernelAdapter;
-use vortex_array::compute::filter;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
@@ -21,10 +20,12 @@ impl FilterKernel for FSSTVTable {
             array.dtype().clone(),
             array.symbols().clone(),
             array.symbol_lengths().clone(),
-            filter(array.codes().as_ref(), mask)?
+            array
+                .codes()
+                .filter(mask.clone())?
                 .as_::<VarBinVTable>()
                 .clone(),
-            filter(array.uncompressed_lengths(), mask)?,
+            array.uncompressed_lengths().filter(mask.clone())?,
         )?
         .into_array())
     }

--- a/encodings/fsst/src/kernel.rs
+++ b/encodings/fsst/src/kernel.rs
@@ -202,7 +202,6 @@ mod tests {
     use vortex_array::arrays::FilterArray;
     use vortex_array::arrays::builder::VarBinBuilder;
     use vortex_array::assert_arrays_eq;
-    use vortex_array::compute::filter;
     use vortex_array::session::ArraySession;
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;
@@ -251,8 +250,8 @@ mod tests {
         let mut ctx = SESSION.create_execution_ctx();
         let result = filter_array.execute::<Canonical>(&mut ctx)?;
 
-        // Compare with filtering the canonical VarBinView
-        let expected = filter(&fsst_array, &mask)?;
+        // Compare with filtering the canonical VarBinView.
+        let expected = fsst_array.filter(mask)?;
 
         assert_eq!(result.len(), 2);
         assert_arrays_eq!(result.into_array(), expected);
@@ -272,7 +271,7 @@ mod tests {
         let mut ctx = SESSION.create_execution_ctx();
         let result = filter_array.execute::<Canonical>(&mut ctx)?;
 
-        let expected = filter(&fsst_array, &mask)?;
+        let expected = fsst_array.filter(mask)?;
 
         assert_eq!(result.len(), 5);
         assert_arrays_eq!(result.into_array(), expected);
@@ -316,7 +315,7 @@ mod tests {
         let mut ctx = SESSION.create_execution_ctx();
         let result = filter_array.execute::<Canonical>(&mut ctx)?;
 
-        let expected = filter(input.as_ref(), &mask)?;
+        let expected = input.filter(mask)?;
 
         assert_eq!(result.len(), 1);
         assert_arrays_eq!(result.into_array(), expected);
@@ -341,7 +340,7 @@ mod tests {
         let mut ctx = SESSION.create_execution_ctx();
         let result = filter_array.execute::<Canonical>(&mut ctx)?;
 
-        let expected = filter(input.as_ref(), &mask)?;
+        let expected = input.filter(mask)?;
 
         assert_eq!(result.len(), 2);
         assert_arrays_eq!(result.into_array(), expected);

--- a/encodings/fsst/src/tests.rs
+++ b/encodings/fsst/src/tests.rs
@@ -8,7 +8,6 @@ use vortex_array::ToCanonical;
 use vortex_array::arrays::builder::VarBinBuilder;
 use vortex_array::assert_arrays_eq;
 use vortex_array::assert_nth_scalar;
-use vortex_array::compute::filter;
 use vortex_array::compute::take;
 use vortex_buffer::buffer;
 use vortex_dtype::DType;
@@ -87,7 +86,7 @@ fn test_fsst_array_ops() {
     // test filter
     let mask = Mask::from_iter([false, true, true]);
 
-    let fsst_filtered = filter(&fsst_array, &mask).unwrap();
+    let fsst_filtered = fsst_array.filter(mask).unwrap();
 
     assert_eq!(fsst_filtered.len(), 2);
     assert_nth_scalar!(

--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -13,7 +13,6 @@ use vortex_array::ToCanonical;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::compute::FilterKernel;
 use vortex_array::compute::FilterKernelAdapter;
-use vortex_array::compute::filter;
 use vortex_array::register_kernel;
 use vortex_array::validity::Validity;
 use vortex_buffer::BitBuffer;
@@ -54,7 +53,7 @@ impl FilterKernel for RunEndVTable {
                                 mask_values.bit_buffer(),
                             )?
                         });
-                    let values = filter(array.values(), &values_mask)?;
+                    let values = array.values().filter(values_mask)?;
 
                     // SAFETY: guaranteed by implementation of filter_run_end_primitive
                     unsafe {
@@ -88,7 +87,7 @@ pub fn filter_run_end(array: &RunEndArray, mask: &Mask) -> VortexResult<ArrayRef
                     .bit_buffer(),
             )?
         });
-    let values = filter(array.values(), &values_mask)?;
+    let values = array.values().filter(values_mask)?;
 
     // SAFETY: enforced by filter_run_end_primitive
     unsafe {

--- a/encodings/sparse/src/compute/mod.rs
+++ b/encodings/sparse/src/compute/mod.rs
@@ -48,7 +48,6 @@ mod test {
     use vortex_array::compute::conformance::binary_numeric::test_binary_numeric_array;
     use vortex_array::compute::conformance::filter::test_filter_conformance;
     use vortex_array::compute::conformance::mask::test_mask_conformance;
-    use vortex_array::compute::filter;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_dtype::DType;
@@ -77,7 +76,7 @@ mod test {
         predicate.extend_from_slice(&[false; 17]);
         let mask = Mask::from_iter(predicate);
 
-        let filtered_array = filter(&array, &mask).unwrap();
+        let filtered_array = array.filter(mask).unwrap();
 
         // Construct expected SparseArray: index 2 was kept, which had value 33.
         // The new index is 0 (since it's the only element).
@@ -104,7 +103,7 @@ mod test {
         .unwrap()
         .into_array();
 
-        let filtered_array = filter(&array, &mask).unwrap();
+        let filtered_array = array.filter(mask).unwrap();
 
         // Original indices 0, 3, 6 with values 33, 44, 55.
         // Mask keeps indices 1, 3, 5, 6 -> new indices 0, 1, 2, 3.

--- a/encodings/zigzag/src/compute/mod.rs
+++ b/encodings/zigzag/src/compute/mod.rs
@@ -12,7 +12,6 @@ use vortex_array::compute::MaskKernel;
 use vortex_array::compute::MaskKernelAdapter;
 use vortex_array::compute::TakeKernel;
 use vortex_array::compute::TakeKernelAdapter;
-use vortex_array::compute::filter;
 use vortex_array::compute::mask;
 use vortex_array::compute::take;
 use vortex_array::register_kernel;
@@ -24,7 +23,7 @@ use crate::ZigZagVTable;
 
 impl FilterKernel for ZigZagVTable {
     fn filter(&self, array: &ZigZagArray, mask: &Mask) -> VortexResult<ArrayRef> {
-        let encoded = filter(array.encoded(), mask)?;
+        let encoded = array.encoded().filter(mask.clone())?;
         Ok(ZigZagArray::try_new(encoded)?.into_array())
     }
 }
@@ -80,7 +79,6 @@ mod tests {
     use vortex_array::assert_arrays_eq;
     use vortex_array::compute::conformance::binary_numeric::test_binary_numeric_array;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
-    use vortex_array::compute::filter;
     use vortex_array::compute::take;
     use vortex_array::validity::Validity;
     use vortex_buffer::BitBuffer;
@@ -127,7 +125,7 @@ mod tests {
         ))?;
 
         let filter_mask = BitBuffer::from(vec![true, false, true]).into();
-        let actual = filter(zigzag.as_ref(), &filter_mask).unwrap();
+        let actual = zigzag.filter(filter_mask).unwrap();
         let expected =
             zigzag_encode(PrimitiveArray::new(buffer![-189, 1], Validity::AllValid))?.into_array();
         assert_arrays_eq!(actual, expected);

--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -14,7 +14,6 @@ use vortex_array::ToCanonical;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::compute::Operator;
 use vortex_array::compute::compare;
-use vortex_array::compute::filter;
 use vortex_array::expr::lit;
 use vortex_array::expr::root;
 use vortex_buffer::ByteBufferMut;
@@ -51,7 +50,8 @@ fuzz_target!(|fuzz: FuzzFileAction| -> Corpus {
             .apply(&filter_expr.clone().unwrap_or_else(|| lit(true)))
             .vortex_expect("filter expression evaluation should succeed in fuzz test");
         let mask = bool_mask.to_bool().to_mask_fill_null_false();
-        let filtered = filter(&array_data, &mask)
+        let filtered = array_data
+            .filter(mask)
             .vortex_expect("filter operation should succeed in fuzz test");
         filtered
             .apply(&projection_expr.clone().unwrap_or_else(root))

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -549,7 +549,6 @@ pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> crate::error::VortexFuzz
     use vortex_array::compute::cast;
     use vortex_array::compute::compare;
     use vortex_array::compute::fill_null;
-    use vortex_array::compute::filter;
     use vortex_array::compute::mask;
     use vortex_array::compute::min_max;
     use vortex_array::compute::sum;
@@ -591,7 +590,8 @@ pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> crate::error::VortexFuzz
                 assert_search_sorted(sorted, s, side, expected.search(), i)?;
             }
             Action::Filter(mask_val) => {
-                current_array = filter(&current_array, &mask_val)
+                current_array = current_array
+                    .filter(mask_val)
                     .vortex_expect("filter operation should succeed in fuzz test");
                 assert_array_eq(&expected.array(), &current_array, i)?;
             }

--- a/vortex-array/src/arrays/bool/compute/filter.rs
+++ b/vortex-array/src/arrays/bool/compute/filter.rs
@@ -88,14 +88,13 @@ mod test {
     use crate::arrays::bool::compute::filter::filter_slices;
     use crate::canonical::ToCanonical;
     use crate::compute::conformance::filter::test_filter_conformance;
-    use crate::compute::filter;
 
     #[test]
     fn filter_bool_test() {
         let arr = BoolArray::from_iter([true, true, false]);
         let mask = Mask::from_iter([true, false, true]);
 
-        let filtered = filter(arr.as_ref(), &mask).unwrap().to_bool();
+        let filtered = arr.filter(mask).unwrap().to_bool();
         assert_eq!(2, filtered.len());
 
         assert_eq!(

--- a/vortex-array/src/arrays/chunked/compute/filter.rs
+++ b/vortex-array/src/arrays/chunked/compute/filter.rs
@@ -15,7 +15,6 @@ use crate::arrays::ChunkedVTable;
 use crate::arrays::PrimitiveArray;
 use crate::compute::FilterKernel;
 use crate::compute::FilterKernelAdapter;
-use crate::compute::filter;
 use crate::compute::take;
 use crate::register_kernel;
 use crate::search_sorted::SearchSorted;
@@ -75,7 +74,7 @@ fn filter_slices(
             ChunkFilter::None => {}
             // Slices => turn the slices into a boolean buffer.
             ChunkFilter::Slices(slices) => {
-                result.push(filter(chunk, &Mask::from_slices(chunk.len(), slices))?);
+                result.push(chunk.filter(Mask::from_slices(chunk.len(), slices))?);
             }
         }
     }
@@ -215,7 +214,6 @@ mod test {
     use crate::arrays::ChunkedArray;
     use crate::arrays::PrimitiveArray;
     use crate::compute::conformance::filter::test_filter_conformance;
-    use crate::compute::filter;
 
     #[test]
     fn filter_chunked_floats() {
@@ -245,7 +243,7 @@ mod test {
         let mask = Mask::from_iter([
             true, false, false, true, true, true, true, true, true, true, true,
         ]);
-        let filtered = filter(chunked.as_ref(), &mask).unwrap();
+        let filtered = chunked.filter(mask).unwrap();
         assert_eq!(filtered.len(), 9);
     }
 

--- a/vortex-array/src/arrays/dict/compute/mod.rs
+++ b/vortex-array/src/arrays/dict/compute/mod.rs
@@ -22,7 +22,6 @@ use crate::compute::FilterKernel;
 use crate::compute::FilterKernelAdapter;
 use crate::compute::TakeKernel;
 use crate::compute::TakeKernelAdapter;
-use crate::compute::filter;
 use crate::compute::take;
 use crate::register_kernel;
 
@@ -39,7 +38,7 @@ register_kernel!(TakeKernelAdapter(DictVTable).lift());
 
 impl FilterKernel for DictVTable {
     fn filter(&self, array: &DictArray, mask: &Mask) -> VortexResult<ArrayRef> {
-        let codes = filter(array.codes(), mask)?;
+        let codes = array.codes().filter(mask.clone())?;
 
         // SAFETY: filtering codes doesn't change invariants
         // Preserve all_values_referenced since filtering codes doesn't affect which values are referenced

--- a/vortex-array/src/arrays/extension/compute/filter.rs
+++ b/vortex-array/src/arrays/extension/compute/filter.rs
@@ -10,14 +10,13 @@ use crate::arrays::ExtensionArray;
 use crate::arrays::ExtensionVTable;
 use crate::compute::FilterKernel;
 use crate::compute::FilterKernelAdapter;
-use crate::compute::{self};
 use crate::register_kernel;
 
 impl FilterKernel for ExtensionVTable {
     fn filter(&self, array: &ExtensionArray, mask: &Mask) -> VortexResult<ArrayRef> {
         Ok(ExtensionArray::new(
             array.ext_dtype().clone(),
-            compute::filter(array.storage(), mask)?,
+            array.storage().filter(mask.clone())?,
         )
         .into_array())
     }

--- a/vortex-array/src/arrays/filter/execute.rs
+++ b/vortex-array/src/arrays/filter/execute.rs
@@ -29,7 +29,6 @@ use crate::arrays::VarBinViewArray;
 use crate::arrays::VarBinViewVTable;
 use crate::arrays::filter::FilterArray;
 use crate::compute::FilterKernel;
-use crate::compute::filter;
 use crate::validity::Validity;
 
 /// TODO: replace usage of compute fn.
@@ -158,6 +157,9 @@ fn filter_struct(array: &StructArray, mask: &Mask) -> StructArray {
 }
 
 fn filter_extension(array: &ExtensionArray, mask: &Mask) -> ExtensionArray {
-    let filtered_storage = filter(array.storage(), mask).vortex_expect("filter extension storage");
+    let filtered_storage = array
+        .storage()
+        .filter(mask.clone())
+        .vortex_expect("filter extension storage");
     ExtensionArray::new(array.ext_dtype().clone(), filtered_storage)
 }

--- a/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/filter.rs
@@ -11,7 +11,6 @@ use crate::arrays::FixedSizeListArray;
 use crate::arrays::FixedSizeListVTable;
 use crate::compute::FilterKernel;
 use crate::compute::FilterKernelAdapter;
-use crate::compute::{self};
 use crate::register_kernel;
 use crate::vtable::ValidityHelper;
 
@@ -41,7 +40,7 @@ impl FilterKernel for FixedSizeListVTable {
                 let elements_mask = compute_fsl_elements_mask(selection_mask, list_size as usize);
 
                 // Allow the child array to filter itself.
-                let new_elements = compute::filter(elements, &elements_mask)?;
+                let new_elements = elements.filter(elements_mask)?;
                 debug_assert_eq!(new_elements.len(), new_len * list_size as usize);
 
                 new_elements

--- a/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
@@ -18,7 +18,6 @@ use crate::compute::conformance::filter::LARGE_SIZE;
 use crate::compute::conformance::filter::MEDIUM_SIZE;
 use crate::compute::conformance::filter::SMALL_SIZE;
 use crate::compute::conformance::filter::test_filter_conformance;
-use crate::compute::filter;
 use crate::validity::Validity;
 
 // Consolidated parameterized test for degenerate (list_size=0) cases.
@@ -64,7 +63,7 @@ fn test_filter_degenerate_list_size_zero(
     let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, num_lists);
 
     let mask = Mask::from(BitBuffer::from(mask_values));
-    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered = fsl.filter(mask).unwrap();
 
     assert_eq!(filtered.len(), expected_len, "Degenerate FSL filter failed");
 
@@ -87,7 +86,7 @@ fn test_filter_with_nulls() {
     let fsl = FixedSizeListArray::new(elements.into_array(), 2, validity, 3);
 
     let mask = Mask::from(BitBuffer::from(vec![true, false, true]));
-    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered = fsl.filter(mask).unwrap();
 
     assert_eq!(filtered.len(), 2, "Expected lists after filtering out null");
 
@@ -114,7 +113,7 @@ fn test_filter_all_null_array() {
     let fsl = FixedSizeListArray::new(elements.into_array(), 2, validity, 3);
 
     let mask = Mask::from(BitBuffer::from(vec![true, false, true]));
-    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered = fsl.filter(mask).unwrap();
 
     // Verify the result is an array of nulls.
     assert_eq!(filtered.len(), 2, "All-null FSL should produce 2 elements");
@@ -153,7 +152,7 @@ fn test_filter_nested_fixed_size_lists() {
 
     // Filter to keep only the second outer list.
     let mask = Mask::from(BitBuffer::from(vec![false, true]));
-    let filtered = filter(outer_fsl.as_ref(), &mask).unwrap();
+    let filtered = outer_fsl.filter(mask).unwrap();
 
     // Construct expected: second outer list [[7,8], [9,10], [11,12]].
     let expected_inner_elements = buffer![7i32, 8, 9, 10, 11, 12].into_array();
@@ -256,7 +255,7 @@ fn test_filter_all_null_various_list_sizes() {
     let elements0 = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
     let fsl0 = FixedSizeListArray::new(elements0.into_array(), 0, Validity::AllInvalid, 3);
     let mask0 = Mask::from(BitBuffer::from(vec![true, false, true]));
-    let filtered0 = filter(fsl0.as_ref(), &mask0).unwrap();
+    let filtered0 = fsl0.filter(mask0).unwrap();
     assert_eq!(filtered0.len(), 2);
     // Check that all elements are null (might be ConstantArray or FixedSizeListArray).
     assert_nth_scalar_is_null!(filtered0, 0);
@@ -266,7 +265,7 @@ fn test_filter_all_null_various_list_sizes() {
     let elements1 = buffer![1i32, 2, 3].into_array();
     let fsl1 = FixedSizeListArray::new(elements1.into_array(), 1, Validity::AllInvalid, 3);
     let mask1 = Mask::from(BitBuffer::from(vec![false, true, true]));
-    let filtered1 = filter(fsl1.as_ref(), &mask1).unwrap();
+    let filtered1 = fsl1.filter(mask1).unwrap();
     assert_eq!(filtered1.len(), 2);
     // Check that all elements are null.
     assert_nth_scalar_is_null!(filtered1, 0);
@@ -276,7 +275,7 @@ fn test_filter_all_null_various_list_sizes() {
     let elements10 = buffer![0..50i32].into_array();
     let fsl10 = FixedSizeListArray::new(elements10, 10, Validity::AllInvalid, 5);
     let mask10 = Mask::AllTrue(5);
-    let filtered10 = filter(fsl10.as_ref(), &mask10).unwrap();
+    let filtered10 = fsl10.filter(mask10).unwrap();
     assert_eq!(filtered10.len(), 5);
     // Check that all elements are null.
     assert_nth_scalar_is_null!(filtered10, 0);
@@ -308,7 +307,7 @@ fn test_mask_expansion_threshold_boundary() {
     sparse_mask[75] = true;
     let mask = Mask::from(BitBuffer::from(sparse_mask));
 
-    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered = fsl.filter(mask.clone()).unwrap();
 
     // Construct expected FSL with indices 5, 25, 75 from original.
     let expected_elements: Vec<i32> = [5, 25, 75]
@@ -340,7 +339,7 @@ fn test_mask_expansion_threshold_boundary() {
         num_lists,
     );
 
-    let filtered7 = filter(fsl7.as_ref(), &mask).unwrap();
+    let filtered7 = fsl7.filter(mask).unwrap();
 
     // Construct expected FSL with indices 5, 25, 75 from original (list_size=7).
     let expected_elements7: Vec<i32> = [5, 25, 75]
@@ -379,7 +378,7 @@ fn test_filter_large_list_size() {
 
     // Apply a filter keeping lists 1, 3, 4.
     let mask = Mask::from_iter([false, true, false, true, true]);
-    let filtered = filter(fsl.as_ref(), &mask).unwrap();
+    let filtered = fsl.filter(mask).unwrap();
 
     // Construct expected FSL with indices 1, 3, 4 from original.
     let expected_elements: Vec<i64> = [1, 3, 4]
@@ -400,7 +399,7 @@ fn test_filter_large_list_size() {
 
     // Test edge case: filter out all but one large list.
     let mask_single = Mask::from_iter([false, false, true, false, false]);
-    let filtered_single = filter(fsl.as_ref(), &mask_single).unwrap();
+    let filtered_single = fsl.filter(mask_single).unwrap();
 
     // Construct expected FSL with index 2 from original.
     let expected_single_elements: Vec<i64> = {

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -21,7 +21,6 @@ use crate::arrays::ListArray;
 use crate::arrays::ListVTable;
 use crate::compute::FilterKernel;
 use crate::compute::FilterKernelAdapter;
-use crate::compute::filter;
 use crate::register_kernel;
 use crate::vtable::ValidityHelper;
 
@@ -132,7 +131,7 @@ fn compute_filtered_elements_and_offsets<O: IntegerPType>(
 
     // Allow the child array to filter themselves.
     // The `Mask` can determine the best representation based on the buffer's density in the future.
-    let new_elements = filter(elements, &Mask::from_buffer(new_mask_builder.freeze()))?;
+    let new_elements = elements.filter(Mask::from_buffer(new_mask_builder.freeze()))?;
 
     Ok((new_elements, new_offsets))
 }

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -24,7 +24,6 @@ use crate::arrays::PrimitiveArray;
 use crate::assert_arrays_eq;
 use crate::builders::ArrayBuilder;
 use crate::builders::ListBuilder;
-use crate::compute::filter;
 use crate::validity::Validity;
 
 #[test]
@@ -101,7 +100,7 @@ fn test_simple_list_filter() {
         .unwrap()
         .into_array();
 
-    let filtered = filter(&list, &Mask::from(BitBuffer::from(vec![false, true, true])));
+    let filtered = list.filter(Mask::from(BitBuffer::from(vec![false, true, true])));
 
     assert!(filtered.is_ok())
 }
@@ -120,7 +119,7 @@ fn test_list_filter_dense_mask() {
     // Dense mask: keep most elements (indices 1, 2, 3, 4, 5).
     let mask = Mask::from(BitBuffer::from(vec![false, true, true, true, true, true]));
 
-    let filtered = filter(&list, &mask).unwrap();
+    let filtered = list.filter(mask).unwrap();
 
     // Should have 5 lists remaining.
     assert_eq!(filtered.len(), 5);
@@ -153,7 +152,7 @@ fn test_list_filter_sparse_mask() {
         true, false, false, false, false, true,
     ]));
 
-    let filtered = filter(&list, &mask).unwrap();
+    let filtered = list.filter(mask).unwrap();
 
     // Should have 2 lists remaining.
     assert_eq!(filtered.len(), 2);
@@ -183,7 +182,7 @@ fn test_list_filter_empty_lists() {
 
     let mask = Mask::from(BitBuffer::from(vec![true, true, true, false, false, true]));
 
-    let filtered = filter(&list, &mask).unwrap();
+    let filtered = list.filter(mask).unwrap();
 
     assert_eq!(filtered.len(), 4);
 
@@ -214,7 +213,7 @@ fn test_list_filter_with_nulls() {
 
     let mask = Mask::from(BitBuffer::from(vec![true, true, false, true, true]));
 
-    let filtered = filter(&list, &mask).unwrap();
+    let filtered = list.filter(mask).unwrap();
 
     assert_eq!(filtered.len(), 4);
 
@@ -238,7 +237,7 @@ fn test_list_filter_all_true() {
 
     let mask = Mask::AllTrue(4);
 
-    let filtered = filter(&list, &mask).unwrap();
+    let filtered = list.filter(mask).unwrap();
 
     // All lists should be preserved.
     assert_eq!(filtered.len(), 4);
@@ -260,7 +259,7 @@ fn test_list_filter_all_false() {
 
     let mask = Mask::AllFalse(4);
 
-    let filtered = filter(&list, &mask).unwrap();
+    let filtered = list.filter(mask).unwrap();
 
     // When mask is AllFalse, filter returns a canonical empty array (ListViewArray).
     // We need to check the length directly without casting to a specific type.
@@ -280,7 +279,7 @@ fn test_list_filter_single_element() {
 
     let mask = Mask::from(BitBuffer::from(vec![false, false, true, false, false]));
 
-    let filtered = filter(&list, &mask).unwrap();
+    let filtered = list.filter(mask).unwrap();
 
     assert_eq!(filtered.len(), 1);
 
@@ -311,7 +310,7 @@ fn test_list_filter_alternating_pattern() {
         true, false, true, false, true, false, true, false, true, false, true, false,
     ]));
 
-    let filtered = filter(&list, &mask).unwrap();
+    let filtered = list.filter(mask).unwrap();
 
     assert_eq!(filtered.len(), 6);
 
@@ -345,7 +344,7 @@ fn test_list_filter_variable_sizes() {
         true, false, true, true, false, true, true, true,
     ]));
 
-    let filtered = filter(&list, &mask).unwrap();
+    let filtered = list.filter(mask).unwrap();
 
     assert_eq!(filtered.len(), 6);
 

--- a/vortex-array/src/arrays/listview/compute/filter.rs
+++ b/vortex-array/src/arrays/listview/compute/filter.rs
@@ -11,7 +11,6 @@ use crate::arrays::ListViewRebuildMode;
 use crate::arrays::ListViewVTable;
 use crate::compute::FilterKernel;
 use crate::compute::FilterKernelAdapter;
-use crate::compute::{self};
 use crate::register_kernel;
 use crate::vtable::ValidityHelper;
 
@@ -53,8 +52,8 @@ impl FilterKernel for ListViewVTable {
         );
 
         // Simply filter the offsets and sizes arrays.
-        let new_offsets = compute::filter(offsets.as_ref(), selection_mask)?;
-        let new_sizes = compute::filter(sizes.as_ref(), selection_mask)?;
+        let new_offsets = offsets.filter(selection_mask.clone())?;
+        let new_sizes = sizes.filter(selection_mask.clone())?;
 
         // SAFETY: Filter operation maintains all `ListViewArray` invariants:
         // - Offsets and sizes are derived from existing valid child arrays.

--- a/vortex-array/src/arrays/listview/tests/filter.rs
+++ b/vortex-array/src/arrays/listview/tests/filter.rs
@@ -17,7 +17,6 @@ use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
 use crate::assert_arrays_eq;
 use crate::compute::conformance::filter::test_filter_conformance;
-use crate::compute::filter;
 use crate::validity::Validity;
 
 // Conformance tests for common filter scenarios.
@@ -47,7 +46,7 @@ fn test_filter_preserves_unreferenced_elements() {
 
     // Filter to keep only 2 lists.
     let mask = Mask::from_iter([true, false, false, true, false]);
-    let result = filter(&listview, &mask).unwrap();
+    let result = listview.filter(mask).unwrap();
     let result_list = result.to_listview();
 
     assert_eq!(result_list.len(), 2, "Wrong number of filtered lists");
@@ -79,7 +78,7 @@ fn test_filter_with_gaps() {
 
     // Filter to keep lists with gaps and overlaps.
     let mask = Mask::from_iter([false, true, true, true, false]);
-    let result = filter(&listview, &mask).unwrap();
+    let result = listview.filter(mask).unwrap();
     let result_list = result.to_listview();
 
     assert_eq!(result_list.len(), 3, "Wrong filter result length");
@@ -122,7 +121,7 @@ fn test_filter_constant_arrays() {
     .to_array();
 
     let mask1 = Mask::from_iter([true, false, true, false]);
-    let result1 = filter(&const_offset_list, &mask1).unwrap();
+    let result1 = const_offset_list.filter(mask1).unwrap();
     let result1_list = result1.to_listview();
 
     assert_eq!(result1_list.len(), 2);
@@ -145,7 +144,7 @@ fn test_filter_constant_arrays() {
     .to_array();
 
     let mask2 = Mask::from_iter([true, false, true]);
-    let result2 = filter(&both_const_list, &mask2).unwrap();
+    let result2 = both_const_list.filter(mask2).unwrap();
     let result2_list = result2.to_listview();
 
     assert_eq!(result2_list.len(), 2);
@@ -171,7 +170,7 @@ fn test_filter_extreme_offsets() {
 
     // Filter to keep only 2 lists, demonstrating we keep all 10000 elements.
     let mask = Mask::from_iter([false, true, false, false, true]);
-    let result = filter(&listview, &mask).unwrap();
+    let result = listview.filter(mask).unwrap();
     let result_list = result.to_listview();
 
     assert_eq!(result_list.len(), 2);
@@ -206,7 +205,7 @@ fn test_filter_extreme_offsets() {
 
     // Test sparse selection from large dataset.
     let sparse_mask = Mask::from_iter((0..5).map(|i| i == 0 || i == 4));
-    let sparse_result = filter(&listview, &sparse_mask).unwrap();
+    let sparse_result = listview.filter(sparse_mask).unwrap();
     let sparse_list = sparse_result.to_listview();
 
     assert_eq!(sparse_list.len(), 2);

--- a/vortex-array/src/arrays/masked/compute/filter.rs
+++ b/vortex-array/src/arrays/masked/compute/filter.rs
@@ -10,7 +10,6 @@ use crate::arrays::MaskedArray;
 use crate::arrays::MaskedVTable;
 use crate::compute::FilterKernel;
 use crate::compute::FilterKernelAdapter;
-use crate::compute::filter;
 use crate::register_kernel;
 use crate::vtable::ValidityHelper;
 
@@ -21,7 +20,7 @@ impl FilterKernel for MaskedVTable {
 
         // Filter the child array
         // The child is guaranteed to have no nulls, so filtering it is straightforward
-        let filtered_child = filter(&array.child, mask)?;
+        let filtered_child = array.child.filter(mask.clone())?;
 
         // Construct new MaskedArray
         Ok(MaskedArray::try_new(filtered_child, filtered_validity)?.into_array())

--- a/vortex-array/src/arrays/primitive/compute/filter.rs
+++ b/vortex-array/src/arrays/primitive/compute/filter.rs
@@ -45,16 +45,13 @@ mod test {
     use crate::compute::conformance::filter::LARGE_SIZE;
     use crate::compute::conformance::filter::MEDIUM_SIZE;
     use crate::compute::conformance::filter::test_filter_conformance;
-    use crate::compute::filter;
 
     #[test]
     fn filter_run_variant_mixed_test() {
         let mask = [true, true, false, true, true, true, false, true];
         let arr = PrimitiveArray::from_iter([1u32, 24, 54, 2, 3, 2, 3, 2]);
 
-        let filtered = filter(arr.as_ref(), &Mask::from_iter(mask))
-            .unwrap()
-            .to_primitive();
+        let filtered = arr.filter(Mask::from_iter(mask)).unwrap().to_primitive();
         assert_eq!(
             filtered.len(),
             mask.iter().filter(|x| **x).collect_vec().len()

--- a/vortex-array/src/arrays/struct_/compute/filter.rs
+++ b/vortex-array/src/arrays/struct_/compute/filter.rs
@@ -12,7 +12,6 @@ use crate::arrays::StructArray;
 use crate::arrays::StructVTable;
 use crate::compute::FilterKernel;
 use crate::compute::FilterKernelAdapter;
-use crate::compute::filter;
 use crate::register_kernel;
 use crate::vtable::ValidityHelper;
 
@@ -23,7 +22,7 @@ impl FilterKernel for StructVTable {
         let fields: Vec<ArrayRef> = array
             .unmasked_fields()
             .iter()
-            .map(|field| filter(field, mask))
+            .map(|field| field.filter(mask.clone()))
             .try_collect()?;
         let length = fields
             .first()

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -36,7 +36,6 @@ mod tests {
     use crate::compute::conformance::filter::test_filter_conformance;
     use crate::compute::conformance::mask::test_mask_conformance;
     use crate::compute::conformance::take::test_take_conformance;
-    use crate::compute::filter;
     use crate::compute::is_constant;
     use crate::compute::take;
     use crate::validity::Validity;
@@ -48,7 +47,7 @@ mod tests {
         let mask = vec![
             false, true, false, true, false, true, false, true, false, true,
         ];
-        let filtered = filter(struct_arr.as_ref(), &Mask::from_iter(mask)).unwrap();
+        let filtered = struct_arr.filter(Mask::from_iter(mask)).unwrap();
         assert_eq!(filtered.len(), 5);
     }
 
@@ -91,7 +90,7 @@ mod tests {
     fn filter_empty_struct_with_empty_filter() {
         let struct_arr =
             StructArray::try_new(FieldNames::empty(), vec![], 0, Validity::NonNullable).unwrap();
-        let filtered = filter(struct_arr.as_ref(), &Mask::from_iter::<[bool; 0]>([])).unwrap();
+        let filtered = struct_arr.filter(Mask::from_iter::<[bool; 0]>([])).unwrap();
         assert_eq!(filtered.len(), 0);
     }
 

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -35,7 +35,6 @@ use crate::compute::Operator;
 use crate::compute::and;
 use crate::compute::cast;
 use crate::compute::compare;
-use crate::compute::filter;
 use crate::compute::invert;
 use crate::compute::mask;
 use crate::compute::or;
@@ -63,7 +62,9 @@ fn test_filter_take_consistency(array: &dyn Array) {
     let mask = Mask::from_buffer(mask_pattern.clone());
 
     // Filter the array
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
 
     // Create indices where mask is true
     let indices: Vec<u64> = mask_pattern
@@ -191,8 +192,9 @@ fn test_filter_identity(array: &dyn Array) {
     }
 
     let all_true_mask = Mask::new_true(len);
-    let filtered =
-        filter(array, &all_true_mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(all_true_mask)
+        .vortex_expect("filter should succeed in conformance test");
 
     // Filtered array should be identical to original
     assert_eq!(
@@ -299,7 +301,9 @@ fn test_slice_filter_consistency(array: &dyn Array) {
     mask_pattern[1..4.min(len)].fill(true);
 
     let mask = Mask::from_iter(mask_pattern);
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
 
     // Slice should produce the same result
     let sliced = array
@@ -394,7 +398,9 @@ fn test_filter_preserves_order(array: &dyn Array) {
     let mask_pattern: Vec<bool> = (0..len).map(|i| i == 0 || i == 2 || i == 3).collect();
     let mask = Mask::from_iter(mask_pattern);
 
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
 
     // Verify the filtered array contains the right elements in order
     assert_eq!(filtered.len(), 3.min(len));
@@ -465,12 +471,14 @@ fn test_mask_filter_null_consistency(array: &dyn Array) {
     // Then filter to remove the nulls
     let filter_pattern: Vec<bool> = (0..len).map(|i| i % 2 != 0).collect();
     let filter_mask = Mask::from_iter(filter_pattern);
-    let filtered =
-        filter(&masked, &filter_mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = masked
+        .filter(filter_mask.clone())
+        .vortex_expect("filter should succeed in conformance test");
 
     // This should be equivalent to directly filtering the original array
-    let direct_filtered =
-        filter(array, &filter_mask).vortex_expect("filter should succeed in conformance test");
+    let direct_filtered = array
+        .filter(filter_mask)
+        .vortex_expect("filter should succeed in conformance test");
 
     assert_eq!(filtered.len(), direct_filtered.len());
     for i in 0..filtered.len() {
@@ -490,7 +498,8 @@ fn test_empty_operations_consistency(array: &dyn Array) {
     let len = array.len();
 
     // Empty filter
-    let empty_filter = filter(array, &Mask::new_false(len))
+    let empty_filter = array
+        .filter(Mask::new_false(len))
         .vortex_expect("filter should succeed in conformance test");
     assert_eq!(empty_filter.len(), 0);
     assert_eq!(empty_filter.dtype(), array.dtype());
@@ -634,7 +643,9 @@ fn test_large_array_consistency(array: &dyn Array) {
     // Create equivalent filter mask
     let mask_pattern: Vec<bool> = (0..len).map(|i| i % 10 == 0).collect();
     let mask = Mask::from_iter(mask_pattern);
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
 
     // Results should match
     assert_eq!(taken.len(), filtered.len());

--- a/vortex-array/src/compute/conformance/filter.rs
+++ b/vortex-array/src/compute/conformance/filter.rs
@@ -8,7 +8,6 @@ use vortex_mask::Mask;
 use crate::Array;
 use crate::IntoArray;
 use crate::assert_arrays_eq;
-use crate::compute::filter;
 
 // Standard test array sizes
 pub const SMALL_SIZE: usize = 5;
@@ -63,7 +62,9 @@ pub fn create_runs_pattern(len: usize, run_length: usize) -> Vec<bool> {
 fn test_all_filter(array: &dyn Array) {
     let len = array.len();
     let mask = Mask::new_true(len);
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
     assert_arrays_eq!(filtered, array);
 }
 
@@ -71,7 +72,9 @@ fn test_all_filter(array: &dyn Array) {
 fn test_none_filter(array: &dyn Array) {
     let len = array.len();
     let mask = Mask::new_false(len);
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
     assert_eq!(filtered.len(), 0);
     assert_eq!(filtered.dtype(), array.dtype());
 }
@@ -86,7 +89,9 @@ fn test_selective_filter(array: &dyn Array) {
     let mask_values: Vec<bool> = (0..len).map(|i| i % 2 == 0).collect();
     let expected_count = mask_values.iter().filter(|&&v| v).count();
     let mask = Mask::from_iter(mask_values);
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
     assert_eq!(filtered.len(), expected_count);
 
     // Verify correct elements are kept
@@ -107,8 +112,9 @@ fn test_selective_filter(array: &dyn Array) {
         mask_values[0] = true;
         mask_values[len - 1] = true;
         let mask = Mask::from_iter(mask_values);
-        let filtered =
-            filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+        let filtered = array
+            .filter(mask)
+            .vortex_expect("filter should succeed in conformance test");
         assert_eq!(filtered.len(), 2);
         assert_eq!(
             filtered
@@ -139,7 +145,9 @@ fn test_single_element_filter(array: &dyn Array) {
     let mut mask_values = vec![false; len];
     mask_values[0] = true;
     let mask = Mask::from_iter(mask_values);
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
     assert_eq!(filtered.len(), 1);
     assert_eq!(
         filtered
@@ -155,8 +163,9 @@ fn test_single_element_filter(array: &dyn Array) {
         let mut mask_values = vec![false; len];
         mask_values[len - 1] = true;
         let mask = Mask::from_iter(mask_values);
-        let filtered =
-            filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+        let filtered = array
+            .filter(mask)
+            .vortex_expect("filter should succeed in conformance test");
         assert_eq!(filtered.len(), 1);
         assert_eq!(
             filtered
@@ -174,12 +183,14 @@ fn test_empty_array_filter(dtype: &DType) {
 
     let empty_array = Canonical::empty(dtype).into_array();
     let empty_mask = Mask::new_false(0);
-    let filtered = filter(&empty_array, &empty_mask)
+    let filtered = empty_array
+        .filter(empty_mask)
         .vortex_expect("filter should succeed in conformance test");
     assert_eq!(filtered.len(), 0);
 
     let empty_mask = Mask::new_true(0);
-    let filtered = filter(&empty_array, &empty_mask)
+    let filtered = empty_array
+        .filter(empty_mask)
         .vortex_expect("filter should succeed in conformance test");
     assert_eq!(filtered.len(), 0);
 }
@@ -190,7 +201,7 @@ fn test_mismatched_lengths(array: &dyn Array) {
     // Test mask shorter than array
     if len > 0 {
         let short_mask = Mask::new_true(len - 1);
-        let result = filter(array, &short_mask);
+        let result = array.filter(short_mask);
         assert!(
             result.is_err(),
             "Filter should fail with mismatched lengths"
@@ -199,7 +210,7 @@ fn test_mismatched_lengths(array: &dyn Array) {
 
     // Test mask longer than array
     let long_mask = Mask::new_true(len + 1);
-    let result = filter(array, &long_mask);
+    let result = array.filter(long_mask);
     assert!(
         result.is_err(),
         "Filter should fail with mismatched lengths"
@@ -213,7 +224,9 @@ fn test_alternating_pattern_filter(array: &dyn Array) {
     let expected_count = pattern.iter().filter(|&&v| v).count();
 
     let mask = Mask::from_iter(pattern.clone());
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
     assert_eq!(filtered.len(), expected_count);
 
     // Verify correct elements are kept
@@ -245,7 +258,9 @@ fn test_runs_pattern_filter(array: &dyn Array) {
     let expected_count = pattern.iter().filter(|&&v| v).count();
 
     let mask = Mask::from_iter(pattern);
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
     assert_eq!(filtered.len(), expected_count);
 }
 
@@ -261,7 +276,9 @@ fn test_sparse_true_filter(array: &dyn Array) {
     let expected_count = pattern.iter().filter(|&&v| v).count();
 
     let mask = Mask::from_iter(pattern);
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
     assert_eq!(filtered.len(), expected_count);
 }
 
@@ -277,7 +294,9 @@ fn test_sparse_false_filter(array: &dyn Array) {
     let expected_count = pattern.iter().filter(|&&v| v).count();
 
     let mask = Mask::from_iter(pattern);
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
     assert_eq!(filtered.len(), expected_count);
 }
 
@@ -292,6 +311,8 @@ fn test_random_pattern_filter(array: &dyn Array) {
     let expected_count = pattern.iter().filter(|&&v| v).count();
 
     let mask = Mask::from_iter(pattern);
-    let filtered = filter(array, &mask).vortex_expect("filter should succeed in conformance test");
+    let filtered = array
+        .filter(mask)
+        .vortex_expect("filter should succeed in conformance test");
     assert_eq!(filtered.len(), expected_count);
 }

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+// TODO(connor): REMOVE THIS FILE!
+
 use std::sync::LazyLock;
 
 use arcref::ArcRef;
@@ -136,7 +138,7 @@ impl ComputeFnVTable for Filter {
 
         if !array.is_canonical() {
             let canonical = array.to_canonical()?.into_array();
-            return filter(&canonical, mask).map(Into::into);
+            return canonical.filter(mask.clone()).map(Into::into);
         };
 
         vortex_bail!(
@@ -252,26 +254,4 @@ pub fn arrow_filter_fn(array: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef>
     let filtered = arrow_select::filter::filter(array_ref.as_ref(), &mask_array)?;
 
     ArrayRef::from_arrow(filtered.as_ref(), array.dtype().is_nullable())
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::arrays::PrimitiveArray;
-    use crate::canonical::ToCanonical;
-    use crate::compute::filter::filter;
-
-    #[test]
-    fn test_filter() {
-        let items =
-            PrimitiveArray::from_option_iter([Some(0i32), None, Some(1i32), None, Some(2i32)])
-                .into_array();
-        let mask = Mask::from_iter([true, false, true, false, true]);
-
-        let filtered = filter(&items, &mask).unwrap();
-        assert_eq!(
-            filtered.to_primitive().as_slice::<i32>(),
-            &[0i32, 1i32, 2i32]
-        );
-    }
 }

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -40,7 +40,6 @@ use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::PrimitiveArray;
 use crate::compute::cast;
-use crate::compute::filter;
 use crate::compute::is_sorted;
 use crate::compute::take;
 use crate::search_sorted::SearchResult;
@@ -627,8 +626,8 @@ impl Patches {
         }
 
         // SAFETY: filtering indices/values with same mask maintains their 1:1 relationship
-        let filtered_indices = filter(&self.indices, &filter_mask)?;
-        let filtered_values = filter(&self.values, &filter_mask)?;
+        let filtered_indices = self.indices.filter(filter_mask.clone())?;
+        let filtered_values = self.values.filter(filter_mask)?;
 
         Ok(Some(Self {
             array_len: self.array_len,
@@ -1149,10 +1148,8 @@ fn filter_patches_with_mask<T: IntegerPType>(
     }
 
     let new_patch_indices = new_patch_indices.into_array();
-    let new_patch_values = filter(
-        patch_values,
-        &Mask::from_indices(patch_values.len(), new_mask_indices),
-    )?;
+    let new_patch_values =
+        patch_values.filter(Mask::from_indices(patch_values.len(), new_mask_indices))?;
 
     Ok(Some(Patches::new(
         true_count,

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -27,7 +27,6 @@ use crate::ToCanonical;
 use crate::arrays::BoolArray;
 use crate::arrays::ConstantArray;
 use crate::compute::fill_null;
-use crate::compute::filter;
 use crate::compute::sum;
 use crate::compute::take;
 use crate::patches::Patches;
@@ -192,7 +191,7 @@ impl Validity {
             v @ (Validity::NonNullable | Validity::AllValid | Validity::AllInvalid) => {
                 Ok(v.clone())
             }
-            Validity::Array(arr) => Ok(Validity::Array(filter(arr, mask)?)),
+            Validity::Array(arr) => Ok(Validity::Array(arr.filter(mask.clone())?)),
         }
     }
 


### PR DESCRIPTION
This is based on top of https://github.com/vortex-data/vortex/pull/6146/, that needs to merge first.

Simply changes the syntax so that we use the new `FilterArray`, so this is purely a cosmetic change after #6146.

Note that I only made the change when this gets called inside one of the old compute functions, and the code for all of the old filter compute are going to be moved around soon so this is fine.

There are just a few places (around 8) where we call the old `filter` _outside_ of the old compute kernels. I've left those as is so it's easy to search for them later. We still have to figure out what to do with them.

