### PR TITLE
remove unstable_encodings from vortex-bench by default

### DIFF
--- a/vortex-bench/Cargo.toml
+++ b/vortex-bench/Cargo.toml
@@ -62,5 +62,4 @@ vortex = { workspace = true, features = [
     "files",
     "tokio",
     "zstd",
-    "unstable_encodings",
 ] }


### PR DESCRIPTION
## Does this PR closes an open issue or discussion?

<!--
This helps us keep track of fixed issues and changes.
-->

- Closes #.

## What changes are included in this PR?

running nextest on the entire workspace would bring in the unstable encodings feature from vortex-bench, and vortex-e2e would have it enabled, but not vortex-file so the test would fail. 

## What is the rationale for this change?

<!--
Why do you propose this change, and why did you choose this approach.

This helps reviewers and other readers understand changes, creates a shared understanding of the issue and codebase,
and improves their ability to work with this change and offer better suggestions.
-->

## How is this change tested?

<!--
Changes should be tested, we expect changes to fit in one of the following categories:
1. Verifying existing behavior is maintained.
2. For serialization related changes - Compatibility should be maintained or explicitly broken.
3. For new behavior and functionality, this helps us maintaining that desired behavior in the future.
-->

## Are there any user-facing changes?

<!--
Does the change affect users in what of the following ways:
1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the integrations.
3. Should some documentation be changed to reflect this change?

In the case some public API is changed in a breaking way, make sure to add the appropriate label.
-->