### PR TITLE
Use custom-labels to instrument SQL benchmarks

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -80,7 +80,7 @@ jobs:
           labels: "branch=${{ github.ref_name }};gh_run_id=${{ github.run_id }};benchmark=${{ matrix.benchmark.id }}"
           project_uuid: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
           profiling_frequency: 150
-          extra_args: "--off-cpu-threshold=0.01"  # Personally tuned by @brancz
+          extra_args: "--off-cpu-threshold=0.03"  # Personally tuned by @brancz
 
       - name: Run ${{ matrix.benchmark.name }} benchmark
         shell: bash

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -79,7 +79,7 @@ jobs:
           polarsignals_cloud_token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
           labels: "branch=${{ github.ref_name }};gh_run_id=${{ github.run_id }};benchmark=${{ matrix.benchmark.id }}"
           project_uuid: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
-          profiling_frequency: 150
+          profiling_frequency: 199
           extra_args: "--off-cpu-threshold=0.03"  # Personally tuned by @brancz
 
       - name: Run ${{ matrix.benchmark.name }} benchmark

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -78,9 +78,9 @@ jobs:
         with:
           polarsignals_cloud_token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
           labels: "branch=${{ github.ref_name }};gh_run_id=${{ github.run_id }};benchmark=${{ matrix.benchmark.id }}"
-          parca_agent_version: "0.45.0"
           project_uuid: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
-          extra_args: "--off-cpu-threshold=0.001"  # Personally tuned by @brancz
+          profiling_frequency: 150
+          extra_args: "--off-cpu-threshold=0.01"  # Personally tuned by @brancz
 
       - name: Run ${{ matrix.benchmark.name }} benchmark
         shell: bash

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -77,7 +77,7 @@ jobs:
           polarsignals_cloud_token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
           labels: "branch=${{ github.ref_name }};gh_run_id=${{ github.run_id }};benchmark=${{ matrix.benchmark.id }}"
           project_uuid: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
-          profiling_frequency: 150
+          profiling_frequency: 199
           extra_args: "--off-cpu-threshold=0.03"  # Personally tuned by @brancz
 
       - name: Run ${{ matrix.benchmark.name }} benchmark

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -76,9 +76,9 @@ jobs:
         with:
           polarsignals_cloud_token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
           labels: "branch=${{ github.ref_name }};gh_run_id=${{ github.run_id }};benchmark=${{ matrix.benchmark.id }}"
-          parca_agent_version: "0.45.0"
           project_uuid: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
-          extra_args: "--off-cpu-threshold=0.001"  # Personally tuned by @brancz
+          profiling_frequency: 150
+          extra_args: "--off-cpu-threshold=0.01"  # Personally tuned by @brancz
 
       - name: Run ${{ matrix.benchmark.name }} benchmark
         shell: bash

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -78,7 +78,7 @@ jobs:
           labels: "branch=${{ github.ref_name }};gh_run_id=${{ github.run_id }};benchmark=${{ matrix.benchmark.id }}"
           project_uuid: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
           profiling_frequency: 150
-          extra_args: "--off-cpu-threshold=0.01"  # Personally tuned by @brancz
+          extra_args: "--off-cpu-threshold=0.03"  # Personally tuned by @brancz
 
       - name: Run ${{ matrix.benchmark.name }} benchmark
         shell: bash

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -179,9 +179,9 @@ jobs:
         with:
           polarsignals_cloud_token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
           labels: "branch=${{ github.ref_name }};gh_run_id=${{ github.run_id }};benchmark=${{ matrix.id }}"
-          parca_agent_version: "0.45.0"
           project_uuid: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
-          extra_args: "--off-cpu-threshold=0.001"  # Personally tuned by @brancz
+          profiling_frequency: 150
+          extra_args: "--off-cpu-threshold=0.01"  # Personally tuned by @brancz
 
       - name: Run ${{ matrix.name }} benchmark
         if: matrix.remote_storage == null || github.event.pull_request.head.repo.fork == true

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -180,7 +180,7 @@ jobs:
           polarsignals_cloud_token: ${{ secrets.POLAR_SIGNALS_API_KEY }}
           labels: "branch=${{ github.ref_name }};gh_run_id=${{ github.run_id }};benchmark=${{ matrix.id }}"
           project_uuid: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
-          profiling_frequency: 150
+          profiling_frequency: 199
           extra_args: "--off-cpu-threshold=0.03"  # Personally tuned by @brancz
 
       - name: Run ${{ matrix.name }} benchmark

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -181,7 +181,7 @@ jobs:
           labels: "branch=${{ github.ref_name }};gh_run_id=${{ github.run_id }};benchmark=${{ matrix.id }}"
           project_uuid: "e5d846e1-b54c-46e7-9174-8bf055a3af56"
           profiling_frequency: 150
-          extra_args: "--off-cpu-threshold=0.01"  # Personally tuned by @brancz
+          extra_args: "--off-cpu-threshold=0.03"  # Personally tuned by @brancz
 
       - name: Run ${{ matrix.name }} benchmark
         if: matrix.remote_storage == null || github.event.pull_request.head.repo.fork == true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,6 +1284,24 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.10.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -1297,7 +1315,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.114",
 ]
@@ -2297,6 +2315,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom-labels"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1c8a4320177bfad0514f5ee9525499030e2d48e6da0c2047da4a782190ce2"
+dependencies = [
+ "bindgen 0.70.1",
+ "cc",
+ "libc",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,6 +2543,7 @@ dependencies = [
  "anyhow",
  "arrow-ipc 57.2.0",
  "clap",
+ "custom-labels",
  "datafusion 52.1.0",
  "datafusion-common 52.1.0",
  "datafusion-physical-plan 52.1.0",
@@ -7720,7 +7751,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.6.2",
  "thiserror 2.0.18",
@@ -7740,7 +7771,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -8365,6 +8396,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -9214,7 +9251,7 @@ dependencies = [
  "rayon",
  "regex",
  "rust-stemmers",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "sketches-ddsketch",
@@ -10185,7 +10222,7 @@ dependencies = [
  "prost 0.14.3",
  "rand 0.9.2",
  "rstest",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "vortex-array",
  "vortex-buffer",
  "vortex-dtype",
@@ -10234,7 +10271,7 @@ dependencies = [
  "rand_distr 0.5.1",
  "rstest",
  "rstest_reuse",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "simdutf8",
  "tabled",
@@ -10308,7 +10345,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-traits",
  "rand 0.9.2",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "test-with",
  "tracing",
  "tracing-subscriber",
@@ -10388,7 +10425,7 @@ dependencies = [
 name = "vortex-cub"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "libloading 0.8.9",
  "paste",
  "vortex-cuda-macros",
@@ -10567,7 +10604,7 @@ dependencies = [
  "anyhow",
  "async-compat",
  "async-fs",
- "bindgen",
+ "bindgen 0.72.1",
  "bitvec",
  "cbindgen",
  "cc",
@@ -10843,7 +10880,7 @@ dependencies = [
  "pin-project-lite",
  "prost 0.14.3",
  "rstest",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "termtree",
  "tokio",
  "tracing",
@@ -10892,7 +10929,7 @@ dependencies = [
 name = "vortex-nvcomp"
 version = "0.1.0"
 dependencies = [
- "bindgen",
+ "bindgen 0.72.1",
  "libloading 0.8.9",
  "liblzma",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10800,6 +10800,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bytes",
+ "custom-labels",
  "futures",
  "getrandom 0.3.4",
  "handle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2560,6 +2560,7 @@ dependencies = [
  "vortex-bench",
  "vortex-cuda",
  "vortex-datafusion",
+ "vortex-metrics",
 ]
 
 [[package]]
@@ -3862,6 +3863,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "custom-labels",
  "get_dir",
  "similar",
  "tokio",
@@ -10608,6 +10610,7 @@ dependencies = [
  "bitvec",
  "cbindgen",
  "cc",
+ "custom-labels",
  "futures",
  "glob",
  "itertools 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ cudarc = { version = "0.18.2", features = [
     # be specified if a later toolkit version is installed on the system.
     "cuda-12080",
 ] }
-custom-labels = "0.4"
+custom-labels = "0.4.4"
 dashmap = "6.1.0"
 datafusion = { version = "52", default-features = false, features = ["sql"] }
 datafusion-catalog = { version = "52" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ cudarc = { version = "0.18.2", features = [
     # be specified if a later toolkit version is installed on the system.
     "cuda-12080",
 ] }
+custom-labels = "0.4"
 dashmap = "6.1.0"
 datafusion = { version = "52", default-features = false, features = ["sql"] }
 datafusion-catalog = { version = "52" }

--- a/benchmarks/datafusion-bench/Cargo.toml
+++ b/benchmarks/datafusion-bench/Cargo.toml
@@ -39,6 +39,7 @@ url = { workspace = true }
 vortex-bench = { workspace = true }
 vortex-cuda = { workspace = true, optional = true }
 vortex-datafusion = { workspace = true }
+vortex-metrics = { workspace = true }
 
 [build-dependencies]
 get_dir = { workspace = true }

--- a/benchmarks/datafusion-bench/Cargo.toml
+++ b/benchmarks/datafusion-bench/Cargo.toml
@@ -18,6 +18,7 @@ publish = false
 anyhow = { workspace = true }
 arrow-ipc.workspace = true
 clap = { workspace = true, features = ["derive"] }
+custom-labels = { workspace = true }
 datafusion = { workspace = true, features = [
     "parquet",
     "datetime_expressions",
@@ -41,6 +42,7 @@ vortex-datafusion = { workspace = true }
 
 [build-dependencies]
 get_dir = { workspace = true }
+custom-labels = { workspace = true }
 
 [features]
 cuda = ["dep:vortex-cuda"]

--- a/benchmarks/datafusion-bench/build.rs
+++ b/benchmarks/datafusion-bench/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    #[cfg(not(target_os = "macos"))]
+    custom_labels::build::emit_build_instructions();
+}

--- a/benchmarks/datafusion-bench/build.rs
+++ b/benchmarks/datafusion-bench/build.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
 fn main() {
     #[cfg(not(target_os = "macos"))]
     custom_labels::build::emit_build_instructions();

--- a/benchmarks/datafusion-bench/src/lib.rs
+++ b/benchmarks/datafusion-bench/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 pub mod metrics;
+pub mod tracer;
 
 use std::sync::Arc;
 

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -18,6 +18,7 @@ use datafusion::parquet::arrow::ParquetRecordBatchStreamBuilder;
 use datafusion::prelude::SessionContext;
 use datafusion_bench::format_to_df_format;
 use datafusion_bench::metrics::MetricsSetExt;
+use datafusion_bench::tracer::get_labelset_from_global;
 use datafusion_bench::tracer::get_static_tracer;
 use datafusion_bench::tracer::set_labels;
 use datafusion_physical_plan::ExecutionPlan;
@@ -180,8 +181,9 @@ async fn main() -> anyhow::Result<()> {
                 Box::pin(
                     async move {
                         let timer = Instant::now();
-                        let (batches, plan) =
-                            execute_query(session, query).with_current_labels().await?;
+                        let (batches, plan) = execute_query(session, query)
+                            .with_labelset(get_labelset_from_global())
+                            .await?;
                         let time = timer.elapsed();
                         let row_count = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
@@ -324,12 +326,18 @@ pub async fn execute_query(
     ctx: &SessionContext,
     query: &str,
 ) -> anyhow::Result<(Vec<RecordBatch>, Arc<dyn ExecutionPlan>)> {
-    let df = ctx.sql(query).with_current_labels().await?;
+    let df = ctx
+        .sql(query)
+        .with_labelset(get_labelset_from_global())
+        .await?;
 
     let task_ctx = Arc::new(df.task_ctx());
-    let plan = df.create_physical_plan().with_current_labels().await?;
+    let plan = df
+        .create_physical_plan()
+        .with_labelset(get_labelset_from_global())
+        .await?;
     let result = collect(plan.clone(), task_ctx)
-        .with_current_labels()
+        .with_labelset(get_labelset_from_global())
         .await?;
 
     Ok((result, plan))

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -7,6 +7,7 @@ use std::time::Instant;
 
 use clap::Parser;
 use clap::value_parser;
+use custom_labels::asynchronous::Label;
 use datafusion::arrow::array::RecordBatch;
 use datafusion::common::runtime::set_join_set_tracer;
 use datafusion::datasource::listing::ListingOptions;
@@ -176,26 +177,30 @@ async fn main() -> anyhow::Result<()> {
 
                 set_labels(benchmark_name.clone(), query_idx, *format);
 
-                Box::pin(async move {
-                    let timer = Instant::now();
-                    let (batches, plan) = execute_query(session, query).await?;
-                    let time = timer.elapsed();
-                    let row_count = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
+                Box::pin(
+                    async move {
+                        let timer = Instant::now();
+                        let (batches, plan) =
+                            execute_query(session, query).with_current_labels().await?;
+                        let time = timer.elapsed();
+                        let row_count = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
-                    // Store plan for metrics (only store once per query/format combination)
-                    if show_metrics {
-                        let mut plans_mut = plans.lock();
-                        // Only store if we don't already have this query/format combo
-                        if !plans_mut
-                            .iter()
-                            .any(|(idx, f, _)| *idx == query_idx && *f == *format)
-                        {
-                            plans_mut.push((query_idx, *format, plan.clone()));
+                        // Store plan for metrics (only store once per query/format combination)
+                        if show_metrics {
+                            let mut plans_mut = plans.lock();
+                            // Only store if we don't already have this query/format combo
+                            if !plans_mut
+                                .iter()
+                                .any(|(idx, f, _)| *idx == query_idx && *f == *format)
+                            {
+                                plans_mut.push((query_idx, *format, plan.clone()));
+                            }
                         }
-                    }
 
-                    anyhow::Ok((row_count, Some(time), plan))
-                })
+                        anyhow::Ok((row_count, Some(time), plan))
+                    }
+                    .with_current_labels(),
+                )
             },
         )
         .await?;
@@ -319,11 +324,13 @@ pub async fn execute_query(
     ctx: &SessionContext,
     query: &str,
 ) -> anyhow::Result<(Vec<RecordBatch>, Arc<dyn ExecutionPlan>)> {
-    let df = ctx.sql(query).await?;
+    let df = ctx.sql(query).with_current_labels().await?;
 
     let task_ctx = Arc::new(df.task_ctx());
-    let plan = df.create_physical_plan().await?;
-    let result = collect(plan.clone(), task_ctx).await?;
+    let plan = df.create_physical_plan().with_current_labels().await?;
+    let result = collect(plan.clone(), task_ctx)
+        .with_current_labels()
+        .await?;
 
     Ok((result, plan))
 }

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -175,7 +175,7 @@ async fn main() -> anyhow::Result<()> {
             |query_idx, (session, format), query| {
                 let plans = Arc::clone(&collected_plans);
 
-                set_labels(benchmark_name.clone(), query_idx, *format);
+                let labelset = set_labels(benchmark_name.clone(), query_idx, *format);
 
                 Box::pin(
                     async move {
@@ -199,7 +199,7 @@ async fn main() -> anyhow::Result<()> {
 
                         anyhow::Ok((row_count, Some(time), plan))
                     }
-                    .with_current_labels(),
+                    .with_labelset(labelset),
                 )
             },
         )

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 use clap::Parser;
 use clap::value_parser;
 use datafusion::arrow::array::RecordBatch;
+use datafusion::common::runtime::set_join_set_tracer;
 use datafusion::datasource::listing::ListingOptions;
 use datafusion::datasource::listing::ListingTable;
 use datafusion::datasource::listing::ListingTableConfig;
@@ -16,6 +17,8 @@ use datafusion::parquet::arrow::ParquetRecordBatchStreamBuilder;
 use datafusion::prelude::SessionContext;
 use datafusion_bench::format_to_df_format;
 use datafusion_bench::metrics::MetricsSetExt;
+use datafusion_bench::tracer::get_static_tracer;
+use datafusion_bench::tracer::set_labels;
 use datafusion_physical_plan::ExecutionPlan;
 use datafusion_physical_plan::collect;
 use futures::StreamExt;
@@ -103,6 +106,7 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let opts = Opts::from(args.options);
 
+    set_join_set_tracer(get_static_tracer())?;
     setup_logging_and_tracing(args.verbose, args.tracing)?;
 
     let benchmark = create_benchmark(args.benchmark, &opts)?;
@@ -137,6 +141,8 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
+    let benchmark_name = benchmark.dataset().to_string();
+
     let mut runner = SqlBenchmarkRunner::new(
         &*benchmark,
         Engine::DataFusion,
@@ -167,6 +173,8 @@ async fn main() -> anyhow::Result<()> {
             },
             |query_idx, (session, format), query| {
                 let plans = Arc::clone(&collected_plans);
+
+                set_labels(benchmark_name.clone(), query_idx, *format);
 
                 Box::pin(async move {
                     let timer = Instant::now();

--- a/benchmarks/datafusion-bench/src/tracer.rs
+++ b/benchmarks/datafusion-bench/src/tracer.rs
@@ -5,31 +5,44 @@ use std::any::Any;
 
 use custom_labels::Labelset;
 use custom_labels::asynchronous::Label;
-use custom_labels::with_labels;
 use datafusion::common::runtime::JoinSetTracer;
 use futures::FutureExt;
 use futures::future::BoxFuture;
-use parking_lot::RwLock;
 use vortex_bench::Format;
-
-static LABELS: RwLock<Vec<(&str, String)>> = RwLock::new(Vec::new());
+use vortex_metrics::tracing::{get_global_labels, set_global_labels};
 
 pub fn get_static_tracer() -> &'static dyn JoinSetTracer {
     static TRACER: LabelsJoinSetTracer = LabelsJoinSetTracer;
     &TRACER
 }
 
-pub fn set_labels(name: String, query_idx: usize, format: Format) {
+pub fn get_labelset_from_global() -> Labelset {
     let mut labelset = Labelset::clone_from_current();
-    labelset.set("benchmark_name", name.as_bytes());
-    labelset.set("query_idx", query_idx.to_string());
-    labelset.set("format", format.to_string());
 
-    *LABELS.write() = vec![
-        ("benchmark_name", name),
+    let labels = get_global_labels();
+
+    for (k, v) in labels {
+        labelset.set(k, v);
+    }
+
+    labelset
+}
+
+pub fn set_labels(benchmark_name: String, query_idx: usize, format: Format) -> Labelset {
+    let labels = vec![
+        ("benchmark_name", benchmark_name),
         ("query_idx", query_idx.to_string()),
         ("format", format.to_string()),
     ];
+    set_global_labels(labels.clone());
+
+    let mut labelset = Labelset::clone_from_current();
+
+    for (k, v) in labels.into_iter() {
+        labelset.set(k, v);
+    }
+
+    labelset
 }
 
 pub struct LabelsJoinSetTracer;
@@ -39,14 +52,14 @@ impl JoinSetTracer for LabelsJoinSetTracer {
         &self,
         fut: BoxFuture<'static, Box<dyn Any + Send>>,
     ) -> BoxFuture<'static, Box<dyn Any + Send>> {
-        fut.with_labels(LABELS.read().clone()).boxed()
+        fut.with_current_labels().boxed()
     }
 
     fn trace_block(
         &self,
         f: Box<dyn FnOnce() -> Box<dyn Any + Send> + Send>,
     ) -> Box<dyn FnOnce() -> Box<dyn Any + Send> + Send> {
-        let labels = LABELS.read().clone();
-        Box::new(|| with_labels(labels, f))
+        let mut labelset = Labelset::clone_from_current();
+        Box::new(move || labelset.enter(f))
     }
 }

--- a/benchmarks/datafusion-bench/src/tracer.rs
+++ b/benchmarks/datafusion-bench/src/tracer.rs
@@ -1,0 +1,45 @@
+use std::any::Any;
+
+use custom_labels::{CURRENT_LABELSET, asynchronous::Label, with_labels};
+use datafusion::common::runtime::JoinSetTracer;
+use futures::{FutureExt, future::BoxFuture};
+use parking_lot::RwLock;
+use vortex_bench::Format;
+
+static LABELS: RwLock<Vec<(&str, String)>> = RwLock::new(Vec::new());
+
+pub fn get_static_tracer() -> &'static dyn JoinSetTracer {
+    static TRACER: LabelsJoinSetTracer = LabelsJoinSetTracer;
+    &TRACER
+}
+
+pub fn set_labels(name: String, query_idx: usize, format: Format) {
+    CURRENT_LABELSET.set("benchmark_name", name.as_bytes());
+    CURRENT_LABELSET.set("query_idx", query_idx.to_string());
+    CURRENT_LABELSET.set("format", format.to_string());
+
+    *LABELS.write() = vec![
+        ("benchmark_name", name),
+        ("query_idx", query_idx.to_string()),
+        ("format", format.to_string()),
+    ];
+}
+
+pub struct LabelsJoinSetTracer;
+
+impl JoinSetTracer for LabelsJoinSetTracer {
+    fn trace_future(
+        &self,
+        fut: BoxFuture<'static, Box<dyn Any + Send>>,
+    ) -> BoxFuture<'static, Box<dyn Any + Send>> {
+        fut.with_labels(LABELS.read().clone()).boxed()
+    }
+
+    fn trace_block(
+        &self,
+        f: Box<dyn FnOnce() -> Box<dyn Any + Send> + Send>,
+    ) -> Box<dyn FnOnce() -> Box<dyn Any + Send> + Send> {
+        let labels = LABELS.read().clone();
+        Box::new(|| with_labels(labels, f))
+    }
+}

--- a/benchmarks/datafusion-bench/src/tracer.rs
+++ b/benchmarks/datafusion-bench/src/tracer.rs
@@ -53,14 +53,15 @@ impl JoinSetTracer for LabelsJoinSetTracer {
         &self,
         fut: BoxFuture<'static, Box<dyn Any + Send>>,
     ) -> BoxFuture<'static, Box<dyn Any + Send>> {
-        fut.with_current_labels().boxed()
+        let labelset = get_labelset_from_global();
+        fut.with_labelset(labelset).boxed()
     }
 
     fn trace_block(
         &self,
         f: Box<dyn FnOnce() -> Box<dyn Any + Send> + Send>,
     ) -> Box<dyn FnOnce() -> Box<dyn Any + Send> + Send> {
-        let mut labelset = Labelset::clone_from_current();
+        let mut labelset = get_labelset_from_global();
         Box::new(move || labelset.enter(f))
     }
 }

--- a/benchmarks/datafusion-bench/src/tracer.rs
+++ b/benchmarks/datafusion-bench/src/tracer.rs
@@ -3,9 +3,12 @@
 
 use std::any::Any;
 
-use custom_labels::{CURRENT_LABELSET, asynchronous::Label, with_labels};
+use custom_labels::Labelset;
+use custom_labels::asynchronous::Label;
+use custom_labels::with_labels;
 use datafusion::common::runtime::JoinSetTracer;
-use futures::{FutureExt, future::BoxFuture};
+use futures::FutureExt;
+use futures::future::BoxFuture;
 use parking_lot::RwLock;
 use vortex_bench::Format;
 
@@ -17,9 +20,10 @@ pub fn get_static_tracer() -> &'static dyn JoinSetTracer {
 }
 
 pub fn set_labels(name: String, query_idx: usize, format: Format) {
-    CURRENT_LABELSET.set("benchmark_name", name.as_bytes());
-    CURRENT_LABELSET.set("query_idx", query_idx.to_string());
-    CURRENT_LABELSET.set("format", format.to_string());
+    let mut labelset = Labelset::clone_from_current();
+    labelset.set("benchmark_name", name.as_bytes());
+    labelset.set("query_idx", query_idx.to_string());
+    labelset.set("format", format.to_string());
 
     *LABELS.write() = vec![
         ("benchmark_name", name),

--- a/benchmarks/datafusion-bench/src/tracer.rs
+++ b/benchmarks/datafusion-bench/src/tracer.rs
@@ -9,7 +9,8 @@ use datafusion::common::runtime::JoinSetTracer;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use vortex_bench::Format;
-use vortex_metrics::tracing::{get_global_labels, set_global_labels};
+use vortex_metrics::tracing::get_global_labels;
+use vortex_metrics::tracing::set_global_labels;
 
 pub fn get_static_tracer() -> &'static dyn JoinSetTracer {
     static TRACER: LabelsJoinSetTracer = LabelsJoinSetTracer;

--- a/benchmarks/datafusion-bench/src/tracer.rs
+++ b/benchmarks/datafusion-bench/src/tracer.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
 use std::any::Any;
 
 use custom_labels::{CURRENT_LABELSET, asynchronous::Label, with_labels};

--- a/benchmarks/duckdb-bench/Cargo.toml
+++ b/benchmarks/duckdb-bench/Cargo.toml
@@ -17,6 +17,7 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+custom-labels = { workspace = true }
 similar = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
@@ -28,6 +29,7 @@ vortex-duckdb = { workspace = true }
 
 [build-dependencies]
 get_dir = { workspace = true }
+custom-labels = { workspace = true }
 
 [features]
 cuda = ["dep:vortex-cuda"]

--- a/benchmarks/duckdb-bench/build.rs
+++ b/benchmarks/duckdb-bench/build.rs
@@ -19,7 +19,6 @@
 /// The dynamic DuckDB library is preferred over the static version, as DuckDB's
 /// static lib is not self-contained. This means that it includes symbols which
 /// are not defined as part of the static library.
-
 fn main() {
     // Propagate DuckDB rpath from vortex-duckdb
     let duckdb_lib = std::env::var("DEP_DUCKDB_LIB_DIR").unwrap();

--- a/benchmarks/duckdb-bench/build.rs
+++ b/benchmarks/duckdb-bench/build.rs
@@ -22,5 +22,17 @@
 fn main() {
     // Propagate DuckDB rpath from vortex-duckdb
     let duckdb_lib = std::env::var("DEP_DUCKDB_LIB_DIR").unwrap();
-    println!("cargo:rustc-link-arg=-Wl,-rpath,{duckdb_lib}");
+
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{duckdb_lib}");
+    }
+
+    // Include the custom-labels build instruction for non-macos builds
+    #[cfg(not(target_os = "macos"))]
+    {
+        let dlist_path = format!("{}/dlist", std::env::var("OUT_DIR").unwrap());
+        std::fs::write(&dlist_path, include_str!("../dlist")).unwrap();
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{duckdb_lib},--dynamic-list={dlist_path}")
+    }
 }

--- a/benchmarks/duckdb-bench/build.rs
+++ b/benchmarks/duckdb-bench/build.rs
@@ -19,6 +19,7 @@
 /// The dynamic DuckDB library is preferred over the static version, as DuckDB's
 /// static lib is not self-contained. This means that it includes symbols which
 /// are not defined as part of the static library.
+
 fn main() {
     // Propagate DuckDB rpath from vortex-duckdb
     let duckdb_lib = std::env::var("DEP_DUCKDB_LIB_DIR").unwrap();
@@ -28,11 +29,16 @@ fn main() {
         println!("cargo:rustc-link-arg=-Wl,-rpath,{duckdb_lib}");
     }
 
-    // Include the custom-labels build instruction for non-macos builds
     #[cfg(not(target_os = "macos"))]
     {
+        // Inline the dynamically exported symbol list for non-macos targets.
+        const DLIST: &str = "{\
+            custom_labels_abi_version;\
+            custom_labels_current_set;\
+            };";
+
         let dlist_path = format!("{}/dlist", std::env::var("OUT_DIR").unwrap());
-        std::fs::write(&dlist_path, include_str!("../dlist")).unwrap();
+        std::fs::write(&dlist_path, DLIST).unwrap();
         println!("cargo:rustc-link-arg=-Wl,-rpath,{duckdb_lib},--dynamic-list={dlist_path}")
     }
 }

--- a/benchmarks/duckdb-bench/src/main.rs
+++ b/benchmarks/duckdb-bench/src/main.rs
@@ -9,6 +9,7 @@ use clap::Parser;
 use clap::value_parser;
 use duckdb_bench::DuckClient;
 use tokio::runtime::Runtime;
+use vortex::metrics::tracing::set_global_labels;
 use vortex_bench::BenchmarkArg;
 use vortex_bench::CompactionStrategy;
 use vortex_bench::Engine;
@@ -129,6 +130,8 @@ fn main() -> anyhow::Result<()> {
         args.hide_progress_bar,
     )?;
 
+    let benchmark_name = benchmark.dataset().to_string();
+
     runner.run_all(
         &filtered_queries,
         args.iterations,
@@ -142,7 +145,12 @@ fn main() -> anyhow::Result<()> {
             ctx.register_tables(&*benchmark, format)?;
             Ok(ctx)
         },
-        |ctx, query| {
+        |ctx, query_idx, format, query| {
+            set_global_labels(vec![
+                ("format", format.to_string()),
+                ("benchmark_name", benchmark_name.clone()),
+                ("query_idx", query_idx.to_string()),
+            ]);
             // Make sure to reopen the duckdb connection between iterations
             ctx.reopen()?;
             ctx.execute_query(query)

--- a/vortex-bench/src/runner.rs
+++ b/vortex-bench/src/runner.rs
@@ -253,7 +253,7 @@ impl SqlBenchmarkRunner {
     ) -> anyhow::Result<()>
     where
         S: FnMut(Format) -> anyhow::Result<Ctx>,
-        E: FnMut(&mut Ctx, &str) -> anyhow::Result<(usize, Option<Duration>)>,
+        E: FnMut(&mut Ctx, usize, Format, &str) -> anyhow::Result<(usize, Option<Duration>)>,
     {
         let bar_length = queries.len() * self.formats.len();
         let progress_bar = if self.hide_progress_bar || bar_length == 0 {
@@ -269,8 +269,8 @@ impl SqlBenchmarkRunner {
                 let query_idx = *query_idx;
                 tracing::debug!(%format, query_idx, "Running query");
                 self.run_query(query_idx, format, iterations, || {
-                    let (row_count, timing) =
-                        execute(&mut ctx, query.as_str()).unwrap_or_else(|err| {
+                    let (row_count, timing) = execute(&mut ctx, query_idx, format, query.as_str())
+                        .unwrap_or_else(|err| {
                             vortex_panic!("query {query_idx} failed: {err}");
                         });
                     (row_count, timing)

--- a/vortex-duckdb/Cargo.toml
+++ b/vortex-duckdb/Cargo.toml
@@ -28,6 +28,7 @@ anyhow = { workspace = true }
 async-compat = { workspace = true }
 async-fs = { workspace = true }
 bitvec = { workspace = true }
+custom-labels = { workspace = true }
 futures = { workspace = true }
 glob = { workspace = true }
 itertools = { workspace = true }

--- a/vortex-duckdb/src/scan.rs
+++ b/vortex-duckdb/src/scan.rs
@@ -14,6 +14,7 @@ use std::task::Context;
 use std::task::Poll;
 
 use async_compat::Compat;
+use custom_labels::CURRENT_LABELSET;
 use futures::FutureExt;
 use futures::Stream;
 use futures::StreamExt;
@@ -47,6 +48,7 @@ use vortex::file::VortexFile;
 use vortex::file::VortexOpenOptions;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::io::runtime::current::ThreadSafeIterator;
+use vortex::metrics::tracing::get_global_labels;
 use vortex::session::VortexSession;
 use vortex_utils::aliases::hash_set::HashSet;
 
@@ -460,6 +462,21 @@ impl TableFunction for VortexTableFunction {
         _init: &TableInitInput<Self>,
         global: &mut Self::GlobalState,
     ) -> VortexResult<Self::LocalState> {
+        unsafe {
+            use custom_labels::sys;
+
+            if sys::labelset_current().is_null() {
+                let ls = sys::labelset_new(0);
+                sys::labelset_replace(ls);
+            };
+        }
+
+        let global_labels = get_global_labels();
+
+        for (key, value) in global_labels {
+            CURRENT_LABELSET.set(key, value);
+        }
+
         Ok(VortexLocalData {
             iterator: global.iterator.clone(),
             exporter: None,

--- a/vortex-io/Cargo.toml
+++ b/vortex-io/Cargo.toml
@@ -22,18 +22,20 @@ async-fs = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
+custom-labels = { workspace = true }
 futures = { workspace = true, features = ["std", "executor"] }
-# Needed to pickup the "wasm_js" feature for wasm targets from the workspace configuration
-getrandom_v03 = { workspace = true }
+getrandom_v03 = { workspace = true } # Needed to pickup the "wasm_js" feature for wasm targets from the workspace configuration
+handle = "1.0.2"
 kanal = { workspace = true }
 object_store = { workspace = true, optional = true, features = ["fs"] }
 oneshot = { workspace = true }
 parking_lot = { workspace = true }
 pin-project-lite = { workspace = true }
-# this is the maximum subset of fetaures that is safe for wasm32 targets
-custom-labels.workspace = true
-handle = "1.0.2"
-tokio = { workspace = true, features = ["io-util", "rt", "sync"] }
+tokio = { workspace = true, features = [
+    "io-util",
+    "rt",
+    "sync",
+] } # this is the maximum subset of fetaures that is safe for wasm32 targets
 tracing = { workspace = true }
 vortex-array = { workspace = true }
 vortex-buffer = { workspace = true }

--- a/vortex-io/Cargo.toml
+++ b/vortex-io/Cargo.toml
@@ -22,7 +22,6 @@ async-fs = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
-custom-labels = { workspace = true }
 futures = { workspace = true, features = ["std", "executor"] }
 getrandom_v03 = { workspace = true } # Needed to pickup the "wasm_js" feature for wasm targets from the workspace configuration
 handle = "1.0.2"
@@ -42,6 +41,9 @@ vortex-buffer = { workspace = true }
 vortex-error = { workspace = true }
 vortex-metrics = { workspace = true }
 vortex-session = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+custom-labels = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Smol is our default impl, so we don't want it to be optional, but it cannot be part of wasm

--- a/vortex-io/Cargo.toml
+++ b/vortex-io/Cargo.toml
@@ -31,6 +31,7 @@ oneshot = { workspace = true }
 parking_lot = { workspace = true }
 pin-project-lite = { workspace = true }
 # this is the maximum subset of fetaures that is safe for wasm32 targets
+custom-labels.workspace = true
 handle = "1.0.2"
 tokio = { workspace = true, features = ["io-util", "rt", "sync"] }
 tracing = { workspace = true }

--- a/vortex-io/src/runtime/tokio.rs
+++ b/vortex-io/src/runtime/tokio.rs
@@ -85,7 +85,7 @@ impl Executor for tokio::runtime::Handle {
         }
         #[cfg(not(unix))]
         {
-            Box::new(tokio::runtime::Handle::spawn_blocking(task)).abort_handle()
+            Box::new(tokio::runtime::Handle::spawn_blocking(self, task).abort_handle())
         }
     }
 }

--- a/vortex-io/src/runtime/tokio.rs
+++ b/vortex-io/src/runtime/tokio.rs
@@ -4,6 +4,8 @@
 use std::sync::Arc;
 use std::sync::LazyLock;
 
+use custom_labels::Labelset;
+use custom_labels::asynchronous::Label;
 use futures::future::BoxFuture;
 
 use crate::runtime::AbortHandle;
@@ -43,15 +45,22 @@ impl From<tokio::runtime::Handle> for TokioRuntime {
 
 impl Executor for tokio::runtime::Handle {
     fn spawn(&self, fut: BoxFuture<'static, ()>) -> AbortHandleRef {
+        let fut = fut.with_current_labels();
         Box::new(tokio::runtime::Handle::spawn(self, fut).abort_handle())
     }
 
     fn spawn_cpu(&self, cpu: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
-        Box::new(tokio::runtime::Handle::spawn(self, async move { cpu() }).abort_handle())
+        Box::new(
+            tokio::runtime::Handle::spawn(self, async move { cpu() }.with_current_labels())
+                .abort_handle(),
+        )
     }
 
     fn spawn_blocking(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
-        Box::new(tokio::runtime::Handle::spawn_blocking(self, task).abort_handle())
+        let mut set = Labelset::clone_from_current();
+        Box::new(
+            tokio::runtime::Handle::spawn_blocking(self, move || set.enter(task)).abort_handle(),
+        )
     }
 }
 

--- a/vortex-io/src/runtime/tokio.rs
+++ b/vortex-io/src/runtime/tokio.rs
@@ -4,8 +4,6 @@
 use std::sync::Arc;
 use std::sync::LazyLock;
 
-use custom_labels::Labelset;
-use custom_labels::asynchronous::Label;
 use futures::future::BoxFuture;
 
 use crate::runtime::AbortHandle;
@@ -45,22 +43,50 @@ impl From<tokio::runtime::Handle> for TokioRuntime {
 
 impl Executor for tokio::runtime::Handle {
     fn spawn(&self, fut: BoxFuture<'static, ()>) -> AbortHandleRef {
-        let fut = fut.with_current_labels();
-        Box::new(tokio::runtime::Handle::spawn(self, fut).abort_handle())
+        #[cfg(unix)]
+        {
+            use custom_labels::asynchronous::Label;
+
+            let fut = fut.with_current_labels();
+            Box::new(tokio::runtime::Handle::spawn(self, fut).abort_handle())
+        }
+        #[cfg(not(unix))]
+        {
+            Box::new(tokio::runtime::Handle::spawn(self, fut).abort_handle())
+        }
     }
 
     fn spawn_cpu(&self, cpu: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
-        Box::new(
-            tokio::runtime::Handle::spawn(self, async move { cpu() }.with_current_labels())
-                .abort_handle(),
-        )
+        #[cfg(unix)]
+        {
+            use custom_labels::asynchronous::Label;
+
+            Box::new(
+                tokio::runtime::Handle::spawn(self, async move { cpu() }.with_current_labels())
+                    .abort_handle(),
+            )
+        }
+        #[cfg(not(unix))]
+        {
+            Box::new(tokio::runtime::Handle::spawn(self, async move { cpu() }).abort_handle())
+        }
     }
 
     fn spawn_blocking(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
-        let mut set = Labelset::clone_from_current();
-        Box::new(
-            tokio::runtime::Handle::spawn_blocking(self, move || set.enter(task)).abort_handle(),
-        )
+        #[cfg(unix)]
+        {
+            use custom_labels::Labelset;
+
+            let mut set = Labelset::clone_from_current();
+            Box::new(
+                tokio::runtime::Handle::spawn_blocking(self, move || set.enter(task))
+                    .abort_handle(),
+            )
+        }
+        #[cfg(not(unix))]
+        {
+            Box::new(tokio::runtime::Handle::spawn_blocking(task)).abort_handle()
+        }
     }
 }
 

--- a/vortex-metrics/src/lib.rs
+++ b/vortex-metrics/src/lib.rs
@@ -5,6 +5,8 @@
 
 //! Vortex metrics
 
+mod tracing;
+
 use std::borrow::Cow;
 use std::sync::Arc;
 

--- a/vortex-metrics/src/lib.rs
+++ b/vortex-metrics/src/lib.rs
@@ -5,7 +5,7 @@
 
 //! Vortex metrics
 
-mod tracing;
+pub mod tracing;
 
 use std::borrow::Cow;
 use std::sync::Arc;

--- a/vortex-metrics/src/tracing.rs
+++ b/vortex-metrics/src/tracing.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Global tracing and instrumentation
+
+use parking_lot::RwLock;
+
+static LABELS: RwLock<Vec<(&str, String)>> = RwLock::new(Vec::new());
+
+/// Set global labels used for external tracing.
+pub fn set_global_labels<I>(i: I)
+where
+    I: IntoIterator<Item = (&'static str, String)>,
+{
+    let new = Vec::from_iter(i);
+    *LABELS.write() = new;
+}
+
+/// Get the globally set labels for external tracing.
+pub fn get_global_labels() -> Vec<(&'static str, String)> {
+    LABELS.read().clone()
+}


### PR DESCRIPTION
This gives us much more debuggable benchmark data based on polar-signals, without requiring too many invasive changes.