### PR TITLE
feat: reduce size of segments containing fixed-size-list arrays

### DIFF
--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -358,7 +358,7 @@ impl DType {
                         .checked_add(element_size)
                         .vortex_expect("sum of field sizes is bigger than usize");
                 }
-                Some(sum);
+                Some(sum)
             }
             Extension(ext) => ext.storage_dtype().element_size(),
         }

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use DType::*;
 use itertools::Itertools;
 use static_assertions::const_assert_eq;
+use vortex_error::VortexExpect;
 use vortex_error::vortex_panic;
 
 use crate::ExtDType;
@@ -345,13 +346,21 @@ impl DType {
             Decimal(decimal, _) => {
                 Some(DecimalType::smallest_decimal_value_type(decimal).byte_width())
             }
+            Utf8(_) | Binary(_) | List(..) => None,
             FixedSizeList(elem_dtype, list_size, _) => {
                 elem_dtype.element_size().map(|s| s * *list_size as usize)
             }
+            Struct(fields, ..) => {
+                let mut sum = 0_usize;
+                for f in fields.fields() {
+                    let element_size = f.element_size()?;
+                    sum = sum
+                        .checked_add(element_size)
+                        .vortex_expect("sum of field sizes is bigger than usize");
+                }
+                Some(sum);
+            }
             Extension(ext) => ext.storage_dtype().element_size(),
-            // We could sum the elment_size of the fields of the struct, but it is not clear this is
-            // a useful number to know.
-            Struct(..) | Utf8(_) | Binary(_) | List(..) => None,
         }
     }
 

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -333,9 +333,9 @@ impl DType {
         }
     }
 
-    /// Returns the number of bytes occupied by a single scalar of this fixed-width non-struct type.
+    /// Returns the number of bytes occupied by a single scalar of this fixed-width type.
     ///
-    /// For non-fixed-width or struct types, return None.
+    /// For non-fixed-width types, return None.
     ///
     /// [`Bool`] is defined as 1 even though a Vortex array may pack Booleans to one bit per element.
     pub fn element_size(&self) -> Option<usize> {

--- a/vortex-dtype/src/dtype.rs
+++ b/vortex-dtype/src/dtype.rs
@@ -18,6 +18,7 @@ use crate::FieldName;
 use crate::PType;
 use crate::StructFields;
 use crate::decimal::DecimalDType;
+use crate::decimal::DecimalType;
 use crate::nullability::Nullability;
 
 /// The logical types of elements in Vortex arrays.
@@ -331,6 +332,29 @@ impl DType {
         }
     }
 
+    /// Returns the number of bytes occupied by a single scalar of this fixed-width non-struct type.
+    ///
+    /// For non-fixed-width or struct types, return None.
+    ///
+    /// [`Bool`] is defined as 1 even though a Vortex array may pack Booleans to one bit per element.
+    pub fn element_size(&self) -> Option<usize> {
+        match self {
+            Null => Some(0),
+            Bool(_) => Some(1),
+            Primitive(ptype, _) => Some(ptype.byte_width()),
+            Decimal(decimal, _) => {
+                Some(DecimalType::smallest_decimal_value_type(decimal).byte_width())
+            }
+            FixedSizeList(elem_dtype, list_size, _) => {
+                elem_dtype.element_size().map(|s| s * *list_size as usize)
+            }
+            Extension(ext) => ext.storage_dtype().element_size(),
+            // We could sum the elment_size of the fields of the struct, but it is not clear this is
+            // a useful number to know.
+            Struct(..) | Utf8(_) | Binary(_) | List(..) => None,
+        }
+    }
+
     /// Check returns the inner decimal type if the dtype is a [`DType::Decimal`].
     pub fn as_decimal_opt(&self) -> Option<&DecimalDType> {
         if let Decimal(decimal, _) = self {
@@ -505,5 +529,103 @@ impl Display for DType {
                 ext.storage_dtype().nullability(),
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::DType;
+    use crate::Nullability::NonNullable;
+    use crate::PType;
+    use crate::decimal::DecimalDType;
+    use crate::extension::ExtDType;
+    use crate::extension::ExtID;
+
+    #[test]
+    fn element_size_null() {
+        assert_eq!(DType::Null.element_size(), Some(0));
+    }
+
+    #[test]
+    fn element_size_bool() {
+        assert_eq!(DType::Bool(NonNullable).element_size(), Some(1));
+    }
+
+    #[test]
+    fn element_size_primitives() {
+        assert_eq!(
+            DType::Primitive(PType::U8, NonNullable).element_size(),
+            Some(1)
+        );
+        assert_eq!(
+            DType::Primitive(PType::I32, NonNullable).element_size(),
+            Some(4)
+        );
+        assert_eq!(
+            DType::Primitive(PType::F64, NonNullable).element_size(),
+            Some(8)
+        );
+    }
+
+    #[test]
+    fn element_size_decimal() {
+        let decimal = DecimalDType::new(10, 2);
+        // precision 10 -> DecimalType::I64 -> 8 bytes
+        assert_eq!(DType::Decimal(decimal, NonNullable).element_size(), Some(8));
+    }
+
+    #[test]
+    fn element_size_fixed_size_list() {
+        let elem = Arc::new(DType::Primitive(PType::F64, NonNullable));
+        assert_eq!(
+            DType::FixedSizeList(elem.clone(), 1000, NonNullable).element_size(),
+            Some(8000)
+        );
+
+        assert_eq!(
+            DType::FixedSizeList(
+                Arc::new(DType::FixedSizeList(elem, 20, NonNullable)),
+                1000,
+                NonNullable
+            )
+            .element_size(),
+            Some(160_000)
+        );
+    }
+
+    #[test]
+    fn element_size_nested_fixed_size_list() {
+        let inner = Arc::new(DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            10,
+            NonNullable,
+        ));
+        assert_eq!(
+            DType::FixedSizeList(inner, 100, NonNullable).element_size(),
+            Some(8000)
+        );
+    }
+
+    #[test]
+    fn element_size_extension() {
+        let storage = Arc::new(DType::Primitive(PType::I32, NonNullable));
+        let ext = ExtDType::new(ExtID::new("test.ext".into()), storage, None);
+        assert_eq!(DType::Extension(Arc::new(ext)).element_size(), Some(4));
+    }
+
+    #[test]
+    fn element_size_variable_width() {
+        assert_eq!(DType::Utf8(NonNullable).element_size(), None);
+        assert_eq!(DType::Binary(NonNullable).element_size(), None);
+        assert_eq!(
+            DType::List(
+                Arc::new(DType::Primitive(PType::I32, NonNullable)),
+                NonNullable
+            )
+            .element_size(),
+            None
+        );
     }
 }

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -95,6 +95,12 @@ impl WriteStrategyBuilder {
         let coalescing = RepartitionStrategy::new(
             compressing,
             RepartitionWriterOptions {
+                // Write stream partitions roughly become segments. Because Vortex never reads less
+                // than one segment, the size of segments and, therefore, partitions, must be small
+                // enough to both (1) allow fine-grained random access reads and (2) allow
+                // sufficient read concurrency for the desired throughput. One megabyte is small
+                // enough to achieve this for S3 (Durner et al., "Exploiting Cloud Object Storage for
+                // High-Performance Analytics", VLDB Vol 16, Iss 11).
                 block_size_minimum: ONE_MEG,
                 block_len_multiple: self.row_block_size,
                 block_size_target: Some(ONE_MEG),

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -97,6 +97,7 @@ impl WriteStrategyBuilder {
             RepartitionWriterOptions {
                 block_size_minimum: ONE_MEG,
                 block_len_multiple: self.row_block_size,
+                block_size_target: Some(ONE_MEG),
                 canonicalize: true,
             },
         );
@@ -134,6 +135,7 @@ impl WriteStrategyBuilder {
                 block_size_minimum: 0,
                 // Always repartition into 8K row blocks
                 block_len_multiple: self.row_block_size,
+                block_size_target: None,
                 canonicalize: false,
             },
         );

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -34,14 +34,16 @@ pub struct RepartitionWriterOptions {
     pub block_len_multiple: usize,
     /// Optional target uncompressed size in bytes for a block.
     ///
-    /// When set, for fixed-width types (where [`DType::element_size`] is `Some`), the effective
-    /// `block_len_multiple` is reduced so that each block does not exceed this byte target.
-    /// This prevents oversized segments for types with large per-element sizes (e.g.,
-    /// `FixedSizeList(f64, 1000)` which is ~8000 bytes per element).
+    /// The repartition writer attempts to produce partitions with this uncompressed size. This is
+    /// only a best effort attempt: the partitions may be arbitrarily larger or smaller. Reasons for
+    /// this include:
     ///
-    /// When `None`, `block_len_multiple` is used as-is regardless of element size.
+    /// 1. The size of one element may not perfectly divide the target size, resulting in blocks
+    ///    that are either too large or too small.
     ///
-    /// [`DType::element_size`]: vortex_dtype::DType::element_size
+    /// 2. Variable length types are expensive to pack due to the need to read each element length.
+    ///
+    /// 3. View types are expensive to pack due to each view sharing an aribtrary slice of data.
     pub block_size_target: Option<u64>,
     pub canonicalize: bool,
 }

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -13,6 +13,7 @@ use vortex_array::ArrayContext;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::arrays::ChunkedArray;
+use vortex_dtype::DType;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_io::runtime::Handle;
@@ -31,7 +32,41 @@ pub struct RepartitionWriterOptions {
     pub block_size_minimum: u64,
     /// The multiple of the number of rows in each block.
     pub block_len_multiple: usize,
+    /// Optional target uncompressed size in bytes for a block.
+    ///
+    /// When set, for fixed-width types (where [`DType::element_size`] is `Some`), the effective
+    /// `block_len_multiple` is reduced so that each block does not exceed this byte target.
+    /// This prevents oversized segments for types with large per-element sizes (e.g.,
+    /// `FixedSizeList(f64, 1000)` which is ~8000 bytes per element).
+    ///
+    /// When `None`, `block_len_multiple` is used as-is regardless of element size.
+    ///
+    /// [`DType::element_size`]: vortex_dtype::DType::element_size
+    pub block_size_target: Option<u64>,
     pub canonicalize: bool,
+}
+
+impl RepartitionWriterOptions {
+    /// Compute the effective block length for a given [`DType`].
+    ///
+    /// For fixed-width types where [`DType::element_size`] is known and large enough that
+    /// `element_size * block_len_multiple` would exceed `block_size_target`, this reduces the
+    /// block length so each block stays close to the target byte size.
+    fn effective_block_len(&self, dtype: &DType) -> usize {
+        let Some(block_size_target) = self.block_size_target else {
+            return self.block_len_multiple;
+        };
+        match dtype.element_size() {
+            Some(elem_size) if elem_size > 0 => {
+                // `div_ceil` ensures we overshoot the block_size_target; therefore preventing
+                // `write_stream` from combining adjacent 0.9 MiB chunks into one 1.8 MiB chunk.
+                let max_rows = usize::try_from(block_size_target.div_ceil(elem_size as u64))
+                    .unwrap_or(usize::MAX);
+                self.block_len_multiple.min(max_rows).max(1)
+            }
+            _ => self.block_len_multiple,
+        }
+    }
 }
 
 /// Repartition a stream of arrays into blocks.
@@ -81,17 +116,24 @@ impl LayoutStrategy for RepartitionStrategy {
 
         let dtype_clone = dtype.clone();
         let options = self.options.clone();
+
+        // For fixed-width types with large per-element sizes, reduce the block_len_multiple
+        // so that each block targets block_size_target bytes rather than producing oversized
+        // segments.
+        let block_len = options.effective_block_len(&dtype);
+        let block_size_minimum = options.block_size_minimum;
+
         let repartitioned_stream = try_stream! {
             let canonical_stream = stream.peekable();
             pin_mut!(canonical_stream);
 
-            let mut chunks = ChunksBuffer::new(options.clone());
+            let mut chunks = ChunksBuffer::new(block_size_minimum, block_len);
             while let Some(chunk) = canonical_stream.as_mut().next().await {
                 let (sequence_id, chunk) = chunk?;
                 let mut sequence_pointer = sequence_id.descend();
                 let mut offset = 0;
                 while offset < chunk.len() {
-                    let end = (offset + options.block_len_multiple).min(chunk.len());
+                    let end = (offset + block_len).min(chunk.len());
                     let sliced = chunk.slice(offset..end)?;
                     chunks.push_back(sliced);
                     offset = end;
@@ -148,28 +190,29 @@ struct ChunksBuffer {
     data: VecDeque<ArrayRef>,
     row_count: usize,
     nbytes: u64,
-    options: RepartitionWriterOptions,
+    block_size_minimum: u64,
+    block_len_multiple: usize,
 }
 
 impl ChunksBuffer {
-    fn new(options: RepartitionWriterOptions) -> Self {
+    fn new(block_size_minimum: u64, block_len_multiple: usize) -> Self {
         Self {
             data: Default::default(),
             row_count: 0,
             nbytes: 0,
-            options,
+            block_size_minimum,
+            block_len_multiple,
         }
     }
 
     fn have_enough(&self) -> bool {
-        self.nbytes >= self.options.block_size_minimum
-            && self.row_count >= self.options.block_len_multiple
+        self.nbytes >= self.block_size_minimum && self.row_count >= self.block_len_multiple
     }
 
     fn collect_exact_blocks(&mut self) -> VortexResult<Vec<ArrayRef>> {
-        let nblocks = self.row_count / self.options.block_len_multiple;
+        let nblocks = self.row_count / self.block_len_multiple;
         let mut res = Vec::with_capacity(self.data.len());
-        let mut remaining = nblocks * self.options.block_len_multiple;
+        let mut remaining = nblocks * self.block_len_multiple;
         while remaining > 0 {
             let chunk = self
                 .pop_front()
@@ -209,5 +252,193 @@ impl ChunksBuffer {
             self.nbytes -= chunk.nbytes();
         }
         res
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vortex_array::ArrayContext;
+    use vortex_array::IntoArray;
+    use vortex_array::arrays::FixedSizeListArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::validity::Validity;
+    use vortex_dtype::DType;
+    use vortex_dtype::Nullability::NonNullable;
+    use vortex_dtype::PType;
+    use vortex_error::VortexResult;
+    use vortex_io::runtime::single::block_on;
+
+    use super::*;
+    use crate::LayoutStrategy;
+    use crate::layouts::chunked::writer::ChunkedLayoutStrategy;
+    use crate::layouts::flat::writer::FlatLayoutStrategy;
+    use crate::segments::TestSegments;
+    use crate::sequence::SequenceId;
+    use crate::sequence::SequentialArrayStreamExt;
+
+    const ONE_MEG: u64 = 1 << 20;
+
+    #[test]
+    fn effective_block_len_small_elements() {
+        // f64 = 8 bytes/element. 8192 * 8 = 64 KiB << 1 MiB, so no reduction.
+        let dtype = DType::Primitive(PType::F64, NonNullable);
+        let options = RepartitionWriterOptions {
+            block_size_minimum: 0,
+            block_len_multiple: 8192,
+            block_size_target: Some(ONE_MEG),
+            canonicalize: false,
+        };
+        assert_eq!(options.effective_block_len(&dtype), 8192);
+    }
+
+    #[test]
+    fn effective_block_len_large_elements() {
+        // FixedSizeList(f64, 1000) = 8000 bytes/element.
+        // 1 MiB / 8000 = 131, so effective block len = min(8192, 131) = 131.
+        let dtype = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            1000,
+            NonNullable,
+        );
+        let options = RepartitionWriterOptions {
+            block_size_minimum: 0,
+            block_len_multiple: 8192,
+            block_size_target: Some(ONE_MEG),
+            canonicalize: false,
+        };
+        assert_eq!(options.effective_block_len(&dtype), 131);
+    }
+
+    #[test]
+    fn effective_block_len_variable_width() {
+        // Utf8 has no known element_size, so block_len_multiple is unchanged.
+        let dtype = DType::Utf8(NonNullable);
+        let options = RepartitionWriterOptions {
+            block_size_minimum: 0,
+            block_len_multiple: 8192,
+            block_size_target: Some(ONE_MEG),
+            canonicalize: false,
+        };
+        assert_eq!(options.effective_block_len(&dtype), 8192);
+    }
+
+    #[test]
+    fn effective_block_len_very_large_elements() {
+        // FixedSizeList(f64, 1_000_000) = 8_000_000 bytes/element.
+        // 1 MiB / 8_000_000 = 0, clamped to max(1) = 1.
+        let dtype = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::F64, NonNullable)),
+            1_000_000,
+            NonNullable,
+        );
+        let options = RepartitionWriterOptions {
+            block_size_minimum: 0,
+            block_len_multiple: 8192,
+            block_size_target: Some(ONE_MEG),
+            canonicalize: false,
+        };
+        assert_eq!(options.effective_block_len(&dtype), 1);
+    }
+
+    #[test]
+    fn repartition_large_element_type_produces_small_blocks() -> VortexResult<()> {
+        // Create a FixedSizeList(f64, 1000) array with 1000 lists.
+        // Each list is 8000 bytes, so 1000 lists = 8 MiB total.
+        // With block_size_target = 1 MiB, effective block_len = 131.
+        // We expect the repartition to produce blocks of 131 rows each.
+        let list_size: u32 = 1000;
+        let num_lists: usize = 1000;
+        let total_elements = list_size as usize * num_lists;
+
+        let elements = PrimitiveArray::from_iter((0..total_elements).map(|i| i as f64));
+        let fsl = FixedSizeListArray::new(
+            elements.into_array(),
+            list_size,
+            Validity::NonNullable,
+            num_lists,
+        );
+
+        let ctx = ArrayContext::empty();
+        let segments = Arc::new(TestSegments::default());
+        let (ptr, eof) = SequenceId::root().split();
+
+        let child = ChunkedLayoutStrategy::new(FlatLayoutStrategy::default());
+        let strategy = RepartitionStrategy::new(
+            child,
+            RepartitionWriterOptions {
+                block_size_minimum: 0,
+                block_len_multiple: 8192,
+                block_size_target: Some(ONE_MEG),
+                canonicalize: false,
+            },
+        );
+
+        let stream = fsl.into_array().to_array_stream().sequenced(ptr);
+        let layout =
+            block_on(|handle| strategy.write_stream(ctx, segments.clone(), stream, eof, handle))?;
+
+        // The layout should be a ChunkedLayout with multiple children.
+        // With 1000 rows and effective block_len = 131:
+        //   - 7 full blocks of 131 rows = 917 rows
+        //   - 1 remainder block of 83 rows
+        //   - Total: 8 blocks, 1000 rows
+        assert_eq!(layout.row_count(), num_lists as u64);
+
+        // All non-last children should have 131 rows.
+        let nchildren = layout.nchildren();
+        assert!(nchildren > 1, "expected multiple chunks, got {nchildren}");
+
+        for i in 0..nchildren - 1 {
+            let child = layout.child(i)?;
+            assert_eq!(
+                child.row_count(),
+                131,
+                "chunk {i} has {} rows, expected 131",
+                child.row_count()
+            );
+        }
+
+        // Last child gets the remainder.
+        let last = layout.child(nchildren - 1)?;
+        assert_eq!(last.row_count(), 1000 - 131 * (nchildren as u64 - 1));
+
+        Ok(())
+    }
+
+    #[test]
+    fn repartition_small_element_type_unchanged() -> VortexResult<()> {
+        // For f64 (8 bytes/element), effective block_len stays at 8192.
+        // With 10000 elements and block_size_minimum=0, we get one block of 8192
+        // and one remainder of 1808.
+        let num_elements: usize = 10000;
+        let elements = PrimitiveArray::from_iter((0..num_elements).map(|i| i as f64));
+
+        let ctx = ArrayContext::empty();
+        let segments = Arc::new(TestSegments::default());
+        let (ptr, eof) = SequenceId::root().split();
+
+        let child = ChunkedLayoutStrategy::new(FlatLayoutStrategy::default());
+        let strategy = RepartitionStrategy::new(
+            child,
+            RepartitionWriterOptions {
+                block_size_minimum: 0,
+                block_len_multiple: 8192,
+                block_size_target: Some(ONE_MEG),
+                canonicalize: false,
+            },
+        );
+
+        let stream = elements.into_array().to_array_stream().sequenced(ptr);
+        let layout =
+            block_on(|handle| strategy.write_stream(ctx, segments.clone(), stream, eof, handle))?;
+
+        assert_eq!(layout.row_count(), num_elements as u64);
+        assert_eq!(layout.nchildren(), 2);
+        assert_eq!(layout.child(0)?.row_count(), 8192);
+        assert_eq!(layout.child(1)?.row_count(), 1808);
+
+        Ok(())
     }
 }

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn effective_block_len_large_elements() {
         // FixedSizeList(f64, 1000) = 8000 bytes/element.
-        // 1 MiB / 8000 = 131, so effective block len = min(8192, 131) = 131.
+        // div_ceil(1 MiB, 8000) = 132, so effective block len = min(8192, 132) = 132.
         let dtype = DType::FixedSizeList(
             Arc::new(DType::Primitive(PType::F64, NonNullable)),
             1000,
@@ -310,7 +310,7 @@ mod tests {
             block_size_target: Some(ONE_MEG),
             canonicalize: false,
         };
-        assert_eq!(options.effective_block_len(&dtype), 131);
+        assert_eq!(options.effective_block_len(&dtype), 132);
     }
 
     #[test]
@@ -348,8 +348,8 @@ mod tests {
     fn repartition_large_element_type_produces_small_blocks() -> VortexResult<()> {
         // Create a FixedSizeList(f64, 1000) array with 1000 lists.
         // Each list is 8000 bytes, so 1000 lists = 8 MiB total.
-        // With block_size_target = 1 MiB, effective block_len = 131.
-        // We expect the repartition to produce blocks of 131 rows each.
+        // With block_size_target = 1 MiB, effective block_len = 133.
+        // We expect the repartition to produce blocks of 132 rows each.
         let list_size: u32 = 1000;
         let num_lists: usize = 1000;
         let total_elements = list_size as usize * num_lists;
@@ -382,9 +382,9 @@ mod tests {
             block_on(|handle| strategy.write_stream(ctx, segments.clone(), stream, eof, handle))?;
 
         // The layout should be a ChunkedLayout with multiple children.
-        // With 1000 rows and effective block_len = 131:
-        //   - 7 full blocks of 131 rows = 917 rows
-        //   - 1 remainder block of 83 rows
+        // With 1000 rows and effective block_len = 132:
+        //   - 7 full blocks of 132 rows = 924 rows
+        //   - 1 remainder block of 76 rows
         //   - Total: 8 blocks, 1000 rows
         assert_eq!(layout.row_count(), num_lists as u64);
 
@@ -396,7 +396,7 @@ mod tests {
             let child = layout.child(i)?;
             assert_eq!(
                 child.row_count(),
-                131,
+                132,
                 "chunk {i} has {} rows, expected 131",
                 child.row_count()
             );
@@ -404,7 +404,7 @@ mod tests {
 
         // Last child gets the remainder.
         let last = layout.child(nchildren - 1)?;
-        assert_eq!(last.row_count(), 1000 - 131 * (nchildren as u64 - 1));
+        assert_eq!(last.row_count(), 1000 - 132 * (nchildren as u64 - 1));
 
         Ok(())
     }

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -43,7 +43,7 @@ pub struct RepartitionWriterOptions {
     ///
     /// 2. Variable length types are expensive to pack due to the need to read each element length.
     ///
-    /// 3. View types are expensive to pack due to each view sharing an aribtrary slice of data.
+    /// 3. View types are expensive to pack due to each view sharing an arbitrary slice of data.
     pub block_size_target: Option<u64>,
     pub canonicalize: bool,
 }


### PR DESCRIPTION
I also verified this on some fixed-size-list data I have locally and, indeed, I see more reasonable segment sizes (~1MiB).