### PR TITLE
Include config.js in benchmark website docker image

### DIFF
--- a/benchmarks-website-v2/Dockerfile
+++ b/benchmarks-website-v2/Dockerfile
@@ -11,5 +11,6 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY --from=build /app/dist ./dist
 COPY server.js .
+COPY src/config.js ./src/config.js
 EXPOSE 3000
 CMD ["node", "server.js"]


### PR DESCRIPTION
https://github.com/vortex-data/vortex/blob/develop/benchmarks-website-v2/server.js#L9 broke the benchmarks website. Prod has the docker image version pinned until this gets merged.