### PR TITLE
fix: Min btrblocks compressor sample size is 1024 elements

### DIFF
--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -186,11 +186,11 @@ fn estimate_compression_ratio_with_sampling<T: Scheme + ?Sized>(
         // We want to sample about 1% of data
         let source_len = stats.source().len();
 
-        // We want to sample about 1% of data, while keeping a minimal sample of 640 values.
+        // We want to sample about 1% of data, while keeping a minimal sample of 1024 values.
         let sample_count = usize::max(
             (source_len / 100)
                 / usize::try_from(SAMPLE_SIZE).vortex_expect("SAMPLE_SIZE must fit in usize"),
-            10,
+            16,
         );
 
         tracing::trace!(


### PR DESCRIPTION
Signed-off-by: Robert Kruszewski <github@robertk.io>
