### PR TITLE
lazy dict layout values eval

### DIFF
--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -13,8 +13,6 @@ use futures::future::BoxFuture;
 use futures::try_join;
 use vortex_array::Array;
 use vortex_array::ArrayRef;
-use vortex_array::Canonical;
-use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::MaskFuture;
 use vortex_array::VortexSessionExecute;
@@ -119,16 +117,13 @@ impl DictReader {
             return fut.clone();
         }
 
-        let session = self.session.clone();
         self.values_evals
             .entry(expr.clone())
             .or_insert_with(|| {
                 self.values_array()
                     .map(move |array| {
                         let array = array?.apply(&expr)?;
-                        // We execute the array to avoid re-evaluating for every split.
-                        let mut ctx = ExecutionCtx::new(session);
-                        Ok(array.execute::<Canonical>(&mut ctx)?.into_array())
+                        Ok(SharedArray::new(array).into_array())
                     })
                     .boxed()
                     .shared()


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

<!--
This helps us keep track of fixed issues and changes.
-->

- Closes #.

## What changes are included in this PR?

<!--
What changes are included here, if an issue or discussion are attached, there's no need to duplicate the details.
-->
make values child evaluation of an expression in the projection evaluation of a dict layout lazy. We want this because the current execute is assuming cpu only, with shared array we defer to the actual execute call to choose which execution it wants
## What is the rationale for this change?

<!--
Why do you propose this change, and why did you choose this approach.

This helps reviewers and other readers understand changes, creates a shared understanding of the issue and codebase,
and improves their ability to work with this change and offer better suggestions.
-->

## How is this change tested?

<!--
Changes should be tested, we expect changes to fit in one of the following categories:
1. Verifying existing behavior is maintained.
2. For serialization related changes - Compatibility should be maintained or explicitly broken.
3. For new behavior and functionality, this helps us maintaining that desired behavior in the future.
-->

## Are there any user-facing changes?

<!--
Does the change affect users in what of the following ways:
1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the integrations.
3. Should some documentation be changed to reflect this change?

In the case some public API is changed in a breaking way, make sure to add the appropriate label.
-->