### PR TITLE
fix: simd build

### DIFF
--- a/vortex-compute/src/take/slice/portable.rs
+++ b/vortex-compute/src/take/slice/portable.rs
@@ -9,6 +9,8 @@ use std::mem::MaybeUninit;
 use std::mem::size_of;
 use std::mem::transmute;
 use std::simd;
+use std::simd::LaneCount;
+use std::simd::SupportedLaneCount;
 use std::simd::num::SimdUint;
 
 use multiversion::multiversion;
@@ -80,7 +82,7 @@ pub fn take_portable_simd<T, I, const LANE_COUNT: usize>(values: &[T], indices: 
 where
     T: NativePType + simd::SimdElement,
     I: UnsignedPType + simd::SimdElement,
-    simd::LaneCount<LANE_COUNT>: simd::SupportedLaneCount,
+    LaneCount<LANE_COUNT>: SupportedLaneCount,
     simd::Simd<I, LANE_COUNT>: SimdUint<Cast<usize> = simd::Simd<usize, LANE_COUNT>>,
 {
     let indices_len = indices.len();

--- a/vortex-compute/src/take/slice/portable.rs
+++ b/vortex-compute/src/take/slice/portable.rs
@@ -9,8 +9,6 @@ use std::mem::MaybeUninit;
 use std::mem::size_of;
 use std::mem::transmute;
 use std::simd;
-use std::simd::LaneCount;
-use std::simd::SupportedLaneCount;
 use std::simd::num::SimdUint;
 
 use multiversion::multiversion;
@@ -82,7 +80,6 @@ pub fn take_portable_simd<T, I, const LANE_COUNT: usize>(values: &[T], indices: 
 where
     T: NativePType + simd::SimdElement,
     I: UnsignedPType + simd::SimdElement,
-    LaneCount<LANE_COUNT>: SupportedLaneCount,
     simd::Simd<I, LANE_COUNT>: SimdUint<Cast<usize> = simd::Simd<usize, LANE_COUNT>>,
 {
     let indices_len = indices.len();


### PR DESCRIPTION
`LaneCount` and `SupportedLaneCount` are no longer part of the public `std::simd` API.