### PR TITLE
Execute parent to return ArrayRef

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -178,8 +178,8 @@ impl VTable for ALPVTable {
         array: &Self::Array,
         parent: &ArrayRef,
         _child_idx: usize,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
         // CPU-only: if parent is SliceArray, perform slicing of the buffer and any patches
         // Note that this triggers compute (binary searching Patches) which we cannot do when the
         // buffers live in GPU memory.
@@ -195,7 +195,7 @@ impl VTable for ALPVTable {
                     .flatten(),
             )
             .into_array();
-            return Ok(Some(sliced_alp.execute::<Canonical>(ctx)?));
+            return Ok(Some(sliced_alp));
         }
 
         Ok(None)

--- a/encodings/fastlanes/src/bitpacking/vtable/kernels/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/kernels/filter.rs
@@ -5,8 +5,9 @@ use std::mem::MaybeUninit;
 use std::sync::Arc;
 
 use fastlanes::BitPacking;
-use vortex_array::Canonical;
+use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::arrays::FilterArray;
 use vortex_array::arrays::FilterVTable;
 use vortex_array::arrays::PrimitiveArray;
@@ -65,7 +66,7 @@ impl ExecuteParentKernel<BitPackedVTable> for BitPackingFilterKernel {
         parent: &FilterArray,
         _child_idx: usize,
         _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         let values = match parent.filter_mask() {
             Mask::AllTrue(_) | Mask::AllFalse(_) => {
                 return Ok(None);
@@ -98,7 +99,7 @@ impl ExecuteParentKernel<BitPackedVTable> for BitPackingFilterKernel {
             primitive = primitive.patch(&patches)?;
         }
 
-        Ok(Some(Canonical::Primitive(primitive)))
+        Ok(Some(primitive.into_array()))
     }
 }
 

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -262,7 +262,7 @@ impl VTable for BitPackedVTable {
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -184,7 +184,7 @@ impl VTable for RLEVTable {
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -203,7 +203,7 @@ impl VTable for FSSTVTable {
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 

--- a/encodings/fsst/src/kernel.rs
+++ b/encodings/fsst/src/kernel.rs
@@ -8,6 +8,7 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::FilterArray;
 use vortex_array::arrays::FilterVTable;
 use vortex_array::arrays::VarBinVTable;
+use vortex_array::compute::FilterKernel;
 use vortex_array::kernel::ExecuteParentKernel;
 use vortex_array::kernel::ParentKernelSet;
 use vortex_array::matchers::Exact;
@@ -36,16 +37,18 @@ impl ExecuteParentKernel<FSSTVTable> for FSSTFilterKernel {
         _child_idx: usize,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
+        // TODO(ngates): pass execution context when we update the FilterKernel trait.
+        let filtered_codes =
+            FilterKernel::filter(&VarBinVTable, array.codes(), parent.filter_mask())?
+                .as_::<VarBinVTable>()
+                .clone();
+
         Ok(Some(
             FSSTArray::try_new(
                 array.dtype().clone(),
                 array.symbols().clone(),
                 array.symbol_lengths().clone(),
-                array
-                    .codes()
-                    .filter(parent.filter_mask().clone())?
-                    .as_::<VarBinVTable>()
-                    .clone(),
+                filtered_codes,
                 array
                     .uncompressed_lengths()
                     .filter(parent.filter_mask().clone())?,

--- a/encodings/fsst/src/kernel.rs
+++ b/encodings/fsst/src/kernel.rs
@@ -1,36 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::sync::Arc;
-
-use fsst::Decompressor;
-use num_traits::AsPrimitive;
 use vortex_array::Array;
-use vortex_array::Canonical;
+use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::arrays::FilterArray;
 use vortex_array::arrays::FilterVTable;
-use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::VarBinViewArray;
-use vortex_array::arrays::build_views::BinaryView;
-use vortex_array::builtins::ArrayBuiltins;
+use vortex_array::arrays::VarBinVTable;
 use vortex_array::kernel::ExecuteParentKernel;
 use vortex_array::kernel::ParentKernelSet;
 use vortex_array::matchers::Exact;
-use vortex_array::validity::Validity;
-use vortex_array::vtable::ValidityHelper;
-use vortex_buffer::Buffer;
-use vortex_buffer::BufferMut;
-use vortex_buffer::ByteBuffer;
-use vortex_buffer::ByteBufferMut;
-use vortex_dtype::DType;
-use vortex_dtype::IntegerPType;
-use vortex_dtype::Nullability;
-use vortex_dtype::PType;
-use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexResult;
-use vortex_mask::Mask;
-use vortex_mask::MaskValues;
 
 use crate::FSSTArray;
 use crate::FSSTVTable;
@@ -53,141 +34,25 @@ impl ExecuteParentKernel<FSSTVTable> for FSSTFilterKernel {
         array: &FSSTArray,
         parent: &FilterArray,
         _child_idx: usize,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
-        let mask_values = match parent.filter_mask() {
-            Mask::AllTrue(_) | Mask::AllFalse(_) => return Ok(None),
-            Mask::Values(v) => v,
-        };
-
-        // We filter the uncompressed lengths
-        let uncompressed_lens = array
-            .uncompressed_lengths()
-            .filter(parent.filter_mask().clone())?
-            .execute::<Canonical>(ctx)?
-            .into_primitive();
-
-        // Extract the filtered validity
-        let validity = match array.codes().validity().filter(parent.filter_mask())? {
-            Validity::NonNullable | Validity::AllValid => {
-                Mask::new_true(parent.filter_mask().true_count())
-            }
-            Validity::AllInvalid => Mask::new_false(parent.filter_mask().true_count()),
-            Validity::Array(a) => a.execute::<Mask>(ctx)?,
-        };
-
-        // First we unpack the codes VarBinArray to get access to the raw data.
-        let codes_data = array.codes().bytes();
-        let codes_offsets = array
-            .codes()
-            .offsets()
-            .cast(DType::Primitive(PType::U32, Nullability::NonNullable))?
-            .execute::<PrimitiveArray>(ctx)?
-            .to_buffer::<u32>();
-
-        let decompressor = array.decompressor();
-
-        let (views, buffer) = match_each_integer_ptype!(uncompressed_lens.ptype(), |S| {
-            fsst_decode::<S>(
-                decompressor,
-                codes_data,
-                &codes_offsets,
-                mask_values,
-                &validity,
-                &uncompressed_lens.to_buffer::<S>(),
-            )
-        });
-
-        // SAFETY: FSST already validates the bytes for binary/UTF-8.
-        let canonical = unsafe {
-            Canonical::VarBinView(VarBinViewArray::new_unchecked(
-                views,
-                Arc::from(vec![buffer]),
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        Ok(Some(
+            FSSTArray::try_new(
                 array.dtype().clone(),
-                Validity::from_mask(validity, array.dtype().nullability()),
-            ))
-        };
-
-        Ok(Some(canonical))
+                array.symbols().clone(),
+                array.symbol_lengths().clone(),
+                array
+                    .codes()
+                    .filter(parent.filter_mask().clone())?
+                    .as_::<VarBinVTable>()
+                    .clone(),
+                array
+                    .uncompressed_lengths()
+                    .filter(parent.filter_mask().clone())?,
+            )?
+            .into_array(),
+        ))
     }
-}
-
-fn fsst_decode<S: IntegerPType + AsPrimitive<usize> + AsPrimitive<u32>>(
-    decompressor: Decompressor,
-    codes_data: &[u8],
-    codes_offsets: &[u32],
-    filter_mask: &MaskValues,
-    filtered_validity: &Mask,
-    filtered_uncompressed_lengths: &[S],
-) -> (Buffer<BinaryView>, ByteBuffer) {
-    let total_uncompressed_size: usize = filtered_uncompressed_lengths
-        .iter()
-        .map(|x| <S as AsPrimitive<usize>>::as_(*x))
-        .sum();
-
-    // We allocate an extra 7 bytes per the FSST decompressor's requirement for padding.
-    let mut uncompressed = ByteBufferMut::with_capacity(total_uncompressed_size + 7);
-    let mut spare_capacity = uncompressed.spare_capacity_mut();
-
-    match filtered_validity {
-        Mask::AllTrue(_) => {
-            for &idx in filter_mask.indices() {
-                let start = codes_offsets[idx] as usize;
-                let end = codes_offsets[idx + 1] as usize;
-                let compressed_slice = &codes_data[start..end];
-
-                let uncompressed_len =
-                    decompressor.decompress_into(compressed_slice, spare_capacity);
-                spare_capacity = &mut spare_capacity[uncompressed_len..];
-            }
-        }
-        Mask::AllFalse(_) => {
-            // Nothing to decompress - all values are null with length 0
-        }
-        Mask::Values(values) => {
-            for (filtered_idx, (idx, is_valid)) in filter_mask
-                .indices()
-                .iter()
-                .copied()
-                .zip(values.bit_buffer().iter())
-                .enumerate()
-            {
-                if is_valid {
-                    let start = codes_offsets[idx] as usize;
-                    let end = codes_offsets[idx + 1] as usize;
-                    let compressed_slice = &codes_data[start..end];
-
-                    let uncompressed_len =
-                        decompressor.decompress_into(compressed_slice, spare_capacity);
-                    spare_capacity = &mut spare_capacity[uncompressed_len..];
-                } else {
-                    // We advance the output buffer to make it faster to assemble views below.
-                    spare_capacity =
-                        &mut spare_capacity[filtered_uncompressed_lengths[filtered_idx].as_()..];
-                }
-            }
-        }
-    }
-
-    unsafe { uncompressed.set_len(total_uncompressed_size) };
-    let uncompressed = uncompressed.freeze();
-    let uncompressed_slice = uncompressed.as_ref();
-
-    // Loop over the uncompressed lengths to construct the BinaryViews.
-    let mut views = BufferMut::<BinaryView>::with_capacity(filtered_uncompressed_lengths.len());
-    let mut offset = 0u32;
-    for len in filtered_uncompressed_lengths {
-        let view = BinaryView::make_view(
-            &uncompressed_slice[offset as usize..][..len.as_()],
-            0u32,
-            offset,
-        );
-        offset += <S as AsPrimitive<u32>>::as_(*len);
-        unsafe { views.push_unchecked(view) };
-    }
-    unsafe { views.set_len(filtered_uncompressed_lengths.len()) };
-
-    (views.freeze(), uncompressed)
 }
 
 #[cfg(test)]

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -138,7 +138,7 @@ impl VTable for RunEndVTable {
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 

--- a/encodings/runend/src/kernel.rs
+++ b/encodings/runend/src/kernel.rs
@@ -4,7 +4,6 @@
 use std::ops::Range;
 
 use vortex_array::ArrayRef;
-use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::ConstantArray;
@@ -40,11 +39,9 @@ impl ExecuteParentKernel<RunEndVTable> for RunEndSliceKernel {
         array: &RunEndArray,
         parent: &SliceArray,
         _child_idx: usize,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
-        let sliced = slice(array, parent.slice_range().clone())?;
-
-        sliced.execute::<Canonical>(ctx).map(Some)
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        slice(array, parent.slice_range().clone()).map(Some)
     }
 }
 

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -11,6 +11,7 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::DeserializeMetadata;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
@@ -306,7 +307,7 @@ impl VTable for SequenceVTable {
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         // Try parent kernels first (e.g., comparison fusion)
         if let Some(result) = PARENT_KERNELS.execute(array, parent, child_idx, ctx)? {
             return Ok(Some(result));
@@ -319,16 +320,17 @@ impl VTable for SequenceVTable {
 
         match filter.filter_mask().indices() {
             AllOr::All => Ok(None),
-            AllOr::None => Ok(Some(Canonical::empty(array.dtype()))),
+            AllOr::None => Ok(Some(Canonical::empty(array.dtype()).into_array())),
             AllOr::Some(indices) => Ok(Some(match_each_native_ptype!(array.ptype(), |P| {
                 let base = array.base().cast::<P>();
                 let multiplier = array.multiplier().cast::<P>();
-                Canonical::Primitive(execute_iter(
+                execute_iter(
                     base,
                     multiplier,
                     indices.iter().copied(),
                     array.dtype().nullability(),
-                ))
+                )
+                .into_array()
             }))),
         }
     }

--- a/encodings/sequence/src/kernel.rs
+++ b/encodings/sequence/src/kernel.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_array::Canonical;
+use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::BoolArray;
@@ -50,7 +50,7 @@ impl ExecuteParentKernel<SequenceVTable> for SequenceCompareKernel {
         parent: ScalarFnArrayView<'_, Binary>,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         // Only handle comparison operators
         let Some(cmp_op) = parent.options.maybe_cmp_operator() else {
             return Ok(None);
@@ -90,7 +90,7 @@ impl ExecuteParentKernel<SequenceVTable> for SequenceCompareKernel {
             let nullability = array.dtype().nullability() | constant.dtype().nullability();
             let result_array =
                 ConstantArray::new(Scalar::null(DType::Bool(nullability)), array.len).to_array();
-            return Ok(Some(result_array.execute(ctx)?));
+            return Ok(Some(result_array));
         };
 
         let nullability = array.dtype().nullability() | constant.dtype().nullability();
@@ -116,8 +116,8 @@ fn compare_eq_neq(
     constant: PValue,
     nullability: Nullability,
     negate: bool,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<Option<Canonical>> {
+    _ctx: &mut ExecutionCtx,
+) -> VortexResult<Option<ArrayRef>> {
     // For Eq: match_val=true, default_val=false
     // For NotEq: match_val=false, default_val=true
     let match_val = !negate;
@@ -127,12 +127,13 @@ fn compare_eq_neq(
     let Some(set_idx) =
         find_intersection_scalar(array.base(), array.multiplier(), array.len, constant)
     else {
-        let result_array = ConstantArray::new(
-            Scalar::new(DType::Bool(nullability), not_match_val.into()),
-            array.len,
-        )
-        .to_array();
-        return Ok(Some(result_array.execute(ctx)?));
+        return Ok(Some(
+            ConstantArray::new(
+                Scalar::new(DType::Bool(nullability), not_match_val.into()),
+                array.len,
+            )
+            .into_array(),
+        ));
     };
     let idx = set_idx as u64;
     let len = array.len as u64;
@@ -143,7 +144,7 @@ fn compare_eq_neq(
             array.len,
         )
         .to_array();
-        return Ok(Some(result_array.execute(ctx)?));
+        return Ok(Some(result_array));
     }
 
     let (ends, values) = if idx == 0 {
@@ -165,8 +166,7 @@ fn compare_eq_neq(
         .into_array();
         (ends, values)
     };
-    let result_array = RunEndArray::try_new(ends, values)?.into_array();
-    Ok(Some(result_array.execute(ctx)?))
+    Ok(Some(RunEndArray::try_new(ends, values)?.into_array()))
 }
 
 fn compare_ordering(
@@ -174,8 +174,8 @@ fn compare_ordering(
     constant: PValue,
     operator: Operator,
     nullability: Nullability,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<Option<Canonical>> {
+    _ctx: &mut ExecutionCtx,
+) -> VortexResult<Option<ArrayRef>> {
     let transition = find_transition_point(
         array.base(),
         array.multiplier(),
@@ -209,7 +209,7 @@ fn compare_ordering(
         }
     };
 
-    Ok(Some(result_array.execute(ctx)?))
+    Ok(Some(result_array))
 }
 
 enum Transition {

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -291,6 +291,14 @@ impl ListArray {
         &self.offsets
     }
 
+    /// Returns the element dtype of the list array.
+    pub fn element_dtype(&self) -> &Arc<DType> {
+        match &self.dtype {
+            DType::List(element_dtype, _) => element_dtype,
+            _ => vortex_panic!("ListArray has invalid dtype {}", self.dtype),
+        }
+    }
+
     /// Returns the elements array.
     pub fn elements(&self) -> &ArrayRef {
         &self.elements

--- a/vortex-array/src/arrays/list/vtable/kernel/filter.rs
+++ b/vortex-array/src/arrays/list/vtable/kernel/filter.rs
@@ -1,33 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::sync::Arc;
-
+use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
-use vortex_dtype::PTypeDowncastExt;
+use vortex_dtype::Nullability;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
-use vortex_vector::Vector;
-use vortex_vector::VectorMutOps;
-use vortex_vector::listview::ListViewVector;
-use vortex_vector::listview::ListViewVectorMut;
-use vortex_vector::primitive::PVector;
-use vortex_vector::primitive::PrimitiveVector;
 
 use crate::Array;
-use crate::Canonical;
+use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::FilterArray;
 use crate::arrays::FilterVTable;
 use crate::arrays::ListArray;
 use crate::arrays::ListVTable;
+use crate::arrays::ListViewArray;
 use crate::arrays::list::compute::element_mask_from_offsets;
+use crate::builders::ArrayBuilder;
+use crate::builders::ListViewBuilder;
 use crate::kernel::ExecuteParentKernel;
 use crate::matchers::Exact;
 use crate::validity::Validity;
-use crate::vectors::VectorIntoArray;
 use crate::vtable::ValidityHelper;
 
 #[derive(Debug)]
@@ -47,90 +42,66 @@ impl ExecuteParentKernel<ListVTable> for ListFilterKernel {
         parent: &FilterArray,
         _child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         let selection = match parent.filter_mask() {
             Mask::AllTrue(_) | Mask::AllFalse(_) => return Ok(None),
             Mask::Values(v) => v,
         };
 
-        // TODO(ngates): for ultra-sparse masks, we don't need to optimize the entire offsets.
-        let offsets = array
-            .offsets()
-            .clone()
-            .execute::<Vector>(ctx)?
-            .into_primitive();
-
         let new_validity = match array.validity() {
-            Validity::NonNullable | Validity::AllValid => Mask::new_true(selection.true_count()),
+            Validity::NonNullable => Validity::NonNullable,
+            Validity::AllValid => Validity::AllValid,
             Validity::AllInvalid => {
-                let mut vec = ListViewVectorMut::with_capacity(
-                    array.elements().dtype(),
+                let mut builder = ListViewBuilder::<u32, u32>::with_capacity(
+                    array.element_dtype().clone(),
+                    Nullability::Nullable,
                     selection.true_count(),
                     0,
                 );
-                vec.append_nulls(selection.true_count());
-                return Ok(Some(
-                    vec.freeze()
-                        .into_array(array.dtype())
-                        .into_array()
-                        .execute::<Canonical>(ctx)?,
-                ));
+                builder.append_nulls(selection.true_count());
+                return Ok(Some(builder.finish()));
             }
-            Validity::Array(a) => a
-                .filter(parent.filter_mask().clone())?
-                .execute::<Mask>(ctx)?,
+            Validity::Array(a) => Validity::Array(a.filter(parent.filter_mask().clone())?),
         };
 
-        let (new_offsets, new_sizes) = match_each_integer_ptype!(offsets.ptype(), |O| {
-            let offsets = (&offsets).downcast::<O>().elements().as_slice();
-            let mut new_offsets = BufferMut::<O>::with_capacity(selection.true_count());
-            let mut new_sizes = BufferMut::<O>::with_capacity(selection.true_count());
+        // TODO(ngates): for ultra-sparse masks, we don't need to optimize the entire offsets.
+        let offsets = array.offsets().clone();
 
-            let mut offset = 0;
-            for idx in selection.indices() {
-                let start = offsets[*idx];
-                let end = offsets[idx + 1];
-                let size = end - start;
-                unsafe { new_offsets.push_unchecked(offset) };
-                unsafe { new_sizes.push_unchecked(size) };
-                offset += size;
-            }
+        let (new_offsets, new_sizes, element_mask) =
+            match_each_integer_ptype!(offsets.dtype().as_ptype(), |O| {
+                let offsets_buffer = offsets.execute::<Buffer<O>>(ctx)?;
+                let offsets = offsets_buffer.as_slice();
+                let mut new_offsets = BufferMut::<O>::with_capacity(selection.true_count());
+                let mut new_sizes = BufferMut::<O>::with_capacity(selection.true_count());
 
-            let new_offsets = PrimitiveVector::from(PVector::<O>::new(
-                new_offsets.freeze(),
-                Mask::new_true(selection.true_count()),
-            ));
-            let new_sizes = PrimitiveVector::from(PVector::<O>::new(
-                new_sizes.freeze(),
-                Mask::new_true(selection.true_count()),
-            ));
+                let mut offset = 0;
+                for idx in selection.indices() {
+                    let start = offsets[*idx];
+                    let end = offsets[idx + 1];
+                    let size = end - start;
+                    unsafe { new_offsets.push_unchecked(offset) };
+                    unsafe { new_sizes.push_unchecked(size) };
+                    offset += size;
+                }
 
-            (new_offsets, new_sizes)
-        });
+                // TODO(ngates): for very dense masks, there may be no point in filtering the elements,
+                //  and instead we should construct a view against the unfiltered elements.
+                let element_mask = element_mask_from_offsets::<O>(offsets, selection);
 
-        // TODO(ngates): for very dense masks, there may be no point in filtering the elements,
-        //  and instead we should construct a view against the unfiltered elements.
-        let element_mask = match_each_integer_ptype!(offsets.ptype(), |O| {
-            element_mask_from_offsets::<O>((&offsets).downcast::<O>().elements(), selection)
-        });
+                (
+                    new_offsets.freeze().into_array(),
+                    new_sizes.freeze().into_array(),
+                    element_mask,
+                )
+            });
 
-        let new_elements = array
-            .sliced_elements()?
-            .filter(element_mask)?
-            .execute::<Vector>(ctx)?;
+        let new_elements = array.sliced_elements()?.filter(element_mask)?;
 
         Ok(Some(
             unsafe {
-                ListViewVector::new_unchecked(
-                    Arc::new(new_elements),
-                    new_offsets,
-                    new_sizes,
-                    new_validity,
-                )
+                ListViewArray::new_unchecked(new_elements, new_offsets, new_sizes, new_validity)
             }
-            .into_array(array.dtype())
-            .into_array()
-            .execute::<Canonical>(ctx)?,
+            .into_array(),
         ))
     }
 }

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -159,7 +159,7 @@ impl VTable for ListVTable {
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 }

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -3,7 +3,10 @@
 
 use std::sync::Arc;
 
+use vortex_buffer::Buffer;
+use vortex_dtype::NativePType;
 use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
 use vortex_session::VortexSession;
 
 use crate::Array;
@@ -78,20 +81,25 @@ impl ExecutionCtx {
 /// This will replace the recursive usage of `to_canonical()`.
 /// An `ExecutionCtx` is will be used to limit access to buffers.
 impl Executable for Canonical {
-    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+    fn execute(mut array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         // Try and dispatch to a child that can optimize execution.
-        for (child_idx, child) in array.children().iter().enumerate() {
-            if let Some(result) = child
-                .vtable()
-                .execute_canonical_parent(child, &array, child_idx, ctx)?
-            {
-                tracing::debug!(
-                    "Executed array {} via child {} optimization.",
-                    array.encoding_id(),
-                    child.encoding_id()
-                );
-                return Ok(result);
+        // TODO(ngates): maybe put a limit on reduce_parent iterations
+        'outer: loop {
+            for (child_idx, child) in array.children().iter().enumerate() {
+                if let Some(result) = child
+                    .vtable()
+                    .execute_parent(child, &array, child_idx, ctx)?
+                {
+                    tracing::debug!(
+                        "Executed array {} via child {} optimization.",
+                        array.encoding_id(),
+                        child.encoding_id()
+                    );
+                    array = result;
+                    continue 'outer;
+                }
             }
+            break;
         }
 
         // Otherwise fall back to the default execution.
@@ -115,6 +123,20 @@ impl Executable for CanonicalOutput {
 
         tracing::debug!("Executing array {}:\n{}", array, array.display_tree());
         Ok(CanonicalOutput::Array(array.execute(ctx)?))
+    }
+}
+
+/// Execute a primitive array into a buffer of native values.
+///
+/// This will error if the array is not all-valid.
+impl<T: NativePType> Executable for Buffer<T> {
+    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        let array = array.execute::<PrimitiveArray>(ctx)?;
+        vortex_ensure!(
+            array.all_valid()?,
+            "Cannot execute to native buffer: array is not all-valid."
+        );
+        Ok(array.into_buffer())
     }
 }
 

--- a/vortex-array/src/kernel.rs
+++ b/vortex-array/src/kernel.rs
@@ -8,7 +8,6 @@ use std::marker::PhantomData;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
-use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::matchers::Matcher;
 use crate::vtable::VTable;
@@ -46,7 +45,7 @@ impl<V: VTable> ParentKernelSet<V> {
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         for kernel in self.kernels.iter() {
             if !kernel.matches(parent) {
                 continue;
@@ -72,7 +71,7 @@ pub trait ExecuteParentKernel<V: VTable>: Debug {
         parent: <Self::Parent as Matcher>::View<'_>,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>>;
+    ) -> VortexResult<Option<ArrayRef>>;
 }
 
 pub trait DynParentKernel<V: VTable> {
@@ -84,7 +83,7 @@ pub trait DynParentKernel<V: VTable> {
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>>;
+    ) -> VortexResult<Option<ArrayRef>>;
 }
 
 pub struct ParentKernelAdapter<V, K> {
@@ -112,7 +111,7 @@ impl<V: VTable, R: ExecuteParentKernel<V>> DynParentKernel<V> for ParentKernelAd
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         let Some(parent_view) = self.kernel.parent().try_match(parent) else {
             return Ok(None);
         };

--- a/vortex-array/src/vtable/dyn_.rs
+++ b/vortex-array/src/vtable/dyn_.rs
@@ -65,13 +65,13 @@ pub trait DynVTable: 'static + private::Sealed + Send + Sync + Debug {
     ) -> VortexResult<Canonical>;
 
     /// See [`VTable::execute_parent`]
-    fn execute_canonical_parent(
+    fn execute_parent(
         &self,
         array: &ArrayRef,
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>>;
+    ) -> VortexResult<Option<ArrayRef>>;
 
     fn slice(&self, array: &ArrayRef, range: Range<usize>) -> VortexResult<Option<ArrayRef>>;
 }
@@ -171,13 +171,13 @@ impl<V: VTable> DynVTable for ArrayVTableAdapter<V> {
         Ok(result)
     }
 
-    fn execute_canonical_parent(
+    fn execute_parent(
         &self,
         array: &ArrayRef,
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         let Some(result) = V::execute_parent(downcast::<V>(array), parent, child_idx, ctx)? else {
             return Ok(None);
         };

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -159,7 +159,7 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<Canonical>> {
+    ) -> VortexResult<Option<ArrayRef>> {
         _ = (array, parent, child_idx, ctx);
         Ok(None)
     }


### PR DESCRIPTION
This brings it in line with how powerful compute dispatch was prior to the operators change. The major benefits are:

1) It's obvious in this PR there are places we were canonicalizing for no good reason.
2) The existing compute kernels can be reused as parent execution kernels without changing any code.