### PR TITLE
feat: clamp zero I/O concurrency

### DIFF
--- a/vortex-file/src/segments/source.rs
+++ b/vortex-file/src/segments/source.rs
@@ -17,6 +17,7 @@ use vortex_array::buffer::BufferHandle;
 use vortex_buffer::Alignment;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
+use vortex_error::vortex_panic;
 use vortex_io::VortexReadAt;
 use vortex_io::runtime::Handle;
 use vortex_layout::segments::SegmentFuture;
@@ -87,6 +88,12 @@ impl FileSegmentSource {
             config
         });
         let concurrency = reader.concurrency();
+        if concurrency == 0 {
+            vortex_panic!(
+                "VortexReadAt::concurrency returned 0 (uri={:?}); this would stall I/O",
+                reader.uri()
+            );
+        }
 
         let drive_fut = async move {
             let stream = IoRequestStream::new(


### PR DESCRIPTION
This PR adds a small safety guard in FileSegmentSource::open(): if VortexReadAt::concurrency() returns 0, we log a warning and clamp it to 1. This avoids potential stalls or panics from calling buffer_unordered(0) while keeping normal behavior unchanged for valid concurrency values.