### PR TITLE
Perf: Use optimized filter implementations is `FilterArray::execute`

### DIFF
--- a/vortex-array/src/arrays/filter/execute/bool.rs
+++ b/vortex-array/src/arrays/filter/execute/bool.rs
@@ -3,73 +3,29 @@
 
 use std::sync::Arc;
 
-use vortex_buffer::BitBuffer;
-use vortex_buffer::BitBufferMut;
+use vortex_compute::filter::Filter;
 use vortex_error::VortexExpect;
-use vortex_mask::MaskIter;
 use vortex_mask::MaskValues;
 
 use crate::arrays::BoolArray;
 use crate::arrays::filter::execute::filter_validity;
 
-/// If the filter density is above 80%, we use slices to filter the array instead of indices.
-const FILTER_SLICES_DENSITY_THRESHOLD: f64 = 0.8;
-
-// TODO(connor): Use the optimized filters over bit buffers in `vortex-compute`.
 pub fn filter_bool(array: &BoolArray, mask: &Arc<MaskValues>) -> BoolArray {
     let validity = array.validity().vortex_expect("missing BoolArray validity");
     let filtered_validity = filter_validity(validity, mask);
 
     let bit_buffer = array.to_bit_buffer();
-
-    let filtered_buffer = match mask.threshold_iter(FILTER_SLICES_DENSITY_THRESHOLD) {
-        MaskIter::Indices(indices) => {
-            filter_indices(&bit_buffer, mask.true_count(), indices.iter().copied())
-        }
-        MaskIter::Slices(slices) => {
-            filter_slices(&bit_buffer, mask.true_count(), slices.iter().copied())
-        }
-    };
+    let filtered_buffer = bit_buffer.filter(mask.as_ref());
 
     BoolArray::new(filtered_buffer, filtered_validity)
-}
-
-/// Select indices from a boolean buffer.
-/// NOTE: it was benchmarked to be faster using collect_bool to index into a slice than to
-///  pass the indices as an iterator of usize. So we keep this alternate implementation.
-pub fn filter_indices(
-    bools: &BitBuffer,
-    indices_len: usize,
-    mut indices: impl Iterator<Item = usize>,
-) -> BitBuffer {
-    let buffer = bools.inner().as_ref();
-    BitBuffer::collect_bool(indices_len, |_idx| {
-        let idx = indices
-            .next()
-            .vortex_expect("iterator is guaranteed to be within the length of the array.");
-        vortex_buffer::get_bit(buffer, bools.offset() + idx)
-    })
-}
-
-pub fn filter_slices(
-    buffer: &BitBuffer,
-    indices_len: usize,
-    slices: impl Iterator<Item = (usize, usize)>,
-) -> BitBuffer {
-    let mut builder = BitBufferMut::with_capacity(indices_len);
-    for (start, end) in slices {
-        // TODO(ngates): we probably want a borrowed slice for things like this.
-        builder.append_buffer(&buffer.slice(start..end));
-    }
-    builder.freeze()
 }
 
 #[cfg(test)]
 mod test {
     use itertools::Itertools;
+    use rstest::rstest;
     use vortex_mask::Mask;
 
-    use super::*;
     use crate::arrays::BoolArray;
     use crate::canonical::ToCanonical;
     use crate::compute::conformance::filter::test_filter_conformance;
@@ -87,28 +43,6 @@ mod test {
             filtered.into_bit_buffer().iter().collect_vec()
         )
     }
-
-    #[test]
-    fn filter_bool_by_slice_test() {
-        let arr = BoolArray::from_iter([true, true, false]);
-
-        let filtered = filter_slices(&arr.into_bit_buffer(), 2, [(0, 1), (2, 3)].into_iter());
-        assert_eq!(2, filtered.len());
-
-        assert_eq!(vec![true, false], filtered.iter().collect_vec())
-    }
-
-    #[test]
-    fn filter_bool_by_index_test() {
-        let arr = BoolArray::from_iter([true, true, false]);
-
-        let filtered = filter_indices(&arr.into_bit_buffer(), 2, [0, 2].into_iter());
-        assert_eq!(2, filtered.len());
-
-        assert_eq!(vec![true, false], filtered.iter().collect_vec())
-    }
-
-    use rstest::rstest;
 
     #[rstest]
     #[case(BoolArray::from_iter([true, false, true, true, false]))]

--- a/vortex-array/src/arrays/filter/execute/decimal.rs
+++ b/vortex-array/src/arrays/filter/execute/decimal.rs
@@ -3,65 +3,27 @@
 
 use std::sync::Arc;
 
-use vortex_buffer::Buffer;
-use vortex_buffer::BufferMut;
+use vortex_compute::filter::Filter;
 use vortex_dtype::match_each_decimal_value_type;
-use vortex_mask::MaskIter;
 use vortex_mask::MaskValues;
 
 use crate::arrays::DecimalArray;
 use crate::arrays::filter::execute::filter_validity;
 use crate::vtable::ValidityHelper;
 
-/// Threshold for choosing between indices vs slices filtering strategy.
-const FILTER_SLICES_SELECTIVITY_THRESHOLD: f64 = 0.8;
-
 pub fn filter_decimal(array: &DecimalArray, mask: &Arc<MaskValues>) -> DecimalArray {
     let filtered_validity = filter_validity(array.validity().clone(), mask);
 
-    match mask.threshold_iter(FILTER_SLICES_SELECTIVITY_THRESHOLD) {
-        MaskIter::Indices(indices) => match_each_decimal_value_type!(array.values_type(), |T| {
-            let filtered = filter_indices::<T>(array.buffer().as_slice(), indices.iter().copied());
-            // SAFETY: Filter preserves the decimal dtype from the source array. The buffer is
-            // correctly typed and sized based on the filtered indices.
-            unsafe {
-                DecimalArray::new_unchecked(filtered, array.decimal_dtype(), filtered_validity)
-            }
-        }),
-        MaskIter::Slices(slices) => match_each_decimal_value_type!(array.values_type(), |T| {
-            let filtered = filter_slices::<T>(
-                array.buffer().as_slice(),
-                mask.true_count(),
-                slices.iter().copied(),
-            );
-            // SAFETY: Filter preserves the decimal dtype from the source array. The buffer is
-            // correctly typed and sized based on the filtered slices.
-            unsafe {
-                DecimalArray::new_unchecked(filtered, array.decimal_dtype(), filtered_validity)
-            }
-        }),
-    }
-}
+    match_each_decimal_value_type!(array.values_type(), |T| {
+        let filtered_buffer = array.buffer::<T>().filter(mask.as_ref());
 
-fn filter_indices<T: Copy>(values: &[T], indices: impl Iterator<Item = usize>) -> Buffer<T> {
-    indices
-        .map(|idx| {
-            // SAFETY: The mask indices are guaranteed to be within bounds of the array.
-            *unsafe { values.get_unchecked(idx) }
-        })
-        .collect()
-}
-
-fn filter_slices<T: Clone>(
-    values: &[T],
-    output_len: usize,
-    slices: impl Iterator<Item = (usize, usize)>,
-) -> Buffer<T> {
-    let mut output = BufferMut::with_capacity(output_len);
-    for (start, end) in slices {
-        output.extend_from_slice(&values[start..end]);
-    }
-    output.freeze()
+        // SAFETY: We filter both the validity and the buffer with the same mask, so they must have
+        // the same length, and since the buffer came from an existing and valid `DecimalArray` the
+        // values must all be be representable by the decimal type.
+        unsafe {
+            DecimalArray::new_unchecked(filtered_buffer, array.decimal_dtype(), filtered_validity)
+        }
+    })
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/filter/execute/fixed_size_list.rs
+++ b/vortex-array/src/arrays/filter/execute/fixed_size_list.rs
@@ -34,7 +34,8 @@ pub fn filter_fixed_size_list(
     let new_elements = {
         // We want to create a new mask specialized to the underlying `elements` of the array.
         if list_size != 0 {
-            // TODO(connor): Is this something we may want to compute up front (before execute)?
+            // TODO(connor): If we can push down a "indices" or "slices" selection instead that
+            // would be much more performant.
             let elements_mask = compute_mask_for_fsl_elements(selection_mask, list_size as usize);
 
             // Allow the child array to filter itself.

--- a/vortex-array/src/arrays/filter/execute/primitive.rs
+++ b/vortex-array/src/arrays/filter/execute/primitive.rs
@@ -3,20 +3,14 @@
 
 use std::sync::Arc;
 
-use vortex_buffer::Buffer;
-use vortex_buffer::BufferMut;
+use vortex_compute::filter::Filter;
 use vortex_dtype::match_each_native_ptype;
 use vortex_error::VortexExpect;
-use vortex_mask::MaskIter;
 use vortex_mask::MaskValues;
 
 use crate::arrays::PrimitiveArray;
 use crate::arrays::filter::execute::filter_validity;
 
-/// Threshold for choosing between indices vs slices filtering strategy.
-pub const FILTER_SLICES_SELECTIVITY_THRESHOLD: f64 = 0.8;
-
-// TODO(connor): Use the optimized filters over slices in `vortex-compute`.
 pub fn filter_primitive(array: &PrimitiveArray, mask: &Arc<MaskValues>) -> PrimitiveArray {
     let validity = array
         .validity()
@@ -24,43 +18,14 @@ pub fn filter_primitive(array: &PrimitiveArray, mask: &Arc<MaskValues>) -> Primi
     let filtered_validity = filter_validity(validity, mask);
 
     match_each_native_ptype!(array.ptype(), |T| {
-        let filtered_buffer = filter_slice(
-            array.as_slice::<T>(),
-            mask,
-            FILTER_SLICES_SELECTIVITY_THRESHOLD,
-        );
-        PrimitiveArray::new(filtered_buffer, filtered_validity)
-    })
-}
+        // TODO(connor): Ideally we should filter directly on the `BufferHandle` once we implement
+        // `Filter` for that.
+        let filtered_buffer = array.to_buffer::<T>().filter(mask.as_ref());
 
-/// Filter a typed buffer by a mask, returning a new buffer with only the selected elements.
-///
-/// This is the core filtering operation used by both FilterArray execution and the
-/// FilterKernel for primitive arrays.
-///
-/// # Arguments
-/// * `values` - The source slice of values to filter
-/// * `mask` - The mask indicating which elements to keep
-/// * `selectivity_threshold` - Threshold for choosing between indices vs slices strategy
-pub fn filter_slice<T: Copy>(
-    values: &[T],
-    mask: &MaskValues,
-    selectivity_threshold: f64,
-) -> Buffer<T> {
-    match mask.threshold_iter(selectivity_threshold) {
-        MaskIter::Indices(indices) => indices
-            .iter()
-            .copied()
-            .map(|idx| *unsafe { values.get_unchecked(idx) })
-            .collect(),
-        MaskIter::Slices(slices) => {
-            let mut output = BufferMut::with_capacity(mask.true_count());
-            for (start, end) in slices.iter().copied() {
-                output.extend_from_slice(&values[start..end]);
-            }
-            output.freeze()
-        }
-    }
+        // SAFETY: We filter both the validity and the buffer with the same mask, so they must have
+        // the same length.
+        unsafe { PrimitiveArray::new_unchecked(filtered_buffer, filtered_validity) }
+    })
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/filter/execute/varbinview.rs
+++ b/vortex-array/src/arrays/filter/execute/varbinview.rs
@@ -12,6 +12,7 @@ use crate::arrays::filter::execute::values_to_mask;
 use crate::compute::arrow_filter_fn;
 
 pub fn filter_varbinview(array: &VarBinViewArray, mask: &Arc<MaskValues>) -> VarBinViewArray {
+    // Delegate to the Arrow implementation of filter over `VarBinView`.
     arrow_filter_fn(array.as_ref(), &values_to_mask(mask))
         .vortex_expect("VarBinViewArray is Arrow-compatible and supports arrow_filter_fn")
         .as_::<VarBinViewVTable>()

--- a/vortex-buffer/src/bit/mod.rs
+++ b/vortex-buffer/src/bit/mod.rs
@@ -26,36 +26,40 @@ pub use buf_mut::*;
 pub use view::*;
 
 /// Get the bit value at `index` out of `buf`.
+///
+/// # Panics
+///
+/// Panics if `index` is not between 0 and length of `buf * 8`.
 #[inline(always)]
 pub fn get_bit(buf: &[u8], index: usize) -> bool {
     buf[index / 8] & (1 << (index % 8)) != 0
 }
 
-/// Get the bit value at `index` out of `buf` without bounds checking
+/// Get the bit value at `index` out of `buf` without bounds checking.
 ///
 /// # Safety
 ///
-/// `index` must be between 0 and length of `buf`
+/// `index` must be between 0 and length of `buf * 8`.
 #[inline(always)]
 pub unsafe fn get_bit_unchecked(buf: *const u8, index: usize) -> bool {
     (unsafe { *buf.add(index / 8) } & (1 << (index % 8))) != 0
 }
 
-/// Set the bit value at `index` in `buf` without bounds checking
+/// Set the bit value at `index` in `buf` without bounds checking.
 ///
 /// # Safety
 ///
-/// `index` must be between 0 and length of `buf`
+/// `index` must be between 0 and length of `buf * 8`.
 #[inline(always)]
 pub unsafe fn set_bit_unchecked(buf: *mut u8, index: usize) {
     unsafe { *buf.add(index / 8) |= 1 << (index % 8) };
 }
 
-/// Unset the bit value at `index` in `buf` without bounds checking
+/// Unset the bit value at `index` in `buf` without bounds checking.
 ///
 /// # Safety
 ///
-/// `index` must be between 0 and length of `buf`
+/// `index` must be between 0 and length of `buf * 8`.
 #[inline(always)]
 pub unsafe fn unset_bit_unchecked(buf: *mut u8, index: usize) {
     unsafe { *buf.add(index / 8) &= !(1 << (index % 8)) };

--- a/vortex-compute/src/filter/bitbuffer.rs
+++ b/vortex-compute/src/filter/bitbuffer.rs
@@ -9,6 +9,7 @@ use vortex_buffer::get_bit_unchecked;
 use vortex_buffer::set_bit_unchecked;
 use vortex_buffer::unset_bit_unchecked;
 use vortex_mask::Mask;
+use vortex_mask::MaskValues;
 
 use crate::filter::Filter;
 
@@ -16,19 +17,62 @@ impl Filter<Mask> for &BitBuffer {
     type Output = BitBuffer;
 
     fn filter(self, selection_mask: &Mask) -> BitBuffer {
+        match selection_mask {
+            Mask::AllTrue(_) => self.clone(),
+            Mask::AllFalse(_) => BitBuffer::empty(),
+            Mask::Values(v) => self.filter(v.as_ref()),
+        }
+    }
+}
+
+impl Filter<MaskValues> for &BitBuffer {
+    type Output = BitBuffer;
+
+    fn filter(self, mask_values: &MaskValues) -> BitBuffer {
         assert_eq!(
-            selection_mask.len(),
+            mask_values.len(),
             self.len(),
             "Selection mask length must equal the mask length"
         );
 
-        match selection_mask {
-            Mask::AllTrue(_) => self.clone(),
-            Mask::AllFalse(_) => BitBuffer::empty(),
-            Mask::Values(v) => {
-                filter_indices(self.inner().as_ref(), self.offset(), v.indices()).freeze()
+        self.filter(mask_values.indices())
+    }
+}
+
+impl Filter<[usize]> for &BitBuffer {
+    type Output = BitBuffer;
+
+    fn filter(self, indices: &[usize]) -> BitBuffer {
+        let bools = self.inner().as_ref();
+        let bit_offset = self.offset();
+
+        // FIXME(ngates): this is slower than it could be!
+        BitBufferMut::collect_bool(indices.len(), |idx| {
+            let idx = *unsafe { indices.get_unchecked(idx) };
+            get_bit(bools, bit_offset + idx) // Panics if out of bounds.
+        })
+        .freeze()
+    }
+}
+
+impl Filter<[(usize, usize)]> for &BitBuffer {
+    type Output = BitBuffer;
+
+    fn filter(self, slices: &[(usize, usize)]) -> BitBuffer {
+        let bools = self.inner().as_ref();
+        let bit_offset = self.offset();
+        let output_len: usize = slices.iter().map(|(start, end)| end - start).sum();
+
+        let mut out = BitBufferMut::with_capacity(output_len);
+
+        // FIXME(ngates): this is slower than it could be!
+        for &(start, end) in slices {
+            for idx in start..end {
+                out.append(get_bit(bools, bit_offset + idx)); // Panics if out of bounds.
             }
         }
+
+        out.freeze()
     }
 }
 
@@ -36,28 +80,60 @@ impl Filter<Mask> for &mut BitBufferMut {
     type Output = ();
 
     fn filter(self, selection_mask: &Mask) {
-        assert_eq!(
-            selection_mask.len(),
-            self.len(),
-            "Selection mask length must equal the mask length"
-        );
-
         match selection_mask {
             Mask::AllTrue(_) => {}
             Mask::AllFalse(_) => self.clear(),
-            Mask::Values(v) => {
-                *self = filter_indices(self.inner().as_slice(), self.offset(), v.indices())
-            }
+            Mask::Values(v) => self.filter(v.as_ref()),
         }
     }
 }
 
-fn filter_indices(bools: &[u8], bit_offset: usize, indices: &[usize]) -> BitBufferMut {
-    // FIXME(ngates): this is slower than it could be!
-    BitBufferMut::collect_bool(indices.len(), |idx| {
-        let idx = *unsafe { indices.get_unchecked(idx) };
-        get_bit(bools, bit_offset + idx)
-    })
+impl Filter<MaskValues> for &mut BitBufferMut {
+    type Output = ();
+
+    fn filter(self, mask_values: &MaskValues) {
+        assert_eq!(
+            mask_values.len(),
+            self.len(),
+            "Selection mask length must equal the mask length"
+        );
+
+        // BitBufferMut filtering always uses indices for simplicity.
+        self.filter(mask_values.indices())
+    }
+}
+
+impl Filter<[usize]> for &mut BitBufferMut {
+    type Output = ();
+
+    fn filter(self, indices: &[usize]) {
+        let bools = self.inner().as_slice();
+        let bit_offset = self.offset();
+
+        // FIXME(ngates): this is slower than it could be!
+        *self = BitBufferMut::collect_bool(indices.len(), |idx| {
+            let idx = *unsafe { indices.get_unchecked(idx) };
+            get_bit(bools, bit_offset + idx) // Panics if out of bounds.
+        });
+    }
+}
+
+impl Filter<[(usize, usize)]> for &mut BitBufferMut {
+    type Output = ();
+
+    fn filter(self, slices: &[(usize, usize)]) {
+        let bools = self.inner().as_slice();
+        let bit_offset = self.offset();
+        let output_len: usize = slices.iter().map(|(start, end)| end - start).sum();
+
+        let mut out = BitBufferMut::with_capacity(output_len);
+        for &(start, end) in slices {
+            for idx in start..end {
+                out.append(get_bit(bools, bit_offset + idx)); // Panics if out of bounds.
+            }
+        }
+        *self = out;
+    }
 }
 
 impl<const NB: usize> Filter<BitView<'_, NB>> for &BitBuffer {
@@ -121,7 +197,7 @@ mod test {
     #[test]
     fn filter_bool_by_index_test() {
         let buf = bitbuffer![1 1 0];
-        let filtered = filter_indices(buf.inner().as_ref(), 0, &[0, 2]).freeze();
+        let filtered = (&buf).filter([0usize, 2].as_slice());
         assert_eq!(2, filtered.len());
         assert_eq!(filtered, bitbuffer![1 0])
     }

--- a/vortex-compute/src/filter/bitbuffer.rs
+++ b/vortex-compute/src/filter/bitbuffer.rs
@@ -17,6 +17,9 @@ impl Filter<Mask> for &BitBuffer {
     type Output = BitBuffer;
 
     fn filter(self, selection_mask: &Mask) -> BitBuffer {
+        // We delegate checking that the mask length is equal to self to the `MaskValues`
+        // filter implementation below.
+
         match selection_mask {
             Mask::AllTrue(_) => self.clone(),
             Mask::AllFalse(_) => BitBuffer::empty(),
@@ -42,6 +45,16 @@ impl Filter<MaskValues> for &BitBuffer {
 impl Filter<[usize]> for &BitBuffer {
     type Output = BitBuffer;
 
+    /// Filters by indices.
+    ///
+    /// The caller should ensure that the indices are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any index is out of bounds. With the additional constraint that the indices are
+    /// strictly increasing, the length of the indices must be less than or equal to the length of
+    /// `self`.
     fn filter(self, indices: &[usize]) -> BitBuffer {
         let bools = self.inner().as_ref();
         let bit_offset = self.offset();
@@ -58,6 +71,16 @@ impl Filter<[usize]> for &BitBuffer {
 impl Filter<[(usize, usize)]> for &BitBuffer {
     type Output = BitBuffer;
 
+    /// Filters by ranges of indices.
+    ///
+    /// The caller should ensure that the ranges are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any range is out of bounds. With the additional constraint that the ranges are
+    /// strictly increasing, the length of the `slices` array must be less than or equal to the
+    /// length of `self`.
     fn filter(self, slices: &[(usize, usize)]) -> BitBuffer {
         let bools = self.inner().as_ref();
         let bit_offset = self.offset();
@@ -80,6 +103,9 @@ impl Filter<Mask> for &mut BitBufferMut {
     type Output = ();
 
     fn filter(self, selection_mask: &Mask) {
+        // We delegate checking that the mask length is equal to self to the `MaskValues`
+        // filter implementation below.
+
         match selection_mask {
             Mask::AllTrue(_) => {}
             Mask::AllFalse(_) => self.clear(),
@@ -106,6 +132,16 @@ impl Filter<MaskValues> for &mut BitBufferMut {
 impl Filter<[usize]> for &mut BitBufferMut {
     type Output = ();
 
+    /// Filters by indices.
+    ///
+    /// The caller should ensure that the indices are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any index is out of bounds. With the additional constraint that the indices are
+    /// strictly increasing, the length of the indices must be less than or equal to the length of
+    /// `self`.
     fn filter(self, indices: &[usize]) {
         let bools = self.inner().as_slice();
         let bit_offset = self.offset();
@@ -121,6 +157,16 @@ impl Filter<[usize]> for &mut BitBufferMut {
 impl Filter<[(usize, usize)]> for &mut BitBufferMut {
     type Output = ();
 
+    /// Filters by ranges of indices.
+    ///
+    /// The caller should ensure that the ranges are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any range is out of bounds. With the additional constraint that the ranges are
+    /// strictly increasing, the length of the `slices` array must be less than or equal to the
+    /// length of `self`.
     fn filter(self, slices: &[(usize, usize)]) {
         let bools = self.inner().as_slice();
         let bit_offset = self.offset();

--- a/vortex-compute/src/filter/buffer.rs
+++ b/vortex-compute/src/filter/buffer.rs
@@ -16,6 +16,9 @@ where
 {
     type Output = Self;
 
+    /// Filters a `Buffer` according to some selection mask.
+    ///
+    /// This will attempt to filter in-place if possible.
     fn filter(self, selection_mask: &M) -> Self {
         // If we have exclusive access, we can perform the filter in place.
         match self.try_into_mut() {
@@ -33,6 +36,9 @@ impl<T: Copy> Filter<Mask> for &Buffer<T> {
     type Output = Buffer<T>;
 
     fn filter(self, selection_mask: &Mask) -> Buffer<T> {
+        // We delegate checking that the mask length is equal to self to the `MaskValues`
+        // filter implementation below.
+
         match selection_mask {
             Mask::AllTrue(_) => self.clone(),
             Mask::AllFalse(_) => Buffer::empty(),
@@ -45,6 +51,7 @@ impl<T: Copy> Filter<MaskValues> for &Buffer<T> {
     type Output = Buffer<T>;
 
     fn filter(self, mask_values: &MaskValues) -> Buffer<T> {
+        // Delegates to the filter implementation over slices.
         self.as_slice().filter(mask_values)
     }
 }
@@ -52,7 +59,18 @@ impl<T: Copy> Filter<MaskValues> for &Buffer<T> {
 impl<T: Copy> Filter<[usize]> for &Buffer<T> {
     type Output = Buffer<T>;
 
+    /// Filters by indices.
+    ///
+    /// The caller should ensure that the indices are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any index is out of bounds. With the additional constraint that the indices are
+    /// strictly increasing, the length of the indices must be less than or equal to the length of
+    /// `self`.
     fn filter(self, indices: &[usize]) -> Buffer<T> {
+        // Delegates to the filter implementation over slices.
         self.as_slice().filter(indices)
     }
 }
@@ -60,7 +78,18 @@ impl<T: Copy> Filter<[usize]> for &Buffer<T> {
 impl<T: Copy> Filter<[(usize, usize)]> for &Buffer<T> {
     type Output = Buffer<T>;
 
+    /// Filters by ranges of indices.
+    ///
+    /// The caller should ensure that the ranges are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any range is out of bounds. With the additional constraint that the ranges are
+    /// strictly increasing, the length of the `slices` array must be less than or equal to the
+    /// length of `self`.
     fn filter(self, slices: &[(usize, usize)]) -> Buffer<T> {
+        // Delegates to the filter implementation over slices.
         self.as_slice().filter(slices)
     }
 }
@@ -69,6 +98,7 @@ impl<const NB: usize, T: Copy> Filter<BitView<'_, NB>> for &Buffer<T> {
     type Output = Buffer<T>;
 
     fn filter(self, selection: &BitView<'_, NB>) -> Self::Output {
+        // Delegates to the filter implementation over slices.
         self.as_slice().filter(selection)
     }
 }
@@ -80,6 +110,8 @@ where
     type Output = ();
 
     fn filter(self, selection_mask: &M) -> Self::Output {
+        // Delegates to the filter implementation over slices, as that is also an in-place
+        // operation.
         let true_count = self.as_mut_slice().filter(selection_mask).len();
         self.truncate(true_count);
     }
@@ -230,14 +262,5 @@ mod tests {
         buf.filter(&mask);
         let expected: Vec<u32> = (0..1000).filter(|i| i % 3 == 0).collect();
         assert_eq!(buf.as_slice(), &expected[..]);
-    }
-
-    #[test]
-    #[should_panic(expected = "Mask length must equal the slice length")]
-    fn test_filter_length_mismatch() {
-        let mut buf = buffer_mut![1u32, 2, 3];
-        let mask = Mask::new_true(5); // Wrong length.
-
-        buf.filter(&mask);
     }
 }

--- a/vortex-compute/src/filter/buffer.rs
+++ b/vortex-compute/src/filter/buffer.rs
@@ -5,12 +5,9 @@ use vortex_buffer::BitView;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_mask::Mask;
-use vortex_mask::MaskIter;
+use vortex_mask::MaskValues;
 
 use crate::filter::Filter;
-
-// This is modeled after the constant with the equivalent name in arrow-rs.
-const FILTER_SLICES_SELECTIVITY_THRESHOLD: f64 = 0.8;
 
 impl<M, T: Copy> Filter<M> for Buffer<T>
 where
@@ -36,22 +33,35 @@ impl<T: Copy> Filter<Mask> for &Buffer<T> {
     type Output = Buffer<T>;
 
     fn filter(self, selection_mask: &Mask) -> Buffer<T> {
-        assert_eq!(
-            selection_mask.len(),
-            self.len(),
-            "Selection mask length must equal the buffer length"
-        );
-
         match selection_mask {
             Mask::AllTrue(_) => self.clone(),
             Mask::AllFalse(_) => Buffer::empty(),
-            Mask::Values(v) => match v.threshold_iter(FILTER_SLICES_SELECTIVITY_THRESHOLD) {
-                MaskIter::Indices(indices) => filter_indices(self.as_slice(), indices),
-                MaskIter::Slices(slices) => {
-                    filter_slices(self.as_slice(), selection_mask.true_count(), slices)
-                }
-            },
+            Mask::Values(v) => self.filter(v.as_ref()),
         }
+    }
+}
+
+impl<T: Copy> Filter<MaskValues> for &Buffer<T> {
+    type Output = Buffer<T>;
+
+    fn filter(self, mask_values: &MaskValues) -> Buffer<T> {
+        self.as_slice().filter(mask_values)
+    }
+}
+
+impl<T: Copy> Filter<[usize]> for &Buffer<T> {
+    type Output = Buffer<T>;
+
+    fn filter(self, indices: &[usize]) -> Buffer<T> {
+        self.as_slice().filter(indices)
+    }
+}
+
+impl<T: Copy> Filter<[(usize, usize)]> for &Buffer<T> {
+    type Output = Buffer<T>;
+
+    fn filter(self, slices: &[(usize, usize)]) -> Buffer<T> {
+        self.as_slice().filter(slices)
     }
 }
 
@@ -73,18 +83,6 @@ where
         let true_count = self.as_mut_slice().filter(selection_mask).len();
         self.truncate(true_count);
     }
-}
-
-fn filter_indices<T: Copy>(values: &[T], indices: &[usize]) -> Buffer<T> {
-    Buffer::<T>::from_trusted_len_iter(indices.iter().map(|&idx| values[idx]))
-}
-
-fn filter_slices<T>(values: &[T], output_len: usize, slices: &[(usize, usize)]) -> Buffer<T> {
-    let mut out = BufferMut::<T>::with_capacity(output_len);
-    for (start, end) in slices {
-        out.extend_from_slice(&values[*start..*end]);
-    }
-    out.freeze()
 }
 
 #[cfg(test)]
@@ -126,14 +124,14 @@ mod tests {
     #[test]
     fn test_filter_indices_direct() {
         let buf = buffer![100u32, 200, 300, 400];
-        let result = filter_indices(buf.as_slice(), &[0, 2, 3]);
+        let result = (&buf).filter([0usize, 2, 3].as_slice());
         assert_eq!(result, buffer![100u32, 300, 400]);
     }
 
     #[test]
     fn test_filter_slices_direct() {
         let buf = buffer![1u32, 2, 3, 4, 5];
-        let result = filter_slices(buf.as_slice(), 3, &[(0, 2), (4, 5)]);
+        let result = (&buf).filter([(0usize, 2), (4, 5)].as_slice());
         assert_eq!(result, buffer![1u32, 2, 5]);
     }
 

--- a/vortex-compute/src/filter/mask.rs
+++ b/vortex-compute/src/filter/mask.rs
@@ -13,6 +13,9 @@ impl Filter<Mask> for &Mask {
     type Output = Mask;
 
     fn filter(self, selection_mask: &Mask) -> Mask {
+        // We delegate checking that the mask length is equal to self to the `MaskValues`
+        // filter implementation below.
+
         match (self, selection_mask) {
             (Mask::AllTrue(_), _) => Mask::AllTrue(selection_mask.true_count()),
             (Mask::AllFalse(_), _) => Mask::AllFalse(selection_mask.true_count()),
@@ -45,6 +48,16 @@ impl Filter<MaskValues> for &Mask {
 impl Filter<[usize]> for &Mask {
     type Output = Mask;
 
+    /// Filters by indices.
+    ///
+    /// The caller should ensure that the indices are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any index is out of bounds. With the additional constraint that the indices are
+    /// strictly increasing, the length of the indices must be less than or equal to the length of
+    /// `self`.
     fn filter(self, indices: &[usize]) -> Mask {
         match self {
             Mask::AllTrue(_) => Mask::AllTrue(indices.len()),
@@ -57,6 +70,16 @@ impl Filter<[usize]> for &Mask {
 impl Filter<[(usize, usize)]> for &Mask {
     type Output = Mask;
 
+    /// Filters by ranges of indices.
+    ///
+    /// The caller should ensure that the ranges are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any range is out of bounds. With the additional constraint that the ranges are
+    /// strictly increasing, the length of the `slices` array must be less than or equal to the
+    /// length of `self`.
     fn filter(self, slices: &[(usize, usize)]) -> Mask {
         let output_len: usize = slices.iter().map(|(start, end)| end - start).sum();
         match self {
@@ -83,6 +106,9 @@ impl Filter<Mask> for &mut MaskMut {
     type Output = ();
 
     fn filter(self, selection_mask: &Mask) {
+        // We delegate checking that the mask length is equal to self to the `MaskValues`
+        // filter implementation below.
+
         match selection_mask {
             Mask::AllTrue(_) => {}
             Mask::AllFalse(_) => self.clear(),
@@ -110,6 +136,16 @@ impl Filter<MaskValues> for &mut MaskMut {
 impl Filter<[usize]> for &mut MaskMut {
     type Output = ();
 
+    /// Filters by indices.
+    ///
+    /// The caller should ensure that the indices are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any index is out of bounds. With the additional constraint that the indices are
+    /// strictly increasing, the length of the indices must be less than or equal to the length of
+    /// `self`.
     fn filter(self, indices: &[usize]) {
         // TODO(connor): There is definitely a better way to do this (in place).
         let filtered = self.clone().freeze().filter(indices).into_mut();
@@ -120,6 +156,16 @@ impl Filter<[usize]> for &mut MaskMut {
 impl Filter<[(usize, usize)]> for &mut MaskMut {
     type Output = ();
 
+    /// Filters by ranges of indices.
+    ///
+    /// The caller should ensure that the ranges are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any range is out of bounds. With the additional constraint that the ranges are
+    /// strictly increasing, the length of the `slices` array must be less than or equal to the
+    /// length of `self`.
     fn filter(self, slices: &[(usize, usize)]) {
         // TODO(connor): There is definitely a better way to do this (in place).
         let filtered = self.clone().freeze().filter(slices).into_mut();

--- a/vortex-compute/src/filter/mask.rs
+++ b/vortex-compute/src/filter/mask.rs
@@ -5,6 +5,7 @@ use vortex_buffer::BitView;
 use vortex_error::VortexExpect;
 use vortex_mask::Mask;
 use vortex_mask::MaskMut;
+use vortex_mask::MaskValues;
 
 use crate::filter::Filter;
 
@@ -12,21 +13,56 @@ impl Filter<Mask> for &Mask {
     type Output = Mask;
 
     fn filter(self, selection_mask: &Mask) -> Mask {
-        assert_eq!(
-            selection_mask.len(),
-            self.len(),
-            "Selection mask length must equal the mask length"
-        );
-
         match (self, selection_mask) {
             (Mask::AllTrue(_), _) => Mask::AllTrue(selection_mask.true_count()),
             (Mask::AllFalse(_), _) => Mask::AllFalse(selection_mask.true_count()),
 
             (Mask::Values(_), Mask::AllTrue(_)) => self.clone(),
             (Mask::Values(_), Mask::AllFalse(_)) => Mask::new_true(0),
-            (Mask::Values(v1), Mask::Values(_)) => {
-                Mask::from(v1.bit_buffer().filter(selection_mask))
-            }
+            (Mask::Values(_), Mask::Values(v2)) => self.filter(v2.as_ref()),
+        }
+    }
+}
+
+impl Filter<MaskValues> for &Mask {
+    type Output = Mask;
+
+    fn filter(self, mask_values: &MaskValues) -> Mask {
+        assert_eq!(
+            mask_values.len(),
+            self.len(),
+            "Selection mask length must equal the mask length"
+        );
+
+        match self {
+            Mask::AllTrue(_) => Mask::AllTrue(mask_values.true_count()),
+            Mask::AllFalse(_) => Mask::AllFalse(mask_values.true_count()),
+            Mask::Values(v) => Mask::from(v.bit_buffer().filter(mask_values)),
+        }
+    }
+}
+
+impl Filter<[usize]> for &Mask {
+    type Output = Mask;
+
+    fn filter(self, indices: &[usize]) -> Mask {
+        match self {
+            Mask::AllTrue(_) => Mask::AllTrue(indices.len()),
+            Mask::AllFalse(_) => Mask::AllFalse(indices.len()),
+            Mask::Values(v) => Mask::from(v.bit_buffer().filter(indices)),
+        }
+    }
+}
+
+impl Filter<[(usize, usize)]> for &Mask {
+    type Output = Mask;
+
+    fn filter(self, slices: &[(usize, usize)]) -> Mask {
+        let output_len: usize = slices.iter().map(|(start, end)| end - start).sum();
+        match self {
+            Mask::AllTrue(_) => Mask::AllTrue(output_len),
+            Mask::AllFalse(_) => Mask::AllFalse(output_len),
+            Mask::Values(v) => Mask::from(v.bit_buffer().filter(slices)),
         }
     }
 }
@@ -47,14 +83,46 @@ impl Filter<Mask> for &mut MaskMut {
     type Output = ();
 
     fn filter(self, selection_mask: &Mask) {
+        match selection_mask {
+            Mask::AllTrue(_) => {}
+            Mask::AllFalse(_) => self.clear(),
+            Mask::Values(v) => self.filter(v.as_ref()),
+        }
+    }
+}
+
+impl Filter<MaskValues> for &mut MaskMut {
+    type Output = ();
+
+    fn filter(self, mask_values: &MaskValues) {
         assert_eq!(
-            selection_mask.len(),
+            mask_values.len(),
             self.len(),
             "Selection mask length must equal the mask length"
         );
 
         // TODO(connor): There is definitely a better way to do this (in place).
-        let filtered = self.clone().freeze().filter(selection_mask).into_mut();
+        let filtered = self.clone().freeze().filter(mask_values).into_mut();
+        *self = filtered;
+    }
+}
+
+impl Filter<[usize]> for &mut MaskMut {
+    type Output = ();
+
+    fn filter(self, indices: &[usize]) {
+        // TODO(connor): There is definitely a better way to do this (in place).
+        let filtered = self.clone().freeze().filter(indices).into_mut();
+        *self = filtered;
+    }
+}
+
+impl Filter<[(usize, usize)]> for &mut MaskMut {
+    type Output = ();
+
+    fn filter(self, slices: &[(usize, usize)]) {
+        // TODO(connor): There is definitely a better way to do this (in place).
+        let filtered = self.clone().freeze().filter(slices).into_mut();
         *self = filtered;
     }
 }

--- a/vortex-compute/src/filter/slice.rs
+++ b/vortex-compute/src/filter/slice.rs
@@ -17,6 +17,7 @@ use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_mask::Mask;
 use vortex_mask::MaskIter;
+use vortex_mask::MaskValues;
 
 use crate::filter::Filter;
 
@@ -24,39 +25,50 @@ impl<T: Copy> Filter<Mask> for &[T] {
     type Output = Buffer<T>;
 
     fn filter(self, selection_mask: &Mask) -> Buffer<T> {
-        assert_eq!(
-            selection_mask.len(),
-            self.len(),
-            "Selection mask length must equal the buffer length"
-        );
-
         match selection_mask {
             Mask::AllTrue(_) => Buffer::<T>::copy_from(self),
             Mask::AllFalse(_) => Buffer::empty(),
-            Mask::Values(v) => match v.threshold_iter(FILTER_SLICES_SELECTIVITY_THRESHOLD) {
-                MaskIter::Indices(indices) => filter_indices(self, indices),
-                MaskIter::Slices(slices) => {
-                    filter_slices(self, selection_mask.true_count(), slices).freeze()
-                }
-            },
+            Mask::Values(v) => self.filter(v.as_ref()),
         }
     }
 }
 
-pub(super) fn filter_indices<T: Copy>(values: &[T], indices: &[usize]) -> Buffer<T> {
-    Buffer::<T>::from_trusted_len_iter(indices.iter().map(|&idx| values[idx]))
+impl<T: Copy> Filter<MaskValues> for &[T] {
+    type Output = Buffer<T>;
+
+    fn filter(self, mask_values: &MaskValues) -> Buffer<T> {
+        assert_eq!(
+            mask_values.len(),
+            self.len(),
+            "Selection mask length must equal the buffer length"
+        );
+
+        match mask_values.threshold_iter(FILTER_SLICES_SELECTIVITY_THRESHOLD) {
+            MaskIter::Indices(indices) => self.filter(indices),
+            MaskIter::Slices(slices) => self.filter(slices),
+        }
+    }
 }
 
-pub(super) fn filter_slices<T>(
-    values: &[T],
-    output_len: usize,
-    slices: &[(usize, usize)],
-) -> BufferMut<T> {
-    let mut out = BufferMut::<T>::with_capacity(output_len);
-    for (start, end) in slices {
-        out.extend_from_slice(&values[*start..*end]);
+impl<T: Copy> Filter<[usize]> for &[T] {
+    type Output = Buffer<T>;
+
+    fn filter(self, indices: &[usize]) -> Buffer<T> {
+        Buffer::<T>::from_trusted_len_iter(indices.iter().map(|&idx| self[idx]))
     }
-    out
+}
+
+impl<T: Copy> Filter<[(usize, usize)]> for &[T] {
+    type Output = Buffer<T>;
+
+    fn filter(self, slices: &[(usize, usize)]) -> Buffer<T> {
+        let output_len: usize = slices.iter().map(|(start, end)| end - start).sum();
+        let mut out = BufferMut::<T>::with_capacity(output_len);
+        for (start, end) in slices {
+            out.extend_from_slice(&self[*start..*end]);
+        }
+        out.freeze()
+    }
 }
 
 impl<const NB: usize, T: Copy> Filter<BitView<'_, NB>> for &[T] {

--- a/vortex-compute/src/filter/slice.rs
+++ b/vortex-compute/src/filter/slice.rs
@@ -25,6 +25,9 @@ impl<T: Copy> Filter<Mask> for &[T] {
     type Output = Buffer<T>;
 
     fn filter(self, selection_mask: &Mask) -> Buffer<T> {
+        // We delegate checking that the mask length is equal to self to the `MaskValues`
+        // filter implementation below.
+
         match selection_mask {
             Mask::AllTrue(_) => Buffer::<T>::copy_from(self),
             Mask::AllFalse(_) => Buffer::empty(),
@@ -53,6 +56,16 @@ impl<T: Copy> Filter<MaskValues> for &[T] {
 impl<T: Copy> Filter<[usize]> for &[T] {
     type Output = Buffer<T>;
 
+    /// Filters by indices.
+    ///
+    /// The caller should ensure that the indices are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any index is out of bounds. With the additional constraint that the indices are
+    /// strictly increasing, the length of the indices must be less than or equal to the length of
+    /// `self`.
     fn filter(self, indices: &[usize]) -> Buffer<T> {
         Buffer::<T>::from_trusted_len_iter(indices.iter().map(|&idx| self[idx]))
     }
@@ -61,12 +74,24 @@ impl<T: Copy> Filter<[usize]> for &[T] {
 impl<T: Copy> Filter<[(usize, usize)]> for &[T] {
     type Output = Buffer<T>;
 
+    /// Filters by ranges of indices.
+    ///
+    /// The caller should ensure that the ranges are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any range is out of bounds. With the additional constraint that the ranges are
+    /// strictly increasing, the length of the `slices` array must be less than or equal to the
+    /// length of `self`.
     fn filter(self, slices: &[(usize, usize)]) -> Buffer<T> {
         let output_len: usize = slices.iter().map(|(start, end)| end - start).sum();
+
         let mut out = BufferMut::<T>::with_capacity(output_len);
         for (start, end) in slices {
             out.extend_from_slice(&self[*start..*end]);
         }
+
         out.freeze()
     }
 }

--- a/vortex-compute/src/filter/slice_mut.rs
+++ b/vortex-compute/src/filter/slice_mut.rs
@@ -19,11 +19,9 @@ impl<T: Copy> Filter<Mask> for &mut [T] {
     type Output = Self;
 
     fn filter(self, selection: &Mask) -> Self::Output {
-        assert_eq!(
-            self.len(),
-            selection.len(),
-            "Mask length must equal the slice length"
-        );
+        // We delegate checking that the mask length is equal to self to the `MaskValues`
+        // filter implementation below.
+
         match selection {
             Mask::AllTrue(_) => self,
             Mask::AllFalse(_) => &mut self[..0],
@@ -52,6 +50,16 @@ impl<T: Copy> Filter<MaskValues> for &mut [T] {
 impl<T: Copy> Filter<[usize]> for &mut [T] {
     type Output = Self;
 
+    /// Filters by indices.
+    ///
+    /// The caller should ensure that the indices are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any index is out of bounds. With the additional constraint that the indices are
+    /// strictly increasing, the length of the indices must be less than or equal to the length of
+    /// `self`.
     fn filter(self, indices: &[usize]) -> Self::Output {
         let mut write_pos = 0;
 
@@ -74,6 +82,16 @@ impl<T: Copy> Filter<[usize]> for &mut [T] {
 impl<T: Copy> Filter<[(usize, usize)]> for &mut [T] {
     type Output = Self;
 
+    /// Filters by ranges of indices.
+    ///
+    /// The caller should ensure that the ranges are strictly increasing, otherwise the resulting
+    /// buffer might have strange values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any range is out of bounds. With the additional constraint that the ranges are
+    /// strictly increasing, the length of the `slices` array must be less than or equal to the
+    /// length of `self`.
     fn filter(self, slices: &[(usize, usize)]) -> Self::Output {
         let mut write_pos = 0;
 

--- a/vortex-compute/src/filter/slice_mut.rs
+++ b/vortex-compute/src/filter/slice_mut.rs
@@ -11,6 +11,7 @@ use std::ptr;
 
 use vortex_buffer::BitView;
 use vortex_mask::Mask;
+use vortex_mask::MaskValues;
 
 use crate::filter::Filter;
 
@@ -26,53 +27,76 @@ impl<T: Copy> Filter<Mask> for &mut [T] {
         match selection {
             Mask::AllTrue(_) => self,
             Mask::AllFalse(_) => &mut self[..0],
-            Mask::Values(v) => {
-                // We choose to _always_ use slices here because iterating over indices will have
-                // strictly more loop iterations than slices, and the overhead over batched
-                // `ptr::copy(len)` is not worth it.
-                let slices = v.slices();
-
-                // SAFETY: We checked above that the selection mask has the same length as the
-                // buffer.
-                unsafe { filter_slices_in_place(self, slices) }
-            }
+            Mask::Values(v) => self.filter(v.as_ref()),
         }
     }
 }
 
-/// Filters a buffer in-place using slice ranges to determine which values to keep.
-///
-/// Returns the new length of the buffer.
-///
-/// # Safety
-///
-/// The slice ranges must be in the range of the `buffer`.
-unsafe fn filter_slices_in_place<'a, T: Copy>(
-    buffer: &'a mut [T],
-    slices: &[(usize, usize)],
-) -> &'a mut [T] {
-    let mut write_pos = 0;
+impl<T: Copy> Filter<MaskValues> for &mut [T] {
+    type Output = Self;
 
-    // For each range in the selection, copy all of the elements to the current write position.
-    for &(start, end) in slices {
-        // Note that we could add an if statement here that checks `if read_idx != write_idx`, but
-        // it's probably better to just avoid the branch misprediction.
+    fn filter(self, mask_values: &MaskValues) -> Self::Output {
+        assert_eq!(
+            self.len(),
+            mask_values.len(),
+            "Mask length must equal the slice length"
+        );
 
-        let len = end - start;
-
-        // SAFETY: The safety contract enforces that all ranges are within bounds.
-        unsafe {
-            ptr::copy(
-                buffer.as_ptr().add(start),
-                buffer.as_mut_ptr().add(write_pos),
-                len,
-            )
-        };
-
-        write_pos += len;
+        // We choose to _always_ use slices here because iterating over indices will have strictly
+        // more loop iterations than slices (more branches), and the overhead over batched
+        // `ptr::copy(len)` is not that high.
+        self.filter(mask_values.slices())
     }
+}
 
-    &mut buffer[..write_pos]
+impl<T: Copy> Filter<[usize]> for &mut [T] {
+    type Output = Self;
+
+    fn filter(self, indices: &[usize]) -> Self::Output {
+        let mut write_pos = 0;
+
+        for &idx in indices {
+            // SAFETY: indices should be within bounds and we're copying one element at a time.
+            unsafe {
+                ptr::copy_nonoverlapping(
+                    self.as_ptr().add(idx),
+                    self.as_mut_ptr().add(write_pos),
+                    1,
+                )
+            };
+            write_pos += 1;
+        }
+
+        &mut self[..write_pos]
+    }
+}
+
+impl<T: Copy> Filter<[(usize, usize)]> for &mut [T] {
+    type Output = Self;
+
+    fn filter(self, slices: &[(usize, usize)]) -> Self::Output {
+        let mut write_pos = 0;
+
+        // For each range in the selection, copy all of the elements to the current write position.
+        for &(start, end) in slices {
+            // Note that we could add an if statement here that checks `if start != write_pos`, but
+            // it's probably better to just avoid the branch misprediction.
+            let len = end - start;
+
+            // SAFETY: Slices should be within bounds.
+            unsafe {
+                ptr::copy(
+                    self.as_ptr().add(start),
+                    self.as_mut_ptr().add(write_pos),
+                    len,
+                )
+            };
+
+            write_pos += len;
+        }
+
+        &mut self[..write_pos]
+    }
 }
 
 impl<'a, const NB: usize, T: Copy> Filter<BitView<'a, NB>> for &mut [T] {


### PR DESCRIPTION
Makes sure the filter execute implementations use the existing filter implementations that we have in `vortex-compute`.

While this probably won't make a huge difference is performance now, it is nice to have this in 1 place rather than duplicated (sometimes incorrectly/not as performant).

This should be enough to get `FilterArray` in a place that is stable enough to use elsewhere.

Note that this is dependent on https://github.com/vortex-data/vortex/pull/6173