### PR TITLE
fix: install and load httpfs in setup phase

### DIFF
--- a/benchmarks/duckdb-bench/src/lib.rs
+++ b/benchmarks/duckdb-bench/src/lib.rs
@@ -81,6 +81,10 @@ impl DuckClient {
         let connection = db.connect()?;
         vortex_duckdb::register_table_functions(&connection)?;
 
+        // Install and load httpfs so DuckDB can access remote files (S3, GCS, HTTP).
+        connection.query("INSTALL httpfs;")?;
+        connection.query("LOAD httpfs;")?;
+
         // Enable Parquet metadata cache for all benchmark runs.
         //
         // `parquet_metadata_cache` is an extension-specific option that's


### PR DESCRIPTION
## Summary

Change the DuckDB benchmark setup to install and load `httpfs`  to prevent this from implicitly happening during a benchmark run.