### PR TITLE
fix: duckdb object store read coalescing

### DIFF
--- a/vortex-duckdb/src/duckdb/file_system.rs
+++ b/vortex-duckdb/src/duckdb/file_system.rs
@@ -19,23 +19,13 @@ use vortex::io::CoalesceConfig;
 use vortex::io::IoBuf;
 use vortex::io::VortexReadAt;
 use vortex::io::VortexWrite;
+use vortex::io::file::object_store;
 use vortex::io::runtime::BlockingRuntime;
 
 use crate::RUNTIME;
 use crate::cpp;
 use crate::duckdb::ClientContext;
 use crate::lifetime_wrapper;
-
-const DEFAULT_COALESCE: CoalesceConfig = CoalesceConfig {
-    distance: 1024 * 1024,     // 1 MB
-    max_size: 8 * 1024 * 1024, // 8 MB
-};
-
-// Local cap to keep remote reads parallel without overwhelming typical per-host connection limits.
-// The DuckDB httpfs extension does not expose a fixed default concurrency in the vendored sources;
-// 64 is a conservative ceiling that stays well below common cloud limits while keeping range reads
-// busy.
-const DEFAULT_CONCURRENCY: usize = 64;
 
 lifetime_wrapper!(FsFileHandle, cpp::duckdb_vx_file_handle, cpp::duckdb_vx_fs_close, [owned, ref]);
 unsafe impl Send for FsFileHandle {}
@@ -124,11 +114,11 @@ impl VortexReadAt for DuckDbFsReader {
     }
 
     fn coalesce_config(&self) -> Option<CoalesceConfig> {
-        Some(DEFAULT_COALESCE)
+        Some(CoalesceConfig::object_storage())
     }
 
     fn concurrency(&self) -> usize {
-        DEFAULT_CONCURRENCY
+        object_store::DEFAULT_CONCURRENCY
     }
 
     fn size(&self) -> BoxFuture<'static, VortexResult<u64>> {

--- a/vortex-duckdb/src/duckdb/file_system.rs
+++ b/vortex-duckdb/src/duckdb/file_system.rs
@@ -20,6 +20,7 @@ use vortex::io::IoBuf;
 use vortex::io::VortexReadAt;
 use vortex::io::VortexWrite;
 use vortex::io::file::object_store;
+use vortex::io::file::std_file;
 use vortex::io::runtime::BlockingRuntime;
 
 use crate::RUNTIME;
@@ -86,6 +87,7 @@ pub(crate) struct DuckDbFsReader {
     handle: Arc<FsFileHandle>,
     uri: Arc<str>,
     size: Arc<OnceLock<u64>>,
+    is_local: bool,
 }
 
 impl DuckDbFsReader {
@@ -100,10 +102,13 @@ impl DuckDbFsReader {
             return Err(fs_error(err));
         }
 
+        let is_local = url.scheme() == "file";
+
         Ok(Self {
             handle: Arc::new(unsafe { FsFileHandle::own(handle) }),
             uri: Arc::from(url.as_str()),
             size: Arc::new(OnceLock::new()),
+            is_local,
         })
     }
 }
@@ -114,11 +119,19 @@ impl VortexReadAt for DuckDbFsReader {
     }
 
     fn coalesce_config(&self) -> Option<CoalesceConfig> {
-        Some(CoalesceConfig::object_storage())
+        if self.is_local {
+            Some(CoalesceConfig::local())
+        } else {
+            Some(CoalesceConfig::object_storage())
+        }
     }
 
     fn concurrency(&self) -> usize {
-        object_store::DEFAULT_CONCURRENCY
+        if self.is_local {
+            std_file::DEFAULT_CONCURRENCY
+        } else {
+            object_store::DEFAULT_CONCURRENCY
+        }
     }
 
     fn size(&self) -> BoxFuture<'static, VortexResult<u64>> {

--- a/vortex-io/public-api.lock
+++ b/vortex-io/public-api.lock
@@ -28,6 +28,8 @@ pub fn vortex_io::file::object_store::ObjectStoreSource::size(&self) -> futures_
 
 pub fn vortex_io::file::object_store::ObjectStoreSource::uri(&self) -> core::option::Option<&alloc::sync::Arc<str>>
 
+pub const vortex_io::file::object_store::DEFAULT_CONCURRENCY: usize
+
 pub mod vortex_io::file::std_file
 
 pub struct vortex_io::file::std_file::FileReadAdapter
@@ -308,11 +310,11 @@ pub vortex_io::CoalesceConfig::max_size: u64
 
 impl vortex_io::CoalesceConfig
 
-pub fn vortex_io::CoalesceConfig::local() -> Self
+pub const fn vortex_io::CoalesceConfig::local() -> Self
 
-pub fn vortex_io::CoalesceConfig::new(distance: u64, max_size: u64) -> Self
+pub const fn vortex_io::CoalesceConfig::new(distance: u64, max_size: u64) -> Self
 
-pub fn vortex_io::CoalesceConfig::object_storage() -> Self
+pub const fn vortex_io::CoalesceConfig::object_storage() -> Self
 
 impl core::clone::Clone for vortex_io::CoalesceConfig
 

--- a/vortex-io/public-api.lock
+++ b/vortex-io/public-api.lock
@@ -50,6 +50,8 @@ pub fn vortex_io::file::std_file::FileReadAdapter::size(&self) -> futures_core::
 
 pub fn vortex_io::file::std_file::FileReadAdapter::uri(&self) -> core::option::Option<&alloc::sync::Arc<str>>
 
+pub const vortex_io::file::std_file::DEFAULT_CONCURRENCY: usize
+
 pub mod vortex_io::kanal_ext
 
 pub trait vortex_io::kanal_ext::KanalExt<T>

--- a/vortex-io/src/file/object_store.rs
+++ b/vortex-io/src/file/object_store.rs
@@ -26,13 +26,8 @@ use crate::VortexReadAt;
 use crate::file::std_file::read_exact_at;
 use crate::runtime::Handle;
 
-const DEFAULT_COALESCING_CONFIG: CoalesceConfig = CoalesceConfig {
-    distance: 1024 * 1024,      // 1 MB
-    max_size: 16 * 1024 * 1024, // 16 MB
-};
-
 /// Default number of concurrent requests to allow.
-const DEFAULT_CONCURRENCY: usize = 192;
+pub const DEFAULT_CONCURRENCY: usize = 192;
 
 /// An object store backed I/O source.
 pub struct ObjectStoreSource {
@@ -54,7 +49,7 @@ impl ObjectStoreSource {
             uri,
             handle,
             concurrency: DEFAULT_CONCURRENCY,
-            coalesce_config: Some(DEFAULT_COALESCING_CONFIG),
+            coalesce_config: Some(CoalesceConfig::object_storage()),
         }
     }
 

--- a/vortex-io/src/file/std_file.rs
+++ b/vortex-io/src/file/std_file.rs
@@ -62,7 +62,8 @@ const COALESCING_CONFIG: CoalesceConfig = CoalesceConfig {
     distance: 8 * 1024, // KB
     max_size: 8 * 1024, // KB
 };
-const CONCURRENCY: usize = 32;
+/// Default number of concurrent requests to allow for local file I/O.
+pub const DEFAULT_CONCURRENCY: usize = 32;
 
 /// An adapter type wrapping a [`File`] to implement [`VortexReadAt`].
 pub struct FileReadAdapter {
@@ -91,7 +92,7 @@ impl VortexReadAt for FileReadAdapter {
     }
 
     fn concurrency(&self) -> usize {
-        CONCURRENCY
+        DEFAULT_CONCURRENCY
     }
 
     fn size(&self) -> BoxFuture<'static, VortexResult<u64>> {

--- a/vortex-io/src/read.rs
+++ b/vortex-io/src/read.rs
@@ -29,17 +29,17 @@ pub struct CoalesceConfig {
 
 impl CoalesceConfig {
     /// Creates a new coalesce configuration.
-    pub fn new(distance: u64, max_size: u64) -> Self {
+    pub const fn new(distance: u64, max_size: u64) -> Self {
         Self { distance, max_size }
     }
 
     /// Configuration appropriate for fast local storage (memory, NVMe).
-    pub fn local() -> Self {
+    pub const fn local() -> Self {
         Self::new(8 * 1024, 8 * 1024) // 8KB
     }
 
     /// Configuration appropriate for object storage (S3, GCS, etc.).
-    pub fn object_storage() -> Self {
+    pub const fn object_storage() -> Self {
         Self::new(1 << 20, 16 << 20) // 1MB distance, 16MB max
     }
 }


### PR DESCRIPTION
## Summary

Unifies coalescing configs for object store reads. In particular, this includes the coalescing config used for DuckDB.
