### PR TITLE
Fix some things that don't have warnings for some reason

### DIFF
--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -114,19 +114,16 @@ fn random_array_chunk(
         },
         d @ DType::Decimal(decimal, n) => {
             let elem_len = chunk_len.unwrap_or(u.int_in_range(0..=20)?);
-            match_each_decimal_value_type!(
-                DecimalType::smallest_decimal_value_type(decimal),
-                |DVT| {
-                    let mut builder = DecimalBuilder::new::<DVT>(*decimal, *n);
-                    for _i in 0..elem_len {
-                        let random_decimal = random_scalar(u, d)?;
-                        builder.append_scalar(&random_decimal).vortex_expect(
-                            "was somehow unable to append a decimal to a decimal builder",
-                        );
-                    }
-                    Ok(builder.finish())
+            match_each_decimal_value_type!(DecimalType::smallest_decimal_value_type(decimal), |D| {
+                let mut builder = DecimalBuilder::new::<D>(*decimal, *n);
+                for _i in 0..elem_len {
+                    let random_decimal = random_scalar(u, d)?;
+                    builder.append_scalar(&random_decimal).vortex_expect(
+                        "was somehow unable to append a decimal to a decimal builder",
+                    );
                 }
-            )
+                Ok(builder.finish())
+            })
         }
         DType::Utf8(n) => random_string(u, *n, chunk_len),
         DType::Binary(n) => random_bytes(u, *n, chunk_len),

--- a/vortex-array/src/arrays/constant/compute/sum.rs
+++ b/vortex-array/src/arrays/constant/compute/sum.rs
@@ -60,6 +60,7 @@ fn sum_scalar(
                 .map(|v| ScalarValue::Primitive(v.into())))
         }
         DType::Primitive(ptype, _) => {
+            // TODO(connor): T is not used here
             let result = match_each_native_ptype!(
                 ptype,
                 unsigned: |T| { sum_integral::<u64>(scalar.as_primitive(), len, accumulator)?.map(|v| ScalarValue::Primitive(v.into())) },

--- a/vortex-array/src/arrays/primitive/compute/rules.rs
+++ b/vortex-array/src/arrays/primitive/compute/rules.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_dtype::match_each_native_ptype;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
@@ -39,19 +38,18 @@ impl ArrayParentReduceRule<PrimitiveVTable> for PrimitiveMaskedValidityRule {
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         // Merge the parent's validity mask into the child's validity
-        // TODO(joe): make this lazy
-        let masked_array = match_each_native_ptype!(array.ptype(), |T| {
-            // SAFETY: masking validity does not change PrimitiveArray invariants
-            unsafe {
-                PrimitiveArray::new_unchecked_from_handle(
-                    array.buffer_handle().clone(),
-                    array.ptype(),
-                    array.validity().clone().and(parent.validity().clone())?,
-                )
-            }
-            .into_array()
-        });
+        let new_validity = array.validity().clone().and(parent.validity().clone())?;
 
-        Ok(Some(masked_array))
+        // TODO(joe): make this lazy
+        // SAFETY: masking validity does not change PrimitiveArray invariants
+        let masked_array = unsafe {
+            PrimitiveArray::new_unchecked_from_handle(
+                array.buffer_handle().clone(),
+                array.ptype(),
+                new_validity,
+            )
+        };
+
+        Ok(Some(masked_array.into_array()))
     }
 }


### PR DESCRIPTION
## Summary

I am in the process of migrating `vortex-dtype` into `vortex-array` as part of #6547, and I have run into a strange issue where after I move stuff, a bunch of warnings pop up that I didn't see before. These are some of them.

## Testing

N/A for now, these are mostly cosmetic
