### PR TITLE
fix handling of fill_null precondition cast

### DIFF
--- a/vortex-array/src/expr/exprs/fill_null/mod.rs
+++ b/vortex-array/src/expr/exprs/fill_null/mod.rs
@@ -157,7 +157,9 @@ fn fill_null_canonical(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     if let Some(result) = precondition(canonical.as_ref(), fill_value)? {
-        return Ok(result);
+        // The result of precondition may return another ScalarFn, in which case we should
+        // apply it immediately.
+        return result.execute::<ArrayRef>(ctx);
     }
     match canonical {
         CanonicalView::Bool(a) => <BoolVTable as FillNullKernel>::fill_null(a, fill_value, ctx)?


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

Closes #6496


## What changes are included in this PR?

fill_null scalar fn execution will execute() its precondition result. In this case, the precondition was returning an unexecuted `CastArray` which breaks the assumption that ScalarFn::execute() always makes forward progress toward `Columnar`

