### PR TITLE
Configure DuckDB native threads for benchmarking

### DIFF
--- a/benchmarks/duckdb-bench/src/lib.rs
+++ b/benchmarks/duckdb-bench/src/lib.rs
@@ -17,7 +17,6 @@ use vortex_bench::generate_duckdb_registration_sql;
 use vortex_duckdb::duckdb::Config;
 use vortex_duckdb::duckdb::Connection;
 use vortex_duckdb::duckdb::Database;
-use vortex_duckdb::register_extension_options;
 
 /// DuckDB context for benchmarks.
 pub struct DuckClient {
@@ -67,10 +66,12 @@ impl DuckClient {
         path: Option<PathBuf>,
         threads: Option<usize>,
     ) -> Result<(Database, Connection)> {
-        let config = Config::new().vortex_expect("failed to create duckdb config");
+        let mut config = Config::new().vortex_expect("failed to create duckdb config");
 
-        // Register Vortex extension options before creating connection
-        register_extension_options(&config);
+        // Set DuckDB thread count if specified
+        if let Some(thread_count) = threads {
+            config.set("threads", &format!("{}", thread_count))?;
+        }
 
         let db = match path {
             Some(path) => Database::open_with_config(path, config),
@@ -90,11 +91,6 @@ impl DuckClient {
         // "Invalid Input Error: The following options were not recognized:
         // parquet_metadata_cache" when running DuckDB in debug mode.
         connection.query("SET parquet_metadata_cache = true")?;
-
-        // Set vortex_max_threads if specified
-        if let Some(thread_count) = threads {
-            connection.query(&format!("SET vortex_max_threads = {}", thread_count))?;
-        }
 
         Ok((db, connection))
     }

--- a/vortex-duckdb/src/lib.rs
+++ b/vortex-duckdb/src/lib.rs
@@ -16,7 +16,6 @@ use vortex::io::session::RuntimeSessionExt;
 use vortex::session::VortexSession;
 
 use crate::copy::VortexCopyFunction;
-use crate::duckdb::Config;
 pub use crate::duckdb::Connection;
 pub use crate::duckdb::Database;
 pub use crate::duckdb::LogicalType;
@@ -43,36 +42,6 @@ mod e2e_test;
 static RUNTIME: LazyLock<CurrentThreadRuntime> = LazyLock::new(CurrentThreadRuntime::new);
 static SESSION: LazyLock<VortexSession> =
     LazyLock::new(|| VortexSession::default().with_handle(RUNTIME.handle()));
-
-/// Register Vortex extension configuration options with DuckDB.
-/// This must be called before `register_table_functions` to take effect.
-pub fn register_extension_options(config: &Config) {
-    let logical_type = LogicalType::uint64();
-
-    let default_threads = std::thread::available_parallelism()
-        .map(|n| n.get() as u64)
-        .unwrap_or(1);
-    let default_value = Value::from(default_threads);
-
-    // Register the vortex_max_threads extension option
-    // SAFETY: We're passing valid pointers for database, logical_type, and default_value
-    // The C++ code will copy the LogicalType and Value, so we can safely drop them after this call
-    let result = unsafe {
-        cpp::duckdb_vx_add_extension_option(
-            config.as_ptr(),
-            c"vortex_max_threads".as_ptr(),
-            c"Maximum number of threads for Vortex table scans".as_ptr(),
-            logical_type.as_ptr(),
-            default_value.as_ptr(),
-        )
-    };
-
-    assert_eq!(
-        result,
-        cpp::duckdb_state::DuckDBSuccess,
-        "Failed to register vortex_max_threads extension option"
-    );
-}
 
 /// Initialize the Vortex extension by registering the extension functions.
 /// Note: This also registers extension options. If you want to register options
@@ -123,46 +92,4 @@ pub extern "C" fn vortex_extension_version_rust() -> *const c_char {
         CStr::from_bytes_with_nul_unchecked(concat!(env!("CARGO_PKG_VERSION"), "\0").as_bytes())
     }
     .as_ptr()
-}
-
-#[cfg(test)]
-mod tests {
-    use std::ffi::CString;
-
-    use super::*;
-    use crate::duckdb::Config;
-    use crate::duckdb::Database;
-
-    #[test]
-    fn test_vortex_max_threads_option_registration() {
-        let config = Config::new().expect("Failed to create config");
-        register_extension_options(&config);
-        let db = Database::open_in_memory_with_config(config).expect("Failed to open database");
-
-        let conn = db.connect().expect("Failed to connect");
-
-        let _result1 = conn
-            .query("SET vortex_max_threads = 4")
-            .expect("Failed to set vortex_max_threads - option may not be registered");
-
-        let max_threads_cstr = CString::new("vortex_max_threads").unwrap();
-        let ctx = conn.client_context().vortex_expect("ctx exists");
-        assert_eq!(
-            ctx.try_get_current_setting(&max_threads_cstr)
-                .unwrap()
-                .to_string(),
-            "4"
-        );
-
-        let _result2 = conn
-            .query("SET vortex_max_threads = 8")
-            .expect("Failed to set vortex_max_threads to 8");
-
-        assert_eq!(
-            ctx.try_get_current_setting(&max_threads_cstr)
-                .unwrap()
-                .to_string(),
-            "8"
-        );
-    }
 }

--- a/vortex-duckdb/src/scan.rs
+++ b/vortex-duckdb/src/scan.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::cmp::max;
-use std::ffi::CString;
 use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Formatter;
@@ -62,7 +61,6 @@ use crate::duckdb::BindResult;
 use crate::duckdb::Cardinality;
 use crate::duckdb::ClientContext;
 use crate::duckdb::DataChunk;
-use crate::duckdb::ExtractedValue;
 use crate::duckdb::LogicalType;
 use crate::duckdb::TableFunction;
 use crate::duckdb::TableInitInput;
@@ -79,7 +77,6 @@ pub struct VortexBindData {
     file_urls: Vec<Url>,
     column_names: Vec<String>,
     column_types: Vec<LogicalType>,
-    max_threads: u64,
 }
 
 impl Clone for VortexBindData {
@@ -92,7 +89,6 @@ impl Clone for VortexBindData {
             file_urls: self.file_urls.clone(),
             column_names: self.column_names.clone(),
             column_types: self.column_types.clone(),
-            max_threads: self.max_threads,
         }
     }
 }
@@ -260,24 +256,6 @@ impl TableFunction for VortexTableFunction {
             .get_parameter(0)
             .ok_or_else(|| vortex_err!("Missing file glob parameter"))?;
 
-        // Read the vortex_max_threads setting from DuckDB configuration
-        let max_threads_cstr = CString::new("vortex_max_threads")
-            .map_err(|e| vortex_err!("Invalid setting name: {}", e))?;
-        let max_threads = ctx
-            .try_get_current_setting(&max_threads_cstr)
-            .and_then(|v| match v.as_ref().extract() {
-                ExtractedValue::UBigInt(val) => usize::try_from(val).ok(),
-                ExtractedValue::BigInt(val) if val > 0 => usize::try_from(val as u64).ok(),
-                _ => None,
-            })
-            .unwrap_or_else(|| {
-                std::thread::available_parallelism()
-                    .map(|n| n.get())
-                    .unwrap_or(1)
-            });
-
-        tracing::trace!("running scan with max_threads {max_threads}");
-
         let (file_urls, _metadata) = RUNTIME.block_on(Compat::new(expand_glob(
             file_glob_string.as_ref().as_string(),
         )))?;
@@ -309,7 +287,6 @@ impl TableFunction for VortexTableFunction {
             filter_exprs: vec![],
             column_names,
             column_types,
-            max_threads: max_threads as u64,
         })
     }
 
@@ -389,12 +366,12 @@ impl TableFunction for VortexTableFunction {
                 .map_or_else(|| "true".to_string(), |f| f.to_string())
         );
 
-        // Use the max_threads from bind_data (read from vortex_max_threads setting)
-        #[expect(clippy::cast_possible_truncation, reason = "max_threads fits in usize")]
-        let num_workers = bind_data.max_threads as usize;
-
         let client_context = init_input.client_context()?;
         let object_cache = client_context.object_cache();
+
+        let num_workers = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1);
 
         let handle = RUNTIME.handle();
         let first_file = bind_data.first_file.clone();


### PR DESCRIPTION
Benchmarking takes a "threads" flag. We used to only set this on the Vortex table function, not the rest of DuckDB. This was different to how the same flag behaves in DataFusion which configures the entire Tokio runtime with n threads.

I can confirm it runs with a single thread when passed

<img width="653" height="435" alt="Screenshot 2026-02-13 at 20 21 27" src="https://github.com/user-attachments/assets/caacf3fd-7a1a-4e7c-91e5-67917564a659" />
