### PR TITLE
decoding stats should lock once

### DIFF
--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -376,10 +376,9 @@ impl ArrayParts {
 
         // Populate statistics from the serialized array.
         if let Some(stats) = self.flatbuffer().stats() {
-            let decoded_statistics = decoded.statistics();
-            StatsSet::from_flatbuffer(&stats, dtype)?
-                .into_iter()
-                .for_each(|(stat, val)| decoded_statistics.set(stat, val));
+            decoded
+                .statistics()
+                .set_iter(StatsSet::from_flatbuffer(&stats, dtype)?.into_iter());
         }
 
         Ok(decoded)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

setting stats for a decoding array currently locks per stat, api supports to lock it once with `set_iter`
<!--
If this PR is related to a tracked effort, please link to the relevant issue
here (e.g., `Closes: #123`). Otherwise, feel free to ignore / delete this.

In this section, please:

1. Explain the rationale for this change.
2. Summarize the changes included in this PR.

A general rule of thumb is that larger PRs should have larger summaries. If
there are a lot of changes, please help us review the code by explaining what
was changed and why.

If there is an issue or discussion attached, there is no need to duplicate all
the details, but clarity is always preferred over brevity.
-->

Closes: #000

<!--
## API Changes

Uncomment this section if there are any user-facing changes.

Consider whether the change affects users in one of the following ways:

1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the engine integrations.
3. Should some documentation be updated to reflect this change?

If a public API is changed in a breaking manner, make sure to add the
appropriate label. You can run `./scripts/public-api.sh` locally to see if there
are any public API changes (and this also runs in our CI).
-->

## Testing

<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
3. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
