### PR TITLE
register zstd buffers if enabled

### DIFF
--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -182,6 +182,11 @@ pub fn register_default_encodings(session: &mut VortexSession) {
         arrays.register(ZigZagVTable::ID, ZigZagVTable);
         #[cfg(feature = "zstd")]
         arrays.register(vortex_zstd::ZstdVTable::ID, vortex_zstd::ZstdVTable);
+        #[cfg(all(feature = "zstd", feature = "unstable_encodings"))]
+        arrays.register(
+            vortex_zstd::ZstdBuffersVTable::ID,
+            vortex_zstd::ZstdBuffersVTable,
+        );
     }
 
     // Eventually all encodings crates should expose an initialize function. For now it's only

--- a/vortex-test/e2e/Cargo.toml
+++ b/vortex-test/e2e/Cargo.toml
@@ -15,6 +15,9 @@ version = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+unstable_encodings = ["vortex/unstable_encodings"]
+
 [dependencies]
 futures = { workspace = true }
 rstest = { workspace = true }

--- a/vortex-test/e2e/src/lib.rs
+++ b/vortex-test/e2e/src/lib.rs
@@ -25,6 +25,9 @@ mod tests {
             PrimitiveArray::new(Buffer::from_iter(values), Validity::NonNullable).into_array();
 
         // Write in parallel and verify all sizes match expected
+        #[cfg(feature = "unstable_encodings")]
+        const EXPECTED_SIZE: usize = 216188;
+        #[cfg(not(feature = "unstable_encodings"))]
         const EXPECTED_SIZE: usize = 216156;
         let futures: Vec<_> = (0..5)
             .map(|_| {


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

<!--
This helps us keep track of fixed issues and changes.
-->

- Closes #.

## What changes are included in this PR?
if unstable encodings and zstd features are enabled, add zstd buffers to the session
<!--
What changes are included here, if an issue or discussion are attached, there's no need to duplicate the details.
-->

## What is the rationale for this change?

<!--
Why do you propose this change, and why did you choose this approach.

This helps reviewers and other readers understand changes, creates a shared understanding of the issue and codebase,
and improves their ability to work with this change and offer better suggestions.
-->

## How is this change tested?

<!--
Changes should be tested, we expect changes to fit in one of the following categories:
1. Verifying existing behavior is maintained.
2. For serialization related changes - Compatibility should be maintained or explicitly broken.
3. For new behavior and functionality, this helps us maintaining that desired behavior in the future.
-->

## Are there any user-facing changes?

<!--
Does the change affect users in what of the following ways:
1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the integrations.
3. Should some documentation be changed to reflect this change?

In the case some public API is changed in a breaking way, make sure to add the appropriate label.
-->