### PR TITLE
chore: vortex-tui readme points to its own readme not the root package

### DIFF
--- a/vortex-tui/Cargo.toml
+++ b/vortex-tui/Cargo.toml
@@ -8,7 +8,7 @@ homepage = { workspace = true }
 include = { workspace = true }
 keywords = { workspace = true }
 license = { workspace = true }
-readme = { workspace = true }
+readme = "README.md"
 repository = { workspace = true }
 rust-version = { workspace = true }
 version = { workspace = true }


### PR DESCRIPTION
Signed-off-by: Robert Kruszewski <github@robertk.io>
