### PR TITLE
Introduce `VortexError::Other` and simplify `Display` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10393,7 +10393,6 @@ dependencies = [
  "object_store",
  "prost 0.14.3",
  "pyo3",
- "serde_json",
  "serial_test",
  "temp-env",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8075,6 +8075,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8136,6 +8145,12 @@ name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -8310,6 +8325,32 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -9026,6 +9067,15 @@ name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
+]
 
 [[package]]
 name = "tempfile"
@@ -10344,8 +10394,9 @@ dependencies = [
  "prost 0.14.3",
  "pyo3",
  "serde_json",
+ "serial_test",
+ "temp-env",
  "tokio",
- "url",
 ]
 
 [[package]]

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -28,11 +28,11 @@ pub fn decode_to_temporal(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<TemporalArray> {
     let DType::Extension(ext) = array.dtype().clone() else {
-        vortex_panic!(ComputeError: "expected dtype to be DType::Extension variant")
+        vortex_panic!(Compute: "expected dtype to be DType::Extension variant")
     };
 
     let Some(options) = ext.metadata_opt::<Timestamp>() else {
-        vortex_panic!(ComputeError: "must decode TemporalMetadata from extension metadata");
+        vortex_panic!(Compute: "must decode TemporalMetadata from extension metadata");
     };
 
     let divisor = match options.unit {

--- a/encodings/datetime-parts/src/ops.rs
+++ b/encodings/datetime-parts/src/ops.rs
@@ -25,7 +25,7 @@ impl OperationsVTable<DateTimePartsVTable> for DateTimePartsVTable {
         };
 
         let Some(options) = ext.metadata_opt::<Timestamp>() else {
-            vortex_panic!(ComputeError: "must decode TemporalMetadata from extension metadata");
+            vortex_panic!(Compute: "must decode TemporalMetadata from extension metadata");
         };
 
         if !array.is_valid(index)? {

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -50,7 +50,7 @@ pub fn bitpack_encode(
             array.statistics().compute_min::<P>().unwrap_or_default() < 0
         });
         if has_negative_values {
-            vortex_bail!("cannot bitpack_encode array containing negative integers")
+            vortex_bail!(InvalidArgument: "cannot bitpack_encode array containing negative integers")
         }
     }
 
@@ -59,7 +59,7 @@ pub fn bitpack_encode(
     if bit_width >= array.ptype().bit_width() as u8 {
         // Nothing we can do
         vortex_bail!(
-            "Cannot pack - specified bit width {bit_width} >= {}",
+            InvalidArgument: "Cannot pack - specified bit width {bit_width} >= {}",
             array.ptype().bit_width()
         )
     }

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -273,7 +273,7 @@ impl BitPackedArray {
         if let Some(parray) = array.as_opt::<PrimitiveVTable>() {
             bitpack_encode(parray, bit_width, None)
         } else {
-            vortex_bail!("Bitpacking can only encode primitive arrays");
+            vortex_bail!(InvalidArgument: "Bitpacking can only encode primitive arrays");
         }
     }
 

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -289,6 +289,7 @@ pub fn reconstruct_views(buffer: &ByteBuffer) -> Buffer<BinaryView> {
                 .get(offset..offset + size_of::<ViewLen>())
                 .vortex_expect("corrupted zstd length")
                 .try_into()
+                .ok()
                 .vortex_expect("must fit ViewLen size"),
         ) as usize;
         offset += size_of::<ViewLen>();

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -80,7 +80,6 @@ serde = [
     "dep:serde",
     "vortex-buffer/serde",
     "vortex-dtype/serde",
-    "vortex-error/serde",
     "vortex-mask/serde",
 ]
 

--- a/vortex-array/src/arrays/decimal/array.rs
+++ b/vortex-array/src/arrays/decimal/array.rs
@@ -241,7 +241,7 @@ impl DecimalArray {
             let expected_len = values_type.byte_width() * validity_len;
             vortex_ensure!(
                 buffer.len() == expected_len,
-                "expected buffer of size {} bytes, was {} bytes",
+                InvalidArgument: "expected buffer of size {} bytes, was {} bytes",
                 expected_len,
                 buffer.len(),
             );

--- a/vortex-array/src/arrays/fixed_size_list/array.rs
+++ b/vortex-array/src/arrays/fixed_size_list/array.rs
@@ -186,7 +186,7 @@ impl FixedSizeListArray {
         if let Some(validity_len) = validity.maybe_len() {
             vortex_ensure!(
                 len == validity_len,
-                "validity with size {validity_len} does not match fixed-size list array size {len}",
+                InvalidArgument: "validity with size {validity_len} does not match fixed-size list array size {len}",
             );
         }
 
@@ -195,14 +195,14 @@ impl FixedSizeListArray {
         if list_size == 0 {
             vortex_ensure!(
                 elements.is_empty(),
-                "a degenerate (`list_size == 0`) `FixedSizeList` should have no underlying elements"
+                InvalidArgument: "a degenerate (`list_size == 0`) `FixedSizeList` should have no underlying elements"
             );
             return Ok(());
         }
 
         vortex_ensure!(
             len * list_size as usize == elements.len(),
-            "the `elements` array has the incorrect number of elements to construct a \
+            InvalidArgument: "the `elements` array has the incorrect number of elements to construct a \
                 `FixedSizeList[{list_size}] array of length {len}",
         );
 

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -163,13 +163,13 @@ impl ListArray {
         // Offsets must have at least one element
         vortex_ensure!(
             !offsets.is_empty(),
-            "Offsets must have at least one element, [0] for an empty list"
+            InvalidArgument: "Offsets must have at least one element, [0] for an empty list"
         );
 
         // Offsets must be of integer type, and cannot go lower than 0.
         vortex_ensure!(
             offsets.dtype().is_int() && !offsets.dtype().is_nullable(),
-            "offsets have invalid type {}",
+            InvalidArgument: "offsets have invalid type {}",
             offsets.dtype()
         );
 
@@ -178,9 +178,9 @@ impl ListArray {
 
         // Offsets must be sorted (but not strictly sorted, zero-length lists are allowed)
         if let Some(is_sorted) = offsets.statistics().compute_is_sorted() {
-            vortex_ensure!(is_sorted, "offsets must be sorted");
+            vortex_ensure!(is_sorted, InvalidArgument: "offsets must be sorted");
         } else {
-            vortex_bail!("offsets must report is_sorted statistic");
+            vortex_bail!(InvalidArgument: "offsets must report is_sorted statistic");
         }
 
         // Validate that offsets min is non-negative, and max does not exceed the length of
@@ -202,7 +202,7 @@ impl ListArray {
 
                     vortex_ensure!(
                         min >= 0,
-                        "offsets minimum {min} outside valid range [0, {max}]"
+                        InvalidArgument: "offsets minimum {min} outside valid range [0, {max}]"
                     );
 
                     vortex_ensure!(
@@ -211,7 +211,7 @@ impl ListArray {
                             <P as NativePType>::PTYPE,
                             elements.len()
                         )),
-                        "Max offset {max} is beyond the length of the elements array {}",
+                        InvalidArgument: "Max offset {max} is beyond the length of the elements array {}",
                         elements.len()
                     );
                 }
@@ -219,7 +219,7 @@ impl ListArray {
         } else {
             // TODO(aduffy): fallback to slower validation pathway?
             vortex_bail!(
-                "offsets array with encoding {} must support min_max compute function",
+                InvalidArgument: "offsets array with encoding {} must support min_max compute function",
                 offsets.encoding_id()
             );
         };
@@ -228,7 +228,7 @@ impl ListArray {
         if let Some(validity_len) = validity.maybe_len() {
             vortex_ensure!(
                 validity_len == offsets.len() - 1,
-                "validity with size {validity_len} does not match array size {}",
+                InvalidArgument: "validity with size {validity_len} does not match array size {}",
                 offsets.len() - 1
             );
         }

--- a/vortex-array/src/arrays/primitive/array/mod.rs
+++ b/vortex-array/src/arrays/primitive/array/mod.rs
@@ -164,6 +164,7 @@ impl PrimitiveArray {
             && buffer.len() != len
         {
             return Err(vortex_err!(
+                InvalidArgument:
                 "Buffer and validity length mismatch: buffer={}, validity={}",
                 buffer.len(),
                 len

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -67,7 +67,7 @@ fn cast<F: NativePType, T: NativePType>(array: &[F], mask: Mask) -> VortexResult
             let mut buffer = BufferMut::with_capacity(array.len());
             for item in array {
                 let item = T::from(*item).ok_or_else(
-                    || vortex_err!(ComputeError: "Failed to cast {} to {:?}", item, T::PTYPE),
+                    || vortex_err!(Compute: "Failed to cast {} to {:?}", item, T::PTYPE),
                 )?;
                 // SAFETY: we've pre-allocated the required capacity
                 unsafe { buffer.push_unchecked(item) }
@@ -81,7 +81,7 @@ fn cast<F: NativePType, T: NativePType>(array: &[F], mask: Mask) -> VortexResult
             for (item, valid) in array.iter().zip(b.iter()) {
                 if valid {
                     let item = T::from(*item).ok_or_else(
-                        || vortex_err!(ComputeError: "Failed to cast {} to {:?}", item, T::PTYPE),
+                        || vortex_err!(Compute: "Failed to cast {} to {:?}", item, T::PTYPE),
                     )?;
                     // SAFETY: we've pre-allocated the required capacity
                     unsafe { buffer.push_unchecked(item) }
@@ -180,12 +180,9 @@ mod test {
         let error = arr
             .cast(PType::U32.into())
             .and_then(|a| a.to_canonical().map(|c| c.into_array()))
-            .err()
-            .unwrap();
-        let VortexError::ComputeError(s, _) = error else {
-            unreachable!()
-        };
-        assert_eq!(s.to_string(), "Failed to cast -1 to U32");
+            .unwrap_err();
+        assert!(matches!(error, VortexError::Compute(..)));
+        assert!(error.to_string().contains("Failed to cast -1 to U32"));
     }
 
     #[test]
@@ -196,12 +193,11 @@ mod test {
             .cast(PType::I32.into())
             .and_then(|a| a.to_canonical().map(|c| c.into_array()))
             .unwrap_err();
-        let VortexError::InvalidArgument(s, _) = err else {
-            unreachable!()
-        };
-        assert_eq!(
-            s.to_string(),
-            "Cannot cast array with invalid values to non-nullable type."
+
+        assert!(matches!(err, VortexError::InvalidArgument(..)));
+        assert!(
+            err.to_string()
+                .contains("Cannot cast array with invalid values to non-nullable type.")
         );
     }
 

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -299,7 +299,7 @@ impl StructArray {
         // Check field count matches
         if fields.len() != dtype.names().len() {
             vortex_bail!(
-                "Got {} fields but dtype has {} names",
+                InvalidArgument: "Got {} fields but dtype has {} names",
                 fields.len(),
                 dtype.names().len()
             );
@@ -309,7 +309,7 @@ impl StructArray {
         for (i, (field, struct_dt)) in fields.iter().zip(dtype.fields()).enumerate() {
             if field.len() != length {
                 vortex_bail!(
-                    "Field {} has length {} but expected {}",
+                    InvalidArgument: "Field {} has length {} but expected {}",
                     i,
                     field.len(),
                     length
@@ -318,7 +318,7 @@ impl StructArray {
 
             if field.dtype() != &struct_dt {
                 vortex_bail!(
-                    "Field {} has dtype {} but expected {}",
+                    InvalidArgument: "Field {} has dtype {} but expected {}",
                     i,
                     field.dtype(),
                     struct_dt
@@ -331,7 +331,7 @@ impl StructArray {
             && validity_len != length
         {
             vortex_bail!(
-                "Validity has length {} but expected {}",
+                InvalidArgument: "Validity has length {} but expected {}",
                 validity_len,
                 length
             );

--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -189,7 +189,7 @@ impl VarBinArray {
         // Check nullability matches
         vortex_ensure!(
             dtype.is_nullable() != (validity == &Validity::NonNullable),
-            "incorrect validity {:?} for dtype {}",
+            InvalidArgument: "incorrect validity {:?} for dtype {}",
             validity,
             dtype
         );
@@ -197,7 +197,7 @@ impl VarBinArray {
         // Check offsets has at least one element
         vortex_ensure!(
             !offsets.is_empty(),
-            "Offsets must have at least one element"
+            InvalidArgument: "Offsets must have at least one element"
         );
 
         // Skip host-only validation when offsets/bytes are not host-resident.
@@ -206,10 +206,12 @@ impl VarBinArray {
                 .scalar_at(offsets.len() - 1)?
                 .as_primitive()
                 .as_::<usize>()
-                .ok_or_else(|| vortex_err!("Last offset must be convertible to usize"))?;
+                .ok_or_else(
+                    || vortex_err!(InvalidArgument: "Last offset must be convertible to usize"),
+                )?;
             vortex_ensure!(
                 last_offset <= bytes.len(),
-                "Last offset {} exceeds bytes length {}",
+                InvalidArgument: "Last offset {} exceeds bytes length {}",
                 last_offset,
                 bytes.len()
             );

--- a/vortex-array/src/arrays/varbinview/array.rs
+++ b/vortex-array/src/arrays/varbinview/array.rs
@@ -264,7 +264,7 @@ impl VarBinViewArray {
     ) -> VortexResult<()> {
         vortex_ensure!(
             validity.nullability() == dtype.nullability(),
-            "validity {:?} incompatible with nullability {:?}",
+            InvalidArgument: "validity {:?} incompatible with nullability {:?}",
             validity,
             dtype.nullability()
         );
@@ -274,7 +274,7 @@ impl VarBinViewArray {
                 simdutf8::basic::from_utf8(string).is_ok()
             })?,
             DType::Binary(_) => Self::validate_views(views, buffers, validity, |_| true)?,
-            _ => vortex_bail!("invalid DType {dtype} for `VarBinViewArray`"),
+            _ => vortex_bail!(InvalidArgument: "invalid DType {dtype} for `VarBinViewArray`"),
         }
 
         Ok(())
@@ -299,7 +299,7 @@ impl VarBinViewArray {
                 let bytes = &view.as_inlined().data[..view.len() as usize];
                 vortex_ensure!(
                     validator(bytes),
-                    "view at index {idx}: inlined bytes failed utf-8 validation"
+                    InvalidArgument: "view at index {idx}: inlined bytes failed utf-8 validation"
                 );
             } else {
                 // Validate the view pointer
@@ -309,18 +309,18 @@ impl VarBinViewArray {
                 let end_offset = start_offset.saturating_add(view.size as usize);
 
                 let buf = buffers.get(buf_index).ok_or_else(||
-                    vortex_err!("view at index {idx} references invalid buffer: {buf_index} out of bounds for VarBinViewArray with {} buffers",
+                    vortex_err!(InvalidArgument: "view at index {idx} references invalid buffer: {buf_index} out of bounds for VarBinViewArray with {} buffers",
                         buffers.len()))?;
 
                 vortex_ensure!(
                     start_offset < buf.len(),
-                    "start offset {start_offset} out of bounds for buffer {buf_index} with size {}",
+                    InvalidArgument: "start offset {start_offset} out of bounds for buffer {buf_index} with size {}",
                     buf.len(),
                 );
 
                 vortex_ensure!(
                     end_offset <= buf.len(),
-                    "end offset {end_offset} out of bounds for buffer {buf_index} with size {}",
+                    InvalidArgument: "end offset {end_offset} out of bounds for buffer {buf_index} with size {}",
                     buf.len(),
                 );
 
@@ -328,13 +328,13 @@ impl VarBinViewArray {
                 let bytes = &buf[start_offset..end_offset];
                 vortex_ensure!(
                     view.prefix == bytes[..4],
-                    "VarBinView prefix does not match full string"
+                    InvalidArgument: "VarBinView prefix does not match full string"
                 );
 
                 // Validate the full string
                 vortex_ensure!(
                     validator(bytes),
-                    "view at index {idx}: outlined bytes fails utf-8 validation"
+                    InvalidArgument: "view at index {idx}: outlined bytes fails utf-8 validation"
                 );
             }
         }

--- a/vortex-array/src/arrays/varbinview/view.rs
+++ b/vortex-array/src/arrays/varbinview/view.rs
@@ -156,6 +156,7 @@ impl BinaryView {
                     size: u32::try_from(value.len()).vortex_expect("value length must fit in u32"),
                     prefix: value[0..4]
                         .try_into()
+                        .ok()
                         .vortex_expect("prefix must be exactly 4 bytes"),
                     buffer_index: block,
                     offset,

--- a/vortex-array/src/scalar/proto.rs
+++ b/vortex-array/src/scalar/proto.rs
@@ -183,14 +183,14 @@ impl Scalar {
             value
                 .dtype
                 .as_ref()
-                .ok_or_else(|| vortex_err!(InvalidSerde: "Scalar missing dtype"))?,
+                .ok_or_else(|| vortex_err!(Serde: "Scalar missing dtype"))?,
             session,
         )?;
 
         let pb_scalar_value: &pb::ScalarValue = value
             .value
             .as_ref()
-            .ok_or_else(|| vortex_err!(InvalidSerde: "Scalar missing value"))?;
+            .ok_or_else(|| vortex_err!(Serde: "Scalar missing value"))?;
 
         let value: Option<ScalarValue> = ScalarValue::from_proto(pb_scalar_value, &dtype)?;
 
@@ -224,7 +224,7 @@ impl ScalarValue {
         let kind = value
             .kind
             .as_ref()
-            .ok_or_else(|| vortex_err!(InvalidSerde: "Scalar value missing kind"))?;
+            .ok_or_else(|| vortex_err!(Serde: "Scalar value missing kind"))?;
 
         // `DType::Extension` store their serialized values using the storage `DType`.
         let dtype = match dtype {
@@ -251,7 +251,7 @@ impl ScalarValue {
 fn bool_from_proto(v: bool, dtype: &DType) -> VortexResult<ScalarValue> {
     vortex_ensure!(
         dtype.is_boolean(),
-        InvalidSerde: "expected Bool dtype for BoolValue, got {dtype}"
+        Serde: "expected Bool dtype for BoolValue, got {dtype}"
     );
 
     Ok(ScalarValue::Bool(v))
@@ -264,7 +264,7 @@ fn bool_from_proto(v: bool, dtype: &DType) -> VortexResult<ScalarValue> {
 fn int64_from_proto(v: i64, dtype: &DType) -> VortexResult<ScalarValue> {
     vortex_ensure!(
         dtype.is_primitive(),
-        InvalidSerde: "expected Primitive dtype for Int64Value, got {dtype}"
+        Serde: "expected Primitive dtype for Int64Value, got {dtype}"
     );
 
     let pvalue = match dtype.as_ptype() {
@@ -273,10 +273,10 @@ fn int64_from_proto(v: i64, dtype: &DType) -> VortexResult<ScalarValue> {
         PType::I32 => v.to_i32().map(PValue::I32),
         PType::I64 => Some(PValue::I64(v)),
         ptype => vortex_bail!(
-            InvalidSerde: "expected signed integer ptype for Int64Value, got {ptype}"
+            Serde: "expected signed integer ptype for Int64Value, got {ptype}"
         ),
     }
-    .ok_or_else(|| vortex_err!(InvalidSerde: "Int64 value {v} out of range for dtype {dtype}"))?;
+    .ok_or_else(|| vortex_err!(Serde: "Int64 value {v} out of range for dtype {dtype}"))?;
 
     Ok(ScalarValue::Primitive(pvalue))
 }
@@ -289,7 +289,7 @@ fn int64_from_proto(v: i64, dtype: &DType) -> VortexResult<ScalarValue> {
 fn uint64_from_proto(v: u64, dtype: &DType) -> VortexResult<ScalarValue> {
     vortex_ensure!(
         dtype.is_primitive(),
-        InvalidSerde: "expected Primitive dtype for Uint64Value, got {dtype}"
+        Serde: "expected Primitive dtype for Uint64Value, got {dtype}"
     );
 
     let pvalue = match dtype.as_ptype() {
@@ -300,10 +300,10 @@ fn uint64_from_proto(v: u64, dtype: &DType) -> VortexResult<ScalarValue> {
         // Backwards compatibility: f16 values were previously serialized as u64.
         PType::F16 => v.to_u16().map(f16::from_bits).map(PValue::F16),
         ptype => vortex_bail!(
-            InvalidSerde: "expected unsigned integer ptype for Uint64Value, got {ptype}"
+            Serde: "expected unsigned integer ptype for Uint64Value, got {ptype}"
         ),
     }
-    .ok_or_else(|| vortex_err!(InvalidSerde: "Uint64 value {v} out of range for dtype {dtype}"))?;
+    .ok_or_else(|| vortex_err!(Serde: "Uint64 value {v} out of range for dtype {dtype}"))?;
 
     Ok(ScalarValue::Primitive(pvalue))
 }
@@ -312,12 +312,11 @@ fn uint64_from_proto(v: u64, dtype: &DType) -> VortexResult<ScalarValue> {
 fn f16_from_proto(v: u64, dtype: &DType) -> VortexResult<ScalarValue> {
     vortex_ensure!(
         matches!(dtype, DType::Primitive(PType::F16, _)),
-        InvalidSerde: "expected F16 dtype for F16Value, got {dtype}"
+        Serde: "expected F16 dtype for F16Value, got {dtype}"
     );
 
-    let bits = u16::try_from(v).map_err(
-        |_| vortex_err!(InvalidSerde: "f16 bitwise representation has more than 16 bits: {v}"),
-    )?;
+    let bits = u16::try_from(v)
+        .map_err(|_| vortex_err!(Serde: "f16 bitwise representation has more than 16 bits: {v}"))?;
 
     Ok(ScalarValue::Primitive(PValue::F16(f16::from_bits(bits))))
 }
@@ -326,7 +325,7 @@ fn f16_from_proto(v: u64, dtype: &DType) -> VortexResult<ScalarValue> {
 fn f32_from_proto(v: f32, dtype: &DType) -> VortexResult<ScalarValue> {
     vortex_ensure!(
         matches!(dtype, DType::Primitive(PType::F32, _)),
-        InvalidSerde: "expected F32 dtype for F32Value, got {dtype}"
+        Serde: "expected F32 dtype for F32Value, got {dtype}"
     );
 
     Ok(ScalarValue::Primitive(PValue::F32(v)))
@@ -336,7 +335,7 @@ fn f32_from_proto(v: f32, dtype: &DType) -> VortexResult<ScalarValue> {
 fn f64_from_proto(v: f64, dtype: &DType) -> VortexResult<ScalarValue> {
     vortex_ensure!(
         matches!(dtype, DType::Primitive(PType::F64, _)),
-        InvalidSerde: "expected F64 dtype for F64Value, got {dtype}"
+        Serde: "expected F64 dtype for F64Value, got {dtype}"
     );
 
     Ok(ScalarValue::Primitive(PValue::F64(v)))
@@ -349,7 +348,7 @@ fn string_from_proto(s: &str, dtype: &DType) -> VortexResult<ScalarValue> {
         DType::Utf8(_) => Ok(ScalarValue::Utf8(BufferString::from(s))),
         DType::Binary(_) => Ok(ScalarValue::Binary(ByteBuffer::copy_from(s.as_bytes()))),
         _ => vortex_bail!(
-            InvalidSerde: "expected Utf8 or Binary dtype for StringValue, got {dtype}"
+            Serde: "expected Utf8 or Binary dtype for StringValue, got {dtype}"
         ),
     }
 }
@@ -370,19 +369,19 @@ fn bytes_from_proto(bytes: &[u8], dtype: &DType) -> VortexResult<ScalarValue> {
             8 => DecimalValue::I64(i64::from_le_bytes(bytes.try_into()?)),
             16 => DecimalValue::I128(i128::from_le_bytes(bytes.try_into()?)),
             32 => DecimalValue::I256(i256::from_le_bytes(bytes.try_into()?)),
-            l => vortex_bail!(InvalidSerde: "invalid decimal byte length: {l}"),
+            l => vortex_bail!(Serde: "invalid decimal byte length: {l}"),
         })),
         _ => vortex_bail!(
-            InvalidSerde: "expected Utf8, Binary, or Decimal dtype for BytesValue, got {dtype}"
+            Serde: "expected Utf8, Binary, or Decimal dtype for BytesValue, got {dtype}"
         ),
     }
 }
 
 /// Deserialize a [`ScalarValue::List`] from a protobuf `ListValue`.
 fn list_from_proto(v: &ListValue, dtype: &DType) -> VortexResult<ScalarValue> {
-    let element_dtype = dtype.as_list_element_opt().ok_or_else(
-        || vortex_err!(InvalidSerde: "expected List dtype for ListValue, got {dtype}"),
-    )?;
+    let element_dtype = dtype
+        .as_list_element_opt()
+        .ok_or_else(|| vortex_err!(Serde: "expected List dtype for ListValue, got {dtype}"))?;
 
     let mut values = Vec::with_capacity(v.values.len());
     for elem in v.values.iter() {

--- a/vortex-array/src/scalar/proto.rs
+++ b/vortex-array/src/scalar/proto.rs
@@ -364,11 +364,36 @@ fn bytes_from_proto(bytes: &[u8], dtype: &DType) -> VortexResult<ScalarValue> {
         // TODO(connor): This is incorrect, we need to verify this matches the `dtype`.
         DType::Decimal(..) => Ok(ScalarValue::Decimal(match bytes.len() {
             1 => DecimalValue::I8(bytes[0] as i8),
-            2 => DecimalValue::I16(i16::from_le_bytes(bytes.try_into()?)),
-            4 => DecimalValue::I32(i32::from_le_bytes(bytes.try_into()?)),
-            8 => DecimalValue::I64(i64::from_le_bytes(bytes.try_into()?)),
-            16 => DecimalValue::I128(i128::from_le_bytes(bytes.try_into()?)),
-            32 => DecimalValue::I256(i256::from_le_bytes(bytes.try_into()?)),
+            2 => DecimalValue::I16(i16::from_le_bytes(
+                bytes
+                    .try_into()
+                    .ok()
+                    .vortex_expect("Buffer has invalid number of bytes"),
+            )),
+            4 => DecimalValue::I32(i32::from_le_bytes(
+                bytes
+                    .try_into()
+                    .ok()
+                    .vortex_expect("Buffer has invalid number of bytes"),
+            )),
+            8 => DecimalValue::I64(i64::from_le_bytes(
+                bytes
+                    .try_into()
+                    .ok()
+                    .vortex_expect("Buffer has invalid number of bytes"),
+            )),
+            16 => DecimalValue::I128(i128::from_le_bytes(
+                bytes
+                    .try_into()
+                    .ok()
+                    .vortex_expect("Buffer has invalid number of bytes"),
+            )),
+            32 => DecimalValue::I256(i256::from_le_bytes(
+                bytes
+                    .try_into()
+                    .ok()
+                    .vortex_expect("Buffer has invalid number of bytes"),
+            )),
             l => vortex_bail!(Serde: "invalid decimal byte length: {l}"),
         })),
         _ => vortex_bail!(

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -366,7 +366,7 @@ impl Validity {
     pub fn cast_nullability(self, nullability: Nullability, len: usize) -> VortexResult<Validity> {
         match nullability {
             Nullability::NonNullable => self.into_non_nullable(len).ok_or_else(|| {
-                vortex_err!("Cannot cast array with invalid values to non-nullable type.")
+                vortex_err!(InvalidArgument: "Cannot cast array with invalid values to non-nullable type.")
             }),
             Nullability::Nullable => Ok(self.into_nullable()),
         }

--- a/vortex-bench/src/conversions.rs
+++ b/vortex-bench/src/conversions.rs
@@ -27,8 +27,8 @@ use vortex::array::stream::ArrayStreamAdapter;
 use vortex::array::stream::ArrayStreamExt;
 use vortex::dtype::DType;
 use vortex::dtype::arrow::FromArrowType;
-use vortex::error::VortexError;
 use vortex::error::VortexResult;
+use vortex::error::vortex_err;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::session::VortexSession;
 
@@ -89,20 +89,18 @@ pub fn parquet_to_vortex_stream(
     reader: ParquetRecordBatchStream<File>,
 ) -> impl futures::Stream<Item = VortexResult<ArrayRef>> {
     reader.map(move |result| {
-        result
-            .map_err(|e| VortexError::generic(e.into()))
-            .and_then(|rb| {
-                let chunk = ArrayRef::from_arrow(rb, false)?;
-                let mut builder = builder_with_capacity(chunk.dtype(), chunk.len());
+        result.map_err(|e| vortex_err!(External: e)).and_then(|rb| {
+            let chunk = ArrayRef::from_arrow(rb, false)?;
+            let mut builder = builder_with_capacity(chunk.dtype(), chunk.len());
 
-                // Canonicalize the chunk.
-                chunk.append_to_builder(
-                    builder.as_mut(),
-                    &mut VortexSession::default().create_execution_ctx(),
-                )?;
+            // Canonicalize the chunk.
+            chunk.append_to_builder(
+                builder.as_mut(),
+                &mut VortexSession::default().create_execution_ctx(),
+            )?;
 
-                Ok(builder.finish())
-            })
+            Ok(builder.finish())
+        })
     })
 }
 

--- a/vortex-btrblocks/src/compressor/integer/stats.rs
+++ b/vortex-btrblocks/src/compressor/integer/stats.rs
@@ -255,7 +255,7 @@ where
         AllOr::All => {
             for chunk in &mut chunks {
                 inner_loop_nonnull(
-                    chunk.try_into().vortex_expect("chunk size must be 64"),
+                    chunk.try_into().ok().vortex_expect("chunk size must be 64"),
                     count_distinct_values,
                     &mut loop_state,
                 )
@@ -281,13 +281,13 @@ where
                     0 => continue,
                     // Inner loop for when validity check can be elided
                     64 => inner_loop_nonnull(
-                        chunk.try_into().vortex_expect("chunk size must be 64"),
+                        chunk.try_into().ok().vortex_expect("chunk size must be 64"),
                         count_distinct_values,
                         &mut loop_state,
                     ),
                     // Inner loop for when we need to check validity
                     _ => inner_loop_nullable(
-                        chunk.try_into().vortex_expect("chunk size must be 64"),
+                        chunk.try_into().ok().vortex_expect("chunk size must be 64"),
                         count_distinct_values,
                         &validity,
                         &mut loop_state,

--- a/vortex-dtype/src/datetime/timestamp.rs
+++ b/vortex-dtype/src/datetime/timestamp.rs
@@ -97,10 +97,15 @@ impl ExtDTypeVTable for Timestamp {
     }
 
     fn deserialize(&self, data: &[u8]) -> VortexResult<Self::Metadata> {
+        vortex_ensure!(data.len() >= 3);
+
         let tag = data[0];
         let time_unit = TimeUnit::try_from(tag)?;
-        let tz_len_bytes = &data[1..3];
-        let tz_len = u16::from_le_bytes(tz_len_bytes.try_into()?) as usize;
+        let tz_len_bytes: [u8; 2] = data[1..3]
+            .try_into()
+            .ok()
+            .vortex_expect("Verified to have two bytes");
+        let tz_len = u16::from_le_bytes(tz_len_bytes) as usize;
         if tz_len == 0 {
             return Ok(TimestampOptions {
                 unit: time_unit,

--- a/vortex-dtype/src/serde/flatbuffers.rs
+++ b/vortex-dtype/src/serde/flatbuffers.rs
@@ -203,7 +203,7 @@ impl TryFrom<ViewedDType> for DType {
                 );
                 let storage_dtype = fb_ext.storage_dtype().ok_or_else(|| {
                     vortex_err!(
-                InvalidSerde: "storage_dtype must be present on DType fbs message")
+                Serde: "storage_dtype must be present on DType fbs message")
                 })?;
                 let storage_view = ViewedDType::from_fb_loc(
                     storage_dtype._tab.loc(),
@@ -408,7 +408,7 @@ impl TryFrom<fb::PType> for PType {
             fb::PType::F16 => Self::F16,
             fb::PType::F32 => Self::F32,
             fb::PType::F64 => Self::F64,
-            _ => vortex_bail!(InvalidSerde: "Unknown PType variant"),
+            _ => vortex_bail!(Serde: "Unknown PType variant"),
         })
     }
 }

--- a/vortex-dtype/src/serde/proto.rs
+++ b/vortex-dtype/src/serde/proto.rs
@@ -26,7 +26,7 @@ impl DType {
         match value
             .dtype_type
             .as_ref()
-            .ok_or_else(|| vortex_err!(InvalidSerde: "Unrecognized DType"))?
+            .ok_or_else(|| vortex_err!(Serde: "Unrecognized DType"))?
         {
             DtypeType::Null(_) => Ok(Self::Null),
             DtypeType::Bool(b) => Ok(Self::Bool(b.nullable.into())),
@@ -60,7 +60,7 @@ impl DType {
                     DType::from_proto(
                         l.element_type
                             .as_ref()
-                            .ok_or_else(|| vortex_err!(InvalidSerde: "Invalid list element type"))?
+                            .ok_or_else(|| vortex_err!(Serde: "Invalid list element type"))?
                             .as_ref(),
                         session,
                     )
@@ -71,13 +71,16 @@ impl DType {
             DtypeType::FixedSizeList(fsl) => {
                 let nullable = fsl.nullable.into();
                 Ok(Self::FixedSizeList(
-                    DType::from_proto(fsl.element_type
-                        .as_ref()
-                        .ok_or_else(
-                            || vortex_err!(InvalidSerde: "Invalid fixed-size list element type"),
-                        )?
-                        .as_ref(),
-                        session).map(Arc::new)?,
+                    DType::from_proto(
+                        fsl.element_type
+                            .as_ref()
+                            .ok_or_else(
+                                || vortex_err!(Serde: "Invalid fixed-size list element type"),
+                            )?
+                            .as_ref(),
+                        session,
+                    )
+                    .map(Arc::new)?,
                     fsl.size,
                     nullable,
                 ))
@@ -85,7 +88,7 @@ impl DType {
             DtypeType::Extension(e) => {
                 let id = ExtID::new_arc(e.id.as_str().to_string().into());
                 let vtable = session.dtypes().registry().find(&id).ok_or_else(
-                    || vortex_err!(InvalidSerde: "Unregistered extension type ID: {}", e.id),
+                    || vortex_err!(Serde: "Unregistered extension type ID: {}", e.id),
                 )?;
                 let storage_dtype = DType::from_proto(
                     e.storage_dtype
@@ -201,7 +204,7 @@ impl TryFrom<&pb::FieldPath> for FieldPath {
             match field
                 .field_type
                 .as_ref()
-                .ok_or_else(|| vortex_err!(InvalidSerde: "FieldPath part missing type"))?
+                .ok_or_else(|| vortex_err!(Serde: "FieldPath part missing type"))?
             {
                 FieldType::Name(name) => path.push(Field::from(name.as_str())),
             }

--- a/vortex-error/Cargo.toml
+++ b/vortex-error/Cargo.toml
@@ -18,7 +18,6 @@ all-features = true
 
 [features]
 flatbuffers = ["dep:flatbuffers"]
-serde = ["dep:serde_json"]
 
 [dependencies]
 arrow-schema = { workspace = true }
@@ -27,7 +26,6 @@ jiff = { workspace = true }
 object_store = { workspace = true, optional = true }
 prost = { workspace = true }
 pyo3 = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
 
 [dev-dependencies]

--- a/vortex-error/Cargo.toml
+++ b/vortex-error/Cargo.toml
@@ -29,7 +29,10 @@ prost = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
-url = { workspace = true }
+
+[dev-dependencies]
+serial_test = { version = "3.3.1" }
+temp-env = "0.3"
 
 [lints]
 workspace = true

--- a/vortex-error/public-api.lock
+++ b/vortex-error/public-api.lock
@@ -12,31 +12,27 @@ pub macro vortex_error::vortex_panic!
 
 #[non_exhaustive] pub enum vortex_error::VortexError
 
-pub vortex_error::VortexError::ArrowError(arrow_schema::error::ArrowError, alloc::boxed::Box<std::backtrace::Backtrace>)
+pub vortex_error::VortexError::Arrow(arrow_schema::error::ArrowError, alloc::boxed::Box<std::backtrace::Backtrace>)
 
 pub vortex_error::VortexError::AssertionFailed(vortex_error::ErrString, alloc::boxed::Box<std::backtrace::Backtrace>)
 
-pub vortex_error::VortexError::ComputeError(vortex_error::ErrString, alloc::boxed::Box<std::backtrace::Backtrace>)
+pub vortex_error::VortexError::Compute(vortex_error::ErrString, alloc::boxed::Box<std::backtrace::Backtrace>)
 
 pub vortex_error::VortexError::Context(vortex_error::ErrString, alloc::boxed::Box<vortex_error::VortexError>)
 
-pub vortex_error::VortexError::FlatBuffersError(flatbuffers::verifier::InvalidFlatbuffer, alloc::boxed::Box<std::backtrace::Backtrace>)
+pub vortex_error::VortexError::External(alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>, alloc::boxed::Box<std::backtrace::Backtrace>)
 
-pub vortex_error::VortexError::FmtError(core::fmt::Error, alloc::boxed::Box<std::backtrace::Backtrace>)
+pub vortex_error::VortexError::FlatBuffers(flatbuffers::verifier::InvalidFlatbuffer, alloc::boxed::Box<std::backtrace::Backtrace>)
 
-pub vortex_error::VortexError::Generic(alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>, alloc::boxed::Box<std::backtrace::Backtrace>)
-
-pub vortex_error::VortexError::IOError(std::io::error::Error, alloc::boxed::Box<std::backtrace::Backtrace>)
+pub vortex_error::VortexError::Fmt(core::fmt::Error, alloc::boxed::Box<std::backtrace::Backtrace>)
 
 pub vortex_error::VortexError::InvalidArgument(vortex_error::ErrString, alloc::boxed::Box<std::backtrace::Backtrace>)
 
-pub vortex_error::VortexError::InvalidSerde(vortex_error::ErrString, alloc::boxed::Box<std::backtrace::Backtrace>)
+pub vortex_error::VortexError::Io(std::io::error::Error, alloc::boxed::Box<std::backtrace::Backtrace>)
 
-pub vortex_error::VortexError::InvalidState(vortex_error::ErrString, alloc::boxed::Box<std::backtrace::Backtrace>)
+pub vortex_error::VortexError::Jiff(jiff::error::Error, alloc::boxed::Box<std::backtrace::Backtrace>)
 
-pub vortex_error::VortexError::JiffError(jiff::error::Error, alloc::boxed::Box<std::backtrace::Backtrace>)
-
-pub vortex_error::VortexError::JoinError(tokio::runtime::task::error::JoinError, alloc::boxed::Box<std::backtrace::Backtrace>)
+pub vortex_error::VortexError::Join(tokio::runtime::task::error::JoinError, alloc::boxed::Box<std::backtrace::Backtrace>)
 
 pub vortex_error::VortexError::MismatchedTypes(vortex_error::ErrString, vortex_error::ErrString, alloc::boxed::Box<std::backtrace::Backtrace>)
 
@@ -44,21 +40,19 @@ pub vortex_error::VortexError::NotImplemented(vortex_error::ErrString, vortex_er
 
 pub vortex_error::VortexError::ObjectStore(object_store::Error, alloc::boxed::Box<std::backtrace::Backtrace>)
 
+pub vortex_error::VortexError::Other(vortex_error::ErrString, alloc::boxed::Box<std::backtrace::Backtrace>)
+
 pub vortex_error::VortexError::OutOfBounds(usize, usize, usize, alloc::boxed::Box<std::backtrace::Backtrace>)
 
 pub vortex_error::VortexError::Prost(alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>, alloc::boxed::Box<std::backtrace::Backtrace>)
+
+pub vortex_error::VortexError::Serde(vortex_error::ErrString, alloc::boxed::Box<std::backtrace::Backtrace>)
 
 pub vortex_error::VortexError::Shared(alloc::sync::Arc<vortex_error::VortexError>)
 
 pub vortex_error::VortexError::TryFromInt(core::num::error::TryFromIntError, alloc::boxed::Box<std::backtrace::Backtrace>)
 
-pub vortex_error::VortexError::TryFromSliceError(core::array::TryFromSliceError, alloc::boxed::Box<std::backtrace::Backtrace>)
-
-pub vortex_error::VortexError::UrlError(url::parser::ParseError, alloc::boxed::Box<std::backtrace::Backtrace>)
-
 impl vortex_error::VortexError
-
-pub fn vortex_error::VortexError::generic(err: alloc::boxed::Box<(dyn core::error::Error + core::marker::Send + core::marker::Sync + 'static)>) -> Self
 
 pub fn vortex_error::VortexError::with_context<T: core::convert::Into<vortex_error::ErrString>>(self, msg: T) -> Self
 
@@ -73,10 +67,6 @@ pub fn vortex_error::VortexError::from(value: alloc::sync::Arc<vortex_error::Vor
 impl core::convert::From<arrow_schema::error::ArrowError> for vortex_error::VortexError
 
 pub fn vortex_error::VortexError::from(value: arrow_schema::error::ArrowError) -> Self
-
-impl core::convert::From<core::array::TryFromSliceError> for vortex_error::VortexError
-
-pub fn vortex_error::VortexError::from(value: core::array::TryFromSliceError) -> Self
 
 impl core::convert::From<core::convert::Infallible> for vortex_error::VortexError
 
@@ -118,10 +108,6 @@ impl core::convert::From<tokio::runtime::task::error::JoinError> for vortex_erro
 
 pub fn vortex_error::VortexError::from(value: tokio::runtime::task::error::JoinError) -> Self
 
-impl core::convert::From<url::parser::ParseError> for vortex_error::VortexError
-
-pub fn vortex_error::VortexError::from(value: url::parser::ParseError) -> Self
-
 impl core::error::Error for vortex_error::VortexError
 
 pub fn vortex_error::VortexError::source(&self) -> core::option::Option<&(dyn core::error::Error + 'static)>
@@ -133,10 +119,6 @@ pub fn vortex_error::VortexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -
 impl core::fmt::Display for vortex_error::VortexError
 
 pub fn vortex_error::VortexError::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<T> core::convert::From<std::sync::poison::PoisonError<T>> for vortex_error::VortexError
-
-pub fn vortex_error::VortexError::from(_value: std::sync::poison::PoisonError<T>) -> Self
 
 pub struct vortex_error::ErrString(_)
 

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -7,6 +7,7 @@
 //! It also contains a variety of useful macros for error handling.
 
 use std::backtrace::Backtrace;
+use std::backtrace::BacktraceStatus;
 use std::borrow::Cow;
 use std::convert::Infallible;
 use std::env;
@@ -75,21 +76,24 @@ impl From<Infallible> for VortexError {
 const _: () = {
     assert!(size_of::<VortexError>() < 128);
 };
+
 /// The top-level error type for Vortex.
 #[non_exhaustive]
 pub enum VortexError {
-    /// A wrapped generic error
-    Generic(Box<dyn Error + Send + Sync + 'static>, Box<Backtrace>),
+    /// A catch-all error variant
+    Other(ErrString, Box<Backtrace>),
+    /// A wrapped external error
+    External(Box<dyn Error + Send + Sync + 'static>, Box<Backtrace>),
     /// An index is out of bounds.
     OutOfBounds(usize, usize, usize, Box<Backtrace>),
     /// An error occurred while executing a compute kernel.
-    ComputeError(ErrString, Box<Backtrace>),
+    Compute(ErrString, Box<Backtrace>),
     /// An invalid argument was provided.
     InvalidArgument(ErrString, Box<Backtrace>),
     /// The system has reached an invalid state,
     InvalidState(ErrString, Box<Backtrace>),
     /// An error occurred while serializing or deserializing.
-    InvalidSerde(ErrString, Box<Backtrace>),
+    Serde(ErrString, Box<Backtrace>),
     /// An unimplemented function was called.
     NotImplemented(ErrString, ErrString, Box<Backtrace>),
     /// A type mismatch occurred.
@@ -101,33 +105,31 @@ pub enum VortexError {
     /// A wrapper for shared errors that require cloning.
     Shared(Arc<VortexError>),
     /// A wrapper for errors from the Arrow library.
-    ArrowError(arrow_schema::ArrowError, Box<Backtrace>),
+    Arrow(arrow_schema::ArrowError, Box<Backtrace>),
     /// A wrapper for errors from the FlatBuffers library.
     #[cfg(feature = "flatbuffers")]
-    FlatBuffersError(flatbuffers::InvalidFlatbuffer, Box<Backtrace>),
+    FlatBuffers(flatbuffers::InvalidFlatbuffer, Box<Backtrace>),
     /// A wrapper for formatting errors.
-    FmtError(fmt::Error, Box<Backtrace>),
+    Fmt(fmt::Error, Box<Backtrace>),
     /// A wrapper for IO errors.
-    IOError(io::Error, Box<Backtrace>),
+    Io(io::Error, Box<Backtrace>),
     /// A wrapper for errors from the standard library when converting a slice to an array.
-    TryFromSliceError(std::array::TryFromSliceError, Box<Backtrace>),
+    TryFromSlice(std::array::TryFromSliceError, Box<Backtrace>),
     /// A wrapper for errors from the Object Store library.
     #[cfg(feature = "object_store")]
     ObjectStore(object_store::Error, Box<Backtrace>),
     /// A wrapper for errors from the Jiff library.
-    JiffError(jiff::Error, Box<Backtrace>),
+    Jiff(jiff::Error, Box<Backtrace>),
     /// A wrapper for Tokio join error.
     #[cfg(feature = "tokio")]
-    JoinError(tokio::task::JoinError, Box<Backtrace>),
-    /// A wrapper for URL parsing errors.
-    UrlError(url::ParseError, Box<Backtrace>),
+    Join(tokio::task::JoinError, Box<Backtrace>),
     /// Wrap errors for fallible integer casting.
     TryFromInt(TryFromIntError, Box<Backtrace>),
     /// Wrap protobuf-related errors
     Prost(Box<dyn Error + Send + Sync + 'static>, Box<Backtrace>),
     /// Wrap serde and serde json errors
     #[cfg(feature = "serde")]
-    SerdeJsonError(serde_json::Error, Box<Backtrace>),
+    SerdeJson(serde_json::Error, Box<Backtrace>),
 }
 
 impl VortexError {
@@ -136,126 +138,183 @@ impl VortexError {
         VortexError::Context(msg.into(), Box::new(self))
     }
 
-    /// Wrap an a generic error into a Vortex error
-    pub fn generic(err: Box<dyn Error + Send + Sync + 'static>) -> Self {
-        Self::Generic(err, Box::new(Backtrace::capture()))
+    /// Error prefix by variant
+    fn variant_prefix(&self) -> &'static str {
+        use VortexError::*;
+
+        match self {
+            Other(..) => "Other error: ",
+            External(..) => "External error: ",
+            OutOfBounds(..) => "Out of bounds error: ",
+            Compute(..) => "Compute error: ",
+            InvalidArgument(..) => "Invalid argument error: ",
+            InvalidState(..) => "Invalid state error: ",
+            Serde(..) => "Serde error: ",
+            NotImplemented(..) => "Not implemented error: ",
+            MismatchedTypes(..) => "Mismatched types error: ",
+            AssertionFailed(..) => "Assertion failed error: ",
+            Context(..) | Shared(..) => "", // basically delegate to the underlying one
+            Arrow(..) => "Arrow error: ",
+            #[cfg(feature = "flatbuffers")]
+            FlatBuffers(..) => "Flat buffers error: ",
+            Fmt(..) => "Fmt: ",
+            Io(..) => "Io: ",
+            TryFromSlice(..) => "Try from slice error: ",
+            #[cfg(feature = "object_store")]
+            ObjectStore(..) => "Object store error: ",
+            Jiff(..) => "Jiff error: ",
+            #[cfg(feature = "tokio")]
+            Join(..) => "Tokio join error:",
+            TryFromInt(..) => "Try from int error:",
+            Prost(..) => "Prost error:",
+            #[cfg(feature = "serde")]
+            SerdeJson(..) => "JSON serde error:",
+        }
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        use VortexError::*;
+
+        match self {
+            Other(.., bt) => Some(bt.as_ref()),
+            External(.., bt) => Some(bt.as_ref()),
+            OutOfBounds(.., bt) => Some(bt.as_ref()),
+            Compute(.., bt) => Some(bt.as_ref()),
+            InvalidArgument(.., bt) => Some(bt.as_ref()),
+            InvalidState(.., bt) => Some(bt.as_ref()),
+            Serde(.., bt) => Some(bt.as_ref()),
+            NotImplemented(.., bt) => Some(bt.as_ref()),
+            MismatchedTypes(.., bt) => Some(bt.as_ref()),
+            AssertionFailed(.., bt) => Some(bt.as_ref()),
+            Arrow(.., bt) => Some(bt.as_ref()),
+            #[cfg(feature = "flatbuffers")]
+            FlatBuffers(.., bt) => Some(bt.as_ref()),
+            Fmt(.., bt) => Some(bt.as_ref()),
+            Io(.., bt) => Some(bt.as_ref()),
+            TryFromSlice(.., bt) => Some(bt.as_ref()),
+            #[cfg(feature = "object_store")]
+            ObjectStore(.., bt) => Some(bt.as_ref()),
+            Jiff(.., bt) => Some(bt.as_ref()),
+            #[cfg(feature = "tokio")]
+            Join(.., bt) => Some(bt.as_ref()),
+            TryFromInt(.., bt) => Some(bt.as_ref()),
+            Prost(.., bt) => Some(bt.as_ref()),
+            #[cfg(feature = "serde")]
+            SerdeJson(.., bt) => Some(bt.as_ref()),
+            Context(_, inner) => inner.backtrace(),
+            Shared(inner) => inner.backtrace(),
+        }
+    }
+
+    fn message(&self) -> String {
+        use VortexError::*;
+
+        match self {
+            Other(msg, _) => msg.to_string(),
+            External(err, _) => err.to_string(),
+            OutOfBounds(idx, start, stop, _) => {
+                format!("index {idx} out of bounds from {start} to {stop}")
+            }
+            Compute(msg, _)
+            | InvalidArgument(msg, _)
+            | InvalidState(msg, _)
+            | Serde(msg, _)
+            | AssertionFailed(msg, _) => {
+                format!("{msg}")
+            }
+            NotImplemented(func, by_whom, _) => {
+                format!("function {func} not implemented for {by_whom}")
+            }
+            MismatchedTypes(expected, actual, _) => {
+                format!("expected type: {expected} but instead got {actual}")
+            }
+            Context(msg, inner) => {
+                format!("{msg}:\n  {inner}")
+            }
+            Shared(inner) => inner.message(),
+            Arrow(err, _) => {
+                format!("{err}")
+            }
+            #[cfg(feature = "flatbuffers")]
+            FlatBuffers(err, _) => {
+                format!("{err}")
+            }
+            Fmt(err, _) => {
+                format!("{err}")
+            }
+            Io(err, _) => {
+                format!("{err}")
+            }
+            TryFromSlice(err, _) => {
+                format!("{err}")
+            }
+            #[cfg(feature = "object_store")]
+            ObjectStore(err, _) => {
+                format!("{err}")
+            }
+            Jiff(err, _) => {
+                format!("{err}")
+            }
+            #[cfg(feature = "tokio")]
+            Join(err, _) => {
+                format!("{err}")
+            }
+            TryFromInt(err, _) => {
+                format!("{err}")
+            }
+            #[cfg(feature = "serde")]
+            SerdeJson(err, _) => {
+                format!("{err}")
+            }
+            Prost(err, _) => {
+                format!("{err}")
+            }
+        }
     }
 }
 
 impl Display for VortexError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            VortexError::Generic(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::OutOfBounds(idx, start, stop, backtrace) => {
-                write!(
-                    f,
-                    "index {idx} out of bounds from {start} to {stop}\nBacktrace:\n{backtrace}",
-                )
-            }
-            VortexError::ComputeError(msg, backtrace) => {
-                write!(f, "{msg}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::InvalidArgument(msg, backtrace) => {
-                write!(f, "{msg}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::InvalidState(msg, backtrace) => {
-                write!(f, "{msg}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::InvalidSerde(msg, backtrace) => {
-                write!(f, "{msg}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::NotImplemented(func, by_whom, backtrace) => {
-                write!(
-                    f,
-                    "function {func} not implemented for {by_whom}\nBacktrace:\n{backtrace}",
-                )
-            }
-            VortexError::MismatchedTypes(expected, actual, backtrace) => {
-                write!(
-                    f,
-                    "expected type: {expected} but instead got {actual}\nBacktrace:\n{backtrace}",
-                )
-            }
-            VortexError::AssertionFailed(msg, backtrace) => {
-                write!(f, "{msg}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::Context(msg, inner) => {
-                write!(f, "{msg}:\n  {inner}")
-            }
-            VortexError::Shared(inner) => Display::fmt(inner, f),
-            VortexError::ArrowError(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            #[cfg(feature = "flatbuffers")]
-            VortexError::FlatBuffersError(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::FmtError(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::IOError(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::TryFromSliceError(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            #[cfg(feature = "object_store")]
-            VortexError::ObjectStore(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::JiffError(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            #[cfg(feature = "tokio")]
-            VortexError::JoinError(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::UrlError(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::TryFromInt(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            #[cfg(feature = "serde")]
-            VortexError::SerdeJsonError(err, backtrace) => {
-                write!(f, "{err}\nBacktrace:\n{backtrace}")
-            }
-            VortexError::Prost(err, backtrace) => {
-                write!(f, "Protobuf error: {err}\nBacktrace:\n{backtrace}")
-            }
+        write!(f, "{}", self.variant_prefix())?;
+        write!(f, "{}", self.message())?;
+        if let Some(backtrace) = self.backtrace()
+            && backtrace.status() == BacktraceStatus::Captured
+        {
+            write!(f, "\nBacktrace:\n{backtrace}")?;
         }
-    }
-}
 
-impl Error for VortexError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            VortexError::Generic(err, _) => Some(err.as_ref()),
-            VortexError::Context(_, inner) => inner.source(),
-            VortexError::Shared(inner) => inner.source(),
-            VortexError::ArrowError(err, _) => Some(err),
-            #[cfg(feature = "flatbuffers")]
-            VortexError::FlatBuffersError(err, _) => Some(err),
-            VortexError::IOError(err, _) => Some(err),
-            #[cfg(feature = "object_store")]
-            VortexError::ObjectStore(err, _) => Some(err),
-            VortexError::JiffError(err, _) => Some(err),
-            #[cfg(feature = "tokio")]
-            VortexError::JoinError(err, _) => Some(err),
-            VortexError::UrlError(err, _) => Some(err),
-            #[cfg(feature = "serde")]
-            VortexError::SerdeJsonError(err, _) => Some(err),
-            VortexError::Prost(err, _) => Some(err.as_ref()),
-            _ => None,
-        }
+        Ok(())
     }
 }
 
 impl Debug for VortexError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        Display::fmt(self, f)
+        write!(f, "{self}")
+    }
+}
+
+impl Error for VortexError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        use VortexError::*;
+
+        match self {
+            External(err, _) => Some(err.as_ref()),
+            Context(_, inner) => inner.source(),
+            Shared(inner) => inner.source(),
+            Arrow(err, _) => Some(err),
+            #[cfg(feature = "flatbuffers")]
+            FlatBuffers(err, _) => Some(err),
+            Io(err, _) => Some(err),
+            #[cfg(feature = "object_store")]
+            ObjectStore(err, _) => Some(err),
+            Jiff(err, _) => Some(err),
+            #[cfg(feature = "tokio")]
+            Join(err, _) => Some(err),
+            #[cfg(feature = "serde")]
+            SerdeJson(err, _) => Some(err),
+            Prost(err, _) => Some(err.as_ref()),
+            _ => None,
+        }
     }
 }
 
@@ -329,6 +388,13 @@ impl<T> VortexExpect for Option<T> {
 /// A convenient macro for creating a VortexError.
 #[macro_export]
 macro_rules! vortex_err {
+    (Other: $($tts:tt)*) => {{
+        use std::backtrace::Backtrace;
+        let err_string = format!($($tts)*);
+        $crate::__private::must_use(
+            $crate::VortexError::Other(err_string.into(), Box::new(Backtrace::capture()))
+        )
+    }};
     (AssertionFailed: $($tts:tt)*) => {{
         use std::backtrace::Backtrace;
         let err_string = format!($($tts)*);
@@ -371,6 +437,12 @@ macro_rules! vortex_err {
             $crate::VortexError::Context($msg.into(), Box::new($err))
         )
     }};
+    (External: $err:expr) => {{
+        use std::backtrace::Backtrace;
+        $crate::__private::must_use(
+            $crate::VortexError::External($err.into(), Box::new(Backtrace::capture()))
+        )
+    }};
     ($variant:ident: $fmt:literal $(, $arg:expr)* $(,)?) => {{
         use std::backtrace::Backtrace;
         $crate::__private::must_use(
@@ -383,11 +455,11 @@ macro_rules! vortex_err {
         )
     };
     ($fmt:literal $(, $arg:expr)* $(,)?) => {
-        $crate::vortex_err!(InvalidArgument: $fmt, $($arg),*)
+        $crate::vortex_err!(Other: $fmt, $($arg),*)
     };
 }
 
-/// A convenient macro for returning a VortexError.
+/// A convenience macro for returning a VortexError.
 #[macro_export]
 macro_rules! vortex_bail {
     ($($tt:tt)+) => {
@@ -460,26 +532,26 @@ macro_rules! vortex_panic {
 
 impl From<arrow_schema::ArrowError> for VortexError {
     fn from(value: arrow_schema::ArrowError) -> Self {
-        VortexError::ArrowError(value, Box::new(Backtrace::capture()))
+        VortexError::Arrow(value, Box::new(Backtrace::capture()))
     }
 }
 
 #[cfg(feature = "flatbuffers")]
 impl From<flatbuffers::InvalidFlatbuffer> for VortexError {
     fn from(value: flatbuffers::InvalidFlatbuffer) -> Self {
-        VortexError::FlatBuffersError(value, Box::new(Backtrace::capture()))
+        VortexError::FlatBuffers(value, Box::new(Backtrace::capture()))
     }
 }
 
 impl From<io::Error> for VortexError {
     fn from(value: io::Error) -> Self {
-        VortexError::IOError(value, Box::new(Backtrace::capture()))
+        VortexError::Io(value, Box::new(Backtrace::capture()))
     }
 }
 
 impl From<std::array::TryFromSliceError> for VortexError {
     fn from(value: std::array::TryFromSliceError) -> Self {
-        VortexError::TryFromSliceError(value, Box::new(Backtrace::capture()))
+        VortexError::TryFromSlice(value, Box::new(Backtrace::capture()))
     }
 }
 
@@ -492,7 +564,7 @@ impl From<object_store::Error> for VortexError {
 
 impl From<jiff::Error> for VortexError {
     fn from(value: jiff::Error) -> Self {
-        VortexError::JiffError(value, Box::new(Backtrace::capture()))
+        VortexError::Jiff(value, Box::new(Backtrace::capture()))
     }
 }
 
@@ -502,14 +574,8 @@ impl From<tokio::task::JoinError> for VortexError {
         if value.is_panic() {
             std::panic::resume_unwind(value.into_panic())
         } else {
-            VortexError::JoinError(value, Box::new(Backtrace::capture()))
+            VortexError::Join(value, Box::new(Backtrace::capture()))
         }
-    }
-}
-
-impl From<url::ParseError> for VortexError {
-    fn from(value: url::ParseError) -> Self {
-        VortexError::UrlError(value, Box::new(Backtrace::capture()))
     }
 }
 
@@ -522,7 +588,7 @@ impl From<TryFromIntError> for VortexError {
 #[cfg(feature = "serde")]
 impl From<serde_json::Error> for VortexError {
     fn from(value: serde_json::Error) -> Self {
-        VortexError::SerdeJsonError(value, Box::new(Backtrace::capture()))
+        VortexError::SerdeJson(value, Box::new(Backtrace::capture()))
     }
 }
 

--- a/vortex-error/src/lib.rs
+++ b/vortex-error/src/lib.rs
@@ -20,7 +20,6 @@ use std::io;
 use std::num::TryFromIntError;
 use std::ops::Deref;
 use std::sync::Arc;
-use std::sync::PoisonError;
 
 /// A string that can be used as an error message.
 #[derive(Debug)]
@@ -90,8 +89,6 @@ pub enum VortexError {
     Compute(ErrString, Box<Backtrace>),
     /// An invalid argument was provided.
     InvalidArgument(ErrString, Box<Backtrace>),
-    /// The system has reached an invalid state,
-    InvalidState(ErrString, Box<Backtrace>),
     /// An error occurred while serializing or deserializing.
     Serde(ErrString, Box<Backtrace>),
     /// An unimplemented function was called.
@@ -113,8 +110,6 @@ pub enum VortexError {
     Fmt(fmt::Error, Box<Backtrace>),
     /// A wrapper for IO errors.
     Io(io::Error, Box<Backtrace>),
-    /// A wrapper for errors from the standard library when converting a slice to an array.
-    TryFromSlice(std::array::TryFromSliceError, Box<Backtrace>),
     /// A wrapper for errors from the Object Store library.
     #[cfg(feature = "object_store")]
     ObjectStore(object_store::Error, Box<Backtrace>),
@@ -127,9 +122,6 @@ pub enum VortexError {
     TryFromInt(TryFromIntError, Box<Backtrace>),
     /// Wrap protobuf-related errors
     Prost(Box<dyn Error + Send + Sync + 'static>, Box<Backtrace>),
-    /// Wrap serde and serde json errors
-    #[cfg(feature = "serde")]
-    SerdeJson(serde_json::Error, Box<Backtrace>),
 }
 
 impl VortexError {
@@ -148,7 +140,6 @@ impl VortexError {
             OutOfBounds(..) => "Out of bounds error: ",
             Compute(..) => "Compute error: ",
             InvalidArgument(..) => "Invalid argument error: ",
-            InvalidState(..) => "Invalid state error: ",
             Serde(..) => "Serde error: ",
             NotImplemented(..) => "Not implemented error: ",
             MismatchedTypes(..) => "Mismatched types error: ",
@@ -159,7 +150,6 @@ impl VortexError {
             FlatBuffers(..) => "Flat buffers error: ",
             Fmt(..) => "Fmt: ",
             Io(..) => "Io: ",
-            TryFromSlice(..) => "Try from slice error: ",
             #[cfg(feature = "object_store")]
             ObjectStore(..) => "Object store error: ",
             Jiff(..) => "Jiff error: ",
@@ -167,8 +157,6 @@ impl VortexError {
             Join(..) => "Tokio join error:",
             TryFromInt(..) => "Try from int error:",
             Prost(..) => "Prost error:",
-            #[cfg(feature = "serde")]
-            SerdeJson(..) => "JSON serde error:",
         }
     }
 
@@ -181,7 +169,6 @@ impl VortexError {
             OutOfBounds(.., bt) => Some(bt.as_ref()),
             Compute(.., bt) => Some(bt.as_ref()),
             InvalidArgument(.., bt) => Some(bt.as_ref()),
-            InvalidState(.., bt) => Some(bt.as_ref()),
             Serde(.., bt) => Some(bt.as_ref()),
             NotImplemented(.., bt) => Some(bt.as_ref()),
             MismatchedTypes(.., bt) => Some(bt.as_ref()),
@@ -191,7 +178,6 @@ impl VortexError {
             FlatBuffers(.., bt) => Some(bt.as_ref()),
             Fmt(.., bt) => Some(bt.as_ref()),
             Io(.., bt) => Some(bt.as_ref()),
-            TryFromSlice(.., bt) => Some(bt.as_ref()),
             #[cfg(feature = "object_store")]
             ObjectStore(.., bt) => Some(bt.as_ref()),
             Jiff(.., bt) => Some(bt.as_ref()),
@@ -199,8 +185,6 @@ impl VortexError {
             Join(.., bt) => Some(bt.as_ref()),
             TryFromInt(.., bt) => Some(bt.as_ref()),
             Prost(.., bt) => Some(bt.as_ref()),
-            #[cfg(feature = "serde")]
-            SerdeJson(.., bt) => Some(bt.as_ref()),
             Context(_, inner) => inner.backtrace(),
             Shared(inner) => inner.backtrace(),
         }
@@ -215,11 +199,7 @@ impl VortexError {
             OutOfBounds(idx, start, stop, _) => {
                 format!("index {idx} out of bounds from {start} to {stop}")
             }
-            Compute(msg, _)
-            | InvalidArgument(msg, _)
-            | InvalidState(msg, _)
-            | Serde(msg, _)
-            | AssertionFailed(msg, _) => {
+            Compute(msg, _) | InvalidArgument(msg, _) | Serde(msg, _) | AssertionFailed(msg, _) => {
                 format!("{msg}")
             }
             NotImplemented(func, by_whom, _) => {
@@ -245,9 +225,6 @@ impl VortexError {
             Io(err, _) => {
                 format!("{err}")
             }
-            TryFromSlice(err, _) => {
-                format!("{err}")
-            }
             #[cfg(feature = "object_store")]
             ObjectStore(err, _) => {
                 format!("{err}")
@@ -260,10 +237,6 @@ impl VortexError {
                 format!("{err}")
             }
             TryFromInt(err, _) => {
-                format!("{err}")
-            }
-            #[cfg(feature = "serde")]
-            SerdeJson(err, _) => {
                 format!("{err}")
             }
             Prost(err, _) => {
@@ -310,8 +283,6 @@ impl Error for VortexError {
             Jiff(err, _) => Some(err),
             #[cfg(feature = "tokio")]
             Join(err, _) => Some(err),
-            #[cfg(feature = "serde")]
-            SerdeJson(err, _) => Some(err),
             Prost(err, _) => Some(err.as_ref()),
             _ => None,
         }
@@ -549,12 +520,6 @@ impl From<io::Error> for VortexError {
     }
 }
 
-impl From<std::array::TryFromSliceError> for VortexError {
-    fn from(value: std::array::TryFromSliceError) -> Self {
-        VortexError::TryFromSlice(value, Box::new(Backtrace::capture()))
-    }
-}
-
 #[cfg(feature = "object_store")]
 impl From<object_store::Error> for VortexError {
     fn from(value: object_store::Error) -> Self {
@@ -585,13 +550,6 @@ impl From<TryFromIntError> for VortexError {
     }
 }
 
-#[cfg(feature = "serde")]
-impl From<serde_json::Error> for VortexError {
-    fn from(value: serde_json::Error) -> Self {
-        VortexError::SerdeJson(value, Box::new(Backtrace::capture()))
-    }
-}
-
 impl From<prost::EncodeError> for VortexError {
     fn from(value: prost::EncodeError) -> Self {
         Self::Prost(Box::new(value), Box::new(Backtrace::capture()))
@@ -619,12 +577,5 @@ pub mod __private {
     #[must_use]
     pub const fn must_use(error: crate::VortexError) -> crate::VortexError {
         error
-    }
-}
-
-impl<T> From<PoisonError<T>> for VortexError {
-    fn from(_value: PoisonError<T>) -> Self {
-        // We don't include the value since it may be sensitive.
-        Self::InvalidState("Lock poisoned".into(), Box::new(Backtrace::capture()))
     }
 }

--- a/vortex-error/tests/fmt.rs
+++ b/vortex-error/tests/fmt.rs
@@ -18,15 +18,17 @@ fn test_basic_display() {
 
         assert!(
             display.contains("Other error: this is bad"),
-            "should contain error message. Instead got: {display}"
+            "should contain error message"
         );
         assert!(
             display.contains("Backtrace:"),
-            "should contain backtrace header. Instead got: {display}."
+            "should contain backtrace header"
         );
+
+        #[cfg(not(windows))] // for some reason, the windows backtrace is different
         assert!(
             display.contains("test_basic_display"),
-            "backtrace should include test function. Instead got: {display}."
+            "backtrace should include test function"
         );
     });
 }

--- a/vortex-error/tests/fmt.rs
+++ b/vortex-error/tests/fmt.rs
@@ -18,15 +18,15 @@ fn test_basic_display() {
 
         assert!(
             display.contains("Other error: this is bad"),
-            "should contain error message"
+            "should contain error message. Instead got: {display}"
         );
         assert!(
             display.contains("Backtrace:"),
-            "should contain backtrace header"
+            "should contain backtrace header. Instead got: {display}."
         );
         assert!(
             display.contains("test_basic_display"),
-            "backtrace should include test function"
+            "backtrace should include test function. Instead got: {display}."
         );
     });
 }

--- a/vortex-error/tests/fmt.rs
+++ b/vortex-error/tests/fmt.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+// This seems to be a bug in the lint - https://github.com/rust-lang/rust-clippy/issues/11024
+#![allow(clippy::tests_outside_test_module)]
+
+use serial_test::serial;
+use vortex_error::VortexError;
+use vortex_error::vortex_err;
+
+#[test]
+#[serial]
+fn test_basic_display() {
+    temp_env::with_var("RUST_BACKTRACE", Some("1"), || {
+        let err = vortex_err!("this is bad");
+        let display = err.to_string();
+
+        assert!(
+            display.contains("Other error: this is bad"),
+            "should contain error message"
+        );
+        assert!(
+            display.contains("Backtrace:"),
+            "should contain backtrace header"
+        );
+        assert!(
+            display.contains("test_basic_display"),
+            "backtrace should include test function"
+        );
+    });
+}
+
+#[test]
+#[serial]
+fn test_from_arrow_with_backtrace() {
+    temp_env::with_var("RUST_BACKTRACE", Some("1"), || {
+        let arrow_error = arrow_schema::ArrowError::NotYetImplemented(
+            "This feature isn't implemented yet".to_string(),
+        );
+
+        let vx_error = VortexError::from(arrow_error);
+        let display = vx_error.to_string();
+
+        assert!(
+            display
+                .contains("Arrow error: Not yet implemented: This feature isn't implemented yet"),
+            "should contain arrow error message"
+        );
+        assert!(
+            display.contains("Backtrace:"),
+            "should contain backtrace header"
+        );
+    });
+}
+
+#[test]
+#[serial]
+fn test_from_arrow_no_backtrace() {
+    // Detect a nextest run, because `Backtrace::capture` caches whether backtraces are enabled
+    // and `cargo test` runs tests in the same process, while nextest uses separate processes.
+    if std::env::var("NEXTEST_RUN_ID").is_ok() {
+        temp_env::with_var("RUST_BACKTRACE", Some("0"), || {
+            let arrow_error = arrow_schema::ArrowError::NotYetImplemented(
+                "This feature isn't implemented yet".to_string(),
+            );
+
+            let vx_error = VortexError::from(arrow_error);
+            let display = vx_error.to_string();
+
+            assert!(
+                display.contains(
+                    "Arrow error: Not yet implemented: This feature isn't implemented yet"
+                ),
+                "should contain arrow error message"
+            );
+            assert!(
+                !display.contains("Backtrace:"),
+                "should not contain backtrace when RUST_BACKTRACE=0"
+            );
+        });
+    }
+}

--- a/vortex-error/tests/fmt.rs
+++ b/vortex-error/tests/fmt.rs
@@ -10,6 +10,7 @@ use vortex_error::vortex_err;
 
 #[test]
 #[serial]
+#[inline(never)]
 fn test_basic_display() {
     temp_env::with_var("RUST_BACKTRACE", Some("1"), || {
         let err = vortex_err!("this is bad");

--- a/vortex-jni/src/file.rs
+++ b/vortex-jni/src/file.rs
@@ -159,7 +159,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeFileMethods_delete<'local>(
         }
 
         // Pick the first URL to use for building the client
-        let store_url = Url::parse(&delete_uris[0]).map_err(VortexError::from)?;
+        let store_url = Url::parse(&delete_uris[0]).map_err(|e| vortex_err!(External: e))?;
 
         let mut properties: HashMap<String, String> = HashMap::new();
 
@@ -178,7 +178,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeFileMethods_delete<'local>(
         let (store, _) = make_object_store(&store_url, &properties)?;
 
         for uri in delete_uris {
-            let url = Url::parse(&uri).map_err(VortexError::from)?;
+            let url = Url::parse(&uri).map_err(|e| vortex_err!(External: e))?;
             // TODO(aduffy): block on all of them
             TOKIO_RUNTIME
                 .block_on(

--- a/vortex-tui/src/convert.rs
+++ b/vortex-tui/src/convert.rs
@@ -17,8 +17,8 @@ use vortex::array::arrow::FromArrowArray;
 use vortex::array::stream::ArrayStreamAdapter;
 use vortex::dtype::DType;
 use vortex::dtype::arrow::FromArrowType;
-use vortex::error::VortexError;
 use vortex::error::VortexExpect;
+use vortex::error::vortex_err;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::file::WriteStrategyBuilder;
 use vortex::session::VortexSession;
@@ -78,7 +78,7 @@ pub async fn exec_convert(session: &VortexSession, flags: ConvertArgs) -> anyhow
         .build()?
         .map(|record_batch| {
             record_batch
-                .map_err(|e| VortexError::generic(e.into()))
+                .map_err(|e| vortex_err!(External: e))
                 .and_then(|rb| ArrayRef::from_arrow(rb, false))
         })
         .boxed();

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -83,7 +83,6 @@ serde = [
     "vortex-dtype/serde",
     "vortex-buffer/serde",
     "vortex-mask/serde",
-    "vortex-error/serde",
 ]
 # This feature enabled unstable encodings for which we don't guarantee stability.
 unstable_encodings = [


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

This is a long running low burning effort to improve errors.

## What changes are included in this PR?

1. Removes `VortexError::Url`, VortexError::SerdeJson and VortexError::Invalid state - they are all not used.
2. Removes `VortexError::try_from_slice` - this is an invariant and we always panic, no reason to treat it as a useful error.
3. When backtraces are disabled, we don't print them.
4. Splits the `Generic` error variant into `External` and `Other`, where `External` is meant to wrap external errors, and `Other` is for any error that doesn't match an existing variant. `Other` is now also the default of `vortex_err` and `vortex_bail`. They are used widely and often have very different meaning, I think its better to convey vague intent than the wrong one. 
5. I've also split out the individual components of the error `Display` form to make it clearer what gets printed and how its constructed.

## What is the rationale for this change?

Error display is a bit more compact when downstream users don't enable backtraces, and I believe this makes maintaining `vortex-error` a bit easier.

## How is this change tested?

In addition to existing tests that verify the result type, I've added a few tests that 

## Are there any user-facing changes?

One less variant, and `vortex_err` and `vortex_bail` return a different type.