### PR TITLE
Stop IO event stream once there are no more senders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10595,6 +10595,7 @@ dependencies = [
 name = "vortex-file"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bytes",
  "flatbuffers",

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -58,6 +58,7 @@ vortex-zigzag = { workspace = true }
 vortex-zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 vortex-array = { workspace = true, features = ["_test-harness"] }
 vortex-io = { workspace = true, features = ["tokio"] }

--- a/vortex-file/src/read/events.rs
+++ b/vortex-file/src/read/events.rs
@@ -1,18 +1,21 @@
-use std::{
-    pin::Pin,
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
-    task::ready,
-    task::{Context, Poll},
-};
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use futures::{
-    Stream, StreamExt,
-    channel::mpsc::{TrySendError, UnboundedReceiver, UnboundedSender, unbounded},
-    stream::FusedStream,
-};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+
+use futures::Stream;
+use futures::StreamExt;
+use futures::channel::mpsc::TrySendError;
+use futures::channel::mpsc::UnboundedReceiver;
+use futures::channel::mpsc::UnboundedSender;
+use futures::channel::mpsc::unbounded;
+use futures::stream::FusedStream;
+use vortex_error::vortex_panic;
 
 use crate::segments::ReadEvent;
 
@@ -87,14 +90,14 @@ impl Stream for EventsReceiver {
 
         if self.num_senders.load(Ordering::SeqCst) == 0 {
             if std::env::var("PANIC_EVENTS").is_ok() {
-                panic!("Oops");
+                vortex_panic!("Oops");
             }
 
             self.is_done = true;
             return Poll::Ready(None);
         }
 
-        return self.inner.poll_next_unpin(cx);
+        self.inner.poll_next_unpin(cx)
     }
 }
 

--- a/vortex-file/src/read/events.rs
+++ b/vortex-file/src/read/events.rs
@@ -1,0 +1,105 @@
+use std::{
+    pin::Pin,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::ready,
+    task::{Context, Poll},
+};
+
+use futures::{
+    Stream, StreamExt,
+    channel::mpsc::{TrySendError, UnboundedReceiver, UnboundedSender, unbounded},
+    stream::FusedStream,
+};
+
+use crate::segments::ReadEvent;
+
+pub struct EventsChannel;
+
+pub struct EventsReceiver {
+    inner: UnboundedReceiver<ReadEvent>,
+    num_senders: Arc<AtomicUsize>,
+    is_done: bool,
+}
+
+impl EventsReceiver {
+    fn new(inner: UnboundedReceiver<ReadEvent>, num_senders: Arc<AtomicUsize>) -> Self {
+        Self {
+            inner,
+            num_senders,
+            is_done: false,
+        }
+    }
+}
+
+pub struct EventsSender {
+    inner: UnboundedSender<ReadEvent>,
+    num_senders: Arc<AtomicUsize>,
+}
+
+impl Clone for EventsSender {
+    fn clone(&self) -> Self {
+        self.num_senders.fetch_add(1, Ordering::SeqCst);
+        Self {
+            inner: self.inner.clone(),
+            num_senders: self.num_senders.clone(),
+        }
+    }
+}
+
+impl Drop for EventsSender {
+    fn drop(&mut self) {
+        self.num_senders.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+impl EventsSender {
+    fn new(inner: UnboundedSender<ReadEvent>, num_senders: Arc<AtomicUsize>) -> Self {
+        Self { inner, num_senders }
+    }
+
+    pub fn unbounded_send(&self, read_event: ReadEvent) -> Result<(), TrySendError<ReadEvent>> {
+        self.inner.unbounded_send(read_event)
+    }
+}
+
+impl EventsChannel {
+    pub fn unbounded() -> (EventsSender, EventsReceiver) {
+        let (tx, rx) = unbounded();
+        let num_senders = Arc::new(AtomicUsize::new(1));
+
+        (
+            EventsSender::new(tx, num_senders.clone()),
+            EventsReceiver::new(rx, num_senders),
+        )
+    }
+}
+
+impl Stream for EventsReceiver {
+    type Item = ReadEvent;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.is_done || self.inner.is_terminated() {
+            return Poll::Ready(None);
+        }
+
+        if self.num_senders.load(Ordering::SeqCst) == 0 {
+            if std::env::var("PANIC_EVENTS").is_ok() {
+                panic!("Oops");
+            }
+
+            self.is_done = true;
+            return Poll::Ready(None);
+        }
+
+        return self.inner.poll_next_unpin(cx);
+    }
+}
+
+impl FusedStream for EventsReceiver {
+    fn is_terminated(&self) -> bool {
+        self.is_done || self.inner.is_terminated()
+    }
+}

--- a/vortex-file/src/read/events.rs
+++ b/vortex-file/src/read/events.rs
@@ -15,14 +15,14 @@ use futures::channel::mpsc::UnboundedReceiver;
 use futures::channel::mpsc::UnboundedSender;
 use futures::channel::mpsc::unbounded;
 use futures::stream::FusedStream;
-use vortex_error::vortex_panic;
+use vortex_error::VortexExpect;
 
 use crate::segments::ReadEvent;
 
 pub struct EventsChannel;
 
 pub struct EventsReceiver {
-    inner: UnboundedReceiver<ReadEvent>,
+    inner: Option<UnboundedReceiver<ReadEvent>>,
     num_senders: Arc<AtomicUsize>,
     is_done: bool,
 }
@@ -30,10 +30,15 @@ pub struct EventsReceiver {
 impl EventsReceiver {
     fn new(inner: UnboundedReceiver<ReadEvent>, num_senders: Arc<AtomicUsize>) -> Self {
         Self {
-            inner,
+            inner: Some(inner),
             num_senders,
             is_done: false,
         }
+    }
+
+    fn terminate(&mut self) {
+        self.is_done = true;
+        self.inner.take();
     }
 }
 
@@ -84,25 +89,58 @@ impl Stream for EventsReceiver {
     type Item = ReadEvent;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if self.is_done || self.inner.is_terminated() {
+        if self.is_done || self.inner.as_ref().is_some_and(|rx| rx.is_terminated()) {
+            self.terminate();
             return Poll::Ready(None);
         }
 
         if self.num_senders.load(Ordering::SeqCst) == 0 {
-            if std::env::var("PANIC_EVENTS").is_ok() {
-                vortex_panic!("Oops");
-            }
+            self.terminate();
 
-            self.is_done = true;
             return Poll::Ready(None);
         }
 
-        self.inner.poll_next_unpin(cx)
+        self.inner
+            .as_mut()
+            .vortex_expect("Must exist here")
+            .poll_next_unpin(cx)
     }
 }
 
 impl FusedStream for EventsReceiver {
     fn is_terminated(&self) -> bool {
-        self.is_done || self.inner.is_terminated()
+        self.is_done || self.inner.as_ref().is_some_and(|rx| rx.is_terminated())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use futures::future::FusedFuture;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cancellation_no_senders() -> anyhow::Result<()> {
+        let (tx, mut rx) = EventsChannel::unbounded();
+        tx.unbounded_send(ReadEvent::Polled(1))?;
+        tx.unbounded_send(ReadEvent::Polled(2))?;
+        tx.unbounded_send(ReadEvent::Polled(3))?;
+        let tx2 = tx.clone();
+        tx2.unbounded_send(ReadEvent::Polled(4))?;
+
+        assert!(rx.next().await.is_some());
+        assert!(rx.next().await.is_some());
+
+        drop(tx);
+        assert!(rx.next().await.is_some());
+        drop(tx2);
+
+        // We technically still have one event, but we stop anyway.
+        assert!(rx.next().await.is_none());
+        assert!(rx.next().is_terminated());
+        assert!(rx.next().await.is_none());
+
+        Ok(())
     }
 }

--- a/vortex-file/src/read/mod.rs
+++ b/vortex-file/src/read/mod.rs
@@ -2,8 +2,10 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 mod driver;
+mod events;
 mod request;
 
 pub(crate) use driver::IoRequestStream;
+pub(crate) use events::{EventsChannel, EventsReceiver, EventsSender};
 pub(crate) use request::ReadRequest;
 pub(crate) use request::RequestId;

--- a/vortex-file/src/read/mod.rs
+++ b/vortex-file/src/read/mod.rs
@@ -6,6 +6,7 @@ mod events;
 mod request;
 
 pub(crate) use driver::IoRequestStream;
-pub(crate) use events::{EventsChannel, EventsReceiver, EventsSender};
+pub(crate) use events::EventsChannel;
+pub(crate) use events::EventsSender;
 pub(crate) use request::ReadRequest;
 pub(crate) use request::RequestId;

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -72,7 +72,6 @@ impl FileSegmentSource {
         handle: Handle,
         metrics: VortexMetrics,
     ) -> Self {
-        // let (send, recv) = mpsc::unbounded();
         let (send, recv) = EventsChannel::unbounded();
 
         let max_alignment = segments

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -11,7 +11,6 @@ use std::task::Poll;
 
 use futures::FutureExt;
 use futures::StreamExt;
-use futures::channel::mpsc;
 use vortex_array::buffer::BufferHandle;
 use vortex_buffer::Alignment;
 use vortex_error::VortexResult;

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -24,6 +24,8 @@ use vortex_layout::segments::SegmentSource;
 use vortex_metrics::VortexMetrics;
 
 use crate::SegmentSpec;
+use crate::read::EventsChannel;
+use crate::read::EventsSender;
 use crate::read::IoRequestStream;
 use crate::read::ReadRequest;
 use crate::read::RequestId;
@@ -59,7 +61,7 @@ pub enum ReadEvent {
 pub struct FileSegmentSource {
     segments: Arc<[SegmentSpec]>,
     /// A queue for sending read request events to the I/O stream.
-    events: mpsc::UnboundedSender<ReadEvent>,
+    events: EventsSender,
     /// The next read request ID.
     next_id: Arc<AtomicUsize>,
 }
@@ -71,7 +73,8 @@ impl FileSegmentSource {
         handle: Handle,
         metrics: VortexMetrics,
     ) -> Self {
-        let (send, recv) = mpsc::unbounded();
+        // let (send, recv) = mpsc::unbounded();
+        let (send, recv) = EventsChannel::unbounded();
 
         let max_alignment = segments
             .iter()
@@ -144,8 +147,10 @@ impl SegmentSource for FileSegmentSource {
 
             // If we fail to submit the event, we create a future that has failed.
             if let Err(e) = self.events.unbounded_send(event) {
-                return async move { Err(vortex_err!("Failed to submit read request: {e}")) }
-                    .boxed();
+                return std::future::ready({
+                    Err(vortex_err!("Failed to submit read request: {e}"))
+                })
+                .boxed();
             }
 
             ReadFuture {
@@ -174,7 +179,7 @@ struct ReadFuture {
     id: usize,
     recv: oneshot::Receiver<VortexResult<BufferHandle>>,
     polled: bool,
-    events: mpsc::UnboundedSender<ReadEvent>,
+    events: EventsSender,
 }
 
 impl Future for ReadFuture {

--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -202,8 +202,6 @@ impl Future for ReadFuture {
 
 impl Drop for ReadFuture {
     fn drop(&mut self) {
-        // When the FileHandle is dropped, we can send a shutdown event to the I/O stream.
-        // If the I/O stream has already been dropped, this will fail silently.
         drop(self.events.unbounded_send(ReadEvent::Dropped(self.id)));
     }
 }


### PR DESCRIPTION
Implement a stream that wraps the underlying event channels, that stop once all senders are dropped, which I understand the flow correctly only happens once all read futures and the `FileSegmentSource` are dropped.
When running benchmarks its very easy to trigger that case, in which case the background task will keep processing work that no one consumes.