### PR TITLE
chore: make auto `clang-format` consistent

### DIFF
--- a/vortex-cuda/build.rs
+++ b/vortex-cuda/build.rs
@@ -55,7 +55,19 @@ fn main() {
         generate_unpack::<u32>(&kernels_src, 32).expect("Failed to generate unpack for u32"),
         generate_unpack::<u64>(&kernels_src, 16).expect("Failed to generate unpack for u64"),
     ];
-    clang_format(&unpack_files);
+    // Run clang-format on the generated files.
+    if let Ok(status) = Command::new("clang-format")
+        .arg("-i")
+        .arg("--style=file")
+        .args(&unpack_files)
+        .status()
+    {
+        if !status.success() {
+            println!("cargo:warning=clang-format exited with status {status}");
+        }
+    } else {
+        println!("cargo:warning=clang-format not found, skipping formatting of generated files");
+    }
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
     generate_dynamic_dispatch_bindings(&kernels_src, &out_dir);
@@ -101,27 +113,6 @@ fn generate_unpack<T: FastLanes>(output_dir: &Path, thread_count: usize) -> io::
     let mut cu_writer = IndentedWriter::new(&mut cu_file);
     generate_cuda_unpack_for_width::<T, _>(&mut cu_writer, thread_count)?;
     Ok(path)
-}
-
-/// Run `clang-format` in-place on the given files.
-///
-/// If `clang-format` is not available, this is a no-op.
-fn clang_format(paths: &[PathBuf]) {
-    let Ok(output) = Command::new("clang-format")
-        .arg("-i")
-        .arg("--style=file")
-        .args(paths)
-        .output()
-    else {
-        return;
-    };
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        for line in stderr.lines() {
-            println!("cargo:warning=clang-format: {line}");
-        }
-    }
 }
 
 fn nvcc_compile_ptx(

--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -11,6 +11,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Command;
 
 use bindgen::Abi;
 use once_cell::sync::Lazy;
@@ -248,11 +249,7 @@ fn extract_duckdb_source(source_dir: &Path) -> Result<PathBuf, Box<dyn std::erro
 /// Build DuckDB from source. Used for commit hashes or when VX_DUCKDB_DEBUG is set.
 fn build_duckdb(duckdb_source_dir: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
     // Check for ninja
-    if std::process::Command::new("ninja")
-        .arg("--version")
-        .output()
-        .is_err()
-    {
+    if Command::new("ninja").arg("--version").output().is_err() {
         return Err(
             "'ninja' is required to build DuckDB. Install it via your package manager.".into(),
         );
@@ -284,7 +281,7 @@ fn build_duckdb(duckdb_source_dir: &Path) -> Result<PathBuf, Box<dyn std::error:
                 ("1", "0")
             };
 
-        let output = std::process::Command::new("make")
+        let output = Command::new("make")
             .current_dir(&duckdb_repo_dir)
             .env("GEN", "ninja")
             .env("DISABLE_SANITIZER", asan_option)
@@ -488,7 +485,7 @@ fn main() {
         .write_to_file(&generated_header);
 
     // Run clang-format on the generated header.
-    if let Ok(status) = std::process::Command::new("clang-format")
+    if let Ok(status) = Command::new("clang-format")
         .arg("-i")
         .arg("--style=file")
         .arg(&generated_header)

--- a/vortex-ffi/build.rs
+++ b/vortex-ffi/build.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::panic)]
 use std::env;
 use std::path::PathBuf;
+use std::process::Command;
 
 fn main() {
     // Set up dependency tracking
@@ -20,7 +21,7 @@ fn main() {
     }
 
     // We require the macro expansion feature of cbindgen to generate the header, which is only available on nightly.
-    let is_nightly = std::process::Command::new("rustc")
+    let is_nightly = Command::new("rustc")
         .arg("-V")
         .output()
         .map(|output| String::from_utf8_lossy(&output.stdout).contains("nightly"))
@@ -49,19 +50,19 @@ fn main() {
             bindings.write_to_file(&output_file);
 
             // Run clang-format on the generated header.
-            let status = std::process::Command::new("clang-format")
+            if let Ok(status) = Command::new("clang-format")
                 .arg("-i")
                 .arg("--style=file")
                 .arg(&output_file)
-                .status();
-            match status {
-                Ok(s) if s.success() => {}
-                Ok(s) => println!(
-                    "cargo:warning=clang-format exited with status {} for {}",
-                    s,
-                    output_file.display()
-                ),
-                Err(e) => println!("cargo:warning=clang-format not found or failed to run: {e}"),
+                .status()
+            {
+                if !status.success() {
+                    println!("cargo:warning=clang-format exited with status {status}");
+                }
+            } else {
+                println!(
+                    "cargo:warning=clang-format not found, skipping formatting of generated header"
+                );
             }
         }
         Err(e) => {


### PR DESCRIPTION
## Summary

All calls to clang-format in diff `build.rs` should follow the same pattern.