### PR TITLE
fix: vortex-layout doc tests require zstd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10899,6 +10899,7 @@ dependencies = [
  "vortex-error",
  "vortex-flatbuffers",
  "vortex-io",
+ "vortex-layout",
  "vortex-mask",
  "vortex-metrics",
  "vortex-pco",

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -60,8 +60,8 @@ rstest = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 vortex-array = { path = "../vortex-array", features = ["_test-harness"] }
 vortex-io = { path = "../vortex-io", features = ["tokio"] }
-vortex-utils = { workspace = true, features = ["_test-harness"] }
 vortex-layout = { path = ".", features = ["zstd"] }
+vortex-utils = { workspace = true, features = ["_test-harness"] }
 
 [features]
 _test-harness = []

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -61,6 +61,7 @@ tokio = { workspace = true, features = ["rt", "macros"] }
 vortex-array = { path = "../vortex-array", features = ["_test-harness"] }
 vortex-io = { path = "../vortex-io", features = ["tokio"] }
 vortex-utils = { workspace = true, features = ["_test-harness"] }
+vortex-layout = { path = ".", features = ["zstd"] }
 
 [features]
 _test-harness = []


### PR DESCRIPTION
Maybe I am the only one who runs `cargo test -p vortex-layout`? `ci.yml` uses `--all-features`.