### PR TITLE
feat[cuda]: basic filter kernel for primitive

### DIFF
--- a/vortex-array/src/arrays/filter/array.rs
+++ b/vortex-array/src/arrays/filter/array.rs
@@ -16,6 +16,11 @@ pub struct FilterArray {
     pub(super) stats: ArrayStats,
 }
 
+pub struct FilterArrayParts {
+    pub child: ArrayRef,
+    pub mask: Mask,
+}
+
 impl FilterArray {
     pub fn new(array: ArrayRef, mask: Mask) -> Self {
         Self::try_new(array, mask).vortex_expect("new FilterArray")
@@ -44,5 +49,13 @@ impl FilterArray {
     /// The mask used to filter the child array.
     pub fn filter_mask(&self) -> &Mask {
         &self.mask
+    }
+
+    /// Consume the `FilterArray` into its components.
+    pub fn into_parts(self) -> FilterArrayParts {
+        FilterArrayParts {
+            child: self.child,
+            mask: self.mask,
+        }
     }
 }

--- a/vortex-cuda/Cargo.toml
+++ b/vortex-cuda/Cargo.toml
@@ -64,3 +64,7 @@ harness = false
 [[bench]]
 name = "zstd_cuda"
 harness = false
+
+[[bench]]
+name = "filter_cuda"
+harness = false

--- a/vortex-cuda/benches/filter_cuda.rs
+++ b/vortex-cuda/benches/filter_cuda.rs
@@ -1,3 +1,267 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+//! CUDA benchmarks for filter operations.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::cast_possible_truncation)]
+
+use std::mem::size_of;
+use std::time::Duration;
+use std::time::Instant;
+
+use criterion::BenchmarkId;
+use criterion::Criterion;
+use criterion::Throughput;
+use futures::executor::block_on;
+use vortex_array::IntoArray;
+use vortex_array::arrays::FilterArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::validity::Validity;
+use vortex_buffer::BitBufferMut;
+use vortex_buffer::Buffer;
+use vortex_cuda::CudaSession;
+use vortex_cuda::executor::CudaArrayExt;
+use vortex_cuda_macros::cuda_available;
+use vortex_cuda_macros::cuda_not_available;
+use vortex_error::VortexExpect;
+use vortex_mask::Mask;
+use vortex_session::VortexSession;
+
+const BENCH_ARGS: &[(usize, usize, &str)] = &[
+    (10_000_000, 2, "10M_50pct"),
+    (10_000_000, 10, "10M_10pct"),
+    (10_000_000, 100, "10M_1pct"),
+];
+
+/// Creates a mask with the given selectivity pattern.
+fn make_mask(len: usize, selectivity: usize) -> Mask {
+    let mut mask = BitBufferMut::with_capacity(len);
+    for idx in 0..len {
+        if idx % selectivity == 0 {
+            mask.append_true();
+        } else {
+            mask.append_false();
+        }
+    }
+    Mask::from_buffer(mask.freeze())
+}
+
+/// Creates a FilterArray of u32 with a selectivity pattern.
+fn make_filter_array_u32(len: usize, selectivity: usize) -> FilterArray {
+    let buf: Buffer<u32> = (0..len as u32).collect();
+    let array = PrimitiveArray::new(buf, Validity::NonNullable);
+    FilterArray::new(array.into_array(), make_mask(len, selectivity))
+}
+
+/// Creates a FilterArray of u64 with a selectivity pattern.
+fn make_filter_array_u64(len: usize, selectivity: usize) -> FilterArray {
+    let buf: Buffer<u64> = (0..len as u64).collect();
+    let array = PrimitiveArray::new(buf, Validity::NonNullable);
+    FilterArray::new(array.into_array(), make_mask(len, selectivity))
+}
+
+/// Creates a FilterArray of i32 with a selectivity pattern.
+fn make_filter_array_i32(len: usize, selectivity: usize) -> FilterArray {
+    let buf: Buffer<i32> = (0..len as i32).collect();
+    let array = PrimitiveArray::new(buf, Validity::NonNullable);
+    FilterArray::new(array.into_array(), make_mask(len, selectivity))
+}
+
+/// Creates a FilterArray of f64 with a selectivity pattern.
+fn make_filter_array_f64(len: usize, selectivity: usize) -> FilterArray {
+    let buf: Buffer<f64> = (0..len).map(|i| i as f64).collect();
+    let array = PrimitiveArray::new(buf, Validity::NonNullable);
+    FilterArray::new(array.into_array(), make_mask(len, selectivity))
+}
+
+/// Benchmark u32 filter operations
+fn benchmark_filter_u32(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Filter_cuda_u32");
+    group.sample_size(10);
+
+    for (len, selectivity, label) in BENCH_ARGS {
+        let filter_array = make_filter_array_u32(*len, *selectivity);
+
+        group.throughput(Throughput::Bytes((len * size_of::<u32>()) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("u32_Filter", label),
+            &filter_array,
+            |b, filter_array| {
+                b.iter_custom(|iters| {
+                    let mut total_time = Duration::ZERO;
+
+                    for _ in 0..iters {
+                        let mut cuda_ctx =
+                            CudaSession::create_execution_ctx(&VortexSession::empty())
+                                .vortex_expect("failed to create execution context");
+
+                        let start = Instant::now();
+                        let _result = block_on(
+                            filter_array
+                                .clone()
+                                .into_array()
+                                .execute_cuda(&mut cuda_ctx),
+                        )
+                        .vortex_expect("GPU filter failed");
+                        cuda_ctx
+                            .synchronize_stream()
+                            .vortex_expect("failed to synchronize");
+                        total_time += start.elapsed();
+                    }
+
+                    total_time
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark u64 filter operations
+fn benchmark_filter_u64(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Filter_cuda_u64");
+    group.sample_size(10);
+
+    for (len, selectivity, label) in BENCH_ARGS {
+        let filter_array = make_filter_array_u64(*len, *selectivity);
+
+        group.throughput(Throughput::Bytes((len * size_of::<u64>()) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("u64_Filter", label),
+            &filter_array,
+            |b, filter_array| {
+                b.iter_custom(|iters| {
+                    let mut total_time = Duration::ZERO;
+
+                    for _ in 0..iters {
+                        let mut cuda_ctx =
+                            CudaSession::create_execution_ctx(&VortexSession::empty())
+                                .vortex_expect("failed to create execution context");
+
+                        let start = Instant::now();
+                        let _result = block_on(
+                            filter_array
+                                .clone()
+                                .into_array()
+                                .execute_cuda(&mut cuda_ctx),
+                        )
+                        .vortex_expect("GPU filter failed");
+                        cuda_ctx
+                            .synchronize_stream()
+                            .vortex_expect("failed to synchronize");
+                        total_time += start.elapsed();
+                    }
+
+                    total_time
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark i32 filter operations
+fn benchmark_filter_i32(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Filter_cuda_i32");
+    group.sample_size(10);
+
+    for (len, selectivity, label) in BENCH_ARGS {
+        let filter_array = make_filter_array_i32(*len, *selectivity);
+
+        group.throughput(Throughput::Bytes((len * size_of::<i32>()) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("i32_Filter", label),
+            &filter_array,
+            |b, filter_array| {
+                b.iter_custom(|iters| {
+                    let mut total_time = Duration::ZERO;
+
+                    for _ in 0..iters {
+                        let mut cuda_ctx =
+                            CudaSession::create_execution_ctx(&VortexSession::empty())
+                                .vortex_expect("failed to create execution context");
+
+                        let start = Instant::now();
+                        let _result = block_on(
+                            filter_array
+                                .clone()
+                                .into_array()
+                                .execute_cuda(&mut cuda_ctx),
+                        )
+                        .vortex_expect("GPU filter failed");
+                        cuda_ctx
+                            .synchronize_stream()
+                            .vortex_expect("failed to synchronize");
+                        total_time += start.elapsed();
+                    }
+
+                    total_time
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Benchmark f64 filter operations
+fn benchmark_filter_f64(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Filter_cuda_f64");
+    group.sample_size(10);
+
+    for (len, selectivity, label) in BENCH_ARGS {
+        let filter_array = make_filter_array_f64(*len, *selectivity);
+
+        group.throughput(Throughput::Bytes((len * size_of::<f64>()) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("f64_Filter", label),
+            &filter_array,
+            |b, filter_array| {
+                b.iter_custom(|iters| {
+                    let mut total_time = Duration::ZERO;
+
+                    for _ in 0..iters {
+                        let mut cuda_ctx =
+                            CudaSession::create_execution_ctx(&VortexSession::empty())
+                                .vortex_expect("failed to create execution context");
+
+                        let start = Instant::now();
+                        let _result = block_on(
+                            filter_array
+                                .clone()
+                                .into_array()
+                                .execute_cuda(&mut cuda_ctx),
+                        )
+                        .vortex_expect("GPU filter failed");
+                        cuda_ctx
+                            .synchronize_stream()
+                            .vortex_expect("failed to synchronize");
+                        total_time += start.elapsed();
+                    }
+
+                    total_time
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+pub fn benchmark_filter(c: &mut Criterion) {
+    benchmark_filter_u32(c);
+    benchmark_filter_u64(c);
+    benchmark_filter_i32(c);
+    benchmark_filter_f64(c);
+}
+
+criterion::criterion_group!(benches, benchmark_filter);
+
+#[cuda_available]
+criterion::criterion_main!(benches);
+
+#[cuda_not_available]
+fn main() {}

--- a/vortex-cuda/benches/filter_cuda.rs
+++ b/vortex-cuda/benches/filter_cuda.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+

--- a/vortex-cuda/kernels/config.cuh
+++ b/vortex-cuda/kernels/config.cuh
@@ -10,3 +10,6 @@
 //   elements_per_block = 64 * 32 = 2048
 //   grid_dim = ceil(array_len / 2048)
 constexpr uint32_t ELEMENTS_PER_THREAD = 32;
+
+// The size of a thread block for all the Vortex kernels.
+constexpr uint32_t THREADS_PER_BLOCK = 64;

--- a/vortex-cuda/kernels/filter_primitive.cu
+++ b/vortex-cuda/kernels/filter_primitive.cu
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+#include "config.cuh"
+
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+// Execute a filter kernel on the inputs, scattering them to the output nodes.
+// We need to perform a prefix sum so we know where to write all of the sized things.
+// We need to know how many bits come before so we can create indices instead.
+template<typename T>
+__device__ void filter_primitive(
+    const T *const __restrict input,
+    const uint8_t *const __restrict mask,
+    T *const __restrict output,
+    const uint32_t maskOffset,
+    const uint32_t maskLen
+) {
+
+    // ASSUMPTIONS:
+    //  1. We only have a single thread block active. Attempting to launch with > 1 thread block will fail and instead
+    //     we just fall back to using a single block.
+    //  2. Each thread in the block is responsible for a range of input mask values. If there are T threads in the block and N values,
+    //     this means that every thread is responsible for counting N / T values.
+    //  3. The input is provided as a bitset packed into a uint8_t array, possibly with an offset applied.
+    //
+    //
+    // ALGORITHM
+    // =========
+    //
+    // The algorithm is an implementation of a parallel prefix scan operation, similar to the DeviceSelect::Flagged() routing from CUB.
+    //
+    // It operates in two phases, or "sweeps" as you'll see them called in other documentation.
+    //
+    // The first phase occurs across all threads in the thread blocks. Each thread counts the number of true bits in its portion of the mask,
+    // and writes that into a shared memory cache.
+    //
+    // The next phase computes the prefix sum over the values in the block, allowing each thread to know which range of the output buffer
+    // it owns for the writing phase. (TODO: do this in parallel)
+    //
+    // The final phase scatters the elements into their output location based on the computed indices.
+
+
+    // Declare the shared memory upfront
+    // We assume that there are at most 512 threads in the thread block.
+    __shared__ uint32_t validCounts[512];
+
+    // calculate which worker ID is running, and its data range.
+    // const uint32_t workerIdx = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint32_t workerIdx = threadIdx.x;
+
+    // total number of bytes in the mask
+    const uint32_t maskBytes = (maskLen + maskOffset + 7) / 8;
+    // Total number of bytes each worker has access to
+    const uint32_t workerBytes = MIN(maskBytes < blockDim.x, 1);
+    const uint32_t workerByteStart = workerIdx * workerBytes;
+    const uint32_t workerElemStart = workerByteStart * 8 - maskOffset;
+    const uint32_t workerElemEnd = MIN((workerByteStart + workerBytes) * 8 - maskOffset, maskLen);
+
+    // Superfluous worker, ignore it.
+    if (workerByteStart > maskBytes) {
+        return;
+    }
+
+    // SWEEP 1: Local sums. Each thread calculates the total number of valid elements in its range.
+    uint32_t validCount = 0;
+    for (uint32_t byteOffset = 0; byteOffset < workerBytes; byteOffset++) {
+        // Issue workerBytes popcnt operations, one per each byte.
+        // NOTE(aduffy): it'd be preferable to do this with an unaligned u64 load, but my understanding
+        //  is that NVIDIA GPUs don't support unaligned loads.
+        uint32_t byteIdx = workerByteStart + byteOffset;
+
+        if (byteIdx >= maskBytes) {
+            break;
+        }
+
+        uint8_t byte = mask[byteIdx];
+
+        // Apply any mask offset before measuring
+        if (byteIdx == 0 && maskOffset) {
+            // Shift out the offset
+            byte = byte >> maskOffset;
+        }
+
+        // Handle final byte. Only take remainder
+        if (byteIdx == maskBytes) {
+            uint32_t remainder = (maskOffset + maskLen) % 8;
+            // Only consider the first `remainder` bits of the last byte.
+            byte = byte & ((1 << remainder) - 1);
+        }
+
+        validCount += __popc(static_cast<uint32_t>(byte));
+    }
+
+    validCounts[threadIdx.x] = validCount;
+
+    // wait for all threads in the block to set the valid counts.
+    __syncthreads();
+
+    // worker 0 computes the prefix sum.
+    // TODO(aduffy): REPLACE THIS WITH PARALLEL SUM
+    if (threadIdx.x == 0) {
+        for (size_t i = 1; i < 512; i++) {
+            validCounts[i] += validCounts[i-1];
+        }
+    }
+
+    // synchronize so all threads see the updated shared validCounts, now containing prefix sums
+    __syncthreads();
+
+
+    // SWEEP 2: Each iterates through the mask again, scattering valid inputs to the output buffer
+    //  Now that we have the prefix sums, we don't need to coordinate because each thread knows
+    //  which range of the output it owns.
+
+    // FAST PATH: if validCount from sweep 1 was zero, then we add no elements to the output, so we
+    //  terminate early.
+    if (validCount == 0) {
+        return;
+    }
+
+    const uint32_t outputStart = threadIdx.x == 0 ? 0 : validCounts[threadIdx.x - 1];
+    const uint32_t outputEnd = outputStart + validCount;
+
+    uint32_t outputIdx = outputStart;
+
+    for (uint32_t inputIdx = workerElemStart; inputIdx < workerElemEnd; inputIdx++) {
+        uint32_t byteIdx = (inputIdx + maskOffset) / 8;
+        uint32_t bitIdx = (inputIdx + maskOffset) % 8;
+        bool keep = mask[byteIdx] & (1 << bitIdx);
+        if (keep) {
+            output[outputIdx++] = input[inputIdx];
+        }
+    }
+}
+
+#define GENERATE_KERNEL(suffix, T) \
+extern "C" __global__ void filter_primitive_##suffix( \
+    const T *const __restrict input, \
+    const uint8_t *const __restrict mask, \
+    T *const __restrict output, \
+    const uint32_t mask_offset, \
+    const uint32_t mask_len \
+) { \
+    filter_primitive(input, mask, output, mask_offset, mask_len); \
+}
+
+// GENERATE_KERNEL(u8, uint8_t)
+// GENERATE_KERNEL(u16, uint16_t)
+GENERATE_KERNEL(u32, uint32_t)
+// GENERATE_KERNEL(u64, uint64_t)
+//
+// GENERATE_KERNEL(i8, int8_t)
+// GENERATE_KERNEL(i16, int16_t)
+// GENERATE_KERNEL(i32, int32_t)
+// GENERATE_KERNEL(i64, int64_t)

--- a/vortex-cuda/kernels/filter_primitive.cu
+++ b/vortex-cuda/kernels/filter_primitive.cu
@@ -149,12 +149,12 @@ extern "C" __global__ void filter_primitive_##suffix( \
     filter_primitive(input, mask, output, mask_offset, mask_len); \
 }
 
-// GENERATE_KERNEL(u8, uint8_t)
-// GENERATE_KERNEL(u16, uint16_t)
+GENERATE_KERNEL(u8, uint8_t)
+GENERATE_KERNEL(u16, uint16_t)
 GENERATE_KERNEL(u32, uint32_t)
-// GENERATE_KERNEL(u64, uint64_t)
-//
-// GENERATE_KERNEL(i8, int8_t)
-// GENERATE_KERNEL(i16, int16_t)
-// GENERATE_KERNEL(i32, int32_t)
-// GENERATE_KERNEL(i64, int64_t)
+GENERATE_KERNEL(u64, uint64_t)
+
+GENERATE_KERNEL(i8, int8_t)
+GENERATE_KERNEL(i16, int16_t)
+GENERATE_KERNEL(i32, int32_t)
+GENERATE_KERNEL(i64, int64_t)

--- a/vortex-cuda/src/kernel/arrays/filter.rs
+++ b/vortex-cuda/src/kernel/arrays/filter.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! A CUDA kernel executor for `FilterArray`.
+//!
+//! The filter array is constructed with a mask and a child. We first execute the child on the GPU
+//! into its canonical form, and then execute filter over it.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cudarc::driver::DeviceRepr;
+use cudarc::driver::LaunchArgs;
+use cudarc::driver::PushKernelArg;
+use cudarc::driver::sys::CUevent_flags;
+use cudarc::driver::sys::CUevent_flags::CU_EVENT_DISABLE_TIMING;
+use vortex_array::Array;
+use vortex_array::ArrayRef;
+use vortex_array::Canonical;
+use vortex_array::arrays::FilterArray;
+use vortex_array::arrays::FilterArrayParts;
+use vortex_array::arrays::FilterVTable;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::buffer::BufferHandle;
+use vortex_cuda_macros::cuda_tests;
+use vortex_dtype::DType;
+use vortex_dtype::NativePType;
+use vortex_dtype::PType;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
+use vortex_mask::Mask;
+
+use crate::CudaBufferExt;
+use crate::CudaDeviceBuffer;
+use crate::CudaExecutionCtx;
+use crate::CudaKernelEvents;
+use crate::executor::CudaArrayExt;
+use crate::executor::CudaExecute;
+
+#[derive(Debug)]
+pub struct FilterExecutor;
+
+#[async_trait]
+impl CudaExecute for FilterExecutor {
+    async fn execute(
+        &self,
+        array: ArrayRef,
+        ctx: &mut CudaExecutionCtx,
+    ) -> VortexResult<Canonical> {
+        let Ok(filter_array) = array.try_into::<FilterVTable>() else {
+            vortex_bail!("FilterExecutor expected FilterArray input");
+        };
+
+        match filter_array.dtype() {
+            DType::Primitive(ptype, _) => {
+                match ptype {
+                    PType::U8 => execute_filter_primitive::<u8>(filter_array, ctx).await,
+                    PType::U16 => execute_filter_primitive::<u16>(filter_array, ctx).await,
+                    PType::U32 => execute_filter_primitive::<u32>(filter_array, ctx).await,
+                    PType::U64 => execute_filter_primitive::<u64>(filter_array, ctx).await,
+                    PType::I8 => execute_filter_primitive::<i8>(filter_array, ctx).await,
+                    PType::I16 => execute_filter_primitive::<i16>(filter_array, ctx).await,
+                    PType::I32 => execute_filter_primitive::<i32>(filter_array, ctx).await,
+                    PType::I64 => execute_filter_primitive::<i64>(filter_array, ctx).await,
+                    PType::F16 => {
+                        // TODO(aduffy): filter as u16 instead
+                        vortex_bail!("f16 not supported for filter_primitive kernel");
+                    }
+                    PType::F32 => execute_filter_primitive::<f32>(filter_array, ctx).await,
+                    PType::F64 => execute_filter_primitive::<f64>(filter_array, ctx).await,
+                }
+            }
+            // DType::Decimal(_, _) => {}
+            dtype => vortex_bail!("unsupported DType for GPU filter kernel {dtype}"),
+        }
+    }
+}
+
+async fn execute_filter_primitive<T: NativePType + DeviceRepr>(
+    filter_array: FilterArray,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<Canonical> {
+    let FilterArrayParts { child, mask } = filter_array.into_parts();
+
+    match mask {
+        Mask::AllTrue(_) => child.execute_cuda(ctx).await,
+        Mask::AllFalse(_) => Ok(Canonical::empty(child.dtype())),
+        m @ Mask::Values(_) => {
+            let output_validity = child.validity()?.filter(&m)?;
+
+            let bits = m.into_bit_buffer().shrink_offset();
+            // TODO(aduffy): eliminate the true counting here?
+            let kept = bits.true_count();
+
+            // Allocate an output buffer of T's to hold the result.
+            let output = ctx.device_alloc::<T>(kept)?;
+
+            // Copy the mask and the child onto device buffer
+            let (mask_offset, mask_len, buffer) = bits.into_inner();
+            let mask_offset = u32::try_from(mask_offset)?;
+            let mask_len = u32::try_from(mask_len)?;
+            let mask_buf = ctx.copy_to_device(buffer)?.await?;
+
+            let child = child.execute_cuda(ctx).await?.into_primitive();
+            let input_buf = child.buffer_handle().clone();
+            let input_device = if input_buf.is_on_device() {
+                input_buf
+            } else {
+                ctx.move_to_device::<T>(input_buf)?.await?
+            };
+
+            let input_view = input_device.cuda_view::<T>()?;
+            let mask_view = mask_buf.cuda_view::<u8>()?;
+            let output_view = output.as_view();
+
+            // What is the array len?
+            let kernel = ctx.load_function_ptype("filter_primitive", &[T::PTYPE])?;
+            let mut launch_builder = ctx.launch_builder(&kernel);
+            launch_builder.arg(&input_view);
+            launch_builder.arg(&mask_view);
+            launch_builder.arg(&output_view);
+            launch_builder.arg(&mask_offset);
+            launch_builder.arg(&mask_len);
+
+            let _cuda_events = launch_filter_kernel(&mut launch_builder, CU_EVENT_DISABLE_TIMING)?;
+
+            // TODO(aduffy): actually filter validity too.
+            Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
+                BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(output))),
+                T::PTYPE,
+                output_validity,
+            )))
+        }
+    }
+}
+
+fn launch_filter_kernel(
+    launch_builder: &mut LaunchArgs,
+    event_flags: CUevent_flags,
+) -> VortexResult<CudaKernelEvents> {
+    // We cap this at 1 thread block.
+    let config = cudarc::driver::LaunchConfig {
+        grid_dim: (1, 1, 1),
+        block_dim: (512, 1, 1),
+        shared_mem_bytes: 0,
+    };
+
+    launch_builder.record_kernel_launch(event_flags);
+
+    unsafe {
+        launch_builder
+            .launch(config)
+            .map_err(|e| vortex_err!("Failed to launch kernel: {}", e))
+            .and_then(|events| {
+                events
+                    .ok_or_else(|| vortex_err!("CUDA events not recorded"))
+                    .map(|(before_launch, after_launch)| CudaKernelEvents {
+                        before_launch,
+                        after_launch,
+                    })
+            })
+    }
+}
+
+#[cuda_tests]
+mod tests {
+    use vortex_array::IntoArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::assert_arrays_eq;
+    use vortex_array::validity::Validity::NonNullable;
+    use vortex_buffer::BitBufferMut;
+    use vortex_buffer::Buffer;
+    use vortex_error::VortexExpect;
+    use vortex_session::VortexSession;
+
+    use super::*;
+    use crate::session::CudaSession;
+
+    /// Copy a CUDA primitive array result to host memory.
+    fn cuda_primitive_to_host(prim: PrimitiveArray) -> VortexResult<PrimitiveArray> {
+        Ok(PrimitiveArray::from_byte_buffer(
+            prim.buffer_handle().try_to_host_sync()?,
+            prim.ptype(),
+            prim.validity()?,
+        ))
+    }
+
+    #[tokio::test]
+    async fn test_filter_u32() -> VortexResult<()> {
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+            .vortex_expect("failed to create execution context");
+
+        let values: Buffer<u32> = (0..512).collect();
+        let values = PrimitiveArray::new(values, NonNullable);
+
+        // Create a filter mask that takes the first item from every block of 8.
+        let mut mask = BitBufferMut::with_capacity(512);
+        for idx in 0..512 {
+            if idx % 16 == 0 {
+                mask.append_true();
+            } else {
+                mask.append_false();
+            }
+        }
+        let mask = mask.freeze();
+
+        // Construct the filter operation and execute it on GPU.
+        let filter_array = FilterArray::new(values.into_array(), Mask::from_buffer(mask));
+
+        // Get baseline from CPU canonicalization
+        let baseline = filter_array.to_canonical()?;
+
+        // Execute on CUDA
+        let cuda_result = FilterExecutor
+            .execute(filter_array.to_array(), &mut cuda_ctx)
+            .await
+            .vortex_expect("GPU decompression failed")
+            .into_primitive();
+        cuda_ctx.synchronize_stream()?;
+        let cuda_result = cuda_primitive_to_host(cuda_result)?;
+
+        // Compare CUDA result with baseline
+        assert_arrays_eq!(cuda_result.into_array(), baseline.into_array());
+        Ok(())
+    }
+}

--- a/vortex-cuda/src/kernel/arrays/filter.rs
+++ b/vortex-cuda/src/kernel/arrays/filter.rs
@@ -21,6 +21,7 @@ use vortex_array::arrays::FilterArray;
 use vortex_array::arrays::FilterArrayParts;
 use vortex_array::arrays::FilterVTable;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::PrimitiveArrayParts;
 use vortex_array::buffer::BufferHandle;
 use vortex_cuda_macros::cuda_tests;
 use vortex_dtype::DType;
@@ -64,8 +65,23 @@ impl CudaExecute for FilterExecutor {
                     PType::I32 => execute_filter_primitive::<i32>(filter_array, ctx).await,
                     PType::I64 => execute_filter_primitive::<i64>(filter_array, ctx).await,
                     PType::F16 => {
-                        // TODO(aduffy): filter as u16 instead
-                        vortex_bail!("f16 not supported for filter_primitive kernel");
+                        let PrimitiveArrayParts {
+                            buffer, validity, ..
+                        } = execute_filter_primitive::<u16>(filter_array, ctx)
+                            .await?
+                            .into_primitive()
+                            .into_parts();
+
+                        Ok(Canonical::Primitive(
+                            // SAFETY: u16/f16 have same layout
+                            unsafe {
+                                PrimitiveArray::new_unchecked_from_handle(
+                                    buffer,
+                                    PType::F16,
+                                    validity,
+                                )
+                            },
+                        ))
                     }
                     PType::F32 => execute_filter_primitive::<f32>(filter_array, ctx).await,
                     PType::F64 => execute_filter_primitive::<f64>(filter_array, ctx).await,

--- a/vortex-cuda/src/kernel/arrays/mod.rs
+++ b/vortex-cuda/src/kernel/arrays/mod.rs
@@ -2,4 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod dict;
+mod filter;
+
 pub use dict::DictExecutor;
+pub use filter::FilterExecutor;

--- a/vortex-cuda/src/kernel/mod.rs
+++ b/vortex-cuda/src/kernel/mod.rs
@@ -24,6 +24,7 @@ mod arrays;
 mod encodings;
 
 pub use arrays::DictExecutor;
+pub use arrays::FilterExecutor;
 pub use encodings::*;
 
 use crate::CudaKernelEvents;

--- a/vortex-cuda/src/lib.rs
+++ b/vortex-cuda/src/lib.rs
@@ -20,6 +20,7 @@ pub use executor::CudaKernelEvents;
 use kernel::ALPExecutor;
 use kernel::DecimalBytePartsExecutor;
 use kernel::DictExecutor;
+use kernel::FilterExecutor;
 use kernel::FoRExecutor;
 use kernel::ZigZagExecutor;
 use kernel::ZstdExecutor;
@@ -30,6 +31,7 @@ pub use session::CudaSession;
 pub use session::CudaSessionExt;
 use vortex_alp::ALPVTable;
 use vortex_array::arrays::DictVTable;
+use vortex_array::arrays::FilterVTable;
 use vortex_decimal_byte_parts::DecimalBytePartsVTable;
 use vortex_fastlanes::FoRVTable;
 pub use vortex_nvcomp as nvcomp;
@@ -53,4 +55,5 @@ pub fn initialize_cuda(session: &CudaSession) {
     session.register_kernel(ZigZagVTable::ID, &ZigZagExecutor);
     session.register_kernel(DecimalBytePartsVTable::ID, &DecimalBytePartsExecutor);
     session.register_kernel(ZstdVTable::ID, &ZstdExecutor);
+    session.register_kernel(FilterVTable::ID, &FilterExecutor)
 }


### PR DESCRIPTION
We add a filter kernel for the Primitive types.

It seems that in the GPGPU space, what we call `filter` is generally called either "stream compaction", "scanning", or "selection".

Stream compaction is non-trivial because unlike most scalar operations, a thread needs to coordinate with other threads so it knows where in the output buffer to start writing.

The best algorithm for this was published in 2009 and seems to be the basis of how NVIDIA's `cub::DeviceSelect::Flagged()` kernel works. I've ported a very minimal version of this here that we will need to improve on.


## Algorithm

Most GPU-based stream reduction algorithms work in two passes:

1. Every thread block is assigned a fixed range of the input mask. The threads count the number of set bits in it section of the mask, and puts that partial sum into a slot in some shared memory
2. A parallel prefix sum algorithm is run to turn the partial sums into prefix sums. The prefix sums are the starting positions in the output buffer where each thread is supposed to write its data

This is a fairly complex algorithm and I've only implemented a pretty simple variant of it here. In particular

* We hard-peg to 1 thread block, 512 worker threads. This puts a really hard upper bound on the amount of parallelism we get. The reason mostly is that exchange across thread blocks is pretty gnarly and I haven't worked it out yet. Seems like it requires some spin locking?
* We're doing serial prefix sum rn on one worker.

# More info

* [`cub::DeviceSelect::Flagged` docs](https://nvidia.github.io/cccl/cub/api/structcub_1_1DeviceSelect.html#_CPPv4I0000EN3cub12DeviceSelect7FlaggedE11cudaError_tPvR6size_t14InputIteratorT12FlagIterator15OutputIteratorT20NumSelectedIteratorTN4cudaSt7int64_tE12cudaStream_t)
* [Slides](https://www.highperformancegraphics.org/previous/www_2009/presentations/billeter-efficient.pdf)
* [Paper](https://www.cse.chalmers.se/~uffe/streamcompaction.pdf)
* [Very old blog post](https://developer.nvidia.com/gpugems/gpugems3/part-vi-gpu-computing/chapter-39-parallel-prefix-sum-scan-cuda)