### PR TITLE
Improve visitor performance by reducing `Vec` and String allocations 

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -444,11 +444,22 @@ impl BaseArrayVTable<ALPVTable> for ALPVTable {
 impl VisitorVTable<ALPVTable> for ALPVTable {
     fn visit_buffers(_array: &ALPArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &ALPArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &ALPArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("encoded", array.encoded());
         if let Some(patches) = array.patches() {
             visitor.visit_patches(patches);
         }
+    }
+
+    fn nchildren(array: &ALPArray) -> usize {
+        // encoded + optional patches (indices + values + optional chunk_offsets)
+        1 + array
+            .patches()
+            .map_or(0, |p| 2 + p.chunk_offsets().is_some() as usize)
     }
 }
 

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -461,12 +461,23 @@ impl BaseArrayVTable<ALPRDVTable> for ALPRDVTable {
 impl VisitorVTable<ALPRDVTable> for ALPRDVTable {
     fn visit_buffers(_array: &ALPRDArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &ALPRDArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &ALPRDArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("left_parts", array.left_parts());
         visitor.visit_child("right_parts", array.right_parts());
         if let Some(patches) = array.left_parts_patches() {
             visitor.visit_patches(patches);
         }
+    }
+
+    fn nchildren(array: &ALPRDArray) -> usize {
+        // left_parts + right_parts + optional patches (indices + values)
+        2 + array
+            .left_parts_patches()
+            .map_or(0, |p| 2 + p.chunk_offsets().is_some() as usize)
     }
 }
 

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -27,6 +27,7 @@ use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityHelper;
 use vortex_array::vtable::ValidityVTableFromValidityHelper;
 use vortex_array::vtable::VisitorVTable;
+use vortex_array::vtable::validity_nchildren;
 use vortex_buffer::BitBuffer;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
@@ -240,8 +241,16 @@ impl VisitorVTable<ByteBoolVTable> for ByteBoolVTable {
         visitor.visit_buffer_handle("values", array.buffer());
     }
 
+    fn nbuffers(_array: &ByteBoolArray) -> usize {
+        1
+    }
+
     fn visit_children(array: &ByteBoolArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(array.validity(), array.len());
+    }
+
+    fn nchildren(array: &ByteBoolArray) -> usize {
+        validity_nchildren(array.validity())
     }
 }
 

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -309,9 +309,17 @@ impl ValidityChild<DateTimePartsVTable> for DateTimePartsVTable {
 impl VisitorVTable<DateTimePartsVTable> for DateTimePartsVTable {
     fn visit_buffers(_array: &DateTimePartsArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &DateTimePartsArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &DateTimePartsArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("days", array.days());
         visitor.visit_child("seconds", array.seconds());
         visitor.visit_child("subseconds", array.subseconds());
+    }
+
+    fn nchildren(_array: &DateTimePartsArray) -> usize {
+        3
     }
 }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -303,8 +303,16 @@ impl ValidityChild<DecimalBytePartsVTable> for DecimalBytePartsVTable {
 impl VisitorVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
     fn visit_buffers(_array: &DecimalBytePartsArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &DecimalBytePartsArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &DecimalBytePartsArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("msp", &array.msp);
+    }
+
+    fn nchildren(_array: &DecimalBytePartsArray) -> usize {
+        1
     }
 }
 

--- a/encodings/fastlanes/src/bitpacking/vtable/visitor.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/visitor.rs
@@ -5,6 +5,7 @@ use vortex_array::ArrayBufferVisitor;
 use vortex_array::ArrayChildVisitor;
 use vortex_array::vtable::ValidityHelper;
 use vortex_array::vtable::VisitorVTable;
+use vortex_array::vtable::validity_nchildren;
 
 use crate::BitPackedArray;
 use crate::BitPackedVTable;
@@ -14,10 +15,22 @@ impl VisitorVTable<BitPackedVTable> for BitPackedVTable {
         visitor.visit_buffer_handle("packed", array.packed());
     }
 
+    fn nbuffers(_array: &BitPackedArray) -> usize {
+        1
+    }
+
     fn visit_children(array: &BitPackedArray, visitor: &mut dyn ArrayChildVisitor) {
         if let Some(patches) = array.patches() {
             visitor.visit_patches(patches);
         }
         visitor.visit_validity(array.validity(), array.len());
+    }
+
+    fn nchildren(array: &BitPackedArray) -> usize {
+        // optional patches (indices + values + optional chunk_offsets) + optional validity
+        array
+            .patches()
+            .map_or(0, |p| 2 + p.chunk_offsets().is_some() as usize)
+            + validity_nchildren(array.validity())
     }
 }

--- a/encodings/fastlanes/src/delta/vtable/visitor.rs
+++ b/encodings/fastlanes/src/delta/vtable/visitor.rs
@@ -11,8 +11,16 @@ use crate::DeltaArray;
 impl VisitorVTable<DeltaVTable> for DeltaVTable {
     fn visit_buffers(_array: &DeltaArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &DeltaArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &DeltaArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("bases", array.bases());
         visitor.visit_child("deltas", array.deltas());
+    }
+
+    fn nchildren(_array: &DeltaArray) -> usize {
+        2
     }
 }

--- a/encodings/fastlanes/src/for/vtable/visitor.rs
+++ b/encodings/fastlanes/src/for/vtable/visitor.rs
@@ -11,7 +11,15 @@ use crate::FoRArray;
 impl VisitorVTable<FoRVTable> for FoRVTable {
     fn visit_buffers(_array: &FoRArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &FoRArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &FoRArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("encoded", array.encoded())
+    }
+
+    fn nchildren(_array: &FoRArray) -> usize {
+        1
     }
 }

--- a/encodings/fastlanes/src/rle/vtable/visitor.rs
+++ b/encodings/fastlanes/src/rle/vtable/visitor.rs
@@ -13,10 +13,18 @@ impl VisitorVTable<RLEVTable> for RLEVTable {
         // RLE stores all data in child arrays, no direct buffers
     }
 
+    fn nbuffers(_array: &RLEArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &RLEArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("values", array.values());
         visitor.visit_child("indices", array.indices());
         visitor.visit_child("values_idx_offsets", array.values_idx_offsets());
         // Don't call visit_validity since the nullability is stored in the indices array.
+    }
+
+    fn nchildren(_array: &RLEArray) -> usize {
+        3
     }
 }

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -40,6 +40,7 @@ use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityHelper;
 use vortex_array::vtable::ValidityVTableFromChild;
 use vortex_array::vtable::VisitorVTable;
+use vortex_array::vtable::validity_nchildren;
 use vortex_buffer::Buffer;
 use vortex_buffer::ByteBuffer;
 use vortex_dtype::DType;
@@ -488,10 +489,19 @@ impl VisitorVTable<FSSTVTable> for FSSTVTable {
         visitor.visit_buffer_handle("compressed_codes", array.codes.bytes_handle())
     }
 
+    fn nbuffers(_array: &FSSTArray) -> usize {
+        3
+    }
+
     fn visit_children(array: &FSSTArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("uncompressed_lengths", array.uncompressed_lengths());
         visitor.visit_child("codes_offsets", array.codes.offsets());
         visitor.visit_validity(array.codes.validity(), array.codes.len());
+    }
+
+    fn nchildren(array: &FSSTArray) -> usize {
+        // uncompressed_lengths + codes_offsets + optional validity
+        2 + validity_nchildren(array.codes.validity())
     }
 }
 

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -42,6 +42,7 @@ use vortex_array::vtable::ValidityHelper;
 use vortex_array::vtable::ValiditySliceHelper;
 use vortex_array::vtable::ValidityVTableFromValiditySliceHelper;
 use vortex_array::vtable::VisitorVTable;
+use vortex_array::vtable::validity_nchildren;
 use vortex_buffer::BufferMut;
 use vortex_buffer::ByteBuffer;
 use vortex_buffer::ByteBufferMut;
@@ -553,8 +554,16 @@ impl VisitorVTable<PcoVTable> for PcoVTable {
         }
     }
 
+    fn nbuffers(array: &PcoArray) -> usize {
+        array.chunk_metas.len() + array.pages.len()
+    }
+
     fn visit_children(array: &PcoArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(&array.unsliced_validity, array.unsliced_n_rows());
+    }
+
+    fn nchildren(array: &PcoArray) -> usize {
+        validity_nchildren(&array.unsliced_validity)
     }
 }
 

--- a/encodings/runend/src/lib.rs
+++ b/encodings/runend/src/lib.rs
@@ -34,9 +34,17 @@ use vortex_session::VortexSession;
 impl VisitorVTable<RunEndVTable> for RunEndVTable {
     fn visit_buffers(_array: &RunEndArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &RunEndArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &RunEndArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("ends", array.ends());
         visitor.visit_child("values", array.values());
+    }
+
+    fn nchildren(_array: &RunEndArray) -> usize {
+        2
     }
 }
 

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -371,7 +371,15 @@ impl VisitorVTable<SequenceVTable> for SequenceVTable {
         // TODO(joe): expose scalar values
     }
 
+    fn nbuffers(_array: &SequenceArray) -> usize {
+        0
+    }
+
     fn visit_children(_array: &SequenceArray, _visitor: &mut dyn ArrayChildVisitor) {}
+
+    fn nchildren(_array: &SequenceArray) -> usize {
+        0
+    }
 }
 
 #[derive(Debug)]

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -424,8 +424,17 @@ impl VisitorVTable<SparseVTable> for SparseVTable {
         visitor.visit_buffer_handle("fill_value", &BufferHandle::new_host(fill_value_buffer));
     }
 
+    fn nbuffers(_array: &SparseArray) -> usize {
+        1
+    }
+
     fn visit_children(array: &SparseArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_patches(array.patches())
+    }
+
+    fn nchildren(array: &SparseArray) -> usize {
+        // patches have indices + values + optional chunk_offsets
+        2 + array.patches().chunk_offsets().is_some() as usize
     }
 }
 

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -221,8 +221,16 @@ impl ValidityChild<ZigZagVTable> for ZigZagVTable {
 impl VisitorVTable<ZigZagVTable> for ZigZagVTable {
     fn visit_buffers(_array: &ZigZagArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &ZigZagArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &ZigZagArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("encoded", array.encoded())
+    }
+
+    fn nchildren(_array: &ZigZagArray) -> usize {
+        1
     }
 }
 

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -38,6 +38,7 @@ use vortex_array::vtable::ValidityHelper;
 use vortex_array::vtable::ValiditySliceHelper;
 use vortex_array::vtable::ValidityVTableFromValiditySliceHelper;
 use vortex_array::vtable::VisitorVTable;
+use vortex_array::vtable::validity_nchildren;
 use vortex_buffer::Alignment;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
@@ -914,7 +915,15 @@ impl VisitorVTable<ZstdVTable> for ZstdVTable {
         }
     }
 
+    fn nbuffers(array: &ZstdArray) -> usize {
+        array.dictionary.is_some() as usize + array.frames.len()
+    }
+
     fn visit_children(array: &ZstdArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(&array.unsliced_validity, array.unsliced_n_rows());
+    }
+
+    fn nchildren(array: &ZstdArray) -> usize {
+        validity_nchildren(&array.unsliced_validity)
     }
 }

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -651,6 +651,10 @@ impl<V: VTable> ArrayVisitor for ArrayAdapter<V> {
         <V::VisitorVTable as VisitorVTable<V>>::nchildren(&self.0)
     }
 
+    fn nth_child(&self, idx: usize) -> Option<ArrayRef> {
+        <V::VisitorVTable as VisitorVTable<V>>::nth_child(&self.0, idx)
+    }
+
     fn children_names(&self) -> Vec<String> {
         struct ChildNameCollector {
             names: Vec<String>,

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -634,8 +634,8 @@ impl<V: VTable> ArrayVisitor for ArrayAdapter<V> {
             children: Vec<ArrayRef>,
         }
 
-        impl ArrayChildVisitor for ChildrenCollector {
-            fn visit_child(&mut self, _name: &str, array: &ArrayRef) {
+        impl ArrayChildVisitorUnnamed for ChildrenCollector {
+            fn visit_child(&mut self, array: &ArrayRef) {
                 self.children.push(array.clone());
             }
         }
@@ -643,7 +643,7 @@ impl<V: VTable> ArrayVisitor for ArrayAdapter<V> {
         let mut collector = ChildrenCollector {
             children: Vec::new(),
         };
-        <V::VisitorVTable as VisitorVTable<V>>::visit_children(&self.0, &mut collector);
+        <V::VisitorVTable as VisitorVTable<V>>::visit_children_unnamed(&self.0, &mut collector);
         collector.children
     }
 

--- a/vortex-array/src/array/visitor.rs
+++ b/vortex-array/src/array/visitor.rs
@@ -156,6 +156,40 @@ pub trait ArrayBufferVisitor {
     fn visit_buffer_handle(&mut self, _name: &str, handle: &BufferHandle);
 }
 
+/// A visitor for array children that does not require names.
+///
+/// This is more efficient than [`ArrayChildVisitor`] when you only need to
+/// iterate over children without accessing their names (e.g., for counting
+/// or accessing by index).
+pub trait ArrayChildVisitorUnnamed {
+    /// Visit a child of this array.
+    fn visit_child(&mut self, array: &ArrayRef);
+
+    /// Utility for visiting Array validity.
+    fn visit_validity(&mut self, validity: &Validity, len: usize) {
+        if let Some(vlen) = validity.maybe_len() {
+            assert_eq!(vlen, len, "Validity length mismatch");
+        }
+
+        match validity {
+            Validity::NonNullable | Validity::AllValid => {}
+            Validity::AllInvalid => self.visit_child(&ConstantArray::new(false, len).into_array()),
+            Validity::Array(array) => {
+                self.visit_child(array);
+            }
+        }
+    }
+
+    /// Utility for visiting Array patches.
+    fn visit_patches(&mut self, patches: &Patches) {
+        self.visit_child(patches.indices());
+        self.visit_child(patches.values());
+        if let Some(chunk_offsets) = patches.chunk_offsets() {
+            self.visit_child(chunk_offsets);
+        }
+    }
+}
+
 pub trait ArrayChildVisitor {
     /// Visit a child of this array.
     fn visit_child(&mut self, _name: &str, _array: &ArrayRef);

--- a/vortex-array/src/array/visitor.rs
+++ b/vortex-array/src/array/visitor.rs
@@ -22,6 +22,11 @@ pub trait ArrayVisitor {
     /// Returns the number of children of the array.
     fn nchildren(&self) -> usize;
 
+    /// Returns the nth child of the array without allocating a Vec.
+    ///
+    /// Returns `None` if the index is out of bounds.
+    fn nth_child(&self, idx: usize) -> Option<ArrayRef>;
+
     /// Returns the names of the children of the array.
     fn children_names(&self) -> Vec<String>;
 
@@ -63,6 +68,10 @@ impl ArrayVisitor for Arc<dyn Array> {
 
     fn nchildren(&self) -> usize {
         self.as_ref().nchildren()
+    }
+
+    fn nth_child(&self, idx: usize) -> Option<ArrayRef> {
+        self.as_ref().nth_child(idx)
     }
 
     fn children_names(&self) -> Vec<String> {

--- a/vortex-array/src/arrays/bool/vtable/visitor.rs
+++ b/vortex-array/src/arrays/bool/vtable/visitor.rs
@@ -3,9 +3,12 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::BoolArray;
 use crate::arrays::BoolVTable;
 use crate::vtable::VisitorVTable;
+use crate::vtable::validity_nchildren;
+use crate::vtable::validity_to_child;
 
 impl VisitorVTable<BoolVTable> for BoolVTable {
     fn visit_buffers(array: &BoolArray, visitor: &mut dyn ArrayBufferVisitor) {
@@ -14,5 +17,16 @@ impl VisitorVTable<BoolVTable> for BoolVTable {
 
     fn visit_children(array: &BoolArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(&array.validity, array.len());
+    }
+
+    fn nchildren(array: &BoolArray) -> usize {
+        validity_nchildren(&array.validity)
+    }
+
+    fn nth_child(array: &BoolArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => validity_to_child(&array.validity, array.len()),
+            _ => None,
+        }
     }
 }

--- a/vortex-array/src/arrays/bool/vtable/visitor.rs
+++ b/vortex-array/src/arrays/bool/vtable/visitor.rs
@@ -15,6 +15,10 @@ impl VisitorVTable<BoolVTable> for BoolVTable {
         visitor.visit_buffer_handle("bits", &array.bits);
     }
 
+    fn nbuffers(_array: &BoolArray) -> usize {
+        1
+    }
+
     fn visit_children(array: &BoolArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(&array.validity, array.len());
     }

--- a/vortex-array/src/arrays/chunked/vtable/visitor.rs
+++ b/vortex-array/src/arrays/chunked/vtable/visitor.rs
@@ -26,4 +26,15 @@ impl VisitorVTable<ChunkedVTable> for ChunkedVTable {
             visitor.visit_child(chunk);
         }
     }
+
+    fn nchildren(array: &ChunkedArray) -> usize {
+        1 + array.chunks().len()
+    }
+
+    fn nth_child(array: &ChunkedArray, idx: usize) -> Option<crate::ArrayRef> {
+        match idx {
+            0 => Some(array.chunk_offsets.to_array()),
+            n => array.chunks().get(n - 1).cloned(),
+        }
+    }
 }

--- a/vortex-array/src/arrays/chunked/vtable/visitor.rs
+++ b/vortex-array/src/arrays/chunked/vtable/visitor.rs
@@ -3,6 +3,7 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayChildVisitorUnnamed;
 use crate::arrays::ChunkedArray;
 use crate::arrays::ChunkedVTable;
 use crate::vtable::VisitorVTable;
@@ -15,6 +16,14 @@ impl VisitorVTable<ChunkedVTable> for ChunkedVTable {
 
         for (idx, chunk) in array.chunks().iter().enumerate() {
             visitor.visit_child(format!("chunks[{idx}]").as_str(), chunk);
+        }
+    }
+
+    fn visit_children_unnamed(array: &ChunkedArray, visitor: &mut dyn ArrayChildVisitorUnnamed) {
+        visitor.visit_child(&array.chunk_offsets.to_array());
+
+        for chunk in array.chunks().iter() {
+            visitor.visit_child(chunk);
         }
     }
 }

--- a/vortex-array/src/arrays/chunked/vtable/visitor.rs
+++ b/vortex-array/src/arrays/chunked/vtable/visitor.rs
@@ -11,6 +11,10 @@ use crate::vtable::VisitorVTable;
 impl VisitorVTable<ChunkedVTable> for ChunkedVTable {
     fn visit_buffers(_array: &ChunkedArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &ChunkedArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &ChunkedArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("chunk_offsets", &array.chunk_offsets.to_array());
 

--- a/vortex-array/src/arrays/constant/vtable/visitor.rs
+++ b/vortex-array/src/arrays/constant/vtable/visitor.rs
@@ -18,6 +18,10 @@ impl VisitorVTable<ConstantVTable> for ConstantVTable {
         visitor.visit_buffer_handle("scalar", &BufferHandle::new_host(buffer));
     }
 
+    fn nbuffers(_array: &ConstantArray) -> usize {
+        1
+    }
+
     fn visit_children(_array: &ConstantArray, _visitor: &mut dyn ArrayChildVisitor) {}
 
     fn nchildren(_array: &ConstantArray) -> usize {

--- a/vortex-array/src/arrays/constant/vtable/visitor.rs
+++ b/vortex-array/src/arrays/constant/vtable/visitor.rs
@@ -6,6 +6,7 @@ use vortex_scalar::ScalarValue;
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::ConstantArray;
 use crate::arrays::ConstantVTable;
 use crate::buffer::BufferHandle;
@@ -18,4 +19,12 @@ impl VisitorVTable<ConstantVTable> for ConstantVTable {
     }
 
     fn visit_children(_array: &ConstantArray, _visitor: &mut dyn ArrayChildVisitor) {}
+
+    fn nchildren(_array: &ConstantArray) -> usize {
+        0
+    }
+
+    fn nth_child(_array: &ConstantArray, _idx: usize) -> Option<ArrayRef> {
+        None
+    }
 }

--- a/vortex-array/src/arrays/decimal/vtable/visitor.rs
+++ b/vortex-array/src/arrays/decimal/vtable/visitor.rs
@@ -3,10 +3,13 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::DecimalArray;
 use crate::arrays::DecimalVTable;
 use crate::vtable::ValidityHelper;
 use crate::vtable::VisitorVTable;
+use crate::vtable::validity_nchildren;
+use crate::vtable::validity_to_child;
 
 impl VisitorVTable<DecimalVTable> for DecimalVTable {
     fn visit_buffers(array: &DecimalArray, visitor: &mut dyn ArrayBufferVisitor) {
@@ -15,5 +18,16 @@ impl VisitorVTable<DecimalVTable> for DecimalVTable {
 
     fn visit_children(array: &DecimalArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(array.validity(), array.len())
+    }
+
+    fn nchildren(array: &DecimalArray) -> usize {
+        validity_nchildren(array.validity())
+    }
+
+    fn nth_child(array: &DecimalArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => validity_to_child(array.validity(), array.len()),
+            _ => None,
+        }
     }
 }

--- a/vortex-array/src/arrays/decimal/vtable/visitor.rs
+++ b/vortex-array/src/arrays/decimal/vtable/visitor.rs
@@ -16,6 +16,10 @@ impl VisitorVTable<DecimalVTable> for DecimalVTable {
         visitor.visit_buffer_handle("values", &array.values);
     }
 
+    fn nbuffers(_array: &DecimalArray) -> usize {
+        1
+    }
+
     fn visit_children(array: &DecimalArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(array.validity(), array.len())
     }

--- a/vortex-array/src/arrays/dict/vtable/visitor.rs
+++ b/vortex-array/src/arrays/dict/vtable/visitor.rs
@@ -4,6 +4,7 @@
 use super::DictVTable;
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::dict::DictArray;
 use crate::vtable::VisitorVTable;
 
@@ -13,5 +14,17 @@ impl VisitorVTable<DictVTable> for DictVTable {
     fn visit_children(array: &DictArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("codes", array.codes());
         visitor.visit_child("values", array.values());
+    }
+
+    fn nchildren(_array: &DictArray) -> usize {
+        2
+    }
+
+    fn nth_child(array: &DictArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => Some(array.codes().clone()),
+            1 => Some(array.values().clone()),
+            _ => None,
+        }
     }
 }

--- a/vortex-array/src/arrays/dict/vtable/visitor.rs
+++ b/vortex-array/src/arrays/dict/vtable/visitor.rs
@@ -11,6 +11,10 @@ use crate::vtable::VisitorVTable;
 impl VisitorVTable<DictVTable> for DictVTable {
     fn visit_buffers(_array: &DictArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &DictArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &DictArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("codes", array.codes());
         visitor.visit_child("values", array.values());

--- a/vortex-array/src/arrays/extension/vtable/visitor.rs
+++ b/vortex-array/src/arrays/extension/vtable/visitor.rs
@@ -3,6 +3,7 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::extension::ExtensionArray;
 use crate::arrays::extension::ExtensionVTable;
 use crate::vtable::VisitorVTable;
@@ -12,5 +13,16 @@ impl VisitorVTable<ExtensionVTable> for ExtensionVTable {
 
     fn visit_children(array: &ExtensionArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("storage", &array.storage);
+    }
+
+    fn nchildren(_array: &ExtensionArray) -> usize {
+        1
+    }
+
+    fn nth_child(array: &ExtensionArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => Some(array.storage.clone()),
+            _ => None,
+        }
     }
 }

--- a/vortex-array/src/arrays/extension/vtable/visitor.rs
+++ b/vortex-array/src/arrays/extension/vtable/visitor.rs
@@ -11,6 +11,10 @@ use crate::vtable::VisitorVTable;
 impl VisitorVTable<ExtensionVTable> for ExtensionVTable {
     fn visit_buffers(_array: &ExtensionArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &ExtensionArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &ExtensionArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("storage", &array.storage);
     }

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -176,6 +176,17 @@ impl VisitorVTable<FilterVTable> for FilterVTable {
     fn visit_children(array: &FilterArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("child", &array.child);
     }
+
+    fn nchildren(_array: &FilterArray) -> usize {
+        1
+    }
+
+    fn nth_child(array: &FilterArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => Some(array.child.clone()),
+            _ => None,
+        }
+    }
 }
 
 pub struct FilterMetadata(pub(super) Mask);

--- a/vortex-array/src/arrays/fixed_size_list/vtable/visitor.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/visitor.rs
@@ -16,6 +16,10 @@ impl VisitorVTable<FixedSizeListVTable> for FixedSizeListVTable {
         // `FixedSizeListArray` has no byte buffers.
     }
 
+    fn nbuffers(_array: &FixedSizeListArray) -> usize {
+        0
+    }
+
     // We define the children for [`FixedSizeListArray`] as the `elements` array and the `validity`.
     fn visit_children(array: &FixedSizeListArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("elements", array.elements());

--- a/vortex-array/src/arrays/fixed_size_list/vtable/visitor.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/visitor.rs
@@ -3,10 +3,13 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::FixedSizeListVTable;
 use crate::vtable::ValidityHelper;
 use crate::vtable::VisitorVTable;
+use crate::vtable::validity_nchildren;
+use crate::vtable::validity_to_child;
 
 impl VisitorVTable<FixedSizeListVTable> for FixedSizeListVTable {
     fn visit_buffers(_array: &FixedSizeListArray, _visitor: &mut dyn ArrayBufferVisitor) {
@@ -17,5 +20,17 @@ impl VisitorVTable<FixedSizeListVTable> for FixedSizeListVTable {
     fn visit_children(array: &FixedSizeListArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("elements", array.elements());
         visitor.visit_validity(array.validity(), array.len());
+    }
+
+    fn nchildren(array: &FixedSizeListArray) -> usize {
+        1 + validity_nchildren(array.validity())
+    }
+
+    fn nth_child(array: &FixedSizeListArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => Some(array.elements().clone()),
+            1 => validity_to_child(array.validity(), array.len()),
+            _ => None,
+        }
     }
 }

--- a/vortex-array/src/arrays/list/vtable/visitor.rs
+++ b/vortex-array/src/arrays/list/vtable/visitor.rs
@@ -3,10 +3,13 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::ListArray;
 use crate::arrays::ListVTable;
 use crate::vtable::ValidityHelper;
 use crate::vtable::VisitorVTable;
+use crate::vtable::validity_nchildren;
+use crate::vtable::validity_to_child;
 
 impl VisitorVTable<ListVTable> for ListVTable {
     fn visit_buffers(_array: &ListArray, _visitor: &mut dyn ArrayBufferVisitor) {}
@@ -15,5 +18,18 @@ impl VisitorVTable<ListVTable> for ListVTable {
         visitor.visit_child("elements", array.elements());
         visitor.visit_child("offsets", array.offsets());
         visitor.visit_validity(array.validity(), array.len());
+    }
+
+    fn nchildren(array: &ListArray) -> usize {
+        2 + validity_nchildren(array.validity())
+    }
+
+    fn nth_child(array: &ListArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => Some(array.elements().clone()),
+            1 => Some(array.offsets().clone()),
+            2 => validity_to_child(array.validity(), array.len()),
+            _ => None,
+        }
     }
 }

--- a/vortex-array/src/arrays/list/vtable/visitor.rs
+++ b/vortex-array/src/arrays/list/vtable/visitor.rs
@@ -14,6 +14,10 @@ use crate::vtable::validity_to_child;
 impl VisitorVTable<ListVTable> for ListVTable {
     fn visit_buffers(_array: &ListArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &ListArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &ListArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("elements", array.elements());
         visitor.visit_child("offsets", array.offsets());

--- a/vortex-array/src/arrays/listview/vtable/visitor.rs
+++ b/vortex-array/src/arrays/listview/vtable/visitor.rs
@@ -16,6 +16,10 @@ impl VisitorVTable<ListViewVTable> for ListViewVTable {
         // ListView has no byte buffers.
     }
 
+    fn nbuffers(_array: &ListViewArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &ListViewArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("elements", array.elements());
         visitor.visit_child("offsets", array.offsets());

--- a/vortex-array/src/arrays/listview/vtable/visitor.rs
+++ b/vortex-array/src/arrays/listview/vtable/visitor.rs
@@ -3,10 +3,13 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::ListViewArray;
 use crate::arrays::ListViewVTable;
 use crate::vtable::ValidityHelper;
 use crate::vtable::VisitorVTable;
+use crate::vtable::validity_nchildren;
+use crate::vtable::validity_to_child;
 
 impl VisitorVTable<ListViewVTable> for ListViewVTable {
     fn visit_buffers(_array: &ListViewArray, _visitor: &mut dyn ArrayBufferVisitor) {
@@ -18,5 +21,19 @@ impl VisitorVTable<ListViewVTable> for ListViewVTable {
         visitor.visit_child("offsets", array.offsets());
         visitor.visit_child("sizes", array.sizes());
         visitor.visit_validity(array.validity(), array.len());
+    }
+
+    fn nchildren(array: &ListViewArray) -> usize {
+        3 + validity_nchildren(array.validity())
+    }
+
+    fn nth_child(array: &ListViewArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => Some(array.elements().clone()),
+            1 => Some(array.offsets().clone()),
+            2 => Some(array.sizes().clone()),
+            3 => validity_to_child(array.validity(), array.len()),
+            _ => None,
+        }
     }
 }

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -34,6 +34,8 @@ use crate::vtable::ArrayId;
 use crate::vtable::VTable;
 use crate::vtable::ValidityVTableFromValidityHelper;
 use crate::vtable::VisitorVTable;
+use crate::vtable::validity_nchildren;
+use crate::vtable::validity_to_child;
 
 mod kernel;
 
@@ -52,6 +54,18 @@ impl VisitorVTable<MaskedVTable> for MaskedVTable {
     fn visit_children(array: &MaskedArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("child", &array.child);
         visitor.visit_validity(&array.validity, array.child.len());
+    }
+
+    fn nchildren(array: &MaskedArray) -> usize {
+        1 + validity_nchildren(&array.validity)
+    }
+
+    fn nth_child(array: &MaskedArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => Some(array.child.clone()),
+            1 => validity_to_child(&array.validity, array.child.len()),
+            _ => None,
+        }
     }
 }
 

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -171,6 +171,14 @@ impl VisitorVTable<NullVTable> for NullVTable {
     fn visit_buffers(_array: &NullArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(_array: &NullArray, _visitor: &mut dyn ArrayChildVisitor) {}
+
+    fn nchildren(_array: &NullArray) -> usize {
+        0
+    }
+
+    fn nth_child(_array: &NullArray, _idx: usize) -> Option<ArrayRef> {
+        None
+    }
 }
 
 impl OperationsVTable<NullVTable> for NullVTable {

--- a/vortex-array/src/arrays/primitive/vtable/visitor.rs
+++ b/vortex-array/src/arrays/primitive/vtable/visitor.rs
@@ -3,10 +3,13 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::PrimitiveVTable;
 use crate::vtable::ValidityHelper;
 use crate::vtable::VisitorVTable;
+use crate::vtable::validity_nchildren;
+use crate::vtable::validity_to_child;
 
 impl VisitorVTable<PrimitiveVTable> for PrimitiveVTable {
     fn visit_buffers(array: &PrimitiveArray, visitor: &mut dyn ArrayBufferVisitor) {
@@ -15,5 +18,16 @@ impl VisitorVTable<PrimitiveVTable> for PrimitiveVTable {
 
     fn visit_children(array: &PrimitiveArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(array.validity(), array.len());
+    }
+
+    fn nchildren(array: &PrimitiveArray) -> usize {
+        validity_nchildren(array.validity())
+    }
+
+    fn nth_child(array: &PrimitiveArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => validity_to_child(array.validity(), array.len()),
+            _ => None,
+        }
     }
 }

--- a/vortex-array/src/arrays/primitive/vtable/visitor.rs
+++ b/vortex-array/src/arrays/primitive/vtable/visitor.rs
@@ -16,6 +16,10 @@ impl VisitorVTable<PrimitiveVTable> for PrimitiveVTable {
         visitor.visit_buffer_handle("values", array.buffer_handle());
     }
 
+    fn nbuffers(_array: &PrimitiveArray) -> usize {
+        1
+    }
+
     fn visit_children(array: &PrimitiveArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(array.validity(), array.len());
     }

--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -121,7 +121,10 @@ impl ReduceNode for ArrayRef {
     }
 
     fn child(&self, idx: usize) -> ReduceNodeRef {
-        Arc::new(<dyn Array>::children(self)[idx].clone())
+        Arc::new(
+            self.nth_child(idx)
+                .vortex_expect("child index out of bounds"),
+        )
     }
 
     fn child_count(&self) -> usize {

--- a/vortex-array/src/arrays/scalar_fn/vtable/visitor.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/visitor.rs
@@ -12,6 +12,10 @@ use crate::vtable::VisitorVTable;
 impl VisitorVTable<ScalarFnVTable> for ScalarFnVTable {
     fn visit_buffers(_array: &ScalarFnArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &ScalarFnArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &ScalarFnArray, visitor: &mut dyn ArrayChildVisitor) {
         for (idx, child) in array.children.iter().enumerate() {
             let name = array.scalar_fn.signature().child_name(idx);

--- a/vortex-array/src/arrays/scalar_fn/vtable/visitor.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/visitor.rs
@@ -3,6 +3,7 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayChildVisitorUnnamed;
 use crate::ArrayRef;
 use crate::arrays::scalar_fn::array::ScalarFnArray;
 use crate::arrays::scalar_fn::vtable::ScalarFnVTable;
@@ -16,6 +17,16 @@ impl VisitorVTable<ScalarFnVTable> for ScalarFnVTable {
             let name = array.scalar_fn.signature().child_name(idx);
             visitor.visit_child(name.as_ref(), child)
         }
+    }
+
+    fn visit_children_unnamed(array: &ScalarFnArray, visitor: &mut dyn ArrayChildVisitorUnnamed) {
+        for child in array.children.iter() {
+            visitor.visit_child(child);
+        }
+    }
+
+    fn nchildren(array: &ScalarFnArray) -> usize {
+        array.children.len()
     }
 
     fn nth_child(array: &ScalarFnArray, idx: usize) -> Option<ArrayRef> {

--- a/vortex-array/src/arrays/scalar_fn/vtable/visitor.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/visitor.rs
@@ -3,6 +3,7 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::scalar_fn::array::ScalarFnArray;
 use crate::arrays::scalar_fn::vtable::ScalarFnVTable;
 use crate::vtable::VisitorVTable;
@@ -15,5 +16,9 @@ impl VisitorVTable<ScalarFnVTable> for ScalarFnVTable {
             let name = array.scalar_fn.signature().child_name(idx);
             visitor.visit_child(name.as_ref(), child)
         }
+    }
+
+    fn nth_child(array: &ScalarFnArray, idx: usize) -> Option<ArrayRef> {
+        array.children.get(idx).cloned()
     }
 }

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -144,4 +144,15 @@ impl VisitorVTable<SharedVTable> for SharedVTable {
     fn visit_children(array: &SharedArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("source", &array.current_array_ref());
     }
+
+    fn nchildren(_array: &SharedArray) -> usize {
+        1
+    }
+
+    fn nth_child(array: &SharedArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => Some(array.current_array_ref()),
+            _ => None,
+        }
+    }
 }

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -175,6 +175,17 @@ impl VisitorVTable<SliceVTable> for SliceVTable {
     fn visit_children(array: &SliceArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("child", &array.child);
     }
+
+    fn nchildren(_array: &SliceArray) -> usize {
+        1
+    }
+
+    fn nth_child(array: &SliceArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => Some(array.child.clone()),
+            _ => None,
+        }
+    }
 }
 
 pub struct SliceMetadata(pub(super) Range<usize>);

--- a/vortex-array/src/arrays/struct_/vtable/visitor.rs
+++ b/vortex-array/src/arrays/struct_/vtable/visitor.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayChildVisitorUnnamed;
 use crate::arrays::struct_::StructArray;
 use crate::arrays::struct_::StructVTable;
 use crate::vtable::ValidityHelper;
@@ -17,6 +18,13 @@ impl VisitorVTable<StructVTable> for StructVTable {
         visitor.visit_validity(array.validity(), array.len());
         for (name, field) in array.names().iter().zip_eq(array.unmasked_fields().iter()) {
             visitor.visit_child(name.as_ref(), field);
+        }
+    }
+
+    fn visit_children_unnamed(array: &StructArray, visitor: &mut dyn ArrayChildVisitorUnnamed) {
+        visitor.visit_validity(array.validity(), array.len());
+        for field in array.unmasked_fields().iter() {
+            visitor.visit_child(field);
         }
     }
 }

--- a/vortex-array/src/arrays/struct_/vtable/visitor.rs
+++ b/vortex-array/src/arrays/struct_/vtable/visitor.rs
@@ -17,6 +17,10 @@ use crate::vtable::validity_to_child;
 impl VisitorVTable<StructVTable> for StructVTable {
     fn visit_buffers(_array: &StructArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
+    fn nbuffers(_array: &StructArray) -> usize {
+        0
+    }
+
     fn visit_children(array: &StructArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(array.validity(), array.len());
         for (name, field) in array.names().iter().zip_eq(array.unmasked_fields().iter()) {

--- a/vortex-array/src/arrays/struct_/vtable/visitor.rs
+++ b/vortex-array/src/arrays/struct_/vtable/visitor.rs
@@ -6,10 +6,13 @@ use itertools::Itertools;
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
 use crate::ArrayChildVisitorUnnamed;
+use crate::ArrayRef;
 use crate::arrays::struct_::StructArray;
 use crate::arrays::struct_::StructVTable;
 use crate::vtable::ValidityHelper;
 use crate::vtable::VisitorVTable;
+use crate::vtable::validity_nchildren;
+use crate::vtable::validity_to_child;
 
 impl VisitorVTable<StructVTable> for StructVTable {
     fn visit_buffers(_array: &StructArray, _visitor: &mut dyn ArrayBufferVisitor) {}
@@ -25,6 +28,22 @@ impl VisitorVTable<StructVTable> for StructVTable {
         visitor.visit_validity(array.validity(), array.len());
         for field in array.unmasked_fields().iter() {
             visitor.visit_child(field);
+        }
+    }
+
+    fn nchildren(array: &StructArray) -> usize {
+        validity_nchildren(array.validity()) + array.unmasked_fields().len()
+    }
+
+    fn nth_child(array: &StructArray, idx: usize) -> Option<ArrayRef> {
+        let validity_children = validity_nchildren(array.validity());
+        if idx < validity_children {
+            validity_to_child(array.validity(), array.len())
+        } else {
+            array
+                .unmasked_fields()
+                .get(idx - validity_children)
+                .cloned()
         }
     }
 }

--- a/vortex-array/src/arrays/varbin/vtable/visitor.rs
+++ b/vortex-array/src/arrays/varbin/vtable/visitor.rs
@@ -3,10 +3,13 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::VarBinArray;
 use crate::arrays::VarBinVTable;
 use crate::vtable::ValidityHelper;
 use crate::vtable::VisitorVTable;
+use crate::vtable::validity_nchildren;
+use crate::vtable::validity_to_child;
 
 impl VisitorVTable<VarBinVTable> for VarBinVTable {
     fn visit_buffers(array: &VarBinArray, visitor: &mut dyn ArrayBufferVisitor) {
@@ -17,5 +20,17 @@ impl VisitorVTable<VarBinVTable> for VarBinVTable {
     fn visit_children(array: &VarBinArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("offsets", array.offsets());
         visitor.visit_validity(array.validity(), array.len());
+    }
+
+    fn nchildren(array: &VarBinArray) -> usize {
+        1 + validity_nchildren(array.validity())
+    }
+
+    fn nth_child(array: &VarBinArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => Some(array.offsets().clone()),
+            1 => validity_to_child(array.validity(), array.len()),
+            _ => None,
+        }
     }
 }

--- a/vortex-array/src/arrays/varbin/vtable/visitor.rs
+++ b/vortex-array/src/arrays/varbin/vtable/visitor.rs
@@ -17,6 +17,10 @@ impl VisitorVTable<VarBinVTable> for VarBinVTable {
         visitor.visit_buffer_handle("bytes", array.bytes_handle());
     }
 
+    fn nbuffers(_array: &VarBinArray) -> usize {
+        1
+    }
+
     fn visit_children(array: &VarBinArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_child("offsets", array.offsets());
         visitor.visit_validity(array.validity(), array.len());

--- a/vortex-array/src/arrays/varbinview/vtable/visitor.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/visitor.rs
@@ -4,9 +4,12 @@
 use super::VarBinViewVTable;
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayRef;
 use crate::arrays::VarBinViewArray;
 use crate::vtable::ValidityHelper;
 use crate::vtable::VisitorVTable;
+use crate::vtable::validity_nchildren;
+use crate::vtable::validity_to_child;
 
 impl VisitorVTable<VarBinViewVTable> for VarBinViewVTable {
     fn visit_buffers(array: &VarBinViewArray, visitor: &mut dyn ArrayBufferVisitor) {
@@ -18,5 +21,16 @@ impl VisitorVTable<VarBinViewVTable> for VarBinViewVTable {
 
     fn visit_children(array: &VarBinViewArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(array.validity(), array.len())
+    }
+
+    fn nchildren(array: &VarBinViewArray) -> usize {
+        validity_nchildren(array.validity())
+    }
+
+    fn nth_child(array: &VarBinViewArray, idx: usize) -> Option<ArrayRef> {
+        match idx {
+            0 => validity_to_child(array.validity(), array.len()),
+            _ => None,
+        }
     }
 }

--- a/vortex-array/src/arrays/varbinview/vtable/visitor.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/visitor.rs
@@ -19,6 +19,10 @@ impl VisitorVTable<VarBinViewVTable> for VarBinViewVTable {
         visitor.visit_buffer_handle("views", array.views_handle());
     }
 
+    fn nbuffers(array: &VarBinViewArray) -> usize {
+        array.buffers().len() + 1
+    }
+
     fn visit_children(array: &VarBinViewArray, visitor: &mut dyn ArrayChildVisitor) {
         visitor.visit_validity(array.validity(), array.len())
     }

--- a/vortex-array/src/arrow/array.rs
+++ b/vortex-array/src/arrow/array.rs
@@ -178,4 +178,12 @@ impl VisitorVTable<ArrowVTable> for ArrowVTable {
     fn visit_buffers(_array: &ArrowArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(_array: &ArrowArray, _visitor: &mut dyn ArrayChildVisitor) {}
+
+    fn nchildren(_array: &ArrowArray) -> usize {
+        0
+    }
+
+    fn nth_child(_array: &ArrowArray, _idx: usize) -> Option<ArrayRef> {
+        None
+    }
 }

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -7,7 +7,6 @@ use std::fmt::Display;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
-use itertools::Itertools;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -7,6 +7,8 @@ use std::fmt::Display;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 
+use itertools::Itertools;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 
@@ -166,8 +168,9 @@ impl Executable for ArrayRef {
         }
 
         // 2. reduce_parent (child-driven metadata-only rewrites)
-        for (child_idx, child) in array.children().iter().enumerate() {
-            if let Some(reduced_parent) = child.vtable().reduce_parent(child, &array, child_idx)? {
+        for child_idx in 0..array.nchildren() {
+            let child = array.nth_child(child_idx).vortex_expect("checked length");
+            if let Some(reduced_parent) = child.vtable().reduce_parent(&child, &array, child_idx)? {
                 ctx.log(format_args!(
                     "reduce_parent: child[{}]({}) rewrote {} -> {}",
                     child_idx,
@@ -181,10 +184,11 @@ impl Executable for ArrayRef {
         }
 
         // 3. execute_parent (child-driven optimized execution)
-        for (child_idx, child) in array.children().iter().enumerate() {
+        for child_idx in 0..array.nchildren() {
+            let child = array.nth_child(child_idx).vortex_expect("checked length");
             if let Some(executed_parent) = child
                 .vtable()
-                .execute_parent(child, &array, child_idx, ctx)?
+                .execute_parent(&child, &array, child_idx, ctx)?
             {
                 ctx.log(format_args!(
                     "execute_parent: child[{}]({}) rewrote {} -> {}",

--- a/vortex-array/src/optimizer/mod.rs
+++ b/vortex-array/src/optimizer/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
@@ -46,6 +47,7 @@ fn try_optimize(array: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         }
 
         // Apply parent reduction rules to each child in the context of the current array.
+        // Its important to take all children here, as `current_array` can change inside the loop.
         for (idx, child) in current_array.children().iter().enumerate() {
             if let Some(new_array) = child.vtable().reduce_parent(child, &current_array, idx)? {
                 // If the parent was replaced, then we attempt to reduce it again.

--- a/vortex-array/src/optimizer/mod.rs
+++ b/vortex-array/src/optimizer/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 

--- a/vortex-array/src/vtable/visitor.rs
+++ b/vortex-array/src/vtable/visitor.rs
@@ -5,8 +5,34 @@ use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
 use crate::ArrayChildVisitorUnnamed;
 use crate::ArrayRef;
+use crate::IntoArray;
+use crate::arrays::ConstantArray;
 use crate::buffer::BufferHandle;
+use crate::validity::Validity;
 use crate::vtable::VTable;
+
+/// Returns the validity as a child array if it produces one.
+///
+/// - `NonNullable` and `AllValid` produce no child (returns `None`)
+/// - `AllInvalid` produces a `ConstantArray` of `false` values
+/// - `Array` returns the validity array
+#[inline]
+pub fn validity_to_child(validity: &Validity, len: usize) -> Option<ArrayRef> {
+    match validity {
+        Validity::NonNullable | Validity::AllValid => None,
+        Validity::AllInvalid => Some(ConstantArray::new(false, len).into_array()),
+        Validity::Array(array) => Some(array.clone()),
+    }
+}
+
+/// Returns 1 if validity produces a child, 0 otherwise.
+#[inline]
+pub fn validity_nchildren(validity: &Validity) -> usize {
+    match validity {
+        Validity::NonNullable | Validity::AllValid => 0,
+        Validity::AllInvalid | Validity::Array(_) => 1,
+    }
+}
 
 pub trait VisitorVTable<V: VTable> {
     /// Visit the buffers of the array.

--- a/vortex-array/src/vtable/visitor.rs
+++ b/vortex-array/src/vtable/visitor.rs
@@ -58,4 +58,32 @@ pub trait VisitorVTable<V: VTable> {
         <V::VisitorVTable as VisitorVTable<V>>::visit_children(array, &mut visitor);
         visitor.0
     }
+
+    /// Get the nth child of the array without allocating a Vec.
+    ///
+    /// Returns `None` if the index is out of bounds.
+    fn nth_child(array: &V::Array, idx: usize) -> Option<ArrayRef> {
+        struct NthChildVisitor {
+            target_idx: usize,
+            current_idx: usize,
+            result: Option<ArrayRef>,
+        }
+
+        impl ArrayChildVisitor for NthChildVisitor {
+            fn visit_child(&mut self, _name: &str, array: &ArrayRef) {
+                if self.current_idx == self.target_idx && self.result.is_none() {
+                    self.result = Some(array.clone());
+                }
+                self.current_idx += 1;
+            }
+        }
+
+        let mut visitor = NthChildVisitor {
+            target_idx: idx,
+            current_idx: 0,
+            result: None,
+        };
+        <V::VisitorVTable as VisitorVTable<V>>::visit_children(array, &mut visitor);
+        visitor.result
+    }
 }

--- a/vortex-array/src/vtable/visitor.rs
+++ b/vortex-array/src/vtable/visitor.rs
@@ -47,7 +47,7 @@ pub trait VisitorVTable<V: VTable> {
 
     /// Visit the children of the array without names.
     ///
-    /// This is more efficient than [`visit_children`] when you don't need the
+    /// This is more efficient than [`Self::visit_children`] when you don't need the
     /// child names (e.g., for counting or accessing by index). The default
     /// implementation wraps the named visitor, but array types can override
     /// this to avoid allocating names.

--- a/vortex-array/src/vtable/visitor.rs
+++ b/vortex-array/src/vtable/visitor.rs
@@ -3,6 +3,7 @@
 
 use crate::ArrayBufferVisitor;
 use crate::ArrayChildVisitor;
+use crate::ArrayChildVisitorUnnamed;
 use crate::ArrayRef;
 use crate::buffer::BufferHandle;
 use crate::vtable::VTable;
@@ -44,18 +45,36 @@ pub trait VisitorVTable<V: VTable> {
     /// Visit the children of the array.
     fn visit_children(array: &V::Array, visitor: &mut dyn ArrayChildVisitor);
 
+    /// Visit the children of the array without names.
+    ///
+    /// This is more efficient than [`visit_children`] when you don't need the
+    /// child names (e.g., for counting or accessing by index). The default
+    /// implementation wraps the named visitor, but array types can override
+    /// this to avoid allocating names.
+    fn visit_children_unnamed(array: &V::Array, visitor: &mut dyn ArrayChildVisitorUnnamed) {
+        struct UnnamedWrapper<'a>(&'a mut dyn ArrayChildVisitorUnnamed);
+
+        impl ArrayChildVisitor for UnnamedWrapper<'_> {
+            fn visit_child(&mut self, _name: &str, array: &ArrayRef) {
+                self.0.visit_child(array);
+            }
+        }
+
+        <V::VisitorVTable as VisitorVTable<V>>::visit_children(array, &mut UnnamedWrapper(visitor));
+    }
+
     /// Count the number of children in the array.
     fn nchildren(array: &V::Array) -> usize {
         struct NChildren(usize);
 
-        impl ArrayChildVisitor for NChildren {
-            fn visit_child(&mut self, _name: &str, _array: &ArrayRef) {
+        impl ArrayChildVisitorUnnamed for NChildren {
+            fn visit_child(&mut self, _array: &ArrayRef) {
                 self.0 += 1;
             }
         }
 
         let mut visitor = NChildren(0);
-        <V::VisitorVTable as VisitorVTable<V>>::visit_children(array, &mut visitor);
+        <V::VisitorVTable as VisitorVTable<V>>::visit_children_unnamed(array, &mut visitor);
         visitor.0
     }
 
@@ -69,8 +88,8 @@ pub trait VisitorVTable<V: VTable> {
             result: Option<ArrayRef>,
         }
 
-        impl ArrayChildVisitor for NthChildVisitor {
-            fn visit_child(&mut self, _name: &str, array: &ArrayRef) {
+        impl ArrayChildVisitorUnnamed for NthChildVisitor {
+            fn visit_child(&mut self, array: &ArrayRef) {
                 if self.current_idx == self.target_idx && self.result.is_none() {
                     self.result = Some(array.clone());
                 }
@@ -83,7 +102,7 @@ pub trait VisitorVTable<V: VTable> {
             current_idx: 0,
             result: None,
         };
-        <V::VisitorVTable as VisitorVTable<V>>::visit_children(array, &mut visitor);
+        <V::VisitorVTable as VisitorVTable<V>>::visit_children_unnamed(array, &mut visitor);
         visitor.result
     }
 }

--- a/vortex-compute/src/filter/slice.rs
+++ b/vortex-compute/src/filter/slice.rs
@@ -16,7 +16,6 @@ use vortex_buffer::BitView;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_mask::Mask;
-use vortex_mask::MaskIter;
 use vortex_mask::MaskValues;
 
 use crate::filter::Filter;
@@ -46,9 +45,16 @@ impl<T: Copy> Filter<MaskValues> for &[T] {
             "Selection mask length must equal the buffer length"
         );
 
-        match mask_values.threshold_iter(FILTER_SLICES_SELECTIVITY_THRESHOLD) {
-            MaskIter::Indices(indices) => self.filter(indices),
-            MaskIter::Slices(slices) => self.filter(slices),
+        if mask_values.density() >= FILTER_SLICES_SELECTIVITY_THRESHOLD {
+            // High density: use slices (contiguous ranges)
+            self.filter(mask_values.slices())
+        } else {
+            // Low density: stream indices directly from bitmap without allocating
+            let mut out = BufferMut::<T>::with_capacity(mask_values.true_count());
+            for idx in mask_values.bit_buffer().set_indices() {
+                out.push(self[idx]);
+            }
+            out.freeze()
         }
     }
 }

--- a/vortex-compute/src/filter/slice.rs
+++ b/vortex-compute/src/filter/slice.rs
@@ -16,6 +16,7 @@ use vortex_buffer::BitView;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
 use vortex_mask::Mask;
+use vortex_mask::MaskIter;
 use vortex_mask::MaskValues;
 
 use crate::filter::Filter;
@@ -45,16 +46,9 @@ impl<T: Copy> Filter<MaskValues> for &[T] {
             "Selection mask length must equal the buffer length"
         );
 
-        if mask_values.density() >= FILTER_SLICES_SELECTIVITY_THRESHOLD {
-            // High density: use slices (contiguous ranges)
-            self.filter(mask_values.slices())
-        } else {
-            // Low density: stream indices directly from bitmap without allocating
-            let mut out = BufferMut::<T>::with_capacity(mask_values.true_count());
-            for idx in mask_values.bit_buffer().set_indices() {
-                out.push(self[idx]);
-            }
-            out.freeze()
+        match mask_values.threshold_iter(FILTER_SLICES_SELECTIVITY_THRESHOLD) {
+            MaskIter::Indices(indices) => self.filter(indices),
+            MaskIter::Slices(slices) => self.filter(slices),
         }
     }
 }


### PR DESCRIPTION
Using `dhat`, identified these two code paths as heavy allocators, running the full tpch benchmark.

This PR fills out many default implementations in `VisitorVTable`, making them much more efficient for many cases, both by reducing recursive function calls and by not formatting names. As far as I can tell - many of the improvements shown by codspeed are completely real here.

1. ~Using the existing iterator when filtering instead of allocating a Vec saves about 2GB of memory allocation (around 1.6% of all memory allocated), which happens in a tiny amount of allocations (0.02%).~ Moving to a separate PR, I want to try and make a bigger change and be able to measure it.
2. The `nth_child` (should just be `child`?) was just another offender that was easy to experiment with, it doesn't allocate a lot of data but it does save ~0.6% of all allocations.


