### PR TITLE
fix[ci]: add lance to compression benchmarks

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,7 +49,8 @@ jobs:
             formats: "parquet,lance,vortex"
           - id: compress-bench
             name: Compression
-            formats: "parquet,vortex"
+            build_args: "--features lance"
+            formats: "parquet,lance,vortex"
     steps:
       - uses: runs-on/action@v2
         with:


### PR DESCRIPTION
Revert mistakenly removing lance from post-commit compression benchmarks