### PR TITLE
fix shared array race

### DIFF
--- a/vortex-array/src/arrays/shared/array.rs
+++ b/vortex-array/src/arrays/shared/array.rs
@@ -62,10 +62,14 @@ impl SharedArray {
     }
 
     pub(super) fn canonicalize(&self, ctx: &mut ExecutionCtx) -> VortexResult<Canonical> {
-        if let Some(existing) = self.cached() {
-            return Ok(existing);
-        }
-        let canonical = self.as_source().execute::<Canonical>(ctx)?;
+        let source = {
+            let state = self.state.read();
+            match &*state {
+                SharedState::Cached(existing) => return Ok(existing.clone()),
+                SharedState::Source(source) => source.clone(),
+            }
+        };
+        let canonical = source.execute::<Canonical>(ctx)?;
         Ok(self.cache_or_return(canonical))
     }
 


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

<!--
This helps us keep track of fixed issues and changes.
-->

- Closes #.

## What changes are included in this PR?

shared array canonicalise was racy, now it is not racy but we can end up with multiple in flight canonical calls

## What is the rationale for this change?

<!--
Why do you propose this change, and why did you choose this approach.

This helps reviewers and other readers understand changes, creates a shared understanding of the issue and codebase,
and improves their ability to work with this change and offer better suggestions.
-->

## How is this change tested?

<!--
Changes should be tested, we expect changes to fit in one of the following categories:
1. Verifying existing behavior is maintained.
2. For serialization related changes - Compatibility should be maintained or explicitly broken.
3. For new behavior and functionality, this helps us maintaining that desired behavior in the future.
-->

## Are there any user-facing changes?

<!--
Does the change affect users in what of the following ways:
1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the integrations.
3. Should some documentation be changed to reflect this change?

In the case some public API is changed in a breaking way, make sure to add the appropriate label.
-->