### PR TITLE
Add more SQL tests comparing DF and DuckDB

### DIFF
--- a/vortex-duckdb/src/duckdb/logical_type.rs
+++ b/vortex-duckdb/src/duckdb/logical_type.rs
@@ -135,12 +135,20 @@ impl LogicalType {
         Self::new(DUCKDB_TYPE::DUCKDB_TYPE_UBIGINT)
     }
 
+    pub fn uint128() -> Self {
+        Self::new(DUCKDB_TYPE::DUCKDB_TYPE_UHUGEINT)
+    }
+
     pub fn int32() -> Self {
         Self::new(DUCKDB_TYPE::DUCKDB_TYPE_INTEGER)
     }
 
     pub fn int64() -> Self {
         Self::new(DUCKDB_TYPE::DUCKDB_TYPE_BIGINT)
+    }
+
+    pub fn int128() -> Self {
+        Self::new(DUCKDB_TYPE::DUCKDB_TYPE_HUGEINT)
     }
 
     pub fn bool() -> Self {
@@ -153,6 +161,14 @@ impl LogicalType {
 
     pub fn float64() -> Self {
         Self::new(DUCKDB_TYPE::DUCKDB_TYPE_DOUBLE)
+    }
+
+    pub fn timestamp() -> Self {
+        Self::new(DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP)
+    }
+
+    pub fn timestamp_tz() -> Self {
+        Self::new(DUCKDB_TYPE::DUCKDB_TYPE_TIMESTAMP_TZ)
     }
 
     pub fn as_decimal(&self) -> (u8, u8) {

--- a/vortex-sqllogictest/slt/aggregations.slt
+++ b/vortex-sqllogictest/slt/aggregations.slt
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Aggregation tests - derived from vortex-duckdb tests
+
+include ./setup.slt
+
+# Create test data for aggregations
+query I
+COPY (SELECT * FROM (VALUES
+    ('apple', 10),
+    ('banana', 20),
+    ('apple', 30),
+    ('cherry', 40),
+    ('banana', 50)
+) AS t(name, val)) TO '$__TEST_DIR__/agg.vortex';
+----
+5
+
+# Test COUNT
+query I
+SELECT COUNT(*) FROM '$__TEST_DIR__/agg.vortex';
+----
+5
+
+# Test COUNT with filter
+query I
+SELECT COUNT(*) FROM '$__TEST_DIR__/agg.vortex' WHERE val > 20;
+----
+3
+
+# Test SUM
+query I
+SELECT SUM(val) FROM '$__TEST_DIR__/agg.vortex';
+----
+150
+
+# Test MIN/MAX
+query II
+SELECT MIN(val), MAX(val) FROM '$__TEST_DIR__/agg.vortex';
+----
+10 50

--- a/vortex-sqllogictest/slt/booleans.slt
+++ b/vortex-sqllogictest/slt/booleans.slt
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Boolean operations tests - derived from vortex-duckdb vortex_scan_test.rs
+
+include ./setup.slt
+
+# Create a file with boolean data
+query I
+COPY (SELECT * FROM (VALUES (true), (false), (true), (true), (false)) AS t(flag)) TO '$__TEST_DIR__/booleans.vortex';
+----
+5
+
+# Test COUNT with boolean filter
+query I
+SELECT COUNT(*) FROM '$__TEST_DIR__/booleans.vortex' WHERE flag = true;
+----
+3
+
+# Test COUNT for false values
+query I
+SELECT COUNT(*) FROM '$__TEST_DIR__/booleans.vortex' WHERE flag = false;
+----
+2

--- a/vortex-sqllogictest/slt/dictionary_filter.slt
+++ b/vortex-sqllogictest/slt/dictionary_filter.slt
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Dictionary column filter tests - derived from vortex-datafusion schema_evolution.rs
+# These tests filter on columns that would typically be dictionary-encoded
+
+include ./setup.slt
+
+# Create test data simulating dictionary-encoded columns
+query I
+COPY (SELECT * FROM (VALUES
+    ('agent', 'samples', 1),
+    ('agent', 'samples', 2),
+    ('agent', 'samples', 3)
+) AS t(producer, sample_type, val)) TO '$__TEST_DIR__/dict_filter.vortex';
+----
+3
+
+# Test filtering on dictionary-like columns
+query I
+SELECT val FROM '$__TEST_DIR__/dict_filter.vortex'
+WHERE producer = 'agent' AND sample_type = 'samples'
+ORDER BY val;
+----
+1
+2
+3

--- a/vortex-sqllogictest/slt/floats.slt
+++ b/vortex-sqllogictest/slt/floats.slt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Float operations tests - derived from vortex-duckdb vortex_scan_test.rs
+
+include ./setup.slt
+
+# Create a file with float data
+query I
+COPY (SELECT * FROM (VALUES (1.5), (-2.5), (0.0), (42.42)) AS t(val)) TO '$__TEST_DIR__/floats.vortex';
+----
+4
+
+# Test COUNT with filter on floats
+query I
+SELECT COUNT(*) FROM '$__TEST_DIR__/floats.vortex' WHERE val > 0;
+----
+2

--- a/vortex-sqllogictest/slt/integers.slt
+++ b/vortex-sqllogictest/slt/integers.slt
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Integer operations tests - derived from vortex-duckdb vortex_scan_test.rs
+
+include ./setup.slt
+
+# Create a file with integer data
+query I
+COPY (SELECT * FROM (VALUES (1), (42), (100), (-5), (0)) AS t(num)) TO '$__TEST_DIR__/integers.vortex';
+----
+5
+
+# Test integer sum
+query I
+SELECT SUM(num) FROM '$__TEST_DIR__/integers.vortex';
+----
+138
+
+# Test IN clause filtering
+query I
+SELECT SUM(num) FROM '$__TEST_DIR__/integers.vortex' WHERE num IN (1, 42, -5);
+----
+38
+
+# Test range filtering with AND
+query I
+SELECT SUM(num) FROM '$__TEST_DIR__/integers.vortex' WHERE num > 0 AND num < 100;
+----
+43
+
+# Test NOT IN filtering (issue 5927)
+query I
+SELECT SUM(num) FROM '$__TEST_DIR__/integers.vortex' WHERE num NOT IN (42, 100);
+----
+-4

--- a/vortex-sqllogictest/slt/multi_column.slt
+++ b/vortex-sqllogictest/slt/multi_column.slt
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Multi-column operations tests - derived from vortex-duckdb vortex_scan_test.rs
+
+include ./setup.slt
+
+# Create a file with multiple columns: bool, int, int
+query I
+COPY (SELECT * FROM (VALUES
+    (true, 0, 100),
+    (false, 1, 101),
+    (true, 2, 102),
+    (true, 3, 103),
+    (false, 4, 104)
+) AS t(f1, f2, f3)) TO '$__TEST_DIR__/multi_column.vortex';
+----
+5
+
+# Test multi-column filtering (f1 = true AND f2 >= 2)
+query I
+SELECT f2 FROM '$__TEST_DIR__/multi_column.vortex' WHERE f1 = true AND f2 >= 2 ORDER BY f2;
+----
+2
+3

--- a/vortex-sqllogictest/slt/nulls.slt
+++ b/vortex-sqllogictest/slt/nulls.slt
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# NULL handling tests - derived from vortex-datafusion and vortex-duckdb tests
+
+include ./setup.slt
+
+# Create test data with NULL values
+query I
+COPY (SELECT * FROM (VALUES
+    ('one', 1),
+    ('two', 2),
+    (NULL, 3),
+    ('four', NULL),
+    (NULL, NULL)
+) AS t(name, val)) TO '$__TEST_DIR__/nulls.vortex';
+----
+5
+
+# Test IS NULL filter
+query I
+SELECT COUNT(*) FROM '$__TEST_DIR__/nulls.vortex' WHERE name IS NULL;
+----
+2
+
+# Test IS NOT NULL filter
+query I
+SELECT COUNT(*) FROM '$__TEST_DIR__/nulls.vortex' WHERE name IS NOT NULL;
+----
+3
+
+# Test SUM with NULL values (should ignore NULLs)
+query I
+SELECT SUM(val) FROM '$__TEST_DIR__/nulls.vortex';
+----
+6
+
+# Test COUNT on nullable column (should count non-NULLs)
+query I
+SELECT COUNT(val) FROM '$__TEST_DIR__/nulls.vortex';
+----
+3
+
+# Test COUNT(*) vs COUNT(column) with NULLs
+query II
+SELECT COUNT(*), COUNT(name) FROM '$__TEST_DIR__/nulls.vortex';
+----
+5 3

--- a/vortex-sqllogictest/slt/order_limit.slt
+++ b/vortex-sqllogictest/slt/order_limit.slt
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# ORDER BY and LIMIT tests
+
+include ./setup.slt
+
+# Create test data
+query I
+COPY (SELECT * FROM (VALUES (5), (3), (1), (4), (2)) AS t(num)) TO '$__TEST_DIR__/order.vortex';
+----
+5
+
+# Test ORDER BY ASC
+query I
+SELECT num FROM '$__TEST_DIR__/order.vortex' ORDER BY num ASC;
+----
+1
+2
+3
+4
+5
+
+# Test ORDER BY DESC
+query I
+SELECT num FROM '$__TEST_DIR__/order.vortex' ORDER BY num DESC;
+----
+5
+4
+3
+2
+1
+
+# Test LIMIT
+query I
+SELECT num FROM '$__TEST_DIR__/order.vortex' ORDER BY num LIMIT 3;
+----
+1
+2
+3
+
+# Test LIMIT with OFFSET
+query I
+SELECT num FROM '$__TEST_DIR__/order.vortex' ORDER BY num LIMIT 2 OFFSET 2;
+----
+3
+4

--- a/vortex-sqllogictest/slt/projections.slt
+++ b/vortex-sqllogictest/slt/projections.slt
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Projection expression tests - derived from vortex-datafusion schema_evolution.rs
+
+include ./setup.slt
+
+# Create file with numeric columns for arithmetic projections
+query I
+COPY (SELECT * FROM (VALUES
+    (1, 10),
+    (2, 20),
+    (3, 30)
+) AS t(a, b)) TO '$__TEST_DIR__/projections.vortex';
+----
+3
+
+# Test arithmetic projection: a + b * 2
+query I
+SELECT a + b * 2 AS computed FROM '$__TEST_DIR__/projections.vortex' ORDER BY computed;
+----
+21
+42
+63

--- a/vortex-sqllogictest/slt/strings.slt
+++ b/vortex-sqllogictest/slt/strings.slt
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# String operations tests - derived from vortex-duckdb vortex_scan_test.rs
+
+include ./setup.slt
+
+# Create a file with string data
+query I
+COPY (SELECT * FROM (VALUES ('Hello'), ('Hi'), ('Hey')) AS t(str)) TO '$__TEST_DIR__/strings.vortex';
+----
+3
+
+# Test string aggregation
+query T
+SELECT string_agg(str, ',') FROM '$__TEST_DIR__/strings.vortex';
+----
+Hello,Hi,Hey
+
+# Test string filtering with LIKE
+query T
+SELECT string_agg(str, ',') FROM '$__TEST_DIR__/strings.vortex' WHERE str LIKE '%He%';
+----
+Hello,Hey

--- a/vortex-sqllogictest/slt/structs.slt
+++ b/vortex-sqllogictest/slt/structs.slt
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Struct filtering tests - test filtering on nested struct fields
+
+include ./setup.slt
+
+# Create a file with nested struct data
+query I
+COPY (SELECT * FROM (VALUES
+    ({'name': 'alice', 'info': {'age': 30, 'city': 'NYC'}}, 100),
+    ({'name': 'bob', 'info': {'age': 25, 'city': 'LA'}}, 200),
+    ({'name': 'charlie', 'info': {'age': 35, 'city': 'NYC'}}, 300),
+    ({'name': 'diana', 'info': {'age': 28, 'city': 'SF'}}, 400),
+    ({'name': 'eve', 'info': {'age': 30, 'city': 'LA'}}, 500)
+) AS t(person, value)) TO '$__TEST_DIR__/nested_structs.vortex';
+----
+5
+
+# Test filter on top-level struct field
+query I rowsort
+SELECT value FROM '$__TEST_DIR__/nested_structs.vortex' WHERE person.name = 'bob';
+----
+200
+
+# Test filter on nested struct field (age)
+query I rowsort
+SELECT value FROM '$__TEST_DIR__/nested_structs.vortex' WHERE person.info.age = 30 ORDER BY value;
+----
+100
+500
+
+# Test filter on nested struct field (city)
+query I rowsort
+SELECT value FROM '$__TEST_DIR__/nested_structs.vortex' WHERE person.info.city = 'NYC' ORDER BY value;
+----
+100
+300
+
+# Test comparison on nested struct field
+query I rowsort
+SELECT value FROM '$__TEST_DIR__/nested_structs.vortex' WHERE person.info.age > 28 ORDER BY value;
+----
+100
+300
+500
+
+# Test combined filter on multiple nested fields
+query I rowsort
+SELECT value FROM '$__TEST_DIR__/nested_structs.vortex' WHERE person.info.age >= 30 AND person.info.city = 'NYC';
+----
+100
+300
+
+# Test IN clause on nested struct field
+query I rowsort
+SELECT SUM(value) FROM '$__TEST_DIR__/nested_structs.vortex' WHERE person.info.city IN ('NYC', 'SF');
+----
+800
+
+# Create a file with deeper nesting
+query I
+COPY (SELECT * FROM (VALUES
+    ({'level1': {'level2': {'level3': 1}}}, 'a'),
+    ({'level1': {'level2': {'level3': 2}}}, 'b'),
+    ({'level1': {'level2': {'level3': 3}}}, 'c'),
+    ({'level1': {'level2': {'level3': 1}}}, 'd')
+) AS t(deep, label)) TO '$__TEST_DIR__/deep_nested.vortex';
+----
+4
+
+# Test filter on deeply nested field
+query T rowsort
+SELECT label FROM '$__TEST_DIR__/deep_nested.vortex' WHERE deep.level1.level2.level3 = 1 ORDER BY label;
+----
+a
+d
+
+# Test range filter on deeply nested field
+query T rowsort
+SELECT label FROM '$__TEST_DIR__/deep_nested.vortex' WHERE deep.level1.level2.level3 >= 2 ORDER BY label;
+----
+b
+c

--- a/vortex-sqllogictest/slt/timestamps.slt
+++ b/vortex-sqllogictest/slt/timestamps.slt
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+include ./setup.slt
+
+# Write timestamp with timezone
+query I
+COPY (SELECT TIMESTAMP WITH TIME ZONE '2025-05-03 16:19:14.338895+03:00' AS tstz) TO '$__TEST_DIR__/timestamps.vortex';
+----
+1
+
+# Read back the timestamp
+# note that result drops the tz info due to this issue https://github.com/apache/datafusion/issues/12218
+onlyif datafusion
+query P
+SELECT * FROM '$__TEST_DIR__/timestamps.vortex';
+----
+2025-05-03T13:19:14.338895
+
+onlyif duckdb
+query P
+SELECT tstz FROM '$__TEST_DIR__/timestamps.vortex';
+----
+2025-05-03 13:19:14.338895+00

--- a/vortex-sqllogictest/src/duckdb.rs
+++ b/vortex-sqllogictest/src/duckdb.rs
@@ -61,11 +61,14 @@ impl DuckDB {
     /// Turn the DuckDB logical type into a `DFColumnType`, which
     /// tells the runner what types they are. We use the one from DataFusion
     /// as its richer than the default one.
-    fn normalize_column_type(dtype: LogicalType) -> DFColumnType {
-        let type_id = dtype.as_type_id();
+    fn normalize_column_type(logical_type: LogicalType) -> DFColumnType {
+        let type_id = logical_type.as_type_id();
+
         if type_id == LogicalType::int32().as_type_id()
             || type_id == LogicalType::int64().as_type_id()
             || type_id == LogicalType::uint64().as_type_id()
+            || type_id == LogicalType::int128().as_type_id()
+            || type_id == LogicalType::uint128().as_type_id()
         {
             DFColumnType::Integer
         } else if type_id == LogicalType::varchar().as_type_id() {
@@ -76,6 +79,10 @@ impl DuckDB {
             || type_id == LogicalType::float64().as_type_id()
         {
             DFColumnType::Float
+        } else if type_id == LogicalType::timestamp().as_type_id()
+            || type_id == LogicalType::timestamp_tz().as_type_id()
+        {
+            DFColumnType::Timestamp
         } else {
             DFColumnType::Another
         }


### PR DESCRIPTION
More tests covering a bunch of basic SQL flows using both SQL engines we integrate with.

This is mostly about improving coverage and making sure we behave as expected on both, or that we can explain any difference.