### PR TITLE
bitunpacking cuda kernels store output into shared memory before copying to main memory

### DIFF
--- a/vortex-cuda/cuda_kernel_generator/mod.rs
+++ b/vortex-cuda/cuda_kernel_generator/mod.rs
@@ -108,7 +108,7 @@ fn generate_device_kernel_for_width<T: FastLanes, W: Write>(
 
         writeln!(output, "for (int i = 0; i < {shared_copy_ncount}; i++) {{")?;
         output.indent(|output| {
-            writeln!(output, "auto idx = i * {shared_copy_ncount} + threadIdx.x;")?;
+            writeln!(output, "auto idx = i * {thread_count} + thread_idx;")?;
             writeln!(output, "out[idx] = shared_out[idx];")
         })?;
         writeln!(output, "}}")

--- a/vortex-cuda/cuda_kernel_generator/mod.rs
+++ b/vortex-cuda/cuda_kernel_generator/mod.rs
@@ -99,10 +99,18 @@ fn generate_device_kernel_for_width<T: FastLanes, W: Write>(
     writeln!(output, "__device__ void _{func_name}{local_func_params} {{")?;
 
     output.indent(|output| {
+        writeln!(output, "__shared__ uint{bits}_t shared_out[1024];")?;
+
         for thread_lane in 0..per_thread_loop_count {
-            writeln!(output, "_bit_unpack_{bits}_{bit_width}bw_lane(in, out, thread_idx * {per_thread_loop_count} + {thread_lane});")?;
+            writeln!(output, "_bit_unpack_{bits}_{bit_width}bw_lane(in, shared_out, thread_idx * {per_thread_loop_count} + {thread_lane});")?;
         }
-        Ok(())
+
+        writeln!(output, "for (int i = 0; i < {thread_count}; i++) {{")?;
+        output.indent(|output| {
+            writeln!(output, "auto idx = i * {thread_count} + threadIdx.x;")?;
+            writeln!(output, "out[idx] = shared_out[idx];")
+        })?;
+        writeln!(output, "}}")
     })?;
 
     writeln!(output, "}}")

--- a/vortex-cuda/cuda_kernel_generator/mod.rs
+++ b/vortex-cuda/cuda_kernel_generator/mod.rs
@@ -89,6 +89,7 @@ fn generate_device_kernel_for_width<T: FastLanes, W: Write>(
     let bits = <T>::T;
     let lanes = T::LANES;
     let per_thread_loop_count = lanes / thread_count;
+    let shared_copy_ncount = 1024 / thread_count;
 
     let func_name = format!("bit_unpack_{bits}_{bit_width}bw_{thread_count}t");
 
@@ -105,9 +106,9 @@ fn generate_device_kernel_for_width<T: FastLanes, W: Write>(
             writeln!(output, "_bit_unpack_{bits}_{bit_width}bw_lane(in, shared_out, thread_idx * {per_thread_loop_count} + {thread_lane});")?;
         }
 
-        writeln!(output, "for (int i = 0; i < {thread_count}; i++) {{")?;
+        writeln!(output, "for (int i = 0; i < {shared_copy_ncount}; i++) {{")?;
         output.indent(|output| {
-            writeln!(output, "auto idx = i * {thread_count} + threadIdx.x;")?;
+            writeln!(output, "auto idx = i * {shared_copy_ncount} + threadIdx.x;")?;
             writeln!(output, "out[idx] = shared_out[idx];")
         })?;
         writeln!(output, "}}")

--- a/vortex-cuda/kernels/src/bit_unpack_16.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_16.cu
@@ -27,8 +27,13 @@ __device__ void _bit_unpack_16_0bw_lane(const uint16_t *__restrict in, uint16_t 
 }
 
 __device__ void _bit_unpack_16_0bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_0bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_0bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_0bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_0bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_0bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -79,8 +84,13 @@ __device__ void _bit_unpack_16_1bw_lane(const uint16_t *__restrict in, uint16_t 
 }
 
 __device__ void _bit_unpack_16_1bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_1bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_1bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_1bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_1bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_1bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -133,8 +143,13 @@ __device__ void _bit_unpack_16_2bw_lane(const uint16_t *__restrict in, uint16_t 
 }
 
 __device__ void _bit_unpack_16_2bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_2bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_2bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_2bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_2bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_2bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -189,8 +204,13 @@ __device__ void _bit_unpack_16_3bw_lane(const uint16_t *__restrict in, uint16_t 
 }
 
 __device__ void _bit_unpack_16_3bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_3bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_3bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_3bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_3bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_3bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -247,8 +267,13 @@ __device__ void _bit_unpack_16_4bw_lane(const uint16_t *__restrict in, uint16_t 
 }
 
 __device__ void _bit_unpack_16_4bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_4bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_4bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_4bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_4bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_4bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -307,8 +332,13 @@ __device__ void _bit_unpack_16_5bw_lane(const uint16_t *__restrict in, uint16_t 
 }
 
 __device__ void _bit_unpack_16_5bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_5bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_5bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_5bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_5bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_5bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -369,8 +399,13 @@ __device__ void _bit_unpack_16_6bw_lane(const uint16_t *__restrict in, uint16_t 
 }
 
 __device__ void _bit_unpack_16_6bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_6bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_6bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_6bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_6bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_6bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -433,8 +468,13 @@ __device__ void _bit_unpack_16_7bw_lane(const uint16_t *__restrict in, uint16_t 
 }
 
 __device__ void _bit_unpack_16_7bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_7bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_7bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_7bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_7bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_7bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -499,8 +539,13 @@ __device__ void _bit_unpack_16_8bw_lane(const uint16_t *__restrict in, uint16_t 
 }
 
 __device__ void _bit_unpack_16_8bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_8bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_8bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_8bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_8bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_8bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -567,8 +612,13 @@ __device__ void _bit_unpack_16_9bw_lane(const uint16_t *__restrict in, uint16_t 
 }
 
 __device__ void _bit_unpack_16_9bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_9bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_9bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_9bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_9bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_9bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -637,8 +687,13 @@ __device__ void _bit_unpack_16_10bw_lane(const uint16_t *__restrict in, uint16_t
 }
 
 __device__ void _bit_unpack_16_10bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_10bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_10bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_10bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_10bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_10bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -709,8 +764,13 @@ __device__ void _bit_unpack_16_11bw_lane(const uint16_t *__restrict in, uint16_t
 }
 
 __device__ void _bit_unpack_16_11bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_11bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_11bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_11bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_11bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_11bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -783,8 +843,13 @@ __device__ void _bit_unpack_16_12bw_lane(const uint16_t *__restrict in, uint16_t
 }
 
 __device__ void _bit_unpack_16_12bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_12bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_12bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_12bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_12bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_12bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -859,8 +924,13 @@ __device__ void _bit_unpack_16_13bw_lane(const uint16_t *__restrict in, uint16_t
 }
 
 __device__ void _bit_unpack_16_13bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_13bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_13bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_13bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_13bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_13bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -937,8 +1007,13 @@ __device__ void _bit_unpack_16_14bw_lane(const uint16_t *__restrict in, uint16_t
 }
 
 __device__ void _bit_unpack_16_14bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_14bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_14bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_14bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_14bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_14bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -1017,8 +1092,13 @@ __device__ void _bit_unpack_16_15bw_lane(const uint16_t *__restrict in, uint16_t
 }
 
 __device__ void _bit_unpack_16_15bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_15bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_15bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_15bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_15bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_15bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {
@@ -1050,8 +1130,13 @@ __device__ void _bit_unpack_16_16bw_lane(const uint16_t *__restrict in, uint16_t
 }
 
 __device__ void _bit_unpack_16_16bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, int thread_idx) {
-    _bit_unpack_16_16bw_lane(in, out, thread_idx * 2 + 0);
-    _bit_unpack_16_16bw_lane(in, out, thread_idx * 2 + 1);
+    __shared__ uint16_t shared_out[1024];
+    _bit_unpack_16_16bw_lane(in, shared_out, thread_idx * 2 + 0);
+    _bit_unpack_16_16bw_lane(in, shared_out, thread_idx * 2 + 1);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_16_16bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out) {

--- a/vortex-cuda/kernels/src/bit_unpack_16.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_16.cu
@@ -31,7 +31,7 @@ __device__ void _bit_unpack_16_0bw_32t(const uint16_t *__restrict in, uint16_t *
     _bit_unpack_16_0bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_0bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -88,7 +88,7 @@ __device__ void _bit_unpack_16_1bw_32t(const uint16_t *__restrict in, uint16_t *
     _bit_unpack_16_1bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_1bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -147,7 +147,7 @@ __device__ void _bit_unpack_16_2bw_32t(const uint16_t *__restrict in, uint16_t *
     _bit_unpack_16_2bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_2bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -208,7 +208,7 @@ __device__ void _bit_unpack_16_3bw_32t(const uint16_t *__restrict in, uint16_t *
     _bit_unpack_16_3bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_3bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -271,7 +271,7 @@ __device__ void _bit_unpack_16_4bw_32t(const uint16_t *__restrict in, uint16_t *
     _bit_unpack_16_4bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_4bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -336,7 +336,7 @@ __device__ void _bit_unpack_16_5bw_32t(const uint16_t *__restrict in, uint16_t *
     _bit_unpack_16_5bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_5bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -403,7 +403,7 @@ __device__ void _bit_unpack_16_6bw_32t(const uint16_t *__restrict in, uint16_t *
     _bit_unpack_16_6bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_6bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -472,7 +472,7 @@ __device__ void _bit_unpack_16_7bw_32t(const uint16_t *__restrict in, uint16_t *
     _bit_unpack_16_7bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_7bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -543,7 +543,7 @@ __device__ void _bit_unpack_16_8bw_32t(const uint16_t *__restrict in, uint16_t *
     _bit_unpack_16_8bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_8bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -616,7 +616,7 @@ __device__ void _bit_unpack_16_9bw_32t(const uint16_t *__restrict in, uint16_t *
     _bit_unpack_16_9bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_9bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -691,7 +691,7 @@ __device__ void _bit_unpack_16_10bw_32t(const uint16_t *__restrict in, uint16_t 
     _bit_unpack_16_10bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_10bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -768,7 +768,7 @@ __device__ void _bit_unpack_16_11bw_32t(const uint16_t *__restrict in, uint16_t 
     _bit_unpack_16_11bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_11bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -847,7 +847,7 @@ __device__ void _bit_unpack_16_12bw_32t(const uint16_t *__restrict in, uint16_t 
     _bit_unpack_16_12bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_12bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -928,7 +928,7 @@ __device__ void _bit_unpack_16_13bw_32t(const uint16_t *__restrict in, uint16_t 
     _bit_unpack_16_13bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_13bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1011,7 +1011,7 @@ __device__ void _bit_unpack_16_14bw_32t(const uint16_t *__restrict in, uint16_t 
     _bit_unpack_16_14bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_14bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1096,7 +1096,7 @@ __device__ void _bit_unpack_16_15bw_32t(const uint16_t *__restrict in, uint16_t 
     _bit_unpack_16_15bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_15bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1134,7 +1134,7 @@ __device__ void _bit_unpack_16_16bw_32t(const uint16_t *__restrict in, uint16_t 
     _bit_unpack_16_16bw_lane(in, shared_out, thread_idx * 2 + 0);
     _bit_unpack_16_16bw_lane(in, shared_out, thread_idx * 2 + 1);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }

--- a/vortex-cuda/kernels/src/bit_unpack_32.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_32.cu
@@ -46,7 +46,7 @@ __device__ void _bit_unpack_32_0bw_32t(const uint32_t *__restrict in, uint32_t *
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_0bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -134,7 +134,7 @@ __device__ void _bit_unpack_32_1bw_32t(const uint32_t *__restrict in, uint32_t *
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_1bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -224,7 +224,7 @@ __device__ void _bit_unpack_32_2bw_32t(const uint32_t *__restrict in, uint32_t *
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_2bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -316,7 +316,7 @@ __device__ void _bit_unpack_32_3bw_32t(const uint32_t *__restrict in, uint32_t *
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_3bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -410,7 +410,7 @@ __device__ void _bit_unpack_32_4bw_32t(const uint32_t *__restrict in, uint32_t *
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_4bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -506,7 +506,7 @@ __device__ void _bit_unpack_32_5bw_32t(const uint32_t *__restrict in, uint32_t *
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_5bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -604,7 +604,7 @@ __device__ void _bit_unpack_32_6bw_32t(const uint32_t *__restrict in, uint32_t *
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_6bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -704,7 +704,7 @@ __device__ void _bit_unpack_32_7bw_32t(const uint32_t *__restrict in, uint32_t *
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_7bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -806,7 +806,7 @@ __device__ void _bit_unpack_32_8bw_32t(const uint32_t *__restrict in, uint32_t *
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_8bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -910,7 +910,7 @@ __device__ void _bit_unpack_32_9bw_32t(const uint32_t *__restrict in, uint32_t *
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_9bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1016,7 +1016,7 @@ __device__ void _bit_unpack_32_10bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_10bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1124,7 +1124,7 @@ __device__ void _bit_unpack_32_11bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_11bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1234,7 +1234,7 @@ __device__ void _bit_unpack_32_12bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_12bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1346,7 +1346,7 @@ __device__ void _bit_unpack_32_13bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_13bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1460,7 +1460,7 @@ __device__ void _bit_unpack_32_14bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_14bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1576,7 +1576,7 @@ __device__ void _bit_unpack_32_15bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_15bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1694,7 +1694,7 @@ __device__ void _bit_unpack_32_16bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_16bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1814,7 +1814,7 @@ __device__ void _bit_unpack_32_17bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_17bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1936,7 +1936,7 @@ __device__ void _bit_unpack_32_18bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_18bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2060,7 +2060,7 @@ __device__ void _bit_unpack_32_19bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_19bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2186,7 +2186,7 @@ __device__ void _bit_unpack_32_20bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_20bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2314,7 +2314,7 @@ __device__ void _bit_unpack_32_21bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_21bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2444,7 +2444,7 @@ __device__ void _bit_unpack_32_22bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_22bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2576,7 +2576,7 @@ __device__ void _bit_unpack_32_23bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_23bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2710,7 +2710,7 @@ __device__ void _bit_unpack_32_24bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_24bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2846,7 +2846,7 @@ __device__ void _bit_unpack_32_25bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_25bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2984,7 +2984,7 @@ __device__ void _bit_unpack_32_26bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_26bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -3124,7 +3124,7 @@ __device__ void _bit_unpack_32_27bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_27bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -3266,7 +3266,7 @@ __device__ void _bit_unpack_32_28bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_28bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -3410,7 +3410,7 @@ __device__ void _bit_unpack_32_29bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_29bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -3556,7 +3556,7 @@ __device__ void _bit_unpack_32_30bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_30bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -3704,7 +3704,7 @@ __device__ void _bit_unpack_32_31bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_31bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -3757,7 +3757,7 @@ __device__ void _bit_unpack_32_32bw_32t(const uint32_t *__restrict in, uint32_t 
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_32bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }

--- a/vortex-cuda/kernels/src/bit_unpack_32.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_32.cu
@@ -43,7 +43,12 @@ __device__ void _bit_unpack_32_0bw_lane(const uint32_t *__restrict in, uint32_t 
 }
 
 __device__ void _bit_unpack_32_0bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_0bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_0bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_0bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -126,7 +131,12 @@ __device__ void _bit_unpack_32_1bw_lane(const uint32_t *__restrict in, uint32_t 
 }
 
 __device__ void _bit_unpack_32_1bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_1bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_1bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_1bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -211,7 +221,12 @@ __device__ void _bit_unpack_32_2bw_lane(const uint32_t *__restrict in, uint32_t 
 }
 
 __device__ void _bit_unpack_32_2bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_2bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_2bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_2bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -298,7 +313,12 @@ __device__ void _bit_unpack_32_3bw_lane(const uint32_t *__restrict in, uint32_t 
 }
 
 __device__ void _bit_unpack_32_3bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_3bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_3bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_3bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -387,7 +407,12 @@ __device__ void _bit_unpack_32_4bw_lane(const uint32_t *__restrict in, uint32_t 
 }
 
 __device__ void _bit_unpack_32_4bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_4bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_4bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_4bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -478,7 +503,12 @@ __device__ void _bit_unpack_32_5bw_lane(const uint32_t *__restrict in, uint32_t 
 }
 
 __device__ void _bit_unpack_32_5bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_5bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_5bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_5bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -571,7 +601,12 @@ __device__ void _bit_unpack_32_6bw_lane(const uint32_t *__restrict in, uint32_t 
 }
 
 __device__ void _bit_unpack_32_6bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_6bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_6bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_6bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -666,7 +701,12 @@ __device__ void _bit_unpack_32_7bw_lane(const uint32_t *__restrict in, uint32_t 
 }
 
 __device__ void _bit_unpack_32_7bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_7bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_7bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_7bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -763,7 +803,12 @@ __device__ void _bit_unpack_32_8bw_lane(const uint32_t *__restrict in, uint32_t 
 }
 
 __device__ void _bit_unpack_32_8bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_8bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_8bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_8bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -862,7 +907,12 @@ __device__ void _bit_unpack_32_9bw_lane(const uint32_t *__restrict in, uint32_t 
 }
 
 __device__ void _bit_unpack_32_9bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_9bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_9bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_9bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -963,7 +1013,12 @@ __device__ void _bit_unpack_32_10bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_10bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_10bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_10bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_10bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -1066,7 +1121,12 @@ __device__ void _bit_unpack_32_11bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_11bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_11bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_11bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_11bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -1171,7 +1231,12 @@ __device__ void _bit_unpack_32_12bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_12bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_12bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_12bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_12bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -1278,7 +1343,12 @@ __device__ void _bit_unpack_32_13bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_13bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_13bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_13bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_13bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -1387,7 +1457,12 @@ __device__ void _bit_unpack_32_14bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_14bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_14bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_14bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_14bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -1498,7 +1573,12 @@ __device__ void _bit_unpack_32_15bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_15bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_15bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_15bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_15bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -1611,7 +1691,12 @@ __device__ void _bit_unpack_32_16bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_16bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_16bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_16bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_16bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -1726,7 +1811,12 @@ __device__ void _bit_unpack_32_17bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_17bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_17bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_17bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_17bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -1843,7 +1933,12 @@ __device__ void _bit_unpack_32_18bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_18bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_18bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_18bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_18bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -1962,7 +2057,12 @@ __device__ void _bit_unpack_32_19bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_19bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_19bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_19bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_19bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -2083,7 +2183,12 @@ __device__ void _bit_unpack_32_20bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_20bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_20bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_20bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_20bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -2206,7 +2311,12 @@ __device__ void _bit_unpack_32_21bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_21bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_21bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_21bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_21bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -2331,7 +2441,12 @@ __device__ void _bit_unpack_32_22bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_22bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_22bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_22bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_22bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -2458,7 +2573,12 @@ __device__ void _bit_unpack_32_23bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_23bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_23bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_23bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_23bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -2587,7 +2707,12 @@ __device__ void _bit_unpack_32_24bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_24bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_24bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_24bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_24bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -2718,7 +2843,12 @@ __device__ void _bit_unpack_32_25bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_25bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_25bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_25bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_25bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -2851,7 +2981,12 @@ __device__ void _bit_unpack_32_26bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_26bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_26bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_26bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_26bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -2986,7 +3121,12 @@ __device__ void _bit_unpack_32_27bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_27bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_27bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_27bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_27bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -3123,7 +3263,12 @@ __device__ void _bit_unpack_32_28bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_28bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_28bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_28bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_28bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -3262,7 +3407,12 @@ __device__ void _bit_unpack_32_29bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_29bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_29bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_29bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_29bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -3403,7 +3553,12 @@ __device__ void _bit_unpack_32_30bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_30bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_30bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_30bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_30bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -3546,7 +3701,12 @@ __device__ void _bit_unpack_32_31bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_31bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_31bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_31bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_31bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {
@@ -3594,7 +3754,12 @@ __device__ void _bit_unpack_32_32bw_lane(const uint32_t *__restrict in, uint32_t
 }
 
 __device__ void _bit_unpack_32_32bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, int thread_idx) {
-    _bit_unpack_32_32bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint32_t shared_out[1024];
+    _bit_unpack_32_32bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_32_32bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out) {

--- a/vortex-cuda/kernels/src/bit_unpack_64.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_64.cu
@@ -77,8 +77,8 @@ __device__ void _bit_unpack_64_0bw_lane(const uint64_t *__restrict in, uint64_t 
 __device__ void _bit_unpack_64_0bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_0bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -229,8 +229,8 @@ __device__ void _bit_unpack_64_1bw_lane(const uint64_t *__restrict in, uint64_t 
 __device__ void _bit_unpack_64_1bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_1bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -383,8 +383,8 @@ __device__ void _bit_unpack_64_2bw_lane(const uint64_t *__restrict in, uint64_t 
 __device__ void _bit_unpack_64_2bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_2bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -539,8 +539,8 @@ __device__ void _bit_unpack_64_3bw_lane(const uint64_t *__restrict in, uint64_t 
 __device__ void _bit_unpack_64_3bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_3bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -697,8 +697,8 @@ __device__ void _bit_unpack_64_4bw_lane(const uint64_t *__restrict in, uint64_t 
 __device__ void _bit_unpack_64_4bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_4bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -857,8 +857,8 @@ __device__ void _bit_unpack_64_5bw_lane(const uint64_t *__restrict in, uint64_t 
 __device__ void _bit_unpack_64_5bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_5bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -1019,8 +1019,8 @@ __device__ void _bit_unpack_64_6bw_lane(const uint64_t *__restrict in, uint64_t 
 __device__ void _bit_unpack_64_6bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_6bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -1183,8 +1183,8 @@ __device__ void _bit_unpack_64_7bw_lane(const uint64_t *__restrict in, uint64_t 
 __device__ void _bit_unpack_64_7bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_7bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -1349,8 +1349,8 @@ __device__ void _bit_unpack_64_8bw_lane(const uint64_t *__restrict in, uint64_t 
 __device__ void _bit_unpack_64_8bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_8bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -1517,8 +1517,8 @@ __device__ void _bit_unpack_64_9bw_lane(const uint64_t *__restrict in, uint64_t 
 __device__ void _bit_unpack_64_9bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_9bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -1687,8 +1687,8 @@ __device__ void _bit_unpack_64_10bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_10bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_10bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -1859,8 +1859,8 @@ __device__ void _bit_unpack_64_11bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_11bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_11bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -2033,8 +2033,8 @@ __device__ void _bit_unpack_64_12bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_12bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_12bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -2209,8 +2209,8 @@ __device__ void _bit_unpack_64_13bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_13bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_13bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -2387,8 +2387,8 @@ __device__ void _bit_unpack_64_14bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_14bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_14bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -2567,8 +2567,8 @@ __device__ void _bit_unpack_64_15bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_15bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_15bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -2749,8 +2749,8 @@ __device__ void _bit_unpack_64_16bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_16bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_16bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -2933,8 +2933,8 @@ __device__ void _bit_unpack_64_17bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_17bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_17bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -3119,8 +3119,8 @@ __device__ void _bit_unpack_64_18bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_18bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_18bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -3307,8 +3307,8 @@ __device__ void _bit_unpack_64_19bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_19bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_19bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -3497,8 +3497,8 @@ __device__ void _bit_unpack_64_20bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_20bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_20bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -3689,8 +3689,8 @@ __device__ void _bit_unpack_64_21bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_21bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_21bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -3883,8 +3883,8 @@ __device__ void _bit_unpack_64_22bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_22bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_22bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -4079,8 +4079,8 @@ __device__ void _bit_unpack_64_23bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_23bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_23bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -4277,8 +4277,8 @@ __device__ void _bit_unpack_64_24bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_24bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_24bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -4477,8 +4477,8 @@ __device__ void _bit_unpack_64_25bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_25bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_25bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -4679,8 +4679,8 @@ __device__ void _bit_unpack_64_26bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_26bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_26bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -4883,8 +4883,8 @@ __device__ void _bit_unpack_64_27bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_27bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_27bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -5089,8 +5089,8 @@ __device__ void _bit_unpack_64_28bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_28bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_28bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -5297,8 +5297,8 @@ __device__ void _bit_unpack_64_29bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_29bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_29bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -5507,8 +5507,8 @@ __device__ void _bit_unpack_64_30bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_30bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_30bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -5719,8 +5719,8 @@ __device__ void _bit_unpack_64_31bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_31bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_31bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -5933,8 +5933,8 @@ __device__ void _bit_unpack_64_32bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_32bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_32bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -6149,8 +6149,8 @@ __device__ void _bit_unpack_64_33bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_33bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_33bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -6367,8 +6367,8 @@ __device__ void _bit_unpack_64_34bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_34bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_34bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -6587,8 +6587,8 @@ __device__ void _bit_unpack_64_35bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_35bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_35bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -6809,8 +6809,8 @@ __device__ void _bit_unpack_64_36bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_36bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_36bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -7033,8 +7033,8 @@ __device__ void _bit_unpack_64_37bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_37bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_37bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -7259,8 +7259,8 @@ __device__ void _bit_unpack_64_38bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_38bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_38bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -7487,8 +7487,8 @@ __device__ void _bit_unpack_64_39bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_39bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_39bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -7717,8 +7717,8 @@ __device__ void _bit_unpack_64_40bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_40bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_40bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -7949,8 +7949,8 @@ __device__ void _bit_unpack_64_41bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_41bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_41bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -8183,8 +8183,8 @@ __device__ void _bit_unpack_64_42bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_42bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_42bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -8419,8 +8419,8 @@ __device__ void _bit_unpack_64_43bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_43bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_43bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -8657,8 +8657,8 @@ __device__ void _bit_unpack_64_44bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_44bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_44bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -8897,8 +8897,8 @@ __device__ void _bit_unpack_64_45bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_45bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_45bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -9139,8 +9139,8 @@ __device__ void _bit_unpack_64_46bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_46bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_46bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -9383,8 +9383,8 @@ __device__ void _bit_unpack_64_47bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_47bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_47bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -9629,8 +9629,8 @@ __device__ void _bit_unpack_64_48bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_48bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_48bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -9877,8 +9877,8 @@ __device__ void _bit_unpack_64_49bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_49bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_49bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -10127,8 +10127,8 @@ __device__ void _bit_unpack_64_50bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_50bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_50bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -10379,8 +10379,8 @@ __device__ void _bit_unpack_64_51bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_51bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_51bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -10633,8 +10633,8 @@ __device__ void _bit_unpack_64_52bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_52bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_52bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -10889,8 +10889,8 @@ __device__ void _bit_unpack_64_53bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_53bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_53bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -11147,8 +11147,8 @@ __device__ void _bit_unpack_64_54bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_54bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_54bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -11407,8 +11407,8 @@ __device__ void _bit_unpack_64_55bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_55bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_55bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -11669,8 +11669,8 @@ __device__ void _bit_unpack_64_56bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_56bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_56bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -11933,8 +11933,8 @@ __device__ void _bit_unpack_64_57bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_57bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_57bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -12199,8 +12199,8 @@ __device__ void _bit_unpack_64_58bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_58bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_58bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -12467,8 +12467,8 @@ __device__ void _bit_unpack_64_59bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_59bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_59bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -12737,8 +12737,8 @@ __device__ void _bit_unpack_64_60bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_60bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_60bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -13009,8 +13009,8 @@ __device__ void _bit_unpack_64_61bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_61bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_61bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -13283,8 +13283,8 @@ __device__ void _bit_unpack_64_62bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_62bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_62bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -13559,8 +13559,8 @@ __device__ void _bit_unpack_64_63bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_63bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_63bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }
@@ -13644,8 +13644,8 @@ __device__ void _bit_unpack_64_64bw_lane(const uint64_t *__restrict in, uint64_t
 __device__ void _bit_unpack_64_64bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_64bw_lane(in, shared_out, thread_idx * 1 + 0);
-    for (int i = 0; i < 16; i++) {
-        auto idx = i * 16 + threadIdx.x;
+    for (int i = 0; i < 64; i++) {
+        auto idx = i * 64 + threadIdx.x;
         out[idx] = shared_out[idx];
     }
 }

--- a/vortex-cuda/kernels/src/bit_unpack_64.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_64.cu
@@ -78,7 +78,7 @@ __device__ void _bit_unpack_64_0bw_16t(const uint64_t *__restrict in, uint64_t *
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_0bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -230,7 +230,7 @@ __device__ void _bit_unpack_64_1bw_16t(const uint64_t *__restrict in, uint64_t *
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_1bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -384,7 +384,7 @@ __device__ void _bit_unpack_64_2bw_16t(const uint64_t *__restrict in, uint64_t *
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_2bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -540,7 +540,7 @@ __device__ void _bit_unpack_64_3bw_16t(const uint64_t *__restrict in, uint64_t *
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_3bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -698,7 +698,7 @@ __device__ void _bit_unpack_64_4bw_16t(const uint64_t *__restrict in, uint64_t *
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_4bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -858,7 +858,7 @@ __device__ void _bit_unpack_64_5bw_16t(const uint64_t *__restrict in, uint64_t *
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_5bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1020,7 +1020,7 @@ __device__ void _bit_unpack_64_6bw_16t(const uint64_t *__restrict in, uint64_t *
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_6bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1184,7 +1184,7 @@ __device__ void _bit_unpack_64_7bw_16t(const uint64_t *__restrict in, uint64_t *
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_7bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1350,7 +1350,7 @@ __device__ void _bit_unpack_64_8bw_16t(const uint64_t *__restrict in, uint64_t *
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_8bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1518,7 +1518,7 @@ __device__ void _bit_unpack_64_9bw_16t(const uint64_t *__restrict in, uint64_t *
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_9bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1688,7 +1688,7 @@ __device__ void _bit_unpack_64_10bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_10bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -1860,7 +1860,7 @@ __device__ void _bit_unpack_64_11bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_11bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2034,7 +2034,7 @@ __device__ void _bit_unpack_64_12bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_12bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2210,7 +2210,7 @@ __device__ void _bit_unpack_64_13bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_13bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2388,7 +2388,7 @@ __device__ void _bit_unpack_64_14bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_14bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2568,7 +2568,7 @@ __device__ void _bit_unpack_64_15bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_15bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2750,7 +2750,7 @@ __device__ void _bit_unpack_64_16bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_16bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -2934,7 +2934,7 @@ __device__ void _bit_unpack_64_17bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_17bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -3120,7 +3120,7 @@ __device__ void _bit_unpack_64_18bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_18bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -3308,7 +3308,7 @@ __device__ void _bit_unpack_64_19bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_19bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -3498,7 +3498,7 @@ __device__ void _bit_unpack_64_20bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_20bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -3690,7 +3690,7 @@ __device__ void _bit_unpack_64_21bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_21bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -3884,7 +3884,7 @@ __device__ void _bit_unpack_64_22bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_22bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -4080,7 +4080,7 @@ __device__ void _bit_unpack_64_23bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_23bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -4278,7 +4278,7 @@ __device__ void _bit_unpack_64_24bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_24bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -4478,7 +4478,7 @@ __device__ void _bit_unpack_64_25bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_25bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -4680,7 +4680,7 @@ __device__ void _bit_unpack_64_26bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_26bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -4884,7 +4884,7 @@ __device__ void _bit_unpack_64_27bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_27bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -5090,7 +5090,7 @@ __device__ void _bit_unpack_64_28bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_28bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -5298,7 +5298,7 @@ __device__ void _bit_unpack_64_29bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_29bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -5508,7 +5508,7 @@ __device__ void _bit_unpack_64_30bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_30bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -5720,7 +5720,7 @@ __device__ void _bit_unpack_64_31bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_31bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -5934,7 +5934,7 @@ __device__ void _bit_unpack_64_32bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_32bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -6150,7 +6150,7 @@ __device__ void _bit_unpack_64_33bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_33bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -6368,7 +6368,7 @@ __device__ void _bit_unpack_64_34bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_34bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -6588,7 +6588,7 @@ __device__ void _bit_unpack_64_35bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_35bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -6810,7 +6810,7 @@ __device__ void _bit_unpack_64_36bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_36bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -7034,7 +7034,7 @@ __device__ void _bit_unpack_64_37bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_37bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -7260,7 +7260,7 @@ __device__ void _bit_unpack_64_38bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_38bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -7488,7 +7488,7 @@ __device__ void _bit_unpack_64_39bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_39bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -7718,7 +7718,7 @@ __device__ void _bit_unpack_64_40bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_40bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -7950,7 +7950,7 @@ __device__ void _bit_unpack_64_41bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_41bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -8184,7 +8184,7 @@ __device__ void _bit_unpack_64_42bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_42bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -8420,7 +8420,7 @@ __device__ void _bit_unpack_64_43bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_43bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -8658,7 +8658,7 @@ __device__ void _bit_unpack_64_44bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_44bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -8898,7 +8898,7 @@ __device__ void _bit_unpack_64_45bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_45bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -9140,7 +9140,7 @@ __device__ void _bit_unpack_64_46bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_46bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -9384,7 +9384,7 @@ __device__ void _bit_unpack_64_47bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_47bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -9630,7 +9630,7 @@ __device__ void _bit_unpack_64_48bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_48bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -9878,7 +9878,7 @@ __device__ void _bit_unpack_64_49bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_49bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -10128,7 +10128,7 @@ __device__ void _bit_unpack_64_50bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_50bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -10380,7 +10380,7 @@ __device__ void _bit_unpack_64_51bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_51bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -10634,7 +10634,7 @@ __device__ void _bit_unpack_64_52bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_52bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -10890,7 +10890,7 @@ __device__ void _bit_unpack_64_53bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_53bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -11148,7 +11148,7 @@ __device__ void _bit_unpack_64_54bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_54bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -11408,7 +11408,7 @@ __device__ void _bit_unpack_64_55bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_55bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -11670,7 +11670,7 @@ __device__ void _bit_unpack_64_56bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_56bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -11934,7 +11934,7 @@ __device__ void _bit_unpack_64_57bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_57bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -12200,7 +12200,7 @@ __device__ void _bit_unpack_64_58bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_58bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -12468,7 +12468,7 @@ __device__ void _bit_unpack_64_59bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_59bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -12738,7 +12738,7 @@ __device__ void _bit_unpack_64_60bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_60bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -13010,7 +13010,7 @@ __device__ void _bit_unpack_64_61bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_61bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -13284,7 +13284,7 @@ __device__ void _bit_unpack_64_62bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_62bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -13560,7 +13560,7 @@ __device__ void _bit_unpack_64_63bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_63bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -13645,7 +13645,7 @@ __device__ void _bit_unpack_64_64bw_16t(const uint64_t *__restrict in, uint64_t 
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_64bw_lane(in, shared_out, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
-        auto idx = i * 64 + threadIdx.x;
+        auto idx = i * 16 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }

--- a/vortex-cuda/kernels/src/bit_unpack_64.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_64.cu
@@ -75,7 +75,12 @@ __device__ void _bit_unpack_64_0bw_lane(const uint64_t *__restrict in, uint64_t 
 }
 
 __device__ void _bit_unpack_64_0bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_0bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_0bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_0bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -222,7 +227,12 @@ __device__ void _bit_unpack_64_1bw_lane(const uint64_t *__restrict in, uint64_t 
 }
 
 __device__ void _bit_unpack_64_1bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_1bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_1bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_1bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -371,7 +381,12 @@ __device__ void _bit_unpack_64_2bw_lane(const uint64_t *__restrict in, uint64_t 
 }
 
 __device__ void _bit_unpack_64_2bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_2bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_2bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_2bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -522,7 +537,12 @@ __device__ void _bit_unpack_64_3bw_lane(const uint64_t *__restrict in, uint64_t 
 }
 
 __device__ void _bit_unpack_64_3bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_3bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_3bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_3bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -675,7 +695,12 @@ __device__ void _bit_unpack_64_4bw_lane(const uint64_t *__restrict in, uint64_t 
 }
 
 __device__ void _bit_unpack_64_4bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_4bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_4bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_4bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -830,7 +855,12 @@ __device__ void _bit_unpack_64_5bw_lane(const uint64_t *__restrict in, uint64_t 
 }
 
 __device__ void _bit_unpack_64_5bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_5bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_5bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_5bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -987,7 +1017,12 @@ __device__ void _bit_unpack_64_6bw_lane(const uint64_t *__restrict in, uint64_t 
 }
 
 __device__ void _bit_unpack_64_6bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_6bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_6bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_6bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -1146,7 +1181,12 @@ __device__ void _bit_unpack_64_7bw_lane(const uint64_t *__restrict in, uint64_t 
 }
 
 __device__ void _bit_unpack_64_7bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_7bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_7bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_7bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -1307,7 +1347,12 @@ __device__ void _bit_unpack_64_8bw_lane(const uint64_t *__restrict in, uint64_t 
 }
 
 __device__ void _bit_unpack_64_8bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_8bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_8bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_8bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -1470,7 +1515,12 @@ __device__ void _bit_unpack_64_9bw_lane(const uint64_t *__restrict in, uint64_t 
 }
 
 __device__ void _bit_unpack_64_9bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_9bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_9bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_9bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -1635,7 +1685,12 @@ __device__ void _bit_unpack_64_10bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_10bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_10bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_10bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_10bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -1802,7 +1857,12 @@ __device__ void _bit_unpack_64_11bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_11bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_11bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_11bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_11bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -1971,7 +2031,12 @@ __device__ void _bit_unpack_64_12bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_12bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_12bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_12bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_12bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -2142,7 +2207,12 @@ __device__ void _bit_unpack_64_13bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_13bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_13bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_13bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_13bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -2315,7 +2385,12 @@ __device__ void _bit_unpack_64_14bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_14bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_14bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_14bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_14bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -2490,7 +2565,12 @@ __device__ void _bit_unpack_64_15bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_15bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_15bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_15bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_15bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -2667,7 +2747,12 @@ __device__ void _bit_unpack_64_16bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_16bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_16bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_16bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_16bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -2846,7 +2931,12 @@ __device__ void _bit_unpack_64_17bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_17bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_17bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_17bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_17bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -3027,7 +3117,12 @@ __device__ void _bit_unpack_64_18bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_18bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_18bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_18bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_18bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -3210,7 +3305,12 @@ __device__ void _bit_unpack_64_19bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_19bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_19bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_19bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_19bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -3395,7 +3495,12 @@ __device__ void _bit_unpack_64_20bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_20bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_20bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_20bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_20bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -3582,7 +3687,12 @@ __device__ void _bit_unpack_64_21bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_21bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_21bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_21bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_21bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -3771,7 +3881,12 @@ __device__ void _bit_unpack_64_22bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_22bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_22bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_22bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_22bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -3962,7 +4077,12 @@ __device__ void _bit_unpack_64_23bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_23bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_23bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_23bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_23bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -4155,7 +4275,12 @@ __device__ void _bit_unpack_64_24bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_24bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_24bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_24bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_24bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -4350,7 +4475,12 @@ __device__ void _bit_unpack_64_25bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_25bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_25bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_25bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_25bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -4547,7 +4677,12 @@ __device__ void _bit_unpack_64_26bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_26bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_26bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_26bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_26bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -4746,7 +4881,12 @@ __device__ void _bit_unpack_64_27bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_27bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_27bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_27bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_27bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -4947,7 +5087,12 @@ __device__ void _bit_unpack_64_28bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_28bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_28bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_28bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_28bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -5150,7 +5295,12 @@ __device__ void _bit_unpack_64_29bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_29bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_29bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_29bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_29bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -5355,7 +5505,12 @@ __device__ void _bit_unpack_64_30bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_30bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_30bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_30bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_30bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -5562,7 +5717,12 @@ __device__ void _bit_unpack_64_31bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_31bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_31bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_31bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_31bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -5771,7 +5931,12 @@ __device__ void _bit_unpack_64_32bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_32bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_32bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_32bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_32bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -5982,7 +6147,12 @@ __device__ void _bit_unpack_64_33bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_33bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_33bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_33bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_33bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -6195,7 +6365,12 @@ __device__ void _bit_unpack_64_34bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_34bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_34bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_34bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_34bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -6410,7 +6585,12 @@ __device__ void _bit_unpack_64_35bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_35bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_35bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_35bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_35bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -6627,7 +6807,12 @@ __device__ void _bit_unpack_64_36bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_36bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_36bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_36bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_36bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -6846,7 +7031,12 @@ __device__ void _bit_unpack_64_37bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_37bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_37bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_37bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_37bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -7067,7 +7257,12 @@ __device__ void _bit_unpack_64_38bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_38bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_38bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_38bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_38bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -7290,7 +7485,12 @@ __device__ void _bit_unpack_64_39bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_39bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_39bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_39bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_39bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -7515,7 +7715,12 @@ __device__ void _bit_unpack_64_40bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_40bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_40bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_40bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_40bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -7742,7 +7947,12 @@ __device__ void _bit_unpack_64_41bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_41bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_41bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_41bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_41bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -7971,7 +8181,12 @@ __device__ void _bit_unpack_64_42bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_42bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_42bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_42bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_42bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -8202,7 +8417,12 @@ __device__ void _bit_unpack_64_43bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_43bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_43bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_43bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_43bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -8435,7 +8655,12 @@ __device__ void _bit_unpack_64_44bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_44bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_44bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_44bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_44bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -8670,7 +8895,12 @@ __device__ void _bit_unpack_64_45bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_45bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_45bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_45bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_45bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -8907,7 +9137,12 @@ __device__ void _bit_unpack_64_46bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_46bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_46bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_46bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_46bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -9146,7 +9381,12 @@ __device__ void _bit_unpack_64_47bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_47bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_47bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_47bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_47bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -9387,7 +9627,12 @@ __device__ void _bit_unpack_64_48bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_48bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_48bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_48bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_48bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -9630,7 +9875,12 @@ __device__ void _bit_unpack_64_49bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_49bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_49bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_49bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_49bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -9875,7 +10125,12 @@ __device__ void _bit_unpack_64_50bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_50bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_50bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_50bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_50bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -10122,7 +10377,12 @@ __device__ void _bit_unpack_64_51bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_51bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_51bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_51bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_51bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -10371,7 +10631,12 @@ __device__ void _bit_unpack_64_52bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_52bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_52bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_52bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_52bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -10622,7 +10887,12 @@ __device__ void _bit_unpack_64_53bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_53bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_53bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_53bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_53bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -10875,7 +11145,12 @@ __device__ void _bit_unpack_64_54bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_54bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_54bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_54bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_54bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -11130,7 +11405,12 @@ __device__ void _bit_unpack_64_55bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_55bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_55bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_55bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_55bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -11387,7 +11667,12 @@ __device__ void _bit_unpack_64_56bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_56bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_56bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_56bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_56bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -11646,7 +11931,12 @@ __device__ void _bit_unpack_64_57bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_57bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_57bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_57bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_57bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -11907,7 +12197,12 @@ __device__ void _bit_unpack_64_58bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_58bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_58bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_58bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_58bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -12170,7 +12465,12 @@ __device__ void _bit_unpack_64_59bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_59bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_59bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_59bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_59bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -12435,7 +12735,12 @@ __device__ void _bit_unpack_64_60bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_60bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_60bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_60bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_60bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -12702,7 +13007,12 @@ __device__ void _bit_unpack_64_61bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_61bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_61bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_61bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_61bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -12971,7 +13281,12 @@ __device__ void _bit_unpack_64_62bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_62bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_62bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_62bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_62bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -13242,7 +13557,12 @@ __device__ void _bit_unpack_64_63bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_63bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_63bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_63bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_63bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {
@@ -13322,7 +13642,12 @@ __device__ void _bit_unpack_64_64bw_lane(const uint64_t *__restrict in, uint64_t
 }
 
 __device__ void _bit_unpack_64_64bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, int thread_idx) {
-    _bit_unpack_64_64bw_lane(in, out, thread_idx * 1 + 0);
+    __shared__ uint64_t shared_out[1024];
+    _bit_unpack_64_64bw_lane(in, shared_out, thread_idx * 1 + 0);
+    for (int i = 0; i < 16; i++) {
+        auto idx = i * 16 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_64_64bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out) {

--- a/vortex-cuda/kernels/src/bit_unpack_8.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_8.cu
@@ -19,10 +19,15 @@ __device__ void _bit_unpack_8_0bw_lane(const uint8_t *__restrict in, uint8_t *__
 }
 
 __device__ void _bit_unpack_8_0bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, int thread_idx) {
-    _bit_unpack_8_0bw_lane(in, out, thread_idx * 4 + 0);
-    _bit_unpack_8_0bw_lane(in, out, thread_idx * 4 + 1);
-    _bit_unpack_8_0bw_lane(in, out, thread_idx * 4 + 2);
-    _bit_unpack_8_0bw_lane(in, out, thread_idx * 4 + 3);
+    __shared__ uint8_t shared_out[1024];
+    _bit_unpack_8_0bw_lane(in, shared_out, thread_idx * 4 + 0);
+    _bit_unpack_8_0bw_lane(in, shared_out, thread_idx * 4 + 1);
+    _bit_unpack_8_0bw_lane(in, shared_out, thread_idx * 4 + 2);
+    _bit_unpack_8_0bw_lane(in, shared_out, thread_idx * 4 + 3);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_8_0bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out) {
@@ -57,10 +62,15 @@ __device__ void _bit_unpack_8_1bw_lane(const uint8_t *__restrict in, uint8_t *__
 }
 
 __device__ void _bit_unpack_8_1bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, int thread_idx) {
-    _bit_unpack_8_1bw_lane(in, out, thread_idx * 4 + 0);
-    _bit_unpack_8_1bw_lane(in, out, thread_idx * 4 + 1);
-    _bit_unpack_8_1bw_lane(in, out, thread_idx * 4 + 2);
-    _bit_unpack_8_1bw_lane(in, out, thread_idx * 4 + 3);
+    __shared__ uint8_t shared_out[1024];
+    _bit_unpack_8_1bw_lane(in, shared_out, thread_idx * 4 + 0);
+    _bit_unpack_8_1bw_lane(in, shared_out, thread_idx * 4 + 1);
+    _bit_unpack_8_1bw_lane(in, shared_out, thread_idx * 4 + 2);
+    _bit_unpack_8_1bw_lane(in, shared_out, thread_idx * 4 + 3);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_8_1bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out) {
@@ -97,10 +107,15 @@ __device__ void _bit_unpack_8_2bw_lane(const uint8_t *__restrict in, uint8_t *__
 }
 
 __device__ void _bit_unpack_8_2bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, int thread_idx) {
-    _bit_unpack_8_2bw_lane(in, out, thread_idx * 4 + 0);
-    _bit_unpack_8_2bw_lane(in, out, thread_idx * 4 + 1);
-    _bit_unpack_8_2bw_lane(in, out, thread_idx * 4 + 2);
-    _bit_unpack_8_2bw_lane(in, out, thread_idx * 4 + 3);
+    __shared__ uint8_t shared_out[1024];
+    _bit_unpack_8_2bw_lane(in, shared_out, thread_idx * 4 + 0);
+    _bit_unpack_8_2bw_lane(in, shared_out, thread_idx * 4 + 1);
+    _bit_unpack_8_2bw_lane(in, shared_out, thread_idx * 4 + 2);
+    _bit_unpack_8_2bw_lane(in, shared_out, thread_idx * 4 + 3);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_8_2bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out) {
@@ -139,10 +154,15 @@ __device__ void _bit_unpack_8_3bw_lane(const uint8_t *__restrict in, uint8_t *__
 }
 
 __device__ void _bit_unpack_8_3bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, int thread_idx) {
-    _bit_unpack_8_3bw_lane(in, out, thread_idx * 4 + 0);
-    _bit_unpack_8_3bw_lane(in, out, thread_idx * 4 + 1);
-    _bit_unpack_8_3bw_lane(in, out, thread_idx * 4 + 2);
-    _bit_unpack_8_3bw_lane(in, out, thread_idx * 4 + 3);
+    __shared__ uint8_t shared_out[1024];
+    _bit_unpack_8_3bw_lane(in, shared_out, thread_idx * 4 + 0);
+    _bit_unpack_8_3bw_lane(in, shared_out, thread_idx * 4 + 1);
+    _bit_unpack_8_3bw_lane(in, shared_out, thread_idx * 4 + 2);
+    _bit_unpack_8_3bw_lane(in, shared_out, thread_idx * 4 + 3);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_8_3bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out) {
@@ -183,10 +203,15 @@ __device__ void _bit_unpack_8_4bw_lane(const uint8_t *__restrict in, uint8_t *__
 }
 
 __device__ void _bit_unpack_8_4bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, int thread_idx) {
-    _bit_unpack_8_4bw_lane(in, out, thread_idx * 4 + 0);
-    _bit_unpack_8_4bw_lane(in, out, thread_idx * 4 + 1);
-    _bit_unpack_8_4bw_lane(in, out, thread_idx * 4 + 2);
-    _bit_unpack_8_4bw_lane(in, out, thread_idx * 4 + 3);
+    __shared__ uint8_t shared_out[1024];
+    _bit_unpack_8_4bw_lane(in, shared_out, thread_idx * 4 + 0);
+    _bit_unpack_8_4bw_lane(in, shared_out, thread_idx * 4 + 1);
+    _bit_unpack_8_4bw_lane(in, shared_out, thread_idx * 4 + 2);
+    _bit_unpack_8_4bw_lane(in, shared_out, thread_idx * 4 + 3);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_8_4bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out) {
@@ -229,10 +254,15 @@ __device__ void _bit_unpack_8_5bw_lane(const uint8_t *__restrict in, uint8_t *__
 }
 
 __device__ void _bit_unpack_8_5bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, int thread_idx) {
-    _bit_unpack_8_5bw_lane(in, out, thread_idx * 4 + 0);
-    _bit_unpack_8_5bw_lane(in, out, thread_idx * 4 + 1);
-    _bit_unpack_8_5bw_lane(in, out, thread_idx * 4 + 2);
-    _bit_unpack_8_5bw_lane(in, out, thread_idx * 4 + 3);
+    __shared__ uint8_t shared_out[1024];
+    _bit_unpack_8_5bw_lane(in, shared_out, thread_idx * 4 + 0);
+    _bit_unpack_8_5bw_lane(in, shared_out, thread_idx * 4 + 1);
+    _bit_unpack_8_5bw_lane(in, shared_out, thread_idx * 4 + 2);
+    _bit_unpack_8_5bw_lane(in, shared_out, thread_idx * 4 + 3);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_8_5bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out) {
@@ -277,10 +307,15 @@ __device__ void _bit_unpack_8_6bw_lane(const uint8_t *__restrict in, uint8_t *__
 }
 
 __device__ void _bit_unpack_8_6bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, int thread_idx) {
-    _bit_unpack_8_6bw_lane(in, out, thread_idx * 4 + 0);
-    _bit_unpack_8_6bw_lane(in, out, thread_idx * 4 + 1);
-    _bit_unpack_8_6bw_lane(in, out, thread_idx * 4 + 2);
-    _bit_unpack_8_6bw_lane(in, out, thread_idx * 4 + 3);
+    __shared__ uint8_t shared_out[1024];
+    _bit_unpack_8_6bw_lane(in, shared_out, thread_idx * 4 + 0);
+    _bit_unpack_8_6bw_lane(in, shared_out, thread_idx * 4 + 1);
+    _bit_unpack_8_6bw_lane(in, shared_out, thread_idx * 4 + 2);
+    _bit_unpack_8_6bw_lane(in, shared_out, thread_idx * 4 + 3);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_8_6bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out) {
@@ -327,10 +362,15 @@ __device__ void _bit_unpack_8_7bw_lane(const uint8_t *__restrict in, uint8_t *__
 }
 
 __device__ void _bit_unpack_8_7bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, int thread_idx) {
-    _bit_unpack_8_7bw_lane(in, out, thread_idx * 4 + 0);
-    _bit_unpack_8_7bw_lane(in, out, thread_idx * 4 + 1);
-    _bit_unpack_8_7bw_lane(in, out, thread_idx * 4 + 2);
-    _bit_unpack_8_7bw_lane(in, out, thread_idx * 4 + 3);
+    __shared__ uint8_t shared_out[1024];
+    _bit_unpack_8_7bw_lane(in, shared_out, thread_idx * 4 + 0);
+    _bit_unpack_8_7bw_lane(in, shared_out, thread_idx * 4 + 1);
+    _bit_unpack_8_7bw_lane(in, shared_out, thread_idx * 4 + 2);
+    _bit_unpack_8_7bw_lane(in, shared_out, thread_idx * 4 + 3);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_8_7bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out) {
@@ -354,10 +394,15 @@ __device__ void _bit_unpack_8_8bw_lane(const uint8_t *__restrict in, uint8_t *__
 }
 
 __device__ void _bit_unpack_8_8bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, int thread_idx) {
-    _bit_unpack_8_8bw_lane(in, out, thread_idx * 4 + 0);
-    _bit_unpack_8_8bw_lane(in, out, thread_idx * 4 + 1);
-    _bit_unpack_8_8bw_lane(in, out, thread_idx * 4 + 2);
-    _bit_unpack_8_8bw_lane(in, out, thread_idx * 4 + 3);
+    __shared__ uint8_t shared_out[1024];
+    _bit_unpack_8_8bw_lane(in, shared_out, thread_idx * 4 + 0);
+    _bit_unpack_8_8bw_lane(in, shared_out, thread_idx * 4 + 1);
+    _bit_unpack_8_8bw_lane(in, shared_out, thread_idx * 4 + 2);
+    _bit_unpack_8_8bw_lane(in, shared_out, thread_idx * 4 + 3);
+    for (int i = 0; i < 32; i++) {
+        auto idx = i * 32 + threadIdx.x;
+        out[idx] = shared_out[idx];
+    }
 }
 
 extern "C" __global__ void bit_unpack_8_8bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out) {

--- a/vortex-cuda/kernels/src/bit_unpack_8.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_8.cu
@@ -25,7 +25,7 @@ __device__ void _bit_unpack_8_0bw_32t(const uint8_t *__restrict in, uint8_t *__r
     _bit_unpack_8_0bw_lane(in, shared_out, thread_idx * 4 + 2);
     _bit_unpack_8_0bw_lane(in, shared_out, thread_idx * 4 + 3);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -68,7 +68,7 @@ __device__ void _bit_unpack_8_1bw_32t(const uint8_t *__restrict in, uint8_t *__r
     _bit_unpack_8_1bw_lane(in, shared_out, thread_idx * 4 + 2);
     _bit_unpack_8_1bw_lane(in, shared_out, thread_idx * 4 + 3);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -113,7 +113,7 @@ __device__ void _bit_unpack_8_2bw_32t(const uint8_t *__restrict in, uint8_t *__r
     _bit_unpack_8_2bw_lane(in, shared_out, thread_idx * 4 + 2);
     _bit_unpack_8_2bw_lane(in, shared_out, thread_idx * 4 + 3);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -160,7 +160,7 @@ __device__ void _bit_unpack_8_3bw_32t(const uint8_t *__restrict in, uint8_t *__r
     _bit_unpack_8_3bw_lane(in, shared_out, thread_idx * 4 + 2);
     _bit_unpack_8_3bw_lane(in, shared_out, thread_idx * 4 + 3);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -209,7 +209,7 @@ __device__ void _bit_unpack_8_4bw_32t(const uint8_t *__restrict in, uint8_t *__r
     _bit_unpack_8_4bw_lane(in, shared_out, thread_idx * 4 + 2);
     _bit_unpack_8_4bw_lane(in, shared_out, thread_idx * 4 + 3);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -260,7 +260,7 @@ __device__ void _bit_unpack_8_5bw_32t(const uint8_t *__restrict in, uint8_t *__r
     _bit_unpack_8_5bw_lane(in, shared_out, thread_idx * 4 + 2);
     _bit_unpack_8_5bw_lane(in, shared_out, thread_idx * 4 + 3);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -313,7 +313,7 @@ __device__ void _bit_unpack_8_6bw_32t(const uint8_t *__restrict in, uint8_t *__r
     _bit_unpack_8_6bw_lane(in, shared_out, thread_idx * 4 + 2);
     _bit_unpack_8_6bw_lane(in, shared_out, thread_idx * 4 + 3);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -368,7 +368,7 @@ __device__ void _bit_unpack_8_7bw_32t(const uint8_t *__restrict in, uint8_t *__r
     _bit_unpack_8_7bw_lane(in, shared_out, thread_idx * 4 + 2);
     _bit_unpack_8_7bw_lane(in, shared_out, thread_idx * 4 + 3);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }
@@ -400,7 +400,7 @@ __device__ void _bit_unpack_8_8bw_32t(const uint8_t *__restrict in, uint8_t *__r
     _bit_unpack_8_8bw_lane(in, shared_out, thread_idx * 4 + 2);
     _bit_unpack_8_8bw_lane(in, shared_out, thread_idx * 4 + 3);
     for (int i = 0; i < 32; i++) {
-        auto idx = i * 32 + threadIdx.x;
+        auto idx = i * 32 + thread_idx;
         out[idx] = shared_out[idx];
     }
 }


### PR DESCRIPTION
Signed-off-by: Robert Kruszewski <github@robertk.io>
