### PR TITLE
fix[layout]: snapshot nbytes at push time in ChunksBuffer to avoid underflow

### DIFF
--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -155,7 +155,7 @@ impl LayoutStrategy for RepartitionStrategy {
                 }
                 if canonical_stream.as_mut().peek().await.is_none() {
                     let to_flush = ChunkedArray::try_new(
-                        chunks.data.drain(..).collect(),
+                        chunks.data.drain(..).map(|(arr, _)| arr).collect(),
                         dtype_clone.clone(),
                     )?;
                     if !to_flush.is_empty() {
@@ -189,7 +189,10 @@ impl LayoutStrategy for RepartitionStrategy {
 }
 
 struct ChunksBuffer {
-    data: VecDeque<ArrayRef>,
+    /// Each entry stores the chunk and the `nbytes()` snapshot taken at push time.
+    /// This avoids accounting mismatches when interior-mutable arrays (e.g. `SharedArray`)
+    /// change their reported size after being pushed.
+    data: VecDeque<(ArrayRef, u64)>,
     row_count: usize,
     nbytes: u64,
     block_size_minimum: u64,
@@ -216,7 +219,7 @@ impl ChunksBuffer {
         let mut res = Vec::with_capacity(self.data.len());
         let mut remaining = nblocks * self.block_len_multiple;
         while remaining > 0 {
-            let chunk = self
+            let (chunk, _) = self
                 .pop_front()
                 .vortex_expect("must have at least one chunk");
             let len = chunk.len();
@@ -236,22 +239,25 @@ impl ChunksBuffer {
     }
 
     fn push_back(&mut self, chunk: ArrayRef) {
+        let nb = chunk.nbytes();
         self.row_count += chunk.len();
-        self.nbytes += chunk.nbytes();
-        self.data.push_back(chunk);
+        self.nbytes += nb;
+        self.data.push_back((chunk, nb));
     }
 
     fn push_front(&mut self, chunk: ArrayRef) {
+        let nb = chunk.nbytes();
         self.row_count += chunk.len();
-        self.nbytes += chunk.nbytes();
-        self.data.push_front(chunk);
+        self.nbytes += nb;
+        self.data.push_front((chunk, nb));
     }
 
-    fn pop_front(&mut self) -> Option<ArrayRef> {
+    fn pop_front(&mut self) -> Option<(ArrayRef, u64)> {
         let res = self.data.pop_front();
-        if let Some(chunk) = res.as_ref() {
+        // if let Some((chunk, nb)) = res.as_ref() {
+        if let Some((chunk, nb)) = res.as_ref() {
             self.row_count -= chunk.len();
-            self.nbytes -= chunk.nbytes();
+            self.nbytes -= nb;
         }
         res
     }
@@ -440,6 +446,45 @@ mod tests {
         assert_eq!(layout.nchildren(), 2);
         assert_eq!(layout.child(0)?.row_count(), 8192);
         assert_eq!(layout.child(1)?.row_count(), 1808);
+
+        Ok(())
+    }
+
+    /// Regression test: `SharedArray` slices sharing an `Arc<Mutex<SharedState>>` can
+    /// transition from Source to Cached when any one of them is canonicalized. This caused
+    /// `pop_front` to panic with `attempt to subtract with overflow` because the buffer's
+    /// running `nbytes` total was accumulated with the smaller Source-era values while
+    /// `pop_front` subtracted the larger Cached-era values.
+    #[test]
+    fn chunks_buffer_pop_front_no_panic_after_shared_execution() -> VortexResult<()> {
+        use vortex_array::Array;
+        use vortex_array::arrays::ConstantArray;
+        use vortex_array::arrays::SharedArray;
+
+        let n = 20_000usize;
+        let block_len = 10_000usize;
+
+        let constant = ConstantArray::new(42i64, n);
+        let shared = SharedArray::new(constant.into_array());
+        let shared_handle = shared.clone();
+        let arr = shared.into_array();
+
+        let s1 = arr.slice(0..block_len)?;
+        let s2 = arr.slice(block_len..n)?;
+
+        let mut buf = ChunksBuffer::new(0, block_len);
+        buf.push_back(s1);
+        buf.push_back(s2);
+
+        let _output = buf.pop_front().unwrap();
+
+        // Transition SharedState from Source to Cached for ALL slices sharing this Arc.
+        shared_handle.get_or_compute(|source| source.to_canonical())?;
+
+        // Before the fix this panicked with "attempt to subtract with overflow".
+        let _s2 = buf.pop_front().unwrap();
+        assert_eq!(buf.nbytes, 0);
+        assert_eq!(buf.row_count, 0);
 
         Ok(())
     }

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -254,7 +254,6 @@ impl ChunksBuffer {
 
     fn pop_front(&mut self) -> Option<(ArrayRef, u64)> {
         let res = self.data.pop_front();
-        // if let Some((chunk, nb)) = res.as_ref() {
         if let Some((chunk, nb)) = res.as_ref() {
             self.row_count -= chunk.len();
             self.nbytes -= nb;
@@ -267,10 +266,13 @@ impl ChunksBuffer {
 mod tests {
     use std::sync::Arc;
 
+    use vortex_array::Array;
     use vortex_array::ArrayContext;
     use vortex_array::IntoArray;
+    use vortex_array::arrays::ConstantArray;
     use vortex_array::arrays::FixedSizeListArray;
     use vortex_array::arrays::PrimitiveArray;
+    use vortex_array::arrays::SharedArray;
     use vortex_array::validity::Validity;
     use vortex_dtype::DType;
     use vortex_dtype::Nullability::NonNullable;
@@ -457,10 +459,6 @@ mod tests {
     /// `pop_front` subtracted the larger Cached-era values.
     #[test]
     fn chunks_buffer_pop_front_no_panic_after_shared_execution() -> VortexResult<()> {
-        use vortex_array::Array;
-        use vortex_array::arrays::ConstantArray;
-        use vortex_array::arrays::SharedArray;
-
         let n = 20_000usize;
         let block_len = 10_000usize;
 


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

- N/A

## What changes are included in this PR?

- Changed ChunksBuffer.data from VecDeque<ArrayRef> to VecDeque<(ArrayRef, u64)>, snapshotting each chunk's nbytes() at push time.
- pop_front now subtracts the stored snapshot instead of re-querying chunk.nbytes().
- Added a regression test that reproduces the underflow via SharedArray state transition.

## What is the rationale for this change?

SharedArray slices sharing an Arc<Mutex<SharedState>> can transition from Source to Cached when any one of them is canonicalized. This is interior mutation — it happens without the ChunksBuffer knowing. Because nbytes() traverses the current array tree, a chunk that reported a small nbytes() at push time (compressed/source-era) can report a much larger value at pop time (decompressed/cached-era). The running nbytes total was accumulated with the smaller values, so subtracting the larger value causes an integer underflow panic (attempt to subtract with overflow).

By snapshotting nbytes() once at push time and storing it alongside the chunk, the accounting stays self-consistent regardless of any interior state changes between push and pop.

## How is this change tested?

A new unit test chunks_buffer_pop_front_no_panic_after_shared_execution reproduces the exact failure scenario:

1. Creates a ConstantArray (tiny nbytes) wrapped in a SharedArray.
2. Slices it into two chunks and pushes both into a ChunksBuffer.
3. Pops the first chunk (succeeds, no state change yet).
4. Triggers canonicalization via shared_handle.get_or_compute(), which transitions all slices to Cached state with much larger nbytes.
5. Pops the second chunk — before this fix, this panicked with underflow.

## Are there any user-facing changes?

No. This is an internal bug fix in the repartition writer. No public APIs are changed.
