### PR TITLE
vortex-btrblocks: write listviews when elements expand > 50%

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10280,6 +10280,7 @@ dependencies = [
  "num-traits",
  "pco",
  "rand 0.9.2",
+ "rstest",
  "rustc-hash 2.1.1",
  "test-with",
  "tracing",

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -183,7 +183,7 @@ impl Canonical {
         match self {
             Canonical::VarBinView(array) => Ok(Canonical::VarBinView(array.compact_buffers()?)),
             Canonical::List(array) => Ok(Canonical::List(
-                array.rebuild(ListViewRebuildMode::MakeZeroCopyToList)?,
+                array.rebuild(ListViewRebuildMode::TrimElements)?,
             )),
             _ => Ok(self.clone()),
         }

--- a/vortex-btrblocks/Cargo.toml
+++ b/vortex-btrblocks/Cargo.toml
@@ -43,6 +43,7 @@ vortex-zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 divan = { workspace = true }
+rstest = { workspace = true }
 test-with = { workspace = true }
 tracing-subscriber = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -12,12 +12,14 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::ListArray;
+use vortex_array::arrays::ListViewArray;
 use vortex_array::arrays::StructArray;
 use vortex_array::arrays::TemporalArray;
 use vortex_array::arrays::list_from_list_view;
 use vortex_array::compute::Cost;
 use vortex_array::compute::IsConstantOpts;
 use vortex_array::compute::is_constant_opts;
+use vortex_array::compute::sum;
 use vortex_array::vtable::ValidityHelper;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
@@ -37,6 +39,13 @@ use crate::compressor::float::FloatScheme;
 use crate::compressor::integer::IntegerScheme;
 use crate::compressor::string::StringScheme;
 use crate::compressor::temporal::compress_temporal;
+use crate::sample::sample;
+use crate::sample::sample_count_approx_one_percent;
+use crate::stats::SAMPLE_SIZE;
+
+/// Maximum ratio of expanded (List) element count to shared (ListView) element count
+/// below which we prefer List encoding over ListView.
+const MAX_LIST_EXPANSION_RATIO: f64 = 1.5;
 
 /// Trait for compressors that can compress canonical arrays.
 ///
@@ -137,6 +146,63 @@ impl BtrBlocksCompressor {
             btr_blocks_compressor: self,
         }
     }
+
+    /// Compresses a [`ListArray`] by narrowing offsets and recursively compressing elements.
+    fn compress_list_array(
+        &self,
+        list_array: ListArray,
+        ctx: CompressorContext,
+    ) -> VortexResult<ArrayRef> {
+        // Reset the offsets to remove garbage data that might prevent us from narrowing our
+        // offsets (there could be a large amount of trailing garbage data that the current
+        // views do not reference at all).
+        let list_array = list_array.reset_offsets(true)?;
+
+        let compressed_elems = self.compress(list_array.elements())?;
+
+        // Note that since the type of our offsets are not encoded in our `DType`, and since
+        // we guarantee above that all elements are referenced by offsets, we may narrow the
+        // widths.
+        let compressed_offsets = self.compress_canonical(
+            Canonical::Primitive(list_array.offsets().to_primitive().narrow()?),
+            ctx,
+            Excludes::from(&[IntCode::Dict]),
+        )?;
+
+        Ok(ListArray::try_new(
+            compressed_elems,
+            compressed_offsets,
+            list_array.validity().clone(),
+        )?
+        .into_array())
+    }
+
+    /// Compresses a [`ListViewArray`] by narrowing offsets/sizes and recursively compressing
+    /// elements.
+    fn compress_list_view_array(
+        &self,
+        list_view: ListViewArray,
+        ctx: CompressorContext,
+    ) -> VortexResult<ArrayRef> {
+        let compressed_elems = self.compress(list_view.elements())?;
+        let compressed_offsets = self.compress_canonical(
+            Canonical::Primitive(list_view.offsets().to_primitive().narrow()?),
+            ctx,
+            Excludes::none(),
+        )?;
+        let compressed_sizes = self.compress_canonical(
+            Canonical::Primitive(list_view.sizes().to_primitive().narrow()?),
+            ctx,
+            Excludes::none(),
+        )?;
+        Ok(ListViewArray::try_new(
+            compressed_elems,
+            compressed_offsets,
+            compressed_sizes,
+            list_view.validity().clone(),
+        )?
+        .into_array())
+    }
 }
 
 impl CanonicalCompressor for BtrBlocksCompressor {
@@ -179,33 +245,37 @@ impl CanonicalCompressor for BtrBlocksCompressor {
                 .into_array())
             }
             Canonical::List(list_view_array) => {
-                // TODO(joe): We might want to write list views in the future and chose between
-                // list and list view.
-                let list_array = list_from_list_view(list_view_array)?;
+                let elements_len = list_view_array.elements().len();
+                if list_view_array.is_zero_copy_to_list() || elements_len == 0 {
+                    // We can avoid the sizes array.
+                    let list_array = list_from_list_view(list_view_array)?;
+                    return self.compress_list_array(list_array, ctx);
+                }
 
-                // Reset the offsets to remove garbage data that might prevent us from narrowing our
-                // offsets (there could be a large amount of trailing garbage data that the current
-                // views do not reference at all).
-                let list_array = list_array.reset_offsets(true)?;
+                // Sample the sizes to estimate the total expanded element
+                // count, then decide List vs ListView with the expansion
+                // threshold.
+                let sampled_sizes = sample(
+                    list_view_array.sizes(),
+                    SAMPLE_SIZE,
+                    sample_count_approx_one_percent(list_view_array.len()),
+                );
+                let sampled_sum = sum(&*sampled_sizes)?
+                    .as_primitive()
+                    .as_::<usize>()
+                    .unwrap_or(0);
 
-                let compressed_elems = self.compress(list_array.elements())?;
+                let estimated_expanded_elements_len =
+                    sampled_sum * list_view_array.len() / sampled_sizes.len();
 
-                // Note that since the type of our offsets are not encoded in our `DType`, and since
-                // we guarantee above that all elements are referenced by offsets, we may narrow the
-                // widths.
-
-                let compressed_offsets = self.compress_canonical(
-                    Canonical::Primitive(list_array.offsets().to_primitive().narrow()?),
-                    ctx,
-                    Excludes::from(&[IntCode::Dict]),
-                )?;
-
-                Ok(ListArray::try_new(
-                    compressed_elems,
-                    compressed_offsets,
-                    list_array.validity().clone(),
-                )?
-                .into_array())
+                if estimated_expanded_elements_len as f64
+                    <= elements_len as f64 * MAX_LIST_EXPANSION_RATIO
+                {
+                    let list_array = list_from_list_view(list_view_array)?;
+                    self.compress_list_array(list_array, ctx)
+                } else {
+                    self.compress_list_view_array(list_view_array, ctx)
+                }
             }
             Canonical::FixedSizeList(fsl_array) => {
                 let compressed_elems = self.compress(fsl_array.elements())?;
@@ -273,5 +343,88 @@ impl CanonicalCompressor for BtrBlocksCompressor {
 
     fn string_schemes(&self) -> &[&'static dyn StringScheme] {
         &self.string_schemes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_array::Array;
+    use vortex_array::IntoArray;
+    use vortex_array::arrays::ListVTable;
+    use vortex_array::arrays::ListViewArray;
+    use vortex_array::arrays::ListViewVTable;
+    use vortex_array::assert_arrays_eq;
+    use vortex_array::validity::Validity;
+    use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
+
+    use crate::BtrBlocksCompressor;
+
+    /// ZCTL: [[1,2,3], [4,5], [6,7,8,9]]. Monotonic offsets, no overlap.
+    fn zctl_listview() -> ListViewArray {
+        let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
+        let offsets = buffer![0i32, 3, 5].into_array();
+        let sizes = buffer![3i32, 2, 4].into_array();
+        unsafe {
+            ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
+                .with_zero_copy_to_list(true)
+        }
+    }
+
+    /// Non-ZCTL, low duplication: [[7,8,9], [1,2,3], [4,5,6]]. Unsorted but disjoint.
+    fn non_zctl_low_dup_listview() -> ListViewArray {
+        let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
+        let offsets = buffer![6i32, 0, 3].into_array();
+        let sizes = buffer![3i32, 3, 3].into_array();
+        ListViewArray::new(elements, offsets, sizes, Validity::NonNullable)
+    }
+
+    /// Non-ZCTL, high duplication: [[1,2,3]] x 4.
+    fn non_zctl_high_dup_listview() -> ListViewArray {
+        let elements = buffer![1i32, 2, 3].into_array();
+        let offsets = buffer![0i32, 0, 0, 0].into_array();
+        let sizes = buffer![3i32, 3, 3, 3].into_array();
+        ListViewArray::new(elements, offsets, sizes, Validity::NonNullable)
+    }
+
+    /// Nullable with overlap: [[1,2,3], null, [1,2,3], [1,2,3]].
+    fn nullable_overlap_listview() -> ListViewArray {
+        let elements = buffer![1i32, 2, 3].into_array();
+        let offsets = buffer![0i32, 0, 0, 0].into_array();
+        let sizes = buffer![3i32, 0, 3, 3].into_array();
+        let validity = Validity::from_iter([true, false, true, true]);
+        ListViewArray::new(elements, offsets, sizes, validity)
+    }
+
+    /// Tests that each ListView variant compresses to the expected encoding and roundtrips.
+    #[rstest]
+    #[case::zctl(zctl_listview(), true)]
+    #[case::non_zctl_low_dup(non_zctl_low_dup_listview(), true)]
+    #[case::non_zctl_high_dup(non_zctl_high_dup_listview(), false)]
+    #[case::nullable_overlap(nullable_overlap_listview(), false)]
+    fn list_view_compress_roundtrip(
+        #[case] input: ListViewArray,
+        #[case] expect_list: bool,
+    ) -> VortexResult<()> {
+        let compressor = BtrBlocksCompressor::default();
+        let result = compressor.compress(input.as_ref())?;
+
+        if expect_list {
+            assert!(
+                result.as_opt::<ListVTable>().is_some(),
+                "Expected ListArray, got: {}",
+                result.encoding_id()
+            );
+        } else {
+            assert!(
+                result.as_opt::<ListViewVTable>().is_some(),
+                "Expected ListViewArray, got: {}",
+                result.encoding_id()
+            );
+        }
+
+        assert_arrays_eq!(result, input);
+        Ok(())
     }
 }

--- a/vortex-btrblocks/src/sample.rs
+++ b/vortex-btrblocks/src/sample.rs
@@ -10,6 +10,9 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::ChunkedArray;
 use vortex_error::VortexExpect;
 
+use crate::stats::SAMPLE_COUNT;
+use crate::stats::SAMPLE_SIZE;
+
 pub(crate) fn sample(input: &dyn Array, sample_size: u32, sample_count: u32) -> ArrayRef {
     if input.len() <= (sample_size as usize) * (sample_count as usize) {
         return input.to_array();
@@ -34,6 +37,22 @@ pub(crate) fn sample(input: &dyn Array, sample_size: u32, sample_count: u32) -> 
     ChunkedArray::try_new(chunks, input.dtype().clone())
         .vortex_expect("sample slices should form valid chunked array")
         .into_array()
+}
+
+/// Computes the number of sample chunks to cover approximately 1% of `len` elements,
+/// with a minimum of `SAMPLE_SIZE * SAMPLE_COUNT` (1024) values.
+pub(crate) fn sample_count_approx_one_percent(len: usize) -> u32 {
+    let approximately_one_percent =
+        (len / 100) / usize::try_from(SAMPLE_SIZE).vortex_expect("SAMPLE_SIZE must fit in usize");
+    u32::max(
+        u32::next_multiple_of(
+            approximately_one_percent
+                .try_into()
+                .vortex_expect("sample count must fit in u32"),
+            16,
+        ),
+        SAMPLE_COUNT,
+    )
 }
 
 pub fn stratified_slices(

--- a/vortex-btrblocks/src/scheme.rs
+++ b/vortex-btrblocks/src/scheme.rs
@@ -8,13 +8,12 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use vortex_array::ArrayRef;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::BtrBlocksCompressor;
 use crate::CompressorContext;
 use crate::CompressorStats;
-use crate::stats::SAMPLE_COUNT;
+use crate::sample::sample_count_approx_one_percent;
 use crate::stats::SAMPLE_SIZE;
 
 /// Top-level compression scheme trait.
@@ -89,21 +88,8 @@ pub trait SchemeExt: Scheme {
         let sample = if ctx.is_sample {
             stats.clone()
         } else {
-            // We want to sample about 1% of data
             let source_len = stats.source().len();
-
-            // We want to sample about 1% of data, while keeping a minimal sample of 1024 values.
-            let approximately_one_percent = (source_len / 100)
-                / usize::try_from(SAMPLE_SIZE).vortex_expect("SAMPLE_SIZE must fit in usize");
-            let sample_count = u32::max(
-                u32::next_multiple_of(
-                    approximately_one_percent
-                        .try_into()
-                        .vortex_expect("sample count must fit in u32"),
-                    16,
-                ),
-                SAMPLE_COUNT,
-            );
+            let sample_count = sample_count_approx_one_percent(source_len);
 
             tracing::trace!(
                 "Sampling {} values out of {}",


### PR DESCRIPTION
Previously, listview arrays were always written as lists. This involves materializing the views (i.e. expanding the elements and reorganizing the offsets).

This commit chooses to write listviews on compression if the elements would expand > 50% when converting to lists to save on CPU cost and storage space. ZCTL listviews and listviews with low duplication are still encoded as lists, which saves writing the sizes.