### PR TITLE
Minor memory-related improvements in vortex-array and vortex-duckdb

### DIFF
--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -219,14 +219,14 @@ impl BoolArray {
 
     /// Returns the underlying [`BitBuffer`] of the array.
     pub fn to_bit_buffer(&self) -> BitBuffer {
-        self.clone().into_bit_buffer()
+        let buffer = self.bits.as_host().clone();
+
+        BitBuffer::new_with_offset(buffer, self.len, self.offset)
     }
 
     /// Returns the underlying [`BitBuffer`] of the array
     pub fn into_bit_buffer(self) -> BitBuffer {
-        let buffer = self.bits.as_host().clone();
-
-        BitBuffer::new_with_offset(buffer, self.len, self.offset)
+        self.to_bit_buffer()
     }
 
     pub fn to_mask(&self) -> Mask {

--- a/vortex-duckdb/src/duckdb/value.rs
+++ b/vortex-duckdb/src/duckdb/value.rs
@@ -159,9 +159,9 @@ impl<'a> ValueRef<'a> {
 
 impl<'a> Debug for ValueRef<'a> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let debug = unsafe { cpp::duckdb_value_to_string(self.as_ptr()) };
-        write!(f, "{}", unsafe { CStr::from_ptr(debug).to_string_lossy() })?;
-        unsafe { cpp::duckdb_free(debug.cast()) };
+        let ptr = unsafe { cpp::duckdb_value_to_string(self.as_ptr()) };
+        write!(f, "{}", unsafe { CStr::from_ptr(ptr).to_string_lossy() })?;
+        unsafe { cpp::duckdb_free(ptr.cast()) };
         Ok(())
     }
 }
@@ -248,11 +248,10 @@ impl Value {
 
 impl Display for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let debug = unsafe { cpp::duckdb_vx_value_to_string(self.as_ptr()) };
-        let str = unsafe { CStr::from_ptr(debug) }
-            .to_string_lossy()
-            .to_string();
-        f.write_str(&str)?;
+        let ptr = unsafe { cpp::duckdb_vx_value_to_string(self.as_ptr()) };
+        write!(f, "{}", unsafe { CStr::from_ptr(ptr) }.to_string_lossy())?;
+        unsafe { cpp::duckdb_free(ptr.cast()) };
+
         Ok(())
     }
 }
@@ -264,7 +263,7 @@ pub fn i128_from_parts(high: i64, low: u64) -> i128 {
 
 impl Debug for Value {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.to_string())
+        write!(f, "{self}",)
     }
 }
 


### PR DESCRIPTION
1. No need to clone the whole `BoolArray` when turning it into a `BitBuffer`, it contains a bunch of stuff we don't need, and that code path is identical to `into_bit_buffer`.
2. Addresses a small memory leak in `Value`'s `Display` implementation and rename some things.