### PR TITLE
chore[array]: `fill_null` remove compute entry point 

### DIFF
--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -6,7 +6,7 @@ use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::TakeExecute;
-use vortex_array::compute::fill_null;
+use vortex_array::builtins::ArrayBuiltins;
 use vortex_error::VortexResult;
 use vortex_scalar::Scalar;
 
@@ -33,10 +33,10 @@ impl TakeExecute for ALPRDVTable {
                 p.cast_values(&values_dtype)
             })
             .transpose()?;
-        let right_parts = fill_null(
-            &array.right_parts().take(indices.to_array())?,
-            &Scalar::zero_value(array.right_parts().dtype()),
-        )?;
+        let right_parts = array
+            .right_parts()
+            .take(indices.to_array())?
+            .fill_null(Scalar::zero_value(array.right_parts().dtype()))?;
 
         Ok(Some(
             ALPRDArray::try_new(

--- a/encodings/datetime-parts/src/compute/take.rs
+++ b/encodings/datetime-parts/src/compute/take.rs
@@ -7,7 +7,7 @@ use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
 use vortex_array::arrays::TakeExecute;
-use vortex_array::compute::fill_null;
+use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::expr::stats::Stat;
 use vortex_array::expr::stats::StatsProvider;
 use vortex_dtype::Nullability;
@@ -68,7 +68,7 @@ fn take_datetime_parts(array: &DateTimePartsArray, indices: &dyn Array) -> Vorte
         .map(|s| s.into_inner())
         .unwrap_or_else(|| Scalar::primitive(0i64, Nullability::NonNullable))
         .cast(array.seconds().dtype())?;
-    let taken_seconds = fill_null(taken_seconds.as_ref(), &seconds_fill)?;
+    let taken_seconds = taken_seconds.fill_null(seconds_fill)?;
 
     let subseconds_fill = array
         .subseconds()
@@ -77,7 +77,7 @@ fn take_datetime_parts(array: &DateTimePartsArray, indices: &dyn Array) -> Vorte
         .map(|s| s.into_inner())
         .unwrap_or_else(|| Scalar::primitive(0i64, Nullability::NonNullable))
         .cast(array.subseconds().dtype())?;
-    let taken_subseconds = fill_null(taken_subseconds.as_ref(), &subseconds_fill)?;
+    let taken_subseconds = taken_subseconds.fill_null(subseconds_fill)?;
 
     Ok(
         DateTimePartsArray::try_new(dtype, taken_days, taken_seconds, taken_subseconds)?

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -11,7 +11,7 @@ use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::TakeExecute;
 use vortex_array::arrays::VarBinVTable;
-use vortex_array::compute::fill_null;
+use vortex_array::builtins::ArrayBuiltins;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
@@ -38,10 +38,12 @@ impl TakeExecute for FSSTVTable {
                     .vortex_expect("cannot fail")
                     .try_into::<VarBinVTable>()
                     .map_err(|_| vortex_err!("take for codes must return varbin array"))?,
-                fill_null(
-                    &array.uncompressed_lengths().take(indices.to_array())?,
-                    &Scalar::zero_value(&array.uncompressed_lengths_dtype().clone()),
-                )?,
+                array
+                    .uncompressed_lengths()
+                    .take(indices.to_array())?
+                    .fill_null(Scalar::zero_value(
+                        &array.uncompressed_lengths_dtype().clone(),
+                    ))?,
             )?
             .into_array(),
         ))

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -19,9 +19,9 @@ use vortex_array::ProstMetadata;
 use vortex_array::ToCanonical;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::buffer::BufferHandle;
+use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::compute::Operator;
 use vortex_array::compute::compare;
-use vortex_array::compute::fill_null;
 use vortex_array::compute::filter;
 use vortex_array::compute::sub_scalar;
 use vortex_array::patches::Patches;
@@ -343,12 +343,10 @@ impl SparseArray {
 
         let fill_array = ConstantArray::new(fill.clone(), array.len()).into_array();
         let non_top_mask = Mask::from_buffer(
-            fill_null(
-                &compare(array, &fill_array, Operator::NotEq)?,
-                &Scalar::bool(true, Nullability::NonNullable),
-            )?
-            .to_bool()
-            .to_bit_buffer(),
+            compare(array, &fill_array, Operator::NotEq)?
+                .fill_null(Scalar::bool(true, Nullability::NonNullable))?
+                .to_bool()
+                .to_bit_buffer(),
         );
 
         let non_top_values = filter(array, &non_top_mask)?;

--- a/fuzz/src/array/fill_null.rs
+++ b/fuzz/src/array/fill_null.rs
@@ -10,7 +10,7 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::VarBinViewArray;
-use vortex_array::compute::fill_null;
+use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::ValidityHelper;
 use vortex_buffer::Buffer;
@@ -43,7 +43,7 @@ pub fn fill_null_canonical_array(
         Canonical::Struct(_)
         | Canonical::List(_)
         | Canonical::FixedSizeList(_)
-        | Canonical::Extension(_) => fill_null(canonical.as_ref(), fill_value)?,
+        | Canonical::Extension(_) => canonical.into_array().fill_null(fill_value.clone())?,
     })
 }
 

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -551,9 +551,9 @@ pub fn compress_array(array: &dyn Array, _strategy: CompressorStrategy) -> Array
 #[allow(clippy::result_large_err)]
 pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> crate::error::VortexFuzzResult<bool> {
     use vortex_array::arrays::ConstantArray;
+    use vortex_array::builtins::ArrayBuiltins;
     use vortex_array::compute::cast;
     use vortex_array::compute::compare;
-    use vortex_array::compute::fill_null;
     use vortex_array::compute::mask;
     use vortex_array::compute::min_max;
     use vortex_array::compute::sum;
@@ -636,7 +636,8 @@ pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> crate::error::VortexFuzz
                 assert_min_max_eq(&expected.min_max(), &min_max_result, i)?;
             }
             Action::FillNull(fill_value) => {
-                current_array = fill_null(&current_array, &fill_value)
+                current_array = current_array
+                    .fill_null(fill_value.clone())
                     .vortex_expect("fill_null operation should succeed in fuzz test");
                 assert_array_eq(&expected.array(), &current_array, i)?;
             }

--- a/vortex-array/src/arrays/bool/compute/fill_null.rs
+++ b/vortex-array/src/arrays/bool/compute/fill_null.rs
@@ -47,10 +47,11 @@ mod tests {
     use vortex_buffer::bitbuffer;
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;
+    use vortex_scalar::Scalar;
 
     use crate::arrays::BoolArray;
+    use crate::builtins::ArrayBuiltins;
     use crate::canonical::ToCanonical;
-    use crate::compute::fill_null;
     use crate::validity::Validity;
 
     #[rstest]
@@ -61,7 +62,9 @@ mod tests {
             BitBuffer::from_iter([true, true, false, false]),
             Validity::from_iter([true, false, true, false]),
         );
-        let non_null_array = fill_null(bool_array.as_ref(), &fill_value.into())
+        let non_null_array = bool_array
+            .to_array()
+            .fill_null(Scalar::from(fill_value))
             .unwrap()
             .to_bool();
         assert_eq!(non_null_array.to_bit_buffer(), expected);

--- a/vortex-array/src/arrays/bool/compute/take.rs
+++ b/vortex-array/src/arrays/bool/compute/take.rs
@@ -18,7 +18,7 @@ use crate::arrays::BoolArray;
 use crate::arrays::BoolVTable;
 use crate::arrays::ConstantArray;
 use crate::arrays::TakeExecute;
-use crate::compute::fill_null;
+use crate::builtins::ArrayBuiltins;
 use crate::executor::ExecutionCtx;
 use crate::vtable::ValidityHelper;
 
@@ -36,7 +36,9 @@ impl TakeExecute for BoolVTable {
                         .into_array(),
                 ));
             }
-            Mask::Values(_) => fill_null(indices, &Scalar::from(0).cast(indices.dtype())?)?,
+            Mask::Values(_) => indices
+                .to_array()
+                .fill_null(Scalar::from(0).cast(indices.dtype())?)?,
         };
         let indices_nulls_zeroed = indices_nulls_zeroed.to_primitive();
         let buffer = match_each_integer_ptype!(indices_nulls_zeroed.ptype(), |I| {

--- a/vortex-array/src/arrays/chunked/compute/fill_null.rs
+++ b/vortex-array/src/arrays/chunked/compute/fill_null.rs
@@ -32,11 +32,12 @@ mod tests {
     use vortex_buffer::BitBuffer;
     use vortex_dtype::DType;
     use vortex_dtype::Nullability;
+    use vortex_scalar::Scalar;
 
     use crate::array::Array;
     use crate::arrays::BoolArray;
     use crate::arrays::ChunkedArray;
-    use crate::compute::fill_null;
+    use crate::builtins::ArrayBuiltins;
     use crate::validity::Validity;
 
     #[test]
@@ -50,7 +51,7 @@ mod tests {
         )
         .unwrap();
 
-        let filled = fill_null(chunked.as_ref(), &false.into()).unwrap();
+        let filled = chunked.to_array().fill_null(Scalar::from(false)).unwrap();
         assert_eq!(*filled.dtype(), DType::Bool(Nullability::NonNullable));
     }
 }

--- a/vortex-array/src/arrays/constant/compute/fill_null.rs
+++ b/vortex-array/src/arrays/constant/compute/fill_null.rs
@@ -30,15 +30,14 @@ mod test {
     use crate::IntoArray as _;
     use crate::arrays::ConstantArray;
     use crate::arrow::IntoArrowArray as _;
-    use crate::compute::fill_null;
+    use crate::builtins::ArrayBuiltins;
 
     #[test]
     fn test_null() {
-        let actual = fill_null(
-            &ConstantArray::new(Scalar::null_native::<i32>(), 3).into_array(),
-            &Scalar::from(1),
-        )
-        .unwrap();
+        let actual = ConstantArray::new(Scalar::null_native::<i32>(), 3)
+            .into_array()
+            .fill_null(Scalar::from(1))
+            .unwrap();
         let expected = ConstantArray::new(Scalar::from(1), 3).into_array();
 
         assert!(!actual.dtype().is_nullable());
@@ -56,11 +55,10 @@ mod test {
 
     #[test]
     fn test_non_null() {
-        let actual = fill_null(
-            &ConstantArray::new(Scalar::from(Some(1)), 3).into_array(),
-            &Scalar::from(1),
-        )
-        .unwrap();
+        let actual = ConstantArray::new(Scalar::from(Some(1)), 3)
+            .into_array()
+            .fill_null(Scalar::from(1))
+            .unwrap();
         let expected = ConstantArray::new(Scalar::from(1), 3).into_array();
 
         assert!(!actual.dtype().is_nullable());
@@ -78,11 +76,10 @@ mod test {
 
     #[test]
     fn test_non_nullable_with_nullable() {
-        let actual = fill_null(
-            &ConstantArray::new(Scalar::from(1), 3).into_array(),
-            &Scalar::from(Some(1)),
-        )
-        .unwrap();
+        let actual = ConstantArray::new(Scalar::from(1), 3)
+            .into_array()
+            .fill_null(Scalar::from(Some(1)))
+            .unwrap();
         let expected = ConstantArray::new(Scalar::from(1), 3).into_array();
 
         assert!(!Scalar::from(1).dtype().is_nullable());

--- a/vortex-array/src/arrays/decimal/compute/fill_null.rs
+++ b/vortex-array/src/arrays/decimal/compute/fill_null.rs
@@ -93,8 +93,8 @@ mod tests {
 
     use crate::arrays::decimal::DecimalArray;
     use crate::assert_arrays_eq;
+    use crate::builtins::ArrayBuiltins;
     use crate::canonical::ToCanonical;
-    use crate::compute::fill_null;
     use crate::validity::Validity;
 
     #[test]
@@ -104,16 +104,15 @@ mod tests {
             [None, Some(800i128), None, Some(1000i128), None],
             decimal_dtype,
         );
-        let p = fill_null(
-            arr.as_ref(),
-            &Scalar::decimal(
+        let p = arr
+            .to_array()
+            .fill_null(Scalar::decimal(
                 DecimalValue::I128(4200i128),
                 DecimalDType::new(19, 2),
                 Nullability::NonNullable,
-            ),
-        )
-        .unwrap()
-        .to_decimal();
+            ))
+            .unwrap()
+            .to_decimal();
         assert_arrays_eq!(
             p,
             DecimalArray::from_iter([4200, 800, 4200, 1000, 4200], decimal_dtype)
@@ -134,16 +133,15 @@ mod tests {
             decimal_dtype,
         );
 
-        let p = fill_null(
-            arr.as_ref(),
-            &Scalar::decimal(
+        let p = arr
+            .to_array()
+            .fill_null(Scalar::decimal(
                 DecimalValue::I128(25500i128),
                 DecimalDType::new(19, 2),
                 Nullability::NonNullable,
-            ),
-        )
-        .unwrap()
-        .to_decimal();
+            ))
+            .unwrap()
+            .to_decimal();
         assert_arrays_eq!(
             p,
             DecimalArray::from_iter([25500, 25500, 25500, 25500, 25500], decimal_dtype)
@@ -156,16 +154,15 @@ mod tests {
         let decimal_dtype = DecimalDType::new(3, 0);
         let arr = DecimalArray::from_option_iter([None, Some(10i8), None], decimal_dtype);
         // i8 max is 127, so 200 doesn't fit — the array should be widened to i16.
-        let result = fill_null(
-            arr.as_ref(),
-            &Scalar::decimal(
+        let result = arr
+            .to_array()
+            .fill_null(Scalar::decimal(
                 DecimalValue::I128(200i128),
                 DecimalDType::new(3, 0),
                 Nullability::NonNullable,
-            ),
-        )
-        .unwrap()
-        .to_decimal();
+            ))
+            .unwrap()
+            .to_decimal();
         assert_arrays_eq!(
             result,
             DecimalArray::from_iter([200i16, 10, 200], decimal_dtype)
@@ -181,16 +178,15 @@ mod tests {
             decimal_dtype,
             Validity::NonNullable,
         );
-        let p = fill_null(
-            arr.as_ref(),
-            &Scalar::decimal(
+        let p = arr
+            .to_array()
+            .fill_null(Scalar::decimal(
                 DecimalValue::I128(25500i128),
                 DecimalDType::new(19, 2),
                 Nullability::NonNullable,
-            ),
-        )
-        .unwrap()
-        .to_decimal();
+            ))
+            .unwrap()
+            .to_decimal();
         assert_arrays_eq!(
             p,
             DecimalArray::from_iter([800i128, 1000, 1200, 1400, 1600], decimal_dtype)

--- a/vortex-array/src/arrays/dict/compute/fill_null.rs
+++ b/vortex-array/src/arrays/dict/compute/fill_null.rs
@@ -14,10 +14,10 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::ConstantArray;
+use crate::builtins::ArrayBuiltins;
 use crate::compute::FillNullKernel;
 use crate::compute::Operator;
 use crate::compute::compare;
-use crate::compute::fill_null;
 
 impl FillNullKernel for DictVTable {
     fn fill_null(
@@ -39,10 +39,12 @@ impl FillNullKernel for DictVTable {
             found_fill_values.to_bit_buffer().set_indices().next()
         else {
             // No fill values found, so we must canonicalize and fill_null.
-            return Ok(Some(fill_null(
-                &array.to_canonical()?.into_array(),
-                fill_value,
-            )?));
+            return Ok(Some(
+                array
+                    .to_canonical()?
+                    .into_array()
+                    .fill_null(fill_value.clone())?,
+            ));
         };
 
         // Now we rewrite the nullable codes to point at the fill value.
@@ -61,11 +63,11 @@ impl FillNullKernel for DictVTable {
 
         // Fill nulls in both the codes and the values. Note that the precondition of this function
         // states that the fill value is non-null, so we do not have to worry about the nullability.
-        let codes = fill_null(
-            codes,
-            &Scalar::try_new(codes.dtype().as_nonnullable(), Some(fill_scalar_value))?,
-        )?;
-        let values = fill_null(array.values(), fill_value)?;
+        let codes = codes.to_array().fill_null(Scalar::try_new(
+            codes.dtype().as_nonnullable(),
+            Some(fill_scalar_value),
+        )?)?;
+        let values = array.values().to_array().fill_null(fill_value.clone())?;
 
         // SAFETY: invariants are still satisfied after patching nulls.
         unsafe {
@@ -91,7 +93,7 @@ mod tests {
     use crate::arrays::PrimitiveArray;
     use crate::arrays::dict::DictArray;
     use crate::assert_arrays_eq;
-    use crate::compute::fill_null;
+    use crate::builtins::ArrayBuiltins;
     use crate::validity::Validity;
 
     #[test]
@@ -106,11 +108,10 @@ mod tests {
         )
         .vortex_expect("operation should succeed in test");
 
-        let filled = fill_null(
-            dict.as_ref(),
-            &Scalar::primitive(20, Nullability::NonNullable),
-        )
-        .vortex_expect("operation should succeed in test");
+        let filled = dict
+            .to_array()
+            .fill_null(Scalar::primitive(20, Nullability::NonNullable))
+            .vortex_expect("operation should succeed in test");
         let filled_primitive = filled.to_primitive();
         assert_arrays_eq!(filled_primitive, PrimitiveArray::from_iter([10, 20, 20]));
         assert!(filled_primitive.all_valid().unwrap());

--- a/vortex-array/src/arrays/dict/vtable/validity.rs
+++ b/vortex-array/src/arrays/dict/vtable/validity.rs
@@ -10,7 +10,6 @@ use crate::Array;
 use crate::IntoArray;
 use crate::arrays::dict::DictArray;
 use crate::builtins::ArrayBuiltins;
-use crate::compute::fill_null;
 use crate::validity::Validity;
 use crate::vtable::ValidityVTable;
 
@@ -41,10 +40,8 @@ impl ValidityVTable<DictVTable> for DictVTable {
                     let values_valid_mask =
                         unsafe { DictArray::new_unchecked(array.codes().clone(), values_validity) }
                             .into_array();
-                    let values_valid_mask = fill_null(
-                        &values_valid_mask,
-                        &Scalar::bool(false, Nullability::NonNullable),
-                    )?;
+                    let values_valid_mask = values_valid_mask
+                        .fill_null(Scalar::bool(false, Nullability::NonNullable))?;
 
                     Validity::Array(values_valid_mask)
                 }

--- a/vortex-array/src/arrays/listview/compute/take.rs
+++ b/vortex-array/src/arrays/listview/compute/take.rs
@@ -14,7 +14,7 @@ use crate::arrays::ListViewArray;
 use crate::arrays::ListViewRebuildMode;
 use crate::arrays::ListViewVTable;
 use crate::arrays::TakeExecute;
-use crate::compute;
+use crate::builtins::ArrayBuiltins;
 use crate::executor::ExecutionCtx;
 use crate::vtable::ValidityHelper;
 
@@ -64,16 +64,11 @@ impl TakeExecute for ListViewVTable {
         // Since `take` returns nullable arrays, we simply cast it back to non-nullable (filled with
         // zeros to represent null lists).
         let new_offsets = match_each_integer_ptype!(nullable_new_offsets.dtype().as_ptype(), |O| {
-            compute::fill_null(
-                &nullable_new_offsets,
-                &Scalar::primitive(O::zero(), Nullability::NonNullable),
-            )?
+            nullable_new_offsets
+                .fill_null(Scalar::primitive(O::zero(), Nullability::NonNullable))?
         });
         let new_sizes = match_each_integer_ptype!(nullable_new_sizes.dtype().as_ptype(), |S| {
-            compute::fill_null(
-                &nullable_new_sizes,
-                &Scalar::primitive(S::zero(), Nullability::NonNullable),
-            )?
+            nullable_new_sizes.fill_null(Scalar::primitive(S::zero(), Nullability::NonNullable))?
         });
         // SAFETY: Take operation maintains all `ListViewArray` invariants:
         // - `new_offsets` and `new_sizes` are derived from existing valid child arrays.

--- a/vortex-array/src/arrays/masked/compute/take.rs
+++ b/vortex-array/src/arrays/masked/compute/take.rs
@@ -11,7 +11,7 @@ use crate::IntoArray;
 use crate::arrays::MaskedArray;
 use crate::arrays::MaskedVTable;
 use crate::arrays::TakeExecute;
-use crate::compute::fill_null;
+use crate::builtins::ArrayBuiltins;
 use crate::vtable::ValidityHelper;
 
 impl TakeExecute for MaskedVTable {
@@ -23,7 +23,7 @@ impl TakeExecute for MaskedVTable {
         let taken_child = if !indices.all_valid()? {
             // This is safe because we'll mask out these positions in the validity.
             let fill_scalar = Scalar::zero_value(indices.dtype());
-            let filled_take_indices = fill_null(indices, &fill_scalar)?;
+            let filled_take_indices = indices.to_array().fill_null(fill_scalar)?;
             array
                 .child
                 .take(filled_take_indices)?

--- a/vortex-array/src/arrays/primitive/compute/fill_null.rs
+++ b/vortex-array/src/arrays/primitive/compute/fill_null.rs
@@ -55,14 +55,16 @@ mod test {
     use crate::arrays::BoolArray;
     use crate::arrays::primitive::PrimitiveArray;
     use crate::assert_arrays_eq;
+    use crate::builtins::ArrayBuiltins;
     use crate::canonical::ToCanonical;
-    use crate::compute::fill_null;
     use crate::validity::Validity;
 
     #[test]
     fn fill_null_leading_none() {
         let arr = PrimitiveArray::from_option_iter([None, Some(8u8), None, Some(10), None]);
-        let p = fill_null(arr.as_ref(), &Scalar::from(42u8))
+        let p = arr
+            .to_array()
+            .fill_null(Scalar::from(42u8))
             .unwrap()
             .to_primitive();
         assert_arrays_eq!(p, PrimitiveArray::from_iter([42u8, 8, 42, 10, 42]));
@@ -73,7 +75,9 @@ mod test {
     fn fill_null_all_none() {
         let arr = PrimitiveArray::from_option_iter([Option::<u8>::None, None, None, None, None]);
 
-        let p = fill_null(arr.as_ref(), &Scalar::from(255u8))
+        let p = arr
+            .to_array()
+            .fill_null(Scalar::from(255u8))
             .unwrap()
             .to_primitive();
         assert_arrays_eq!(p, PrimitiveArray::from_iter([255u8, 255, 255, 255, 255]));
@@ -86,7 +90,9 @@ mod test {
             buffer![8u8, 10, 12, 14, 16],
             Validity::Array(BoolArray::from_iter([true, true, true, true, true]).into_array()),
         );
-        let p = fill_null(arr.as_ref(), &Scalar::from(255u8))
+        let p = arr
+            .to_array()
+            .fill_null(Scalar::from(255u8))
             .unwrap()
             .to_primitive();
         assert_arrays_eq!(p, PrimitiveArray::from_iter([8u8, 10, 12, 14, 16]));
@@ -96,9 +102,7 @@ mod test {
     #[test]
     fn fill_null_non_nullable() {
         let arr = buffer![8u8, 10, 12, 14, 16].into_array();
-        let p = fill_null(&arr, &Scalar::from(255u8))
-            .unwrap()
-            .to_primitive();
+        let p = arr.fill_null(Scalar::from(255u8)).unwrap().to_primitive();
         assert_arrays_eq!(p, PrimitiveArray::from_iter([8u8, 10, 12, 14, 16]));
         assert!(p.validity_mask().unwrap().all_true());
     }

--- a/vortex-array/src/arrays/struct_/compute/take.rs
+++ b/vortex-array/src/arrays/struct_/compute/take.rs
@@ -11,7 +11,7 @@ use crate::IntoArray;
 use crate::arrays::StructArray;
 use crate::arrays::StructVTable;
 use crate::arrays::TakeExecute;
-use crate::compute;
+use crate::builtins::ArrayBuiltins;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
@@ -40,7 +40,7 @@ impl TakeExecute for StructVTable {
         // Note that we strip nullability so that `Take::return_dtype` doesn't union nullable into
         // each field's dtype (the struct-level validity already captures which rows are null).
         let fill_scalar = Scalar::zero_value(&indices.dtype().as_nonnullable());
-        let inner_indices = &compute::fill_null(indices, &fill_scalar)?;
+        let inner_indices = &indices.to_array().fill_null(fill_scalar)?;
 
         StructArray::try_new_with_dtype(
             array

--- a/vortex-array/src/compute/fill_null.rs
+++ b/vortex-array/src/compute/fill_null.rs
@@ -23,7 +23,7 @@ use crate::builtins::ArrayBuiltins;
 /// let array = fill_null(array.as_ref(), &Scalar::from(42i32)).unwrap();
 /// assert_eq!(array.display_values().to_string(), "[0i32, 42i32, 1i32, 42i32, 2i32]");
 /// ```
-// TODO(joe): deprecate me.
+#[deprecated(note = "use array.fill_null(scalar) via ArrayBuiltins instead")]
 pub fn fill_null(array: &dyn Array, fill_value: &Scalar) -> VortexResult<ArrayRef> {
     vortex_ensure!(
         !fill_value.is_null(),

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -16,7 +16,7 @@ use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrow::FromArrowArray;
 use crate::arrow::IntoArrowArray;
-use crate::compute::fill_null;
+use crate::builtins::ArrayBuiltins;
 
 /// Keep only the elements for which the corresponding mask value is true.
 ///
@@ -60,7 +60,9 @@ impl dyn Array + '_ {
         }
 
         // Convert nulls to false first in case this can be done cheaply by the encoding.
-        let array = fill_null(self, &Scalar::bool(false, self.dtype().nullability()))?;
+        let array = self
+            .to_array()
+            .fill_null(Scalar::bool(false, self.dtype().nullability()))?;
 
         Ok(array.to_bool().to_mask_fill_null_false())
     }

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -31,6 +31,7 @@ use crate::arrays::ConstantArray;
 use crate::arrays::ConstantVTable;
 use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
+use crate::builtins::ArrayBuiltins;
 use crate::compute::BinaryArgs;
 use crate::compute::ComputeFn;
 use crate::compute::ComputeFnVTable;
@@ -232,14 +233,12 @@ fn constant_list_scalar_contains(
     let false_scalar = Scalar::bool(false, nullability);
 
     for element in elements {
-        let res = compute::fill_null(
-            &compute::compare(
-                ConstantArray::new(element, len).as_ref(),
-                values,
-                Operator::Eq,
-            )?,
-            &false_scalar,
-        )?;
+        let res = compute::compare(
+            ConstantArray::new(element, len).as_ref(),
+            values,
+            Operator::Eq,
+        )?
+        .fill_null(false_scalar.clone())?;
         if let Some(acc) = result {
             result = Some(compute::or(&acc, &res)?)
         } else {

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -89,7 +89,6 @@ pub fn warm_up_vtables() {
     boolean::warm_up_vtable();
     cast::warm_up_vtable();
     compare::warm_up_vtable();
-
     invert::warm_up_vtable();
     is_constant::warm_up_vtable();
     is_sorted::warm_up_vtable();

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -28,7 +28,7 @@ use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::BoolArray;
 use crate::arrays::ConstantArray;
-use crate::compute::fill_null;
+use crate::builtins::ArrayBuiltins;
 use crate::compute::sum;
 use crate::patches::Patches;
 
@@ -189,7 +189,7 @@ impl Validity {
                     .to_canonical()?
                     .into_array();
                 // Null indices invalidate that position.
-                let is_valid = fill_null(&maybe_is_valid, &Scalar::from(false))?;
+                let is_valid = maybe_is_valid.fill_null(Scalar::from(false))?;
                 Ok(Self::Array(is_valid))
             }
         }


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

<!--
This helps us keep track of fixed issues and changes.
-->

- Closes #.

## What changes are included in this PR?

Cleaned & deprecated up the `fill_null` compute function, replaced with ArrayBuiltins.

<!--
What changes are included here, if an issue or discussion are attached, there's no need to duplicate the details.
-->

## What is the rationale for this change?

<!--
Why do you propose this change, and why did you choose this approach.

This helps reviewers and other readers understand changes, creates a shared understanding of the issue and codebase,
and improves their ability to work with this change and offer better suggestions.
-->

## How is this change tested?

<!--
Changes should be tested, we expect changes to fit in one of the following categories:
1. Verifying existing behavior is maintained.
2. For serialization related changes - Compatibility should be maintained or explicitly broken.
3. For new behavior and functionality, this helps us maintaining that desired behavior in the future.
-->

## Are there any user-facing changes?

<!--
Does the change affect users in what of the following ways:
1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the integrations.
3. Should some documentation be changed to reflect this change?

In the case some public API is changed in a breaking way, make sure to add the appropriate label.
-->

`#[deprecated(note = "use array.fill_null(scalar) via ArrayBuiltins instead")]`