### PR TITLE
Check read-only cache first

### DIFF
--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -116,6 +116,12 @@ impl DictReader {
         // after applying the filter, so if the expression is fallible this might fail when it
         // shouldn't.
         // TODO(joe): fixme
+
+        // Check cache first with read-only lock
+        if let Some(fut) = self.values_evals.get(&expr) {
+            return fut.clone();
+        }
+
         let session = self.session.clone();
         self.values_evals
             .entry(expr.clone())

--- a/vortex-layout/src/layouts/row_idx/mod.rs
+++ b/vortex-layout/src/layouts/row_idx/mod.rs
@@ -63,8 +63,15 @@ impl RowIdxLayoutReader {
     }
 
     fn partition_expr(&self, expr: &Expression) -> Partitioning {
+        let key = ExactExpr(expr.clone());
+
+        // Check cache first with read-only lock.
+        if let Some(partitioning) = self.partition_cache.get(&key) {
+            return partitioning.clone();
+        }
+
         self.partition_cache
-            .entry(ExactExpr(expr.clone()))
+            .entry(key)
             .or_insert_with(|| {
                 // Partition the expression into row idx and child expressions.
                 let mut partitioned = partition(expr.clone(), self.dtype(), |expr| {

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -150,6 +150,11 @@ impl ZonedReader {
 
     /// Returns a pruning mask where `true` means the chunk _can be pruned_.
     fn pruning_mask_future(&self, expr: Expression) -> Option<SharedPruningResult> {
+        // Check cache first with read-only lock
+        if let Some(result) = self.pruning_result.get(&expr) {
+            return result.value().clone();
+        }
+
         self.pruning_result
             .entry(expr.clone())
             .or_insert_with(|| match self.pruning_predicate(expr.clone()) {


### PR DESCRIPTION
Annoyingly the DashMap is a fragile API that can easily require a write-lock when one isn't required. There's no good clippy lint to forbid here either since the fallback is Entry::or_insert_with