### PR TITLE
RFC: Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+
+## Does this PR closes an open issue or discussion?
+
+<!--
+This helps us keep track of fixed issues and changes.
+-->
+
+- Closes #.
+
+## What changes are included in this PR
+
+<!--
+What changes are included here, if an issue or discussion are attached, there's no need to duplicate the details.
+-->
+
+## What is the rationale for this change?
+
+<!--
+Why do you propose this change, and why did you choose this approach.
+
+This helps reviewers and other readers understand changes, creates a shared understanding of the issue and codebase,
+and improves their ability to work with this change and offer better suggestions.
+-->
+
+## How is this change tests
+
+<!--
+Changes should be tested, we expect changes to fit in one of the following categories:
+1. Verifying existing behavior is maintained.
+2. For serialization related changes - Compatibility should be maintained or explicitly broken.
+3. For new behavior and functionality, this helps us maintaining that desired behavior in the future.
+-->
+
+## Are there any user-facing changes?
+
+<!--
+Does the change affect users in what of the following ways:
+1. Breaks public APIs in some way.
+2. Changes the underlying behavior of one of the integrations.
+3. Should some documentation be changed to reflect this change?
+
+In the case some public API is changed in a breaking way, make sure to add the appropriate label.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ This helps us keep track of fixed issues and changes.
 
 - Closes #.
 
-## What changes are included in this PR
+## What changes are included in this PR?
 
 <!--
 What changes are included here, if an issue or discussion are attached, there's no need to duplicate the details.
@@ -22,7 +22,7 @@ This helps reviewers and other readers understand changes, creates a shared unde
 and improves their ability to work with this change and offer better suggestions.
 -->
 
-## How is this change tests
+## How is this change tested?
 
 <!--
 Changes should be tested, we expect changes to fit in one of the following categories:


### PR DESCRIPTION
I think the change is pretty self explanatory, I don't care about the details of the template here as much as I think we have too many PRs that are effectively opaque, with the details hiding in some discussion that isn't link, slack or being discussed offline.