### PR TITLE
lower your expectations

### DIFF
--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -89,8 +89,7 @@ impl VTable for ALPRDVTable {
             right_bit_width: array.right_bit_width() as u32,
             dict_len: array.left_parts_dictionary().len() as u32,
             dict,
-            left_parts_ptype: PType::try_from(array.left_parts().dtype())
-                .vortex_expect("Must be a valid PType") as i32,
+            left_parts_ptype: array.left_parts.dtype().as_ptype() as i32,
             patches: array
                 .left_parts_patches()
                 .map(|p| p.to_metadata(array.len(), array.left_parts().dtype()))

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -36,7 +36,6 @@ use vortex_buffer::Buffer;
 use vortex_dtype::DType;
 use vortex_dtype::Nullability;
 use vortex_dtype::PType;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -390,7 +390,7 @@ impl PcoArray {
         let mut page_value_start = 0;
         let mut n_skipped_values = 0;
         for (chunk_info, chunk_meta) in self.metadata.chunks.iter().zip(&self.chunk_metas) {
-            let mut cd: Option<ChunkDecompressor<T>> = None;
+            let mut chunk_decompressor: Option<ChunkDecompressor<T>> = None;
             for page_info in &chunk_info.pages {
                 let page_n_values = page_info.n_values as usize;
                 let page_value_stop = page_value_start + page_n_values;
@@ -409,19 +409,28 @@ impl PcoArray {
                     }
                     let chunk_meta_bytes: &[u8] = chunk_meta.as_ref();
                     let page: &[u8] = self.pages[page_idx].as_ref();
-                    if cd.is_none() {
-                        let (new_cd, _) = fd
-                            .chunk_decompressor(chunk_meta_bytes)
-                            .map_err(vortex_err_from_pco)?;
-                        cd = Some(new_cd);
-                    }
-                    let mut pd = cd
+
+                    // Use the initialized chunk decompressor to decode the page, or initialize
+                    // a new one if this is the first page in the chunk.
+                    let page_decompressor = match chunk_decompressor.take() {
+                        Some(d) => d,
+                        None => {
+                            let (new_cd, _) = fd
+                                .chunk_decompressor(chunk_meta_bytes)
+                                .map_err(vortex_err_from_pco)?;
+                            new_cd
+                        }
+                    };
+
+                    let mut pd = chunk_decompressor
                         .as_mut()
-                        .unwrap()
+                        .vortex_expect("cd is always initialized here")
                         .page_decompressor(page, page_n_values)
                         .map_err(vortex_err_from_pco)?;
                     pd.read(&mut decompressed_values[old_len..new_len])
                         .map_err(vortex_err_from_pco)?;
+
+                    chunk_decompressor = Some(page_decompressor);
                 } else {
                     n_skipped_values += page_n_values;
                 }

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -358,7 +358,7 @@ impl PcoArray {
         let values_byte_buffer = match_number_enum!(
             number_type,
             NumberType<T> => {
-              self.decompress_values_typed::<T>()
+              self.decompress_values_typed::<T>()?
             }
         );
 
@@ -371,8 +371,7 @@ impl PcoArray {
         ))
     }
 
-    #[allow(clippy::unwrap_in_result, clippy::unwrap_used)]
-    fn decompress_values_typed<T: Number>(&self) -> ByteBuffer {
+    fn decompress_values_typed<T: Number>(&self) -> VortexResult<ByteBuffer> {
         // To start, we figure out what range of values we need to decompress.
         let slice_value_indices = self
             .unsliced_validity
@@ -384,9 +383,8 @@ impl PcoArray {
 
         // Then we decompress those pages into a buffer. Note that these values
         // may exceed the bounds of the slice, so we need to slice later.
-        let (fd, _) = FileDecompressor::new(self.metadata.header.as_slice())
-            .map_err(vortex_err_from_pco)
-            .vortex_expect("FileDecompressor::new should succeed with valid header");
+        let (fd, _) =
+            FileDecompressor::new(self.metadata.header.as_slice()).map_err(vortex_err_from_pco)?;
         let mut decompressed_values = BufferMut::<T>::with_capacity(slice_n_values);
         let mut page_idx = 0;
         let mut page_value_start = 0;
@@ -414,21 +412,16 @@ impl PcoArray {
                     if cd.is_none() {
                         let (new_cd, _) = fd
                             .chunk_decompressor(chunk_meta_bytes)
-                            .map_err(vortex_err_from_pco)
-                            .vortex_expect(
-                                "chunk_decompressor should succeed with valid chunk metadata",
-                            );
+                            .map_err(vortex_err_from_pco)?;
                         cd = Some(new_cd);
                     }
                     let mut pd = cd
                         .as_mut()
                         .unwrap()
                         .page_decompressor(page, page_n_values)
-                        .map_err(vortex_err_from_pco)
-                        .vortex_expect("page_decompressor should succeed with valid page data");
+                        .map_err(vortex_err_from_pco)?;
                     pd.read(&mut decompressed_values[old_len..new_len])
-                        .map_err(vortex_err_from_pco)
-                        .vortex_expect("decompress should succeed with valid compressed data");
+                        .map_err(vortex_err_from_pco)?;
                 } else {
                     n_skipped_values += page_n_values;
                 }
@@ -440,10 +433,10 @@ impl PcoArray {
 
         // Slice only the values requested.
         let value_offset = slice_value_start - n_skipped_values;
-        decompressed_values
+        Ok(decompressed_values
             .freeze()
             .slice(value_offset..value_offset + slice_n_values)
-            .into_byte_buffer()
+            .into_byte_buffer())
     }
 
     pub(crate) fn _slice(&self, start: usize, stop: usize) -> Self {

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -390,6 +390,7 @@ impl PcoArray {
         let mut page_value_start = 0;
         let mut n_skipped_values = 0;
         for (chunk_info, chunk_meta) in self.metadata.chunks.iter().zip(&self.chunk_metas) {
+            // lazily initialize chunk decompressor
             let mut chunk_decompressor: Option<ChunkDecompressor<T>> = None;
             for page_info in &chunk_info.pages {
                 let page_n_values = page_info.n_values as usize;
@@ -407,30 +408,25 @@ impl PcoArray {
                     unsafe {
                         decompressed_values.set_len(new_len);
                     }
-                    let chunk_meta_bytes: &[u8] = chunk_meta.as_ref();
                     let page: &[u8] = self.pages[page_idx].as_ref();
 
-                    // Use the initialized chunk decompressor to decode the page, or initialize
-                    // a new one if this is the first page in the chunk.
-                    let page_decompressor = match chunk_decompressor.take() {
+                    let mut cd = match chunk_decompressor.take() {
                         Some(d) => d,
                         None => {
                             let (new_cd, _) = fd
-                                .chunk_decompressor(chunk_meta_bytes)
+                                .chunk_decompressor(chunk_meta.as_ref())
                                 .map_err(vortex_err_from_pco)?;
                             new_cd
                         }
                     };
 
-                    let mut pd = chunk_decompressor
-                        .as_mut()
-                        .vortex_expect("cd is always initialized here")
+                    let mut pd = cd
                         .page_decompressor(page, page_n_values)
                         .map_err(vortex_err_from_pco)?;
                     pd.read(&mut decompressed_values[old_len..new_len])
                         .map_err(vortex_err_from_pco)?;
 
-                    chunk_decompressor = Some(page_decompressor);
+                    chunk_decompressor = Some(cd);
                 } else {
                     n_skipped_values += page_n_values;
                 }

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -648,11 +648,10 @@ impl ZstdArray {
 
         // then we actually decompress those frames
         let mut decompressor = if let Some(dictionary) = &self.dictionary {
-            zstd::bulk::Decompressor::with_dictionary(dictionary)
+            zstd::bulk::Decompressor::with_dictionary(dictionary)?
         } else {
-            zstd::bulk::Decompressor::new()
-        }
-        .vortex_expect("Decompressor encountered io error");
+            zstd::bulk::Decompressor::new()?
+        };
         let mut decompressed = ByteBufferMut::with_capacity_aligned(
             uncompressed_size_to_decompress,
             Alignment::new(byte_width),
@@ -665,8 +664,7 @@ impl ZstdArray {
         let mut uncompressed_start = 0;
         for frame in frames_to_decompress {
             let uncompressed_written = decompressor
-                .decompress_to_buffer(frame.as_slice(), &mut decompressed[uncompressed_start..])
-                .vortex_expect("error while decompressing zstd array");
+                .decompress_to_buffer(frame.as_slice(), &mut decompressed[uncompressed_start..])?;
             uncompressed_start += uncompressed_written;
         }
         if uncompressed_start != uncompressed_size_to_decompress {

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -267,8 +267,7 @@ impl ZstdBuffersArray {
     pub fn decode_plan(&self) -> VortexResult<ZstdBuffersDecodePlan> {
         // If invariants are somehow broken, device decompression could have UB, so ensure
         // they still hold.
-        self.validate()
-            .vortex_expect("zstd_buffers invariant violated before decode_plan");
+        self.validate()?;
 
         let output_sizes = self
             .uncompressed_sizes

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -31,7 +31,6 @@ use vortex_buffer::Alignment;
 use vortex_buffer::ByteBuffer;
 use vortex_buffer::ByteBufferMut;
 use vortex_dtype::DType;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure_eq;
 use vortex_error::vortex_err;


### PR DESCRIPTION
Just removing a few ambient `.vortex_expect()` calls I found in PCo and ALP that I don't think are correct or necessary