### PR TITLE
Make projection pushdown in DF an opt-in feature

### DIFF
--- a/benchmarks/datafusion-bench/src/lib.rs
+++ b/benchmarks/datafusion-bench/src/lib.rs
@@ -28,6 +28,7 @@ use vortex_bench::Format;
 use vortex_bench::SESSION;
 use vortex_datafusion::VortexFormat;
 use vortex_datafusion::VortexFormatFactory;
+use vortex_datafusion::VortexOptions;
 
 #[allow(clippy::expect_used)]
 pub fn get_session_context() -> SessionContext {
@@ -44,7 +45,10 @@ pub fn get_session_context() -> SessionContext {
         .build_arc()
         .expect("could not build runtime environment");
 
-    let factory = VortexFormatFactory::new();
+    let factory = VortexFormatFactory::new().with_options(VortexOptions {
+        projection_pushdown: true,
+        ..Default::default()
+    });
 
     let mut session_state_builder = SessionStateBuilder::new()
         .with_config(SessionConfig::from_env().expect("shouldn't fail"))

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -76,6 +76,32 @@ pub trait ExpressionConvertor: Send + Sync {
         input_schema: &Schema,
         output_schema: &Schema,
     ) -> DFResult<ProcessedProjection>;
+
+    /// Create a projection that reads only the required columns without pushing down
+    /// any expressions. All projection logic is applied after the scan.
+    fn no_pushdown_projection(
+        &self,
+        source_projection: ProjectionExprs,
+        input_schema: &Schema,
+    ) -> DFResult<ProcessedProjection> {
+        // Get all unique column indices referenced by the projection
+        let column_indices = source_projection.column_indices();
+
+        // Create scan projection that reads the required columns
+        let scan_columns: Vec<(String, Expression)> = column_indices
+            .into_iter()
+            .map(|idx| {
+                let field = input_schema.field(idx);
+                let name = field.name().clone();
+                (name.clone(), get_item(name, root()))
+            })
+            .collect();
+
+        Ok(ProcessedProjection {
+            scan_projection: pack(scan_columns, Nullability::NonNullable),
+            leftover_projection: source_projection,
+        })
+    }
 }
 
 /// The default [`ExpressionConvertor`].
@@ -444,6 +470,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::common_tests::TestSessionContext;
 
     #[rstest::fixture]
     fn test_schema() -> Schema {
@@ -746,5 +773,38 @@ mod tests {
             Arc::new(df_expr::LikeExpr::new(false, false, expr, pattern)) as Arc<dyn PhysicalExpr>;
 
         assert!(!can_be_pushed_down_impl(&like_expr, &test_schema));
+    }
+
+    // https://github.com/vortex-data/vortex/issues/6211
+    #[tokio::test]
+    async fn test_cast_int_to_string() -> anyhow::Result<()> {
+        let ctx = TestSessionContext::default();
+
+        ctx.session
+            .sql(r#"copy (select 1 as id) to 'example.vortex'"#)
+            .await?
+            .show()
+            .await?;
+
+        ctx.session
+            .sql(r#"select cast(id as string) as sid from 'example.vortex' where id > 0"#)
+            .await?
+            .show()
+            .await?;
+
+        ctx.session
+            .sql(r#"select id from 'example.vortex' where cast (id as string) == '1'"#)
+            .await?
+            .show()
+            .await?;
+
+        // This fails as it pushes string cast to the scan
+        ctx.session
+            .sql(r#"select cast(id as string) from 'example.vortex'"#)
+            .await?
+            .collect()
+            .await?;
+
+        Ok(())
     }
 }

--- a/vortex-datafusion/src/lib.rs
+++ b/vortex-datafusion/src/lib.rs
@@ -75,6 +75,7 @@ mod common_tests {
     use vortex::session::VortexSession;
 
     use crate::VortexFormatFactory;
+    use crate::VortexOptions;
 
     static VX_SESSION: LazyLock<VortexSession> = LazyLock::new(VortexSession::default);
 
@@ -85,25 +86,37 @@ mod common_tests {
 
     impl Default for TestSessionContext {
         fn default() -> Self {
+            Self::new(false)
+        }
+    }
+
+    impl TestSessionContext {
+        /// Create a new test session context with the given projection pushdown setting.
+        pub fn new(projection_pushdown: bool) -> Self {
             let store = Arc::new(InMemory::new());
-            let factory = Arc::new(VortexFormatFactory::new());
-            let session_state_builder = SessionStateBuilder::new()
+            let opts = VortexOptions {
+                projection_pushdown,
+                ..Default::default()
+            };
+            let factory = Arc::new(VortexFormatFactory::new().with_options(opts));
+            let mut session_state_builder = SessionStateBuilder::new()
                 .with_default_features()
                 .with_table_factory(
                     factory.get_ext().to_uppercase(),
                     Arc::new(DefaultTableFactory::new()),
                 )
-                .with_file_formats(vec![factory])
                 .with_object_store(&Url::try_from("file://").unwrap(), store.clone());
+
+            if let Some(file_formats) = session_state_builder.file_formats() {
+                file_formats.push(factory as _);
+            }
 
             let session: SessionContext =
                 SessionContext::new_with_state(session_state_builder.build()).enable_url_table();
 
             Self { store, session }
         }
-    }
 
-    impl TestSessionContext {
         // Write arrow data into a vortex file.
         pub async fn write_arrow_batch<P>(&self, path: P, batch: &RecordBatch) -> anyhow::Result<()>
         where

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -96,6 +96,12 @@ config_namespace! {
         /// Values smaller than `MAX_POSTSCRIPT_SIZE + EOF_SIZE` will be clamped to that minimum
         /// during footer parsing.
         pub footer_initial_read_size_bytes: usize, default = DEFAULT_FOOTER_INITIAL_READ_SIZE_BYTES
+        /// Whether to enable projection pushdown into the underlying Vortex scan.
+        ///
+        /// When enabled, projection expressions may be partially evaluated during
+        /// the scan. When disabled, Vortex reads only the referenced columns and
+        /// all expressions are evaluated after the scan.
+        pub projection_pushdown: bool, default = false
     }
 }
 
@@ -497,7 +503,10 @@ impl FileFormat for VortexFormat {
     }
 
     fn file_source(&self, table_schema: TableSchema) -> Arc<dyn FileSource> {
-        Arc::new(VortexSource::new(table_schema, self.session.clone()))
+        Arc::new(
+            VortexSource::new(table_schema, self.session.clone())
+                .with_projection_pushdown(self.opts.projection_pushdown),
+        )
     }
 }
 

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -92,6 +92,8 @@ pub(crate) struct VortexOpener {
 
     pub expression_convertor: Arc<dyn ExpressionConvertor>,
     pub file_metadata_cache: Option<Arc<dyn FileMetadataCache>>,
+    /// Whether to enable expression pushdown into the underlying Vortex scan.
+    pub projection_pushdown: bool,
 }
 
 impl FileOpener for VortexOpener {
@@ -124,6 +126,7 @@ impl FileOpener for VortexOpener {
         let has_output_ordering = self.has_output_ordering;
 
         let expr_convertor = self.expression_convertor.clone();
+        let projection_pushdown = self.projection_pushdown;
 
         // Replace column access for partition columns with literals
         #[allow(clippy::disallowed_types)]
@@ -225,11 +228,17 @@ impl FileOpener for VortexOpener {
             let ProcessedProjection {
                 scan_projection,
                 leftover_projection,
-            } = expr_convertor.split_projection(
-                projection,
-                &this_file_schema,
-                &projected_physical_schema,
-            )?;
+            } = if projection_pushdown {
+                expr_convertor.split_projection(
+                    projection,
+                    &this_file_schema,
+                    &projected_physical_schema,
+                )?
+            } else {
+                // When projection pushdown is disabled, read only the required columns
+                // and apply the full projection after the scan.
+                expr_convertor.no_pushdown_projection(projection, &this_file_schema)?
+            };
 
             // The schema of the stream returned from the vortex scan.
             // We use the physical_file_schema as reference for types that don't roundtrip.
@@ -541,6 +550,7 @@ mod tests {
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
+            projection_pushdown: false,
         }
     }
 
@@ -633,6 +643,7 @@ mod tests {
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
+            projection_pushdown: false,
         };
 
         let filter = col("a").lt(lit(100_i32));
@@ -717,6 +728,7 @@ mod tests {
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
+            projection_pushdown: false,
         };
 
         // The opener should successfully open the file and reorder columns
@@ -870,6 +882,7 @@ mod tests {
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
+            projection_pushdown: false,
         };
 
         // This should succeed and return the correctly projected and cast data
@@ -927,6 +940,7 @@ mod tests {
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
+            projection_pushdown: false,
         }
     }
 
@@ -1126,6 +1140,7 @@ mod tests {
             has_output_ordering: false,
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: None,
+            projection_pushdown: false,
         };
 
         let file = PartitionedFile::new(file_path.to_string(), data_size);

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::sync::Weak;
 
+use arrow_schema::Schema;
 use datafusion_common::DataFusionError;
 use datafusion_common::Result as DFResult;
 use datafusion_common::ScalarValue;
@@ -230,22 +231,36 @@ impl FileOpener for VortexOpener {
                 leftover_projection,
             } = if projection_pushdown {
                 expr_convertor.split_projection(
-                    projection,
+                    projection.clone(),
                     &this_file_schema,
                     &projected_physical_schema,
                 )?
             } else {
                 // When projection pushdown is disabled, read only the required columns
                 // and apply the full projection after the scan.
-                expr_convertor.no_pushdown_projection(projection, &this_file_schema)?
+                expr_convertor.no_pushdown_projection(projection.clone(), &this_file_schema)?
             };
 
             // The schema of the stream returned from the vortex scan.
-            // We use the physical_file_schema as reference for types that don't roundtrip.
+            // We use a reference schema for types that don't roundtrip (Dictionary, Utf8, etc.).
             let scan_dtype = scan_projection.return_dtype(vxf.dtype()).map_err(|_e| {
                 exec_datafusion_err!("Couldn't get the dtype for the underlying Vortex scan")
             })?;
-            let stream_schema = calculate_physical_schema(&scan_dtype, &projected_physical_schema)?;
+
+            // When projection pushdown is enabled, the scan outputs the projected columns.
+            // When disabled, the scan outputs raw columns and the projection is applied after.
+            let scan_reference_schema = if projection_pushdown {
+                projected_physical_schema
+            } else {
+                // Build schema from the raw columns being read
+                let column_indices = projection.column_indices();
+                let fields: Vec<_> = column_indices
+                    .into_iter()
+                    .map(|idx| this_file_schema.field(idx).clone())
+                    .collect();
+                Schema::new(fields)
+            };
+            let stream_schema = calculate_physical_schema(&scan_dtype, &scan_reference_schema)?;
 
             let leftover_projection = leftover_projection
                 .try_map_exprs(|expr| reassign_expr_columns(expr, &stream_schema))?;

--- a/vortex-datafusion/src/persistent/source.rs
+++ b/vortex-datafusion/src/persistent/source.rs
@@ -64,6 +64,8 @@ pub struct VortexSource {
     pub(crate) vortex_reader_factory: Option<Arc<dyn VortexReaderFactory>>,
     vx_metrics_registry: Arc<dyn MetricsRegistry>,
     file_metadata_cache: Option<Arc<dyn FileMetadataCache>>,
+    /// Whether to enable expression pushdown into the underlying Vortex scan.
+    projection_pushdown: bool,
 }
 
 impl VortexSource {
@@ -85,7 +87,14 @@ impl VortexSource {
             vortex_reader_factory: None,
             vx_metrics_registry: Arc::new(DefaultMetricsRegistry::default()),
             file_metadata_cache: None,
+            projection_pushdown: false,
         }
+    }
+
+    /// Enable or disable expression pushdown into the underlying Vortex scan.
+    pub fn with_projection_pushdown(mut self, enabled: bool) -> Self {
+        self.projection_pushdown = enabled;
+        self
     }
 
     /// Set a [`ExpressionConvertor`] to control how Datafusion expression should be converted and pushed down.
@@ -160,6 +169,7 @@ impl FileSource for VortexSource {
             has_output_ordering: !base_config.output_ordering.is_empty(),
             expression_convertor: Arc::new(DefaultExpressionConvertor::default()),
             file_metadata_cache: self.file_metadata_cache.clone(),
+            projection_pushdown: self.projection_pushdown,
         };
 
         Ok(Arc::new(opener))

--- a/vortex-datafusion/src/tests/schema_evolution.rs
+++ b/vortex-datafusion/src/tests/schema_evolution.rs
@@ -23,12 +23,16 @@ use datafusion_common::record_batch;
 use datafusion_expr::col;
 use datafusion_expr::lit;
 use datafusion_functions::expr_fn::get_field;
+use rstest::rstest;
 
 use crate::common_tests::TestSessionContext;
 
+#[rstest]
 #[tokio::test]
-async fn test_filter_with_schema_evolution() -> anyhow::Result<()> {
-    let ctx = TestSessionContext::default();
+async fn test_filter_with_schema_evolution(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
 
     // file1 only contains field "a"
     ctx.write_arrow_batch(
@@ -80,9 +84,12 @@ async fn test_filter_with_schema_evolution() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_filter_schema_evolution_order() -> anyhow::Result<()> {
-    let ctx = TestSessionContext::default();
+async fn test_filter_schema_evolution_order(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
 
     // file1 only contains field "a"
     ctx.write_arrow_batch(
@@ -163,9 +170,12 @@ async fn test_filter_schema_evolution_order() -> anyhow::Result<()> {
 /// Test for correct schema evolution behavior in the presence of nested struct fields.
 /// We use a hypothetical schema of some observability data with "wide records", struct columns
 /// with nullable payloads that may or may not be present for every file.
+#[rstest]
 #[tokio::test]
-async fn test_filter_schema_evolution_struct_fields() -> anyhow::Result<()> {
-    let ctx = TestSessionContext::default();
+async fn test_filter_schema_evolution_struct_fields(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
 
     fn make_metrics(
         hostname: &str,
@@ -287,9 +297,12 @@ async fn test_filter_schema_evolution_struct_fields() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_schema_evolution_struct_of_dict() -> anyhow::Result<()> {
-    let ctx = TestSessionContext::default();
+async fn test_schema_evolution_struct_of_dict(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
 
     // First file
     let struct_fields = Fields::from(vec![
@@ -398,9 +411,12 @@ async fn test_schema_evolution_struct_of_dict() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[rstest]
 #[tokio::test]
-async fn test_schema_evolution_struct_field_order() -> anyhow::Result<()> {
-    let ctx = TestSessionContext::default();
+async fn test_schema_evolution_struct_field_order(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
 
     // File1: labels = {region, service} - service at position 1
     let file1_labels: ArrowArrayRef = Arc::new(StructArray::new(
@@ -476,6 +492,56 @@ async fn test_schema_evolution_struct_field_order() -> anyhow::Result<()> {
             "|         | api     | host-0   | scraper |",
             "|         | api     | host-1   | scraper |",
             "+---------+---------+----------+---------+",
+        ],
+        &result
+    );
+
+    Ok(())
+}
+
+/// Test that complex projection expressions (arithmetic) work correctly
+/// with both projection pushdown enabled and disabled.
+#[rstest]
+#[tokio::test]
+async fn test_projection_expressions(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
+
+    ctx.write_arrow_batch(
+        "files/data.vortex",
+        &record_batch!(
+            ("a", Int32, vec![Some(1), Some(2), Some(3)]),
+            ("b", Int32, vec![Some(10), Some(20), Some(30)])
+        )?,
+    )
+    .await?;
+
+    ctx.session
+        .sql(
+            "CREATE EXTERNAL TABLE my_tbl \
+                STORED AS vortex  \
+                LOCATION '/files/'",
+        )
+        .await?;
+
+    let table = ctx.session.table("my_tbl").await?;
+
+    // Test arithmetic projection: a + b * 2
+    let result = table
+        .select(vec![(col("a") + col("b") * lit(2)).alias("computed")])?
+        .collect()
+        .await?;
+
+    assert_batches_eq!(
+        &[
+            "+----------+",
+            "| computed |",
+            "+----------+",
+            "| 21       |",
+            "| 42       |",
+            "| 63       |",
+            "+----------+",
         ],
         &result
     );

--- a/vortex-datafusion/src/tests/schema_evolution.rs
+++ b/vortex-datafusion/src/tests/schema_evolution.rs
@@ -548,3 +548,409 @@ async fn test_projection_expressions(
 
     Ok(())
 }
+
+/// Test that Dictionary columns are preserved correctly when scanning with a defined schema.
+/// This reproduces an issue from the polarsignals benchmark where Dictionary(UInt32, Utf8)
+/// columns were being returned as Utf8View.
+#[rstest]
+#[tokio::test]
+async fn test_dictionary_column_type_preservation(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
+
+    // Create a batch with Dictionary columns (like polarsignals schema)
+    let dict_fields = Fields::from(vec![
+        Field::new_dictionary("producer", DataType::UInt32, DataType::Utf8, false),
+        Field::new_dictionary("sample_type", DataType::UInt32, DataType::Utf8, false),
+    ]);
+
+    let producer_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "agent", "agent", "agent",
+    ]));
+    let sample_type_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "samples", "samples", "samples",
+    ]));
+
+    let batch = RecordBatch::try_new(
+        Arc::new(Schema::new(dict_fields.to_vec())),
+        vec![producer_array, sample_type_array],
+    )?;
+
+    ctx.write_arrow_batch("files/data.vortex", &batch).await?;
+
+    // Create table with explicit schema that expects Dictionary types
+    let table_schema = batch.schema();
+    let provider = ctx
+        .table_provider("tbl", "/files/", table_schema.clone())
+        .await?;
+
+    let table = ctx.session.read_table(provider)?;
+
+    // Verify the schema matches
+    assert_eq!(table.schema().as_arrow(), table_schema.as_ref());
+
+    // Query and verify the result schema preserves Dictionary types
+    let result = table
+        .filter(col("producer").eq(lit("agent")))?
+        .collect()
+        .await?;
+
+    assert!(!result.is_empty(), "Expected results from query");
+
+    // Check that the result schema preserves Dictionary types
+    let result_schema = result[0].schema();
+    assert_eq!(
+        result_schema.field(0).data_type(),
+        &DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+        "producer column should preserve Dictionary type"
+    );
+    assert_eq!(
+        result_schema.field(1).data_type(),
+        &DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+        "sample_type column should preserve Dictionary type"
+    );
+
+    Ok(())
+}
+
+/// Test that nested struct fields with Dictionary types are preserved correctly.
+/// This reproduces the polarsignals benchmark issue where accessing `labels.comm`
+/// (a Dictionary field inside a struct) returns Utf8View instead of Dictionary.
+#[rstest]
+#[tokio::test]
+async fn test_nested_struct_dictionary_type_preservation(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
+
+    // Create a struct with Dictionary fields (like polarsignals labels)
+    let labels_fields = Fields::from(vec![
+        Field::new_dictionary("comm", DataType::UInt32, DataType::Utf8, true),
+        Field::new_dictionary("node", DataType::UInt32, DataType::Utf8, true),
+    ]);
+
+    let comm_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "proc_a", "proc_b", "proc_a",
+    ]));
+    let node_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "node_1", "node_1", "node_2",
+    ]));
+
+    let labels_struct = StructArray::new(labels_fields.clone(), vec![comm_array, node_array], None);
+
+    // Add other columns like in polarsignals
+    let value_array = create_array!(Int64, vec![Some(100i64), Some(200), Some(300)]);
+    let producer_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "agent", "agent", "agent",
+    ]));
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("labels", DataType::Struct(labels_fields.clone()), false),
+        Field::new("value", DataType::Int64, false),
+        Field::new_dictionary("producer", DataType::UInt32, DataType::Utf8, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(labels_struct), value_array, producer_array],
+    )?;
+
+    ctx.write_arrow_batch("files/data.vortex", &batch).await?;
+
+    let provider = ctx.table_provider("tbl", "/files/", schema.clone()).await?;
+    let table = ctx.session.read_table(provider)?;
+
+    // Query that projects a nested struct field (like in polarsignals Q0)
+    let result = table
+        .clone()
+        .filter(col("producer").eq(lit("agent")))?
+        .select(vec![
+            col("value"),
+            get_field(col("labels"), "comm").alias("comm"),
+        ])?
+        .collect()
+        .await?;
+
+    assert!(!result.is_empty(), "Expected results from query");
+
+    // The nested dictionary field should preserve its type
+    let result_schema = result[0].schema();
+    assert_eq!(
+        result_schema.field(1).data_type(),
+        &DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+        "labels.comm should preserve Dictionary type, got {:?}",
+        result_schema.field(1).data_type()
+    );
+
+    Ok(())
+}
+
+/// Test reproducing the polarsignals benchmark schema with multiple dictionary columns
+/// and filters on dictionary columns.
+#[rstest]
+#[tokio::test]
+async fn test_polarsignals_like_schema(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
+
+    // Create labels struct with dictionary fields
+    let labels_fields = Fields::from(vec![Field::new_dictionary(
+        "comm",
+        DataType::UInt32,
+        DataType::Utf8,
+        true,
+    )]);
+
+    let comm_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "proc_a", "proc_b", "proc_a",
+    ]));
+
+    let labels_struct = StructArray::new(labels_fields.clone(), vec![comm_array], None);
+
+    // Create multiple dictionary columns like polarsignals
+    let value_array = create_array!(Int64, vec![Some(1i64), Some(2), Some(3)]);
+    let producer_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "agent", "agent", "agent",
+    ]));
+    let sample_type_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "samples", "samples", "samples",
+    ]));
+    let sample_unit_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "count", "count", "count",
+    ]));
+    let period_type_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "cpu", "cpu", "cpu",
+    ]));
+    let period_unit_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "nanoseconds",
+        "nanoseconds",
+        "nanoseconds",
+    ]));
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("labels", DataType::Struct(labels_fields.clone()), false),
+        Field::new("value", DataType::Int64, false),
+        Field::new_dictionary("producer", DataType::UInt32, DataType::Utf8, false),
+        Field::new_dictionary("sample_type", DataType::UInt32, DataType::Utf8, false),
+        Field::new_dictionary("sample_unit", DataType::UInt32, DataType::Utf8, false),
+        Field::new_dictionary("period_type", DataType::UInt32, DataType::Utf8, false),
+        Field::new_dictionary("period_unit", DataType::UInt32, DataType::Utf8, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(labels_struct),
+            value_array,
+            producer_array,
+            sample_type_array,
+            sample_unit_array,
+            period_type_array,
+            period_unit_array,
+        ],
+    )?;
+
+    ctx.write_arrow_batch("files/data.vortex", &batch).await?;
+
+    let provider = ctx.table_provider("tbl", "/files/", schema.clone()).await?;
+    let table = ctx.session.read_table(provider)?;
+
+    // Query like polarsignals Q0: filter on multiple dictionary columns, project value and labels.comm
+    let result = table
+        .filter(col("producer").eq(lit("agent")))?
+        .filter(col("sample_type").eq(lit("samples")))?
+        .filter(col("sample_unit").eq(lit("count")))?
+        .filter(col("period_type").eq(lit("cpu")))?
+        .filter(col("period_unit").eq(lit("nanoseconds")))?
+        .select(vec![
+            col("value"),
+            get_field(col("labels"), "comm").alias("comm"),
+        ])?
+        .collect()
+        .await?;
+
+    assert!(!result.is_empty(), "Expected results from query");
+
+    // Verify result values
+    assert_batches_eq!(
+        &[
+            "+-------+--------+",
+            "| value | comm   |",
+            "+-------+--------+",
+            "| 1     | proc_a |",
+            "| 2     | proc_b |",
+            "| 3     | proc_a |",
+            "+-------+--------+",
+        ],
+        &result
+    );
+
+    Ok(())
+}
+
+/// Test using SQL to create an external table (closer to how benchmarks work).
+/// This tests that Dictionary column types are preserved when using ListingTable.
+#[rstest]
+#[tokio::test]
+async fn test_external_table_dictionary_columns(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
+
+    // Create a simple batch with dictionary columns
+    let producer_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "agent", "agent", "agent",
+    ]));
+    let sample_type_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "samples", "samples", "samples",
+    ]));
+    let value_array = create_array!(Int64, vec![Some(1i64), Some(2), Some(3)]);
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new_dictionary("producer", DataType::UInt32, DataType::Utf8, false),
+        Field::new_dictionary("sample_type", DataType::UInt32, DataType::Utf8, false),
+        Field::new("value", DataType::Int64, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![producer_array, sample_type_array, value_array],
+    )?;
+
+    ctx.write_arrow_batch("files/data.vortex", &batch).await?;
+
+    // Use SQL to create external table (like the benchmark does)
+    ctx.session
+        .sql(
+            "CREATE EXTERNAL TABLE stacktraces \
+                STORED AS vortex \
+                LOCATION '/files/'",
+        )
+        .await?;
+
+    // Query with filter on dictionary column and projection
+    let result = ctx
+        .session
+        .sql(
+            "SELECT value, sample_type FROM stacktraces \
+             WHERE producer = 'agent' AND sample_type = 'samples'",
+        )
+        .await?
+        .collect()
+        .await?;
+
+    assert!(!result.is_empty(), "Expected results from query");
+
+    assert_batches_eq!(
+        &[
+            "+-------+-------------+",
+            "| value | sample_type |",
+            "+-------+-------------+",
+            "| 1     | samples     |",
+            "| 2     | samples     |",
+            "| 3     | samples     |",
+            "+-------+-------------+",
+        ],
+        &result
+    );
+
+    Ok(())
+}
+
+/// Test using SQL to access struct fields with dictionary types (like polarsignals Q0).
+/// This reproduces the polarsignals benchmark error where `labels.comm` returns
+/// Utf8View instead of Dictionary(UInt32, Utf8).
+#[rstest]
+#[tokio::test]
+async fn test_sql_struct_field_dictionary_type(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
+
+    // Create labels struct with dictionary fields (like polarsignals)
+    let labels_fields = Fields::from(vec![
+        Field::new_dictionary("comm", DataType::UInt32, DataType::Utf8, true),
+        Field::new_dictionary("node", DataType::UInt32, DataType::Utf8, true),
+    ]);
+
+    let comm_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "proc_a", "proc_b", "proc_a",
+    ]));
+    let node_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "node_1", "node_1", "node_2",
+    ]));
+
+    let labels_struct = StructArray::new(labels_fields.clone(), vec![comm_array, node_array], None);
+
+    // Add other columns like in polarsignals
+    let value_array = create_array!(Int64, vec![Some(1i64), Some(2), Some(3)]);
+    let producer_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "agent", "agent", "agent",
+    ]));
+    let sample_type_array: ArrowArrayRef = Arc::new(DictionaryArray::<UInt32Type>::from_iter([
+        "samples", "samples", "samples",
+    ]));
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("labels", DataType::Struct(labels_fields.clone()), false),
+        Field::new("value", DataType::Int64, false),
+        Field::new_dictionary("producer", DataType::UInt32, DataType::Utf8, false),
+        Field::new_dictionary("sample_type", DataType::UInt32, DataType::Utf8, false),
+    ]));
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(labels_struct),
+            value_array,
+            producer_array,
+            sample_type_array,
+        ],
+    )?;
+
+    ctx.write_arrow_batch("files/data.vortex", &batch).await?;
+
+    // Create table provider with explicit schema (like the benchmark)
+    let provider = ctx.table_provider("stacktraces", "/files/", schema).await?;
+    ctx.session.register_table("stacktraces", provider)?;
+
+    // Query like polarsignals Q0: filter on dictionary columns, project struct field
+    let result = ctx
+        .session
+        .sql(
+            "SELECT value, labels.comm FROM stacktraces \
+             WHERE producer = 'agent' AND sample_type = 'samples'",
+        )
+        .await?
+        .collect()
+        .await?;
+
+    assert!(!result.is_empty(), "Expected results from query");
+
+    // Verify the result values
+    assert_batches_eq!(
+        [
+            "+-------+--------------------------+",
+            "| value | stacktraces.labels[comm] |",
+            "+-------+--------------------------+",
+            "| 1     | proc_a                   |",
+            "| 2     | proc_b                   |",
+            "| 3     | proc_a                   |",
+            "+-------+--------------------------+",
+        ],
+        &result
+    );
+
+    // Verify that labels.comm preserves Dictionary type
+    let result_schema = result[0].schema();
+    assert_eq!(
+        result_schema.field(1).data_type(),
+        &DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+        "labels.comm should preserve Dictionary type, got {:?}",
+        result_schema.field(1).data_type()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
The implementation of expression pushdown is missing some features, and it might not work for all use cases and query patterns. This PR makes it possible to disable it so existing code can keep working.

I think this change is sensible following a few bug reports by people testing the tip of `develop`