### PR TITLE
Chore: Remove the old filter compute function

### DIFF
--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -26,11 +26,9 @@ use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
-use vortex_array::ToCanonical;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::PrimitiveVTable;
 use vortex_array::buffer::BufferHandle;
-use vortex_array::compute::filter;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::stats::ArrayStats;
 use vortex_array::stats::StatsSetRef;
@@ -198,9 +196,13 @@ pub(crate) fn number_type_from_dtype(dtype: &DType) -> NumberType {
     }
 }
 
-fn collect_valid(parray: &PrimitiveArray) -> VortexResult<PrimitiveArray> {
+fn collect_valid(parray: &PrimitiveArray, ctx: &mut ExecutionCtx) -> VortexResult<PrimitiveArray> {
     let mask = parray.validity_mask()?;
-    Ok(filter(&parray.to_array(), &mask)?.to_primitive())
+    Ok(parray
+        .to_array()
+        .filter(mask)?
+        .execute::<Canonical>(ctx)?
+        .into_primitive())
 }
 
 pub(crate) fn vortex_err_from_pco(err: PcoError) -> VortexError {
@@ -258,8 +260,15 @@ impl PcoArray {
         parray: &PrimitiveArray,
         level: usize,
         values_per_page: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
-        Self::from_primitive_with_values_per_chunk(parray, level, VALUES_PER_CHUNK, values_per_page)
+        Self::from_primitive_with_values_per_chunk(
+            parray,
+            level,
+            VALUES_PER_CHUNK,
+            values_per_page,
+            ctx,
+        )
     }
 
     pub(crate) fn from_primitive_with_values_per_chunk(
@@ -267,6 +276,7 @@ impl PcoArray {
         level: usize,
         values_per_chunk: usize,
         values_per_page: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
         let number_type = number_type_from_dtype(parray.dtype());
         let values_per_page = if values_per_page == 0 {
@@ -280,7 +290,7 @@ impl PcoArray {
             .with_compression_level(level)
             .with_paging_spec(PagingSpec::EqualPagesUpTo(values_per_page));
 
-        let values = collect_valid(parray)?;
+        let values = collect_valid(parray, ctx)?;
         let n_values = values.len();
 
         let fc = FileCompressor::default();
@@ -335,9 +345,14 @@ impl PcoArray {
         ))
     }
 
-    pub fn from_array(array: ArrayRef, level: usize, nums_per_page: usize) -> VortexResult<Self> {
+    pub fn from_array(
+        array: ArrayRef,
+        level: usize,
+        nums_per_page: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Self> {
         if let Some(parray) = array.as_opt::<PrimitiveVTable>() {
-            Self::from_primitive(parray, level, nums_per_page)
+            Self::from_primitive(parray, level, nums_per_page, ctx)
         } else {
             Err(vortex_err!("Pco can only encode primitive arrays"))
         }
@@ -555,6 +570,8 @@ impl VisitorVTable<PcoVTable> for PcoVTable {
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::validity::Validity;
@@ -569,7 +586,9 @@ mod tests {
             Buffer::copy_from(vec![10u32, 20, 30, 40, 50, 60]),
             Validity::from_iter([false, true, true, true, true, false]),
         );
-        let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
+        let pco =
+            PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap();
         assert_arrays_eq!(
             pco,
             PrimitiveArray::from_option_iter([

--- a/encodings/pco/src/compute/cast.rs
+++ b/encodings/pco/src/compute/cast.rs
@@ -55,6 +55,8 @@ register_kernel!(CastKernelAdapter(PcoVTable).lift());
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::compute::cast;
@@ -73,7 +75,9 @@ mod tests {
             Buffer::copy_from(vec![1.0f32, 2.0, 3.0, 4.0, 5.0]),
             Validity::NonNullable,
         );
-        let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
+        let pco =
+            PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap();
 
         let casted = cast(
             pco.as_ref(),
@@ -98,7 +102,9 @@ mod tests {
             Buffer::copy_from(vec![10u32, 20, 30, 40]),
             Validity::NonNullable,
         );
-        let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
+        let pco =
+            PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap();
 
         let casted = cast(
             pco.as_ref(),
@@ -117,7 +123,9 @@ mod tests {
             Buffer::copy_from(vec![10u32, 20, 30, 40, 50, 60]),
             Validity::from_iter([true, true, true, true, true, true]),
         );
-        let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
+        let pco =
+            PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap();
         let sliced = pco.slice(1..5).unwrap();
         let casted = cast(
             sliced.as_ref(),
@@ -142,7 +150,9 @@ mod tests {
             Some(50),
             Some(60),
         ]);
-        let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
+        let pco =
+            PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap();
         let sliced = pco.slice(1..5).unwrap();
         let casted = cast(
             sliced.as_ref(),
@@ -178,7 +188,9 @@ mod tests {
         Validity::NonNullable,
     ))]
     fn test_cast_pco_conformance(#[case] values: PrimitiveArray) {
-        let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
+        let pco =
+            PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap();
         test_cast_conformance(pco.as_ref());
     }
 }

--- a/encodings/pco/src/compute/mod.rs
+++ b/encodings/pco/src/compute/mod.rs
@@ -6,6 +6,8 @@ mod cast;
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
     use vortex_buffer::Buffer;
@@ -17,7 +19,8 @@ mod tests {
             Buffer::copy_from(vec![1.23f32, 4.56, 7.89, 10.11, 12.13]),
             vortex_array::validity::Validity::NonNullable,
         );
-        PcoArray::from_primitive(&values, 0, 128).unwrap()
+        PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_f64() -> PcoArray {
@@ -25,7 +28,8 @@ mod tests {
             Buffer::copy_from(vec![100.1f64, 200.2, 300.3, 400.4, 500.5]),
             vortex_array::validity::Validity::NonNullable,
         );
-        PcoArray::from_primitive(&values, 0, 128).unwrap()
+        PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_i32() -> PcoArray {
@@ -33,7 +37,8 @@ mod tests {
             Buffer::copy_from(vec![100i32, 200, 300, 400, 500]),
             vortex_array::validity::Validity::NonNullable,
         );
-        PcoArray::from_primitive(&values, 0, 128).unwrap()
+        PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_u64() -> PcoArray {
@@ -41,7 +46,8 @@ mod tests {
             Buffer::copy_from(vec![1000u64, 2000, 3000, 4000]),
             vortex_array::validity::Validity::NonNullable,
         );
-        PcoArray::from_primitive(&values, 0, 128).unwrap()
+        PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_i16() -> PcoArray {
@@ -49,7 +55,8 @@ mod tests {
             Buffer::copy_from(vec![10i16, 20, 30, 40, 50]),
             vortex_array::validity::Validity::NonNullable,
         );
-        PcoArray::from_primitive(&values, 0, 128).unwrap()
+        PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_i32_alt() -> PcoArray {
@@ -57,7 +64,8 @@ mod tests {
             Buffer::copy_from(vec![1i32, 2, 3, 4, 5]),
             vortex_array::validity::Validity::NonNullable,
         );
-        PcoArray::from_primitive(&values, 0, 128).unwrap()
+        PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_single() -> PcoArray {
@@ -65,7 +73,8 @@ mod tests {
             Buffer::copy_from(vec![42.42f64]),
             vortex_array::validity::Validity::NonNullable,
         );
-        PcoArray::from_primitive(&values, 0, 128).unwrap()
+        PcoArray::from_primitive(&values, 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_large() -> PcoArray {
@@ -73,7 +82,8 @@ mod tests {
             Buffer::copy_from((0..1000).map(|i| i as u32).collect::<Vec<_>>()),
             vortex_array::validity::Validity::NonNullable,
         );
-        PcoArray::from_primitive(&values, 3, 128).unwrap()
+        PcoArray::from_primitive(&values, 3, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     #[rstest]

--- a/encodings/pco/src/test.rs
+++ b/encodings/pco/src/test.rs
@@ -2,10 +2,9 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 #![allow(clippy::cast_possible_truncation)]
 
-use std::sync::LazyLock;
-
 use vortex_array::ArrayContext;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
 use vortex_array::ToCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
@@ -25,10 +24,6 @@ use vortex_dtype::Nullability;
 use vortex_dtype::PType;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
-use vortex_session::VortexSession;
-
-static LEGACY_SESSION: LazyLock<VortexSession> =
-    LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
 use crate::PcoArray;
 use crate::PcoVTable;
@@ -37,7 +32,8 @@ use crate::PcoVTable;
 fn test_compress_decompress() {
     let data: Vec<i32> = (0..200).collect();
     let array = PrimitiveArray::from_iter(data.clone());
-    let compressed = PcoArray::from_primitive(&array, 3, 0).unwrap();
+    let compressed =
+        PcoArray::from_primitive(&array, 3, 0, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
     // this data should be compressible
     assert!(compressed.pages.len() < array.nbytes() as usize);
 
@@ -59,7 +55,8 @@ fn test_compress_decompress() {
 #[test]
 fn test_compress_decompress_small() {
     let array = PrimitiveArray::from_option_iter([None, Some(1)]);
-    let compressed = PcoArray::from_primitive(&array, 3, 0).unwrap();
+    let compressed =
+        PcoArray::from_primitive(&array, 3, 0, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
 
     let expected = array.into_array();
     assert_arrays_eq!(compressed, expected);
@@ -72,7 +69,9 @@ fn test_compress_decompress_small() {
 fn test_empty() {
     let data: Vec<i32> = vec![];
     let array = PrimitiveArray::from_iter(data.clone());
-    let compressed = PcoArray::from_primitive(&array, 3, 100).unwrap();
+    let compressed =
+        PcoArray::from_primitive(&array, 3, 100, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
     let primitive = compressed.decompress().unwrap();
     assert_arrays_eq!(primitive, PrimitiveArray::from_iter(data));
 }
@@ -95,6 +94,7 @@ fn test_validity_and_multiple_chunks_and_pages() {
         compression_level,
         values_per_chunk,
         values_per_page,
+        &mut LEGACY_SESSION.create_execution_ctx(),
     )
     .unwrap();
 
@@ -127,7 +127,8 @@ fn test_validity_vtable() {
         data.iter().cloned().collect::<Buffer<_>>(),
         Validity::Array(BoolArray::from_iter(mask_bools.clone()).to_array()),
     );
-    let compressed = PcoArray::from_primitive(&array, 3, 0).unwrap();
+    let compressed =
+        PcoArray::from_primitive(&array, 3, 0, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
     assert_eq!(
         compressed.validity_mask().unwrap(),
         Mask::from_iter(mask_bools)
@@ -141,7 +142,8 @@ fn test_validity_vtable() {
 #[test]
 fn test_serde() -> VortexResult<()> {
     let data: PrimitiveArray = (0i32..1_000_000).collect();
-    let pco = PcoArray::from_primitive(&data, 3, 100)?.to_array();
+    let pco = PcoArray::from_primitive(&data, 3, 100, &mut LEGACY_SESSION.create_execution_ctx())?
+        .to_array();
 
     let session = ArraySession::default();
     session.registry().register(PcoVTable::ID, PcoVTable);

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -23,7 +23,6 @@ use vortex_array::buffer::BufferHandle;
 use vortex_array::compute::Operator;
 use vortex_array::compute::compare;
 use vortex_array::compute::fill_null;
-use vortex_array::compute::filter;
 use vortex_array::compute::sub_scalar;
 use vortex_array::patches::Patches;
 use vortex_array::patches::PatchesMetadata;
@@ -285,7 +284,14 @@ impl SparseArray {
     /// Encode given array as a SparseArray.
     ///
     /// Optionally provided fill value will be respected if the array is less than 90% null.
-    pub fn encode(array: &dyn Array, fill_value: Option<Scalar>) -> VortexResult<ArrayRef> {
+    ///
+    /// Since we must perform a filter over the array to remove some values before we compress, this
+    /// function takes an [`ExecutionCtx`].
+    pub fn encode(
+        array: &dyn Array,
+        fill_value: Option<Scalar>,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
         if let Some(fill_value) = fill_value.as_ref()
             && array.dtype() != fill_value.dtype()
         {
@@ -304,7 +310,10 @@ impl SparseArray {
             );
         } else if mask.false_count() as f64 > (0.9 * mask.len() as f64) {
             // Array is dominated by NULL but has non-NULL values
-            let non_null_values = filter(array, &mask)?;
+            let non_null_values = array
+                .filter(mask.clone())?
+                .execute::<Canonical>(ctx)?
+                .into_array();
             let non_null_indices = match mask.indices() {
                 AllOr::All => {
                     // We already know that the mask is 90%+ false
@@ -355,7 +364,10 @@ impl SparseArray {
             .to_bit_buffer(),
         );
 
-        let non_top_values = filter(array, &non_top_mask)?;
+        let non_top_values = array
+            .filter(non_top_mask.clone())?
+            .execute::<Canonical>(ctx)?
+            .into_array();
 
         let indices: Buffer<u64> = match non_top_mask {
             Mask::AllTrue(count) => {
@@ -440,6 +452,8 @@ impl VisitorVTable<SparseVTable> for SparseVTable {
 mod test {
     use itertools::Itertools;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::ConstantArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
@@ -608,8 +622,12 @@ mod test {
                 true, true, false, true, false, true, false, true, true, false, true, false,
             ]),
         );
-        let sparse = SparseArray::encode(&original.clone().into_array(), None)
-            .vortex_expect("SparseArray::encode should succeed for test data");
+        let sparse = SparseArray::encode(
+            &original.clone().into_array(),
+            None,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("SparseArray::encode should succeed for test data");
         assert_eq!(
             sparse.validity_mask().unwrap(),
             Mask::from_iter(vec![

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -16,16 +16,16 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
-use vortex_array::ToCanonical;
+use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::build_views::BinaryView;
 use vortex_array::buffer::BufferHandle;
-use vortex_array::compute::filter;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::stats::ArrayStats;
 use vortex_array::stats::StatsSetRef;
@@ -236,9 +236,16 @@ fn choose_max_dict_size(uncompressed_size: usize) -> usize {
     (uncompressed_size / 100).clamp(256, 100 * 1024)
 }
 
-fn collect_valid_primitive(parray: &PrimitiveArray) -> VortexResult<PrimitiveArray> {
+fn collect_valid_primitive(
+    parray: &PrimitiveArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<PrimitiveArray> {
     let mask = parray.validity_mask()?;
-    Ok(filter(&parray.to_array(), &mask)?.to_primitive())
+    Ok(parray
+        .to_array()
+        .filter(mask)?
+        .execute::<Canonical>(ctx)?
+        .into_primitive())
 }
 
 fn collect_valid_vbv(vbv: &VarBinViewArray) -> VortexResult<(ByteBuffer, Vec<usize>)> {
@@ -409,8 +416,9 @@ impl ZstdArray {
         parray: &PrimitiveArray,
         level: i32,
         values_per_frame: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
-        Self::from_primitive_impl(parray, level, values_per_frame, false)
+        Self::from_primitive_impl(parray, level, values_per_frame, false, ctx)
     }
 
     fn from_primitive_impl(
@@ -418,12 +426,13 @@ impl ZstdArray {
         level: i32,
         values_per_frame: usize,
         use_dictionary: bool,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
         let dtype = parray.dtype().clone();
         let byte_width = parray.ptype().byte_width();
 
         // We compress only the valid elements.
-        let values = collect_valid_primitive(parray)?;
+        let values = collect_valid_primitive(parray, ctx)?;
         let n_values = values.len();
         let values_per_frame = if values_per_frame > 0 {
             values_per_frame

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -45,40 +45,6 @@ pub(crate) fn warm_up_vtable() -> usize {
     FILTER_FN.kernels().len()
 }
 
-/// Keep only the elements for which the corresponding mask value is true.
-///
-/// # Examples
-///
-/// ```
-/// use vortex_array::{Array, IntoArray};
-/// use vortex_array::arrays::{BoolArray, PrimitiveArray};
-/// use vortex_array::compute::{ filter, mask};
-/// use vortex_error::VortexResult;
-/// use vortex_mask::Mask;
-/// use vortex_scalar::Scalar;
-///
-/// # fn main() -> VortexResult<()> {
-/// let array =
-///     PrimitiveArray::from_option_iter([Some(0i32), None, Some(1i32), None, Some(2i32)]);
-/// let mask = Mask::from_iter([true, false, false, false, true]);
-///
-/// let filtered = filter(array.as_ref(), &mask)?;
-/// assert_eq!(filtered.len(), 2);
-/// assert_eq!(filtered.scalar_at(0)?, Scalar::from(Some(0_i32)));
-/// assert_eq!(filtered.scalar_at(1)?, Scalar::from(Some(2_i32)));
-/// # Ok(())
-/// # }
-/// ```
-///
-/// # Panics
-///
-/// The `predicate` must receive an Array with type non-nullable bool, and will panic if this is
-/// not the case.
-pub fn filter(array: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef> {
-    // TODO(connor): Remove this function completely!!!
-    Ok(array.filter(mask.clone())?.to_canonical()?.into_array())
-}
-
 struct Filter;
 
 impl ComputeFnVTable for Filter {

--- a/vortex-array/src/lib.rs
+++ b/vortex-array/src/lib.rs
@@ -73,5 +73,5 @@ pub mod flatbuffers {
 // TODO(ngates): canonicalize doesn't currently take a session, therefore we cannot invoke execute
 //  from the new array encodings to support back-compat for legacy encodings. So we hold a session
 //  here...
-static LEGACY_SESSION: LazyLock<VortexSession> =
+pub static LEGACY_SESSION: LazyLock<VortexSession> =
     LazyLock::new(|| VortexSession::empty().with::<ArraySession>());

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -36,13 +36,15 @@ use vortex_vector::primitive::PrimitiveVectorMut;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::IntoArray;
+use crate::LEGACY_SESSION;
 use crate::ToCanonical;
 use crate::arrays::PrimitiveArray;
 use crate::compute::cast;
-use crate::compute::filter;
 use crate::compute::is_sorted;
 use crate::compute::take;
+use crate::executor::VortexSessionExecute;
 use crate::search_sorted::SearchResult;
 use crate::search_sorted::SearchSorted;
 use crate::search_sorted::SearchSortedSide;
@@ -626,9 +628,19 @@ impl Patches {
             return Ok(None);
         }
 
+        // TODO(connor): This goes away when we get a `PatchesArray`.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // SAFETY: filtering indices/values with same mask maintains their 1:1 relationship
-        let filtered_indices = filter(&self.indices, &filter_mask)?;
-        let filtered_values = filter(&self.values, &filter_mask)?;
+        let filtered_indices = self
+            .indices
+            .filter(filter_mask.clone())?
+            .execute::<Canonical>(&mut ctx)?
+            .into_array();
+        let filtered_values = self
+            .values
+            .filter(filter_mask)?
+            .execute::<Canonical>(&mut ctx)?
+            .into_array();
 
         Ok(Some(Self {
             array_len: self.array_len,
@@ -1149,10 +1161,11 @@ fn filter_patches_with_mask<T: IntegerPType>(
     }
 
     let new_patch_indices = new_patch_indices.into_array();
-    let new_patch_values = filter(
-        patch_values,
-        &Mask::from_indices(patch_values.len(), new_mask_indices),
-    )?;
+    let new_patch_values = patch_values
+        .filter(Mask::from_indices(patch_values.len(), new_mask_indices))?
+        // TODO(connor): This goes away when we get a `PatchesArray`.
+        .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+        .into_array();
 
     Ok(Some(Patches::new(
         true_count,

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -22,13 +22,16 @@ use vortex_scalar::Scalar;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::IntoArray;
+use crate::LEGACY_SESSION;
 use crate::ToCanonical;
 use crate::arrays::BoolArray;
 use crate::arrays::ConstantArray;
 use crate::compute::fill_null;
 use crate::compute::sum;
 use crate::compute::take;
+use crate::executor::VortexSessionExecute;
 use crate::patches::Patches;
 
 /// Validity information for an array
@@ -196,10 +199,11 @@ impl Validity {
                 Ok(v.clone())
             }
             Validity::Array(arr) => Ok(Validity::Array(
+                // TODO(connor): This is wrong!!! We should not be eagerly decompressing the
+                // validity array.
+                // We need to fix this in the compressor and then we can revert this.
                 arr.filter(mask.clone())?
-                    // TODO(connor): This is wrong!!! We should not be eagerly decompressing the
-                    // validity array.
-                    .to_canonical()?
+                    .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
                     .into_array(),
             )),
         }

--- a/vortex-btrblocks/src/float.rs
+++ b/vortex-btrblocks/src/float.rs
@@ -437,11 +437,12 @@ impl Scheme for NullDominated {
         is_sample: bool,
         allowed_cascading: usize,
         _excludes: &[Self::CodeType],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         assert!(allowed_cascading > 0);
 
         // We pass None as we only run this pathway for NULL-dominated float arrays
-        let sparse_encoded = SparseArray::encode(stats.src.as_ref(), None)?;
+        let sparse_encoded = SparseArray::encode(stats.src.as_ref(), None, ctx)?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {
             // Compress the values

--- a/vortex-btrblocks/src/integer.rs
+++ b/vortex-btrblocks/src/integer.rs
@@ -510,6 +510,7 @@ impl Scheme for SparseScheme {
         is_sample: bool,
         allowed_cascading: usize,
         excludes: &[IntCode],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         assert!(allowed_cascading > 0);
         let (top_pvalue, top_count) = stats.typed.top_value_and_count();
@@ -533,6 +534,7 @@ impl Scheme for SparseScheme {
                 top_pvalue.ptype(),
                 stats.src.dtype().nullability(),
             )),
+            ctx,
         )?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {

--- a/vortex-btrblocks/src/lib.rs
+++ b/vortex-btrblocks/src/lib.rs
@@ -36,6 +36,7 @@ use std::hash::Hash;
 use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
 use vortex_array::arrays::ConstantArray;
@@ -178,6 +179,7 @@ pub trait Scheme: Debug {
         is_sample: bool,
         allowed_cascading: usize,
         excludes: &[Self::CodeType],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef>;
 }
 

--- a/vortex-btrblocks/src/string.rs
+++ b/vortex-btrblocks/src/string.rs
@@ -417,11 +417,12 @@ impl Scheme for NullDominated {
         is_sample: bool,
         allowed_cascading: usize,
         _excludes: &[Self::CodeType],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         assert!(allowed_cascading > 0);
 
         // We pass None as we only run this pathway for NULL-dominated string arrays
-        let sparse_encoded = SparseArray::encode(stats.src.as_ref(), None)?;
+        let sparse_encoded = SparseArray::encode(stats.src.as_ref(), None, ctx)?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {
             // Compress the values

--- a/vortex-layout/src/layouts/row_idx/mod.rs
+++ b/vortex-layout/src/layouts/row_idx/mod.rs
@@ -15,10 +15,10 @@ pub use expr::*;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use vortex_array::ArrayRef;
+use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::MaskFuture;
 use vortex_array::VortexSessionExecute;
-use vortex_array::compute::filter;
 use vortex_array::expr::ExactExpr;
 use vortex_array::expr::Expression;
 use vortex_array::expr::is_root;
@@ -279,7 +279,7 @@ fn row_idx_array_future(
     let expr = expr.clone();
     async move {
         let array = idx_array(row_offset, &row_range).into_array();
-        let array = filter(&array, &mask.await?)?;
+        let array = array.filter(mask.await?)?;
         array.apply(&expr)
     }
     .boxed()

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -24,7 +24,11 @@ use pyo3::types::PyRangeMethods;
 use pyo3_bytes::PyBytes;
 use vortex::array::Array;
 use vortex::array::ArrayRef;
+use vortex::array::Canonical;
+use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
 use vortex::array::ToCanonical;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::ChunkedVTable;
 use vortex::array::arrow::IntoArrowArray;
 use vortex::array::compute::take;
@@ -495,7 +499,7 @@ impl PyArray {
     fn filter(slf: Bound<Self>, mask: PyArrayRef) -> PyVortexResult<PyArrayRef> {
         let slf = PyArrayRef::extract(slf.as_any().as_borrowed())?.into_inner();
         let mask = (&*mask as &dyn Array).to_bool().to_mask_fill_null_false();
-        let inner = vortex::compute::filter(&*slf, &mask)?;
+        let inner = slf.filter(mask)?;
         Ok(PyArrayRef::from(inner))
     }
 


### PR DESCRIPTION
As part of the work to make filters lazy, we can now remove the old standalone `filter` function.

Note that the existing implementation code still have to move out of the kernels (which requires us to copy paste move a lot of code around), but that can be in a separate PR.

There is also still the issue where validity is eagerly filtered (which we don't want but we can't change yet until we make a relatively small change to the way we canonicalize before running through the compressor), and that will come in the next followup PR.