### PR TITLE
oncelock shared array future on cuda flat layout

### DIFF
--- a/vortex-cuda/src/layout.rs
+++ b/vortex-cuda/src/layout.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeSet;
 use std::ops::BitAnd;
 use std::ops::Range;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use async_trait::async_trait;
 use futures::FutureExt;
@@ -183,6 +184,7 @@ impl VTable for CudaFlatVTable {
             name,
             segment_source,
             session: session.clone(),
+            array: Default::default(),
         }))
     }
 
@@ -229,34 +231,39 @@ pub struct CudaFlatReader {
     name: Arc<str>,
     segment_source: Arc<dyn SegmentSource>,
     session: VortexSession,
+    array: OnceLock<SharedArrayFuture>,
 }
 
 impl CudaFlatReader {
     fn array_future(&self) -> SharedArrayFuture {
-        let row_count =
-            usize::try_from(self.layout.row_count).vortex_expect("row count must fit in usize");
+        self.array
+            .get_or_init(|| {
+                let row_count = usize::try_from(self.layout.row_count)
+                    .vortex_expect("row count must fit in usize");
 
-        let segment_fut = self.segment_source.request(self.layout.segment_id);
+                let segment_fut = self.segment_source.request(self.layout.segment_id);
 
-        let ctx = self.layout.ctx.clone();
-        let session = self.session.clone();
-        let dtype = self.layout.dtype.clone();
-        let array_tree = self.layout.array_tree.clone();
-        let host_buffers = self.layout.host_buffers.clone();
+                let ctx = self.layout.ctx.clone();
+                let session = self.session.clone();
+                let dtype = self.layout.dtype.clone();
+                let array_tree = self.layout.array_tree.clone();
+                let host_buffers = self.layout.host_buffers.clone();
 
-        async move {
-            let segment = segment_fut.await?;
-            let parts = ArrayParts::from_flatbuffer_and_segment_with_overrides(
-                array_tree,
-                segment,
-                &host_buffers,
-            )?;
-            parts
-                .decode(&dtype, row_count, &ctx, &session)
-                .map_err(Arc::new)
-        }
-        .boxed()
-        .shared()
+                async move {
+                    let segment = segment_fut.await?;
+                    let parts = ArrayParts::from_flatbuffer_and_segment_with_overrides(
+                        array_tree,
+                        segment,
+                        &host_buffers,
+                    )?;
+                    parts
+                        .decode(&dtype, row_count, &ctx, &session)
+                        .map_err(Arc::new)
+                }
+                .boxed()
+                .shared()
+            })
+            .clone()
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

shared array future is recreated on each call to `array_future`. Oncelock that to share the same array for filter and projection evaluations
<!--
If this PR is related to a tracked effort, please link to the relevant issue
here (e.g., `Closes: #123`). Otherwise, feel free to ignore / delete this.

In this section, please:

1. Explain the rationale for this change.
2. Summarize the changes included in this PR.

A general rule of thumb is that larger PRs should have larger summaries. If
there are a lot of changes, please help us review the code by explaining what
was changed and why.

If there is an issue or discussion attached, there is no need to duplicate all
the details, but clarity is always preferred over brevity.
-->

Closes: #000

<!--
## API Changes

Uncomment this section if there are any user-facing changes.

Consider whether the change affects users in one of the following ways:

1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the engine integrations.
3. Should some documentation be updated to reflect this change?

If a public API is changed in a breaking manner, make sure to add the
appropriate label. You can run `./scripts/public-api.sh` locally to see if there
are any public API changes (and this also runs in our CI).
-->

## Testing

<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
3. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
