### PR TITLE
fix[array]: disallow serialize of filter + slice

### DIFF
--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -68,7 +68,8 @@ impl VTable for FilterVTable {
     }
 
     fn serialize(_metadata: Self::Metadata) -> VortexResult<Option<Vec<u8>>> {
-        Ok(None)
+        // TODO(joe): make this configurable
+        vortex_bail!("Filter array is not serializable")
     }
 
     fn deserialize(_bytes: &[u8]) -> VortexResult<Self::Metadata> {

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -67,7 +67,8 @@ impl VTable for SliceVTable {
     }
 
     fn serialize(_metadata: Self::Metadata) -> VortexResult<Option<Vec<u8>>> {
-        Ok(None)
+        // TODO(joe): make this configurable
+        vortex_bail!("Slice array is not serializable")
     }
 
     fn deserialize(_bytes: &[u8]) -> VortexResult<Self::Metadata> {


### PR DESCRIPTION
This should never had been allowed to be written to a file!

Edit from @connortsui20: So just to be clear, filter and slice were never actually being written to files. It was just an error where we didn't get rid of them on the write path.