### PR TITLE
Use built-in DF cache for file metadata and fix metrics wiring

### DIFF
--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -17,6 +17,7 @@ use datafusion::prelude::SessionContext;
 use datafusion_bench::format_to_df_format;
 use datafusion_bench::metrics::MetricsSetExt;
 use datafusion_physical_plan::ExecutionPlan;
+use datafusion_physical_plan::collect;
 use futures::StreamExt;
 use parking_lot::Mutex;
 use tokio::fs::File;
@@ -300,10 +301,11 @@ pub async fn execute_query(
 ) -> anyhow::Result<(Vec<RecordBatch>, Arc<dyn ExecutionPlan>)> {
     let df = ctx.sql(query).await?;
 
-    let physical_plan = df.clone().create_physical_plan().await?;
-    let result = df.collect().await?;
+    let task_ctx = Arc::new(df.task_ctx());
+    let plan = df.create_physical_plan().await?;
+    let result = collect(plan.clone(), task_ctx).await?;
 
-    Ok((result, physical_plan))
+    Ok((result, plan))
 }
 
 /// Print Vortex metrics from execution plans.

--- a/vortex-datafusion/src/persistent/cache.rs
+++ b/vortex-datafusion/src/persistent/cache.rs
@@ -29,9 +29,37 @@ use vortex::layout::segments::SegmentId;
 use vortex::session::VortexSession;
 use vortex::utils::aliases::DefaultHashBuilder;
 
+/// Cached Vortex file metadata for use with DataFusion's [`FileMetadataCache`].
 pub struct CachedVortexMetadata {
-    pub dtype: DType,
-    pub file_stats: Arc<StatsSet>,
+    dtype: DType,
+    file_stats: Option<Arc<[StatsSet]>>,
+    row_count: u64,
+}
+
+impl CachedVortexMetadata {
+    /// Create a new cached metadata entry from a VortexFile.
+    pub fn new(vortex_file: &VortexFile) -> Self {
+        Self {
+            dtype: vortex_file.dtype().clone(),
+            file_stats: vortex_file.file_stats().cloned(),
+            row_count: vortex_file.row_count(),
+        }
+    }
+
+    /// Get the cached dtype.
+    pub fn dtype(&self) -> &DType {
+        &self.dtype
+    }
+
+    /// Get the cached file stats.
+    pub fn file_stats(&self) -> Option<&Arc<[StatsSet]>> {
+        self.file_stats.as_ref()
+    }
+
+    /// Get the cached row count.
+    pub fn row_count(&self) -> u64 {
+        self.row_count
+    }
 }
 
 impl FileMetadata for CachedVortexMetadata {
@@ -40,7 +68,18 @@ impl FileMetadata for CachedVortexMetadata {
     }
 
     fn memory_size(&self) -> usize {
-        todo!()
+        // Estimate based on dtype size + stats size
+        let stats_size = self
+            .file_stats
+            .as_ref()
+            .map(|stats| {
+                stats
+                    .iter()
+                    .map(|s| s.iter().count() * (size_of::<Stat>() + size_of::<Precision<ScalarValue>>()))
+                    .sum::<usize>()
+            })
+            .unwrap_or(0);
+        size_of::<DType>() + stats_size + size_of::<u64>()
     }
 
     fn extra_info(&self) -> std::collections::HashMap<String, String> {

--- a/vortex-datafusion/src/persistent/cache.rs
+++ b/vortex-datafusion/src/persistent/cache.rs
@@ -2,46 +2,32 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::mem::size_of;
-use std::sync::Arc;
 
 use datafusion_common::ScalarValue;
 use datafusion_execution::cache::cache_manager::FileMetadata;
-use vortex::array::stats::StatsSet;
-use vortex::dtype::DType;
 use vortex::expr::stats::Precision;
 use vortex::expr::stats::Stat;
+use vortex::file::Footer;
+use vortex::file::SegmentSpec;
 use vortex::file::VortexFile;
+use vortex::layout::segments::SegmentId;
 
 /// Cached Vortex file metadata for use with DataFusion's [`FileMetadataCache`].
 pub struct CachedVortexMetadata {
-    dtype: DType,
-    file_stats: Option<Arc<[StatsSet]>>,
-    row_count: u64,
+    footer: Footer,
 }
 
 impl CachedVortexMetadata {
     /// Create a new cached metadata entry from a VortexFile.
     pub fn new(vortex_file: &VortexFile) -> Self {
         Self {
-            dtype: vortex_file.dtype().clone(),
-            file_stats: vortex_file.file_stats().cloned(),
-            row_count: vortex_file.row_count(),
+            footer: vortex_file.footer().clone(),
         }
     }
 
-    /// Get the cached dtype.
-    pub fn dtype(&self) -> &DType {
-        &self.dtype
-    }
-
-    /// Get the cached file stats.
-    pub fn file_stats(&self) -> Option<&Arc<[StatsSet]>> {
-        self.file_stats.as_ref()
-    }
-
-    /// Get the cached row count.
-    pub fn row_count(&self) -> u64 {
-        self.row_count
+    /// Get the cached footer.
+    pub fn footer(&self) -> &Footer {
+        &self.footer
     }
 }
 
@@ -51,24 +37,34 @@ impl FileMetadata for CachedVortexMetadata {
     }
 
     fn memory_size(&self) -> usize {
-        // Estimate based on dtype size + stats size
-        let stats_size = self
-            .file_stats
-            .as_ref()
-            .map(|stats| {
-                stats
-                    .iter()
-                    .map(|s| {
-                        s.iter().count() * (size_of::<Stat>() + size_of::<Precision<ScalarValue>>())
-                    })
-                    .sum::<usize>()
-            })
-            .unwrap_or(0);
-        size_of::<DType>() + stats_size + size_of::<u64>()
+        estimate_footer_size(&self.footer)
     }
 
     #[allow(clippy::disallowed_types)]
     fn extra_info(&self) -> std::collections::HashMap<String, String> {
         Default::default()
     }
+}
+
+/// Approximate the in-memory size of a footer.
+fn estimate_footer_size(footer: &Footer) -> usize {
+    let segments_size = footer.segment_map().len() * size_of::<SegmentSpec>();
+    let stats_size = footer
+        .statistics()
+        .map(|stats| {
+            stats
+                .iter()
+                .map(|s| {
+                    s.iter().count() * (size_of::<Stat>() + size_of::<Precision<ScalarValue>>())
+                })
+                .sum::<usize>()
+        })
+        .unwrap_or(0);
+
+    let root_layout = footer.layout();
+    let layout_size = size_of_val(footer.dtype())
+        + root_layout.metadata().len()
+        + root_layout.segment_ids().len() * size_of::<SegmentId>();
+
+    segments_size + stats_size + layout_size
 }

--- a/vortex-datafusion/src/persistent/cache.rs
+++ b/vortex-datafusion/src/persistent/cache.rs
@@ -1,33 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::mem::size_of;
 use std::sync::Arc;
 
-use async_trait::async_trait;
-use chrono::DateTime;
-use chrono::Utc;
 use datafusion_common::ScalarValue;
 use datafusion_execution::cache::cache_manager::FileMetadata;
-use moka::future::Cache;
-use object_store::ObjectMeta;
-use object_store::path::Path;
 use vortex::array::stats::StatsSet;
-use vortex::buffer::ByteBuffer;
 use vortex::dtype::DType;
-use vortex::error::VortexError;
-use vortex::error::VortexResult;
-use vortex::error::vortex_err;
 use vortex::expr::stats::Precision;
 use vortex::expr::stats::Stat;
-use vortex::file::Footer;
-use vortex::file::OpenOptionsSessionExt;
-use vortex::file::SegmentSpec;
 use vortex::file::VortexFile;
-use vortex::io::VortexReadAt;
-use vortex::layout::segments::SegmentCache;
-use vortex::layout::segments::SegmentId;
-use vortex::session::VortexSession;
-use vortex::utils::aliases::DefaultHashBuilder;
 
 /// Cached Vortex file metadata for use with DataFusion's [`FileMetadataCache`].
 pub struct CachedVortexMetadata {
@@ -75,162 +58,17 @@ impl FileMetadata for CachedVortexMetadata {
             .map(|stats| {
                 stats
                     .iter()
-                    .map(|s| s.iter().count() * (size_of::<Stat>() + size_of::<Precision<ScalarValue>>()))
+                    .map(|s| {
+                        s.iter().count() * (size_of::<Stat>() + size_of::<Precision<ScalarValue>>())
+                    })
                     .sum::<usize>()
             })
             .unwrap_or(0);
         size_of::<DType>() + stats_size + size_of::<u64>()
     }
 
+    #[allow(clippy::disallowed_types)]
     fn extra_info(&self) -> std::collections::HashMap<String, String> {
         Default::default()
     }
-}
-
-#[derive(Clone)]
-pub(crate) struct VortexFileCache {
-    file_cache: Cache<FileKey, VortexFile, DefaultHashBuilder>,
-    segment_cache: Cache<SegmentKey, ByteBuffer, DefaultHashBuilder>,
-    session: VortexSession,
-    footer_initial_read_size_bytes: usize,
-}
-
-/// Cache key for a [`VortexFile`].
-#[derive(Hash, Eq, PartialEq, Debug, Clone)]
-struct FileKey {
-    location: Arc<Path>,
-    m_time: DateTime<Utc>,
-}
-
-impl From<&ObjectMeta> for FileKey {
-    fn from(value: &ObjectMeta) -> Self {
-        Self {
-            location: Arc::new(value.location.clone()),
-            m_time: value.last_modified,
-        }
-    }
-}
-
-/// Global cache key for a segment.
-#[derive(Hash, Eq, PartialEq, Debug)]
-struct SegmentKey {
-    file: FileKey,
-    segment_id: SegmentId,
-}
-
-impl VortexFileCache {
-    pub fn new(
-        size_mb: usize,
-        segment_size_mb: usize,
-        footer_initial_read_size_bytes: usize,
-        session: VortexSession,
-    ) -> Self {
-        let file_cache = Cache::builder()
-            .max_capacity(size_mb as u64 * (1 << 20))
-            .eviction_listener(|k: Arc<FileKey>, _v: VortexFile, cause| {
-                tracing::trace!("Removed {k:?} due to {cause:?}");
-            })
-            .weigher(|_k, vxf| {
-                u32::try_from(estimate_layout_size(vxf.footer())).unwrap_or(u32::MAX)
-            })
-            .build_with_hasher(DefaultHashBuilder::default());
-
-        let segment_cache = Cache::builder()
-            .max_capacity(segment_size_mb as u64 * (1 << 20))
-            .eviction_listener(|k: Arc<SegmentKey>, _v: ByteBuffer, cause| {
-                tracing::trace!("Removed {k:?} due to {cause:?}");
-            })
-            .weigher(|_k, v| u32::try_from(v.len()).unwrap_or(u32::MAX))
-            .build_with_hasher(DefaultHashBuilder::default());
-
-        Self {
-            file_cache,
-            segment_cache,
-            session,
-            footer_initial_read_size_bytes,
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn footer_initial_read_size_bytes(&self) -> usize {
-        self.footer_initial_read_size_bytes
-    }
-
-    pub async fn try_get<R: VortexReadAt + Clone>(
-        &self,
-        object: &ObjectMeta,
-        reader: R,
-    ) -> VortexResult<VortexFile> {
-        let file_key = FileKey::from(object);
-        self.file_cache
-            .try_get_with(
-                file_key.clone(),
-                self.session
-                    .open_options()
-                    .with_initial_read_size(self.footer_initial_read_size_bytes)
-                    .with_file_size(object.size)
-                    .with_segment_cache(Arc::new(VortexFileSegmentCache {
-                        file_key,
-                        segment_cache: self.segment_cache.clone(),
-                    }))
-                    .open_read(reader),
-            )
-            .await
-            .map_err(|e: Arc<VortexError>| {
-                Arc::try_unwrap(e).unwrap_or_else(|e| vortex_err!("{}", e.to_string()))
-            })
-    }
-}
-
-/// A [`SegmentCache`] implementation that uses the shared global segment cache.
-struct VortexFileSegmentCache {
-    file_key: FileKey,
-    segment_cache: Cache<SegmentKey, ByteBuffer, DefaultHashBuilder>,
-}
-
-#[async_trait]
-impl SegmentCache for VortexFileSegmentCache {
-    async fn get(&self, segment_id: SegmentId) -> VortexResult<Option<ByteBuffer>> {
-        Ok(self
-            .segment_cache
-            .get(&SegmentKey {
-                file: self.file_key.clone(),
-                segment_id,
-            })
-            .await)
-    }
-
-    async fn put(&self, segment_id: SegmentId, buffer: ByteBuffer) -> VortexResult<()> {
-        self.segment_cache
-            .insert(
-                SegmentKey {
-                    file: self.file_key.clone(),
-                    segment_id,
-                },
-                buffer,
-            )
-            .await;
-        Ok(())
-    }
-}
-
-/// Approximate the in-memory size of a layout
-fn estimate_layout_size(footer: &Footer) -> usize {
-    let segments_size = footer.segment_map().len() * size_of::<SegmentSpec>();
-    let stats_size = footer
-        .statistics()
-        .iter()
-        .map(|v| {
-            v.iter()
-                .map(|_| size_of::<Stat>() + size_of::<Precision<ScalarValue>>())
-                .sum::<usize>()
-        })
-        .sum::<usize>();
-
-    let root_layout = footer.layout();
-    let layout_size = size_of::<DType>()
-        + root_layout.metadata().len()
-        + root_layout.segment_ids().len() * size_of::<SegmentId>();
-
-    segments_size + stats_size + layout_size
 }

--- a/vortex-datafusion/src/persistent/cache.rs
+++ b/vortex-datafusion/src/persistent/cache.rs
@@ -10,6 +10,7 @@ use vortex::expr::stats::Stat;
 use vortex::file::Footer;
 use vortex::file::SegmentSpec;
 use vortex::file::VortexFile;
+use vortex::layout::Layout;
 use vortex::layout::segments::SegmentId;
 
 /// Cached Vortex file metadata for use with DataFusion's [`FileMetadataCache`].
@@ -61,10 +62,17 @@ fn estimate_footer_size(footer: &Footer) -> usize {
         })
         .unwrap_or(0);
 
-    let root_layout = footer.layout();
-    let layout_size = size_of_val(footer.dtype())
-        + root_layout.metadata().len()
-        + root_layout.segment_ids().len() * size_of::<SegmentId>();
+    let layout_size = footer
+        .layout()
+        .depth_first_traversal()
+        .filter_map(|l| l.ok().map(|l| layout_size(l.as_ref())))
+        .sum::<usize>();
 
     segments_size + stats_size + layout_size
+}
+
+fn layout_size(layout: &dyn Layout) -> usize {
+    size_of_val(layout.dtype())
+        + layout.metadata().len()
+        + layout.segment_ids().len() * size_of::<SegmentId>()
 }

--- a/vortex-datafusion/src/persistent/cache.rs
+++ b/vortex-datafusion/src/persistent/cache.rs
@@ -7,9 +7,11 @@ use async_trait::async_trait;
 use chrono::DateTime;
 use chrono::Utc;
 use datafusion_common::ScalarValue;
+use datafusion_execution::cache::cache_manager::FileMetadata;
 use moka::future::Cache;
 use object_store::ObjectMeta;
 use object_store::path::Path;
+use vortex::array::stats::StatsSet;
 use vortex::buffer::ByteBuffer;
 use vortex::dtype::DType;
 use vortex::error::VortexError;
@@ -26,6 +28,25 @@ use vortex::layout::segments::SegmentCache;
 use vortex::layout::segments::SegmentId;
 use vortex::session::VortexSession;
 use vortex::utils::aliases::DefaultHashBuilder;
+
+pub struct CachedVortexMetadata {
+    pub dtype: DType,
+    pub file_stats: Arc<StatsSet>,
+}
+
+impl FileMetadata for CachedVortexMetadata {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn memory_size(&self) -> usize {
+        todo!()
+    }
+
+    fn extra_info(&self) -> std::collections::HashMap<String, String> {
+        Default::default()
+    }
+}
 
 #[derive(Clone)]
 pub(crate) struct VortexFileCache {

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -28,6 +28,7 @@ use datafusion_datasource::file_compression_type::FileCompressionType;
 use datafusion_datasource::file_format::FileFormat;
 use datafusion_datasource::file_format::FileFormatFactory;
 use datafusion_datasource::file_scan_config::FileScanConfig;
+use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::file_sink_config::FileSinkConfig;
 use datafusion_datasource::sink::DataSinkExec;
 use datafusion_datasource::source::DataSourceExec;
@@ -464,15 +465,24 @@ impl FileFormat for VortexFormat {
 
     async fn create_physical_plan(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         file_scan_config: FileScanConfig,
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
-        // We make sure the scan's source is the right type, but we don't have anything else to do here.
-        if !file_scan_config.file_source().as_any().is::<VortexSource>() {
-            return Err(internal_datafusion_err!("Expected VortexSource"));
-        }
+        let mut source = file_scan_config
+            .file_source()
+            .as_any()
+            .downcast_ref::<VortexSource>()
+            .cloned()
+            .ok_or_else(|| internal_datafusion_err!("Expected VortexSource"))?;
 
-        Ok(DataSourceExec::from_data_source(file_scan_config))
+        source = source
+            .with_file_metadata_cache(state.runtime_env().cache_manager.get_file_metadata_cache());
+
+        let conf = FileScanConfigBuilder::from(file_scan_config)
+            .with_source(Arc::new(source))
+            .build();
+
+        Ok(DataSourceExec::from_data_source(conf))
     }
 
     async fn create_writer_physical_plan(

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -54,12 +54,14 @@ use vortex::expr::stats;
 use vortex::expr::stats::Stat;
 use vortex::file::EOF_SIZE;
 use vortex::file::MAX_POSTSCRIPT_SIZE;
+use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VORTEX_FILE_EXTENSION;
 use vortex::io::file::object_store::ObjectStoreSource;
 use vortex::io::session::RuntimeSessionExt;
 use vortex::scalar::Scalar;
 use vortex::session::VortexSession;
 
+use super::cache::CachedVortexMetadata;
 use super::cache::VortexFileCache;
 use super::sink::VortexSink;
 use super::source::VortexSource;
@@ -246,28 +248,43 @@ impl FileFormat for VortexFormat {
         let file_metadata_cache = state.runtime_env().cache_manager.get_file_metadata_cache();
 
         let mut file_schemas = stream::iter(objects.iter().cloned())
-            .map(|o| {
-                let reader = Arc::new(ObjectStoreSource::new(
-                    store.clone(),
-                    o.location.clone(),
-                    self.session.handle(),
-                ));
+            .map(|object| {
+                let store = store.clone();
+                let session = self.session.clone();
+                let opts = self.opts.clone();
+                let cache = file_metadata_cache.clone();
 
                 SpawnedTask::spawn(async move {
-                self.session
-                    .open_options()
-                    .with_initial_read_size(self.footer_initial_read_size_bytes)
-                    .with_file_size(object.size)
-                    .with_segment_cache(Arc::new(VortexFileSegmentCache {
-                        file_key,
-                        segment_cache: self.segment_cache.clone(),
-                    }))
-                    .open_read(reader)?
+                    // Check if we have cached metadata for this file
+                    if let Some(cached) = cache.get_with_extra(&object, &object) {
+                        if let Some(cached_vortex) =
+                            cached.as_any().downcast_ref::<CachedVortexMetadata>()
+                        {
+                            let inferred_schema = cached_vortex.dtype().to_arrow_schema()?;
+                            return VortexResult::Ok((object.location, inferred_schema));
+                        }
+                    }
 
+                    // Not cached or invalid - open the file
+                    let reader = Arc::new(ObjectStoreSource::new(
+                        store,
+                        object.location.clone(),
+                        session.handle(),
+                    ));
 
-                    let vxf = cache.try_get(&o, reader).await?;
+                    let vxf = session
+                        .open_options()
+                        .with_initial_read_size(opts.footer_initial_read_size_bytes)
+                        .with_file_size(object.size)
+                        .open_read(reader)
+                        .await?;
+
+                    // Cache the metadata
+                    let cached_metadata = Arc::new(CachedVortexMetadata::new(&vxf));
+                    cache.put_with_extra(&object, cached_metadata, &object);
+
                     let inferred_schema = vxf.dtype().to_arrow_schema()?;
-                    VortexResult::Ok((o.location, inferred_schema))
+                    VortexResult::Ok((object.location, inferred_schema))
                 })
                 .map(|f| f.vortex_expect("Failed to spawn infer_schema"))
             })
@@ -286,40 +303,75 @@ impl FileFormat for VortexFormat {
     #[tracing::instrument(skip_all, fields(location = object.location.as_ref()))]
     async fn infer_stats(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         store: &Arc<dyn ObjectStore>,
         table_schema: SchemaRef,
         object: &ObjectMeta,
     ) -> DFResult<Statistics> {
         let object = object.clone();
         let store = store.clone();
-        let cache = self.file_cache.clone();
-        let handle = self.session.handle();
+        let session = self.session.clone();
+        let opts = self.opts.clone();
+        let file_metadata_cache = state.runtime_env().cache_manager.get_file_metadata_cache();
 
         SpawnedTask::spawn(async move {
-            let reader = Arc::new(ObjectStoreSource::new(
-                store.clone(),
-                object.location.clone(),
-                handle,
-            ));
-            let vxf = cache.try_get(&object, reader).await.map_err(|e| {
-                DataFusionError::Execution(format!(
-                    "Failed to open Vortex file {}: {e}",
-                    object.location
-                ))
-            })?;
+            // Try to get cached metadata first
+            let cached_metadata = if let Some(cached) =
+                file_metadata_cache.get_with_extra(&object, &object)
+            {
+                cached
+                    .as_any()
+                    .downcast_ref::<CachedVortexMetadata>()
+                    .map(|m| (m.dtype().clone(), m.file_stats().cloned(), m.row_count()))
+            } else {
+                None
+            };
 
-            let struct_dtype = vxf
-                .dtype()
+            let (dtype, file_stats, row_count) = match cached_metadata {
+                Some(metadata) => metadata,
+                None => {
+                    // Not cached - open the file
+                    let reader = Arc::new(ObjectStoreSource::new(
+                        store,
+                        object.location.clone(),
+                        session.handle(),
+                    ));
+
+                    let vxf = session
+                        .open_options()
+                        .with_initial_read_size(opts.footer_initial_read_size_bytes)
+                        .with_file_size(object.size)
+                        .open_read(reader)
+                        .await
+                        .map_err(|e| {
+                            DataFusionError::Execution(format!(
+                                "Failed to open Vortex file {}: {e}",
+                                object.location
+                            ))
+                        })?;
+
+                    // Cache the metadata
+                    let cached = Arc::new(CachedVortexMetadata::new(&vxf));
+                    file_metadata_cache.put_with_extra(&object, cached, &object);
+
+                    (
+                        vxf.dtype().clone(),
+                        vxf.file_stats().cloned(),
+                        vxf.row_count(),
+                    )
+                }
+            };
+
+            let struct_dtype = dtype
                 .as_struct_fields_opt()
                 .vortex_expect("dtype is not a struct");
 
             // Evaluate the statistics for each column that we are able to return to DataFusion.
-            let Some(file_stats) = vxf.file_stats() else {
+            let Some(file_stats) = file_stats else {
                 // If the file has no column stats, the best we can do is return a row count.
                 return Ok(Statistics {
                     num_rows: Precision::Exact(
-                        usize::try_from(vxf.row_count())
+                        usize::try_from(row_count)
                             .map_err(|_| vortex_err!("Row count overflow"))
                             .vortex_expect("Row count overflow"),
                     ),
@@ -406,7 +458,7 @@ impl FileFormat for VortexFormat {
 
             Ok(Statistics {
                 num_rows: Precision::Exact(
-                    usize::try_from(vxf.row_count())
+                    usize::try_from(row_count)
                         .map_err(|_| vortex_err!("Row count overflow"))
                         .vortex_expect("Row count overflow"),
                 ),

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -243,6 +243,8 @@ impl FileFormat for VortexFormat {
         store: &Arc<dyn ObjectStore>,
         objects: &[ObjectMeta],
     ) -> DFResult<SchemaRef> {
+        let file_metadata_cache = state.runtime_env().cache_manager.get_file_metadata_cache();
+
         let mut file_schemas = stream::iter(objects.iter().cloned())
             .map(|o| {
                 let reader = Arc::new(ObjectStoreSource::new(
@@ -250,8 +252,19 @@ impl FileFormat for VortexFormat {
                     o.location.clone(),
                     self.session.handle(),
                 ));
-                let cache = self.file_cache.clone();
+
                 SpawnedTask::spawn(async move {
+                self.session
+                    .open_options()
+                    .with_initial_read_size(self.footer_initial_read_size_bytes)
+                    .with_file_size(object.size)
+                    .with_segment_cache(Arc::new(VortexFileSegmentCache {
+                        file_key,
+                        segment_cache: self.segment_cache.clone(),
+                    }))
+                    .open_read(reader)?
+
+
                     let vxf = cache.try_get(&o, reader).await?;
                     let inferred_schema = vxf.dtype().to_arrow_schema()?;
                     VortexResult::Ok((o.location, inferred_schema))

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -62,7 +62,6 @@ use vortex::scalar::Scalar;
 use vortex::session::VortexSession;
 
 use super::cache::CachedVortexMetadata;
-use super::cache::VortexFileCache;
 use super::sink::VortexSink;
 use super::source::VortexSource;
 use crate::PrecisionExt as _;
@@ -73,7 +72,6 @@ const DEFAULT_FOOTER_INITIAL_READ_SIZE_BYTES: usize = MAX_POSTSCRIPT_SIZE as usi
 /// Vortex implementation of a DataFusion [`FileFormat`].
 pub struct VortexFormat {
     session: VortexSession,
-    file_cache: VortexFileCache,
     opts: VortexOptions,
 }
 
@@ -195,16 +193,7 @@ impl VortexFormat {
 
     /// Creates a new instance with configured by a [`VortexOptions`].
     pub fn new_with_options(session: VortexSession, opts: VortexOptions) -> Self {
-        Self {
-            session: session.clone(),
-            file_cache: VortexFileCache::new(
-                opts.footer_cache_size_mb,
-                opts.segment_cache_size_mb,
-                opts.footer_initial_read_size_bytes,
-                session,
-            ),
-            opts,
-        }
+        Self { session, opts }
     }
 
     /// Return the format specific configuration
@@ -256,13 +245,12 @@ impl FileFormat for VortexFormat {
 
                 SpawnedTask::spawn(async move {
                     // Check if we have cached metadata for this file
-                    if let Some(cached) = cache.get_with_extra(&object, &object) {
-                        if let Some(cached_vortex) =
+                    if let Some(cached) = cache.get_with_extra(&object, &object)
+                        && let Some(cached_vortex) =
                             cached.as_any().downcast_ref::<CachedVortexMetadata>()
-                        {
-                            let inferred_schema = cached_vortex.dtype().to_arrow_schema()?;
-                            return VortexResult::Ok((object.location, inferred_schema));
-                        }
+                    {
+                        let inferred_schema = cached_vortex.dtype().to_arrow_schema()?;
+                        return VortexResult::Ok((object.location, inferred_schema));
                     }
 
                     // Not cached or invalid - open the file
@@ -281,7 +269,7 @@ impl FileFormat for VortexFormat {
 
                     // Cache the metadata
                     let cached_metadata = Arc::new(CachedVortexMetadata::new(&vxf));
-                    cache.put_with_extra(&object, cached_metadata, &object);
+                    cache.put(&object, cached_metadata);
 
                     let inferred_schema = vxf.dtype().to_arrow_schema()?;
                     VortexResult::Ok((object.location, inferred_schema))
@@ -316,16 +304,15 @@ impl FileFormat for VortexFormat {
 
         SpawnedTask::spawn(async move {
             // Try to get cached metadata first
-            let cached_metadata = if let Some(cached) =
-                file_metadata_cache.get_with_extra(&object, &object)
-            {
-                cached
-                    .as_any()
-                    .downcast_ref::<CachedVortexMetadata>()
-                    .map(|m| (m.dtype().clone(), m.file_stats().cloned(), m.row_count()))
-            } else {
-                None
-            };
+            let cached_metadata =
+                if let Some(cached) = file_metadata_cache.get_with_extra(&object, &object) {
+                    cached
+                        .as_any()
+                        .downcast_ref::<CachedVortexMetadata>()
+                        .map(|m| (m.dtype().clone(), m.file_stats().cloned(), m.row_count()))
+                } else {
+                    None
+                };
 
             let (dtype, file_stats, row_count) = match cached_metadata {
                 Some(metadata) => metadata,
@@ -352,7 +339,7 @@ impl FileFormat for VortexFormat {
 
                     // Cache the metadata
                     let cached = Arc::new(CachedVortexMetadata::new(&vxf));
-                    file_metadata_cache.put_with_extra(&object, cached, &object);
+                    file_metadata_cache.put(&object, cached);
 
                     (
                         vxf.dtype().clone(),
@@ -501,11 +488,7 @@ impl FileFormat for VortexFormat {
     }
 
     fn file_source(&self, table_schema: TableSchema) -> Arc<dyn FileSource> {
-        Arc::new(VortexSource::new(
-            table_schema,
-            self.session.clone(),
-            self.file_cache.clone(),
-        ))
+        Arc::new(VortexSource::new(table_schema, self.session.clone()))
     }
 }
 
@@ -572,6 +555,6 @@ mod tests {
         opts.set("footer_initial_read_size_bytes", "12345").unwrap();
 
         let format = VortexFormat::new_with_options(VortexSession::default(), opts);
-        assert_eq!(format.file_cache.footer_initial_read_size_bytes(), 12345);
+        assert_eq!(format.options().footer_initial_read_size_bytes, 12345);
     }
 }

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -246,7 +246,7 @@ impl FileFormat for VortexFormat {
 
                 SpawnedTask::spawn(async move {
                     // Check if we have cached metadata for this file
-                    if let Some(cached) = cache.get_with_extra(&object, &object)
+                    if let Some(cached) = cache.get(&object)
                         && let Some(cached_vortex) =
                             cached.as_any().downcast_ref::<CachedVortexMetadata>()
                     {
@@ -305,20 +305,18 @@ impl FileFormat for VortexFormat {
 
         SpawnedTask::spawn(async move {
             // Try to get cached metadata first
-            let cached_metadata = file_metadata_cache
-                .get_with_extra(&object, &object)
-                .and_then(|cached| {
-                    cached
-                        .as_any()
-                        .downcast_ref::<CachedVortexMetadata>()
-                        .map(|m| {
-                            (
-                                m.footer().dtype().clone(),
-                                m.footer().statistics().cloned(),
-                                m.footer().row_count(),
-                            )
-                        })
-                });
+            let cached_metadata = file_metadata_cache.get(&object).and_then(|cached| {
+                cached
+                    .as_any()
+                    .downcast_ref::<CachedVortexMetadata>()
+                    .map(|m| {
+                        (
+                            m.footer().dtype().clone(),
+                            m.footer().statistics().cloned(),
+                            m.footer().row_count(),
+                        )
+                    })
+            });
 
             let (dtype, file_stats, row_count) = match cached_metadata {
                 Some(metadata) => metadata,

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -91,10 +91,6 @@ config_namespace! {
     ///
     /// [`SessionConfig`]: https://docs.rs/datafusion/latest/datafusion/prelude/struct.SessionConfig.html
     pub struct VortexOptions {
-        /// The size of the in-memory [`vortex::file::Footer`] cache.
-        pub footer_cache_size_mb: usize, default = 64
-        /// The size of the in-memory segment cache.
-        pub segment_cache_size_mb: usize, default = 0
         /// The number of bytes to read when parsing a file footer.
         ///
         /// Values smaller than `MAX_POSTSCRIPT_SIZE + EOF_SIZE` will be clamped to that minimum
@@ -552,7 +548,7 @@ mod tests {
                 (c1 VARCHAR NOT NULL, c2 INT NOT NULL) \
                 STORED AS vortex \
                 LOCATION '{}' \
-                OPTIONS( segment_cache_size_mb '5', footer_initial_read_size_bytes '12345' );",
+                OPTIONS( footer_initial_read_size_bytes '12345' );",
                 dir.path().to_str().unwrap()
             ))
             .await

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -249,7 +249,7 @@ impl FileFormat for VortexFormat {
                         && let Some(cached_vortex) =
                             cached.as_any().downcast_ref::<CachedVortexMetadata>()
                     {
-                        let inferred_schema = cached_vortex.dtype().to_arrow_schema()?;
+                        let inferred_schema = cached_vortex.footer().dtype().to_arrow_schema()?;
                         return VortexResult::Ok((object.location, inferred_schema));
                     }
 
@@ -304,15 +304,20 @@ impl FileFormat for VortexFormat {
 
         SpawnedTask::spawn(async move {
             // Try to get cached metadata first
-            let cached_metadata =
-                if let Some(cached) = file_metadata_cache.get_with_extra(&object, &object) {
+            let cached_metadata = file_metadata_cache
+                .get_with_extra(&object, &object)
+                .and_then(|cached| {
                     cached
                         .as_any()
                         .downcast_ref::<CachedVortexMetadata>()
-                        .map(|m| (m.dtype().clone(), m.file_stats().cloned(), m.row_count()))
-                } else {
-                    None
-                };
+                        .map(|m| {
+                            (
+                                m.footer().dtype().clone(),
+                                m.footer().statistics().cloned(),
+                                m.footer().row_count(),
+                            )
+                        })
+                });
 
             let (dtype, file_stats, row_count) = match cached_metadata {
                 Some(metadata) => metadata,

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -166,7 +166,10 @@ impl FileOpener for VortexOpener {
                 return Ok(stream::empty().boxed());
             }
 
-            let mut open_opts = session.open_options().with_file_size(file.object_meta.size);
+            let mut open_opts = session
+                .open_options()
+                .with_file_size(file.object_meta.size)
+                .with_metrics(metrics.clone());
 
             if let Some(file_metadata_cache) = file_metadata_cache
                 && let Some(file_metadata) = file_metadata_cache.get(&file.object_meta)

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -34,6 +34,7 @@ use vortex::array::ArrayRef;
 use vortex::array::VortexSessionExecute;
 use vortex::array::arrow::ArrowArrayExecutor;
 use vortex::error::VortexError;
+use vortex::file::OpenOptionsSessionExt;
 use vortex::io::InstrumentedReadAt;
 use vortex::layout::LayoutReader;
 use vortex::metrics::VortexMetrics;
@@ -42,7 +43,6 @@ use vortex::session::VortexSession;
 use vortex_utils::aliases::dash_map::DashMap;
 use vortex_utils::aliases::dash_map::Entry;
 
-use super::cache::VortexFileCache;
 use crate::VortexAccessPlan;
 use crate::VortexReaderFactory;
 use crate::convert::exprs::ExpressionConvertor;
@@ -69,8 +69,6 @@ pub(crate) struct VortexOpener {
     /// This is the table's schema without partition columns. It may contain fields which do
     /// not exist in the file, and are supplied by the `schema_adapter_factory`.
     pub table_schema: TableSchema,
-    /// Caching Vortex file opener
-    pub file_cache: VortexFileCache,
     /// A hint for the desired row count of record batches returned from the scan.
     pub batch_size: usize,
     /// If provided, the scan will not return more than this many rows.
@@ -107,7 +105,6 @@ impl FileOpener for VortexOpener {
         let file_pruning_predicate = self.file_pruning_predicate.clone();
         let expr_adapter_factory = self.expr_adapter_factory.clone();
 
-        let file_cache = self.file_cache.clone();
         let unified_file_schema = self.table_schema.file_schema().clone();
         let batch_size = self.batch_size;
         let limit = self.limit;
@@ -165,8 +162,10 @@ impl FileOpener for VortexOpener {
                 return Ok(stream::empty().boxed());
             }
 
-            let vxf = file_cache
-                .try_get(&file.object_meta, reader)
+            let vxf = session
+                .open_options()
+                .with_file_size(file.object_meta.size)
+                .open_read(reader)
                 .await
                 .map_err(|e| exec_datafusion_err!("Failed to open Vortex file {e}"))?;
 
@@ -507,8 +506,6 @@ mod tests {
             filter,
             file_pruning_predicate: None,
             expr_adapter_factory: Arc::new(DefaultPhysicalExprAdapterFactory),
-
-            file_cache: VortexFileCache::new(1, 1, 161984, SESSION.clone()),
             table_schema,
             batch_size: 100,
             limit: None,
@@ -599,7 +596,6 @@ mod tests {
             filter: Some(filter),
             file_pruning_predicate: None,
             expr_adapter_factory: Arc::new(DefaultPhysicalExprAdapterFactory),
-            file_cache: VortexFileCache::new(1, 1, 161984, SESSION.clone()),
             table_schema: table_schema.clone(),
             batch_size: 100,
             limit: None,
@@ -682,7 +678,6 @@ mod tests {
             filter: None,
             file_pruning_predicate: None,
             expr_adapter_factory: Arc::new(DefaultPhysicalExprAdapterFactory),
-            file_cache: VortexFileCache::new(1, 1, 161984, SESSION.clone()),
             table_schema: TableSchema::from_file_schema(table_schema.clone()),
             batch_size: 100,
             limit: None,
@@ -834,7 +829,6 @@ mod tests {
             filter: None,
             file_pruning_predicate: None,
             expr_adapter_factory: Arc::new(DefaultPhysicalExprAdapterFactory),
-            file_cache: VortexFileCache::new(1, 1, 161984, SESSION.clone()),
             table_schema: table_schema.clone(),
             batch_size: 100,
             limit: None,
@@ -890,7 +884,6 @@ mod tests {
             filter: None,
             file_pruning_predicate: None,
             expr_adapter_factory: Arc::new(DefaultPhysicalExprAdapterFactory),
-            file_cache: VortexFileCache::new(1, 1, 161984, SESSION.clone()),
             table_schema: TableSchema::from_file_schema(schema),
             batch_size: 100,
             limit: None,
@@ -1088,7 +1081,6 @@ mod tests {
             filter: None,
             file_pruning_predicate: None,
             expr_adapter_factory: Arc::new(DefaultPhysicalExprAdapterFactory),
-            file_cache: VortexFileCache::new(1, 1, 161984, SESSION.clone()),
             table_schema,
             batch_size: 100,
             limit: None,

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -14,6 +14,7 @@ use datafusion_datasource::PartitionedFile;
 use datafusion_datasource::TableSchema;
 use datafusion_datasource::file_stream::FileOpenFuture;
 use datafusion_datasource::file_stream::FileOpener;
+use datafusion_execution::cache::cache_manager::FileMetadataCache;
 use datafusion_physical_expr::PhysicalExprRef;
 use datafusion_physical_expr::projection::ProjectionExprs;
 use datafusion_physical_expr::simplifier::PhysicalExprSimplifier;
@@ -49,6 +50,7 @@ use crate::convert::exprs::ExpressionConvertor;
 use crate::convert::exprs::ProcessedProjection;
 use crate::convert::exprs::make_vortex_predicate;
 use crate::convert::schema::calculate_physical_schema;
+use crate::persistent::cache::CachedVortexMetadata;
 use crate::persistent::stream::PrunableStream;
 
 #[derive(Clone)]
@@ -84,6 +86,7 @@ pub(crate) struct VortexOpener {
     pub has_output_ordering: bool,
 
     pub expression_convertor: Arc<dyn ExpressionConvertor>,
+    pub file_metadata_cache: Option<Arc<dyn FileMetadataCache>>,
 }
 
 impl FileOpener for VortexOpener {
@@ -104,6 +107,7 @@ impl FileOpener for VortexOpener {
 
         let file_pruning_predicate = self.file_pruning_predicate.clone();
         let expr_adapter_factory = self.expr_adapter_factory.clone();
+        let file_metadata_cache = self.file_metadata_cache.clone();
 
         let unified_file_schema = self.table_schema.file_schema().clone();
         let batch_size = self.batch_size;
@@ -162,9 +166,18 @@ impl FileOpener for VortexOpener {
                 return Ok(stream::empty().boxed());
             }
 
-            let vxf = session
-                .open_options()
-                .with_file_size(file.object_meta.size)
+            let mut open_opts = session.open_options().with_file_size(file.object_meta.size);
+
+            if let Some(file_metadata_cache) = file_metadata_cache
+                && let Some(file_metadata) = file_metadata_cache.get(&file.object_meta)
+                && let Some(vortex_metadata) = file_metadata
+                    .as_any()
+                    .downcast_ref::<CachedVortexMetadata>()
+            {
+                open_opts = open_opts.with_footer(vortex_metadata.footer().clone());
+            }
+
+            let vxf = open_opts
                 .open_read(reader)
                 .await
                 .map_err(|e| exec_datafusion_err!("Failed to open Vortex file {e}"))?;
@@ -513,6 +526,7 @@ mod tests {
             layout_readers: Default::default(),
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
+            file_metadata_cache: None,
         }
     }
 
@@ -603,6 +617,7 @@ mod tests {
             layout_readers: Default::default(),
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
+            file_metadata_cache: None,
         };
 
         let filter = col("a").lt(lit(100_i32));
@@ -685,6 +700,7 @@ mod tests {
             layout_readers: Default::default(),
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
+            file_metadata_cache: None,
         };
 
         // The opener should successfully open the file and reorder columns
@@ -836,6 +852,7 @@ mod tests {
             layout_readers: Default::default(),
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
+            file_metadata_cache: None,
         };
 
         // This should succeed and return the correctly projected and cast data
@@ -891,6 +908,7 @@ mod tests {
             layout_readers: Default::default(),
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
+            file_metadata_cache: None,
         }
     }
 
@@ -1088,6 +1106,7 @@ mod tests {
             layout_readers: Default::default(),
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
+            file_metadata_cache: None,
         };
 
         let file = PartitionedFile::new(file_path.to_string(), data_size);

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -32,7 +32,6 @@ use vortex::metrics::VortexMetrics;
 use vortex::session::VortexSession;
 use vortex_utils::aliases::dash_map::DashMap;
 
-use super::cache::VortexFileCache;
 use super::metrics::PARTITION_LABEL;
 use super::opener::VortexOpener;
 use crate::DefaultVortexReaderFactory;
@@ -46,7 +45,6 @@ use crate::convert::exprs::ExpressionConvertor;
 #[derive(Clone)]
 pub struct VortexSource {
     pub(crate) session: VortexSession,
-    pub(crate) file_cache: VortexFileCache,
     pub(crate) table_schema: TableSchema,
     pub(crate) projection: ProjectionExprs,
     /// Combined predicate expression containing all filters from DataFusion query planning.
@@ -67,18 +65,13 @@ pub struct VortexSource {
 }
 
 impl VortexSource {
-    pub(crate) fn new(
-        table_schema: TableSchema,
-        session: VortexSession,
-        file_cache: VortexFileCache,
-    ) -> Self {
+    pub(crate) fn new(table_schema: TableSchema, session: VortexSession) -> Self {
         let full_schema = table_schema.table_schema();
         let indices = (0..full_schema.fields().len()).collect::<Vec<_>>();
         let projection = ProjectionExprs::from_indices(&indices, full_schema);
 
         Self {
             session,
-            file_cache,
             table_schema,
             projection,
             full_predicate: None,
@@ -151,7 +144,6 @@ impl FileSource for VortexSource {
             file_pruning_predicate: self.full_predicate.clone(),
             expr_adapter_factory,
             table_schema: self.table_schema.clone(),
-            file_cache: self.file_cache.clone(),
             batch_size,
             limit: base_config.limit,
             metrics: partition_metrics,

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -12,6 +12,7 @@ use datafusion_datasource::TableSchema;
 use datafusion_datasource::file::FileSource;
 use datafusion_datasource::file_scan_config::FileScanConfig;
 use datafusion_datasource::file_stream::FileOpener;
+use datafusion_execution::cache::cache_manager::FileMetadataCache;
 use datafusion_physical_expr::PhysicalExprRef;
 use datafusion_physical_expr::conjunction;
 use datafusion_physical_expr::projection::ProjectionExprs;
@@ -62,6 +63,7 @@ pub struct VortexSource {
     expression_convertor: Arc<dyn ExpressionConvertor>,
     pub(crate) vortex_reader_factory: Option<Arc<dyn VortexReaderFactory>>,
     vx_metrics: VortexMetrics,
+    file_metadata_cache: Option<Arc<dyn FileMetadataCache>>,
 }
 
 impl VortexSource {
@@ -82,6 +84,7 @@ impl VortexSource {
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             vortex_reader_factory: None,
             vx_metrics: VortexMetrics::default(),
+            file_metadata_cache: None,
         }
     }
 
@@ -108,6 +111,15 @@ impl VortexSource {
     /// The metrics instance attached to this source.
     pub fn vx_metrics(&self) -> &VortexMetrics {
         &self.vx_metrics
+    }
+
+    /// Override the file metadata cache
+    pub fn with_file_metadata_cache(
+        mut self,
+        file_metadata_cache: Arc<dyn FileMetadataCache>,
+    ) -> Self {
+        self.file_metadata_cache = Some(file_metadata_cache);
+        self
     }
 }
 
@@ -150,6 +162,7 @@ impl FileSource for VortexSource {
             layout_readers: self.layout_readers.clone(),
             has_output_ordering: !base_config.output_ordering.is_empty(),
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
+            file_metadata_cache: self.file_metadata_cache.clone(),
         };
 
         Ok(Arc::new(opener))

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -156,7 +156,7 @@ impl VortexOpenOptions {
 
     /// An API for opening a [`VortexFile`] using any [`VortexReadAt`] implementation.
     pub async fn open_read<R: VortexReadAt + Clone>(self, reader: R) -> VortexResult<VortexFile> {
-        let metrics = VortexMetrics::default();
+        let metrics = self.metrics.clone().unwrap_or_default();
         let footer = if let Some(footer) = self.footer {
             footer
         } else {


### PR DESCRIPTION
Instead of using our own custom file cache, we delegate to DataFusion's file metadata cache to stash footers we've already read, allowing users to re-use other existing DF code and extensions while reducing the amount of code we have to care about.

It also makes wiring metrics simpler, as we don't cache the layout readers created during `infer_schema` or `infer_stats`, which is desired because `FileFormat` is long living while `FileSource` isn't, so we don't want it to hold a metrics instance.