### PR TITLE
chore: Renovate applies changelog/chore instead of chore to its prs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     "groupName": "all patch updates"
   },
   "labels": [
-    "chore"
+    "changelog/chore"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Signed-off-by: Robert Kruszewski <github@robertk.io>
