### PR TITLE
fix(datafusion): nested struct field access in expression conversion

### DIFF
--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -113,26 +113,30 @@ impl DefaultExpressionConvertor {
     fn try_convert_scalar_function(&self, scalar_fn: &ScalarFunctionExpr) -> DFResult<Expression> {
         if let Some(get_field_fn) = ScalarFunctionExpr::try_downcast_func::<GetFieldFunc>(scalar_fn)
         {
-            let source_expr = get_field_fn
+            // DataFusion's GetFieldFunc flattens nested field access into a single call
+            // with multiple field name arguments. For example, `outer.inner.leaf` becomes
+            // get_field(Column("outer"), "inner", "leaf"). We build a chain of get_item
+            // calls for each field name in the path.
+            let (source_expr, field_names) = get_field_fn
                 .args()
-                .first()
-                .ok_or_else(|| exec_datafusion_err!("get_field missing source expression"))?
-                .as_ref();
-            let field_name_expr = get_field_fn
-                .args()
-                .get(1)
-                .ok_or_else(|| exec_datafusion_err!("get_field missing field name argument"))?;
-            let field_name = field_name_expr
-                .as_any()
-                .downcast_ref::<df_expr::Literal>()
-                .ok_or_else(|| exec_datafusion_err!("get_field field name must be a literal"))?
-                .value()
-                .try_as_str()
-                .flatten()
-                .ok_or_else(|| {
-                    exec_datafusion_err!("get_field field name must be a UTF-8 string")
-                })?;
-            return Ok(get_item(field_name.to_string(), self.convert(source_expr)?));
+                .split_first()
+                .ok_or_else(|| exec_datafusion_err!("get_field missing source expression"))?;
+
+            let mut result = self.convert(source_expr.as_ref())?;
+            for expr in field_names {
+                let field_name = expr
+                    .as_any()
+                    .downcast_ref::<df_expr::Literal>()
+                    .ok_or_else(|| exec_datafusion_err!("get_field field name must be a literal"))?
+                    .value()
+                    .try_as_str()
+                    .flatten()
+                    .ok_or_else(|| {
+                        exec_datafusion_err!("get_field field name must be a UTF-8 string")
+                    })?;
+                result = get_item(field_name.to_string(), result);
+            }
+            return Ok(result);
         }
 
         Err(exec_datafusion_err!(

--- a/vortex-datafusion/src/tests/mod.rs
+++ b/vortex-datafusion/src/tests/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+mod nested_projection;
 mod schema_evolution;

--- a/vortex-datafusion/src/tests/nested_projection.rs
+++ b/vortex-datafusion/src/tests/nested_projection.rs
@@ -58,8 +58,7 @@ async fn test_nested_struct_leaf_projection(
     let ctx = TestSessionContext::new(projection_pushdown);
 
     let batch = make_nested_batch();
-    ctx.write_arrow_batch("files/nested.vortex", &batch)
-        .await?;
+    ctx.write_arrow_batch("files/nested.vortex", &batch).await?;
 
     let schema = batch.schema();
     let provider = ctx
@@ -101,8 +100,7 @@ async fn test_nested_struct_mid_level_projection(
     let ctx = TestSessionContext::new(projection_pushdown);
 
     let batch = make_nested_batch();
-    ctx.write_arrow_batch("files/nested.vortex", &batch)
-        .await?;
+    ctx.write_arrow_batch("files/nested.vortex", &batch).await?;
 
     let schema = batch.schema();
     let provider = ctx

--- a/vortex-datafusion/src/tests/nested_projection.rs
+++ b/vortex-datafusion/src/tests/nested_projection.rs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Test that projection pushdown works correctly with deeply nested structs.
+
+use std::sync::Arc;
+
+use arrow_schema::DataType;
+use arrow_schema::Field;
+use datafusion::arrow::array::ArrayRef as ArrowArrayRef;
+use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::array::StructArray;
+use datafusion_common::assert_batches_eq;
+use datafusion_common::create_array;
+use datafusion_expr::col;
+use datafusion_functions::expr_fn::get_field;
+use rstest::rstest;
+
+use crate::common_tests::TestSessionContext;
+
+/// Schema: {id: Int64, outer: {inner: {leaf: Utf8, value: Int64}, extra: Int64}}
+fn make_nested_batch() -> RecordBatch {
+    let leaf_array: ArrowArrayRef = create_array!(Utf8, vec![Some("a"), Some("b"), Some("c")]);
+    let value_array: ArrowArrayRef = create_array!(Int64, vec![10i64, 20, 30]);
+
+    let inner_struct: ArrowArrayRef = Arc::new(StructArray::new(
+        vec![
+            Field::new("leaf", DataType::Utf8, true),
+            Field::new("value", DataType::Int64, true),
+        ]
+        .into(),
+        vec![leaf_array, value_array],
+        None,
+    ));
+
+    let extra_array: ArrowArrayRef = create_array!(Int64, vec![100i64, 200, 300]);
+
+    let outer_struct: ArrowArrayRef = Arc::new(StructArray::new(
+        vec![
+            Field::new("inner", inner_struct.data_type().clone(), true),
+            Field::new("extra", DataType::Int64, true),
+        ]
+        .into(),
+        vec![inner_struct, extra_array],
+        None,
+    ));
+
+    let id_array: ArrowArrayRef = create_array!(Int64, vec![1i64, 2, 3]);
+    RecordBatch::try_from_iter(vec![("id", id_array), ("outer", outer_struct)]).unwrap()
+}
+
+/// Test projecting a leaf field from a deeply nested struct (root.outer.inner.leaf).
+#[rstest]
+#[tokio::test]
+async fn test_nested_struct_leaf_projection(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
+
+    let batch = make_nested_batch();
+    ctx.write_arrow_batch("files/nested.vortex", &batch)
+        .await?;
+
+    let schema = batch.schema();
+    let provider = ctx
+        .table_provider("nested_tbl", "/files/", schema.as_ref().clone())
+        .await?;
+
+    let table = ctx.session.read_table(provider)?;
+
+    let result = table
+        .select(vec![
+            col("id"),
+            get_field(get_field(col("outer"), "inner"), "leaf").alias("leaf"),
+        ])?
+        .collect()
+        .await?;
+
+    assert_batches_eq!(
+        [
+            "+----+------+",
+            "| id | leaf |",
+            "+----+------+",
+            "| 1  | a    |",
+            "| 2  | b    |",
+            "| 3  | c    |",
+            "+----+------+",
+        ],
+        &result
+    );
+
+    Ok(())
+}
+
+/// Test projecting a mid-level struct from a nested struct (root.outer.inner).
+#[rstest]
+#[tokio::test]
+async fn test_nested_struct_mid_level_projection(
+    #[values(false, true)] projection_pushdown: bool,
+) -> anyhow::Result<()> {
+    let ctx = TestSessionContext::new(projection_pushdown);
+
+    let batch = make_nested_batch();
+    ctx.write_arrow_batch("files/nested.vortex", &batch)
+        .await?;
+
+    let schema = batch.schema();
+    let provider = ctx
+        .table_provider("nested_tbl", "/files/", schema.as_ref().clone())
+        .await?;
+
+    let table = ctx.session.read_table(provider)?;
+
+    let result = table
+        .select(vec![
+            col("id"),
+            get_field(col("outer"), "inner").alias("inner"),
+        ])?
+        .collect()
+        .await?;
+
+    assert_batches_eq!(
+        [
+            "+----+----------------------+",
+            "| id | inner                |",
+            "+----+----------------------+",
+            "| 1  | {leaf: a, value: 10} |",
+            "| 2  | {leaf: b, value: 20} |",
+            "| 3  | {leaf: c, value: 30} |",
+            "+----+----------------------+",
+        ],
+        &result
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

- Closes #6415

## What changes are included in this PR?



DataFusion's GetFieldFunc flattens nested field access (e.g., `outer.inner.leaf`) into a single call with multiple field name arguments. Previously only a single field name was handled in `vortex-datafusion/src/convert/exprs.rs`, causing failures on deeply nested structs. Now we iterate over all field names to build the correct chain of get_item calls.

## How is this change tested?

Adds nested struct tests in `vortex-datafusion/src/tests/nested_projection.rs`, validated with TDD.

## Are there any user-facing changes?

`projection_pushdown: true` works more correctly
