### PR TITLE
pvalue::cast returns VortexResult

### DIFF
--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -133,7 +133,9 @@ impl SequenceArray {
 
         // A sequence A[i] = base + i * multiplier is sorted iff multiplier >= 0,
         // and strictly sorted iff multiplier > 0.
-        let m_int = multiplier.cast::<i64>();
+        let m_int = multiplier
+            .cast::<i64>()
+            .vortex_expect("must be able to cast");
         let is_sorted = m_int >= 0;
         let is_strict_sorted = m_int > 0;
 
@@ -179,9 +181,8 @@ impl SequenceArray {
             let len_t = <P>::from_usize(length - 1)
                 .ok_or_else(|| vortex_err!("cannot convert length {} into {}", length, ptype))?;
 
-            let base = base.cast::<P>();
-            let multiplier = multiplier.cast::<P>();
-
+            let base = base.cast::<P>()?;
+            let multiplier = multiplier.cast::<P>()?;
             let last = len_t
                 .checked_mul(multiplier)
                 .and_then(|offset| offset.checked_add(base))
@@ -194,8 +195,11 @@ impl SequenceArray {
         assert!(idx < self.len, "index_value({idx}): index out of bounds");
 
         match_each_native_ptype!(self.ptype(), |P| {
-            let base = self.base.cast::<P>();
-            let multiplier = self.multiplier.cast::<P>();
+            let base = self.base.cast::<P>().vortex_expect("must be able to cast");
+            let multiplier = self
+                .multiplier
+                .cast::<P>()
+                .vortex_expect("must be able to cast");
             let value = base + (multiplier * <P>::from_usize(idx).vortex_expect("must fit"));
 
             PValue::from(value)
@@ -310,8 +314,8 @@ impl VTable for SequenceVTable {
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
         let prim = match_each_native_ptype!(array.ptype(), |P| {
-            let base = array.base().cast::<P>();
-            let multiplier = array.multiplier().cast::<P>();
+            let base = array.base().cast::<P>()?;
+            let multiplier = array.multiplier().cast::<P>()?;
             let values = BufferMut::from_iter(
                 (0..array.len())
                     .map(|i| base + <P>::from_usize(i).vortex_expect("must fit") * multiplier),

--- a/encodings/sequence/src/compute/compare.rs
+++ b/encodings/sequence/src/compute/compare.rs
@@ -14,6 +14,8 @@ use vortex_dtype::Nullability;
 use vortex_dtype::match_each_integer_ptype;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
 use vortex_scalar::PValue;
 use vortex_scalar::Scalar;
 
@@ -53,7 +55,7 @@ impl CompareKernel for SequenceVTable {
             Nullability::Nullable => vortex_array::validity::Validity::AllValid,
         };
 
-        if let Some(set_idx) = set_idx {
+        if let Ok(set_idx) = set_idx {
             let buffer = BitBuffer::from_iter((0..lhs.len()).map(|idx| idx == set_idx));
             Ok(Some(BoolArray::new(buffer, validity).to_array()))
         } else {
@@ -66,8 +68,10 @@ impl CompareKernel for SequenceVTable {
 
 /// Find the index where `base + idx * multiplier == intercept`, if one exists.
 ///
-/// Returns `None` if:
+/// # Errors
+/// Return `VortexError` if:
 /// - `len` is 0
+/// - `intercept` or `multiplier` can't be cast to `base`'s PType
 /// - `intercept` is outside the range of the sequence
 /// - `intercept` doesn't fall exactly on a sequence value
 pub(crate) fn find_intersection_scalar(
@@ -75,11 +79,11 @@ pub(crate) fn find_intersection_scalar(
     multiplier: PValue,
     len: usize,
     intercept: PValue,
-) -> Option<usize> {
+) -> VortexResult<usize> {
     match_each_integer_ptype!(base.ptype(), |P| {
-        let intercept = intercept.cast::<P>().ok()?;
-        let base = base.cast::<P>().ok()?;
-        let multiplier = multiplier.cast::<P>().ok()?;
+        let intercept = intercept.cast::<P>()?;
+        let base = base.cast::<P>()?;
+        let multiplier = multiplier.cast::<P>()?;
         find_intersection(base, multiplier, len, intercept)
     })
 }
@@ -89,9 +93,9 @@ fn find_intersection<P: NativePType>(
     multiplier: P,
     len: usize,
     intercept: P,
-) -> Option<usize> {
+) -> VortexResult<usize> {
     if len == 0 {
-        return None;
+        vortex_bail!("len == 0")
     }
 
     let count = P::from_usize(len - 1).vortex_expect("idx must fit into type");
@@ -106,22 +110,27 @@ fn find_intersection<P: NativePType>(
 
     // Check if intercept is in range
     if !intercept.is_ge(min_val) || !intercept.is_le(max_val) {
-        return None;
+        vortex_bail!("{intercept} is outside of ({min_val}, {max_val}) range")
     }
 
     // Handle zero multiplier (constant sequence)
     if multiplier == P::zero() {
-        return (intercept == base).then_some(0);
+        if intercept == base {
+            return Ok(0);
+        } else {
+            vortex_bail!("{intercept} != {base} with zero multiplier")
+        }
     }
 
     // Check if (intercept - base) is evenly divisible by multiplier
     let diff = intercept - base;
     if diff % multiplier != P::zero() {
-        return None;
+        vortex_bail!("{diff} % {multiplier} != 0")
     }
 
     let idx = diff / multiplier;
     idx.to_usize()
+        .ok_or_else(|| vortex_err!("Cannot represent {idx} as usize"))
 }
 
 #[cfg(test)]

--- a/encodings/sequence/src/compute/compare.rs
+++ b/encodings/sequence/src/compute/compare.rs
@@ -77,9 +77,9 @@ pub(crate) fn find_intersection_scalar(
     intercept: PValue,
 ) -> Option<usize> {
     match_each_integer_ptype!(base.ptype(), |P| {
-        let intercept = intercept.cast::<P>();
-        let base = base.cast::<P>();
-        let multiplier = multiplier.cast::<P>();
+        let intercept = intercept.cast::<P>().ok()?;
+        let base = base.cast::<P>().ok()?;
+        let multiplier = multiplier.cast::<P>().ok()?;
         find_intersection(base, multiplier, len, intercept)
     })
 }

--- a/encodings/sequence/src/compute/filter.rs
+++ b/encodings/sequence/src/compute/filter.rs
@@ -25,8 +25,8 @@ impl FilterKernel for SequenceVTable {
     ) -> VortexResult<Option<ArrayRef>> {
         let validity = Validity::from(array.dtype().nullability());
         match_each_native_ptype!(array.ptype(), |P| {
-            let mul = array.multiplier().cast::<P>();
-            let base = array.base().cast::<P>();
+            let mul = array.multiplier().cast::<P>()?;
+            let base = array.base().cast::<P>()?;
             Ok(Some(filter_impl(mul, base, mask, validity)))
         })
     }

--- a/encodings/sequence/src/compute/is_sorted.rs
+++ b/encodings/sequence/src/compute/is_sorted.rs
@@ -14,12 +14,16 @@ use crate::SequenceVTable;
 impl IsSortedKernel for SequenceVTable {
     fn is_sorted(&self, array: &SequenceArray) -> VortexResult<Option<bool>> {
         let m = array.multiplier();
-        match_each_native_ptype!(m.ptype(), |P| { Ok(Some(m.cast::<P>() >= zero::<P>())) })
+        match_each_native_ptype!(m.ptype(), |P| {
+            m.cast::<P>().map(|x| Some(x >= zero::<P>()))
+        })
     }
 
     fn is_strict_sorted(&self, array: &SequenceArray) -> VortexResult<Option<bool>> {
         let m = array.multiplier();
-        match_each_native_ptype!(m.ptype(), |P| { Ok(Some(m.cast::<P>() > zero::<P>())) })
+        match_each_native_ptype!(m.ptype(), |P| {
+            m.cast::<P>().map(|x| Some(x > zero::<P>()))
+        })
     }
 }
 

--- a/encodings/sequence/src/compute/list_contains.rs
+++ b/encodings/sequence/src/compute/list_contains.rs
@@ -28,19 +28,20 @@ impl ListContainsKernel for SequenceVTable {
             .elements()
             .vortex_expect("non-null element (checked in entry)");
 
-        let set_indices = list_elements
-            .iter()
-            .flat_map(|elem| {
-                elem.as_primitive().pvalue().and_then(|intercept| {
-                    find_intersection_scalar(
-                        element.base(),
-                        element.multiplier(),
-                        element.len(),
-                        intercept,
-                    )
-                })
-            })
-            .collect::<Vec<_>>();
+        let mut set_indices: Vec<usize> = Vec::new();
+        for intercept in list_elements.iter() {
+            let Some(intercept) = intercept.as_primitive().pvalue() else {
+                continue;
+            };
+            if let Ok(intersection) = find_intersection_scalar(
+                element.base(),
+                element.multiplier(),
+                element.len(),
+                intercept,
+            ) {
+                set_indices.push(intersection)
+            }
+        }
 
         let nullability = list.dtype().nullability() | element.dtype().nullability();
 

--- a/encodings/sequence/src/compute/take.rs
+++ b/encodings/sequence/src/compute/take.rs
@@ -86,8 +86,8 @@ impl TakeExecute for SequenceVTable {
         match_each_integer_ptype!(indices.ptype(), |T| {
             let indices = indices.as_slice::<T>();
             match_each_native_ptype!(array.ptype(), |S| {
-                let mul = array.multiplier().cast::<S>();
-                let base = array.base().cast::<S>();
+                let mul = array.multiplier().cast::<S>()?;
+                let base = array.base().cast::<S>()?;
                 Ok(Some(take_inner(
                     mul,
                     base,

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -155,9 +155,10 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
             scalar.dtype()
         );
 
-        match scalar.as_primitive().pvalue() {
-            Some(pv) => self.append_value(pv.cast::<T>()),
-            None => self.append_null(),
+        if let Some(pv) = scalar.as_primitive().pvalue() {
+            self.append_value(pv.cast::<T>()?)
+        } else {
+            self.append_null()
         }
 
         Ok(())

--- a/vortex-cuda/src/kernel/encodings/sequence.rs
+++ b/vortex-cuda/src/kernel/encodings/sequence.rs
@@ -48,9 +48,8 @@ impl CudaExecute for SequenceExecutor {
         } = array.into_parts();
 
         match_each_native_ptype!(ptype, |P| {
-            let base = base.cast::<P>();
-            let multiplier = multiplier.cast::<P>();
-
+            let base = base.cast::<P>()?;
+            let multiplier = multiplier.cast::<P>()?;
             execute_typed::<P>(base, multiplier, len, nullability, ctx).await
         })
     }

--- a/vortex-scalar/public-api.lock
+++ b/vortex-scalar/public-api.lock
@@ -212,9 +212,7 @@ pub fn vortex_scalar::PValue::as_u64(self) -> core::option::Option<u64>
 
 pub fn vortex_scalar::PValue::as_u8(self) -> core::option::Option<u8>
 
-pub fn vortex_scalar::PValue::cast<T: vortex_dtype::ptype::NativePType>(&self) -> T
-
-pub fn vortex_scalar::PValue::cast_opt<T: vortex_dtype::ptype::NativePType>(&self) -> core::option::Option<T>
+pub fn vortex_scalar::PValue::cast<T: vortex_dtype::ptype::NativePType>(&self) -> vortex_error::VortexResult<T>
 
 pub fn vortex_scalar::PValue::is_instance_of(&self, ptype: &vortex_dtype::ptype::PType) -> bool
 

--- a/vortex-scalar/src/convert/primitive.rs
+++ b/vortex-scalar/src/convert/primitive.rs
@@ -50,9 +50,7 @@ macro_rules! primitive_scalar {
             type Error = VortexError;
 
             fn try_from(value: &ScalarValue) -> VortexResult<Self> {
-                value.as_primitive().cast_opt::<$T>().ok_or_else(|| {
-                    vortex_err!("Unable to convert the `ScalarValue` to the target type")
-                })
+                value.as_primitive().cast::<$T>()
             }
         }
 
@@ -154,10 +152,7 @@ impl TryFrom<&ScalarValue> for usize {
     type Error = VortexError;
 
     fn try_from(value: &ScalarValue) -> VortexResult<Self> {
-        let val = value
-            .as_primitive()
-            .cast_opt::<u64>()
-            .ok_or_else(|| vortex_err!("Unable to convert the `ScalarValue` to the target type"))?;
+        let val = value.as_primitive().cast::<u64>()?;
         Ok(usize::try_from(val)?)
     }
 }

--- a/vortex-scalar/src/tests/casting.rs
+++ b/vortex-scalar/src/tests/casting.rs
@@ -103,7 +103,7 @@ mod tests {
         assert!(
             result
                 .as_ref()
-                .is_err_and(|err| { err.to_string().contains("Cannot cast u16 to u8") }),
+                .is_err_and(|err| { err.to_string().contains("Cannot cast 1000u16 to u8") }),
             "{result:?}"
         );
     }

--- a/vortex-scalar/src/tests/nested.rs
+++ b/vortex-scalar/src/tests/nested.rs
@@ -369,7 +369,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Cannot cast u16 to u8")
+                .contains("Cannot cast 256u16 to u8")
         );
     }
 

--- a/vortex-scalar/src/typed_view/primitive/pvalue.rs
+++ b/vortex-scalar/src/typed_view/primitive/pvalue.rs
@@ -198,18 +198,11 @@ impl PValue {
 
     /// Converts this value to a specific native primitive type.
     ///
-    /// Panics if the conversion is not supported or would overflow.
+    /// # Errors
+    /// Returns `VortexError` if the conversion is not supported or would overflow.
     #[inline]
-    pub fn cast<T: NativePType>(&self) -> T {
-        self.cast_opt::<T>().vortex_expect("as_primitive")
-    }
-
-    /// Converts this value to a specific native primitive type.
-    ///
-    /// Returns `None` if the conversion is not supported or would overflow.
-    #[inline]
-    pub fn cast_opt<T: NativePType>(&self) -> Option<T> {
-        match *self {
+    pub fn cast<T: NativePType>(&self) -> VortexResult<T> {
+        let res = match *self {
             PValue::U8(u) => T::from_u8(u),
             PValue::U16(u) => T::from_u16(u),
             PValue::U32(u) => T::from_u32(u),
@@ -221,7 +214,9 @@ impl PValue {
             PValue::F16(f) => T::from_f16(f),
             PValue::F32(f) => T::from_f32(f),
             PValue::F64(f) => T::from_f64(f),
-        }
+        };
+        let to = T::PTYPE;
+        res.ok_or_else(|| vortex_err!("Cannot cast {self} to {to}"))
     }
 
     /// Returns true if the value of float type and is NaN.
@@ -322,21 +317,21 @@ macro_rules! int_pvalue {
             type Error = VortexError;
 
             fn try_from(value: PValue) -> Result<Self, Self::Error> {
-                match value {
+                if matches!(
+                    value,
                     PValue::U8(_)
-                    | PValue::U16(_)
-                    | PValue::U32(_)
-                    | PValue::U64(_)
-                    | PValue::I8(_)
-                    | PValue::I16(_)
-                    | PValue::I32(_)
-                    | PValue::I64(_) => Some(value),
-                    _ => None,
+                        | PValue::U16(_)
+                        | PValue::U32(_)
+                        | PValue::U64(_)
+                        | PValue::I8(_)
+                        | PValue::I16(_)
+                        | PValue::I32(_)
+                        | PValue::I64(_)
+                ) {
+                    PValue::cast(&value)
+                } else {
+                    vortex_bail!("Cannot read primitive value {:?} as {}", value, PType::$PT)
                 }
-                .and_then(|v| PValue::cast_opt(&v))
-                .ok_or_else(|| {
-                    vortex_err!("Cannot read primitive value {:?} as {}", value, PType::$PT)
-                })
             }
         }
     };
@@ -349,9 +344,7 @@ macro_rules! float_pvalue {
             type Error = VortexError;
 
             fn try_from(value: PValue) -> Result<Self, Self::Error> {
-                value.cast_opt().ok_or_else(|| {
-                    vortex_err!("Cannot read primitive value {:?} as {}", value, PType::$PT)
-                })
+                value.cast()
             }
         }
     };
@@ -362,8 +355,8 @@ impl TryFrom<PValue> for usize {
 
     fn try_from(value: PValue) -> Result<Self, Self::Error> {
         value
-            .cast_opt::<u64>()
-            .and_then(|v| v.to_usize())
+            .cast::<u64>()?
+            .to_usize()
             .ok_or_else(|| vortex_err!("Cannot read primitive value {:?} as usize", value))
     }
 }

--- a/vortex-scalar/src/typed_view/primitive/scalar.rs
+++ b/vortex-scalar/src/typed_view/primitive/scalar.rs
@@ -24,7 +24,6 @@ use vortex_error::VortexError;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
-use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 
 use super::pvalue::CoercePValue;
@@ -137,8 +136,7 @@ impl<'a> PrimitiveScalar<'a> {
             T::PTYPE
         );
 
-        // TODO(connor): This should really use `cast_opt`...
-        self.pvalue.map(|pv| pv.cast::<T>())
+        self.pvalue.and_then(|pv| pv.cast::<T>().ok())
     }
 
     /// Returns the value as a specific native primitive type.
@@ -157,8 +155,11 @@ impl<'a> PrimitiveScalar<'a> {
             T::PTYPE
         );
 
-        // TODO(connor): This should really use `cast_opt`...
-        Ok(self.pvalue.map(|pv| pv.cast::<T>()))
+        if let Some(pv) = self.pvalue {
+            pv.cast::<T>().map(Some)
+        } else {
+            Ok(None)
+        }
     }
 
     /// Casts this scalar to the given `dtype`.
@@ -168,12 +169,7 @@ impl<'a> PrimitiveScalar<'a> {
             .pvalue
             .vortex_expect("nullness handled in Scalar::cast");
         Ok(match_each_native_ptype!(ptype, |Q| {
-            Scalar::primitive(
-                pvalue
-                    .cast_opt::<Q>()
-                    .ok_or_else(|| vortex_err!("Cannot cast {} to {}", self.ptype, dtype))?,
-                dtype.nullability(),
-            )
+            Scalar::primitive(pvalue.cast::<Q>()?, dtype.nullability())
         }))
     }
 


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

No

## What changes are included in this PR?

- PValue::cast returns VortexResult instead of Option.
- find_intersection* and a couple of other functions also return VortexResult instead of Option.

## What is the rationale for this change?

First issue

## How is this change tested?

Existing tests

## Are there any user-facing changes?

Public API method signature changed
