### PR TITLE
chore: replace macros with fns

### DIFF
--- a/vortex-cuda/kernels/src/config.cuh
+++ b/vortex-cuda/kernels/src/config.cuh
@@ -13,7 +13,13 @@
 //   grid_dim = ceil(array_len / 2048)
 constexpr uint32_t ELEMENTS_PER_THREAD = 32;
 
-#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+// We use `::min` from CUDA's `crt/math_functions.hpp` (declared `__host__ __device__`)
+// rather than `std::min` which is host-only.
 
-#define START_ELEM(idx, len) MIN((idx) * ELEMENTS_PER_THREAD, (len))
-#define STOP_ELEM(idx, len)  MIN(START_ELEM(idx, len) + ELEMENTS_PER_THREAD, (len))
+__device__ constexpr inline uint32_t start_elem(uint32_t idx, uint32_t len) {
+    return ::min(idx * ELEMENTS_PER_THREAD, len);
+}
+
+__device__ constexpr inline uint32_t stop_elem(uint32_t idx, uint32_t len) {
+    return ::min(start_elem(idx, len) + ELEMENTS_PER_THREAD, len);
+}

--- a/vortex-cuda/kernels/src/config.cuh
+++ b/vortex-cuda/kernels/src/config.cuh
@@ -16,10 +16,12 @@ constexpr uint32_t ELEMENTS_PER_THREAD = 32;
 // We use `::min` from CUDA's `crt/math_functions.hpp` (declared `__host__ __device__`)
 // rather than `std::min` which is host-only.
 
-__device__ constexpr inline uint32_t start_elem(uint32_t idx, uint32_t len) {
-    return ::min(idx * ELEMENTS_PER_THREAD, len);
+template <typename T>
+__device__ constexpr inline T start_elem(T idx, T len) {
+    return ::min(idx * static_cast<T>(ELEMENTS_PER_THREAD), len);
 }
 
-__device__ constexpr inline uint32_t stop_elem(uint32_t idx, uint32_t len) {
-    return ::min(start_elem(idx, len) + ELEMENTS_PER_THREAD, len);
+template <typename T>
+__device__ constexpr inline T stop_elem(T idx, T len) {
+    return ::min(start_elem(idx, len) + static_cast<T>(ELEMENTS_PER_THREAD), len);
 }

--- a/vortex-cuda/kernels/src/constant_numeric.cu
+++ b/vortex-cuda/kernels/src/constant_numeric.cu
@@ -9,8 +9,8 @@
 template <typename T>
 __device__ void constant_fill(T *__restrict output, T value, uint64_t array_len) {
     const uint64_t worker = blockIdx.x * blockDim.x + threadIdx.x;
-    const uint64_t startElem = START_ELEM(worker, array_len);
-    const uint64_t stopElem = STOP_ELEM(worker, array_len);
+    const uint64_t startElem = start_elem(worker, array_len);
+    const uint64_t stopElem = stop_elem(worker, array_len);
 
     if (startElem >= array_len) {
         return;

--- a/vortex-cuda/kernels/src/patches.cu
+++ b/vortex-cuda/kernels/src/patches.cu
@@ -13,8 +13,8 @@ __device__ void patches(ValueT *const values,
                         const ValueT *const patchValues,
                         uint64_t patchesLen) {
     const uint64_t worker = blockIdx.x * blockDim.x + threadIdx.x;
-    const uint64_t startElem = START_ELEM(worker, patchesLen);
-    const uint64_t stopElem = STOP_ELEM(worker, patchesLen);
+    const uint64_t startElem = start_elem(worker, patchesLen);
+    const uint64_t stopElem = stop_elem(worker, patchesLen);
 
     if (startElem >= patchesLen) {
         return;

--- a/vortex-cuda/kernels/src/sequence.cu
+++ b/vortex-cuda/kernels/src/sequence.cu
@@ -7,8 +7,8 @@ template <typename ValueT>
 __device__ void sequence(ValueT *const output, ValueT base, ValueT multiplier, uint64_t len) {
     const uint64_t worker = blockIdx.x * blockDim.x + threadIdx.x;
 
-    const uint64_t startElem = START_ELEM(worker, len);
-    const uint64_t stopElem = STOP_ELEM(worker, len);
+    const uint64_t startElem = start_elem(worker, len);
+    const uint64_t stopElem = stop_elem(worker, len);
 
     for (uint64_t idx = startElem; idx < stopElem; idx++) {
         output[idx] = static_cast<ValueT>(idx) * multiplier + base;


### PR DESCRIPTION
## What changes are included in this PR?

Replaces macros used in CUDA code with constexpr functions.