### PR TITLE
Remove `chunked_bool_into_canonical` benchmark due to excessive noise

### DIFF
--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -62,15 +62,6 @@ fn chunked_opt_bool_canonical_into(bencher: Bencher, (len, chunk_count): (usize,
 }
 
 #[divan::bench(args = BENCH_ARGS)]
-fn chunked_bool_into_canonical(bencher: Bencher, (len, chunk_count): (usize, usize)) {
-    let chunk = make_bool_chunks(len, chunk_count);
-
-    bencher
-        .with_inputs(|| &chunk)
-        .bench_refs(|chunk| chunk.to_canonical())
-}
-
-#[divan::bench(args = BENCH_ARGS)]
 fn chunked_opt_bool_into_canonical(bencher: Bencher, (len, chunk_count): (usize, usize)) {
     let chunk = make_opt_bool_chunks(len, chunk_count);
 


### PR DESCRIPTION
This benchmarks seems to swing by 20% in either direction constantly, even when PRs have 0 code changes