### PR TITLE
chore[vortex-bench]: add polarsignals benchmark

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -175,4 +175,11 @@ jobs:
             "remote_storage": "s3://vortex-bench-dev-eu/${{github.ref_name}}/${{github.run_id}}/fineweb/",
             "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact"
           },
+          {
+            "id": "polarsignals",
+            "subcommand": "polarsignals",
+            "name": "PolarSignals Profiling",
+            "targets": "datafusion:vortex",
+            "scale_factor": "1"
+          },
         ]

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -85,6 +85,13 @@ on:
               "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact",
               "scale_factor": "100"
             },
+            {
+              "id": "polarsignals",
+              "subcommand": "polarsignals",
+              "name": "PolarSignals Profiling",
+              "targets": "datafusion:vortex",
+              "scale_factor": "1"
+            },
           ]
 
 jobs:

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -220,10 +220,20 @@ async fn register_benchmark_tables<B: Benchmark + ?Sized>(
                 let pattern = benchmark.pattern(table.name, format);
                 let table_url = ListingTableUrl::try_new(benchmark_base.clone(), pattern)?;
 
-                let mut config = ListingTableConfig::new(table_url).with_listing_options(
-                    ListingOptions::new(file_format.clone())
-                        .with_session_config_options(session.state().config()),
-                );
+                let mut listing_options = ListingOptions::new(file_format.clone())
+                    .with_session_config_options(session.state().config());
+                if benchmark.dataset_name() == "polarsignals" && format == Format::Parquet {
+                    // Work around a DataFusion bug (fixed in 53.0.0) where the
+                    // constant-column optimization extracts ScalarValues using
+                    // the statistic scalar type, which may not match the table
+                    // column type.
+                    // See: https://github.com/apache/datafusion/pull/20042
+                    // TODO(asubiotto): Remove this after the datafusion 53
+                    // upgrade.
+                    listing_options = listing_options.with_collect_stat(false);
+                }
+                let mut config =
+                    ListingTableConfig::new(table_url).with_listing_options(listing_options);
 
                 config = match table.schema.as_ref() {
                     Some(schema) => config.with_schema(Arc::new(schema.clone())),

--- a/vortex-bench/polarsignals.sql
+++ b/vortex-bench/polarsignals.sql
@@ -1,0 +1,106 @@
+-- Q0: Narrow time range with filters.
+SELECT locations, value, period, time_nanos, labels.comm FROM stacktraces
+ WHERE time_nanos >= arrow_cast(0, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND time_nanos <= arrow_cast(50000000000, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND producer = 'parca_agent'
+   AND sample_type = 'samples'
+   AND sample_unit = 'count'
+   AND period_type = 'cpu'
+   AND period_unit = 'nanoseconds'
+   AND temporality = 'delta';
+-- Q1: Wider time range with filters.
+SELECT locations, value, period, time_nanos, labels.comm FROM stacktraces
+ WHERE time_nanos >= arrow_cast(0, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND time_nanos <= arrow_cast(250000000000, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND producer = 'parca_agent'
+   AND sample_type = 'samples'
+   AND sample_unit = 'count'
+   AND period_type = 'cpu'
+   AND period_unit = 'nanoseconds'
+   AND temporality = 'delta';
+-- Q2: Q1 + label equality filter.
+SELECT locations, value, period, time_nanos, labels.comm FROM stacktraces
+ WHERE time_nanos >= arrow_cast(0, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND time_nanos <= arrow_cast(250000000000, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND producer = 'parca_agent'
+   AND sample_type = 'samples'
+   AND sample_unit = 'count'
+   AND period_type = 'cpu'
+   AND period_unit = 'nanoseconds'
+   AND temporality = 'delta'
+   AND labels.comm = 'comm_0';
+-- Q3: Q1 + label regex matcher.
+SELECT locations, value, period, time_nanos, labels.comm FROM stacktraces
+ WHERE time_nanos >= arrow_cast(0, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND time_nanos <= arrow_cast(250000000000, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND producer = 'parca_agent'
+   AND sample_type = 'samples'
+   AND sample_unit = 'count'
+   AND period_type = 'cpu'
+   AND period_unit = 'nanoseconds'
+   AND temporality = 'delta'
+   AND labels.comm ~ '^comm_0$';
+-- Q4: Time-based aggregation.
+SELECT date_bin(INTERVAL '1 second', time_nanos) AS timestamp_bucket,
+       SUM(value) AS value, SUM(duration) AS duration
+  FROM stacktraces
+ WHERE time_nanos >= arrow_cast(0, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND time_nanos <= arrow_cast(250000000000, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND producer = 'parca_agent'
+   AND sample_type = 'samples'
+   AND sample_unit = 'count'
+   AND period_type = 'cpu'
+   AND period_unit = 'nanoseconds'
+   AND temporality = 'delta'
+ GROUP BY timestamp_bucket;
+-- Q5: Q4 + label grouping.
+SELECT date_bin(INTERVAL '1 second', time_nanos) AS timestamp_bucket,
+       SUM(value) AS value, SUM(duration) AS duration,
+       labels.comm
+  FROM stacktraces
+ WHERE time_nanos >= arrow_cast(0, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND time_nanos <= arrow_cast(250000000000, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND producer = 'parca_agent'
+   AND sample_type = 'samples'
+   AND sample_unit = 'count'
+   AND period_type = 'cpu'
+   AND period_unit = 'nanoseconds'
+   AND temporality = 'delta'
+ GROUP BY timestamp_bucket, labels.comm;
+-- Q6: Distinct label sets.
+SELECT DISTINCT labels FROM stacktraces
+ WHERE time_nanos >= arrow_cast(0, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND time_nanos <= arrow_cast(250000000000, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND producer = 'parca_agent'
+   AND sample_type = 'samples'
+   AND sample_unit = 'count'
+   AND period_type = 'cpu'
+   AND period_unit = 'nanoseconds'
+   AND temporality = 'delta';
+-- Q7: Distinct single label values.
+SELECT DISTINCT labels.comm FROM stacktraces
+ WHERE time_nanos >= arrow_cast(0, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND time_nanos <= arrow_cast(250000000000, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND producer = 'parca_agent'
+   AND sample_type = 'samples'
+   AND sample_unit = 'count'
+   AND period_type = 'cpu'
+   AND period_unit = 'nanoseconds'
+   AND temporality = 'delta'
+   AND labels.comm IS NOT NULL;
+-- Q8: Distinct mapping files via unnest.
+SELECT DISTINCT location.mapping_file
+  FROM (SELECT unnest(locations) AS location FROM stacktraces
+ WHERE time_nanos >= arrow_cast(0, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND time_nanos <= arrow_cast(250000000000, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND producer = 'parca_agent'
+   AND sample_type = 'samples'
+   AND sample_unit = 'count'
+   AND period_type = 'cpu'
+   AND period_unit = 'nanoseconds'
+   AND temporality = 'delta');
+-- Q9: Distinct profile types.
+SELECT DISTINCT producer, sample_type, sample_unit, period_type, period_unit, temporality
+  FROM stacktraces
+ WHERE time_nanos >= arrow_cast(0, 'Timestamp(Nanosecond, Some("UTC"))')
+   AND time_nanos <= arrow_cast(250000000000, 'Timestamp(Nanosecond, Some("UTC"))');

--- a/vortex-bench/src/datasets/mod.rs
+++ b/vortex-bench/src/datasets/mod.rs
@@ -43,6 +43,8 @@ pub enum BenchmarkDataset {
     PublicBi { name: String },
     #[serde(rename = "statpopgen")]
     StatPopGen { n_rows: u64 },
+    #[serde(rename = "polarsignals")]
+    PolarSignals { n_rows: usize },
     #[serde(rename = "fineweb")]
     Fineweb,
     #[serde(rename = "gharchive")]
@@ -57,6 +59,7 @@ impl BenchmarkDataset {
             BenchmarkDataset::ClickBench { .. } => "clickbench",
             BenchmarkDataset::PublicBi { .. } => "public-bi",
             BenchmarkDataset::StatPopGen { .. } => "statpopgen",
+            BenchmarkDataset::PolarSignals { .. } => "polarsignals",
             BenchmarkDataset::Fineweb => "fineweb",
             BenchmarkDataset::GhArchive => "gharchive",
         }
@@ -74,6 +77,9 @@ impl Display for BenchmarkDataset {
             },
             BenchmarkDataset::PublicBi { name } => write!(f, "public-bi({name})"),
             BenchmarkDataset::StatPopGen { n_rows } => write!(f, "statpopgen(n_rows={n_rows})"),
+            BenchmarkDataset::PolarSignals { n_rows } => {
+                write!(f, "polarsignals(n_rows={n_rows})")
+            }
             BenchmarkDataset::Fineweb => write!(f, "fineweb"),
             BenchmarkDataset::GhArchive => write!(f, "gharchive"),
         }
@@ -115,6 +121,7 @@ impl BenchmarkDataset {
             ],
             BenchmarkDataset::ClickBench { .. } | BenchmarkDataset::PublicBi { .. } => todo!(),
             BenchmarkDataset::StatPopGen { .. } => &["statpopgen"],
+            BenchmarkDataset::PolarSignals { .. } => &["stacktraces"],
             BenchmarkDataset::Fineweb => &["fineweb"],
             BenchmarkDataset::GhArchive => &["events"],
         }

--- a/vortex-bench/src/lib.rs
+++ b/vortex-bench/src/lib.rs
@@ -15,6 +15,7 @@ use clickbench::ClickBenchBenchmark;
 use clickbench::Flavor;
 use fineweb::FinewebBenchmark;
 use itertools::Itertools;
+use polarsignals::PolarSignalsBenchmark;
 use public_bi::PBIDataset;
 use public_bi::PublicBiBenchmark;
 use realnest::gharchive::GithubArchiveBenchmark;
@@ -43,6 +44,7 @@ pub mod fineweb;
 pub mod measurements;
 pub mod memory;
 pub mod output;
+pub mod polarsignals;
 pub mod public_bi;
 pub mod random_access;
 pub mod realnest;
@@ -236,6 +238,8 @@ pub enum BenchmarkArg {
     Fineweb,
     #[clap(name = "gharchive")]
     GhArchive,
+    #[clap(name = "polarsignals")]
+    PolarSignals,
     #[clap(name = "public-bi")]
     PublicBi,
 }
@@ -280,6 +284,11 @@ pub fn create_benchmark(b: BenchmarkArg, opts: &Opts) -> anyhow::Result<Box<dyn 
         BenchmarkArg::GhArchive => {
             let remote_data_dir = opts.get_as::<String>(REMOTE_DATA_KEY);
             let benchmark = GithubArchiveBenchmark::with_remote_data_dir(remote_data_dir)?;
+            Ok(Box::new(benchmark) as _)
+        }
+        BenchmarkArg::PolarSignals => {
+            let scale_factor = opts.get_as::<usize>(SCALE_FACTOR_KEY).unwrap_or(1);
+            let benchmark = PolarSignalsBenchmark::new(scale_factor)?;
             Ok(Box::new(benchmark) as _)
         }
         BenchmarkArg::PublicBi => {

--- a/vortex-bench/src/polarsignals/benchmark.rs
+++ b/vortex-bench/src/polarsignals/benchmark.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! PolarSignals benchmark implementation.
+
+use std::fs;
+
+use anyhow::Result;
+use url::Url;
+
+use super::data::generate_polarsignals_parquet;
+use super::schema::STACKTRACES_SCHEMA;
+use crate::Benchmark;
+use crate::BenchmarkDataset;
+use crate::Format;
+use crate::IdempotentPath;
+use crate::TableSpec;
+use crate::idempotent;
+use crate::workspace_root;
+
+const FILE_NAME: &str = "stacktraces";
+
+/// Benchmark modeled on PolarSignals profiling data to exercise scan-layer
+/// performance (projection + filter pushdown) on deeply nested schemas.
+pub struct PolarSignalsBenchmark {
+    /// Base URL for the dataset location.
+    pub data_url: Url,
+    /// Scale factor (1 = 1M rows).
+    pub scale_factor: usize,
+    /// Total number of rows in the dataset.
+    pub n_rows: usize,
+}
+
+impl PolarSignalsBenchmark {
+    /// Creates a new PolarSignalsBenchmark.
+    ///
+    /// `scale_factor` of 1 produces 1M rows.
+    pub fn new(scale_factor: usize) -> Result<Self> {
+        let n_rows = scale_factor * 1_000_000;
+        let data_path = "polarsignals".to_data_path().join(format!("{n_rows}/"));
+        let data_url =
+            Url::from_directory_path(data_path).map_err(|_| anyhow::anyhow!("bad data path"))?;
+
+        Ok(Self {
+            data_url,
+            scale_factor,
+            n_rows,
+        })
+    }
+
+    fn parquet_path(&self) -> Result<std::path::PathBuf> {
+        self.data_url
+            .join("parquet/")?
+            .join(&format!("{FILE_NAME}.parquet"))?
+            .to_file_path()
+            .map_err(|_| anyhow::anyhow!("failed to convert data URL to filesystem path"))
+    }
+}
+
+#[async_trait::async_trait]
+impl Benchmark for PolarSignalsBenchmark {
+    fn queries(&self) -> Result<Vec<(usize, String)>> {
+        let queries_file = workspace_root()
+            .join("vortex-bench")
+            .join("polarsignals")
+            .with_extension("sql");
+        let contents = fs::read_to_string(queries_file)?;
+        Ok(contents
+            .trim()
+            .split_terminator(";")
+            .map(str::to_string)
+            .enumerate()
+            .collect())
+    }
+
+    async fn generate_base_data(&self) -> Result<()> {
+        if self.data_url.scheme() != "file" {
+            anyhow::bail!(
+                "unsupported URL scheme '{}' - only 'file://' URLs are supported",
+                self.data_url.scheme()
+            );
+        }
+
+        let n_rows = self.n_rows;
+        let parquet_path = self.parquet_path()?;
+        idempotent(&parquet_path, |tmp_path| {
+            tracing::info!(
+                n_rows,
+                path = %parquet_path.display(),
+                "generating PolarSignals parquet data"
+            );
+            generate_polarsignals_parquet(n_rows, tmp_path)
+        })?;
+        Ok(())
+    }
+
+    fn dataset(&self) -> BenchmarkDataset {
+        BenchmarkDataset::PolarSignals {
+            n_rows: self.n_rows,
+        }
+    }
+
+    fn dataset_name(&self) -> &str {
+        "polarsignals"
+    }
+
+    fn dataset_display(&self) -> String {
+        format!("polarsignals(sf={})", self.scale_factor)
+    }
+
+    fn data_url(&self) -> &Url {
+        &self.data_url
+    }
+
+    fn table_specs(&self) -> Vec<TableSpec> {
+        vec![TableSpec::new(
+            "stacktraces",
+            Some(STACKTRACES_SCHEMA.clone()),
+        )]
+    }
+
+    #[expect(clippy::expect_used, clippy::unwrap_in_result)]
+    fn pattern(&self, _table_name: &str, format: Format) -> Option<glob::Pattern> {
+        Some(
+            format!("{FILE_NAME}.{}", format.ext())
+                .parse()
+                .expect("valid glob pattern"),
+        )
+    }
+}

--- a/vortex-bench/src/polarsignals/data.rs
+++ b/vortex-bench/src/polarsignals/data.rs
@@ -1,0 +1,464 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Synthetic data generation for the PolarSignals benchmark.
+//!
+//! Data is generated in sorted order by labels then `time_nanos`. Label values
+//! come from a pre-enumerated set of `NUM_LABEL_SETS` distinct label
+//! combinations that are sorted lexicographically (null < any value). Rows are
+//! distributed evenly across these sorted sets so that each label achieves its
+//! target cardinality while the overall row order remains sorted.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use arrow_array::RecordBatch;
+use arrow_array::builder::ListBuilder;
+use arrow_array::builder::StructBuilder;
+use arrow_schema::DataType;
+use arrow_schema::Field;
+use arrow_schema::Schema;
+use parquet::arrow::ArrowWriter;
+use parquet::basic::Compression;
+use parquet::file::properties::WriterProperties;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+
+use super::schema::Int64DictBuilder;
+use super::schema::LABELS;
+use super::schema::STACKTRACES_SCHEMA;
+use super::schema::StringDictBuilder;
+use super::schema::UInt64DictBuilder;
+use super::schema::label_fields;
+use super::schema::lines_fields;
+use super::schema::location_fields;
+
+pub const BASE_TIMESTAMP_NS: i64 = 0;
+
+/// Fixed step between consecutive rows (0.5ms = 500µs).
+const TIMESTAMP_STEP_NS: i64 = 500_000;
+
+const FUNCTION_NAME_POOL_SIZE: usize = 500;
+
+const FRAME_TYPES: &[&str] = &["regular", "kernel", "inline", "native"];
+const MAPPING_FILES: &[&str] = &[
+    "/usr/bin/app",
+    "/lib/x86_64-linux-gnu/libc.so.6",
+    "/lib/x86_64-linux-gnu/libpthread.so.0",
+    "[vdso]",
+    "[kernel]",
+];
+
+/// Number of distinct label-set combinations to enumerate.
+///
+/// Must be >= the largest `num_distinct` across all labels so that every label
+/// achieves its target cardinality.
+const NUM_LABEL_SETS: usize = 1000;
+
+/// Pre-computed label sets sorted by ascending cardinality.
+///
+/// `field_indices[pos]` gives the LABELS field index for position `pos` in each
+/// set vec. Values within each set are stored in ascending-cardinality order
+/// (ties broken alphabetically) so that plain lexicographic Vec sort produces
+/// the correct row ordering (low-cardinality labels as outermost sort keys).
+struct LabelSets {
+    field_indices: Vec<usize>,
+    sets: Vec<Vec<Option<usize>>>,
+}
+
+fn generate_sorted_label_sets() -> LabelSets {
+    // Sort LABELS indices by ascending cardinality, alphabetical tiebreak.
+    let mut field_indices: Vec<usize> = (0..LABELS.len()).collect();
+    field_indices.sort_by(|&a, &b| {
+        LABELS[a]
+            .2
+            .cmp(&LABELS[b].2)
+            .then_with(|| LABELS[a].0.cmp(LABELS[b].0))
+    });
+
+    // Generate sets with values in cardinality order.
+    let mut sets: Vec<Vec<Option<usize>>> = (0..NUM_LABEL_SETS)
+        .map(|s| {
+            field_indices
+                .iter()
+                .map(|&idx| {
+                    let (_, fill, distinct) = LABELS[idx];
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    let null_count = ((1.0 - fill) * NUM_LABEL_SETS as f64).round() as usize;
+                    if s < null_count || distinct == 0 {
+                        None
+                    } else {
+                        Some((s - null_count) % distinct)
+                    }
+                })
+                .collect()
+        })
+        .collect();
+
+    // Plain lexicographic sort: None < Some, low-cardinality fields outermost.
+    sets.sort();
+    LabelSets {
+        field_indices,
+        sets,
+    }
+}
+
+/// Map a global row index to the label-set index it belongs to.
+///
+/// Rows are distributed evenly: each of the `NUM_LABEL_SETS` sets gets
+/// `n_rows / S` rows, with the first `n_rows % S` sets receiving one extra.
+fn set_for_row(row_idx: usize, n_rows: usize) -> usize {
+    let base = n_rows / NUM_LABEL_SETS;
+    let extra = n_rows % NUM_LABEL_SETS;
+    let big = extra * (base + 1);
+    if row_idx < big {
+        row_idx / (base + 1)
+    } else {
+        extra + (row_idx - big) / base
+    }
+}
+
+/// Format a label value string for a given field and value index.
+fn format_label_value(field_index: usize, value_index: usize) -> String {
+    format!("{}_{value_index}", LABELS[field_index].0)
+}
+
+/// Generate synthetic PolarSignals profiling data and write to Parquet.
+pub fn generate_polarsignals_parquet(n_rows: usize, output_path: &Path) -> Result<()> {
+    let schema = Arc::new(STACKTRACES_SCHEMA.clone());
+    let label_sets = generate_sorted_label_sets();
+
+    let function_names: Arc<[String]> = (0..FUNCTION_NAME_POOL_SIZE)
+        .map(|i| format!("func_{i}"))
+        .collect();
+    let function_filenames: Arc<[String]> = (0..100)
+        .map(|i| format!("/src/pkg{}/{}.go", i / 10, i % 10))
+        .collect();
+    let build_ids: Arc<[String]> = (0..20).map(|i| format!("build_{i:040x}")).collect();
+    let label_sets = Arc::new(label_sets);
+
+    let file = std::fs::File::create(output_path)?;
+    let props = WriterProperties::builder()
+        .set_compression(Compression::SNAPPY)
+        .build();
+    let mut writer = ArrowWriter::try_new(file, schema.clone(), Some(props))?;
+
+    let batch_size = 10_000;
+    let num_threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+
+    let batch_ranges: Vec<(usize, usize)> = (0..n_rows)
+        .step_by(batch_size)
+        .map(|start| (start, batch_size.min(n_rows - start)))
+        .collect();
+
+    batch_ranges.chunks(num_threads).try_for_each(|chunk| {
+        chunk
+            .iter()
+            .map(|&(start, len)| {
+                let schema = schema.clone();
+                let label_sets = label_sets.clone();
+                let function_names = function_names.clone();
+                let function_filenames = function_filenames.clone();
+                let build_ids = build_ids.clone();
+                std::thread::spawn(move || {
+                    let mut rng = StdRng::seed_from_u64(42 + start as u64);
+                    build_batch(
+                        &schema,
+                        len,
+                        &mut rng,
+                        start,
+                        n_rows,
+                        &label_sets,
+                        &function_names,
+                        &function_filenames,
+                        &build_ids,
+                    )
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .try_for_each(|h| -> Result<()> {
+                writer.write(&h.join().unwrap()?)?;
+                Ok(())
+            })
+    })?;
+
+    writer.close()?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_batch(
+    schema: &Arc<Schema>,
+    n: usize,
+    rng: &mut StdRng,
+    batch_start_row: usize,
+    n_rows: usize,
+    label_sets: &LabelSets,
+    function_names: &[String],
+    function_filenames: &[String],
+    build_ids: &[String],
+) -> Result<RecordBatch> {
+    let labels_array = build_labels(n, batch_start_row, n_rows, label_sets);
+    let locations_array = build_locations(n, rng, function_names, function_filenames, build_ids);
+
+    let mut value_builder = arrow_array::builder::Int64Builder::with_capacity(n);
+    let mut producer_builder = StringDictBuilder::new();
+    let mut sample_type_builder = StringDictBuilder::new();
+    let mut sample_unit_builder = StringDictBuilder::new();
+    let mut period_type_builder = StringDictBuilder::new();
+    let mut period_unit_builder = StringDictBuilder::new();
+    let mut temporality_builder = StringDictBuilder::new();
+    let mut period_builder = arrow_array::builder::Int64Builder::with_capacity(n);
+    let mut duration_builder = arrow_array::builder::Int64Builder::with_capacity(n);
+    let mut time_nanos_builder =
+        arrow_array::builder::TimestampNanosecondBuilder::with_capacity(n).with_timezone("UTC");
+
+    for i in 0..n {
+        value_builder.append_value(1);
+        producer_builder.append_value("parca_agent");
+        sample_type_builder.append_value("samples");
+        sample_unit_builder.append_value("count");
+        period_type_builder.append_value("cpu");
+        period_unit_builder.append_value("nanoseconds");
+        temporality_builder.append_value("delta");
+        period_builder.append_value(52_631_578);
+        duration_builder.append_value(1_000_000_000);
+
+        let row_idx = batch_start_row + i;
+        let ts = BASE_TIMESTAMP_NS + (row_idx as i64) * TIMESTAMP_STEP_NS;
+        time_nanos_builder.append_value(ts);
+    }
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(labels_array),
+            Arc::new(locations_array),
+            Arc::new(value_builder.finish()),
+            Arc::new(producer_builder.finish()),
+            Arc::new(sample_type_builder.finish()),
+            Arc::new(sample_unit_builder.finish()),
+            Arc::new(period_type_builder.finish()),
+            Arc::new(period_unit_builder.finish()),
+            Arc::new(temporality_builder.finish()),
+            Arc::new(period_builder.finish()),
+            Arc::new(duration_builder.finish()),
+            Arc::new(time_nanos_builder.finish()),
+        ],
+    )?;
+
+    Ok(batch)
+}
+
+fn build_labels(
+    n: usize,
+    batch_start_row: usize,
+    n_rows: usize,
+    label_sets: &LabelSets,
+) -> arrow_array::StructArray {
+    let fields = label_fields();
+    let num_fields = LABELS.len();
+
+    let field_builders: Vec<Box<dyn arrow_array::builder::ArrayBuilder>> = (0..num_fields)
+        .map(|_| Box::new(StringDictBuilder::new()) as Box<dyn arrow_array::builder::ArrayBuilder>)
+        .collect();
+
+    let mut struct_builder = StructBuilder::new(fields.to_vec(), field_builders);
+
+    for i in 0..n {
+        let row_idx = batch_start_row + i;
+        let set_idx = set_for_row(row_idx, n_rows);
+        let set = &label_sets.sets[set_idx];
+
+        // set stores values in cardinality order; map back to LABELS field order.
+        for (pos, &val) in set.iter().enumerate() {
+            let field_idx = label_sets.field_indices[pos];
+            let fb = struct_builder
+                .field_builder::<StringDictBuilder>(field_idx)
+                .unwrap();
+            match val {
+                Some(val_idx) => {
+                    fb.append_value(format_label_value(field_idx, val_idx));
+                }
+                None => {
+                    fb.append_null();
+                }
+            }
+        }
+        struct_builder.append(true);
+    }
+
+    struct_builder.finish()
+}
+
+fn make_lines_struct_builder() -> StructBuilder {
+    let fields = lines_fields().to_vec();
+    let builders: Vec<Box<dyn arrow_array::builder::ArrayBuilder>> = vec![
+        Box::new(Int64DictBuilder::new()),  // line
+        Box::new(StringDictBuilder::new()), // function_name
+        Box::new(StringDictBuilder::new()), // function_system_name
+        Box::new(StringDictBuilder::new()), // function_filename
+        Box::new(Int64DictBuilder::new()),  // function_start_line
+    ];
+    StructBuilder::new(fields, builders)
+}
+
+fn make_location_struct_builder() -> StructBuilder {
+    let lines_list_builder = ListBuilder::new(make_lines_struct_builder()).with_field(Field::new(
+        "item",
+        DataType::Struct(lines_fields()),
+        true,
+    ));
+
+    let fields = location_fields().to_vec();
+    let builders: Vec<Box<dyn arrow_array::builder::ArrayBuilder>> = vec![
+        Box::new(UInt64DictBuilder::new()), // address
+        Box::new(StringDictBuilder::new()), // frame_type
+        Box::new(StringDictBuilder::new()), // mapping_file
+        Box::new(StringDictBuilder::new()), // mapping_build_id
+        Box::new(lines_list_builder),       // lines
+    ];
+    StructBuilder::new(fields, builders)
+}
+
+fn build_locations(
+    n: usize,
+    rng: &mut StdRng,
+    function_names: &[String],
+    function_filenames: &[String],
+    build_ids: &[String],
+) -> arrow_array::ListArray {
+    let location_builder = make_location_struct_builder();
+    let mut list_builder = ListBuilder::new(location_builder).with_field(Field::new(
+        "item",
+        DataType::Struct(location_fields()),
+        true,
+    ));
+
+    for _ in 0..n {
+        let num_locations = rng.random_range(5i32..50);
+        let loc_struct = list_builder.values();
+
+        for _ in 0..num_locations {
+            // address
+            loc_struct
+                .field_builder::<UInt64DictBuilder>(0)
+                .unwrap()
+                .append_value(rng.random::<u64>());
+            // frame_type
+            loc_struct
+                .field_builder::<StringDictBuilder>(1)
+                .unwrap()
+                .append_value(FRAME_TYPES[rng.random_range(0..FRAME_TYPES.len())]);
+            // mapping_file
+            loc_struct
+                .field_builder::<StringDictBuilder>(2)
+                .unwrap()
+                .append_value(MAPPING_FILES[rng.random_range(0..MAPPING_FILES.len())]);
+            // mapping_build_id
+            loc_struct
+                .field_builder::<StringDictBuilder>(3)
+                .unwrap()
+                .append_value(&build_ids[rng.random_range(0..build_ids.len())]);
+
+            // lines
+            let lines_list = loc_struct
+                .field_builder::<ListBuilder<StructBuilder>>(4)
+                .unwrap();
+            let num_lines = rng.random_range(1i32..5);
+            let lines_struct = lines_list.values();
+            for _ in 0..num_lines {
+                // line
+                lines_struct
+                    .field_builder::<Int64DictBuilder>(0)
+                    .unwrap()
+                    .append_value(rng.random_range(1..2000));
+                // function_name
+                lines_struct
+                    .field_builder::<StringDictBuilder>(1)
+                    .unwrap()
+                    .append_value(&function_names[rng.random_range(0..function_names.len())]);
+                // function_system_name
+                lines_struct
+                    .field_builder::<StringDictBuilder>(2)
+                    .unwrap()
+                    .append_value(&function_names[rng.random_range(0..function_names.len())]);
+                // function_filename
+                lines_struct
+                    .field_builder::<StringDictBuilder>(3)
+                    .unwrap()
+                    .append_value(
+                        &function_filenames[rng.random_range(0..function_filenames.len())],
+                    );
+                // function_start_line
+                lines_struct
+                    .field_builder::<Int64DictBuilder>(4)
+                    .unwrap()
+                    .append_value(rng.random_range(1..2000));
+                lines_struct.append(true);
+            }
+            lines_list.append(true);
+
+            loc_struct.append(true);
+        }
+
+        list_builder.append(true);
+    }
+
+    list_builder.finish()
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_types)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn test_label_cardinality() {
+        let ls = generate_sorted_label_sets();
+
+        // field_indices maps cardinality-order position → LABELS field index.
+        for (pos, &field_idx) in ls.field_indices.iter().enumerate() {
+            let (name, fill, distinct) = LABELS[field_idx];
+            let unique_values: HashSet<Option<usize>> = ls.sets.iter().map(|s| s[pos]).collect();
+
+            if distinct == 0 {
+                assert_eq!(
+                    unique_values.len(),
+                    1,
+                    "label {name} should be all null but has {} distinct values",
+                    unique_values.len()
+                );
+                assert!(unique_values.contains(&None));
+            } else {
+                let non_null_count = unique_values.iter().filter(|v| v.is_some()).count();
+                assert_eq!(
+                    non_null_count, distinct,
+                    "label {name} (fill={fill}) should have {distinct} distinct non-null values, got {non_null_count}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_set_for_row_covers_all_sets() {
+        let n_rows: usize = 5000;
+        let mut seen = HashSet::new();
+        for i in 0..n_rows {
+            seen.insert(set_for_row(i, n_rows));
+        }
+        assert_eq!(
+            seen.len(),
+            NUM_LABEL_SETS,
+            "not all label sets are used: got {} of {NUM_LABEL_SETS}",
+            seen.len()
+        );
+    }
+}

--- a/vortex-bench/src/polarsignals/mod.rs
+++ b/vortex-bench/src/polarsignals/mod.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! PolarSignals profiling data benchmark.
+//!
+//! The schema features a sparse struct (10 nullable label fields covering five
+//! fill-rate tiers), deeply nested locations
+//! (List<Struct<..., List<Struct<...>>>>), and several low-cardinality string
+//! columns.
+
+mod benchmark;
+mod data;
+mod schema;
+
+pub use benchmark::*;

--- a/vortex-bench/src/polarsignals/schema.rs
+++ b/vortex-bench/src/polarsignals/schema.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Schema definition for the PolarSignals benchmark.
+//!
+//! The target Arrow schema (`STACKTRACES_SCHEMA`) is a simplified version of the
+//! production PolarSignals writer defined in `pkg/profile/schema.go`. Labels are
+//! reduced to 10 representative fields (from 84) covering five fill-rate tiers.
+//! RunEndEncoded wrappers are stripped (not yet supported in vortex Arrow
+//! execution); Dictionary types are preserved.
+
+use std::sync::Arc;
+use std::sync::LazyLock;
+
+use arrow_array::builder::GenericByteDictionaryBuilder;
+use arrow_array::builder::PrimitiveDictionaryBuilder;
+use arrow_array::types::Int64Type;
+use arrow_array::types::UInt32Type;
+use arrow_array::types::UInt64Type;
+use arrow_array::types::Utf8Type;
+use arrow_schema::DataType;
+use arrow_schema::Field;
+use arrow_schema::Fields;
+use arrow_schema::Schema;
+use arrow_schema::TimeUnit;
+
+/// Label definitions: (field_name, fill_rate, num_distinct) reduced to 10
+/// representative labels covering five fill-rate tiers and a range of
+/// cardinalities.
+///
+/// Tiers:
+///   - Always filled (100%): cpu, node, thread_name
+///   - Near-full (~99%):     comm (queried in Q2)
+///   - Mostly filled (~97%): container, namespace
+///   - Sparse (~1%):         app, k8s_app
+///   - Always null (0%):     action, instance
+pub(super) const LABELS: &[(&str, f64, usize)] = &[
+    ("action", 0.0, 0),
+    ("app", 0.01, 4),
+    ("comm", 0.99, 800),
+    ("container", 0.97, 50),
+    ("cpu", 1.0, 32),
+    ("instance", 0.0, 0),
+    ("k8s_app", 0.01, 7),
+    ("namespace", 0.97, 14),
+    ("node", 1.0, 30),
+    ("thread_name", 1.0, 390),
+];
+
+/// Shorthand type aliases matching production builder types.
+pub(super) type StringDictBuilder = GenericByteDictionaryBuilder<UInt32Type, Utf8Type>;
+pub(super) type Int64DictBuilder = PrimitiveDictionaryBuilder<UInt32Type, Int64Type>;
+pub(super) type UInt64DictBuilder = PrimitiveDictionaryBuilder<UInt32Type, UInt64Type>;
+
+/// Helper: `Dictionary(UInt32, value_type)`.
+pub(super) fn dict_u32(value_type: DataType) -> DataType {
+    DataType::Dictionary(Box::new(DataType::UInt32), Box::new(value_type))
+}
+
+// ── Schema helpers matching production field order from schema.go ────────────
+
+pub(super) fn label_fields() -> Fields {
+    LABELS
+        .iter()
+        .map(|(name, ..)| Field::new(*name, dict_u32(DataType::Utf8), true))
+        .collect()
+}
+
+/// Production line struct field order: line, function_name, function_system_name,
+/// function_filename, function_start_line.
+pub(super) fn lines_fields() -> Fields {
+    vec![
+        Field::new("line", dict_u32(DataType::Int64), true),
+        Field::new("function_name", dict_u32(DataType::Utf8), true),
+        Field::new("function_system_name", dict_u32(DataType::Utf8), true),
+        Field::new("function_filename", dict_u32(DataType::Utf8), true),
+        Field::new("function_start_line", dict_u32(DataType::Int64), true),
+    ]
+    .into()
+}
+
+/// Production location struct field order: address, frame_type, mapping_file,
+/// mapping_build_id, lines.
+pub(super) fn location_fields() -> Fields {
+    vec![
+        Field::new("address", dict_u32(DataType::UInt64), true),
+        Field::new("frame_type", dict_u32(DataType::Utf8), true),
+        Field::new("mapping_file", dict_u32(DataType::Utf8), true),
+        Field::new("mapping_build_id", dict_u32(DataType::Utf8), true),
+        Field::new(
+            "lines",
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Struct(lines_fields()),
+                true,
+            ))),
+            true,
+        ),
+    ]
+    .into()
+}
+
+/// Target Arrow schema matching production `StructuredStacktraceSchema` from
+/// `pkg/profile/schema.go`. REE wrappers are stripped (unsupported in vortex
+/// Arrow execution); Dictionary types are preserved.
+///
+/// Field order: labels, locations, value, producer, sample_type, sample_unit,
+/// period_type, period_unit, temporality, period, duration, time_nanos.
+pub static STACKTRACES_SCHEMA: LazyLock<Schema> = LazyLock::new(|| {
+    Schema::new(vec![
+        Field::new("labels", DataType::Struct(label_fields()), false),
+        Field::new(
+            "locations",
+            DataType::List(Arc::new(Field::new(
+                "item",
+                DataType::Struct(location_fields()),
+                true,
+            ))),
+            true,
+        ),
+        Field::new("value", DataType::Int64, false),
+        Field::new("producer", dict_u32(DataType::Utf8), false),
+        Field::new("sample_type", dict_u32(DataType::Utf8), false),
+        Field::new("sample_unit", dict_u32(DataType::Utf8), false),
+        Field::new("period_type", dict_u32(DataType::Utf8), false),
+        Field::new("period_unit", dict_u32(DataType::Utf8), false),
+        Field::new("temporality", dict_u32(DataType::Utf8), true),
+        Field::new("period", DataType::Int64, false),
+        Field::new("duration", DataType::Int64, false),
+        Field::new(
+            "time_nanos",
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".into())),
+            false,
+        ),
+    ])
+});


### PR DESCRIPTION
Results vs our currently checked out commit:

```
 ┌───────┬─────────────────────────┬─────────────────────────┬────────────────────┐
 │ Query │      PS (current)       │          HEAD           │ Vortex improvement │
 ├───────┼─────────────────────────┼─────────────────────────┼────────────────────┤
 │ Q0    │ 392 ms                  │ 167 ms                  │ 2.3x faster        │
 ├───────┼─────────────────────────┼─────────────────────────┼────────────────────┤
 │ Q1    │ 503 ms                  │ 412 ms                  │ 1.2x faster        │
 ├───────┼─────────────────────────┼─────────────────────────┼────────────────────┤
 │ Q2    │ 13 ms                   │ 12 ms                   │ ~same              │
 └───────┴─────────────────────────┴─────────────────────────┴────────────────────┘
```

A good data point that this benchmark is representative is that the benchmark OOMs without #6304

The benchmark queries are relatively simple to focus on the scan layer. I might add some more queries in another PR.

This benchmark currently generates data in parallel. Another option is to store a pre-generated file somewhere. Let me know what you prefer. On one hand pre-generated is quicker, on the other hand we won't test writer changes (which have caused problems in the past e.g. with listview->list).

A lot of the boilerplate was written by claude, so feel free to point out anything that doesn't make sense since it is probably wrong.