### PR TITLE
coalesced request align all segments

### DIFF
--- a/vortex-file/src/read/driver.rs
+++ b/vortex-file/src/read/driver.rs
@@ -213,7 +213,7 @@ impl State {
         let mut requests = vec![first_req];
         let mut current_start = requests[0].offset;
         let mut current_end = requests[0].offset + requests[0].length as u64;
-        let alignment = requests[0].alignment;
+        let mut max_alignment = requests[0].alignment;
 
         let mut keys_to_remove = Vec::new();
         let mut found_new_requests = true;
@@ -256,12 +256,16 @@ impl State {
                     // Calculate what the new range would be if we include this request
                     let new_start = current_start.min(req_offset);
                     let new_end = current_end.max(req_end);
-                    let new_total_size = new_end - new_start;
+                    let new_alignment = max_alignment.max(req.alignment);
+                    let align = *new_alignment as u64;
+                    let aligned_start = new_start - (new_start % align);
+                    let new_total_size = new_end - aligned_start;
 
                     // Check if the coalesced request would exceed max_size
                     if new_total_size <= window.max_size {
                         current_start = new_start;
                         current_end = new_end;
+                        max_alignment = new_alignment;
 
                         let req = self
                             .polled_requests
@@ -290,17 +294,20 @@ impl State {
         // Sort requests by offset for correct slicing in resolve
         requests.sort_unstable_by_key(|r| r.offset);
 
+        let align = *max_alignment as u64;
+        let aligned_start = current_start - (current_start % align);
+
         tracing::debug!(
             "Coalesced {} requests into range {}..{} (len={})",
             requests.len(),
-            current_start,
+            aligned_start,
             current_end,
-            current_end - current_start,
+            current_end - aligned_start,
         );
 
         Some(CoalescedRequest {
-            range: current_start..current_end,
-            alignment,
+            range: aligned_start..current_end,
+            alignment: max_alignment,
             requests,
         })
     }

--- a/vortex-file/src/read/driver.rs
+++ b/vortex-file/src/read/driver.rs
@@ -10,6 +10,7 @@ use std::task::Poll;
 
 use futures::Stream;
 use pin_project_lite::pin_project;
+use vortex_buffer::Alignment;
 use vortex_error::VortexExpect;
 use vortex_io::CoalesceConfig;
 use vortex_metrics::Counter;
@@ -47,6 +48,7 @@ impl<S> IoRequestStream<S> {
     pub(crate) fn new(
         events: S,
         coalesce_window: Option<CoalesceConfig>,
+        coalesced_buffer_alignment: Alignment,
         metrics: VortexMetrics,
     ) -> Self
     where
@@ -56,7 +58,7 @@ impl<S> IoRequestStream<S> {
             events,
             inner_done: false,
             coalesce_window,
-            state: State::new(metrics),
+            state: State::new(metrics, coalesced_buffer_alignment),
         }
     }
 }
@@ -117,6 +119,7 @@ struct State {
 
     // Metrics for tracking I/O request patterns
     metrics: StateMetrics,
+    coalesced_buffer_alignment: Alignment,
 }
 
 struct StateMetrics {
@@ -136,12 +139,13 @@ impl StateMetrics {
 }
 
 impl State {
-    fn new(metrics: VortexMetrics) -> Self {
+    fn new(metrics: VortexMetrics, coalesced_buffer_alignment: Alignment) -> Self {
         Self {
             requests: BTreeMap::new(),
             polled_requests: BTreeMap::new(),
             requests_by_offset: BTreeSet::new(),
             metrics: StateMetrics::new(metrics),
+            coalesced_buffer_alignment,
         }
     }
 
@@ -207,7 +211,7 @@ impl State {
     }
 
     /// Coalesce nearby requests into a single range while aligning the range start down to the
-    /// maximum alignment of all included requests.
+    /// global maximum segment alignment.
     ///
     /// Example (file offsets):
     /// [x, x, x, x, x, x, A, A, A, A, A, x, B]
@@ -222,7 +226,7 @@ impl State {
         let mut requests = vec![first_req];
         let mut current_start = requests[0].offset;
         let mut current_end = requests[0].offset + requests[0].length as u64;
-        let mut max_alignment = requests[0].alignment;
+        let align = *self.coalesced_buffer_alignment as u64;
 
         let mut keys_to_remove = Vec::new();
         let mut found_new_requests = true;
@@ -265,8 +269,6 @@ impl State {
                     // Calculate what the new range would be if we include this request
                     let new_start = current_start.min(req_offset);
                     let new_end = current_end.max(req_end);
-                    let new_alignment = max_alignment.max(req.alignment);
-                    let align = *new_alignment as u64;
                     let aligned_start = new_start - (new_start % align);
                     let new_total_size = new_end - aligned_start;
 
@@ -277,8 +279,6 @@ impl State {
 
                     current_start = new_start;
                     current_end = new_end;
-                    max_alignment = new_alignment;
-
                     let req = self
                         .polled_requests
                         .remove(&req_id)
@@ -303,7 +303,6 @@ impl State {
         // Sort requests by offset for correct slicing in resolve
         requests.sort_unstable_by_key(|r| r.offset);
 
-        let align = *max_alignment as u64;
         let aligned_start = current_start - (current_start % align);
 
         tracing::debug!(
@@ -316,7 +315,7 @@ impl State {
 
         Some(CoalescedRequest {
             range: aligned_start..current_end,
-            alignment: max_alignment,
+            alignment: self.coalesced_buffer_alignment,
             requests,
         })
     }
@@ -355,9 +354,22 @@ mod tests {
         events: Vec<ReadEvent>,
         coalesce_window: Option<CoalesceConfig>,
     ) -> Vec<IoRequest> {
+        collect_outputs_with_alignment(events, coalesce_window, Alignment::none()).await
+    }
+
+    async fn collect_outputs_with_alignment(
+        events: Vec<ReadEvent>,
+        coalesce_window: Option<CoalesceConfig>,
+        coalesced_buffer_alignment: Alignment,
+    ) -> Vec<IoRequest> {
         let event_stream = stream::iter(events);
         let metrics = VortexMetrics::default();
-        let io_stream = IoRequestStream::new(event_stream, coalesce_window, metrics);
+        let io_stream = IoRequestStream::new(
+            event_stream,
+            coalesce_window,
+            coalesced_buffer_alignment,
+            metrics,
+        );
         io_stream.collect().await
     }
 
@@ -485,12 +497,13 @@ mod tests {
             ReadEvent::Polled(2),
         ];
 
-        let outputs = collect_outputs(
+        let outputs = collect_outputs_with_alignment(
             events,
             Some(CoalesceConfig {
                 distance: 1,
                 max_size: 1024,
             }),
+            Alignment::new(4),
         )
         .await;
 
@@ -675,6 +688,7 @@ mod tests {
                 distance: 5,
                 max_size: 1024,
             }),
+            Alignment::none(),
             metrics.clone(),
         );
 
@@ -728,7 +742,8 @@ mod tests {
         let event_stream = stream::iter(events);
         let metrics = VortexMetrics::default();
         // No coalescing window - should be individual requests
-        let io_stream = IoRequestStream::new(event_stream, None, metrics.clone());
+        let io_stream =
+            IoRequestStream::new(event_stream, None, Alignment::none(), metrics.clone());
 
         let outputs: Vec<IoRequest> = io_stream.collect().await;
         assert_eq!(outputs.len(), 2);

--- a/vortex-file/src/read/driver.rs
+++ b/vortex-file/src/read/driver.rs
@@ -206,6 +206,15 @@ impl State {
         None
     }
 
+    /// Coalesce nearby requests into a single range while aligning the range start down to the
+    /// maximum alignment of all included requests.
+    ///
+    /// Example (file offsets):
+    /// [x, x, x, x, x, x, A, A, A, A, A, x, B]
+    /// A aligned to 2, B aligned to 4
+    /// Coalesced range starts at 4, so the buffer is:
+    /// [x, x, A, A, A, A, A, x, B]
+    /// A stays 2-aligned, B stays 4-aligned
     fn next_coalesced(&mut self, window: &CoalesceConfig) -> Option<CoalescedRequest> {
         // Find the next valid request in priority order
         let first_req = self.next_uncoalesced()?;
@@ -261,24 +270,24 @@ impl State {
                     let aligned_start = new_start - (new_start % align);
                     let new_total_size = new_end - aligned_start;
 
-                    // Check if the coalesced request would exceed max_size
-                    if new_total_size <= window.max_size {
-                        current_start = new_start;
-                        current_end = new_end;
-                        max_alignment = new_alignment;
-
-                        let req = self
-                            .polled_requests
-                            .remove(&req_id)
-                            .or_else(|| self.requests.remove(&req_id))
-                            .vortex_expect("Missing request in requests_by_offset");
-
-                        requests.push(req);
-                        keys_to_remove.push((req_offset, req_id));
-                        found_new_requests = true;
+                    if new_total_size > window.max_size {
+                        // Skip it but keep it available for future coalescing operations.
+                        continue;
                     }
-                    // If adding this request would exceed max_size, we skip it but don't remove it
-                    // so it can be considered for future coalescing operations
+
+                    current_start = new_start;
+                    current_end = new_end;
+                    max_alignment = new_alignment;
+
+                    let req = self
+                        .polled_requests
+                        .remove(&req_id)
+                        .or_else(|| self.requests.remove(&req_id))
+                        .vortex_expect("Missing request in requests_by_offset");
+
+                    requests.push(req);
+                    keys_to_remove.push((req_offset, req_id));
+                    found_new_requests = true;
                 }
             }
         }
@@ -446,6 +455,56 @@ mod tests {
         match outputs[0].inner() {
             IoRequestInner::Coalesced(c) => assert_eq!(c.requests.len(), 2),
             _ => panic!("Expected coalesced"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_coalesce_alignment_adjustment() {
+        let (tx1, _rx1) = oneshot::channel();
+        let (tx2, _rx2) = oneshot::channel();
+
+        let req1 = ReadRequest {
+            id: 1,
+            offset: 6,
+            length: 5,
+            alignment: Alignment::new(2),
+            callback: tx1,
+        };
+        let req2 = ReadRequest {
+            id: 2,
+            offset: 12,
+            length: 1,
+            alignment: Alignment::new(4),
+            callback: tx2,
+        };
+
+        let events = vec![
+            ReadEvent::Request(req1),
+            ReadEvent::Request(req2),
+            ReadEvent::Polled(1),
+            ReadEvent::Polled(2),
+        ];
+
+        let outputs = collect_outputs(
+            events,
+            Some(CoalesceConfig {
+                distance: 1,
+                max_size: 1024,
+            }),
+        )
+        .await;
+
+        assert_eq!(outputs.len(), 1);
+        match outputs[0].inner() {
+            IoRequestInner::Coalesced(coalesced) => {
+                assert_eq!(coalesced.range.start, 4);
+                assert_eq!(coalesced.alignment, Alignment::new(4));
+                for req in &coalesced.requests {
+                    let rel = req.offset - coalesced.range.start;
+                    assert_eq!(rel % *req.alignment as u64, 0);
+                }
+            }
+            _ => panic!("Expected coalesced request"),
         }
     }
 

--- a/vortex-file/src/read/request.rs
+++ b/vortex-file/src/read/request.rs
@@ -116,7 +116,7 @@ impl ReadRequest {
 /// A set of I/O requests that have been coalesced into a single larger request.
 pub(crate) struct CoalescedRequest {
     pub(crate) range: Range<u64>,
-    pub(crate) alignment: Alignment, // The alignment of the first request in the coalesced range.
+    pub(crate) alignment: Alignment, // The max alignment of requests in the coalesced range.
     pub(crate) requests: Vec<ReadRequest>, // TODO(ngates): we could have enum of Single/Many to avoid Vec.
 }
 

--- a/vortex-file/src/read/request.rs
+++ b/vortex-file/src/read/request.rs
@@ -116,7 +116,7 @@ impl ReadRequest {
 /// A set of I/O requests that have been coalesced into a single larger request.
 pub(crate) struct CoalescedRequest {
     pub(crate) range: Range<u64>,
-    pub(crate) alignment: Alignment, // The max alignment of requests in the coalesced range.
+    pub(crate) alignment: Alignment, // Global max segment alignment used for the coalesced range.
     pub(crate) requests: Vec<ReadRequest>, // TODO(ngates): we could have enum of Single/Many to avoid Vec.
 }
 

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -13,6 +13,7 @@ use futures::FutureExt;
 use futures::StreamExt;
 use futures::channel::mpsc;
 use vortex_array::buffer::BufferHandle;
+use vortex_buffer::Alignment;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
@@ -75,10 +76,20 @@ impl FileSegmentSource {
 
         let coalesce_config = reader.coalesce_config();
         let concurrency = reader.concurrency();
+        let max_alignment = segments
+            .iter()
+            .map(|segment| segment.alignment)
+            .max()
+            .unwrap_or_else(Alignment::none);
 
         let drive_fut = async move {
-            let stream =
-                IoRequestStream::new(StreamExt::boxed(recv), coalesce_config, metrics).boxed();
+            let stream = IoRequestStream::new(
+                StreamExt::boxed(recv),
+                coalesce_config,
+                max_alignment,
+                metrics,
+            )
+            .boxed();
 
             stream
                 .map(move |req| {

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -74,13 +74,19 @@ impl FileSegmentSource {
     ) -> Self {
         let (send, recv) = mpsc::unbounded();
 
-        let coalesce_config = reader.coalesce_config();
-        let concurrency = reader.concurrency();
         let max_alignment = segments
             .iter()
             .map(|segment| segment.alignment)
             .max()
             .unwrap_or_else(Alignment::none);
+        let coalesce_config = reader.coalesce_config().map(|mut config| {
+            // Aligning the coalesced start down can add up to (alignment - 1) bytes.
+            // Increase max_size to keep the effective payload window consistent.
+            let extra = (*max_alignment as u64).saturating_sub(1);
+            config.max_size = config.max_size.saturating_add(extra);
+            config
+        });
+        let concurrency = reader.concurrency();
 
         let drive_fut = async move {
             let stream = IoRequestStream::new(


### PR DESCRIPTION
We align the coalesced range start down to the max alignment of all requests. That makes `coalesced_start % max_alignment == 0`, just like the file start. Because segment offsets are aligned in the file, their offsets relative to the coalesced start remain aligned, so each buffer stays properly aligned without per‑buffer realignment.

example:
bytes in the file:
[x, x, x, x, x, x, A, A, A, A, A, x, B]
A aligned to 2
B aligned to 4

coalesced read both to a 2 aligned buffer:
[ A, A, A, A, A, x, B]
A aligned to 2
B is not aligned to 4

with this change we read this to the coalesced buffer:
[x, x, A, A, A, A, A, x, B]
A aligned to 2
B aligned to 4
