### PR TITLE
Add execution target that recursively canonicalises as well as canonical with canonical validity

### DIFF
--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -35,7 +35,13 @@ fn take_10_stratified(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]
@@ -47,7 +53,13 @@ fn take_10_contiguous(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -35,12 +35,12 @@ fn take_10_stratified(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -54,12 +54,12 @@ fn take_10_contiguous(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -76,12 +76,12 @@ fn take_10k_random(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -95,12 +95,12 @@ fn take_10k_contiguous(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -114,12 +114,12 @@ fn take_200k_dispersed(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -133,12 +133,12 @@ fn take_200k_first_chunk_only(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -179,12 +179,12 @@ fn patched_take_10_stratified(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -205,12 +205,12 @@ fn patched_take_10_contiguous(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -227,12 +227,12 @@ fn patched_take_10k_random(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -246,12 +246,12 @@ fn patched_take_10k_contiguous_not_patches(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -270,15 +270,14 @@ fn patched_take_10k_contiguous_patches(bencher: Bencher) {
 
     let indices =
         PrimitiveArray::from_iter((BIG_BASE2..BIG_BASE2 + NUM_EXCEPTIONS).cycle().take(10000));
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -289,15 +288,14 @@ fn patched_take_200k_dispersed(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values.clone(), Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0..200_000).map(|i| (i * 42) % values.len() as u64));
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -311,12 +309,12 @@ fn patched_take_200k_first_chunk_only(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }
@@ -337,12 +335,12 @@ fn patched_take_10k_adversarial(bencher: Bencher) {
     let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| {
+        .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(packed, indices, execution_ctx)| {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         })
 }

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -32,7 +32,6 @@ fn take_10_stratified(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0..10).map(|i| i * 10_000));
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
@@ -51,7 +50,6 @@ fn take_10_contiguous(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = buffer![0..10].into_array();
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
@@ -73,7 +71,6 @@ fn take_10k_random(bencher: Bencher) {
 
     let rng = StdRng::seed_from_u64(0);
     let indices = PrimitiveArray::from_iter(rng.sample_iter(range).take(10_000).map(|i| i as u32));
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
@@ -92,7 +89,6 @@ fn take_10k_contiguous(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter(0..10_000);
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
@@ -111,7 +107,6 @@ fn take_200k_dispersed(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values.clone(), Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0..200_000).map(|i| (i * 42) % values.len() as u64));
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
@@ -130,7 +125,6 @@ fn take_200k_first_chunk_only(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0..200_000).map(|i| ((i * 42) % 1024) as u64));
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
@@ -176,7 +170,6 @@ fn patched_take_10_stratified(bencher: Bencher) {
     );
 
     let indices = PrimitiveArray::from_iter((0..10).map(|i| i * 10_000));
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
@@ -202,7 +195,6 @@ fn patched_take_10_contiguous(bencher: Bencher) {
     );
 
     let indices = buffer![0..10].into_array();
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
@@ -224,7 +216,6 @@ fn patched_take_10k_random(bencher: Bencher) {
     let rng = StdRng::seed_from_u64(0);
     let range = Uniform::new(0, values.len()).unwrap();
     let indices = PrimitiveArray::from_iter(rng.sample_iter(range).take(10_000).map(|i| i as u32));
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
@@ -243,7 +234,6 @@ fn patched_take_10k_contiguous_not_patches(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0u32..NUM_EXCEPTIONS).cycle().take(10000));
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
@@ -306,7 +296,6 @@ fn patched_take_200k_first_chunk_only(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0..200_000).map(|i| ((i * 42) % 1024) as u64));
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
@@ -332,7 +321,6 @@ fn patched_take_10k_adversarial(bencher: Bencher) {
             .flat_map(|base_idx| base_idx..(base_idx + per_chunk_count))
             .take(10000),
     );
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -11,6 +11,9 @@ use rand::distr::Uniform;
 use rand::prelude::StdRng;
 use vortex_array::Array;
 use vortex_array::IntoArray as _;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::RecursiveCanonical;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::compute::warm_up_vtables;
 use vortex_array::validity::Validity;
@@ -59,7 +62,13 @@ fn take_10k_random(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]
@@ -71,7 +80,13 @@ fn take_10k_contiguous(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]
@@ -83,7 +98,13 @@ fn take_200k_dispersed(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]
@@ -95,7 +116,13 @@ fn take_200k_first_chunk_only(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 fn fixture(len: usize, bits: usize) -> Buffer<u32> {
@@ -134,7 +161,13 @@ fn patched_take_10_stratified(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]
@@ -153,7 +186,13 @@ fn patched_take_10_contiguous(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]
@@ -168,7 +207,13 @@ fn patched_take_10k_random(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]
@@ -180,7 +225,13 @@ fn patched_take_10k_contiguous_not_patches(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]
@@ -200,7 +251,13 @@ fn patched_take_10k_contiguous_patches(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]
@@ -212,7 +269,13 @@ fn patched_take_200k_dispersed(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]
@@ -224,7 +287,13 @@ fn patched_take_200k_first_chunk_only(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }
 
 #[divan::bench]
@@ -243,5 +312,11 @@ fn patched_take_10k_adversarial(bencher: Bencher) {
 
     bencher
         .with_inputs(|| (&packed, &indices))
-        .bench_refs(|(packed, indices)| packed.take(indices.to_array()).unwrap())
+        .bench_refs(|(packed, indices)| {
+            packed
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        })
 }

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -32,6 +32,7 @@ fn take_10_stratified(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0..10).map(|i| i * 10_000));
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -39,7 +40,7 @@ fn take_10_stratified(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -50,6 +51,7 @@ fn take_10_contiguous(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = buffer![0..10].into_array();
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -57,7 +59,7 @@ fn take_10_contiguous(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -71,6 +73,7 @@ fn take_10k_random(bencher: Bencher) {
 
     let rng = StdRng::seed_from_u64(0);
     let indices = PrimitiveArray::from_iter(rng.sample_iter(range).take(10_000).map(|i| i as u32));
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -78,7 +81,7 @@ fn take_10k_random(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -89,6 +92,7 @@ fn take_10k_contiguous(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter(0..10_000);
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -96,7 +100,7 @@ fn take_10k_contiguous(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -107,6 +111,7 @@ fn take_200k_dispersed(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values.clone(), Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0..200_000).map(|i| (i * 42) % values.len() as u64));
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -114,7 +119,7 @@ fn take_200k_dispersed(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -125,6 +130,7 @@ fn take_200k_first_chunk_only(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0..200_000).map(|i| ((i * 42) % 1024) as u64));
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -132,7 +138,7 @@ fn take_200k_first_chunk_only(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -170,6 +176,7 @@ fn patched_take_10_stratified(bencher: Bencher) {
     );
 
     let indices = PrimitiveArray::from_iter((0..10).map(|i| i * 10_000));
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -177,7 +184,7 @@ fn patched_take_10_stratified(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -195,6 +202,7 @@ fn patched_take_10_contiguous(bencher: Bencher) {
     );
 
     let indices = buffer![0..10].into_array();
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -202,7 +210,7 @@ fn patched_take_10_contiguous(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -216,6 +224,7 @@ fn patched_take_10k_random(bencher: Bencher) {
     let rng = StdRng::seed_from_u64(0);
     let range = Uniform::new(0, values.len()).unwrap();
     let indices = PrimitiveArray::from_iter(rng.sample_iter(range).take(10_000).map(|i| i as u32));
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -223,7 +232,7 @@ fn patched_take_10k_random(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -234,6 +243,7 @@ fn patched_take_10k_contiguous_not_patches(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0u32..NUM_EXCEPTIONS).cycle().take(10000));
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -241,7 +251,7 @@ fn patched_take_10k_contiguous_not_patches(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -260,6 +270,7 @@ fn patched_take_10k_contiguous_patches(bencher: Bencher) {
 
     let indices =
         PrimitiveArray::from_iter((BIG_BASE2..BIG_BASE2 + NUM_EXCEPTIONS).cycle().take(10000));
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -267,7 +278,7 @@ fn patched_take_10k_contiguous_patches(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -278,6 +289,7 @@ fn patched_take_200k_dispersed(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values.clone(), Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0..200_000).map(|i| (i * 42) % values.len() as u64));
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -285,7 +297,7 @@ fn patched_take_200k_dispersed(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -296,6 +308,7 @@ fn patched_take_200k_first_chunk_only(bencher: Bencher) {
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
     let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
     let indices = PrimitiveArray::from_iter((0..200_000).map(|i| ((i * 42) % 1024) as u64));
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -303,7 +316,7 @@ fn patched_take_200k_first_chunk_only(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }
@@ -321,6 +334,7 @@ fn patched_take_10k_adversarial(bencher: Bencher) {
             .flat_map(|base_idx| base_idx..(base_idx + per_chunk_count))
             .take(10000),
     );
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&packed, &indices))
@@ -328,7 +342,7 @@ fn patched_take_10k_adversarial(bencher: Bencher) {
             packed
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         })
 }

--- a/encodings/runend/benches/run_end_compress.rs
+++ b/encodings/runend/benches/run_end_compress.rs
@@ -97,15 +97,19 @@ fn take_indices(bencher: Bencher, (length, run_step): (usize, usize)) {
         .unwrap()
         .to_array();
 
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
-
     bencher
-        .with_inputs(|| (&source_array, &runend_array))
-        .bench_refs(|(array, indices)| {
+        .with_inputs(|| {
+            (
+                &source_array,
+                &runend_array,
+                LEGACY_SESSION.create_execution_ctx(),
+            )
+        })
+        .bench_refs(|(array, indices, execution_ctx)| {
             array
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         });
 }

--- a/encodings/runend/benches/run_end_compress.rs
+++ b/encodings/runend/benches/run_end_compress.rs
@@ -97,13 +97,15 @@ fn take_indices(bencher: Bencher, (length, run_step): (usize, usize)) {
         .unwrap()
         .to_array();
 
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
+
     bencher
         .with_inputs(|| (&source_array, &runend_array))
         .bench_refs(|(array, indices)| {
             array
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         });
 }

--- a/encodings/runend/benches/run_end_compress.rs
+++ b/encodings/runend/benches/run_end_compress.rs
@@ -7,6 +7,9 @@ use divan::Bencher;
 use itertools::repeat_n;
 use vortex_array::Array;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::RecursiveCanonical;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::compute::warm_up_vtables;
 use vortex_array::validity::Validity;
@@ -96,5 +99,11 @@ fn take_indices(bencher: Bencher, (length, run_step): (usize, usize)) {
 
     bencher
         .with_inputs(|| (&source_array, &runend_array))
-        .bench_refs(|(array, indices)| array.take(indices.to_array()).unwrap());
+        .bench_refs(|(array, indices)| {
+            array
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        });
 }

--- a/java/testfiles/Cargo.lock
+++ b/java/testfiles/Cargo.lock
@@ -388,6 +388,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef0a3155e943e341e557863e69a708999c94ede624e37865c8e2a91b94efa78f"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,9 +461,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -457,6 +475,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -474,6 +501,17 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -558,6 +596,18 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "custom-labels"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a750ea4bdb7dbf9584b5d5c668bfa3835f88275781a947b5ea0212945bbdd41f"
+dependencies = [
+ "bindgen",
+ "cc",
+ "libc",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "dashmap"
@@ -657,16 +707,6 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
-]
-
-[[package]]
-name = "exponential-decay-histogram"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7962d7e9baab6ea05af175491fa6a8441f3bf461558037622142573d98dd6d6"
-dependencies = [
- "ordered-float 5.1.0",
- "rand 0.9.2",
 ]
 
 [[package]]
@@ -1108,6 +1148,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1275,6 +1324,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1330,6 +1389,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "moka"
 version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1441,16 @@ name = "never-say-never"
 version = "6.6.666"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nougat"
@@ -1471,24 +1546,6 @@ name = "oneshot"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "parking"
@@ -1660,7 +1717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -1914,16 +1971,6 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde-value"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
-dependencies = [
- "ordered-float 2.10.1",
- "serde",
 ]
 
 [[package]]
@@ -2275,7 +2322,7 @@ dependencies = [
 name = "vortex-alp"
 version = "0.1.0"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "num-traits",
  "prost",
  "rustc-hash",
@@ -2312,7 +2359,7 @@ dependencies = [
  "goldenfile",
  "humansize",
  "inventory",
- "itertools",
+ "itertools 0.14.0",
  "multiversion",
  "num-traits",
  "num_enum",
@@ -2344,9 +2391,11 @@ dependencies = [
 name = "vortex-btrblocks"
 version = "0.1.0"
 dependencies = [
+ "enum-iterator",
  "getrandom 0.3.4",
- "itertools",
+ "itertools 0.14.0",
  "num-traits",
+ "pco",
  "rand 0.9.2",
  "rustc-hash",
  "tracing",
@@ -2360,12 +2409,14 @@ dependencies = [
  "vortex-fastlanes",
  "vortex-fsst",
  "vortex-mask",
+ "vortex-pco",
  "vortex-runend",
  "vortex-scalar",
  "vortex-sequence",
  "vortex-sparse",
  "vortex-utils",
  "vortex-zigzag",
+ "vortex-zstd",
 ]
 
 [[package]]
@@ -2375,7 +2426,7 @@ dependencies = [
  "arrow-buffer",
  "bitvec",
  "bytes",
- "itertools",
+ "itertools 0.14.0",
  "simdutf8",
  "vortex-error",
 ]
@@ -2391,6 +2442,7 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-session",
 ]
 
 [[package]]
@@ -2401,7 +2453,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "itertools",
+ "itertools 0.14.0",
  "multiversion",
  "num-traits",
  "paste",
@@ -2434,6 +2486,7 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-session",
 ]
 
 [[package]]
@@ -2448,6 +2501,7 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-session",
 ]
 
 [[package]]
@@ -2459,7 +2513,7 @@ dependencies = [
  "arrow-schema",
  "flatbuffers",
  "half",
- "itertools",
+ "itertools 0.14.0",
  "jiff",
  "num-traits",
  "num_enum",
@@ -2492,7 +2546,7 @@ version = "0.1.0"
 dependencies = [
  "arrayref",
  "fastlanes",
- "itertools",
+ "itertools 0.14.0",
  "lending-iterator",
  "num-traits",
  "prost",
@@ -2515,7 +2569,7 @@ dependencies = [
  "flatbuffers",
  "futures",
  "getrandom 0.3.4",
- "itertools",
+ "itertools 0.14.0",
  "kanal",
  "oneshot",
  "parking_lot",
@@ -2524,6 +2578,7 @@ dependencies = [
  "uuid",
  "vortex-alp",
  "vortex-array",
+ "vortex-btrblocks",
  "vortex-buffer",
  "vortex-bytebool",
  "vortex-datetime-parts",
@@ -2582,6 +2637,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bytes",
+ "custom-labels",
  "futures",
  "getrandom 0.3.4",
  "handle",
@@ -2607,7 +2663,7 @@ dependencies = [
  "bytes",
  "flatbuffers",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "pin-project-lite",
  "vortex-array",
  "vortex-buffer",
@@ -2626,14 +2682,13 @@ dependencies = [
  "async-trait",
  "flatbuffers",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "kanal",
  "moka",
  "once_cell",
  "oneshot",
  "parking_lot",
  "paste",
- "pco",
  "pin-project-lite",
  "prost",
  "rustc-hash",
@@ -2650,12 +2705,10 @@ dependencies = [
  "vortex-io",
  "vortex-mask",
  "vortex-metrics",
- "vortex-pco",
  "vortex-scalar",
  "vortex-sequence",
  "vortex-session",
  "vortex-utils",
- "vortex-zstd",
 ]
 
 [[package]]
@@ -2663,7 +2716,7 @@ name = "vortex-mask"
 version = "0.1.0"
 dependencies = [
  "arrow-buffer",
- "itertools",
+ "itertools 0.14.0",
  "vortex-buffer",
  "vortex-error",
 ]
@@ -2674,8 +2727,8 @@ version = "0.1.0"
 dependencies = [
  "getrandom 0.3.4",
  "parking_lot",
+ "sketches-ddsketch",
  "vortex-session",
- "witchcraft-metrics",
 ]
 
 [[package]]
@@ -2706,7 +2759,7 @@ name = "vortex-runend"
 version = "0.1.0"
 dependencies = [
  "arrow-array",
- "itertools",
+ "itertools 0.14.0",
  "num-traits",
  "prost",
  "vortex-array",
@@ -2724,7 +2777,7 @@ version = "0.1.0"
 dependencies = [
  "arrow-array",
  "bytes",
- "itertools",
+ "itertools 0.14.0",
  "num-traits",
  "paste",
  "prost",
@@ -2746,7 +2799,7 @@ dependencies = [
  "async-trait",
  "bit-vec",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
  "sketches-ddsketch",
  "tracing",
@@ -2775,6 +2828,7 @@ dependencies = [
  "vortex-proto",
  "vortex-runend",
  "vortex-scalar",
+ "vortex-session",
 ]
 
 [[package]]
@@ -2792,7 +2846,7 @@ dependencies = [
 name = "vortex-sparse"
 version = "0.1.0"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "num-traits",
  "prost",
  "vortex-array",
@@ -2801,6 +2855,7 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-session",
 ]
 
 [[package]]
@@ -2835,6 +2890,7 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-session",
  "zigzag",
 ]
 
@@ -2842,7 +2898,7 @@ dependencies = [
 name = "vortex-zstd"
 version = "0.1.0"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "prost",
  "vortex-array",
  "vortex-buffer",
@@ -2850,6 +2906,7 @@ dependencies = [
  "vortex-error",
  "vortex-mask",
  "vortex-scalar",
+ "vortex-session",
  "zstd",
 ]
 
@@ -3092,19 +3149,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-
-[[package]]
-name = "witchcraft-metrics"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867a74dec702d742179279ab0b5bcab72ca5858c0c3ccf870bdb5c99f54d675b"
-dependencies = [
- "exponential-decay-histogram",
- "once_cell",
- "parking_lot",
- "serde",
- "serde-value",
-]
 
 [[package]]
 name = "writeable"

--- a/vortex-array/benches/take_fsl.rs
+++ b/vortex-array/benches/take_fsl.rs
@@ -61,15 +61,14 @@ fn take_fsl_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize)
     let fsl = create_fsl(LIST_SIZE, NUM_LISTS);
     let indices = create_random_indices(num_indices, NUM_LISTS);
     let indices_array = indices.into_array();
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&fsl, &indices_array))
-        .bench_refs(|(array, indices)| {
+        .with_inputs(|| (&fsl, &indices_array, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(array, indices, execution_ctx)| {
             array
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         });
 }
@@ -87,15 +86,14 @@ fn take_fsl_nullable_random<const LIST_SIZE: usize>(bencher: Bencher, num_indice
 
     let indices = create_random_indices(num_indices, NUM_LISTS);
     let indices_array = indices.into_array();
-    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
-        .with_inputs(|| (&fsl, &indices_array))
-        .bench_refs(|(array, indices)| {
+        .with_inputs(|| (&fsl, &indices_array, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(array, indices, execution_ctx)| {
             array
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut execution_ctx)
+                .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
         });
 }

--- a/vortex-array/benches/take_fsl.rs
+++ b/vortex-array/benches/take_fsl.rs
@@ -61,6 +61,7 @@ fn take_fsl_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize)
     let fsl = create_fsl(LIST_SIZE, NUM_LISTS);
     let indices = create_random_indices(num_indices, NUM_LISTS);
     let indices_array = indices.into_array();
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&fsl, &indices_array))
@@ -68,7 +69,7 @@ fn take_fsl_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize)
             array
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         });
 }
@@ -86,6 +87,7 @@ fn take_fsl_nullable_random<const LIST_SIZE: usize>(bencher: Bencher, num_indice
 
     let indices = create_random_indices(num_indices, NUM_LISTS);
     let indices_array = indices.into_array();
+    let mut execution_ctx = LEGACY_SESSION.create_execution_ctx();
 
     bencher
         .with_inputs(|| (&fsl, &indices_array))
@@ -93,7 +95,7 @@ fn take_fsl_nullable_random<const LIST_SIZE: usize>(bencher: Bencher, num_indice
             array
                 .take(indices.to_array())
                 .unwrap()
-                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .execute::<RecursiveCanonical>(&mut execution_ctx)
                 .unwrap()
         });
 }

--- a/vortex-array/benches/take_fsl.rs
+++ b/vortex-array/benches/take_fsl.rs
@@ -16,6 +16,9 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 use vortex_array::Array;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::RecursiveCanonical;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
@@ -61,7 +64,13 @@ fn take_fsl_random<const LIST_SIZE: usize>(bencher: Bencher, num_indices: usize)
 
     bencher
         .with_inputs(|| (&fsl, &indices_array))
-        .bench_refs(|(array, indices)| array.take(indices.to_array()).unwrap());
+        .bench_refs(|(array, indices)| {
+            array
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        });
 }
 
 #[divan::bench(args = NUM_INDICES, consts = LIST_SIZES)]
@@ -80,5 +89,11 @@ fn take_fsl_nullable_random<const LIST_SIZE: usize>(bencher: Bencher, num_indice
 
     bencher
         .with_inputs(|| (&fsl, &indices_array))
-        .bench_refs(|(array, indices)| array.take(indices.to_array()).unwrap());
+        .bench_refs(|(array, indices)| {
+            array
+                .take(indices.to_array())
+                .unwrap()
+                .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap()
+        });
 }

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -60,7 +60,6 @@ pub struct BoolArray {
 }
 
 pub struct BoolArrayParts {
-    pub dtype: DType,
     pub bits: BufferHandle,
     pub offset: usize,
     pub len: usize,
@@ -196,7 +195,6 @@ impl BoolArray {
     #[inline]
     pub fn into_parts(self) -> BoolArrayParts {
         BoolArrayParts {
-            dtype: self.dtype,
             bits: self.bits,
             offset: self.offset,
             len: self.len,

--- a/vortex-array/src/arrays/decimal/array.rs
+++ b/vortex-array/src/arrays/decimal/array.rs
@@ -12,7 +12,6 @@ use vortex_dtype::DecimalDType;
 use vortex_dtype::DecimalType;
 use vortex_dtype::IntegerPType;
 use vortex_dtype::NativeDecimalType;
-use vortex_dtype::Nullability;
 use vortex_dtype::match_each_decimal_value_type;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexExpect;
@@ -95,7 +94,6 @@ pub struct DecimalArray {
 
 pub struct DecimalArrayParts {
     pub decimal_dtype: DecimalDType,
-    pub nullability: Nullability,
     pub values: BufferHandle,
     pub values_type: DecimalType,
     pub validity: Validity,
@@ -279,12 +277,10 @@ impl DecimalArray {
     }
 
     pub fn into_parts(self) -> DecimalArrayParts {
-        let nullability = self.dtype.nullability();
         let decimal_dtype = self.dtype.into_decimal_opt().vortex_expect("cannot fail");
 
         DecimalArrayParts {
             decimal_dtype,
-            nullability,
             values: self.values,
             values_type: self.values_type,
             validity: self.validity,

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use num_traits::AsPrimitive;
 use vortex_dtype::DType;
 use vortex_dtype::IntegerPType;
-use vortex_dtype::Nullability;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -129,8 +128,6 @@ pub struct ListViewArray {
 }
 
 pub struct ListViewArrayParts {
-    pub nullability: Nullability,
-
     pub elements_dtype: Arc<DType>,
 
     /// See `ListViewArray::elements`
@@ -345,10 +342,8 @@ impl ListViewArray {
     }
 
     pub fn into_parts(self) -> ListViewArrayParts {
-        let nullability = self.dtype.nullability();
         let dtype = self.dtype.into_list_element_opt().vortex_expect("is list");
         ListViewArrayParts {
-            nullability,
             elements_dtype: dtype,
             elements: self.elements,
             offsets: self.offsets,

--- a/vortex-array/src/arrays/primitive/array/mod.rs
+++ b/vortex-array/src/arrays/primitive/array/mod.rs
@@ -77,7 +77,6 @@ pub struct PrimitiveArray {
 
 pub struct PrimitiveArrayParts {
     pub ptype: PType,
-    pub nullability: Nullability,
     pub buffer: BufferHandle,
     pub validity: Validity,
 }
@@ -182,10 +181,8 @@ impl PrimitiveArray {
     /// Consume the primitive array and returns its component parts.
     pub fn into_parts(self) -> PrimitiveArrayParts {
         let ptype = self.ptype();
-        let nullability = self.dtype.nullability();
         PrimitiveArrayParts {
             ptype,
-            nullability,
             buffer: self.buffer,
             validity: self.validity,
         }

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use vortex_dtype::DType;
 use vortex_dtype::FieldName;
 use vortex_dtype::FieldNames;
-use vortex_dtype::Nullability;
 use vortex_dtype::StructFields;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -151,7 +150,6 @@ pub struct StructArray {
 
 pub struct StructArrayParts {
     pub struct_fields: StructFields,
-    pub nullability: Nullability,
     pub fields: Arc<[ArrayRef]>,
     pub validity: Validity,
 }
@@ -356,11 +354,9 @@ impl StructArray {
     }
 
     pub fn into_parts(self) -> StructArrayParts {
-        let nullability = self.dtype.nullability();
         let struct_fields = self.dtype.into_struct_fields();
         StructArrayParts {
             struct_fields,
-            nullability,
             fields: self.fields,
             validity: self.validity,
         }

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -3,6 +3,8 @@
 
 //! Encodings that enable zero-copy sharing of data with Arrow.
 
+use std::sync::Arc;
+
 use vortex_buffer::Buffer;
 use vortex_dtype::DType;
 use vortex_dtype::NativePType;
@@ -18,23 +20,29 @@ use crate::Executable;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
+use crate::arrays::BoolArrayParts;
 use crate::arrays::BoolVTable;
 use crate::arrays::DecimalArray;
+use crate::arrays::DecimalArrayParts;
 use crate::arrays::DecimalVTable;
 use crate::arrays::ExtensionArray;
 use crate::arrays::ExtensionVTable;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::FixedSizeListVTable;
 use crate::arrays::ListViewArray;
+use crate::arrays::ListViewArrayParts;
 use crate::arrays::ListViewRebuildMode;
 use crate::arrays::ListViewVTable;
 use crate::arrays::NullArray;
 use crate::arrays::NullVTable;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::PrimitiveArrayParts;
 use crate::arrays::PrimitiveVTable;
 use crate::arrays::StructArray;
+use crate::arrays::StructArrayParts;
 use crate::arrays::StructVTable;
 use crate::arrays::VarBinViewArray;
+use crate::arrays::VarBinViewArrayParts;
 use crate::arrays::VarBinViewVTable;
 use crate::arrays::constant_canonicalize;
 use crate::builders::builder_with_capacity;
@@ -495,6 +503,242 @@ impl Executable for Canonical {
                 canonical
             }
         })
+    }
+}
+
+/// Recursively execute the array until it reaches canonical form along with its validity.
+///
+/// Callers should prefer to execute into `Columnar` instead of this specific target.
+/// This target is useful when preparing arrays for writing.
+pub struct CanonicalValidity(pub Canonical);
+
+impl Executable for CanonicalValidity {
+    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        match array.execute::<Canonical>(ctx)? {
+            n @ Canonical::Null(_) => Ok(CanonicalValidity(n)),
+            Canonical::Bool(b) => {
+                let BoolArrayParts {
+                    bits,
+                    offset,
+                    len,
+                    validity,
+                } = b.into_parts();
+                Ok(CanonicalValidity(Canonical::Bool(
+                    BoolArray::try_new_from_handle(bits, offset, len, validity.execute(ctx)?)?,
+                )))
+            }
+            Canonical::Primitive(p) => {
+                let PrimitiveArrayParts {
+                    ptype,
+                    buffer,
+                    validity,
+                } = p.into_parts();
+                Ok(CanonicalValidity(Canonical::Primitive(unsafe {
+                    PrimitiveArray::new_unchecked_from_handle(buffer, ptype, validity.execute(ctx)?)
+                })))
+            }
+            Canonical::Decimal(d) => {
+                let DecimalArrayParts {
+                    decimal_dtype,
+                    values,
+                    values_type,
+                    validity,
+                } = d.into_parts();
+                Ok(CanonicalValidity(Canonical::Decimal(unsafe {
+                    DecimalArray::new_unchecked_handle(
+                        values,
+                        values_type,
+                        decimal_dtype,
+                        validity.execute(ctx)?,
+                    )
+                })))
+            }
+            Canonical::VarBinView(vbv) => {
+                let VarBinViewArrayParts {
+                    dtype,
+                    buffers,
+                    views,
+                    validity,
+                } = vbv.into_parts();
+                Ok(CanonicalValidity(Canonical::VarBinView(unsafe {
+                    VarBinViewArray::new_handle_unchecked(
+                        views,
+                        buffers,
+                        dtype,
+                        validity.execute(ctx)?,
+                    )
+                })))
+            }
+            Canonical::List(l) => {
+                let ListViewArrayParts {
+                    elements,
+                    offsets,
+                    sizes,
+                    validity,
+                    ..
+                } = l.into_parts();
+                Ok(CanonicalValidity(Canonical::List(unsafe {
+                    ListViewArray::new_unchecked(elements, offsets, sizes, validity.execute(ctx)?)
+                })))
+            }
+            Canonical::FixedSizeList(fsl) => {
+                let list_size = fsl.list_size();
+                let len = fsl.len();
+                let (elements, validity, _) = fsl.into_parts();
+                Ok(CanonicalValidity(Canonical::FixedSizeList(
+                    FixedSizeListArray::new(elements, list_size, validity.execute(ctx)?, len),
+                )))
+            }
+            Canonical::Struct(st) => {
+                let len = st.len();
+                let StructArrayParts {
+                    struct_fields,
+                    fields,
+                    validity,
+                } = st.into_parts();
+                Ok(CanonicalValidity(Canonical::Struct(unsafe {
+                    StructArray::new_unchecked(fields, struct_fields, len, validity.execute(ctx)?)
+                })))
+            }
+            Canonical::Extension(ext) => Ok(CanonicalValidity(Canonical::Extension(
+                ExtensionArray::new(
+                    ext.ext_dtype().clone(),
+                    ext.storage()
+                        .clone()
+                        .execute::<CanonicalValidity>(ctx)?
+                        .0
+                        .into_array(),
+                ),
+            ))),
+        }
+    }
+}
+
+/// Recursively execute the array until all of its children are canonical.
+///
+/// This method is useful to guarantee that all operators are fully executed,
+/// callers should prefer an execution target that's suitable for their use case instead of this one.
+pub struct RecursiveCanonical(pub Canonical);
+
+impl Executable for RecursiveCanonical {
+    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        match array.execute::<Canonical>(ctx)? {
+            n @ Canonical::Null(_) => Ok(RecursiveCanonical(n)),
+            Canonical::Bool(b) => {
+                let BoolArrayParts {
+                    bits,
+                    offset,
+                    len,
+                    validity,
+                } = b.into_parts();
+                Ok(RecursiveCanonical(Canonical::Bool(
+                    BoolArray::try_new_from_handle(bits, offset, len, validity.execute(ctx)?)?,
+                )))
+            }
+            Canonical::Primitive(p) => {
+                let PrimitiveArrayParts {
+                    ptype,
+                    buffer,
+                    validity,
+                } = p.into_parts();
+                Ok(RecursiveCanonical(Canonical::Primitive(unsafe {
+                    PrimitiveArray::new_unchecked_from_handle(buffer, ptype, validity.execute(ctx)?)
+                })))
+            }
+            Canonical::Decimal(d) => {
+                let DecimalArrayParts {
+                    decimal_dtype,
+                    values,
+                    values_type,
+                    validity,
+                } = d.into_parts();
+                Ok(RecursiveCanonical(Canonical::Decimal(unsafe {
+                    DecimalArray::new_unchecked_handle(
+                        values,
+                        values_type,
+                        decimal_dtype,
+                        validity.execute(ctx)?,
+                    )
+                })))
+            }
+            Canonical::VarBinView(vbv) => {
+                let VarBinViewArrayParts {
+                    dtype,
+                    buffers,
+                    views,
+                    validity,
+                } = vbv.into_parts();
+                Ok(RecursiveCanonical(Canonical::VarBinView(unsafe {
+                    VarBinViewArray::new_handle_unchecked(
+                        views,
+                        buffers,
+                        dtype,
+                        validity.execute(ctx)?,
+                    )
+                })))
+            }
+            Canonical::List(l) => {
+                let ListViewArrayParts {
+                    elements,
+                    offsets,
+                    sizes,
+                    validity,
+                    ..
+                } = l.into_parts();
+                Ok(RecursiveCanonical(Canonical::List(unsafe {
+                    ListViewArray::new_unchecked(
+                        elements.execute::<RecursiveCanonical>(ctx)?.0.into_array(),
+                        offsets.execute::<RecursiveCanonical>(ctx)?.0.into_array(),
+                        sizes.execute::<RecursiveCanonical>(ctx)?.0.into_array(),
+                        validity.execute(ctx)?,
+                    )
+                })))
+            }
+            Canonical::FixedSizeList(fsl) => {
+                let list_size = fsl.list_size();
+                let len = fsl.len();
+                let (elements, validity, _) = fsl.into_parts();
+                Ok(RecursiveCanonical(Canonical::FixedSizeList(
+                    FixedSizeListArray::new(
+                        elements.execute::<RecursiveCanonical>(ctx)?.0.into_array(),
+                        list_size,
+                        validity.execute(ctx)?,
+                        len,
+                    ),
+                )))
+            }
+            Canonical::Struct(st) => {
+                let len = st.len();
+                let StructArrayParts {
+                    struct_fields,
+                    fields,
+                    validity,
+                } = st.into_parts();
+                Ok(RecursiveCanonical(Canonical::Struct(unsafe {
+                    StructArray::new_unchecked(
+                        fields
+                            .iter()
+                            .map(|f| {
+                                Ok(f.clone().execute::<RecursiveCanonical>(ctx)?.0.into_array())
+                            })
+                            .collect::<VortexResult<Arc<[_]>>>()?,
+                        struct_fields,
+                        len,
+                        validity.execute(ctx)?,
+                    )
+                })))
+            }
+            Canonical::Extension(ext) => Ok(RecursiveCanonical(Canonical::Extension(
+                ExtensionArray::new(
+                    ext.ext_dtype().clone(),
+                    ext.storage()
+                        .clone()
+                        .execute::<RecursiveCanonical>(ctx)?
+                        .0
+                        .into_array(),
+                ),
+            ))),
+        }
     }
 }
 

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -714,18 +714,14 @@ impl Executable for RecursiveCanonical {
                     fields,
                     validity,
                 } = st.into_parts();
-                match Arc::try_unwrap(fields) {
-                    Ok(own_fields) => {}
-                    Err(_) => {}
-                }
-                let mapped_fields = fields
+                let executed_fields = fields
                     .iter()
                     .map(|f| Ok(f.clone().execute::<RecursiveCanonical>(ctx)?.0.into_array()))
                     .collect::<VortexResult<Arc<[_]>>>()?;
 
                 Ok(RecursiveCanonical(Canonical::Struct(unsafe {
                     StructArray::new_unchecked(
-                        mapped_fields,
+                        executed_fields,
                         struct_fields,
                         len,
                         validity.execute(ctx)?,

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -714,14 +714,18 @@ impl Executable for RecursiveCanonical {
                     fields,
                     validity,
                 } = st.into_parts();
+                match Arc::try_unwrap(fields) {
+                    Ok(own_fields) => {}
+                    Err(_) => {}
+                }
+                let mapped_fields = fields
+                    .iter()
+                    .map(|f| Ok(f.clone().execute::<RecursiveCanonical>(ctx)?.0.into_array()))
+                    .collect::<VortexResult<Arc<[_]>>>()?;
+
                 Ok(RecursiveCanonical(Canonical::Struct(unsafe {
                     StructArray::new_unchecked(
-                        fields
-                            .iter()
-                            .map(|f| {
-                                Ok(f.clone().execute::<RecursiveCanonical>(ctx)?.0.into_array())
-                            })
-                            .collect::<VortexResult<Arc<[_]>>>()?,
+                        mapped_fields,
                         struct_fields,
                         len,
                         validity.execute(ctx)?,

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -22,6 +22,8 @@ use vortex_scalar::Scalar;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::Canonical;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::BoolArray;
@@ -43,6 +45,16 @@ pub enum Validity {
     ///
     /// True values are valid, false values are invalid ("null").
     Array(ArrayRef),
+}
+
+impl Validity {
+    /// Make a step towards canonicalising validity if necessary
+    pub fn execute(self, ctx: &mut ExecutionCtx) -> VortexResult<Validity> {
+        match self {
+            v @ Validity::NonNullable | v @ Validity::AllValid | v @ Validity::AllInvalid => Ok(v),
+            Validity::Array(a) => Ok(Validity::Array(a.execute::<Canonical>(ctx)?.into_array())),
+        }
+    }
 }
 
 impl Validity {

--- a/vortex-duckdb/src/exporter/decimal.rs
+++ b/vortex-duckdb/src/exporter/decimal.rs
@@ -47,9 +47,9 @@ pub(crate) fn new_exporter(
         decimal_dtype,
         values_type,
         values,
-        nullability,
     } = array.into_parts();
     let dest_values_type = precision_to_duckdb_storage_size(&decimal_dtype)?;
+    let nullability = validity.nullability();
     let validity = validity.to_array(len).execute::<Mask>(ctx)?;
 
     if validity.all_false() {

--- a/vortex-duckdb/src/exporter/list_view.rs
+++ b/vortex-duckdb/src/exporter/list_view.rs
@@ -53,10 +53,10 @@ pub(crate) fn new_exporter(
         offsets,
         sizes,
         validity,
-        nullability,
     } = array.into_parts();
     // Cache an `elements` vector up front so that future exports can reference it.
     let num_elements = elements.len();
+    let nullability = validity.nullability();
     let validity = validity.to_array(len).execute::<Mask>(ctx)?;
 
     if validity.all_false() {


### PR DESCRIPTION
Should there be an explicit option to execute validity just by one step?