### PR TITLE
perf[vortex-array]: avoid expensive list view to list in arrow execution

### DIFF
--- a/vortex-array/src/arrays/list/vtable/kernel/filter.rs
+++ b/vortex-array/src/arrays/list/vtable/kernel/filter.rs
@@ -1,25 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use num_traits::Zero;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
-use vortex_dtype::Nullability;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::ConstantArray;
 use crate::arrays::FilterArray;
 use crate::arrays::FilterVTable;
 use crate::arrays::ListArray;
 use crate::arrays::ListVTable;
-use crate::arrays::ListViewArray;
 use crate::arrays::list::compute::element_mask_from_offsets;
-use crate::builders::ArrayBuilder;
-use crate::builders::ListViewBuilder;
 use crate::kernel::ExecuteParentKernel;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
@@ -30,7 +29,6 @@ pub(super) struct ListFilterKernel;
 impl ExecuteParentKernel<ListVTable> for ListFilterKernel {
     type Parent = FilterVTable;
 
-    // TODO(joe): Remove the vector usage?
     fn execute_parent(
         &self,
         array: &ListArray,
@@ -47,14 +45,11 @@ impl ExecuteParentKernel<ListVTable> for ListFilterKernel {
             Validity::NonNullable => Validity::NonNullable,
             Validity::AllValid => Validity::AllValid,
             Validity::AllInvalid => {
-                let mut builder = ListViewBuilder::<u32, u32>::with_capacity(
-                    array.element_dtype().clone(),
-                    Nullability::Nullable,
-                    selection.true_count(),
-                    0,
-                );
-                builder.append_nulls(selection.true_count());
-                return Ok(Some(builder.finish()));
+                let elements = Canonical::empty(array.element_dtype()).into_array();
+                let offsets = ConstantArray::new(0u64, selection.true_count() + 1).into_array();
+                return Ok(Some(unsafe {
+                    ListArray::new_unchecked(elements, offsets, Validity::AllInvalid).into_array()
+                }));
             }
             Validity::Array(a) => Validity::Array(a.filter(parent.filter_mask().clone())?),
         };
@@ -62,41 +57,33 @@ impl ExecuteParentKernel<ListVTable> for ListFilterKernel {
         // TODO(ngates): for ultra-sparse masks, we don't need to optimize the entire offsets.
         let offsets = array.offsets().clone();
 
-        let (new_offsets, new_sizes, element_mask) =
+        let (new_offsets, element_mask) =
             match_each_integer_ptype!(offsets.dtype().as_ptype(), |O| {
                 let offsets_buffer = offsets.execute::<Buffer<O>>(ctx)?;
                 let offsets = offsets_buffer.as_slice();
-                let mut new_offsets = BufferMut::<O>::with_capacity(selection.true_count());
-                let mut new_sizes = BufferMut::<O>::with_capacity(selection.true_count());
+                let mut new_offsets = BufferMut::<O>::with_capacity(selection.true_count() + 1);
 
-                let mut offset = 0;
+                let mut offset = O::zero();
+                unsafe { new_offsets.push_unchecked(offset) };
                 for idx in selection.indices() {
-                    let start = offsets[*idx];
-                    let end = offsets[idx + 1];
-                    let size = end - start;
-                    unsafe { new_offsets.push_unchecked(offset) };
-                    unsafe { new_sizes.push_unchecked(size) };
+                    let size = offsets[idx + 1] - offsets[*idx];
                     offset += size;
+                    unsafe { new_offsets.push_unchecked(offset) };
                 }
 
                 // TODO(ngates): for very dense masks, there may be no point in filtering the elements,
                 //  and instead we should construct a view against the unfiltered elements.
                 let element_mask = element_mask_from_offsets::<O>(offsets, selection);
 
-                (
-                    new_offsets.freeze().into_array(),
-                    new_sizes.freeze().into_array(),
-                    element_mask,
-                )
+                (new_offsets.freeze().into_array(), element_mask)
             });
 
         let new_elements = array.sliced_elements()?.filter(element_mask)?;
 
-        Ok(Some(
-            unsafe {
-                ListViewArray::new_unchecked(new_elements, new_offsets, new_sizes, new_validity)
-            }
-            .into_array(),
-        ))
+        // SAFETY: new_offsets are monotonically increasing starting from 0 with length
+        // true_count + 1, and the elements have been filtered to match.
+        Ok(Some(unsafe {
+            ListArray::new_unchecked(new_elements, new_offsets, new_validity).into_array()
+        }))
     }
 }

--- a/vortex-array/src/arrow/executor/list.rs
+++ b/vortex-array/src/arrow/executor/list.rs
@@ -63,7 +63,11 @@ pub(super) fn to_arrow_list<O: OffsetSizeTrait + NativePType>(
 
     // Otherwise, we execute the array to become a ListViewArray.
     let list_view = array.execute::<ListViewArray>(ctx)?;
-    list_view_to_list::<O>(list_view, elements_field, ctx)
+    if list_view.is_zero_copy_to_list() {
+        list_view_zctl::<O>(list_view, elements_field, ctx)
+    } else {
+        list_view_to_list::<O>(list_view, elements_field, ctx)
+    }
 
     // FIXME(ngates): we need this PR from arrow-rs:
     //  https://github.com/apache/arrow-rs/pull/8735
@@ -256,11 +260,12 @@ mod tests {
 
     use arrow_array::Array;
     use arrow_array::GenericListArray;
+    use arrow_array::Int32Array;
     use arrow_schema::DataType;
     use arrow_schema::Field;
     use vortex_buffer::buffer;
     use vortex_dtype::DType;
-    use vortex_dtype::Nullability;
+    use vortex_dtype::Nullability::NonNullable;
     use vortex_error::VortexResult;
 
     use crate::Canonical;
@@ -308,10 +313,7 @@ mod tests {
         // Verify the values in the first list.
         let first_list = list.value(0);
         assert_eq!(first_list.len(), 3);
-        let first_values = first_list
-            .as_any()
-            .downcast_ref::<arrow_array::Int32Array>()
-            .unwrap();
+        let first_values = first_list.as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(first_values.value(0), 1);
         assert_eq!(first_values.value(1), 2);
         assert_eq!(first_values.value(2), 3);
@@ -319,10 +321,7 @@ mod tests {
         // Verify the values in the second list.
         let second_list = list.value(1);
         assert_eq!(second_list.len(), 2);
-        let second_values = second_list
-            .as_any()
-            .downcast_ref::<arrow_array::Int32Array>()
-            .unwrap();
+        let second_values = second_list.as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(second_values.value(0), 4);
         assert_eq!(second_values.value(1), 5);
         Ok(())
@@ -368,11 +367,8 @@ mod tests {
     #[test]
     fn test_to_arrow_list_empty_zctl() -> VortexResult<()> {
         let dtype = DType::List(
-            Arc::new(DType::Primitive(
-                vortex_dtype::PType::I32,
-                Nullability::NonNullable,
-            )),
-            Nullability::NonNullable,
+            Arc::new(DType::Primitive(vortex_dtype::PType::I32, NonNullable)),
+            NonNullable,
         );
         let list_array = unsafe {
             Canonical::empty(&dtype)


### PR DESCRIPTION
FilterVTable<ListVTable> produced a ListViewArray that did not have zctl set. This should be trivially zctl but was likely overlooked.

Additionally, after execution into a ListViewArray, the zctl flag can be checked again to use the optimized zctl path.