### PR TITLE
feat: "hedging": issue two concurrent requests for HEAD and GET

### DIFF
--- a/vortex-io/src/file/object_store.rs
+++ b/vortex-io/src/file/object_store.rs
@@ -3,6 +3,7 @@
 
 use std::io;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_compat::Compat;
 use futures::FutureExt;
@@ -94,8 +95,7 @@ impl VortexReadAt for ObjectStoreSource {
         let store = self.store.clone();
         let path = self.path.clone();
         Compat::new(async move {
-            store
-                .head(&path)
+            hedge_request(|| store.head(&path))
                 .await
                 .map(|h| h.size)
                 .map_err(VortexError::from)
@@ -117,15 +117,16 @@ impl VortexReadAt for ObjectStoreSource {
         Compat::new(async move {
             let mut buffer = ByteBufferMut::with_capacity_aligned(length, alignment);
 
-            let response = store
-                .get_opts(
+            let response = hedge_request(|| {
+                store.get_opts(
                     &path,
                     GetOptions {
                         range: Some(GetRange::Bounded(range.clone())),
                         ..Default::default()
                     },
                 )
-                .await?;
+            })
+            .await?;
 
             let buffer = match response.payload {
                 #[cfg(not(target_arch = "wasm32"))]
@@ -164,5 +165,29 @@ impl VortexReadAt for ObjectStoreSource {
             Ok(BufferHandle::new_host(buffer.freeze()))
         })
         .boxed()
+    }
+}
+
+async fn hedge_request<F, FUT, T>(f: F) -> T
+where
+    F: Fn() -> FUT,
+    FUT: Future<Output = T>,
+{
+    let head = f();
+    let hedged = async move {
+        // See "the AnyBlob paper": Durner et al., "Exploiting Cloud Object Storage for
+        // High-Performance Analytics". VLDB Vol 16 Iss 11.
+        // https://www.durner.dev/app/media/papers/anyblob-vldb23.pdf
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        f().await
+    };
+
+    tokio::select! {
+        r = head => {
+            r
+        }
+        r = hedged => {
+            r
+        }
     }
 }


### PR DESCRIPTION
There's a reasonable argument that this should either (a) be implemented via an object_store::HttpService or (b) implemented as a reqwest middleware. Either of those approaches can be upstreamed or made a separate open source library.

From the AnyBlob paper, Durner et al. "Exploiting Cloud Object Storage for High-Performance Analytics". VLDB Vol 16 Iss 11:

> # 2.7 Tail Latency & Request Hedging
>
> Hedging against slow responses. Missing or slow responses from storage servers are a challenge for
> users of cloud object stores. In our latency experiments, we see requests that have a considerable
> tail latency. Some requests get lost without any notice. To mitigate these issues, cloud vendors
> suggest restarting unresponsive requests,known as request hedging [ 10 , 34 ]. For example, the
> typical 16 MiB request duration is below 600ms for AWS. However, less than 5% of objects are not
> downloaded after 600ms. Missing responses can also be found by checking the first byte
> latency. Similarly to the duration, less than 5% have a first byte latency above 200ms. Hedging
> these requests does not introduce significant cost overhead.