### PR TITLE
fix[cuda]: Fix gpu_scan test

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::ops::Range;
 
 use vortex_array::Array;
 use vortex_array::ArrayBufferVisitor;
@@ -14,7 +13,6 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::DeserializeMetadata;
 use vortex_array::ExecutionCtx;
-use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
@@ -172,21 +170,6 @@ impl VTable for ALPVTable {
             array.clone(),
             ctx,
         )?))
-    }
-
-    fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
-        Ok(Some(
-            ALPArray::new(
-                array.encoded().slice(range.clone())?,
-                array.exponents(),
-                array
-                    .patches()
-                    .map(|p| p.slice(range))
-                    .transpose()?
-                    .flatten(),
-            )
-            .into_array(),
-        ))
     }
 }
 

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -13,9 +13,11 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::DeserializeMetadata;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
+use vortex_array::arrays::SliceVTable;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::patches::Patches;
 use vortex_array::patches::PatchesMetadata;
@@ -170,6 +172,33 @@ impl VTable for ALPVTable {
             array.clone(),
             ctx,
         )?))
+    }
+
+    fn execute_parent(
+        array: &Self::Array,
+        parent: &ArrayRef,
+        _child_idx: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<Canonical>> {
+        // CPU-only: if parent is SliceArray, perform slicing of the buffer and any patches
+        // Note that this triggers compute (binary searching Patches) which we cannot do when the
+        // buffers live in GPU memory.
+        if let Some(slice_array) = parent.as_opt::<SliceVTable>() {
+            let range = slice_array.slice_range().clone();
+            let sliced_alp = ALPArray::new(
+                array.encoded().slice(range.clone())?,
+                array.exponents(),
+                array
+                    .patches()
+                    .map(|p| p.slice(range))
+                    .transpose()?
+                    .flatten(),
+            )
+            .into_array();
+            return Ok(Some(sliced_alp.execute::<Canonical>(ctx)?));
+        }
+
+        Ok(None)
     }
 }
 

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -845,4 +845,14 @@ impl<V: VTable> ArrayVisitor for ArrayAdapter<V> {
             Ok(metadata) => Debug::fmt(&metadata, f),
         }
     }
+
+    fn is_host(&self) -> bool {
+        for array in self.depth_first_traversal() {
+            if !array.buffer_handles().iter().all(BufferHandle::is_on_host) {
+                return false;
+            }
+        }
+
+        true
+    }
 }

--- a/vortex-array/src/array/visitor.rs
+++ b/vortex-array/src/array/visitor.rs
@@ -49,6 +49,11 @@ pub trait ArrayVisitor {
 
     /// Formats a human-readable metadata description.
     fn metadata_fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result;
+
+    /// Checks if all buffers in the array tree are host-resident.
+    ///
+    /// This will fail if any buffers of self or child arrays are GPU-resident.
+    fn is_host(&self) -> bool;
 }
 
 impl ArrayVisitor for Arc<dyn Array> {
@@ -94,6 +99,10 @@ impl ArrayVisitor for Arc<dyn Array> {
 
     fn metadata_fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.as_ref().metadata_fmt(f)
+    }
+
+    fn is_host(&self) -> bool {
+        self.as_ref().is_host()
     }
 }
 

--- a/vortex-array/src/arrays/filter/rules.rs
+++ b/vortex-array/src/arrays/filter/rules.rs
@@ -8,12 +8,19 @@ use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::FilterArray;
 use crate::arrays::FilterVTable;
+use crate::arrays::StructArray;
+use crate::arrays::StructArrayParts;
+use crate::arrays::StructVTable;
 use crate::matchers::Exact;
 use crate::optimizer::rules::ArrayParentReduceRule;
+use crate::optimizer::rules::ArrayReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
+use crate::optimizer::rules::ReduceRuleSet;
 
 pub(super) const PARENT_RULES: ParentRuleSet<FilterVTable> =
     ParentRuleSet::new(&[ParentRuleSet::lift(&FilterFilterRule)]);
+
+pub(super) const RULES: ReduceRuleSet<FilterVTable> = ReduceRuleSet::new(&[&FilterStructRule]);
 
 /// A simple redecution rule that simplifies a [`FilterArray`] whose child is also a
 /// [`FilterArray`].
@@ -37,5 +44,43 @@ impl ArrayParentReduceRule<FilterVTable> for FilterFilterRule {
         let new_array = child.child.filter(combined_mask)?;
 
         Ok(Some(new_array.into_array()))
+    }
+}
+
+/// A reduce rule that pushes a filter down into the fields of a StructArray.
+#[derive(Debug)]
+struct FilterStructRule;
+
+impl ArrayReduceRule<FilterVTable> for FilterStructRule {
+    fn reduce(&self, array: &FilterArray) -> VortexResult<Option<ArrayRef>> {
+        let mask = array.filter_mask();
+        let Some(struct_array) = array.child().as_opt::<StructVTable>() else {
+            return Ok(None);
+        };
+
+        let len = mask.true_count();
+        let StructArrayParts {
+            fields,
+            struct_fields,
+            validity,
+            ..
+        } = struct_array.clone().into_parts();
+
+        let filtered_validity = validity.filter(mask)?;
+
+        let filtered_fields = fields
+            .iter()
+            .map(|field| field.filter(mask.clone()))
+            .collect::<VortexResult<Vec<_>>>()?;
+
+        Ok(Some(
+            StructArray::new(
+                struct_fields.names().clone(),
+                filtered_fields,
+                len,
+                filtered_validity,
+            )
+            .into_array(),
+        ))
     }
 }

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -25,6 +25,7 @@ use crate::arrays::filter::array::FilterArray;
 use crate::arrays::filter::execute::execute_filter;
 use crate::arrays::filter::execute::execute_filter_fast_paths;
 use crate::arrays::filter::rules::PARENT_RULES;
+use crate::arrays::filter::rules::RULES;
 use crate::buffer::BufferHandle;
 use crate::executor::ExecutionCtx;
 use crate::serde::ArrayChildren;
@@ -139,6 +140,10 @@ impl VTable for FilterVTable {
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_RULES.evaluate(array, parent, child_idx)
+    }
+
+    fn reduce(array: &Self::Array) -> VortexResult<Option<ArrayRef>> {
+        RULES.evaluate(array)
     }
 }
 

--- a/vortex-array/src/arrays/slice/array.rs
+++ b/vortex-array/src/arrays/slice/array.rs
@@ -15,6 +15,11 @@ pub struct SliceArray {
     pub(super) stats: ArrayStats,
 }
 
+pub struct SliceArrayParts {
+    pub child: ArrayRef,
+    pub range: Range<usize>,
+}
+
 impl SliceArray {
     pub fn new(child: ArrayRef, range: Range<usize>) -> Self {
         if range.end > child.len() {
@@ -39,5 +44,13 @@ impl SliceArray {
     /// The child array being sliced.
     pub fn child(&self) -> &ArrayRef {
         &self.child
+    }
+
+    /// Consume the slice array and return its components.
+    pub fn into_parts(self) -> SliceArrayParts {
+        SliceArrayParts {
+            child: self.child,
+            range: self.range,
+        }
     }
 }

--- a/vortex-array/src/arrays/varbinview/vtable/array.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/array.rs
@@ -4,6 +4,7 @@
 use std::hash::Hash;
 
 use vortex_dtype::DType;
+use vortex_vector::binaryview::BinaryView;
 
 use crate::Precision;
 use crate::arrays::varbinview::VarBinViewArray;
@@ -15,7 +16,7 @@ use crate::vtable::BaseArrayVTable;
 
 impl BaseArrayVTable<VarBinViewVTable> for VarBinViewVTable {
     fn len(array: &VarBinViewArray) -> usize {
-        array.views().len()
+        array.views_handle().len() / size_of::<BinaryView>()
     }
 
     fn dtype(array: &VarBinViewArray) -> &DType {

--- a/vortex-array/src/buffer.rs
+++ b/vortex-array/src/buffer.rs
@@ -83,6 +83,8 @@ pub trait DeviceBuffer: 'static + Send + Sync + Debug + DynEq + DynHash {
 
     /// Create a new buffer that references a subrange of this buffer at the given
     /// slice indices.
+    ///
+    /// Note that slice indices are in byte units.
     fn slice(&self, range: Range<usize>) -> Arc<dyn DeviceBuffer>;
 
     /// Return a buffer with the given alignment. Where possible, this will be zero-copy.

--- a/vortex-array/src/buffer.rs
+++ b/vortex-array/src/buffer.rs
@@ -95,6 +95,19 @@ pub trait DeviceBuffer: 'static + Send + Sync + Debug + DynEq + DynHash {
     fn aligned(self: Arc<Self>, alignment: Alignment) -> VortexResult<Arc<dyn DeviceBuffer>>;
 }
 
+pub trait DeviceBufferExt: DeviceBuffer {
+    /// Slice a range of elements `T` out of the device buffer.
+    fn slice_typed<T: Sized>(&self, range: Range<usize>) -> Arc<dyn DeviceBuffer>;
+}
+
+impl<B: DeviceBuffer> DeviceBufferExt for B {
+    fn slice_typed<T: Sized>(&self, range: Range<usize>) -> Arc<dyn DeviceBuffer> {
+        let start_bytes = range.start * size_of::<T>();
+        let end_bytes = range.end * size_of::<T>();
+        self.slice(start_bytes..end_bytes)
+    }
+}
+
 impl Hash for dyn DeviceBuffer {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.dyn_hash(state);

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -36,11 +36,13 @@ use vortex_vector::primitive::PrimitiveVectorMut;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::ArrayVisitor;
 use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::PrimitiveArray;
 use crate::compute::cast;
 use crate::compute::filter;
+use crate::compute::is_sorted;
 use crate::compute::take;
 use crate::search_sorted::SearchResult;
 use crate::search_sorted::SearchSorted;
@@ -161,34 +163,38 @@ impl Patches {
         values: ArrayRef,
         chunk_offsets: Option<ArrayRef>,
     ) -> VortexResult<Self> {
-        // vortex_ensure!(
-        //     indices.len() == values.len(),
-        //     "Patch indices and values must have the same length"
-        // );
-        // vortex_ensure!(
-        //     indices.dtype().is_unsigned_int() && !indices.dtype().is_nullable(),
-        //     "Patch indices must be non-nullable unsigned integers, got {:?}",
-        //     indices.dtype()
-        // );
-        // vortex_ensure!(
-        //     indices.len() <= array_len,
-        //     "Patch indices must be shorter than the array length"
-        // );
-        // vortex_ensure!(!indices.is_empty(), "Patch indices must not be empty");
-        //
-        // let max = usize::try_from(&indices.scalar_at(indices.len() - 1)?)
-        //     .map_err(|_| vortex_err!("indices must be a number"))?;
-        // vortex_ensure!(
-        //     max - offset < array_len,
-        //     "Patch indices {max:?}, offset {offset} are longer than the array length {array_len}"
-        // );
-        //
-        // debug_assert!(
-        //     is_sorted(indices.as_ref())
-        //         .unwrap_or(Some(false))
-        //         .unwrap_or(false),
-        //     "Patch indices must be sorted"
-        // );
+        // Perform validation of components when they are host-resident.
+        // This is not possible to do eagerly when the data is on GPU memory.
+        if indices.is_host() && values.is_host() {
+            vortex_ensure!(
+                indices.len() == values.len(),
+                "Patch indices and values must have the same length"
+            );
+            vortex_ensure!(
+                indices.dtype().is_unsigned_int() && !indices.dtype().is_nullable(),
+                "Patch indices must be non-nullable unsigned integers, got {:?}",
+                indices.dtype()
+            );
+            vortex_ensure!(
+                indices.len() <= array_len,
+                "Patch indices must be shorter than the array length"
+            );
+            vortex_ensure!(!indices.is_empty(), "Patch indices must not be empty");
+
+            let max = usize::try_from(&indices.scalar_at(indices.len() - 1)?)
+                .map_err(|_| vortex_err!("indices must be a number"))?;
+            vortex_ensure!(
+                max - offset < array_len,
+                "Patch indices {max:?}, offset {offset} are longer than the array length {array_len}"
+            );
+
+            debug_assert!(
+                is_sorted(indices.as_ref())
+                    .unwrap_or(Some(false))
+                    .unwrap_or(false),
+                "Patch indices must be sorted"
+            );
+        }
 
         Ok(Self {
             array_len,

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -163,24 +163,25 @@ impl Patches {
         values: ArrayRef,
         chunk_offsets: Option<ArrayRef>,
     ) -> VortexResult<Self> {
+        vortex_ensure!(
+            indices.len() == values.len(),
+            "Patch indices and values must have the same length"
+        );
+        vortex_ensure!(
+            indices.dtype().is_unsigned_int() && !indices.dtype().is_nullable(),
+            "Patch indices must be non-nullable unsigned integers, got {:?}",
+            indices.dtype()
+        );
+
+        vortex_ensure!(
+            indices.len() <= array_len,
+            "Patch indices must be shorter than the array length"
+        );
+        vortex_ensure!(!indices.is_empty(), "Patch indices must not be empty");
+
         // Perform validation of components when they are host-resident.
         // This is not possible to do eagerly when the data is on GPU memory.
         if indices.is_host() && values.is_host() {
-            vortex_ensure!(
-                indices.len() == values.len(),
-                "Patch indices and values must have the same length"
-            );
-            vortex_ensure!(
-                indices.dtype().is_unsigned_int() && !indices.dtype().is_nullable(),
-                "Patch indices must be non-nullable unsigned integers, got {:?}",
-                indices.dtype()
-            );
-            vortex_ensure!(
-                indices.len() <= array_len,
-                "Patch indices must be shorter than the array length"
-            );
-            vortex_ensure!(!indices.is_empty(), "Patch indices must not be empty");
-
             let max = usize::try_from(&indices.scalar_at(indices.len() - 1)?)
                 .map_err(|_| vortex_err!("indices must be a number"))?;
             vortex_ensure!(

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -41,7 +41,6 @@ use crate::ToCanonical;
 use crate::arrays::PrimitiveArray;
 use crate::compute::cast;
 use crate::compute::filter;
-use crate::compute::is_sorted;
 use crate::compute::take;
 use crate::search_sorted::SearchResult;
 use crate::search_sorted::SearchSorted;
@@ -162,34 +161,34 @@ impl Patches {
         values: ArrayRef,
         chunk_offsets: Option<ArrayRef>,
     ) -> VortexResult<Self> {
-        vortex_ensure!(
-            indices.len() == values.len(),
-            "Patch indices and values must have the same length"
-        );
-        vortex_ensure!(
-            indices.dtype().is_unsigned_int() && !indices.dtype().is_nullable(),
-            "Patch indices must be non-nullable unsigned integers, got {:?}",
-            indices.dtype()
-        );
-        vortex_ensure!(
-            indices.len() <= array_len,
-            "Patch indices must be shorter than the array length"
-        );
-        vortex_ensure!(!indices.is_empty(), "Patch indices must not be empty");
-
-        let max = usize::try_from(&indices.scalar_at(indices.len() - 1)?)
-            .map_err(|_| vortex_err!("indices must be a number"))?;
-        vortex_ensure!(
-            max - offset < array_len,
-            "Patch indices {max:?}, offset {offset} are longer than the array length {array_len}"
-        );
-
-        debug_assert!(
-            is_sorted(indices.as_ref())
-                .unwrap_or(Some(false))
-                .unwrap_or(false),
-            "Patch indices must be sorted"
-        );
+        // vortex_ensure!(
+        //     indices.len() == values.len(),
+        //     "Patch indices and values must have the same length"
+        // );
+        // vortex_ensure!(
+        //     indices.dtype().is_unsigned_int() && !indices.dtype().is_nullable(),
+        //     "Patch indices must be non-nullable unsigned integers, got {:?}",
+        //     indices.dtype()
+        // );
+        // vortex_ensure!(
+        //     indices.len() <= array_len,
+        //     "Patch indices must be shorter than the array length"
+        // );
+        // vortex_ensure!(!indices.is_empty(), "Patch indices must not be empty");
+        //
+        // let max = usize::try_from(&indices.scalar_at(indices.len() - 1)?)
+        //     .map_err(|_| vortex_err!("indices must be a number"))?;
+        // vortex_ensure!(
+        //     max - offset < array_len,
+        //     "Patch indices {max:?}, offset {offset} are longer than the array length {array_len}"
+        // );
+        //
+        // debug_assert!(
+        //     is_sorted(indices.as_ref())
+        //         .unwrap_or(Some(false))
+        //         .unwrap_or(false),
+        //     "Patch indices must be sorted"
+        // );
 
         Ok(Self {
             array_len,

--- a/vortex-cuda/benches/filter_cuda.rs
+++ b/vortex-cuda/benches/filter_cuda.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::cast_possible_truncation)]
 
 use std::ffi::c_void;
+use std::fmt::Debug;
 use std::mem::size_of;
 use std::time::Duration;
 
@@ -124,7 +125,14 @@ async fn run_filter_timed<T: CubFilterable + cudarc::driver::DeviceRepr>(
 /// Benchmark filter for a specific type.
 fn benchmark_filter_type<T>(c: &mut Criterion, type_name: &str)
 where
-    T: CubFilterable + cudarc::driver::DeviceRepr + From<u8> + Clone + Send + Sync + 'static,
+    T: CubFilterable
+        + cudarc::driver::DeviceRepr
+        + From<u8>
+        + Debug
+        + Clone
+        + Send
+        + Sync
+        + 'static,
 {
     let mut group = c.benchmark_group(format!("Filter_cuda_{type_name}"));
     group.sample_size(10);
@@ -161,7 +169,7 @@ where
                             let d_input = d_input_handle
                                 .as_device()
                                 .as_any()
-                                .downcast_ref::<CudaDeviceBuffer<T>>()
+                                .downcast_ref::<CudaDeviceBuffer>()
                                 .unwrap();
 
                             // Copy bitmask to device
@@ -171,7 +179,7 @@ where
                             let d_bitmask = d_bitmask_handle
                                 .as_device()
                                 .as_any()
-                                .downcast_ref::<CudaDeviceBuffer<u8>>()
+                                .downcast_ref::<CudaDeviceBuffer>()
                                 .unwrap();
 
                             // Allocate output and temp buffers

--- a/vortex-cuda/src/canonical.rs
+++ b/vortex-cuda/src/canonical.rs
@@ -20,6 +20,7 @@ use vortex_array::arrays::StructArrayParts;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::VarBinViewArrayParts;
 use vortex_array::buffer::BufferHandle;
+use vortex_buffer::BitBuffer;
 use vortex_buffer::Buffer;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
@@ -46,15 +47,10 @@ impl CanonicalCudaExt for Canonical {
                     ..
                 } = struct_array.into_parts();
 
-                let futures = fields
-                    .iter()
-                    .map(|field| field.to_canonical().map(|c| c.into_host()))
-                    .collect::<VortexResult<Vec<_>>>()?;
-                let host_fields = try_join_all(futures).await?;
-                let host_fields = host_fields
-                    .into_iter()
-                    .map(Canonical::into_array)
-                    .collect::<Vec<_>>();
+                let mut host_fields = vec![];
+                for field in fields.iter() {
+                    host_fields.push(field.to_canonical()?.into_host().await?.into_array());
+                }
 
                 Ok(Canonical::Struct(StructArray::new(
                     struct_fields.names().clone(),
@@ -74,9 +70,9 @@ impl CanonicalCudaExt for Canonical {
                     len,
                     ..
                 } = bool.into_parts();
-                Ok(Canonical::Bool(BoolArray::new_handle(
-                    bits, offset, len, validity,
-                )))
+
+                let bits = BitBuffer::new_with_offset(bits.try_into_host()?.await?, offset, len);
+                Ok(Canonical::Bool(BoolArray::new(bits, validity)))
             }
             Canonical::Primitive(prim) => {
                 let PrimitiveArrayParts {

--- a/vortex-cuda/src/device_buffer.rs
+++ b/vortex-cuda/src/device_buffer.rs
@@ -15,8 +15,8 @@ use futures::future::BoxFuture;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::buffer::DeviceBuffer;
 use vortex_buffer::Alignment;
-use vortex_buffer::BufferMut;
 use vortex_buffer::ByteBuffer;
+use vortex_buffer::ByteBufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
@@ -24,24 +24,77 @@ use vortex_error::vortex_panic;
 
 use crate::stream::await_stream_callback;
 
-/// A CUDA device buffer with offset and length tracking.
-pub struct CudaDeviceBuffer<T> {
-    inner: Arc<CudaSlice<T>>,
+/// A [`DeviceBuffer`] wrapping a CUDA GPU allocation.
+///
+/// Like the host `BufferHandle` variant, all slicing/referencing works in terms of byte units.
+pub struct CudaDeviceBuffer {
+    allocation: Arc<dyn private::DeviceAllocation>,
+    /// Offset in bytes from the start of the allocation
     offset: usize,
+    /// Length in bytes
     len: usize,
+    /// CUDA device pointer
     device_ptr: u64,
-    // This is the min required alignment of the buffer.
+    /// Minimum required alignment of the buffer.
     alignment: Alignment,
 }
 
-impl<T: DeviceRepr> CudaDeviceBuffer<T> {
-    /// Creates a new CUDA device buffer from a [`CudaSlice`].
-    pub fn new(cuda_slice: CudaSlice<T>) -> Self {
-        let len = cuda_slice.len();
-        let device_ptr = cuda_slice.device_ptr(cuda_slice.stream()).0;
+// We can call the sys methods, it's just a lot of extra code...fuck that lol
+
+mod private {
+    use std::fmt::Debug;
+    use std::sync::Arc;
+
+    use cudarc::driver::CudaSlice;
+    use cudarc::driver::CudaStream;
+    use cudarc::driver::CudaView;
+    use cudarc::driver::DeviceRepr;
+    use vortex_buffer::Alignment;
+    use vortex_error::VortexExpect;
+
+    pub trait DeviceAllocation: Debug + Send + Sync + 'static {
+        /// Get the minimum alignment of the allocation.
+        fn alignment(&self) -> Alignment;
+
+        /// Get a reference to the underlying cuStream.
+        fn stream(&self) -> &Arc<CudaStream>;
+
+        /// Access the values as a bytes view
+        fn as_bytes_view(&self) -> CudaView<'_, u8>;
+    }
+
+    // CudaSlice needs to be held by the CudaDeviceBuffer
+    impl<T: DeviceRepr + Debug + Send + Sync + 'static> DeviceAllocation for CudaSlice<T> {
+        fn alignment(&self) -> Alignment {
+            Alignment::of::<T>()
+        }
+
+        fn stream(&self) -> &Arc<CudaStream> {
+            self.stream()
+        }
+
+        fn as_bytes_view(&self) -> CudaView<'_, u8> {
+            let bytes_len = self.len() * size_of::<T>();
+            // SAFETY: all types can be reinterpreted as a byte slice
+            let result = unsafe { self.as_view().transmute::<u8>(bytes_len) };
+            result.vortex_expect("Downcasting CudaSlice<T> => CudaSlice<u8> must succeed")
+        }
+    }
+}
+
+// Get it back out as a View of u8
+
+impl CudaDeviceBuffer {
+    /// Creates a new CUDA device buffer from a [`CudaSlice<T>`].
+    ///
+    /// The device buffer itself is type-erased and only works in terms of bytes, similar to the
+    /// `BufferHandle` interface that it implements.
+    pub fn new<T: DeviceRepr + Debug + Send + Sync + 'static>(cuda_slice: CudaSlice<T>) -> Self {
+        let len = cuda_slice.len() * size_of::<T>();
+        let (device_ptr, _) = cuda_slice.device_ptr(cuda_slice.stream());
 
         Self {
-            inner: Arc::new(cuda_slice),
+            allocation: Arc::new(cuda_slice),
             offset: 0,
             len,
             device_ptr,
@@ -50,8 +103,19 @@ impl<T: DeviceRepr> CudaDeviceBuffer<T> {
     }
 
     /// Returns a [`CudaView`] to the CUDA device buffer.
-    pub fn as_view(&self) -> CudaView<'_, T> {
-        self.inner.slice(self.offset..self.offset + self.len)
+    pub fn as_view<T: DeviceRepr + 'static>(&self) -> CudaView<'_, T> {
+        // Return a new &[T]
+        let new_len = self.len / size_of::<T>();
+
+        // SAFETY: All DeviecRepr types are aligned to < 256 bytes, which is what CUDA allocator
+        //  gives us back. So we should not suffer any alignment issues at runtime.
+        unsafe {
+            self.allocation
+                .as_bytes_view()
+                .slice(self.offset..self.offset + self.len)
+                .transmute::<T>(new_len)
+                .vortex_expect("Failed to transmute from CudaView<u8> to CudaView<T>")
+        }
     }
 }
 
@@ -73,21 +137,17 @@ impl CudaBufferExt for BufferHandle {
 
         let cuda_buf = device_buffer
             .as_any()
-            .downcast_ref::<CudaDeviceBuffer<T>>()
-            .ok_or_else(|| {
-                vortex_err!(
-                    "Device buffer is not a CUDA device buffer for type {}",
-                    std::any::type_name::<T>()
-                )
-            })?;
+            .downcast_ref::<CudaDeviceBuffer>()
+            .ok_or_else(|| vortex_err!("expected CudaDeviceBuffer, was {device_buffer:?}"))?;
 
-        Ok(cuda_buf.as_view())
+        Ok(cuda_buf.as_view::<T>())
     }
 }
 
-impl<T: DeviceRepr> Debug for CudaDeviceBuffer<T> {
+impl Debug for CudaDeviceBuffer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CudaDeviceBuffer")
+            .field("allocation", &self.allocation)
             .field("device_ptr", &self.device_ptr)
             .field("offset", &self.offset)
             .field("len", &self.len)
@@ -95,7 +155,7 @@ impl<T: DeviceRepr> Debug for CudaDeviceBuffer<T> {
     }
 }
 
-impl<T: DeviceRepr> std::hash::Hash for CudaDeviceBuffer<T> {
+impl std::hash::Hash for CudaDeviceBuffer {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.device_ptr.hash(state);
         self.len.hash(state);
@@ -103,16 +163,17 @@ impl<T: DeviceRepr> std::hash::Hash for CudaDeviceBuffer<T> {
     }
 }
 
-impl<T: DeviceRepr> PartialEq for CudaDeviceBuffer<T> {
+// CUDA device buffers are equal if they point to the same extent of GPU memory
+impl PartialEq for CudaDeviceBuffer {
     fn eq(&self, other: &Self) -> bool {
         self.device_ptr == other.device_ptr && self.len == other.len && self.offset == other.offset
     }
 }
 
-impl<T: DeviceRepr + Send + Sync + 'static> DeviceBuffer for CudaDeviceBuffer<T> {
-    /// Returns the number of elements in the buffer of type T.
+impl DeviceBuffer for CudaDeviceBuffer {
+    /// Returns the number of bytes in the device buffer.
     fn len(&self) -> usize {
-        self.len * size_of::<T>()
+        self.len
     }
 
     fn alignment(&self) -> Alignment {
@@ -153,12 +214,13 @@ impl<T: DeviceRepr + Send + Sync + 'static> DeviceBuffer for CudaDeviceBuffer<T>
         &self,
         alignment: Alignment,
     ) -> VortexResult<BoxFuture<'static, VortexResult<ByteBuffer>>> {
-        let stream = self.inner.stream();
+        let stream = self.allocation.stream();
 
         // Add offset to device pointer to account for any previous slicing operations.
-        let src_ptr = self.device_ptr + (self.offset * size_of::<T>()) as u64;
+        let src_ptr = self.device_ptr + self.offset as u64;
 
-        let mut host_buffer: BufferMut<T> = BufferMut::with_capacity_aligned(self.len, alignment);
+        let mut host_buffer: ByteBufferMut =
+            ByteBufferMut::with_capacity_aligned(self.len, alignment);
         let len = self.len;
 
         // SAFETY: We pass a valid pointer to a buffer with sufficient capacity.
@@ -167,14 +229,14 @@ impl<T: DeviceRepr + Send + Sync + 'static> DeviceBuffer for CudaDeviceBuffer<T>
             sys::cuMemcpyDtoHAsync_v2(
                 host_buffer.spare_capacity_mut().as_mut_ptr().cast(),
                 src_ptr,
-                len * size_of::<T>(),
+                len,
                 stream.cu_stream(),
             )
             .result()
             .map_err(|e| vortex_err!("Failed to schedule async copy to host: {}", e))?;
         }
 
-        let cuda_slice = Arc::clone(&self.inner);
+        let cuda_slice = Arc::clone(&self.allocation);
 
         Ok(Box::pin(async move {
             await_stream_callback(cuda_slice.stream()).await?;
@@ -192,33 +254,33 @@ impl<T: DeviceRepr + Send + Sync + 'static> DeviceBuffer for CudaDeviceBuffer<T>
     }
 
     /// Slices the CUDA device buffer to a subrange.
+    ///
+    /// **IMPORTANT**: this is a byte range, not elements range, due to the DeviceBuffer interface.
     fn slice(&self, range: Range<usize>) -> Arc<dyn DeviceBuffer> {
-        let new_offset = self.offset + range.start;
-        let new_len = range.end - range.start;
-        let byte_offset = new_offset * size_of::<T>();
-
-        let trailing = (self.device_ptr + byte_offset as u64).trailing_zeros();
-        let exponent =
-            u8::try_from(min(15, trailing)).vortex_expect("min(15, x) always fits in u8");
-        let slice_align = Alignment::from_exponent(exponent);
-        let alignment = Alignment::of::<T>();
-
-        assert!(
-            slice_align.is_aligned_to(alignment),
-            "slice must respect minimum alignment byte {}, min {}",
-            slice_align,
-            alignment
-        );
-
         assert!(
             range.end <= self.len,
-            "Slice range end {} exceeds buffer length {}",
+            "Slice range end {} exceeds allocation size {}",
             range.end,
             self.len
         );
 
+        let new_offset = self.offset + range.start;
+        let new_len = range.end - range.start;
+
+        let trailing = (self.device_ptr + new_offset as u64).trailing_zeros();
+        let exponent =
+            u8::try_from(min(15, trailing)).vortex_expect("min(15, x) always fits in u8");
+        let slice_align = Alignment::from_exponent(exponent);
+
+        assert!(
+            slice_align.is_aligned_to(self.allocation.alignment()),
+            "slice must respect minimum alignment {}, min {}",
+            slice_align,
+            self.allocation.alignment()
+        );
+
         Arc::new(CudaDeviceBuffer {
-            inner: Arc::clone(&self.inner),
+            allocation: Arc::clone(&self.allocation),
             offset: new_offset,
             len: new_len,
             device_ptr: self.device_ptr,
@@ -231,10 +293,10 @@ impl<T: DeviceRepr + Send + Sync + 'static> DeviceBuffer for CudaDeviceBuffer<T>
     }
 
     fn aligned(self: Arc<Self>, alignment: Alignment) -> VortexResult<Arc<dyn DeviceBuffer>> {
-        let effective_ptr = self.device_ptr + (self.offset * size_of::<T>()) as u64;
+        let effective_ptr = self.device_ptr + self.offset as u64;
         if effective_ptr % (*alignment as u64) == 0 {
             Ok(Arc::new(CudaDeviceBuffer {
-                inner: self.inner.clone(),
+                allocation: self.allocation.clone(),
                 offset: self.offset,
                 len: self.len,
                 device_ptr: self.device_ptr,

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -17,6 +17,10 @@ use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::arrays::StructArray;
+use vortex_array::arrays::StructArrayParts;
+use vortex_array::arrays::StructVTable;
 use vortex_array::buffer::BufferHandle;
 use vortex_dtype::PType;
 use vortex_error::VortexResult;
@@ -125,7 +129,10 @@ impl CudaExecutionCtx {
     }
 
     /// See `VortexCudaStream::device_alloc`.
-    pub fn device_alloc<T: DeviceRepr>(&self, len: usize) -> VortexResult<CudaSlice<T>> {
+    pub fn device_alloc<T: DeviceRepr + Send + Sync + 'static>(
+        &self,
+        len: usize,
+    ) -> VortexResult<CudaSlice<T>> {
         self.stream.device_alloc(len)
     }
 
@@ -135,14 +142,14 @@ impl CudaExecutionCtx {
         data: D,
     ) -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>>
     where
-        T: DeviceRepr + Send + Sync + 'static,
+        T: DeviceRepr + Debug + Send + Sync + 'static,
         D: AsRef<[T]> + Send + 'static,
     {
         self.stream.copy_to_device(data)
     }
 
     /// See `VortexCudaStream::move_to_device`.
-    pub fn move_to_device<T: DeviceRepr + Send + Sync + 'static>(
+    pub fn move_to_device<T: DeviceRepr + Debug + Send + Sync + 'static>(
         &self,
         handle: BufferHandle,
     ) -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>> {
@@ -179,7 +186,30 @@ pub trait CudaArrayExt: Array {
 
 #[async_trait]
 impl CudaArrayExt for ArrayRef {
+    #[allow(clippy::unwrap_in_result, clippy::unwrap_used)]
     async fn execute_cuda(self, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
+        if self.encoding_id() == StructVTable::ID {
+            let len = self.len();
+            let StructArrayParts {
+                fields,
+                struct_fields,
+                validity,
+                ..
+            } = self.try_into::<StructVTable>().unwrap().into_parts();
+
+            let mut cuda_fields = Vec::with_capacity(fields.len());
+            for field in fields.iter() {
+                cuda_fields.push(field.clone().execute_cuda(ctx).await?.into_array());
+            }
+
+            return Ok(Canonical::Struct(StructArray::new(
+                struct_fields.names().clone(),
+                cuda_fields,
+                len,
+                validity,
+            )));
+        }
+
         if self.is_canonical() || self.is_empty() {
             return self.execute(&mut ctx.ctx);
         }

--- a/vortex-cuda/src/kernel/arrays/dict.rs
+++ b/vortex-cuda/src/kernel/arrays/dict.rs
@@ -122,7 +122,7 @@ async fn execute_dict_prim_typed<V: DeviceRepr + NativePType, I: DeviceRepr + Na
     // Get views for kernel launch
     let values_view = values_device.cuda_view::<V>()?;
     let codes_view = codes_device.cuda_view::<I>()?;
-    let output_view = output_device.as_view();
+    let output_view = output_device.as_view::<V>();
 
     let codes_len_u64 = codes_len as u64;
     // Launch the dict kernel
@@ -231,7 +231,7 @@ async fn execute_dict_decimal_typed<
     // Get views for kernel launch
     let values_view = values_device.cuda_view::<V>()?;
     let codes_view = codes_device.cuda_view::<C>()?;
-    let output_view = output_device.as_view();
+    let output_view = output_device.as_view::<V>();
 
     // Load kernel function using string suffixes
     let cuda_function = ctx.load_function("dict", &[value_suffix, &C::PTYPE.to_string()])?;

--- a/vortex-cuda/src/kernel/encodings/alp.rs
+++ b/vortex-cuda/src/kernel/encodings/alp.rs
@@ -34,12 +34,6 @@ use crate::launch_cuda_kernel_impl;
 #[derive(Debug)]
 pub struct ALPExecutor;
 
-impl ALPExecutor {
-    fn try_specialize(array: ArrayRef) -> Option<ALPArray> {
-        array.try_into::<ALPVTable>().ok()
-    }
-}
-
 #[async_trait]
 impl CudaExecute for ALPExecutor {
     async fn execute(
@@ -47,7 +41,9 @@ impl CudaExecute for ALPExecutor {
         array: ArrayRef,
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<Canonical> {
-        let array = Self::try_specialize(array).ok_or_else(|| vortex_err!("Expected ALPArray"))?;
+        let array = array
+            .try_into::<ALPVTable>()
+            .map_err(|_| vortex_err!("Expected ALPArray"))?;
 
         match_each_alp_float_ptype!(array.ptype(), |A| { decode_alp::<A>(array, ctx).await })
     }
@@ -85,7 +81,7 @@ where
     // Allocate output buffer
     let output_slice = ctx.device_alloc::<A>(array_len)?;
     let output_buf = CudaDeviceBuffer::new(output_slice);
-    let output_view = output_buf.as_view();
+    let output_view = output_buf.as_view::<A>();
 
     let array_len_u64 = array_len as u64;
 

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -89,7 +89,7 @@ where
     // Allocate output buffer
     let output_slice = ctx.device_alloc::<A>(len.next_multiple_of(1024))?;
     let output_buf = CudaDeviceBuffer::new(output_slice);
-    let output_view = output_buf.as_view();
+    let output_view = output_buf.as_view::<A>();
 
     // Load kernel function
     // bit_unpack_{bits}_{bit_width}bw_{thread_count}t
@@ -116,7 +116,9 @@ where
         launch_cuda_kernel_with_config(&mut launch_builder, config, CU_EVENT_DISABLE_TIMING)?;
 
     // Build result with newly allocated buffer
-    let output_handle = BufferHandle::new_device(output_buf.slice(offset..offset + len));
+    let output_handle = BufferHandle::new_device(
+        output_buf.slice((offset * size_of::<A>())..(offset + len) * size_of::<A>()),
+    );
     Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
         output_handle,
         A::PTYPE,

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -12,7 +12,7 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
-use vortex_array::buffer::DeviceBuffer;
+use vortex_array::buffer::DeviceBufferExt;
 use vortex_cuda_macros::cuda_tests;
 use vortex_dtype::NativePType;
 use vortex_dtype::match_each_integer_ptype;
@@ -116,9 +116,8 @@ where
         launch_cuda_kernel_with_config(&mut launch_builder, config, CU_EVENT_DISABLE_TIMING)?;
 
     // Build result with newly allocated buffer
-    let output_handle = BufferHandle::new_device(
-        output_buf.slice((offset * size_of::<A>())..(offset + len) * size_of::<A>()),
-    );
+    let output_handle =
+        BufferHandle::new_device(output_buf.slice_typed::<A>(offset..(offset + len)));
     Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
         output_handle,
         A::PTYPE,

--- a/vortex-cuda/src/kernel/filter/mod.rs
+++ b/vortex-cuda/src/kernel/filter/mod.rs
@@ -8,6 +8,7 @@ mod primitive;
 mod varbinview;
 
 use std::ffi::c_void;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -85,7 +86,7 @@ impl CudaExecute for FilterExecutor {
     }
 }
 
-async fn filter_sized<T: DeviceRepr + CubFilterable + Send + Sync + 'static>(
+async fn filter_sized<T: DeviceRepr + CubFilterable + Debug + Send + Sync + 'static>(
     input: BufferHandle,
     mask: Mask,
     ctx: &mut CudaExecutionCtx,
@@ -121,17 +122,17 @@ async fn filter_sized<T: DeviceRepr + CubFilterable + Send + Sync + 'static>(
     let d_input_cuda = d_input
         .as_device()
         .as_any()
-        .downcast_ref::<CudaDeviceBuffer<T>>()
-        .ok_or_else(|| vortex_err!("Expected CudaDeviceBuffer<T> for input"))?;
-    let d_input_ptr = d_input_cuda.as_view().device_ptr(stream).0 as *const T;
+        .downcast_ref::<CudaDeviceBuffer>()
+        .ok_or_else(|| vortex_err!("Expected CudaDeviceBuffer for input, was {d_input:?}",))?;
+    let d_input_ptr = d_input_cuda.as_view::<T>().device_ptr(stream).0 as *const T;
 
     // Downcast to get device pointer.
     let d_packed_cuda = d_flags
         .as_device()
         .as_any()
-        .downcast_ref::<CudaDeviceBuffer<u8>>()
-        .ok_or_else(|| vortex_err!("Expected CudaDeviceBuffer<u8> for packed flags"))?;
-    let d_packed_ptr = d_packed_cuda.as_view().device_ptr(stream).0 as *const u8;
+        .downcast_ref::<CudaDeviceBuffer>()
+        .ok_or_else(|| vortex_err!("Expected CudaDeviceBuffer for packed flags"))?;
+    let d_packed_ptr = d_packed_cuda.as_view::<u8>().device_ptr(stream).0 as *const u8;
 
     let d_temp_ptr = d_temp.device_ptr(stream).0 as *mut c_void;
     let d_output_ptr = d_output.device_ptr_mut(stream).0 as *mut T;

--- a/vortex-cuda/src/kernel/filter/varbinview.rs
+++ b/vortex-cuda/src/kernel/filter/varbinview.rs
@@ -24,7 +24,14 @@ pub(super) async fn filter_varbinview(
     } = array.into_parts();
 
     let filtered_validity = validity.filter(&mask)?;
-    let filtered_views = filter_sized::<i128>(views, mask, ctx).await?;
+
+    let d_views = if views.is_on_device() {
+        views
+    } else {
+        ctx.move_to_device::<i128>(views)?.await?
+    };
+
+    let filtered_views = filter_sized::<i128>(d_views, mask, ctx).await?;
 
     Ok(Canonical::VarBinView(VarBinViewArray::new_handle(
         filtered_views,

--- a/vortex-cuda/src/kernel/mod.rs
+++ b/vortex-cuda/src/kernel/mod.rs
@@ -23,10 +23,12 @@ use vortex_utils::aliases::dash_map::DashMap;
 mod arrays;
 mod encodings;
 mod filter;
+mod slice;
 
 pub use arrays::DictExecutor;
 pub use encodings::*;
 pub use filter::FilterExecutor;
+pub use slice::SliceExecutor;
 
 use crate::CudaKernelEvents;
 

--- a/vortex-cuda/src/kernel/slice/mod.rs
+++ b/vortex-cuda/src/kernel/slice/mod.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use async_trait::async_trait;
+use vortex_array::Array;
+use vortex_array::ArrayRef;
+use vortex_array::Canonical;
+use vortex_array::arrays::SliceArrayParts;
+use vortex_array::arrays::SliceVTable;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
+
+use crate::CudaExecutionCtx;
+use crate::executor::CudaArrayExt;
+use crate::executor::CudaExecute;
+
+#[derive(Debug)]
+pub struct SliceExecutor;
+
+#[async_trait]
+impl CudaExecute for SliceExecutor {
+    async fn execute(
+        &self,
+        array: ArrayRef,
+        ctx: &mut CudaExecutionCtx,
+    ) -> VortexResult<Canonical> {
+        let slice_array = array.try_into::<SliceVTable>().map_err(|array| {
+            vortex_err!(
+                "SliceExecutor requires input of SliceArray, was {}",
+                array.encoding_id()
+            )
+        })?;
+
+        let SliceArrayParts { child, range } = slice_array.into_parts();
+        let child = child.execute_cuda(ctx).await?;
+
+        match child {
+            Canonical::Null(null_array) => null_array.slice(range)?.to_canonical(),
+            Canonical::Bool(bool_array) => bool_array.slice(range)?.to_canonical(),
+            Canonical::Primitive(prim_array) => prim_array.slice(range)?.to_canonical(),
+            Canonical::Decimal(decimal_array) => decimal_array.slice(range)?.to_canonical(),
+            Canonical::VarBinView(varbinview) => varbinview.slice(range)?.to_canonical(),
+            Canonical::Extension(extension_array) => extension_array.slice(range)?.to_canonical(),
+            c => todo!("Slice kernel not implemented for {}", c.dtype()),
+        }
+    }
+}

--- a/vortex-cuda/src/lib.rs
+++ b/vortex-cuda/src/lib.rs
@@ -37,12 +37,15 @@ pub use stream_pool::VortexCudaStreamPool;
 use vortex_alp::ALPVTable;
 use vortex_array::arrays::DictVTable;
 use vortex_array::arrays::FilterVTable;
+use vortex_array::arrays::SliceVTable;
 use vortex_decimal_byte_parts::DecimalBytePartsVTable;
 use vortex_fastlanes::BitPackedVTable;
 use vortex_fastlanes::FoRVTable;
 pub use vortex_nvcomp as nvcomp;
 use vortex_zigzag::ZigZagVTable;
 use vortex_zstd::ZstdVTable;
+
+use crate::kernel::SliceExecutor;
 
 /// Checks if CUDA is available on the system by looking for nvcc.
 pub fn cuda_available() -> bool {
@@ -59,8 +62,11 @@ pub fn initialize_cuda(session: &CudaSession) {
     session.register_kernel(BitPackedVTable::ID, &BitPackedExecutor);
     session.register_kernel(DecimalBytePartsVTable::ID, &DecimalBytePartsExecutor);
     session.register_kernel(DictVTable::ID, &DictExecutor);
-    session.register_kernel(FilterVTable::ID, &FilterExecutor);
     session.register_kernel(FoRVTable::ID, &FoRExecutor);
     session.register_kernel(ZigZagVTable::ID, &ZigZagExecutor);
     session.register_kernel(ZstdVTable::ID, &ZstdExecutor);
+
+    // Operation kernels
+    session.register_kernel(FilterVTable::ID, &FilterExecutor);
+    session.register_kernel(SliceVTable::ID, &SliceExecutor);
 }

--- a/vortex-cuda/src/stream.rs
+++ b/vortex-cuda/src/stream.rs
@@ -3,6 +3,7 @@
 
 //! CUDA stream utility functions.
 
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use cudarc::driver::CudaSlice;
@@ -33,7 +34,10 @@ impl VortexCudaStream {
     ///
     /// Any kernel submitted to the stream after alloc can safely use the
     /// memory, as operations on the stream are ordered sequentially.
-    pub fn device_alloc<T: DeviceRepr>(&self, len: usize) -> VortexResult<CudaSlice<T>> {
+    pub fn device_alloc<T: DeviceRepr + Send + Sync + 'static>(
+        &self,
+        len: usize,
+    ) -> VortexResult<CudaSlice<T>> {
         // SAFETY: No safety guarantees for allocations on the GPU.
         unsafe {
             self.0
@@ -60,7 +64,7 @@ impl VortexCudaStream {
         data: D,
     ) -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>>
     where
-        T: DeviceRepr + Send + Sync + 'static,
+        T: DeviceRepr + Debug + Send + Sync + 'static,
         D: AsRef<[T]> + Send + 'static,
     {
         let host_slice: &[T] = data.as_ref();
@@ -94,7 +98,7 @@ impl VortexCudaStream {
     /// # Returns
     ///
     /// A future that resolves to the device buffer handle when the copy completes.
-    pub fn move_to_device<T: DeviceRepr + Send + Sync + 'static>(
+    pub fn move_to_device<T: DeviceRepr + Debug + Send + Sync + 'static>(
         &self,
         handle: BufferHandle,
     ) -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>> {

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1664,6 +1664,7 @@ mod cuda_tests {
     use vortex_io::file::std_file::FileReadAdapter;
     use vortex_io::session::RuntimeSession;
     use vortex_io::session::RuntimeSessionExt;
+    use vortex_layout::layouts::flat::writer::FlatLayoutStrategy;
     use vortex_layout::session::LayoutSession;
     use vortex_metrics::VortexMetrics;
     use vortex_session::VortexSession;
@@ -1680,7 +1681,7 @@ mod cuda_tests {
             .with::<RuntimeSession>()
             .with::<CudaSession>();
 
-        vortex_cuda::initialize_cuda(&*session.cuda_session());
+        vortex_cuda::initialize_cuda(&session.cuda_session());
         crate::register_default_encodings(&mut session);
 
         session
@@ -1689,6 +1690,12 @@ mod cuda_tests {
     #[tokio::test]
     async fn gpu_scan() -> VortexResult<()> {
         use vortex_alp::alp_encode;
+
+        assert!(
+            std::env::var("FLAT_LAYOUT_INLINE_ARRAY_NODE").is_ok(),
+            "gpu_scan test must be run with FLAT_LAYOUT_INLINE_ARRAY_NODE=1"
+        );
+
         // Create an ALP-encoded array from primitive f64 values
         let primitive = PrimitiveArray::from_iter((0..100).map(|i| i as f64 * 1.1));
         let alp_array = alp_encode(&primitive, None)?;
@@ -1704,11 +1711,15 @@ mod cuda_tests {
             Validity::NonNullable,
         );
 
+        let flat_strategy = Arc::new(FlatLayoutStrategy::default());
+
         // Write to a buffer, then to a temp file
         let temp_path = std::env::temp_dir().join("gpu_scan_test.vortex");
         let mut buf = Vec::new();
         SESSION
             .write_options()
+            // write with flat strategy, don't try and compress
+            .with_strategy(flat_strategy)
             .write(&mut buf, array.to_array_stream())
             .await?;
         std::fs::write(&temp_path, &buf)?;


### PR DESCRIPTION
- Slice not being applied lazily
- execute_cuda for struct needs to pushdown to fields
- CudaDeviceBuffer applying slicing at item instead of byte granularity
- VarBinView had latent GPU bug leftover from BufferHandles conversion
- BitPackedExecutor using wrong slice indices
- `CudaDeviceBuffer` to type-erase the underlying allocation so it matches`BufferHandle` more closely