### PR TITLE
chore: Force transitive dependencies to CVE free versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ num-traits = "0.2.19"
 num_enum = { version = "0.7.3", default-features = false }
 object_store = { version = "0.12.4", default-features = false }
 once_cell = "1.21"
-oneshot = "0.1.11"
+oneshot = "0.1.13"
 opentelemetry = "0.31.0"
 opentelemetry-otlp = "0.31.0"
 opentelemetry_sdk = "0.31.0"

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
     "sphinxext-opengraph>=0.9.1",
     "vortex-data",
     "libclang>=18.1.1",
+    # forced transitive bumps
+    "starlette>=0.49.1",
 ]
 requires-python = ">= 3.11"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ dev = [
     "ruff>=0.7.1",
     "ray>=2.48",
     "pytest-benchmark>=5.1.0",
+    # forced transitive bumps
+    "urllib3>=2.6.3",
+    "filelock>=3.20.3",
+    "protobuf>=6.33.5"
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
     # forced transitive bumps
     "urllib3>=2.6.3",
     "filelock>=3.20.3",
-    "protobuf>=6.33.5"
+    "protobuf>=6.33.5",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -234,6 +234,7 @@ dependencies = [
     { name = "sphinx-inline-tabs" },
     { name = "sphinxcontrib-bibtex" },
     { name = "sphinxext-opengraph" },
+    { name = "starlette" },
     { name = "vortex-data" },
 ]
 
@@ -250,6 +251,7 @@ requires-dist = [
     { name = "sphinx-inline-tabs", specifier = ">=2023.4.21" },
     { name = "sphinxcontrib-bibtex", specifier = ">=2.6.3" },
     { name = "sphinxext-opengraph", specifier = ">=0.9.1" },
+    { name = "starlette", specifier = ">=0.49.1" },
     { name = "vortex-data", editable = "vortex-python" },
 ]
 
@@ -1675,15 +1677,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.48.0"
+version = "0.52.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
 ]
 
 [[package]]
@@ -1773,11 +1775,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]
@@ -2015,6 +2017,7 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "ray" },
     { name = "ruff" },
+    { name = "urllib3" },
 ]
 
 [package.metadata]
@@ -2041,4 +2044,5 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "ray", specifier = ">=2.48" },
     { name = "ruff", specifier = ">=0.7.1" },
+    { name = "urllib3", specifier = ">=2.6.3" },
 ]


### PR DESCRIPTION
Since those are mostly transitive (or dependabot looks at the lower bound in
case of cargo) we need to manually force the higher version since it might be
a while before our dependencies pick them up

Signed-off-by: Robert Kruszewski <github@robertk.io>
