### PR TITLE
DF: Only calculate the size of the metadata cache entry once

### DIFF
--- a/vortex-datafusion/src/persistent/cache.rs
+++ b/vortex-datafusion/src/persistent/cache.rs
@@ -16,13 +16,17 @@ use vortex::layout::segments::SegmentId;
 /// Cached Vortex file metadata for use with DataFusion's [`FileMetadataCache`].
 pub struct CachedVortexMetadata {
     footer: Footer,
+    memory_size: usize,
 }
 
 impl CachedVortexMetadata {
     /// Create a new cached metadata entry from a VortexFile.
     pub fn new(vortex_file: &VortexFile) -> Self {
+        let footer = vortex_file.footer();
+        let memory_size = estimate_footer_size(footer);
         Self {
-            footer: vortex_file.footer().clone(),
+            footer: footer.clone(),
+            memory_size,
         }
     }
 
@@ -38,7 +42,7 @@ impl FileMetadata for CachedVortexMetadata {
     }
 
     fn memory_size(&self) -> usize {
-        estimate_footer_size(&self.footer)
+        self.memory_size
     }
 
     #[allow(clippy::disallowed_types)]


### PR DESCRIPTION
Realized the function is called many times in DF, so it makes sense to store it.