### PR TITLE
chore[ci]: disable semver check until it has a lock filie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,44 +322,44 @@ jobs:
         run: |
           cargo hack --no-dev-deps --ignore-private clippy --no-default-features -- -D warnings
 
-
-  rust-semver:
-    name: "Rust (semver checks)"
-    timeout-minutes: 120
-    if: github.ref != 'refs/heads/develop'
-    runs-on:
-      - runs-on=${{ github.run_id }}
-      - family=m7i+m7i-flex+m7a
-      - cpu=16
-      - image=ubuntu24-full-x64
-      - extras=s3-cache
-      - tag=rust-semver
-    steps:
-      - uses: runs-on/action@v2
-        with:
-          sccache: s3
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - uses: ./.github/actions/setup-rust
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      # We have to set the correct Cargo.toml versions so semver checks uses the previous release.
-      - name: Latest Tag
-        id: latest-tag
-        run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0)
-          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-      - name: Cargo Set Version
-        run: |
-          cargo install cargo-edit
-          cargo set-version --workspace ${{ steps.latest-tag.outputs.tag }}
-
-      - name: Check semver
-        uses: obi1kenobi/cargo-semver-checks-action@v2
-        with:
-          exclude: vortex-cuda
+# TODO: re-enable once updated with a lock file
+#  rust-semver:
+#    name: "Rust (semver checks)"
+#    timeout-minutes: 120
+#    if: github.ref != 'refs/heads/develop'
+#    runs-on:
+#      - runs-on=${{ github.run_id }}
+#      - family=m7i+m7i-flex+m7a
+#      - cpu=16
+#      - image=ubuntu24-full-x64
+#      - extras=s3-cache
+#      - tag=rust-semver
+#    steps:
+#      - uses: runs-on/action@v2
+#        with:
+#          sccache: s3
+#      - uses: actions/checkout@v6
+#        with:
+#          fetch-depth: 0
+#          fetch-tags: true
+#      - uses: ./.github/actions/setup-rust
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      # We have to set the correct Cargo.toml versions so semver checks uses the previous release.
+#      - name: Latest Tag
+#        id: latest-tag
+#        run: |
+#          LATEST_TAG=$(git describe --tags --abbrev=0)
+#          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+#      - name: Cargo Set Version
+#        run: |
+#          cargo install cargo-edit
+#          cargo set-version --workspace ${{ steps.latest-tag.outputs.tag }}
+#
+#      - name: Check semver
+#        uses: obi1kenobi/cargo-semver-checks-action@v2
+#        with:
+#          exclude: vortex-cuda
 
   rust-coverage:
     name: "Rust tests (coverage) (${{ matrix.suite }})"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,45 +322,6 @@ jobs:
         run: |
           cargo hack --no-dev-deps --ignore-private clippy --no-default-features -- -D warnings
 
-# TODO: re-enable once updated with a lock file
-#  rust-semver:
-#    name: "Rust (semver checks)"
-#    timeout-minutes: 120
-#    if: github.ref != 'refs/heads/develop'
-#    runs-on:
-#      - runs-on=${{ github.run_id }}
-#      - family=m7i+m7i-flex+m7a
-#      - cpu=16
-#      - image=ubuntu24-full-x64
-#      - extras=s3-cache
-#      - tag=rust-semver
-#    steps:
-#      - uses: runs-on/action@v2
-#        with:
-#          sccache: s3
-#      - uses: actions/checkout@v6
-#        with:
-#          fetch-depth: 0
-#          fetch-tags: true
-#      - uses: ./.github/actions/setup-rust
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#      # We have to set the correct Cargo.toml versions so semver checks uses the previous release.
-#      - name: Latest Tag
-#        id: latest-tag
-#        run: |
-#          LATEST_TAG=$(git describe --tags --abbrev=0)
-#          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-#      - name: Cargo Set Version
-#        run: |
-#          cargo install cargo-edit
-#          cargo set-version --workspace ${{ steps.latest-tag.outputs.tag }}
-#
-#      - name: Check semver
-#        uses: obi1kenobi/cargo-semver-checks-action@v2
-#        with:
-#          exclude: vortex-cuda
-
   rust-coverage:
     name: "Rust tests (coverage) (${{ matrix.suite }})"
     timeout-minutes: 120


### PR DESCRIPTION
We can re-enable once the check is updated to use a lock file or something