### PR TITLE
Avoid some potential stack overflow cases with deep expression trees

### DIFF
--- a/vortex-array/src/arrays/dict/compute/rules.rs
+++ b/vortex-array/src/arrays/dict/compute/rules.rs
@@ -83,7 +83,7 @@ impl ArrayParentReduceRule<DictVTable> for DictionaryScalarFnValuesPushDownRule 
             tracing::trace!(
                 "Not pushing down fallible scalar function {} over dictionary with sparse codes {}",
                 parent.scalar_fn(),
-                array.display_tree(),
+                array.encoding_id(),
             );
             return Ok(None);
         }
@@ -106,7 +106,7 @@ impl ArrayParentReduceRule<DictVTable> for DictionaryScalarFnValuesPushDownRule 
             tracing::trace!(
                 "Not pushing down null-sensitive scalar function {} over dictionary with null codes {}",
                 parent.scalar_fn(),
-                array.display_tree(),
+                array.encoding_id(),
             );
             return Ok(None);
         }

--- a/vortex-array/src/arrays/scalar_fn/vtable/validity.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/validity.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::sync::Arc;
-
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
@@ -57,7 +55,7 @@ fn execute_expr(expr: &Expression, row_count: usize) -> VortexResult<ArrayRef> {
 
 impl ValidityVTable<ScalarFnVTable> for ScalarFnVTable {
     fn validity(array: &ScalarFnArray) -> VortexResult<Validity> {
-        let inputs: Arc<[_]> = array
+        let inputs: Vec<_> = array
             .children
             .iter()
             .map(|child| {

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -233,6 +233,7 @@ fn constant_list_scalar_contains(
     let len = values.len();
     let mut result: Option<ArrayRef> = None;
     let false_scalar = Scalar::bool(false, nullability);
+
     for element in elements {
         let res = compute::fill_null(
             &compute::compare(

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -156,7 +156,7 @@ impl ComputeFn {
                 args.inputs
                     .iter()
                     .filter_map(|input| input.array())
-                    .format_with(",", |array, f| f(&array.display_tree()))
+                    .format_with(",", |array, f| f(&array.encoding_id()))
             );
         }
         if output.len() != expected_len {

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -121,7 +121,7 @@ impl Executable for CanonicalOutput {
             )));
         }
 
-        tracing::debug!("Executing array {}:\n{}", array, array.display_tree());
+        tracing::debug!("Executing array {}:\n{}", array, array.encoding_id());
         Ok(CanonicalOutput::Array(array.execute(ctx)?))
     }
 }

--- a/vortex-array/src/expr/expression.rs
+++ b/vortex-array/src/expr/expression.rs
@@ -29,7 +29,7 @@ pub struct Expression {
     /// The scalar fn for this node.
     scalar_fn: ScalarFn,
     /// Any children of this expression.
-    children: Arc<[Expression]>,
+    children: Arc<Vec<Expression>>,
 }
 
 impl Deref for Expression {
@@ -44,9 +44,9 @@ impl Expression {
     /// Create a new expression node from a scalar_fn expression and its children.
     pub fn try_new(
         scalar_fn: ScalarFn,
-        children: impl Into<Arc<[Expression]>>,
+        children: impl IntoIterator<Item = Expression>,
     ) -> VortexResult<Self> {
-        let children: Arc<[Expression]> = children.into();
+        let children = Vec::from_iter(children);
 
         vortex_ensure!(
             scalar_fn.signature().arity().matches(children.len()),
@@ -57,7 +57,7 @@ impl Expression {
 
         Ok(Self {
             scalar_fn,
-            children,
+            children: children.into(),
         })
     }
 
@@ -67,7 +67,7 @@ impl Expression {
     }
 
     /// Returns the children of this expression.
-    pub fn children(&self) -> &Arc<[Expression]> {
+    pub fn children(&self) -> &Arc<Vec<Expression>> {
         &self.children
     }
 
@@ -77,15 +77,18 @@ impl Expression {
     }
 
     /// Replace the children of this expression with the provided new children.
-    pub fn with_children(mut self, children: impl Into<Arc<[Expression]>>) -> VortexResult<Self> {
-        let children = children.into();
+    pub fn with_children(
+        mut self,
+        children: impl IntoIterator<Item = Expression>,
+    ) -> VortexResult<Self> {
+        let children = Vec::from_iter(children);
         vortex_ensure!(
             self.signature().arity().matches(children.len()),
             "Expression arity mismatch: expected {} children but got {}",
             self.signature().arity(),
             children.len()
         );
-        self.children = children;
+        self.children = Arc::new(children);
         Ok(self)
     }
 
@@ -223,5 +226,20 @@ impl Expression {
 impl Display for Expression {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.fmt_sql(f)
+    }
+}
+
+/// Iterative drop for expression to avoid stack overflows.
+impl Drop for Expression {
+    fn drop(&mut self) {
+        if let Some(children) = Arc::get_mut(&mut self.children) {
+            let mut children_to_drop = std::mem::take(children);
+
+            while let Some(mut child) = children_to_drop.pop() {
+                if let Some(expr_children) = Arc::get_mut(&mut child.children) {
+                    children_to_drop.append(expr_children);
+                }
+            }
+        }
     }
 }

--- a/vortex-array/src/expr/exprs/binary.rs
+++ b/vortex-array/src/expr/exprs/binary.rs
@@ -509,11 +509,13 @@ where
         }
 
         if !exprs.len().is_multiple_of(2) {
-            exprs[exprs_len / 2] = exprs[exprs.len() - 1].clone();
-            exprs.truncate(exprs_len.div_ceil(2));
-        } else {
-            exprs.truncate(exprs_len.div_ceil(2));
+            // We want the odd nodes to be inside the tree and not at root
+            let lhs = exprs[(exprs.len() / 2) - 1].clone();
+            let rhs = exprs[exprs.len() - 1].clone();
+            exprs[exprs_len / 2 - 1] = combine(lhs, rhs);
         }
+
+        exprs.truncate(exprs_len / 2);
     }
 
     exprs.pop()
@@ -560,37 +562,54 @@ mod tests {
 
     #[test]
     fn and_collect_balanced() {
-        // 3 elements: and(and(1, 2), 3)
-        let values = vec![lit(1), lit(2), lit(3)];
-        assert_eq!(
-            Some(and(and(lit(1), lit(2)), lit(3))),
-            and_collect(values.into_iter())
-        );
+        let values = vec![lit(1), lit(2), lit(3), lit(4), lit(5)];
+
+        insta::assert_snapshot!(and_collect(values.into_iter()).unwrap().display_tree(), @r"
+        vortex.binary(and)
+        ├── lhs: vortex.binary(and)
+        │   ├── lhs: vortex.literal(1i32)
+        │   └── rhs: vortex.literal(2i32)
+        └── rhs: vortex.binary(and)
+            ├── lhs: vortex.binary(and)
+            │   ├── lhs: vortex.literal(3i32)
+            │   └── rhs: vortex.literal(4i32)
+            └── rhs: vortex.literal(5i32)
+        ");
 
         // 4 elements: and(and(1, 2), and(3, 4)) - perfectly balanced
         let values = vec![lit(1), lit(2), lit(3), lit(4)];
-        assert_eq!(
-            Some(and(and(lit(1), lit(2)), and(lit(3), lit(4)))),
-            and_collect(values.into_iter())
-        );
+        insta::assert_snapshot!(and_collect(values.into_iter()).unwrap().display_tree(), @r"
+        vortex.binary(and)
+        ├── lhs: vortex.binary(and)
+        │   ├── lhs: vortex.literal(1i32)
+        │   └── rhs: vortex.literal(2i32)
+        └── rhs: vortex.binary(and)
+            ├── lhs: vortex.literal(3i32)
+            └── rhs: vortex.literal(4i32)
+        ");
 
         // 1 element: just the element
         let values = vec![lit(1)];
-        assert_eq!(Some(lit(1)), and_collect(values.into_iter()));
+        insta::assert_snapshot!(and_collect(values.into_iter()).unwrap().display_tree(), @"vortex.literal(1i32)");
 
         // 0 elements: None
         let values: Vec<Expression> = vec![];
-        assert_eq!(None, and_collect(values.into_iter()));
+        assert!(and_collect(values.into_iter()).is_none());
     }
 
     #[test]
     fn or_collect_balanced() {
         // 4 elements: or(or(1, 2), or(3, 4)) - perfectly balanced
         let values = vec![lit(1), lit(2), lit(3), lit(4)];
-        assert_eq!(
-            Some(or(or(lit(1), lit(2)), or(lit(3), lit(4)))),
-            or_collect(values.into_iter())
-        );
+        insta::assert_snapshot!(or_collect(values.into_iter()).unwrap().display_tree(), @r"
+        vortex.binary(or)
+        ├── lhs: vortex.binary(or)
+        │   ├── lhs: vortex.literal(1i32)
+        │   └── rhs: vortex.literal(2i32)
+        └── rhs: vortex.binary(or)
+            ├── lhs: vortex.literal(3i32)
+            └── rhs: vortex.literal(4i32)
+        ");
     }
 
     #[test]

--- a/vortex-array/src/expr/exprs/binary.rs
+++ b/vortex-array/src/expr/exprs/binary.rs
@@ -499,24 +499,21 @@ where
         return exprs.pop();
     }
 
-    // Iteratively combine pairs until we have a single expression
     while exprs.len() > 1 {
-        let mut next_level = Vec::with_capacity(exprs.len().div_ceil(2));
-        let mut chunks = exprs.chunks_exact(2);
+        let exprs_len = exprs.len();
 
-        for chunk in chunks.by_ref() {
-            // chunk is guaranteed to have exactly 2 elements
-            let left = chunk[0].clone();
-            let right = chunk[1].clone();
-            next_level.push(combine(left, right));
+        for target_idx in 0..(exprs.len() / 2) {
+            let item_idx = target_idx * 2;
+            let new = combine(exprs[item_idx].clone(), exprs[item_idx + 1].clone());
+            exprs[target_idx] = new;
         }
 
-        // Handle the remainder (odd element)
-        if let Some(last) = chunks.remainder().first() {
-            next_level.push(last.clone());
+        if !exprs.len().is_multiple_of(2) {
+            exprs[exprs_len / 2] = exprs[exprs.len() - 1].clone();
+            exprs.truncate(exprs_len.div_ceil(2));
+        } else {
+            exprs.truncate(exprs_len.div_ceil(2));
         }
-
-        exprs = next_level;
     }
 
     exprs.pop()

--- a/vortex-array/src/expr/exprs/binary.rs
+++ b/vortex-array/src/expr/exprs/binary.rs
@@ -8,11 +8,9 @@ use vortex_dtype::DType;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
-use vortex_error::vortex_err;
 use vortex_proto::expr as pb;
 use vortex_session::VortexSession;
 
-use crate::ArrayRef;
 use crate::compute;
 use crate::compute::add;
 use crate::compute::and_kleene;
@@ -105,24 +103,23 @@ impl VTable for Binary {
     }
 
     fn execute(&self, op: &Operator, args: ExecutionArgs) -> VortexResult<ExecutionResult> {
-        let [lhs, rhs]: [ArrayRef; _] = args
-            .inputs
-            .try_into()
-            .map_err(|_| vortex_err!("Wrong arg count"))?;
+        let [lhs, rhs] = &args.inputs[..] else {
+            vortex_bail!("Wrong arg count")
+        };
 
         match op {
-            Operator::Eq => compare(&lhs, &rhs, compute::Operator::Eq),
-            Operator::NotEq => compare(&lhs, &rhs, compute::Operator::NotEq),
-            Operator::Lt => compare(&lhs, &rhs, compute::Operator::Lt),
-            Operator::Lte => compare(&lhs, &rhs, compute::Operator::Lte),
-            Operator::Gt => compare(&lhs, &rhs, compute::Operator::Gt),
-            Operator::Gte => compare(&lhs, &rhs, compute::Operator::Gte),
-            Operator::And => and_kleene(&lhs, &rhs),
-            Operator::Or => or_kleene(&lhs, &rhs),
-            Operator::Add => add(&lhs, &rhs),
-            Operator::Sub => sub(&lhs, &rhs),
-            Operator::Mul => mul(&lhs, &rhs),
-            Operator::Div => div(&lhs, &rhs),
+            Operator::Eq => compare(lhs, rhs, compute::Operator::Eq),
+            Operator::NotEq => compare(lhs, rhs, compute::Operator::NotEq),
+            Operator::Lt => compare(lhs, rhs, compute::Operator::Lt),
+            Operator::Lte => compare(lhs, rhs, compute::Operator::Lte),
+            Operator::Gt => compare(lhs, rhs, compute::Operator::Gt),
+            Operator::Gte => compare(lhs, rhs, compute::Operator::Gte),
+            Operator::And => and_kleene(lhs, rhs),
+            Operator::Or => or_kleene(lhs, rhs),
+            Operator::Add => add(lhs, rhs),
+            Operator::Sub => sub(lhs, rhs),
+            Operator::Mul => mul(lhs, rhs),
+            Operator::Div => div(lhs, rhs),
         }?
         .execute(args.ctx)
     }
@@ -440,16 +437,18 @@ pub fn or(lhs: Expression, rhs: Expression) -> Expression {
         .vortex_expect("Failed to create Or binary expression")
 }
 
-/// Collects a list of `or`ed values into a single vortex, expr
-/// [x, y, z] => x or (y or z)
+/// Collects a list of `or`ed values into a single expression using a balanced tree.
+///
+/// This creates a balanced binary tree to avoid deep nesting that could cause
+/// stack overflow during drop or evaluation.
+///
+/// [a, b, c, d] => or(or(a, b), or(c, d))
 pub fn or_collect<I>(iter: I) -> Option<Expression>
 where
     I: IntoIterator<Item = Expression>,
-    I::IntoIter: DoubleEndedIterator<Item = Expression>,
 {
-    let mut iter = iter.into_iter();
-    let first = iter.next_back()?;
-    Some(iter.rfold(first, |acc, elem| or(elem, acc)))
+    let exprs: Vec<_> = iter.into_iter().collect();
+    balanced_reduce(exprs, or)
 }
 
 /// Create a new [`Binary`] using the [`And`](crate::expr::exprs::operators::Operator::And) operator.
@@ -474,26 +473,53 @@ pub fn and(lhs: Expression, rhs: Expression) -> Expression {
         .vortex_expect("Failed to create And binary expression")
 }
 
-/// Collects a list of `and`ed values into a single vortex, expr
-/// [x, y, z] => x and (y and z)
+/// Collects a list of `and`ed values into a single expression using a balanced tree.
+///
+/// This creates a balanced binary tree to avoid deep nesting that could cause
+/// stack overflow during drop or evaluation.
+///
+/// [a, b, c, d] => and(and(a, b), and(c, d))
 pub fn and_collect<I>(iter: I) -> Option<Expression>
 where
     I: IntoIterator<Item = Expression>,
-    I::IntoIter: DoubleEndedIterator<Item = Expression>,
 {
-    let mut iter = iter.into_iter();
-    let first = iter.next_back()?;
-    Some(iter.rfold(first, |acc, elem| and(elem, acc)))
+    let exprs: Vec<_> = iter.into_iter().collect();
+    balanced_reduce(exprs, and)
 }
 
-/// Collects a list of `and`ed values into a single vortex, expr
-/// [x, y, z] => x and (y and z)
-pub fn and_collect_right<I>(iter: I) -> Option<Expression>
+/// Helper function to reduce a list of expressions into a balanced binary tree.
+fn balanced_reduce<F>(mut exprs: Vec<Expression>, combine: F) -> Option<Expression>
 where
-    I: IntoIterator<Item = Expression>,
+    F: Fn(Expression, Expression) -> Expression + Copy,
 {
-    let iter = iter.into_iter();
-    iter.reduce(and)
+    if exprs.is_empty() {
+        return None;
+    }
+    if exprs.len() == 1 {
+        return exprs.pop();
+    }
+
+    // Iteratively combine pairs until we have a single expression
+    while exprs.len() > 1 {
+        let mut next_level = Vec::with_capacity(exprs.len().div_ceil(2));
+        let mut chunks = exprs.chunks_exact(2);
+
+        for chunk in chunks.by_ref() {
+            // chunk is guaranteed to have exactly 2 elements
+            let left = chunk[0].clone();
+            let right = chunk[1].clone();
+            next_level.push(combine(left, right));
+        }
+
+        // Handle the remainder (odd element)
+        if let Some(last) = chunks.remainder().first() {
+            next_level.push(last.clone());
+        }
+
+        exprs = next_level;
+    }
+
+    exprs.pop()
 }
 
 /// Create a new [`Binary`] using the [`Add`](crate::expr::exprs::operators::Operator::Add) operator.
@@ -536,20 +562,37 @@ mod tests {
     use crate::expr::test_harness;
 
     #[test]
-    fn and_collect_left_assoc() {
-        let values = vec![lit(1), lit(2), lit(3)];
-        assert_eq!(
-            Some(and(lit(1), and(lit(2), lit(3)))),
-            and_collect(values.into_iter())
-        );
-    }
-
-    #[test]
-    fn and_collect_right_assoc() {
+    fn and_collect_balanced() {
+        // 3 elements: and(and(1, 2), 3)
         let values = vec![lit(1), lit(2), lit(3)];
         assert_eq!(
             Some(and(and(lit(1), lit(2)), lit(3))),
-            and_collect_right(values.into_iter())
+            and_collect(values.into_iter())
+        );
+
+        // 4 elements: and(and(1, 2), and(3, 4)) - perfectly balanced
+        let values = vec![lit(1), lit(2), lit(3), lit(4)];
+        assert_eq!(
+            Some(and(and(lit(1), lit(2)), and(lit(3), lit(4)))),
+            and_collect(values.into_iter())
+        );
+
+        // 1 element: just the element
+        let values = vec![lit(1)];
+        assert_eq!(Some(lit(1)), and_collect(values.into_iter()));
+
+        // 0 elements: None
+        let values: Vec<Expression> = vec![];
+        assert_eq!(None, and_collect(values.into_iter()));
+    }
+
+    #[test]
+    fn or_collect_balanced() {
+        // 4 elements: or(or(1, 2), or(3, 4)) - perfectly balanced
+        let values = vec![lit(1), lit(2), lit(3), lit(4)];
+        assert_eq!(
+            Some(or(or(lit(1), lit(2)), or(lit(3), lit(4)))),
+            or_collect(values.into_iter())
         );
     }
 

--- a/vortex-array/src/expr/exprs/list_contains.rs
+++ b/vortex-array/src/expr/exprs/list_contains.rs
@@ -23,7 +23,7 @@ use crate::expr::Expression;
 use crate::expr::StatsCatalog;
 use crate::expr::VTable;
 use crate::expr::VTableExt;
-use crate::expr::exprs::binary::and;
+use crate::expr::and_collect;
 use crate::expr::exprs::binary::gt;
 use crate::expr::exprs::binary::lt;
 use crate::expr::exprs::binary::or;
@@ -142,15 +142,12 @@ impl VTable for ListContains {
             let value_max = needle.stat_max(catalog)?;
             let value_min = needle.stat_min(catalog)?;
 
-            return list_
-                .iter()
-                .map(move |v| {
-                    or(
-                        lt(value_max.clone(), lit(v.clone())),
-                        gt(value_min.clone(), lit(v.clone())),
-                    )
-                })
-                .reduce(and);
+            return and_collect(list_.iter().map(move |v| {
+                or(
+                    lt(value_max.clone(), lit(v.clone())),
+                    gt(value_min.clone(), lit(v.clone())),
+                )
+            }));
         }
 
         None

--- a/vortex-array/src/expr/proto.rs
+++ b/vortex-array/src/expr/proto.rs
@@ -51,7 +51,7 @@ impl Expression {
             .children
             .iter()
             .map(|e| Expression::from_proto(e, session))
-            .collect::<VortexResult<Arc<_>>>()?;
+            .collect::<VortexResult<Vec<_>>>()?;
 
         Expression::try_new(vtable.deserialize(expr.metadata(), session)?, children)
     }

--- a/vortex-array/src/expr/transform/match_between.rs
+++ b/vortex-array/src/expr/transform/match_between.rs
@@ -5,9 +5,9 @@ use crate::compute::BetweenOptions;
 use crate::compute::StrictComparison;
 use crate::expr::Expression;
 use crate::expr::VTableExt;
+use crate::expr::and_collect;
 use crate::expr::exprs::between::Between;
 use crate::expr::exprs::binary::Binary;
-use crate::expr::exprs::binary::and;
 use crate::expr::exprs::get_item::GetItem;
 use crate::expr::exprs::literal::Literal;
 use crate::expr::exprs::literal::lit;
@@ -45,7 +45,7 @@ pub fn find_between(expr: Expression) -> Expression {
         }
     }
 
-    rest.into_iter().reduce(and).unwrap_or_else(|| lit(true))
+    and_collect(rest).unwrap_or_else(|| lit(true))
 }
 
 fn maybe_match(lhs: &Expression, rhs: &Expression) -> Option<Expression> {

--- a/vortex-array/src/expr/traversal/mod.rs
+++ b/vortex-array/src/expr/traversal/mod.rs
@@ -499,7 +499,7 @@ impl Node for Expression {
         &'a self,
         mut f: F,
     ) -> VortexResult<TraversalOrder> {
-        self.children().as_ref().apply_ref_elements(&mut f)
+        self.children().as_ref().apply_elements(&mut f)
     }
 
     fn map_children<F: FnMut(Self) -> VortexResult<Transformed<Self>>>(

--- a/vortex-array/src/expr/vtable.rs
+++ b/vortex-array/src/expr/vtable.rs
@@ -378,7 +378,7 @@ pub trait VTableExt: VTable {
     fn new_expr(
         &'static self,
         options: Self::Options,
-        children: impl Into<Arc<[Expression]>>,
+        children: impl IntoIterator<Item = Expression>,
     ) -> Expression {
         Self::try_new_expr(self, options, children).vortex_expect("Failed to create expression")
     }
@@ -387,9 +387,9 @@ pub trait VTableExt: VTable {
     fn try_new_expr(
         &'static self,
         options: Self::Options,
-        children: impl Into<Arc<[Expression]>>,
+        children: impl IntoIterator<Item = Expression>,
     ) -> VortexResult<Expression> {
-        Expression::try_new(self.bind(options), children.into())
+        Expression::try_new(self.bind(options), children)
     }
 }
 impl<V: VTable> VTableExt for V {}

--- a/vortex-array/src/optimizer/rules.rs
+++ b/vortex-array/src/optimizer/rules.rs
@@ -154,15 +154,15 @@ impl<V: VTable> ParentRuleSet<V> {
                         reduced.len() == parent.len(),
                         "Reduced array length mismatch from {:?}\nFrom:\n{}\nTo:\n{}",
                         rule,
-                        parent.display_tree(),
-                        reduced.display_tree()
+                        parent.encoding_id(),
+                        reduced.encoding_id()
                     );
                     vortex_error::vortex_ensure!(
                         reduced.dtype() == parent.dtype(),
                         "Reduced array dtype mismatch from {:?}\nFrom:\n{}\nTo:\n{}",
                         rule,
-                        parent.display_tree(),
-                        reduced.display_tree()
+                        parent.encoding_id(),
+                        reduced.encoding_id()
                     );
                 }
 

--- a/vortex-array/src/vtable/dyn_.rs
+++ b/vortex-array/src/vtable/dyn_.rs
@@ -106,14 +106,14 @@ impl<V: VTable> DynVTable for ArrayVTableAdapter<V> {
         vortex_ensure!(
             reduced.len() == array.len(),
             "Reduced array length mismatch from {} to {}",
-            array.display_tree(),
-            reduced.display_tree()
+            array.encoding_id(),
+            reduced.encoding_id()
         );
         vortex_ensure!(
             reduced.dtype() == array.dtype(),
             "Reduced array dtype mismatch from {} to {}",
-            array.display_tree(),
-            reduced.display_tree()
+            array.encoding_id(),
+            reduced.encoding_id()
         );
         Ok(Some(reduced))
     }
@@ -131,14 +131,14 @@ impl<V: VTable> DynVTable for ArrayVTableAdapter<V> {
         vortex_ensure!(
             reduced.len() == parent.len(),
             "Reduced array length mismatch from {} to {}",
-            parent.display_tree(),
-            reduced.display_tree()
+            parent.encoding_id(),
+            reduced.encoding_id()
         );
         vortex_ensure!(
             reduced.dtype() == parent.dtype(),
             "Reduced array dtype mismatch from {} to {}",
-            parent.display_tree(),
-            reduced.display_tree()
+            parent.encoding_id(),
+            reduced.encoding_id()
         );
 
         Ok(Some(reduced))

--- a/vortex-btrblocks/src/compressor/integer/mod.rs
+++ b/vortex-btrblocks/src/compressor/integer/mod.rs
@@ -454,7 +454,7 @@ impl Scheme for ZigZagScheme {
             Excludes::int_only(&new_excludes),
         )?;
 
-        tracing::debug!("zigzag output: {}", compressed.display_tree());
+        tracing::debug!("zigzag output: {}", compressed.encoding_id());
 
         Ok(ZigZagArray::try_new(compressed)?.into_array())
     }

--- a/vortex-btrblocks/src/compressor/mod.rs
+++ b/vortex-btrblocks/src/compressor/mod.rs
@@ -146,7 +146,7 @@ where
         if output.nbytes() < array.nbytes() {
             Ok(output)
         } else {
-            tracing::debug!("resulting tree too large: {}", output.display_tree());
+            tracing::debug!("resulting tree too large: {}", output.encoding_id());
             Ok(array.to_array())
         }
     }

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -57,7 +57,7 @@ pub(crate) fn make_vortex_predicate(
         .map(|e| expr_convertor.convert(e.as_ref()))
         .collect::<DFResult<Vec<_>>>()?;
 
-    Ok(and_collect(exprs.into_iter()))
+    Ok(and_collect(exprs))
 }
 
 /// Trait for converting DataFusion expressions to Vortex ones.

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -28,7 +28,7 @@ use vortex::expr::Expression;
 use vortex::expr::Like;
 use vortex::expr::Operator;
 use vortex::expr::VTableExt;
-use vortex::expr::and;
+use vortex::expr::and_collect;
 use vortex::expr::cast;
 use vortex::expr::get_item;
 use vortex::expr::is_null;
@@ -57,7 +57,7 @@ pub(crate) fn make_vortex_predicate(
         .map(|e| expr_convertor.convert(e.as_ref()))
         .collect::<DFResult<Vec<_>>>()?;
 
-    Ok(exprs.into_iter().reduce(and))
+    Ok(and_collect(exprs.into_iter()))
 }
 
 /// Trait for converting DataFusion expressions to Vortex ones.


### PR DESCRIPTION
Closes https://github.com/vortex-data/vortex/issues/6296

1. Collect large `AND`/`OR` expressions into balanced trees instead of a left/right leaning tree, making any recursion into them shorter.
2. Drop `Expression` iteratively instead of the default recursive approach.
3. Following https://github.com/vortex-data/vortex/pull/6251, using encoding ids instead of deep `Array::display_tree` in logs and errors.