### PR TITLE
Bump Rust MSRV to 1.90

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ keywords = ["vortex"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/spiraldb/vortex"
-rust-version = "1.89"
+rust-version = "1.90"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89"
+channel = "1.90"
 components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/vortex-cuda/src/device_buffer.rs
+++ b/vortex-cuda/src/device_buffer.rs
@@ -315,7 +315,7 @@ impl DeviceBuffer for CudaDeviceBuffer {
 
     fn aligned(self: Arc<Self>, alignment: Alignment) -> VortexResult<Arc<dyn DeviceBuffer>> {
         let effective_ptr = self.device_ptr + self.offset as u64;
-        if effective_ptr % (*alignment as u64) == 0 {
+        if effective_ptr.is_multiple_of(*alignment as u64) {
             Ok(Arc::new(CudaDeviceBuffer {
                 allocation: self.allocation.clone(),
                 offset: self.offset,


### PR DESCRIPTION
The main goal is to get stable workspace publishing so we can reduce our usage of nightly rust in CI