### PR TITLE
chore: drop `async` from CUDA traits

### DIFF
--- a/fuzz/src/gpu/mod.rs
+++ b/fuzz/src/gpu/mod.rs
@@ -121,7 +121,7 @@ pub async fn run_compress_gpu(fuzz: FuzzCompressGpu) -> VortexFuzzResult<bool> {
     let mut cuda_ctx =
         CudaSession::create_execution_ctx(&SESSION).vortex_expect("cannot create session");
 
-    let gpu_canonical = match array.clone().execute_cuda(&mut cuda_ctx).await {
+    let gpu_canonical = match array.clone().execute_cuda(&mut cuda_ctx) {
         Ok(c) => c,
         Err(e) => {
             return Err(VortexFuzzError::VortexError(e, Backtrace::capture()));

--- a/vortex-cuda/benches/bitpacked_cuda.rs
+++ b/vortex-cuda/benches/bitpacked_cuda.rs
@@ -18,7 +18,6 @@ use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
 use cudarc::driver::DeviceRepr;
-use futures::executor::block_on;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::validity::Validity::NonNullable;
 use vortex_buffer::Buffer;
@@ -82,7 +81,7 @@ where
                     .with_launch_strategy(Arc::new(timed));
 
                 for _ in 0..iters {
-                    block_on(array.to_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                    array.to_array().execute_cuda(&mut cuda_ctx).unwrap();
                 }
 
                 Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/benches/date_time_parts_cuda.rs
+++ b/vortex-cuda/benches/date_time_parts_cuda.rs
@@ -16,7 +16,6 @@ use std::time::Duration;
 use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
-use futures::executor::block_on;
 use vortex_array::IntoArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -76,7 +75,7 @@ fn benchmark_datetimeparts(c: &mut Criterion) {
 
                     for _ in 0..iters {
                         // block on immediately here
-                        block_on(dtp_array.to_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                        dtp_array.to_array().execute_cuda(&mut cuda_ctx).unwrap();
                     }
 
                     Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/benches/dict_cuda.rs
+++ b/vortex-cuda/benches/dict_cuda.rs
@@ -17,7 +17,6 @@ use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
 use cudarc::driver::DeviceRepr;
-use futures::executor::block_on;
 use vortex_array::IntoArray;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -100,7 +99,9 @@ where
                         .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
-                        block_on(dict_array.to_array().execute_cuda(&mut cuda_ctx))
+                        dict_array
+                            .to_array()
+                            .execute_cuda(&mut cuda_ctx)
                             .vortex_expect("execute");
                     }
 

--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -16,7 +16,6 @@ use cudarc::driver::DevicePtr;
 use cudarc::driver::LaunchConfig;
 use cudarc::driver::PushKernelArg;
 use cudarc::driver::sys::CUevent_flags;
-use futures::executor::block_on;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::validity::Validity::NonNullable;
 use vortex_buffer::Buffer;
@@ -127,11 +126,7 @@ fn run_dynamic_dispatch_bitpacked_timed(
     let len = bitpacked_array.len();
 
     // Move packed data to device.
-    let device_input = if packed.is_on_device() {
-        packed
-    } else {
-        block_on(cuda_ctx.move_to_device(packed)?).vortex_expect("failed to move to device")
-    };
+    let device_input = cuda_ctx.ensure_on_device(packed)?;
 
     let input_ptr = device_input
         .cuda_view::<u32>()

--- a/vortex-cuda/benches/filter_cuda.rs
+++ b/vortex-cuda/benches/filter_cuda.rs
@@ -163,9 +163,9 @@ where
 
                         for _ in 0..iters {
                             // Copy input to device
-                            let d_input_handle =
-                                block_on(cuda_ctx.copy_to_device(input_data.clone()).unwrap())
-                                    .vortex_expect("failed to copy input to device");
+                            let d_input_handle = cuda_ctx
+                                .copy_to_device(input_data.clone())
+                                .vortex_expect("failed to copy input to device");
                             let d_input = d_input_handle
                                 .as_device()
                                 .as_any()
@@ -173,9 +173,9 @@ where
                                 .unwrap();
 
                             // Copy bitmask to device
-                            let d_bitmask_handle =
-                                block_on(cuda_ctx.copy_to_device(bitmask.clone()).unwrap())
-                                    .vortex_expect("failed to copy bitmask to device");
+                            let d_bitmask_handle = cuda_ctx
+                                .copy_to_device(bitmask.clone())
+                                .vortex_expect("failed to copy bitmask to device");
                             let d_bitmask = d_bitmask_handle
                                 .as_device()
                                 .as_any()

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -18,7 +18,6 @@ use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
 use cudarc::driver::DeviceRepr;
-use futures::executor::block_on;
 use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::scalar::Scalar;
@@ -92,7 +91,7 @@ where
                         .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
-                        block_on(for_array.to_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                        for_array.to_array().execute_cuda(&mut cuda_ctx).unwrap();
                     }
 
                     Duration::from_nanos(timer.load(Ordering::Relaxed))
@@ -130,7 +129,7 @@ where
                         .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
-                        block_on(for_array.to_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                        for_array.to_array().execute_cuda(&mut cuda_ctx).unwrap();
                     }
 
                     Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/benches/runend_cuda.rs
+++ b/vortex-cuda/benches/runend_cuda.rs
@@ -17,7 +17,6 @@ use criterion::BenchmarkId;
 use criterion::Criterion;
 use criterion::Throughput;
 use cudarc::driver::DeviceRepr;
-use futures::executor::block_on;
 use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::validity::Validity;
@@ -89,7 +88,7 @@ where
                                 .with_launch_strategy(Arc::new(timed));
 
                         for _ in 0..iters {
-                            block_on(runend_array.to_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                            runend_array.to_array().execute_cuda(&mut cuda_ctx).unwrap();
                         }
 
                         Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/benches/zstd_cuda.rs
+++ b/vortex-cuda/benches/zstd_cuda.rs
@@ -134,7 +134,7 @@ fn benchmark_zstd_cuda_decompress(c: &mut Criterion) {
                         let ZstdArrayParts {
                             frames, metadata, ..
                         } = zstd_array.clone().into_parts();
-                        let exec = block_on(zstd_kernel_prepare(frames, &metadata, &mut cuda_ctx))
+                        let exec = zstd_kernel_prepare(frames, &metadata, &mut cuda_ctx)
                             .vortex_expect("kernel setup failed");
                         let kernel_time = block_on(execute_zstd_kernel(exec, &mut cuda_ctx))
                             .vortex_expect("kernel execution failed");

--- a/vortex-cuda/gpu-scan-cli/src/main.rs
+++ b/vortex-cuda/gpu-scan-cli/src/main.rs
@@ -4,6 +4,7 @@
 #![allow(unused_imports)]
 
 use std::env::args;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -14,8 +15,17 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use vortex::VortexSessionDefault;
 use vortex::array::ToCanonical;
 use vortex::array::arrays::DictVTable;
+use vortex::buffer::ByteBuffer;
+use vortex::buffer::ByteBufferMut;
+use vortex::compressor::BtrBlocksCompressorBuilder;
+use vortex::compressor::FloatCode;
+use vortex::compressor::IntCode;
+use vortex::compressor::StringCode;
 use vortex::error::VortexResult;
+use vortex::file::Footer;
 use vortex::file::OpenOptionsSessionExt;
+use vortex::file::WriteOptionsSessionExt;
+use vortex::file::WriteStrategyBuilder;
 use vortex::session::VortexSession;
 use vortex_cuda::CopyDeviceReadAt;
 use vortex_cuda::CudaSession;
@@ -99,13 +109,10 @@ async fn main() -> VortexResult<()> {
             let span =
                 tracing::info_span!("array execution", chunk = chunk, field_name = field_name);
 
-            async {
-                if field.clone().execute_cuda(&mut cuda_ctx).await.is_err() {
-                    tracing::error!("failed to execute_cuda on column");
-                }
+            let _guard = span.enter();
+            if field.clone().execute_cuda(&mut cuda_ctx).is_err() {
+                tracing::error!("failed to execute_cuda on column");
             }
-            .instrument(span)
-            .await;
         }
 
         chunk += 1;

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use async_trait::async_trait;
-use futures::future::BoxFuture;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::ToCanonical;
@@ -38,16 +36,15 @@ use crate::executor::CudaArrayExt;
 #[derive(Debug)]
 pub(crate) struct CanonicalDeviceArrayExport;
 
-#[async_trait]
 impl ExportDeviceArray for CanonicalDeviceArrayExport {
-    async fn export_device_array(
+    fn export_device_array(
         &self,
         array: ArrayRef,
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<ArrowDeviceArray> {
-        let cuda_array = array.execute_cuda(ctx).await?;
+        let cuda_array = array.execute_cuda(ctx)?;
 
-        let (arrow_array, _) = export_canonical(cuda_array, ctx).await?;
+        let (arrow_array, _) = export_canonical(cuda_array, ctx)?;
 
         Ok(ArrowDeviceArray {
             array: arrow_array,
@@ -62,124 +59,121 @@ impl ExportDeviceArray for CanonicalDeviceArrayExport {
 fn export_canonical(
     cuda_array: Canonical,
     ctx: &mut CudaExecutionCtx,
-) -> BoxFuture<'_, VortexResult<(ArrowArray, SyncEvent)>> {
-    Box::pin(async {
-        match cuda_array {
-            Canonical::Struct(struct_array) => export_struct(struct_array, ctx).await,
-            Canonical::Primitive(primitive) => {
-                let len = primitive.len();
-                let PrimitiveArrayParts {
-                    buffer, validity, ..
-                } = primitive.into_parts();
+) -> VortexResult<(ArrowArray, SyncEvent)> {
+    match cuda_array {
+        Canonical::Struct(struct_array) => export_struct(struct_array, ctx),
+        Canonical::Primitive(primitive) => {
+            let len = primitive.len();
+            let PrimitiveArrayParts {
+                buffer, validity, ..
+            } = primitive.into_parts();
 
-                check_validity_empty(&validity)?;
+            check_validity_empty(&validity)?;
 
-                let buffer = ctx.ensure_on_device(buffer).await?;
+            let buffer = ctx.ensure_on_device(buffer)?;
 
-                export_fixed_size(buffer, len, 0, ctx)
-            }
-            Canonical::Null(null_array) => {
-                let len = null_array.len();
-
-                // The null array has no buffers, no children, just metadata.
-                let mut array = ArrowArray::empty();
-                array.length = len as i64;
-                array.null_count = len as i64;
-                array.release = Some(release_array);
-
-                // we don't need a sync event for Null since no data is copied.
-                Ok((array, None))
-            }
-            Canonical::Decimal(decimal) => {
-                let len = decimal.len();
-                let DecimalArrayParts {
-                    values,
-                    values_type,
-                    validity,
-                    ..
-                } = decimal.into_parts();
-
-                // verify that there is no null buffer
-                check_validity_empty(&validity)?;
-
-                // TODO(aduffy): GPU kernel for upcasting.
-                vortex_ensure!(
-                    values_type >= DecimalType::I32,
-                    "cannot export DecimalArray with values type {values_type}. must be i32 or wider."
-                );
-
-                let buffer = ctx.ensure_on_device(values).await?;
-
-                export_fixed_size(buffer, len, 0, ctx)
-            }
-            Canonical::Extension(extension) => {
-                if !extension.ext_dtype().is::<AnyTemporal>() {
-                    vortex_bail!("only support temporal extension types currently");
-                }
-
-                let values = extension.storage().to_primitive();
-                let len = extension.len();
-
-                let PrimitiveArrayParts {
-                    buffer, validity, ..
-                } = values.into_parts();
-
-                check_validity_empty(&validity)?;
-
-                let buffer = ctx.ensure_on_device(buffer).await?;
-                export_fixed_size(buffer, len, 0, ctx)
-            }
-            Canonical::Bool(bool_array) => {
-                let BoolArrayParts {
-                    bits,
-                    offset,
-                    len,
-                    validity,
-                    ..
-                } = bool_array.into_parts();
-
-                check_validity_empty(&validity)?;
-
-                export_fixed_size(bits, len, offset, ctx)
-            }
-            Canonical::VarBinView(varbinview) => {
-                let len = varbinview.len();
-                check_validity_empty(varbinview.validity())?;
-
-                let BinaryParts { offsets, bytes } =
-                    copy_varbinview_to_varbin(varbinview, ctx).await?;
-
-                let offsets = ctx.ensure_on_device(offsets).await?;
-                let bytes = ctx.ensure_on_device(bytes).await?;
-
-                let buffers = vec![None, Some(offsets), Some(bytes)];
-                let mut private_data = PrivateData::new(buffers, vec![], ctx)?;
-                let sync_event = private_data.sync_event();
-                //
-                let arrow_array = ArrowArray {
-                    length: len as i64,
-                    null_count: 0,
-                    offset: 0,
-                    // 1 (optional) buffer for nulls, one buffer for the data
-                    n_buffers: 2,
-                    buffers: private_data.buffer_ptrs.as_mut_ptr(),
-                    n_children: 0,
-                    children: std::ptr::null_mut(),
-                    release: Some(release_array),
-                    dictionary: std::ptr::null_mut(),
-                    private_data: Box::into_raw(private_data).cast(),
-                };
-
-                Ok((arrow_array, sync_event))
-            }
-            // TODO(aduffy): implement VarBinView. cudf doesn't support it, so we need to
-            //  execute a kernel to translate from VarBinView -> VarBin.
-            c => todo!("support for exporting {} arrays", c.dtype()),
+            export_fixed_size(buffer, len, 0, ctx)
         }
-    })
+        Canonical::Null(null_array) => {
+            let len = null_array.len();
+
+            // The null array has no buffers, no children, just metadata.
+            let mut array = ArrowArray::empty();
+            array.length = len as i64;
+            array.null_count = len as i64;
+            array.release = Some(release_array);
+
+            // we don't need a sync event for Null since no data is copied.
+            Ok((array, None))
+        }
+        Canonical::Decimal(decimal) => {
+            let len = decimal.len();
+            let DecimalArrayParts {
+                values,
+                values_type,
+                validity,
+                ..
+            } = decimal.into_parts();
+
+            // verify that there is no null buffer
+            check_validity_empty(&validity)?;
+
+            // TODO(aduffy): GPU kernel for upcasting.
+            vortex_ensure!(
+                values_type >= DecimalType::I32,
+                "cannot export DecimalArray with values type {values_type}. must be i32 or wider."
+            );
+
+            let buffer = ctx.ensure_on_device(values)?;
+
+            export_fixed_size(buffer, len, 0, ctx)
+        }
+        Canonical::Extension(extension) => {
+            if !extension.ext_dtype().is::<AnyTemporal>() {
+                vortex_bail!("only support temporal extension types currently");
+            }
+
+            let values = extension.storage().to_primitive();
+            let len = extension.len();
+
+            let PrimitiveArrayParts {
+                buffer, validity, ..
+            } = values.into_parts();
+
+            check_validity_empty(&validity)?;
+
+            let buffer = ctx.ensure_on_device(buffer)?;
+            export_fixed_size(buffer, len, 0, ctx)
+        }
+        Canonical::Bool(bool_array) => {
+            let BoolArrayParts {
+                bits,
+                offset,
+                len,
+                validity,
+                ..
+            } = bool_array.into_parts();
+
+            check_validity_empty(&validity)?;
+
+            export_fixed_size(bits, len, offset, ctx)
+        }
+        Canonical::VarBinView(varbinview) => {
+            let len = varbinview.len();
+            check_validity_empty(varbinview.validity())?;
+
+            let BinaryParts { offsets, bytes } = copy_varbinview_to_varbin(varbinview, ctx)?;
+
+            let offsets = ctx.ensure_on_device(offsets)?;
+            let bytes = ctx.ensure_on_device(bytes)?;
+
+            let buffers = vec![None, Some(offsets), Some(bytes)];
+            let mut private_data = PrivateData::new(buffers, vec![], ctx)?;
+            let sync_event = private_data.sync_event();
+            //
+            let arrow_array = ArrowArray {
+                length: len as i64,
+                null_count: 0,
+                offset: 0,
+                // 1 (optional) buffer for nulls, one buffer for the data
+                n_buffers: 2,
+                buffers: private_data.buffer_ptrs.as_mut_ptr(),
+                n_children: 0,
+                children: std::ptr::null_mut(),
+                release: Some(release_array),
+                dictionary: std::ptr::null_mut(),
+                private_data: Box::into_raw(private_data).cast(),
+            };
+
+            Ok((arrow_array, sync_event))
+        }
+        // TODO(aduffy): implement VarBinView. cudf doesn't support it, so we need to
+        //  execute a kernel to translate from VarBinView -> VarBin.
+        c => todo!("support for exporting {} arrays", c.dtype()),
+    }
 }
 
-async fn export_struct(
+fn export_struct(
     array: StructArray,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<(ArrowArray, SyncEvent)> {
@@ -194,8 +188,8 @@ async fn export_struct(
     let mut children = Vec::with_capacity(fields.len());
 
     for field in fields.iter() {
-        let cuda_field = field.clone().execute_cuda(ctx).await?;
-        let (arrow_field, _) = export_canonical(cuda_field, ctx).await?;
+        let cuda_field = field.clone().execute_cuda(ctx)?;
+        let (arrow_field, _) = export_canonical(cuda_field, ctx)?;
         children.push(arrow_field);
     }
 
@@ -316,7 +310,7 @@ mod tests {
         let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
-        let mut device_array = array.export_device_array(&mut ctx).await?;
+        let mut device_array = array.export_device_array(&mut ctx)?;
 
         assert_eq!(device_array.array.length, expected_len);
         assert_eq!(device_array.array.null_count, 0);
@@ -336,7 +330,7 @@ mod tests {
             .vortex_expect("failed to create execution context");
 
         let array = NullArray::new(7).into_array();
-        let mut device_array = array.export_device_array(&mut ctx).await?;
+        let mut device_array = array.export_device_array(&mut ctx)?;
 
         assert_eq!(device_array.array.length, 7);
         assert_eq!(device_array.array.null_count, 7);
@@ -352,7 +346,7 @@ mod tests {
             .vortex_expect("failed to create execution context");
 
         let array = DecimalArray::from_iter(0i128..5, DecimalDType::new(38, 2)).into_array();
-        let mut device_array = array.export_device_array(&mut ctx).await?;
+        let mut device_array = array.export_device_array(&mut ctx)?;
 
         assert_eq!(device_array.array.length, 5);
         assert_eq!(device_array.array.null_count, 0);
@@ -375,7 +369,7 @@ mod tests {
             TimeUnit::Days,
         )
         .into_array();
-        let mut device_array = array.export_device_array(&mut ctx).await?;
+        let mut device_array = array.export_device_array(&mut ctx)?;
 
         assert_eq!(device_array.array.length, 3);
         assert_eq!(device_array.array.null_count, 0);
@@ -399,7 +393,7 @@ mod tests {
             "this is a longer string for out-of-line storage",
         ])
         .into_array();
-        let mut device_array = array.export_device_array(&mut ctx).await?;
+        let mut device_array = array.export_device_array(&mut ctx)?;
 
         assert_eq!(device_array.array.length, 3);
         assert_eq!(device_array.array.null_count, 0);
@@ -428,7 +422,7 @@ mod tests {
             Validity::NonNullable,
         )
         .into_array();
-        let mut device_array = array.export_device_array(&mut ctx).await?;
+        let mut device_array = array.export_device_array(&mut ctx)?;
 
         assert_eq!(device_array.array.length, 5);
         assert_eq!(device_array.array.null_count, 0);

--- a/vortex-cuda/src/arrow/mod.rs
+++ b/vortex-cuda/src/arrow/mod.rs
@@ -16,7 +16,6 @@ use std::fmt::Debug;
 use std::ptr::NonNull;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 pub(crate) use canonical::CanonicalDeviceArrayExport;
 use cudarc::driver::CudaEvent;
 use cudarc::driver::CudaStream;
@@ -181,27 +180,18 @@ impl PrivateData {
     }
 }
 
-#[async_trait]
 pub trait DeviceArrayExt: Array {
-    async fn export_device_array(
-        self,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<ArrowDeviceArray>;
+    fn export_device_array(self, ctx: &mut CudaExecutionCtx) -> VortexResult<ArrowDeviceArray>;
 }
 
-#[async_trait]
 impl DeviceArrayExt for ArrayRef {
-    async fn export_device_array(
-        self,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<ArrowDeviceArray> {
+    fn export_device_array(self, ctx: &mut CudaExecutionCtx) -> VortexResult<ArrowDeviceArray> {
         let exporter = Arc::clone(ctx.exporter());
-        exporter.export_device_array(self, ctx).await
+        exporter.export_device_array(self, ctx)
     }
 }
 
 /// A type that can convert a Vortex array into an [`ArrowDeviceArray`].
-#[async_trait]
 pub trait ExportDeviceArray: Debug + Send + Sync + 'static {
     /// Export a Vortex array as an [`ArrowDeviceArray`].
     ///
@@ -210,7 +200,7 @@ pub trait ExportDeviceArray: Debug + Send + Sync + 'static {
     /// arrays, such as cudf.
     ///
     /// See <https://arrow.apache.org/docs/format/CDeviceDataInterface.html>.
-    async fn export_device_array(
+    fn export_device_array(
         &self,
         array: ArrayRef,
         ctx: &mut CudaExecutionCtx,

--- a/vortex-cuda/src/arrow/varbinview.rs
+++ b/vortex-cuda/src/arrow/varbinview.rs
@@ -28,7 +28,7 @@ pub(crate) struct BinaryParts {
     pub(crate) bytes: BufferHandle,
 }
 
-pub(crate) async fn copy_varbinview_to_varbin(
+pub(crate) fn copy_varbinview_to_varbin(
     array: VarBinViewArray,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<BinaryParts> {
@@ -44,11 +44,11 @@ pub(crate) async fn copy_varbinview_to_varbin(
     check_validity_empty(&validity)?;
 
     // copy all buffers over to device.
-    let views = ctx.ensure_on_device(views).await?;
+    let views = ctx.ensure_on_device(views)?;
     // before string copying, we must copy all string data buffers to the device.
     let mut device_buffers = vec![];
     for buffer in buffers.iter() {
-        device_buffers.push(ctx.ensure_on_device(buffer.clone()).await?);
+        device_buffers.push(ctx.ensure_on_device(buffer.clone())?);
     }
 
     let buffer_ptrs = device_buffers

--- a/vortex-cuda/src/dynamic_dispatch.rs
+++ b/vortex-cuda/src/dynamic_dispatch.rs
@@ -125,7 +125,6 @@ mod tests {
     use vortex_alp::alp_encode;
     use vortex_array::ToCanonical;
     use vortex_array::arrays::PrimitiveArray;
-    use vortex_array::buffer::BufferHandle;
     use vortex_array::validity::Validity::NonNullable;
     use vortex_buffer::Buffer;
     use vortex_error::VortexExpect;
@@ -214,21 +213,6 @@ mod tests {
         Ok(unsafe { std::mem::transmute::<Vec<u32>, Vec<f32>>(result) })
     }
 
-    fn copy_to_device(
-        cuda_ctx: &CudaExecutionCtx,
-        bitpacked: &BitPackedArray,
-    ) -> VortexResult<(u64, BufferHandle)> {
-        let packed = bitpacked.packed().clone();
-        let device_input = futures::executor::block_on(cuda_ctx.move_to_device(packed)?)
-            .vortex_expect("move to device");
-        let ptr = device_input
-            .cuda_view::<u32>()
-            .vortex_expect("input view")
-            .device_ptr(cuda_ctx.stream())
-            .0;
-        Ok((ptr, device_input))
-    }
-
     #[test]
     fn test_bitunpack() -> VortexResult<()> {
         let bit_width: u8 = 10;
@@ -241,7 +225,11 @@ mod tests {
 
         let bitpacked = make_bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (input_ptr, _device_input) = copy_to_device(&cuda_ctx, &bitpacked)?;
+        let _device_input = cuda_ctx.ensure_on_device(bitpacked.packed().clone())?;
+        let input_ptr = _device_input
+            .cuda_view::<u32>()?
+            .device_ptr(cuda_ctx.stream())
+            .0;
 
         let plan = DynamicDispatchPlan::new(SourceOp::bitunpack(bit_width), &[]);
 
@@ -264,7 +252,11 @@ mod tests {
 
         let bitpacked = make_bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (input_ptr, _device_input) = copy_to_device(&cuda_ctx, &bitpacked)?;
+        let device_input = cuda_ctx.ensure_on_device(bitpacked.packed().clone())?;
+        let input_ptr = device_input
+            .cuda_view::<u32>()?
+            .device_ptr(cuda_ctx.stream())
+            .0;
 
         let plan = DynamicDispatchPlan::new(
             SourceOp::bitunpack(bit_width),
@@ -303,7 +295,11 @@ mod tests {
         let alp_e = <f32 as ALPFloat>::IF10[alp_array.exponents().e as usize];
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (input_ptr, _device_input) = copy_to_device(&cuda_ctx, &bitpacked)?;
+        let _device_input = cuda_ctx.ensure_on_device(bitpacked.packed().clone())?;
+        let input_ptr = _device_input
+            .cuda_view::<u32>()?
+            .device_ptr(cuda_ctx.stream())
+            .0;
 
         let plan = DynamicDispatchPlan::new(
             SourceOp::bitunpack(bit_width),
@@ -333,7 +329,11 @@ mod tests {
 
         let bitpacked = make_bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (input_ptr, _device_input) = copy_to_device(&cuda_ctx, &bitpacked)?;
+        let _device_input = cuda_ctx.ensure_on_device(bitpacked.packed().clone())?;
+        let input_ptr = _device_input
+            .cuda_view::<u32>()?
+            .device_ptr(cuda_ctx.stream())
+            .0;
 
         let scalar_ops: Vec<ScalarOp> = references
             .iter()

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -5,7 +5,6 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
-use async_trait::async_trait;
 use cudarc::driver::CudaEvent;
 use cudarc::driver::CudaFunction;
 use cudarc::driver::CudaSlice;
@@ -13,7 +12,6 @@ use cudarc::driver::CudaStream;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::LaunchArgs;
 use cudarc::driver::LaunchConfig;
-use futures::future::BoxFuture;
 use tracing::debug;
 use tracing::trace;
 use vortex_array::Array;
@@ -220,11 +218,12 @@ impl CudaExecutionCtx {
         self.stream.device_alloc(len)
     }
 
-    /// See `VortexCudaStream::copy_to_device`.
-    pub fn copy_to_device<T, D>(
-        &self,
-        data: D,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>>
+    /// Copies host data to the device.
+    ///
+    /// For **pageable** host memory the source is staged synchronously; for
+    /// **pinned** memory the transfer is async. In both cases `data` is
+    /// deferred-dropped via a stream callback.
+    pub fn copy_to_device<T, D>(&self, data: D) -> VortexResult<BufferHandle>
     where
         T: DeviceRepr + Debug + Send + Sync + 'static,
         D: AsRef<[T]> + Send + 'static,
@@ -232,24 +231,19 @@ impl CudaExecutionCtx {
         self.stream.copy_to_device(data)
     }
 
-    /// See `VortexCudaStream::move_to_device`.
-    pub fn move_to_device(
-        &self,
-        handle: BufferHandle,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>> {
-        self.stream.move_to_device(handle)
-    }
-
     /// Ensures a buffer is resident on the device, copying from host if necessary.
     ///
-    /// If the buffer is already on the device it is returned as-is. Otherwise it
-    /// is asynchronously copied to device memory.
-    pub async fn ensure_on_device(&self, handle: BufferHandle) -> VortexResult<BufferHandle> {
+    /// If the buffer is already on the device it is returned as-is. Otherwise
+    /// delegates to `copy_to_device`.
+    pub fn ensure_on_device(&self, handle: BufferHandle) -> VortexResult<BufferHandle> {
         if handle.is_on_device() {
-            Ok(handle)
-        } else {
-            self.move_to_device(handle)?.await
+            return Ok(handle);
         }
+        let host_buffer = handle
+            .as_host_opt()
+            .ok_or_else(|| vortex_err!("Buffer is not on host"))?
+            .clone();
+        self.stream.copy_to_device(host_buffer)
     }
 
     /// Returns a reference to the underlying CUDA stream.
@@ -270,31 +264,61 @@ impl CudaExecutionCtx {
 }
 
 /// Support trait for CUDA-accelerated decompression of arrays.
-#[async_trait]
+///
+/// # Execution model
+///
+/// Work is enqueued onto a single CUDA stream and executes in FIFO order.
+/// Kernel launches are synchronous fire-and-forget: They enqueue work and
+/// return immediately. The returned [`Canonical`] may reference device buffers
+/// with in-flight writes.
+///
+/// ## Pageable vs. page-locked (pinned) host memory
+///
+/// Whether the H2D transfer is asynchronous depends on whether the source
+/// memory is page-locked:
+///
+/// - **Page-locked memory** (allocated via `cuMemAllocHost` / `cudaMallocHost`):
+///   the GPU's DMA engine holds a stable physical address for the allocation and
+///   can transfer directly without CPU involvement. The call returns immediately
+///   and the copy proceeds in parallel with subsequent CPU work.
+///
+/// - **Pageable memory** (ordinary `malloc` / Rust allocator): CUDA must first
+///   stage the data through an internal page-locked bounce buffer, performing a
+///   CPU `memcpy` into that buffer before the DMA can begin. The `memcpy_htod_async`
+///   call blocks until the staging copy finishes, making the transfer effectively
+///   synchronous from the caller's perspective, though the DMA itself still runs
+///   on the stream.
+///
+///
+/// ## Synchronisation
+///
+/// To insert an explicit sync point, use `await_stream_callback`, which completes
+/// when all preceding stream work — including in-flight kernels — has finished.
 pub trait CudaExecute: 'static + Send + Sync + Debug {
     /// Executes the array on CUDA, returning a canonical array.
     ///
     /// # Errors
     ///
     /// Returns an error if execution fails on the GPU.
-    async fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx)
-    -> VortexResult<Canonical>;
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical>;
 }
 
 /// Extension trait for executing arrays on CUDA.
-#[async_trait]
 pub trait CudaArrayExt: Array {
-    /// Recursively executes the array on CUDA, returning a canonical array.
+    /// Recursively walks the encoding tree, dispatching each layer to its
+    /// registered [`CudaExecute`] implementation and returning a canonical array
+    /// on the device.
     ///
-    /// If no CUDA support is registered for the encoding, falls back to CPU execution
-    /// and logs a debug message.
-    async fn execute_cuda(self, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical>;
+    /// See [`CudaExecute`] for details on the execution model.
+    ///
+    /// Falls back to CPU execution if no CUDA support is registered for the
+    /// encoding.
+    fn execute_cuda(self, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical>;
 }
 
-#[async_trait]
 impl CudaArrayExt for ArrayRef {
     #[allow(clippy::unwrap_in_result, clippy::unwrap_used)]
-    async fn execute_cuda(self, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
+    fn execute_cuda(self, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         if self.encoding_id() == StructVTable::ID {
             let len = self.len();
             let StructArrayParts {
@@ -306,7 +330,7 @@ impl CudaArrayExt for ArrayRef {
 
             let mut cuda_fields = Vec::with_capacity(fields.len());
             for field in fields.iter() {
-                cuda_fields.push(field.clone().execute_cuda(ctx).await?.into_array());
+                cuda_fields.push(field.clone().execute_cuda(ctx)?.into_array());
             }
 
             return Ok(Canonical::Struct(StructArray::new(
@@ -335,7 +359,7 @@ impl CudaArrayExt for ArrayRef {
             "Executing array on CUDA device"
         );
 
-        support.execute(self, ctx).await
+        support.execute(self, ctx)
     }
 }
 

--- a/vortex-cuda/src/host_to_device_allocator.rs
+++ b/vortex-cuda/src/host_to_device_allocator.rs
@@ -58,8 +58,7 @@ impl<T: VortexReadAt + Clone> VortexReadAt for CopyDeviceReadAt<T> {
             }
 
             let host_buffer = handle.as_host().clone();
-
-            stream.copy_to_device(host_buffer)?.await
+            stream.copy_to_device(host_buffer)
         }
         .boxed()
     }

--- a/vortex-cuda/src/kernel/arrays/constant.rs
+++ b/vortex-cuda/src/kernel/arrays/constant.rs
@@ -4,7 +4,6 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::PushKernelArg;
 use tracing::instrument;
@@ -45,14 +44,9 @@ impl ConstantNumericExecutor {
     }
 }
 
-#[async_trait]
 impl CudaExecute for ConstantNumericExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let array =
             Self::try_specialize(array).ok_or_else(|| vortex_err!("Expected ConstantArray"))?;
 
@@ -65,7 +59,7 @@ impl CudaExecute for ConstantNumericExecutor {
             DType::Primitive(ptype, nullability) => {
                 let validity: Validity = nullability.into();
                 match_each_native_simd_ptype!(*ptype, |P| {
-                    materialize_constant_primitive::<P>(array, validity, ctx).await
+                    materialize_constant_primitive::<P>(array, validity, ctx)
                 })
             }
             DType::Decimal(decimal_dtype, nullability) => {
@@ -73,7 +67,7 @@ impl CudaExecute for ConstantNumericExecutor {
                 let validity: Validity = nullability.into();
                 let values_type = DecimalType::smallest_decimal_value_type(&decimal_dtype);
                 match_each_decimal_value_type!(values_type, |D| {
-                    materialize_constant_decimal::<D>(array, decimal_dtype, validity, ctx).await
+                    materialize_constant_decimal::<D>(array, decimal_dtype, validity, ctx)
                 })
             }
             dt => vortex_bail!(
@@ -84,7 +78,7 @@ impl CudaExecute for ConstantNumericExecutor {
     }
 }
 
-async fn materialize_constant_primitive<P>(
+fn materialize_constant_primitive<P>(
     array: ConstantArray,
     validity: Validity,
     ctx: &mut CudaExecutionCtx,
@@ -132,7 +126,7 @@ where
     )))
 }
 
-async fn materialize_constant_decimal<D>(
+fn materialize_constant_decimal<D>(
     array: ConstantArray,
     decimal_dtype: DecimalDType,
     validity: Validity,
@@ -231,7 +225,6 @@ mod tests {
 
         let gpu_result = ConstantNumericExecutor
             .execute(constant_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU materialization failed")
             .into_host()
             .await?
@@ -252,7 +245,6 @@ mod tests {
 
         let gpu_result = ConstantNumericExecutor
             .execute(constant_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU materialization failed")
             .into_host()
             .await?
@@ -274,7 +266,6 @@ mod tests {
 
         let gpu_result = ConstantNumericExecutor
             .execute(constant_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU materialization failed")
             .into_host()
             .await?

--- a/vortex-cuda/src/kernel/arrays/dict.rs
+++ b/vortex-cuda/src/kernel/arrays/dict.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::PushKernelArg;
 use tracing::instrument;
@@ -40,14 +39,9 @@ use crate::executor::CudaExecutionCtx;
 #[derive(Debug)]
 pub(crate) struct DictExecutor;
 
-#[async_trait]
 impl CudaExecute for DictExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let dict_array = array
             .try_into::<DictVTable>()
             .ok()
@@ -55,21 +49,20 @@ impl CudaExecute for DictExecutor {
 
         let values_dtype = dict_array.values().dtype().clone();
         match &values_dtype {
-            DType::Decimal(..) => execute_dict_decimal(dict_array, ctx).await,
-            DType::Primitive(..) => execute_dict_prim(dict_array, ctx).await,
-            DType::Utf8(..) | DType::Binary(..) => execute_dict_varbinview(dict_array, ctx).await,
+            DType::Decimal(..) => execute_dict_decimal(dict_array, ctx),
+            DType::Primitive(..) => execute_dict_prim(dict_array, ctx),
+            DType::Utf8(..) | DType::Binary(..) => execute_dict_varbinview(dict_array, ctx),
             dt => vortex_bail!("unsupported decompress for DType={dt}"),
         }
     }
 }
 
-#[expect(clippy::cognitive_complexity)]
-async fn execute_dict_prim(dict: DictArray, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
+fn execute_dict_prim(dict: DictArray, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
     let DictArrayParts { values, codes, .. } = dict.into_parts();
 
     // Execute both children to get them as primitives on the device
-    let values_canonical = values.execute_cuda(ctx).await?;
-    let codes_canonical = codes.execute_cuda(ctx).await?;
+    let values_canonical = values.execute_cuda(ctx)?;
+    let codes_canonical = codes.execute_cuda(ctx)?;
 
     let values_prim = values_canonical.into_primitive();
     let codes_prim = codes_canonical.into_primitive();
@@ -80,12 +73,12 @@ async fn execute_dict_prim(dict: DictArray, ctx: &mut CudaExecutionCtx) -> Vorte
     // Dispatch based on both value type and code type
     match_each_native_simd_ptype!(values_ptype, |V| {
         match_each_integer_ptype!(codes_ptype, |I| {
-            execute_dict_prim_typed::<V, I>(values_prim, codes_prim, ctx).await
+            execute_dict_prim_typed::<V, I>(values_prim, codes_prim, ctx)
         })
     })
 }
 
-async fn execute_dict_prim_typed<V: DeviceRepr + NativePType, I: DeviceRepr + NativePType>(
+fn execute_dict_prim_typed<V: DeviceRepr + NativePType, I: DeviceRepr + NativePType>(
     values: PrimitiveArray,
     codes: PrimitiveArray,
     ctx: &mut CudaExecutionCtx,
@@ -106,8 +99,8 @@ async fn execute_dict_prim_typed<V: DeviceRepr + NativePType, I: DeviceRepr + Na
     } = codes.into_parts();
 
     // Get device buffers for values and codes
-    let values_device = ctx.ensure_on_device(values_buffer).await?;
-    let codes_device = ctx.ensure_on_device(codes_buffer).await?;
+    let values_device = ctx.ensure_on_device(values_buffer)?;
+    let codes_device = ctx.ensure_on_device(codes_buffer)?;
 
     // Allocate output buffer on device
     let output_slice = ctx.device_alloc::<V>(codes_len)?;
@@ -138,11 +131,7 @@ async fn execute_dict_prim_typed<V: DeviceRepr + NativePType, I: DeviceRepr + Na
 /// Execute dict array decompression for decimal types (i128/i256).
 ///
 /// These types don't have a `PType` so we need to handle them separately.
-#[expect(clippy::cognitive_complexity)]
-async fn execute_dict_decimal(
-    dict: DictArray,
-    ctx: &mut CudaExecutionCtx,
-) -> VortexResult<Canonical> {
+fn execute_dict_decimal(dict: DictArray, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
     let DictArrayParts {
         values,
         codes,
@@ -151,25 +140,22 @@ async fn execute_dict_decimal(
     } = dict.into_parts();
 
     // Execute codes to get them as primitives on the device
-    let codes_prim = codes.execute_cuda(ctx).await?.into_primitive();
+    let codes_prim = codes.execute_cuda(ctx)?.into_primitive();
     let codes_ptype = codes_prim.ptype();
 
     // For decimal values, execute recursively to handle any nested encodings
-    let values_decimal = values.execute_cuda(ctx).await?.into_decimal();
+    let values_decimal = values.execute_cuda(ctx)?.into_decimal();
     let decimal_type = values_decimal.values_type();
 
     match_each_decimal_value_type!(decimal_type, |V| {
         match_each_integer_ptype!(codes_ptype, |C| {
-            execute_dict_decimal_typed::<V, C>(values_decimal, codes_prim, dtype, ctx).await
+            execute_dict_decimal_typed::<V, C>(values_decimal, codes_prim, dtype, ctx)
         })
     })
 }
 
 /// Type-parameterized decimal dict execution for a specific code type.
-async fn execute_dict_decimal_typed<
-    V: DeviceRepr + NativeDecimalType,
-    C: DeviceRepr + NativePType,
->(
+fn execute_dict_decimal_typed<V: DeviceRepr + NativeDecimalType, C: DeviceRepr + NativePType>(
     values: DecimalArray,
     codes: PrimitiveArray,
     output_dtype: DType,
@@ -192,8 +178,8 @@ async fn execute_dict_decimal_typed<
     } = codes.into_parts();
 
     // Copy buffers to device if needed
-    let values_device = ctx.ensure_on_device(values_buffer).await?;
-    let codes_device = ctx.ensure_on_device(codes_buffer).await?;
+    let values_device = ctx.ensure_on_device(values_buffer)?;
+    let codes_device = ctx.ensure_on_device(codes_buffer)?;
 
     // Allocate output buffer on device (codes_len * value_byte_width bytes)
     let output_slice = ctx.device_alloc::<V>(codes_len)?;
@@ -230,10 +216,7 @@ async fn execute_dict_decimal_typed<
 /// Reinterprets the dictionary's `BinaryView` buffer as `i128` values and gathers
 /// them by code index. Both inlined (≤ 12 bytes) and outlined (> 12 bytes) views
 /// are supported. For outlined views, the output shares the values' data buffers.
-async fn execute_dict_varbinview(
-    dict: DictArray,
-    ctx: &mut CudaExecutionCtx,
-) -> VortexResult<Canonical> {
+fn execute_dict_varbinview(dict: DictArray, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
     let DictArrayParts {
         values,
         codes,
@@ -241,10 +224,10 @@ async fn execute_dict_varbinview(
         ..
     } = dict.into_parts();
 
-    let codes_prim = codes.execute_cuda(ctx).await?.into_primitive();
+    let codes_prim = codes.execute_cuda(ctx)?.into_primitive();
     let codes_ptype = codes_prim.ptype();
     let codes_len = codes_prim.len();
-    let values_vbv = values.execute_cuda(ctx).await?.into_varbinview();
+    let values_vbv = values.execute_cuda(ctx)?.into_varbinview();
 
     let VarBinViewArrayParts {
         views: values_views_handle,
@@ -260,8 +243,8 @@ async fn execute_dict_varbinview(
     } = codes_prim.into_parts();
 
     // Move buffers to device if needed.
-    let values_device = ctx.ensure_on_device(values_views_handle).await?;
-    let codes_device = ctx.ensure_on_device(codes_buffer).await?;
+    let values_device = ctx.ensure_on_device(values_views_handle)?;
+    let codes_device = ctx.ensure_on_device(codes_buffer)?;
 
     // Allocate output: one i128 per code.
     let output_slice = ctx.device_alloc::<i128>(codes_len)?;
@@ -349,7 +332,6 @@ mod tests {
         // Execute on CUDA
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_primitive();
 
@@ -384,7 +366,6 @@ mod tests {
         // Execute on CUDA
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_primitive();
 
@@ -416,7 +397,6 @@ mod tests {
         // Execute on CUDA
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_primitive();
         let cuda_result = cuda_primitive_to_host(cuda_result)?;
@@ -447,7 +427,6 @@ mod tests {
         // Execute on CUDA
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_primitive();
 
@@ -479,7 +458,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.into_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_primitive();
 
@@ -517,7 +495,6 @@ mod tests {
         // Execute on CUDA
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_primitive();
         let cuda_result = cuda_primitive_to_host(cuda_result)?;
@@ -561,7 +538,6 @@ mod tests {
         // Execute on CUDA
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_primitive();
         let cuda_result = cuda_primitive_to_host(cuda_result)?;
@@ -606,7 +582,6 @@ mod tests {
         // Execute on CUDA
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_primitive();
         let cuda_result = cuda_primitive_to_host(cuda_result)?;
@@ -639,7 +614,6 @@ mod tests {
         // Execute on CUDA
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_primitive();
         let cuda_result = cuda_primitive_to_host(cuda_result)?;
@@ -678,7 +652,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_decimal();
         let cuda_result = cuda_decimal_to_host(cuda_result)?;
@@ -706,7 +679,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_decimal();
         let cuda_result = cuda_decimal_to_host(cuda_result)?;
@@ -734,7 +706,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_decimal();
         let cuda_result = cuda_decimal_to_host(cuda_result)?;
@@ -765,7 +736,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_decimal();
         let cuda_result = cuda_decimal_to_host(cuda_result)?;
@@ -801,7 +771,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_decimal();
         let cuda_result = cuda_decimal_to_host(cuda_result)?;
@@ -834,7 +803,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_varbinview();
         let cuda_result = cuda_varbinview_to_host(cuda_result).await?;
@@ -859,7 +827,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_varbinview();
         let cuda_result = cuda_varbinview_to_host(cuda_result).await?;
@@ -886,7 +853,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_varbinview();
         let cuda_result = cuda_varbinview_to_host(cuda_result).await?;
@@ -916,7 +882,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_varbinview();
         let cuda_result = cuda_varbinview_to_host(cuda_result).await?;
@@ -941,7 +906,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_varbinview();
         let cuda_result = cuda_varbinview_to_host(cuda_result).await?;
@@ -967,7 +931,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_varbinview();
         let cuda_result = cuda_varbinview_to_host(cuda_result).await?;
@@ -1000,7 +963,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_varbinview();
         let cuda_result = cuda_varbinview_to_host(cuda_result).await?;
@@ -1036,7 +998,6 @@ mod tests {
 
         let cuda_result = DictExecutor
             .execute(dict_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_decimal();
         let cuda_result = cuda_decimal_to_host(cuda_result)?;

--- a/vortex-cuda/src/kernel/arrays/shared.rs
+++ b/vortex-cuda/src/kernel/arrays/shared.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use async_trait::async_trait;
 use tracing::instrument;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
@@ -17,21 +16,14 @@ use crate::executor::CudaExecutionCtx;
 #[derive(Debug)]
 pub(crate) struct SharedExecutor;
 
-#[async_trait]
 impl CudaExecute for SharedExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let shared = array
             .try_into::<SharedVTable>()
             .ok()
             .vortex_expect("Array is not a Shared array");
 
-        shared
-            .get_or_compute_async(|source| source.execute_cuda(ctx))
-            .await
+        shared.get_or_compute(|source| source.clone().execute_cuda(ctx))
     }
 }

--- a/vortex-cuda/src/kernel/encodings/alp.rs
+++ b/vortex-cuda/src/kernel/encodings/alp.rs
@@ -4,7 +4,6 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::PushKernelArg;
 use tracing::instrument;
@@ -36,23 +35,18 @@ use crate::kernel::patches::execute_patches;
 #[derive(Debug)]
 pub(crate) struct ALPExecutor;
 
-#[async_trait]
 impl CudaExecute for ALPExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let array = array
             .try_into::<ALPVTable>()
             .map_err(|_| vortex_err!("Expected ALPArray"))?;
 
-        match_each_alp_float_ptype!(array.ptype(), |A| { decode_alp::<A>(array, ctx).await })
+        match_each_alp_float_ptype!(array.ptype(), |A| { decode_alp::<A>(array, ctx) })
     }
 }
 
-async fn decode_alp<A>(array: ALPArray, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical>
+fn decode_alp<A>(array: ALPArray, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical>
 where
     A: ALPFloat + NativePType + DeviceRepr + Send + Sync + 'static,
     A::ALPInt: NativePType + DeviceRepr + Send + Sync + 'static,
@@ -66,13 +60,13 @@ where
     let e: A = A::IF10[exponents.e as usize];
 
     // Execute child and copy to device
-    let canonical = array.encoded().clone().execute_cuda(ctx).await?;
+    let canonical = array.encoded().clone().execute_cuda(ctx)?;
     let primitive = canonical.into_primitive();
     let PrimitiveArrayParts {
         buffer, validity, ..
     } = primitive.into_parts();
 
-    let device_input = ctx.ensure_on_device(buffer).await?;
+    let device_input = ctx.ensure_on_device(buffer)?;
 
     // Get CUDA view of input
     let input_view = device_input.cuda_view::<A::ALPInt>()?;
@@ -99,7 +93,7 @@ where
     // Check if there are any patches to decode here
     let output_buf = if let Some(patches) = array.patches() {
         match_each_unsigned_integer_ptype!(patches.indices_ptype()?, |I| {
-            execute_patches::<A, I>(patches.clone(), output_buf, ctx).await?
+            execute_patches::<A, I>(patches.clone(), output_buf, ctx)?
         })
     } else {
         output_buf
@@ -167,7 +161,6 @@ mod tests {
 
         let gpu_result = ALPExecutor
             .execute(alp_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_host()
             .await?

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -4,7 +4,6 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use cudarc::driver::CudaFunction;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::LaunchConfig;
@@ -44,20 +43,13 @@ impl BitPackedExecutor {
     }
 }
 
-#[async_trait]
 impl CudaExecute for BitPackedExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let array =
             Self::try_specialize(array).ok_or_else(|| vortex_err!("Expected BitPackedArray"))?;
 
-        match_each_integer_ptype!(array.ptype(), |A| {
-            decode_bitpacked::<A>(array, ctx).await
-        })
+        match_each_integer_ptype!(array.ptype(), |A| { decode_bitpacked::<A>(array, ctx) })
     }
 }
 
@@ -87,7 +79,7 @@ pub fn bitpacked_cuda_launch_config(output_width: usize, len: usize) -> VortexRe
     })
 }
 
-pub(crate) async fn decode_bitpacked<A>(
+pub(crate) fn decode_bitpacked<A>(
     array: BitPackedArray,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<Canonical>
@@ -107,7 +99,7 @@ where
     vortex_ensure!(len > 0, "Non empty array");
     let offset = offset as usize;
 
-    let device_input = ctx.ensure_on_device(packed).await?;
+    let device_input = ctx.ensure_on_device(packed)?;
 
     // Get CUDA view of input
     let input_view = device_input.cuda_view::<A::Physical>()?;
@@ -136,7 +128,7 @@ where
                 .clone();
 
             let patched_buf = match_each_unsigned_integer_ptype!(p.indices_ptype()?, |I| {
-                execute_patches::<A, I>(p, buf, ctx).await?
+                execute_patches::<A, I>(p, buf, ctx)?
             });
 
             BufferHandle::new_device(Arc::new(patched_buf))
@@ -186,7 +178,6 @@ mod tests {
         let gpu_result = block_on(async {
             BitPackedExecutor
                 .execute(bp_with_patches.to_array(), &mut cuda_ctx)
-                .await
                 .vortex_expect("GPU decompression failed")
                 .into_host()
                 .await
@@ -226,7 +217,6 @@ mod tests {
         let gpu_result = block_on(async {
             BitPackedExecutor
                 .execute(bitpacked_array.to_array(), &mut cuda_ctx)
-                .await
                 .vortex_expect("GPU decompression failed")
                 .into_host()
                 .await
@@ -274,7 +264,6 @@ mod tests {
         let gpu_result = block_on(async {
             BitPackedExecutor
                 .execute(bitpacked_array.to_array(), &mut cuda_ctx)
-                .await
                 .vortex_expect("GPU decompression failed")
                 .into_host()
                 .await
@@ -338,7 +327,6 @@ mod tests {
         let gpu_result = block_on(async {
             BitPackedExecutor
                 .execute(bitpacked_array.to_array(), &mut cuda_ctx)
-                .await
                 .vortex_expect("GPU decompression failed")
                 .into_host()
                 .await
@@ -433,7 +421,6 @@ mod tests {
         let gpu_result = block_on(async {
             BitPackedExecutor
                 .execute(bitpacked_array.to_array(), &mut cuda_ctx)
-                .await
                 .vortex_expect("GPU decompression failed")
                 .into_host()
                 .await
@@ -475,7 +462,6 @@ mod tests {
         let gpu_result = block_on(async {
             BitPackedExecutor
                 .execute(sliced_array, &mut cuda_ctx)
-                .await
                 .vortex_expect("GPU decompression failed")
                 .into_host()
                 .await

--- a/vortex-cuda/src/kernel/encodings/date_time_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/date_time_parts.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::PushKernelArg;
 use tracing::instrument;
@@ -42,14 +41,10 @@ use crate::executor::CudaExecutionCtx;
 #[derive(Debug)]
 pub(crate) struct DateTimePartsExecutor;
 
-#[async_trait]
 impl CudaExecute for DateTimePartsExecutor {
+    #[allow(clippy::cognitive_complexity)]
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let output_len = array.len();
         let array = array
             .try_into::<DateTimePartsVTable>()
@@ -96,9 +91,9 @@ impl CudaExecute for DateTimePartsExecutor {
             TimeUnit::Days => vortex_bail!("Cannot decode DateTimeParts with TimeUnit::Days"),
         };
 
-        let days_canonical = array.days().clone().execute_cuda(ctx).await?;
-        let seconds_canonical = array.seconds().clone().execute_cuda(ctx).await?;
-        let subseconds_canonical = array.subseconds().clone().execute_cuda(ctx).await?;
+        let days_canonical = array.days().clone().execute_cuda(ctx)?;
+        let seconds_canonical = array.seconds().clone().execute_cuda(ctx)?;
+        let subseconds_canonical = array.subseconds().clone().execute_cuda(ctx)?;
 
         let days_prim = days_canonical.into_primitive();
 
@@ -123,7 +118,6 @@ impl CudaExecute for DateTimePartsExecutor {
                         validity,
                         ctx,
                     )
-                    .await
                 })
             })
         })
@@ -131,7 +125,7 @@ impl CudaExecute for DateTimePartsExecutor {
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn decode_datetimeparts_typed<DaysT, SecondsT, SubsecondsT>(
+fn decode_datetimeparts_typed<DaysT, SecondsT, SubsecondsT>(
     days: PrimitiveArray,
     seconds: PrimitiveArray,
     subseconds: PrimitiveArray,
@@ -162,9 +156,9 @@ where
     } = subseconds.into_parts();
 
     // Move buffers to device if not already there
-    let days_device = ctx.ensure_on_device(days_buffer).await?;
-    let seconds_device = ctx.ensure_on_device(seconds_buffer).await?;
-    let subseconds_device = ctx.ensure_on_device(subseconds_buffer).await?;
+    let days_device = ctx.ensure_on_device(days_buffer)?;
+    let seconds_device = ctx.ensure_on_device(seconds_buffer)?;
+    let subseconds_device = ctx.ensure_on_device(subseconds_buffer)?;
 
     // Allocate output buffer
     let output_slice = ctx.device_alloc::<i64>(output_len)?;
@@ -290,7 +284,6 @@ mod tests {
 
         let gpu_result = DateTimePartsExecutor
             .execute(dtp_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_host()
             .await?
@@ -316,7 +309,6 @@ mod tests {
 
         let gpu_result = DateTimePartsExecutor
             .execute(dtp_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_host()
             .await?
@@ -364,7 +356,6 @@ mod tests {
 
         let gpu_result = DateTimePartsExecutor
             .execute(dtp_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_host()
             .await?

--- a/vortex-cuda/src/kernel/encodings/decimal_byte_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/decimal_byte_parts.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Debug;
 
-use async_trait::async_trait;
 use tracing::instrument;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
@@ -23,14 +22,9 @@ use crate::executor::CudaExecute;
 #[derive(Debug)]
 pub(crate) struct DecimalBytePartsExecutor;
 
-#[async_trait]
 impl CudaExecute for DecimalBytePartsExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let Ok(array) = array.try_into::<DecimalBytePartsVTable>() else {
             vortex_bail!("cannot downcast to DecimalBytePartsArray")
         };
@@ -42,7 +36,7 @@ impl CudaExecute for DecimalBytePartsExecutor {
             ptype,
             validity,
             ..
-        } = msp.execute_cuda(ctx).await?.into_primitive().into_parts();
+        } = msp.execute_cuda(ctx)?.into_primitive().into_parts();
 
         // SAFETY: The primitive array's buffer is already validated with correct type.
         // The decimal dtype matches the array's dtype, and validity is preserved.
@@ -93,7 +87,6 @@ mod tests {
 
         let gpu_result = DecimalBytePartsExecutor
             .execute(dbp_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decode");
 
         assert_arrays_eq!(cpu_result.into_array(), gpu_result.into_array());

--- a/vortex-cuda/src/kernel/encodings/for_.rs
+++ b/vortex-cuda/src/kernel/encodings/for_.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Debug;
 
-use async_trait::async_trait;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::PushKernelArg;
 use tracing::instrument;
@@ -37,21 +36,16 @@ impl FoRExecutor {
     }
 }
 
-#[async_trait]
 impl CudaExecute for FoRExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let array = Self::try_specialize(array).ok_or_else(|| vortex_err!("Expected FoRArray"))?;
 
-        match_each_native_simd_ptype!(array.ptype(), |P| { decode_for::<P>(array, ctx).await })
+        match_each_native_simd_ptype!(array.ptype(), |P| { decode_for::<P>(array, ctx) })
     }
 }
 
-async fn decode_for<P>(array: FoRArray, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical>
+fn decode_for<P>(array: FoRArray, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical>
 where
     P: NativePType + DeviceRepr + Send + Sync + 'static,
 {
@@ -65,13 +59,13 @@ where
         .vortex_expect("Cannot have a null reference");
 
     // Execute child and copy to device
-    let canonical = array.encoded().clone().execute_cuda(ctx).await?;
+    let canonical = array.encoded().clone().execute_cuda(ctx)?;
     let primitive = canonical.into_primitive();
     let PrimitiveArrayParts {
         buffer, validity, ..
     } = primitive.into_parts();
 
-    let device_buffer = ctx.ensure_on_device(buffer).await?;
+    let device_buffer = ctx.ensure_on_device(buffer)?;
 
     // Get CUDA view of the buffer
     let cuda_view = device_buffer.cuda_view::<P>()?;
@@ -133,7 +127,6 @@ mod tests {
 
         let gpu_result = FoRExecutor
             .execute(for_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_host()
             .await?

--- a/vortex-cuda/src/kernel/encodings/runend.rs
+++ b/vortex-cuda/src/kernel/encodings/runend.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::PushKernelArg;
 use tracing::instrument;
@@ -44,14 +43,9 @@ impl RunEndExecutor {
     }
 }
 
-#[async_trait]
 impl CudaExecute for RunEndExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let array =
             Self::try_specialize(array).ok_or_else(|| vortex_err!("Expected RunEndArray"))?;
 
@@ -79,18 +73,18 @@ impl CudaExecute for RunEndExecutor {
                 .to_canonical();
         }
 
-        let ends = ends.execute_cuda(ctx).await?.into_primitive();
-        let values = values.execute_cuda(ctx).await?.into_primitive();
+        let ends = ends.execute_cuda(ctx)?.into_primitive();
+        let values = values.execute_cuda(ctx)?.into_primitive();
 
         match_each_native_ptype!(values_ptype, |V| {
             match_each_unsigned_integer_ptype!(ends_ptype, |E| {
-                decode_runend_typed::<V, E>(ends, values, offset, output_len, ctx).await
+                decode_runend_typed::<V, E>(ends, values, offset, output_len, ctx)
             })
         })
     }
 }
 
-async fn decode_runend_typed<V: DeviceRepr + NativePType, E: DeviceRepr + NativePType>(
+fn decode_runend_typed<V: DeviceRepr + NativePType, E: DeviceRepr + NativePType>(
     ends: PrimitiveArray,
     values: PrimitiveArray,
     offset: usize,
@@ -117,8 +111,8 @@ async fn decode_runend_typed<V: DeviceRepr + NativePType, E: DeviceRepr + Native
     } = ends.into_parts();
 
     // Set up device buffers.
-    let ends_device = ctx.ensure_on_device(ends_buffer).await?;
-    let values_device = ctx.ensure_on_device(values_buffer).await?;
+    let ends_device = ctx.ensure_on_device(ends_buffer)?;
+    let values_device = ctx.ensure_on_device(values_buffer)?;
 
     let output_slice = ctx.device_alloc::<V>(output_len)?;
     let output_device = CudaDeviceBuffer::new(output_slice);
@@ -205,7 +199,6 @@ mod tests {
 
         let gpu_result = RunEndExecutor
             .execute(runend_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_host()
             .await?
@@ -235,7 +228,6 @@ mod tests {
 
         let gpu_result = RunEndExecutor
             .execute(runend_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_host()
             .await?
@@ -257,7 +249,6 @@ mod tests {
 
         let gpu_result = RunEndExecutor
             .execute(runend_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_host()
             .await?
@@ -284,7 +275,6 @@ mod tests {
 
         let gpu_result = RunEndExecutor
             .execute(runend_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_host()
             .await?

--- a/vortex-cuda/src/kernel/encodings/sequence.rs
+++ b/vortex-cuda/src/kernel/encodings/sequence.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::PushKernelArg;
 use tracing::instrument;
@@ -28,14 +27,9 @@ use crate::executor::CudaExecute;
 #[derive(Debug)]
 pub(crate) struct SequenceExecutor;
 
-#[async_trait]
 impl CudaExecute for SequenceExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let array = array
             .try_into::<SequenceVTable>()
             .map_err(|_| vortex_err!("SequenceExecutor can only accept SequenceArray"))?;
@@ -51,12 +45,12 @@ impl CudaExecute for SequenceExecutor {
         match_each_native_ptype!(ptype, |P| {
             let base = base.cast::<P>()?;
             let multiplier = multiplier.cast::<P>()?;
-            execute_typed::<P>(base, multiplier, len, nullability, ctx).await
+            execute_typed::<P>(base, multiplier, len, nullability, ctx)
         })
     }
 }
 
-async fn execute_typed<T: NativePType + DeviceRepr>(
+fn execute_typed<T: NativePType + DeviceRepr>(
     base: T,
     multiplier: T,
     len: usize,
@@ -132,7 +126,6 @@ mod tests {
 
         let gpu_result = SequenceExecutor
             .execute(array.into_array(), &mut cuda_ctx)
-            .await
             .unwrap()
             .into_host()
             .await

--- a/vortex-cuda/src/kernel/encodings/zigzag.rs
+++ b/vortex-cuda/src/kernel/encodings/zigzag.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Debug;
 
-use async_trait::async_trait;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::PushKernelArg;
 use tracing::instrument;
@@ -36,14 +35,9 @@ impl ZigZagExecutor {
     }
 }
 
-#[async_trait]
 impl CudaExecute for ZigZagExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let array =
             Self::try_specialize(array).ok_or_else(|| vortex_err!("Expected ZigZagArray"))?;
 
@@ -52,12 +46,12 @@ impl CudaExecute for ZigZagExecutor {
         let output_ptype = PType::try_from(array.dtype())?;
 
         match_each_unsigned_integer_ptype!(encoded_ptype, |U| {
-            decode_zigzag::<U>(array, output_ptype, ctx).await
+            decode_zigzag::<U>(array, output_ptype, ctx)
         })
     }
 }
 
-async fn decode_zigzag<U>(
+fn decode_zigzag<U>(
     array: ZigZagArray,
     output_ptype: PType,
     ctx: &mut CudaExecutionCtx,
@@ -69,13 +63,13 @@ where
     vortex_ensure!(array_len > 0, "ZigZag array must not be empty");
 
     // Execute child and copy to device
-    let canonical = array.encoded().clone().execute_cuda(ctx).await?;
+    let canonical = array.encoded().clone().execute_cuda(ctx)?;
     let primitive = canonical.into_primitive();
     let PrimitiveArrayParts {
         buffer, validity, ..
     } = primitive.into_parts();
 
-    let device_buffer = ctx.ensure_on_device(buffer).await?;
+    let device_buffer = ctx.ensure_on_device(buffer)?;
 
     // Get CUDA view of the buffer
     let cuda_view = device_buffer.cuda_view::<U>()?;
@@ -128,7 +122,6 @@ mod tests {
 
         let gpu_result = ZigZagExecutor
             .execute(zigzag_array.to_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU decompression failed")
             .into_host()
             .await?

--- a/vortex-cuda/src/kernel/encodings/zstd.rs
+++ b/vortex-cuda/src/kernel/encodings/zstd.rs
@@ -6,11 +6,9 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use cudarc::driver::CudaSlice;
 use cudarc::driver::DevicePtr;
 use cudarc::driver::DevicePtrMut;
-use futures::future::try_join_all;
 use tracing::debug;
 use tracing::instrument;
 use vortex_array::ArrayRef;
@@ -83,7 +81,7 @@ pub struct ZstdKernelPrep {
 /// * `frames` - The compressed ZSTD frames (must not be empty)
 /// * `metadata` - The compression metadata containing frame sizes
 /// * `ctx` - The CUDA execution context
-pub async fn zstd_kernel_prepare(
+pub fn zstd_kernel_prepare(
     frames: Vec<ByteBuffer>,
     metadata: &ZstdMetadata,
     ctx: &mut CudaExecutionCtx,
@@ -108,13 +106,11 @@ pub async fn zstd_kernel_prepare(
         nvcomp_zstd::get_decompress_temp_size(num_frames, output_size_max, output_size_total)
             .map_err(|e| vortex_err!("nvcomp get_decompress_temp_size failed: {}", e))?;
 
-    // Async copy frames to the device.
-    let frame_futs = frames
+    // Copy frames to the device.
+    let device_frame_handles = frames
         .into_iter()
         .map(|frame| ctx.copy_to_device(frame))
         .collect::<VortexResult<Vec<_>>>()?;
-
-    let device_frame_handles = try_join_all(frame_futs).await?;
 
     // Allocate contiguous output buffer for all decompressed data.
     let device_output = ctx.device_alloc::<u8>(output_size_total)?;
@@ -142,13 +138,11 @@ pub async fn zstd_kernel_prepare(
             .collect::<Vec<_>>()
     };
 
-    // Copy metadata asynchronously to the device.
-    let (frame_ptrs_handle, frame_sizes_handle, output_sizes_handle, output_ptrs_handle) = futures::try_join!(
-        ctx.copy_to_device(frame_ptrs)?,
-        ctx.copy_to_device(frame_sizes)?,
-        ctx.copy_to_device(output_sizes)?,
-        ctx.copy_to_device(output_ptrs)?
-    )?;
+    // Copy metadata to the device.
+    let frame_ptrs_handle = ctx.copy_to_device(frame_ptrs)?;
+    let frame_sizes_handle = ctx.copy_to_device(frame_sizes)?;
+    let output_sizes_handle = ctx.copy_to_device(output_sizes)?;
+    let output_ptrs_handle = ctx.copy_to_device(output_ptrs)?;
 
     // Allocate working buffers
     let device_actual_sizes: CudaSlice<usize> = ctx.device_alloc(num_frames)?;
@@ -196,18 +190,13 @@ impl ZstdExecutor {
     }
 }
 
-#[async_trait]
 impl CudaExecute for ZstdExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let zstd = Self::try_specialize(array).ok_or_else(|| vortex_err!("Expected ZstdArray"))?;
 
         match zstd.as_ref().dtype() {
-            DType::Binary(_) | DType::Utf8(_) => decode_zstd(zstd, ctx).await,
+            DType::Binary(_) | DType::Utf8(_) => decode_zstd(zstd, ctx),
             _other => {
                 debug!(
                     dtype = %_other,
@@ -219,7 +208,7 @@ impl CudaExecute for ZstdExecutor {
     }
 }
 
-async fn decode_zstd(array: ZstdArray, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
+fn decode_zstd(array: ZstdArray, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
     let ZstdArrayParts {
         frames,
         metadata,
@@ -249,7 +238,7 @@ async fn decode_zstd(array: ZstdArray, ctx: &mut CudaExecutionCtx) -> VortexResu
         return Ok(Canonical::VarBinView(result));
     }
 
-    let mut exec = zstd_kernel_prepare(frames, &metadata, ctx).await?;
+    let mut exec = zstd_kernel_prepare(frames, &metadata, ctx)?;
 
     let stream = ctx.stream();
 
@@ -276,9 +265,8 @@ async fn decode_zstd(array: ZstdArray, ctx: &mut CudaExecutionCtx) -> VortexResu
     // self-contained. They neither have any parent or child encodings.
     //
     // TODO(0ax1): Don't copy back to host once VarBinView supports buffer handles.
-    let host_buffer = CudaDeviceBuffer::new(exec.device_output)
-        .copy_to_host(Alignment::new(1))?
-        .await?;
+    let host_buffer =
+        CudaDeviceBuffer::new(exec.device_output).copy_to_host_sync(Alignment::new(1))?;
 
     let slice_value_indices = validity
         .to_mask(n_rows)
@@ -320,8 +308,8 @@ mod tests {
     use super::*;
     use crate::session::CudaSession;
 
-    #[tokio::test]
-    async fn test_cuda_zstd_decompression_utf8() -> VortexResult<()> {
+    #[test]
+    fn test_cuda_zstd_decompression_utf8() -> VortexResult<()> {
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
@@ -337,16 +325,14 @@ mod tests {
         let zstd_array = ZstdArray::from_var_bin_view(&strings, 3, 0)?;
 
         let cpu_result = zstd_array.decompress()?.to_canonical()?;
-        let gpu_result = ZstdExecutor
-            .execute(zstd_array.into_array(), &mut cuda_ctx)
-            .await?;
+        let gpu_result = ZstdExecutor.execute(zstd_array.into_array(), &mut cuda_ctx)?;
 
         assert_arrays_eq!(cpu_result.into_array(), gpu_result.into_array());
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_cuda_zstd_decompression_multiple_frames() -> VortexResult<()> {
+    #[test]
+    fn test_cuda_zstd_decompression_multiple_frames() -> VortexResult<()> {
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
@@ -372,16 +358,14 @@ mod tests {
         let zstd_array = ZstdArray::from_var_bin_view(&strings, 3, 3)?;
 
         let cpu_result = zstd_array.decompress()?.to_canonical()?;
-        let gpu_result = ZstdExecutor
-            .execute(zstd_array.into_array(), &mut cuda_ctx)
-            .await?;
+        let gpu_result = ZstdExecutor.execute(zstd_array.into_array(), &mut cuda_ctx)?;
 
         assert_arrays_eq!(cpu_result.into_array(), gpu_result.into_array());
         Ok(())
     }
 
-    #[tokio::test]
-    async fn test_cuda_zstd_decompression_sliced() -> VortexResult<()> {
+    #[test]
+    fn test_cuda_zstd_decompression_sliced() -> VortexResult<()> {
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
@@ -404,9 +388,7 @@ mod tests {
         let sliced_zstd = zstd_array.slice(2..7)?;
 
         let cpu_result = sliced_zstd.to_canonical()?;
-        let gpu_result = ZstdExecutor
-            .execute(sliced_zstd.clone(), &mut cuda_ctx)
-            .await?;
+        let gpu_result = ZstdExecutor.execute(sliced_zstd.clone(), &mut cuda_ctx)?;
 
         assert_arrays_eq!(cpu_result.into_array(), gpu_result.into_array());
         Ok(())

--- a/vortex-cuda/src/kernel/encodings/zstd_buffers.rs
+++ b/vortex-cuda/src/kernel/encodings/zstd_buffers.rs
@@ -6,12 +6,9 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use cudarc::driver::CudaSlice;
 use cudarc::driver::DevicePtr;
 use cudarc::driver::DevicePtrMut;
-use futures::future::BoxFuture;
-use futures::future::try_join_all;
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::buffer::BufferHandle;
@@ -36,21 +33,16 @@ use crate::executor::CudaExecutionCtx;
 #[derive(Debug)]
 pub(crate) struct ZstdBuffersExecutor;
 
-#[async_trait]
 impl CudaExecute for ZstdBuffersExecutor {
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let zstd_buffers = array
             .try_into::<ZstdBuffersVTable>()
             .map_err(|_| vortex_err!("expected zstd buffers array"))?;
-        decode_zstd_buffers(zstd_buffers, ctx).await
+        decode_zstd_buffers(zstd_buffers, ctx)
     }
 }
 
-async fn decode_zstd_buffers(
+fn decode_zstd_buffers(
     array: ZstdBuffersArray,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<Canonical> {
@@ -59,7 +51,7 @@ async fn decode_zstd_buffers(
 
     if compressed_buffers.is_empty() {
         let inner_array = array.build_inner(&[], ctx.session())?;
-        return inner_array.execute_cuda(ctx).await;
+        return inner_array.execute_cuda(ctx);
     }
 
     let nvcomp_temp_buffer_size = nvcomp_zstd::get_decompress_temp_size(
@@ -69,7 +61,7 @@ async fn decode_zstd_buffers(
     )
     .map_err(|e| vortex_err!("nvcomp get_decompress_temp_size failed: {}", e))?;
 
-    let device_frame_handles = move_frames_to_device(compressed_buffers, ctx).await?;
+    let device_frame_handles = move_frames_to_device(compressed_buffers, ctx)?;
     let device_output = ctx.device_alloc::<u8>(plan.output_size_total())?;
 
     macro_rules! device_ptr {
@@ -91,14 +83,11 @@ async fn decode_zstd_buffers(
             .collect::<Vec<_>>()
     };
 
-    // We need to copy nvcomp args to the device; these come from the
-    // host-resident decode plan.
-    let (frame_ptrs_handle, frame_sizes_handle, output_sizes_handle, output_ptrs_handle) = futures::try_join!(
-        ctx.copy_to_device(frame_ptrs)?,
-        ctx.copy_to_device(plan.frame_sizes())?,
-        ctx.copy_to_device(plan.output_sizes())?,
-        ctx.copy_to_device(output_ptrs)?
-    )?;
+    // Copy nvcomp args to the device from the host-resident decode plan.
+    let frame_ptrs_handle = ctx.copy_to_device(frame_ptrs)?;
+    let frame_sizes_handle = ctx.copy_to_device(plan.frame_sizes().to_vec())?;
+    let output_sizes_handle = ctx.copy_to_device(plan.output_sizes().to_vec())?;
+    let output_ptrs_handle = ctx.copy_to_device(output_ptrs)?;
 
     let mut device_actual_sizes: CudaSlice<usize> = ctx.device_alloc(plan.num_frames())?;
     let mut device_statuses: CudaSlice<nvcompStatus_t> = ctx.device_alloc(plan.num_frames())?;
@@ -126,48 +115,35 @@ async fn decode_zstd_buffers(
         .map_err(|e| vortex_err!("nvcomp decompress_async failed: {}", e))?;
     }
 
-    validate_decompress_results(&plan, device_actual_sizes, device_statuses).await?;
+    validate_decompress_results(&plan, device_actual_sizes, device_statuses)?;
 
     let output_handle = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(device_output)));
     let decompressed_buffers = plan.split_output_handle(&output_handle)?;
 
     let inner_array = array.build_inner(&decompressed_buffers, ctx.session())?;
-    inner_array.execute_cuda(ctx).await
+    inner_array.execute_cuda(ctx)
 }
 
-async fn move_frames_to_device(
+fn move_frames_to_device(
     compressed_buffers: &[BufferHandle],
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<Vec<BufferHandle>> {
-    let move_futures = compressed_buffers
+    compressed_buffers
         .iter()
-        .map(
-            |frame| -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>> {
-                if frame.is_on_device() {
-                    let frame = frame.clone();
-                    Ok(Box::pin(async move { Ok(frame) }))
-                } else {
-                    ctx.move_to_device(frame.clone())
-                }
-            },
-        )
-        .collect::<VortexResult<Vec<_>>>()?;
-
-    try_join_all(move_futures).await
+        .map(|frame| ctx.ensure_on_device(frame.clone()))
+        .collect()
 }
 
 // This performs D2H to retrieve the lengths and status arrays.
-async fn validate_decompress_results(
+fn validate_decompress_results(
     plan: &vortex_zstd::ZstdBuffersDecodePlan,
     device_actual_sizes: CudaSlice<usize>,
     device_statuses: CudaSlice<nvcompStatus_t>,
 ) -> VortexResult<()> {
-    let actual_sizes_host = CudaDeviceBuffer::new(device_actual_sizes)
-        .copy_to_host(Alignment::of::<usize>())?
-        .await?;
+    let actual_sizes_host =
+        CudaDeviceBuffer::new(device_actual_sizes).copy_to_host_sync(Alignment::of::<usize>())?;
     let statuses_host = CudaDeviceBuffer::new(device_statuses)
-        .copy_to_host(Alignment::of::<nvcompStatus_t>())?
-        .await?;
+        .copy_to_host_sync(Alignment::of::<nvcompStatus_t>())?;
 
     let actual_sizes = Buffer::<usize>::from_byte_buffer(actual_sizes_host);
     let statuses = Buffer::<nvcompStatus_t>::from_byte_buffer(statuses_host);
@@ -225,8 +201,7 @@ mod tests {
 
         let cpu_result = compressed.clone().into_array().to_canonical()?;
         let gpu_result = ZstdBuffersExecutor
-            .execute(compressed.into_array(), &mut cuda_ctx)
-            .await?
+            .execute(compressed.into_array(), &mut cuda_ctx)?
             .into_host()
             .await?;
 
@@ -252,8 +227,7 @@ mod tests {
 
         let cpu_result = compressed.clone().into_array().to_canonical()?;
         let gpu_result = ZstdBuffersExecutor
-            .execute(compressed.into_array(), &mut cuda_ctx)
-            .await?
+            .execute(compressed.into_array(), &mut cuda_ctx)?
             .into_host()
             .await?;
 

--- a/vortex-cuda/src/kernel/filter/decimal.rs
+++ b/vortex-cuda/src/kernel/filter/decimal.rs
@@ -14,7 +14,7 @@ use vortex_mask::Mask;
 use crate::CudaExecutionCtx;
 use crate::kernel::filter::filter_sized;
 
-pub(super) async fn filter_decimal<D: NativeDecimalType + DeviceRepr + CubFilterable>(
+pub(super) fn filter_decimal<D: NativeDecimalType + DeviceRepr + CubFilterable>(
     array: DecimalArray,
     mask: Mask,
     ctx: &mut CudaExecutionCtx,
@@ -27,7 +27,7 @@ pub(super) async fn filter_decimal<D: NativeDecimalType + DeviceRepr + CubFilter
     } = array.into_parts();
 
     let filtered_validity = validity.filter(&mask)?;
-    let filtered_values = filter_sized::<D>(values, mask, ctx).await?;
+    let filtered_values = filter_sized::<D>(values, mask, ctx)?;
 
     Ok(Canonical::Decimal(DecimalArray::new_handle(
         filtered_values,
@@ -99,7 +99,6 @@ mod tests {
 
         let gpu_result = FilterExecutor
             .execute(filter_array.into_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU filter failed")
             .into_host()
             .await?
@@ -128,7 +127,6 @@ mod tests {
 
         let gpu_result = FilterExecutor
             .execute(filter_array.into_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU filter failed")
             .into_host()
             .await?

--- a/vortex-cuda/src/kernel/filter/mod.rs
+++ b/vortex-cuda/src/kernel/filter/mod.rs
@@ -11,7 +11,6 @@ use std::ffi::c_void;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use cudarc::driver::DevicePtr;
 use cudarc::driver::DevicePtrMut;
 use cudarc::driver::DeviceRepr;
@@ -41,14 +40,9 @@ use crate::kernel::filter::varbinview::filter_varbinview;
 #[derive(Debug)]
 pub struct FilterExecutor;
 
-#[async_trait]
 impl CudaExecute for FilterExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let filter_array = array
             .try_into::<FilterVTable>()
             .map_err(|_| vortex_err!("Expected FilterArray"))?;
@@ -59,28 +53,26 @@ impl CudaExecute for FilterExecutor {
         match mask {
             Mask::AllTrue(_) => {
                 // No data filtered => execute child without any post-processing
-                child.execute_cuda(ctx).await
+                child.execute_cuda(ctx)
             }
             Mask::AllFalse(_) => {
                 // All data filtered => empty canonical
                 Ok(Canonical::empty(child.dtype()))
             }
             m @ Mask::Values(_) => {
-                let canonical = child.execute_cuda(ctx).await?;
+                let canonical = child.execute_cuda(ctx)?;
                 match canonical {
                     Canonical::Primitive(prim) => {
                         match_each_native_simd_ptype!(prim.ptype(), |T| {
-                            filter_primitive::<T>(prim, m, ctx).await
+                            filter_primitive::<T>(prim, m, ctx)
                         })
                     }
                     Canonical::Decimal(decimal) => {
                         match_each_decimal_value_type!(decimal.values_type(), |D| {
-                            filter_decimal::<D>(decimal, m, ctx).await
+                            filter_decimal::<D>(decimal, m, ctx)
                         })
                     }
-                    Canonical::VarBinView(varbinview) => {
-                        filter_varbinview(varbinview, m, ctx).await
-                    }
+                    Canonical::VarBinView(varbinview) => filter_varbinview(varbinview, m, ctx),
                     _ => unimplemented!(),
                 }
             }
@@ -88,18 +80,18 @@ impl CudaExecute for FilterExecutor {
     }
 }
 
-async fn filter_sized<T: DeviceRepr + CubFilterable + Debug + Send + Sync + 'static>(
+fn filter_sized<T: DeviceRepr + CubFilterable + Debug + Send + Sync + 'static>(
     input: BufferHandle,
     mask: Mask,
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<BufferHandle> {
-    let d_input = ctx.ensure_on_device(input).await?;
+    let d_input = ctx.ensure_on_device(input)?;
 
     // Construct the inputs for the cub::DeviceSelect::Flagged call.
     let output_len = mask.true_count();
     let (offset, len, flags) = mask.into_bit_buffer().into_inner();
 
-    let d_flags = ctx.copy_to_device(flags.to_vec())?.await?;
+    let d_flags = ctx.copy_to_device(flags.to_vec())?;
 
     let offset = offset as u64;
     let len = len as i64;

--- a/vortex-cuda/src/kernel/filter/primitive.rs
+++ b/vortex-cuda/src/kernel/filter/primitive.rs
@@ -15,7 +15,7 @@ use crate::CudaExecutionCtx;
 use crate::kernel::filter::filter_sized;
 
 /// Execute a filter operation over the primitive array on a GPU.
-pub(super) async fn filter_primitive<T>(
+pub(super) fn filter_primitive<T>(
     array: PrimitiveArray,
     mask: Mask,
     ctx: &mut CudaExecutionCtx,
@@ -28,7 +28,7 @@ where
     } = array.into_parts();
 
     let filtered_validity = validity.filter(&mask)?;
-    let filtered_values = filter_sized::<T>(buffer, mask, ctx).await?;
+    let filtered_values = filter_sized::<T>(buffer, mask, ctx)?;
 
     Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
         filtered_values,
@@ -93,7 +93,6 @@ mod tests {
 
         let gpu_result = FilterExecutor
             .execute(filter_array.into_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU filter failed")
             .into_host()
             .await?
@@ -122,7 +121,6 @@ mod tests {
 
         let gpu_result = FilterExecutor
             .execute(filter_array.into_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU filter failed")
             .into_host()
             .await?

--- a/vortex-cuda/src/kernel/filter/varbinview.rs
+++ b/vortex-cuda/src/kernel/filter/varbinview.rs
@@ -11,7 +11,7 @@ use vortex_mask::Mask;
 use crate::CudaExecutionCtx;
 use crate::kernel::filter::filter_sized;
 
-pub(super) async fn filter_varbinview(
+pub(super) fn filter_varbinview(
     array: VarBinViewArray,
     mask: Mask,
     ctx: &mut CudaExecutionCtx,
@@ -25,9 +25,9 @@ pub(super) async fn filter_varbinview(
 
     let filtered_validity = validity.filter(&mask)?;
 
-    let d_views = ctx.ensure_on_device(views).await?;
+    let d_views = ctx.ensure_on_device(views)?;
 
-    let filtered_views = filter_sized::<i128>(d_views, mask, ctx).await?;
+    let filtered_views = filter_sized::<i128>(d_views, mask, ctx)?;
 
     Ok(Canonical::VarBinView(VarBinViewArray::new_handle(
         filtered_views,
@@ -79,7 +79,6 @@ mod tests {
 
         let gpu_result = FilterExecutor
             .execute(filter_array.into_array(), &mut cuda_ctx)
-            .await
             .vortex_expect("GPU filter failed")
             .into_host()
             .await?

--- a/vortex-cuda/src/kernel/patches/mod.rs
+++ b/vortex-cuda/src/kernel/patches/mod.rs
@@ -18,7 +18,7 @@ use crate::CudaExecutionCtx;
 use crate::executor::CudaArrayExt;
 
 /// Apply a set of patches in-place onto a [`CudaDeviceBuffer`] holding `ValuesT`.
-pub(crate) async fn execute_patches<
+pub(crate) fn execute_patches<
     ValuesT: NativePType + DeviceRepr,
     IndicesT: NativePType + DeviceRepr,
 >(
@@ -30,8 +30,8 @@ pub(crate) async fn execute_patches<
     let values = patches.values().clone();
     drop(patches);
 
-    let indices = indices.execute_cuda(ctx).await?.into_primitive();
-    let values = values.execute_cuda(ctx).await?.into_primitive();
+    let indices = indices.execute_cuda(ctx)?.into_primitive();
+    let values = values.execute_cuda(ctx)?.into_primitive();
 
     let supported = matches!(
         values.validity(),
@@ -69,8 +69,8 @@ pub(crate) async fn execute_patches<
         ..
     } = values.into_parts();
 
-    let d_patch_indices = ctx.ensure_on_device(indices_buffer).await?;
-    let d_patch_values = ctx.ensure_on_device(values_buffer).await?;
+    let d_patch_indices = ctx.ensure_on_device(indices_buffer)?;
+    let d_patch_values = ctx.ensure_on_device(values_buffer)?;
 
     let d_target_view = target.as_view::<ValuesT>();
     let d_patch_indices_view = d_patch_indices.cuda_view::<IndicesT>()?;
@@ -113,30 +113,32 @@ mod tests {
     use crate::CudaSession;
     use crate::kernel::patches::execute_patches;
 
-    #[tokio::test]
-    async fn test_patches() {
-        test_case::<u8>().await;
-        test_case::<u16>().await;
-        test_case::<u32>().await;
-        test_case::<u64>().await;
+    #[test]
+    fn test_patches() {
+        test_case::<u8>();
+        test_case::<u16>();
+        test_case::<u32>();
+        test_case::<u64>();
 
-        test_case::<i8>().await;
-        test_case::<i16>().await;
-        test_case::<i32>().await;
-        test_case::<i64>().await;
+        test_case::<i8>();
+        test_case::<i16>();
+        test_case::<i32>();
+        test_case::<i64>();
 
-        test_case::<f32>().await;
-        test_case::<f64>().await;
+        test_case::<f32>();
+        test_case::<f64>();
     }
 
-    async fn test_case<Values: NativePType + DeviceRepr>() {
-        full_test_case::<Values, u8>().await;
-        full_test_case::<Values, u16>().await;
-        full_test_case::<Values, u32>().await;
-        full_test_case::<Values, u64>().await;
+    fn test_case<Values: NativePType + DeviceRepr>() {
+        full_test_case::<Values, u8>();
+        full_test_case::<Values, u16>();
+        full_test_case::<Values, u32>();
+        full_test_case::<Values, u64>();
     }
 
-    async fn full_test_case<Values: NativePType + DeviceRepr, Indices: NativePType + DeviceRepr>() {
+    fn full_test_case<Values: NativePType + DeviceRepr, Indices: NativePType + DeviceRepr>() {
+        use futures::executor::block_on;
+
         let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty()).unwrap();
 
         let values = PrimitiveArray::from_iter(0..128);
@@ -159,7 +161,7 @@ mod tests {
             ..
         } = values.into_parts();
 
-        let handle = ctx.move_to_device(cuda_buffer).unwrap().await.unwrap();
+        let handle = ctx.ensure_on_device(cuda_buffer).unwrap();
         let device_buf = handle
             .as_device()
             .as_any()
@@ -167,9 +169,8 @@ mod tests {
             .unwrap()
             .clone();
 
-        let patched_buf = execute_patches::<Values, Indices>(patches, device_buf, &mut ctx)
-            .await
-            .unwrap();
+        let patched_buf =
+            execute_patches::<Values, Indices>(patches, device_buf, &mut ctx).unwrap();
 
         let gpu_result = PrimitiveArray::from_buffer_handle(
             BufferHandle::new_device(Arc::new(patched_buf)),
@@ -177,11 +178,8 @@ mod tests {
             Validity::NonNullable,
         )
         .to_canonical()
-        .unwrap()
-        .into_host()
-        .await
-        .unwrap()
-        .into_primitive();
+        .unwrap();
+        let gpu_result = block_on(gpu_result.into_host()).unwrap().into_primitive();
 
         assert_arrays_eq!(cpu_result, gpu_result);
     }

--- a/vortex-cuda/src/kernel/slice/mod.rs
+++ b/vortex-cuda/src/kernel/slice/mod.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use async_trait::async_trait;
 use tracing::instrument;
 use vortex_array::Array;
 use vortex_array::ArrayRef;
@@ -18,14 +17,9 @@ use crate::executor::CudaExecute;
 #[derive(Debug)]
 pub struct SliceExecutor;
 
-#[async_trait]
 impl CudaExecute for SliceExecutor {
     #[instrument(level = "trace", skip_all, fields(executor = ?self))]
-    async fn execute(
-        &self,
-        array: ArrayRef,
-        ctx: &mut CudaExecutionCtx,
-    ) -> VortexResult<Canonical> {
+    fn execute(&self, array: ArrayRef, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
         let slice_array = array.try_into::<SliceVTable>().map_err(|array| {
             vortex_err!(
                 "SliceExecutor requires input of SliceArray, was {}",
@@ -34,7 +28,7 @@ impl CudaExecute for SliceExecutor {
         })?;
 
         let SliceArrayParts { child, range } = slice_array.into_parts();
-        let child = child.execute_cuda(ctx).await?;
+        let child = child.execute_cuda(ctx)?;
 
         match child {
             Canonical::Null(null_array) => null_array.slice(range)?.to_canonical(),

--- a/vortex-cuda/src/stream.rs
+++ b/vortex-cuda/src/stream.rs
@@ -12,7 +12,6 @@ use cudarc::driver::DevicePtrMut;
 use cudarc::driver::DeviceRepr;
 use cudarc::driver::result::memcpy_htod_async;
 use cudarc::driver::result::stream;
-use futures::future::BoxFuture;
 use kanal::Sender;
 use tracing::warn;
 use vortex_array::buffer::BufferHandle;
@@ -22,7 +21,7 @@ use vortex_error::vortex_err;
 use crate::CudaDeviceBuffer;
 
 #[derive(Clone)]
-pub struct VortexCudaStream(pub Arc<CudaStream>);
+pub struct VortexCudaStream(pub(crate) Arc<CudaStream>);
 
 impl VortexCudaStream {
     /// Allocates a typed buffer on the GPU.
@@ -34,7 +33,7 @@ impl VortexCudaStream {
     ///
     /// Any kernel submitted to the stream after alloc can safely use the
     /// memory, as operations on the stream are ordered sequentially.
-    pub fn device_alloc<T: DeviceRepr + Send + Sync + 'static>(
+    pub(crate) fn device_alloc<T: DeviceRepr + Send + Sync + 'static>(
         &self,
         len: usize,
     ) -> VortexResult<CudaSlice<T>> {
@@ -46,23 +45,15 @@ impl VortexCudaStream {
         }
     }
 
-    /// Copies host data to the device asynchronously.
+    /// Copies host data to the device.
     ///
-    /// Allocates device memory, schedules an async copy, and returns a future
-    /// that completes when the copy is finished. The source data is moved into
-    /// the future to ensure it remains valid until the copy completes.
+    /// For **pageable** host memory, `memcpy_htod_async` stages the source
+    /// synchronously before returning. For **pinned** host memory the transfer
+    /// is async and the source must stay alive until the copy completes.
+    /// In order to be async, the memory must be allocated with `cuMemAllocHost`.
     ///
-    /// # Arguments
-    ///
-    /// * `data` - The host data to copy.
-    ///
-    /// # Returns
-    ///
-    /// A future that resolves to the device buffer handle when the copy completes.
-    pub fn copy_to_device<T, D>(
-        &self,
-        data: D,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>>
+    /// In both cases `data` is deferred-dropped via `register_drop_on_stream`.
+    pub(crate) fn copy_to_device<T, D>(&self, data: D) -> VortexResult<BufferHandle>
     where
         T: DeviceRepr + Debug + Send + Sync + 'static,
         D: AsRef<[T]> + Send + 'static,
@@ -76,38 +67,44 @@ impl VortexCudaStream {
                 .map_err(|e| vortex_err!("Failed to schedule async copy to device: {}", e))?;
         }
 
-        let cuda_buf = CudaDeviceBuffer::new(cuda_slice);
-        let stream = Arc::clone(&self.0);
+        let handle = BufferHandle::new_device(Arc::new(CudaDeviceBuffer::new(cuda_slice)));
+        register_drop_on_stream(&self.0, data)?;
+        Ok(handle)
+    }
+}
 
-        Ok(Box::pin(async move {
-            await_stream_callback(&stream).await?;
+/// Registers a CUDA host-function callback that drops `data` once all preceding
+/// stream work has completed.
+pub(crate) fn register_drop_on_stream<T: Send + 'static>(
+    stream: &CudaStream,
+    data: T,
+) -> VortexResult<()> {
+    let ptr = Box::into_raw(Box::new(data)) as *mut std::ffi::c_void;
 
-            // Keep source memory alive until copy completes.
-            let _keep_alive = data;
-
-            Ok(BufferHandle::new_device(Arc::new(cuda_buf)))
-        }))
+    /// Called from the CUDA driver thread when all preceding stream work completes.
+    /// Drops the boxed value, freeing the memory.
+    unsafe extern "C" fn drop_callback<T>(user_data: *mut std::ffi::c_void) {
+        // SAFETY: `user_data` was created by `Box::into_raw` in
+        // `register_drop_on_stream` and is consumed exactly once here.
+        drop(unsafe { Box::from_raw(user_data as *mut T) });
     }
 
-    /// Moves a host buffer handle to the device asynchronously.
-    ///
-    /// # Arguments
-    ///
-    /// * `handle` - The host buffer to move. Must be a host buffer.
-    ///
-    /// # Returns
-    ///
-    /// A future that resolves to the device buffer handle when the copy completes.
-    pub fn move_to_device(
-        &self,
-        handle: BufferHandle,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>> {
-        let host_buffer = handle
-            .as_host_opt()
-            .ok_or_else(|| vortex_err!("Buffer is not on host"))?;
-
-        self.copy_to_device(host_buffer.clone())
+    // SAFETY:
+    // 1. Valid stream handle from the borrowed `CudaStream`.
+    // 2. `drop_callback::<T>` has the correct signature for a host function callback.
+    // 3. `ptr` is a valid heap allocation consumed exactly once by the callback.
+    unsafe {
+        stream::launch_host_function(stream.cu_stream(), drop_callback::<T>, ptr).map_err(
+            |err| {
+                // SAFETY: Registration failed, so the callback will never run.
+                // We have unique ownership and must free it ourselves.
+                drop(Box::from_raw(ptr as *mut T));
+                vortex_err!("Failed to register drop callback: {}", err)
+            },
+        )?;
     }
+
+    Ok(())
 }
 
 /// Registers a callback and asynchronously waits for its completion.
@@ -126,7 +123,7 @@ impl VortexCudaStream {
 ///
 /// Returns an error if registering the stream callback fails or if the callback
 /// channel closes unexpectedly.
-pub async fn await_stream_callback(stream: &CudaStream) -> VortexResult<()> {
+pub(crate) async fn await_stream_callback(stream: &CudaStream) -> VortexResult<()> {
     let rx = register_stream_callback(stream)?;
 
     rx.recv()

--- a/vortex-test/e2e-cuda/src/lib.rs
+++ b/vortex-test/e2e-cuda/src/lib.rs
@@ -31,7 +31,6 @@ use arrow_schema::DataType;
 use arrow_schema::Field;
 use arrow_schema::Fields;
 use arrow_schema::ffi::FFI_ArrowSchema;
-use futures::executor::block_on;
 use vortex::array::IntoArray;
 use vortex::array::arrays::DecimalArray;
 use vortex::array::arrays::PrimitiveArray;
@@ -105,7 +104,7 @@ pub unsafe extern "C" fn export_array(
 
     *schema_ptr = FFI_ArrowSchema::try_from(data_type).expect("data_type to FFI_ArrowSchema");
 
-    match block_on(array.export_device_array(&mut ctx)) {
+    match array.export_device_array(&mut ctx) {
         Ok(exported) => {
             *array_ptr = exported;
             0


### PR DESCRIPTION
## Summary

Removes async from CUDA Vortex traits.

#### Execution model

For a given execution context, all work (with the exception to host buf copies) is enqueued onto a single CUDA stream and executes in FIFO order. Kernel launches are synchronous fire-and-forget: they enqueue work and return immediately. The returned `Canonical` may reference device buffers with in-flight writes; correctness is guaranteed by CUDA stream ordering, not by any CPU-side synchronization.

The only operations that require waiting for GPU work to complete are device-to-host copies, where the CPU must block until data lands in host memory.

To insert an explicit sync point, use `await_stream_callback`, which completes when all preceding stream work has finished.