### PR TITLE
chore: re-export BtrBlocksCompressorBuilder in vortex crate

### DIFF
--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -32,6 +32,7 @@ pub mod compute2 {
 
 pub mod compressor {
     pub use vortex_btrblocks::BtrBlocksCompressor;
+    pub use vortex_btrblocks::BtrBlocksCompressorBuilder;
 }
 
 pub mod dtype {


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

<!--
This helps us keep track of fixed issues and changes.
-->

- Closes #.

## What changes are included in this PR?

re export the BtrBlocksCompressorBuilder in the vortex crate

## What is the rationale for this change?

i see we export BtrBlocksCompressor in vortex crate, seem like no reason not export it Builder struct

## How is this change tested?

<!--
Changes should be tested, we expect changes to fit in one of the following categories:
1. Verifying existing behavior is maintained.
2. For serialization related changes - Compatibility should be maintained or explicitly broken.
3. For new behavior and functionality, this helps us maintaining that desired behavior in the future.
-->

## Are there any user-facing changes?

<!--
Does the change affect users in what of the following ways:
1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the integrations.
3. Should some documentation be changed to reflect this change?

In the case some public API is changed in a breaking way, make sure to add the appropriate label.
-->