### PR TITLE
vx convert to support cuda compatible vortex files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10858,6 +10858,7 @@ dependencies = [
  "taffy",
  "tokio",
  "vortex",
+ "vortex-cuda",
  "vortex-datafusion",
 ]
 

--- a/vortex-tui/Cargo.toml
+++ b/vortex-tui/Cargo.toml
@@ -36,6 +36,12 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 vortex = { workspace = true, features = ["tokio"] }
 vortex-datafusion = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+vortex-cuda = { workspace = true, optional = true }
+
+[features]
+cuda = ["dep:vortex-cuda"]
+
 [lints]
 workspace = true
 

--- a/vortex-tui/src/convert.rs
+++ b/vortex-tui/src/convert.rs
@@ -31,6 +31,9 @@ pub enum Strategy {
     Btrblocks,
     /// Use the Compact compression strategy for more aggressive compression.
     Compact,
+    #[cfg(all(target_os = "linux", feature = "cuda"))]
+    /// Use CUDA-compatible encodings with CudaFlatLayout.
+    Cuda,
 }
 
 /// Command-line flags for the convert command.
@@ -95,6 +98,15 @@ pub async fn exec_convert(session: &VortexSession, flags: ConvertArgs) -> anyhow
     let strategy = match flags.strategy {
         Strategy::Btrblocks => strategy,
         Strategy::Compact => strategy.with_compact_encodings(),
+        #[cfg(all(target_os = "linux", feature = "cuda"))]
+        Strategy::Cuda => {
+            use std::sync::Arc;
+            strategy
+                .with_cuda_compatible_encodings()
+                .with_flat_strategy(Arc::new(
+                    vortex_cuda::layout::CudaFlatLayoutStrategy::default(),
+                ))
+        }
     };
 
     let mut file = File::create(output_path).await?;


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

<!--
This helps us keep track of fixed issues and changes.
-->

- Closes #.

## What changes are included in this PR?

<!--
What changes are included here, if an issue or discussion are attached, there's no need to duplicate the details.
-->

## What is the rationale for this change?

support vortex-cuda vortex variant with `vx convert`, these files have the cuda flat layout that inlines constant buffers into the layout metadata, and also only use cuda compatible encodings
<!--
Why do you propose this change, and why did you choose this approach.

This helps reviewers and other readers understand changes, creates a shared understanding of the issue and codebase,
and improves their ability to work with this change and offer better suggestions.
-->

## How is this change tested?

<!--
Changes should be tested, we expect changes to fit in one of the following categories:
1. Verifying existing behavior is maintained.
2. For serialization related changes - Compatibility should be maintained or explicitly broken.
3. For new behavior and functionality, this helps us maintaining that desired behavior in the future.
-->

## Are there any user-facing changes?

<!--
Does the change affect users in what of the following ways:
1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the integrations.
3. Should some documentation be changed to reflect this change?

In the case some public API is changed in a breaking way, make sure to add the appropriate label.
-->