### PR TITLE
vortex-cuda format in benchmarks

### DIFF
--- a/benchmarks/datafusion-bench/src/lib.rs
+++ b/benchmarks/datafusion-bench/src/lib.rs
@@ -109,7 +109,7 @@ pub fn format_to_df_format(format: Format) -> Arc<dyn FileFormat> {
         Format::Csv => Arc::new(CsvFormat::default()) as _,
         Format::Arrow => Arc::new(ArrowFormat),
         Format::Parquet => Arc::new(ParquetFormat::new()),
-        Format::OnDiskVortex | Format::VortexCompact => {
+        Format::OnDiskVortex | Format::VortexCompact | Format::VortexCuda => {
             Arc::new(VortexFormat::new(SESSION.clone()))
         }
         Format::OnDiskDuckDB | Format::Lance => {

--- a/vortex-bench/src/bin/data-gen.rs
+++ b/vortex-bench/src/bin/data-gen.rs
@@ -79,6 +79,11 @@ async fn main() -> anyhow::Result<()> {
             convert_parquet_directory_to_vortex(&base_path, CompactionStrategy::Compact).await?;
         }
 
+        if args.formats.iter().any(|f| matches!(f, Format::VortexCuda)) {
+            convert_parquet_directory_to_vortex(&base_path, CompactionStrategy::CudaCompatible)
+                .await?;
+        }
+
         if args
             .formats
             .iter()

--- a/vortex-bench/src/conversions.rs
+++ b/vortex-bench/src/conversions.rs
@@ -151,6 +151,7 @@ pub async fn convert_parquet_directory_to_vortex(
 ) -> anyhow::Result<()> {
     let (format, dir_name) = match compaction {
         CompactionStrategy::Compact => (Format::VortexCompact, Format::VortexCompact.name()),
+        CompactionStrategy::CudaCompatible => (Format::VortexCuda, Format::VortexCuda.name()),
         CompactionStrategy::Default => (Format::OnDiskVortex, Format::OnDiskVortex.name()),
     };
 

--- a/vortex-bench/src/lib.rs
+++ b/vortex-bench/src/lib.rs
@@ -137,6 +137,9 @@ pub enum Format {
     #[clap(name = "vortex-compact")]
     #[serde(rename = "vortex-compact")]
     VortexCompact,
+    #[clap(name = "vortex-cuda")]
+    #[serde(rename = "vortex-cuda")]
+    VortexCuda,
     #[clap(name = "duckdb")]
     #[serde(rename = "duckdb")]
     OnDiskDuckDB,
@@ -176,6 +179,7 @@ impl Format {
             Format::Parquet => "parquet",
             Format::OnDiskVortex => "vortex-file-compressed",
             Format::VortexCompact => "vortex-compact",
+            Format::VortexCuda => "vortex-cuda",
             Format::OnDiskDuckDB => "duckdb",
             Format::Lance => "lance",
         }
@@ -188,6 +192,7 @@ impl Format {
             Format::Parquet => "parquet",
             Format::OnDiskVortex => "vortex",
             Format::VortexCompact => "vortex",
+            Format::VortexCuda => "vortex",
             Format::OnDiskDuckDB => "duckdb",
             Format::Lance => "lance",
         }
@@ -222,6 +227,7 @@ impl Display for Engine {
 #[derive(Debug, Clone, Copy, Default)]
 pub enum CompactionStrategy {
     Compact,
+    CudaCompatible,
     #[default]
     Default,
 }
@@ -232,6 +238,11 @@ impl CompactionStrategy {
             CompactionStrategy::Compact => options.with_strategy(
                 WriteStrategyBuilder::default()
                     .with_compact_encodings()
+                    .build(),
+            ),
+            CompactionStrategy::CudaCompatible => options.with_strategy(
+                WriteStrategyBuilder::default()
+                    .with_cuda_compatible_encodings()
                     .build(),
             ),
             CompactionStrategy::Default => options,


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

<!--
This helps us keep track of fixed issues and changes.
-->

- Closes #.

## What changes are included in this PR?

allows benchmarks to create and ran against vortex-cuda files, which are vortex files that only include cuda compatible encodings

## What is the rationale for this change?

<!--
Why do you propose this change, and why did you choose this approach.

This helps reviewers and other readers understand changes, creates a shared understanding of the issue and codebase,
and improves their ability to work with this change and offer better suggestions.
-->

## How is this change tested?

<!--
Changes should be tested, we expect changes to fit in one of the following categories:
1. Verifying existing behavior is maintained.
2. For serialization related changes - Compatibility should be maintained or explicitly broken.
3. For new behavior and functionality, this helps us maintaining that desired behavior in the future.
-->

## Are there any user-facing changes?

<!--
Does the change affect users in what of the following ways:
1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the integrations.
3. Should some documentation be changed to reflect this change?

In the case some public API is changed in a breaking way, make sure to add the appropriate label.
-->