### PR TITLE
fix[array]: dict value nullable values

### DIFF
--- a/vortex-array/src/arrays/dict/compute/cast.rs
+++ b/vortex-array/src/arrays/dict/compute/cast.rs
@@ -16,6 +16,16 @@ use crate::register_kernel;
 
 impl CastKernel for DictVTable {
     fn cast(&self, array: &DictArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
+        // Can have un-reference null values making the cast of values fail without a possible mask.
+        // TODO(joe): optimize this, could look at accessible values and fill_null not those?
+        if !dtype.is_nullable()
+            && array.values().dtype().is_nullable()
+            && !array.values().all_valid()?
+        {
+            let canonical = array.to_canonical()?.into_array();
+            return Ok(Some(cast(canonical.as_ref(), dtype)?));
+        }
+
         // Cast the dictionary values to the target type
         let casted_values = cast(array.values(), dtype)?;
 
@@ -187,5 +197,47 @@ mod tests {
     #[case(dict_encode(&buffer![1.5f32, 2.5, 1.5, 3.5].into_array()).unwrap().into_array())]
     fn test_cast_dict_conformance(#[case] array: crate::ArrayRef) {
         test_cast_conformance(array.as_ref());
+    }
+
+    #[test]
+    fn test_cast_dict_with_unreferenced_null_values_to_nonnullable() {
+        use crate::arrays::dict::DictArray;
+        use crate::validity::Validity;
+
+        // Create a dict with nullable values that have unreferenced null entries.
+        // Values: [1.0, null, 3.0] (index 1 is null but no code points to it)
+        // Codes: [0, 2, 0] (only reference indices 0 and 2, never 1)
+        let values = PrimitiveArray::new(
+            buffer![1.0f64, 0.0f64, 3.0f64],
+            Validity::from(vortex_buffer::BitBuffer::from(vec![true, false, true])),
+        )
+        .into_array();
+        let codes = buffer![0u32, 2, 0].into_array();
+        let dict = DictArray::try_new(codes, values).unwrap();
+
+        // The dict is Nullable (because values are nullable), but all codes point to valid values.
+        assert_eq!(
+            dict.dtype(),
+            &DType::Primitive(PType::F64, Nullability::Nullable)
+        );
+
+        // Casting to NonNullable should succeed since all logical values are non-null.
+        let result = cast(
+            dict.as_ref(),
+            &DType::Primitive(PType::F64, Nullability::NonNullable),
+        );
+        assert!(
+            result.is_ok(),
+            "cast to NonNullable should succeed for dict with only unreferenced null values"
+        );
+        let casted = result.unwrap();
+        assert_eq!(
+            casted.dtype(),
+            &DType::Primitive(PType::F64, Nullability::NonNullable)
+        );
+        assert_arrays_eq!(
+            casted.to_primitive(),
+            PrimitiveArray::from_iter([1.0f64, 3.0, 1.0])
+        );
     }
 }


### PR DESCRIPTION
Can have non-accessible value which cannot be casted to non-nullable