### PR TITLE
docs: clarify cuda async execution model

### DIFF
--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -127,11 +127,7 @@ fn run_dynamic_dispatch_bitpacked_timed(
     let len = bitpacked_array.len();
 
     // Move packed data to device.
-    let device_input = if packed.is_on_device() {
-        packed
-    } else {
-        block_on(cuda_ctx.move_to_device(packed)?).vortex_expect("failed to move to device")
-    };
+    let device_input = block_on(cuda_ctx.ensure_on_device(packed))?;
 
     let input_ptr = device_input
         .cuda_view::<u32>()

--- a/vortex-cuda/src/dynamic_dispatch.rs
+++ b/vortex-cuda/src/dynamic_dispatch.rs
@@ -120,9 +120,9 @@ mod tests {
     use cudarc::driver::DevicePtr;
     use cudarc::driver::LaunchConfig;
     use cudarc::driver::PushKernelArg;
+    use futures::executor::block_on;
     use vortex::array::ToCanonical;
     use vortex::array::arrays::PrimitiveArray;
-    use vortex::array::buffer::BufferHandle;
     use vortex::array::validity::Validity::NonNullable;
     use vortex::buffer::Buffer;
     use vortex::encodings::alp::ALPFloat;
@@ -214,21 +214,6 @@ mod tests {
         Ok(unsafe { std::mem::transmute::<Vec<u32>, Vec<f32>>(result) })
     }
 
-    fn copy_to_device(
-        cuda_ctx: &CudaExecutionCtx,
-        bitpacked: &BitPackedArray,
-    ) -> VortexResult<(u64, BufferHandle)> {
-        let packed = bitpacked.packed().clone();
-        let device_input = futures::executor::block_on(cuda_ctx.move_to_device(packed)?)
-            .vortex_expect("move to device");
-        let ptr = device_input
-            .cuda_view::<u32>()
-            .vortex_expect("input view")
-            .device_ptr(cuda_ctx.stream())
-            .0;
-        Ok((ptr, device_input))
-    }
-
     #[test]
     fn test_bitunpack() -> VortexResult<()> {
         let bit_width: u8 = 10;
@@ -241,7 +226,11 @@ mod tests {
 
         let bitpacked = make_bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (input_ptr, _device_input) = copy_to_device(&cuda_ctx, &bitpacked)?;
+        let _device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
+        let input_ptr = _device_input
+            .cuda_view::<u32>()?
+            .device_ptr(cuda_ctx.stream())
+            .0;
 
         let plan = DynamicDispatchPlan::new(SourceOp::bitunpack(bit_width), &[]);
 
@@ -264,7 +253,11 @@ mod tests {
 
         let bitpacked = make_bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (input_ptr, _device_input) = copy_to_device(&cuda_ctx, &bitpacked)?;
+        let _device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
+        let input_ptr = _device_input
+            .cuda_view::<u32>()?
+            .device_ptr(cuda_ctx.stream())
+            .0;
 
         let plan = DynamicDispatchPlan::new(
             SourceOp::bitunpack(bit_width),
@@ -303,7 +296,11 @@ mod tests {
         let alp_e = <f32 as ALPFloat>::IF10[alp_array.exponents().e as usize];
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (input_ptr, _device_input) = copy_to_device(&cuda_ctx, &bitpacked)?;
+        let _device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
+        let input_ptr = _device_input
+            .cuda_view::<u32>()?
+            .device_ptr(cuda_ctx.stream())
+            .0;
 
         let plan = DynamicDispatchPlan::new(
             SourceOp::bitunpack(bit_width),
@@ -333,7 +330,11 @@ mod tests {
 
         let bitpacked = make_bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (input_ptr, _device_input) = copy_to_device(&cuda_ctx, &bitpacked)?;
+        let _device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
+        let input_ptr = _device_input
+            .cuda_view::<u32>()?
+            .device_ptr(cuda_ctx.stream())
+            .0;
 
         let scalar_ops: Vec<ScalarOp> = references
             .iter()

--- a/vortex-cuda/src/dynamic_dispatch.rs
+++ b/vortex-cuda/src/dynamic_dispatch.rs
@@ -226,8 +226,8 @@ mod tests {
 
         let bitpacked = make_bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let _device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
-        let input_ptr = _device_input
+        let device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
+        let input_ptr = device_input
             .cuda_view::<u32>()?
             .device_ptr(cuda_ctx.stream())
             .0;
@@ -253,8 +253,8 @@ mod tests {
 
         let bitpacked = make_bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let _device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
-        let input_ptr = _device_input
+        let device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
+        let input_ptr = device_input
             .cuda_view::<u32>()?
             .device_ptr(cuda_ctx.stream())
             .0;
@@ -296,8 +296,8 @@ mod tests {
         let alp_e = <f32 as ALPFloat>::IF10[alp_array.exponents().e as usize];
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let _device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
-        let input_ptr = _device_input
+        let device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
+        let input_ptr = device_input
             .cuda_view::<u32>()?
             .device_ptr(cuda_ctx.stream())
             .0;
@@ -330,8 +330,8 @@ mod tests {
 
         let bitpacked = make_bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let _device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
-        let input_ptr = _device_input
+        let device_input = block_on(cuda_ctx.ensure_on_device(bitpacked.packed().clone()))?;
+        let input_ptr = device_input
             .cuda_view::<u32>()?
             .device_ptr(cuda_ctx.stream())
             .0;

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -220,7 +220,11 @@ impl CudaExecutionCtx {
         self.stream.device_alloc(len)
     }
 
-    /// See `VortexCudaStream::copy_to_device`.
+    /// Copies host data to the device.
+    ///
+    /// For **pageable** host memory the source is staged synchronously; for
+    /// **pinned** memory the transfer is async. In both cases `data` is
+    /// kept alive by the returned future until the copy completes.
     pub fn copy_to_device<T, D>(
         &self,
         data: D,
@@ -232,24 +236,19 @@ impl CudaExecutionCtx {
         self.stream.copy_to_device(data)
     }
 
-    /// See `VortexCudaStream::move_to_device`.
-    pub fn move_to_device(
-        &self,
-        handle: BufferHandle,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>> {
-        self.stream.move_to_device(handle)
-    }
-
     /// Ensures a buffer is resident on the device, copying from host if necessary.
     ///
-    /// If the buffer is already on the device it is returned as-is. Otherwise it
-    /// is asynchronously copied to device memory.
+    /// If the buffer is already on the device it is returned as-is. Otherwise
+    /// delegates to `copy_to_device`.
     pub async fn ensure_on_device(&self, handle: BufferHandle) -> VortexResult<BufferHandle> {
         if handle.is_on_device() {
-            Ok(handle)
-        } else {
-            self.move_to_device(handle)?.await
+            return Ok(handle);
         }
+        let host_buffer = handle
+            .as_host_opt()
+            .ok_or_else(|| vortex_err!("Buffer is not on host"))?
+            .clone();
+        self.stream.copy_to_device(host_buffer)?.await
     }
 
     /// Returns a reference to the underlying CUDA stream.
@@ -270,6 +269,36 @@ impl CudaExecutionCtx {
 }
 
 /// Support trait for CUDA-accelerated decompression of arrays.
+///
+/// # Execution model
+///
+/// Work is enqueued onto a single CUDA stream and executes in FIFO order.
+/// Kernel launches are synchronous fire-and-forget: They enqueue work and
+/// return immediately. The returned [`Canonical`] may reference device buffers
+/// with in-flight writes.
+///
+/// ## Pageable vs. page-locked (pinned) host memory
+///
+/// Whether the H2D transfer is asynchronous depends on whether the source
+/// memory is page-locked:
+///
+/// - **Page-locked memory** (allocated via `cuMemAllocHost` / `cudaMallocHost`):
+///   the GPU's DMA engine holds a stable physical address for the allocation and
+///   can transfer directly without CPU involvement. The call returns immediately
+///   and the copy proceeds in parallel with subsequent CPU work.
+///
+/// - **Pageable memory** (ordinary `malloc` / Rust allocator): CUDA must first
+///   stage the data through an internal page-locked bounce buffer, performing a
+///   CPU `memcpy` into that buffer before the DMA can begin. The `memcpy_htod_async`
+///   call blocks until the staging copy finishes, making the transfer effectively
+///   synchronous from the caller's perspective, though the DMA itself still runs
+///   on the stream.
+///
+///
+/// ## Synchronisation
+///
+/// To insert an explicit sync point, use `await_stream_callback`, which completes
+/// when all preceding stream work — including in-flight kernels — has finished.
 #[async_trait]
 pub trait CudaExecute: 'static + Send + Sync + Debug {
     /// Executes the array on CUDA, returning a canonical array.
@@ -284,10 +313,14 @@ pub trait CudaExecute: 'static + Send + Sync + Debug {
 /// Extension trait for executing arrays on CUDA.
 #[async_trait]
 pub trait CudaArrayExt: Array {
-    /// Recursively executes the array on CUDA, returning a canonical array.
+    /// Recursively walks the encoding tree, dispatching each layer to its
+    /// registered [`CudaExecute`] implementation and returning a canonical array
+    /// on the device.
     ///
-    /// If no CUDA support is registered for the encoding, falls back to CPU execution
-    /// and logs a debug message.
+    /// See [`CudaExecute`] for details on the execution model.
+    ///
+    /// Falls back to CPU execution if no CUDA support is registered for the
+    /// encoding.
     async fn execute_cuda(self, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical>;
 }
 

--- a/vortex-cuda/src/kernel/encodings/zstd_buffers.rs
+++ b/vortex-cuda/src/kernel/encodings/zstd_buffers.rs
@@ -10,8 +10,6 @@ use async_trait::async_trait;
 use cudarc::driver::CudaSlice;
 use cudarc::driver::DevicePtr;
 use cudarc::driver::DevicePtrMut;
-use futures::future::BoxFuture;
-use futures::future::try_join_all;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::buffer::BufferHandle;
@@ -139,21 +137,11 @@ async fn move_frames_to_device(
     compressed_buffers: &[BufferHandle],
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<Vec<BufferHandle>> {
-    let move_futures = compressed_buffers
-        .iter()
-        .map(
-            |frame| -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>> {
-                if frame.is_on_device() {
-                    let frame = frame.clone();
-                    Ok(Box::pin(async move { Ok(frame) }))
-                } else {
-                    ctx.move_to_device(frame.clone())
-                }
-            },
-        )
-        .collect::<VortexResult<Vec<_>>>()?;
-
-    try_join_all(move_futures).await
+    let mut results = Vec::with_capacity(compressed_buffers.len());
+    for frame in compressed_buffers {
+        results.push(ctx.ensure_on_device(frame.clone()).await?);
+    }
+    Ok(results)
 }
 
 // This performs D2H to retrieve the lengths and status arrays.

--- a/vortex-cuda/src/kernel/patches/mod.rs
+++ b/vortex-cuda/src/kernel/patches/mod.rs
@@ -161,7 +161,7 @@ mod tests {
             ..
         } = values.into_parts();
 
-        let handle = ctx.move_to_device(cuda_buffer).unwrap().await.unwrap();
+        let handle = ctx.ensure_on_device(cuda_buffer).await.unwrap();
         let device_buf = handle
             .as_device()
             .as_any()

--- a/vortex-cuda/src/stream.rs
+++ b/vortex-cuda/src/stream.rs
@@ -22,7 +22,7 @@ use vortex::error::vortex_err;
 use crate::CudaDeviceBuffer;
 
 #[derive(Clone)]
-pub struct VortexCudaStream(pub Arc<CudaStream>);
+pub struct VortexCudaStream(pub(crate) Arc<CudaStream>);
 
 impl VortexCudaStream {
     /// Allocates a typed buffer on the GPU.
@@ -34,7 +34,7 @@ impl VortexCudaStream {
     ///
     /// Any kernel submitted to the stream after alloc can safely use the
     /// memory, as operations on the stream are ordered sequentially.
-    pub fn device_alloc<T: DeviceRepr + Send + Sync + 'static>(
+    pub(crate) fn device_alloc<T: DeviceRepr + Send + Sync + 'static>(
         &self,
         len: usize,
     ) -> VortexResult<CudaSlice<T>> {
@@ -46,20 +46,17 @@ impl VortexCudaStream {
         }
     }
 
-    /// Copies host data to the device asynchronously.
+    /// Copies host data to the device.
     ///
     /// Allocates device memory, schedules an async copy, and returns a future
     /// that completes when the copy is finished. The source data is moved into
     /// the future to ensure it remains valid until the copy completes.
     ///
-    /// # Arguments
-    ///
-    /// * `data` - The host data to copy.
-    ///
-    /// # Returns
-    ///
-    /// A future that resolves to the device buffer handle when the copy completes.
-    pub fn copy_to_device<T, D>(
+    /// For **pageable** host memory, `memcpy_htod_async` stages the source
+    /// synchronously before returning. For **pinned** host memory the transfer
+    /// is truly async and the source must stay alive until the copy completes
+    /// (guaranteed by the returned future capturing it).
+    pub(crate) fn copy_to_device<T, D>(
         &self,
         data: D,
     ) -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>>
@@ -88,26 +85,6 @@ impl VortexCudaStream {
             Ok(BufferHandle::new_device(Arc::new(cuda_buf)))
         }))
     }
-
-    /// Moves a host buffer handle to the device asynchronously.
-    ///
-    /// # Arguments
-    ///
-    /// * `handle` - The host buffer to move. Must be a host buffer.
-    ///
-    /// # Returns
-    ///
-    /// A future that resolves to the device buffer handle when the copy completes.
-    pub fn move_to_device(
-        &self,
-        handle: BufferHandle,
-    ) -> VortexResult<BoxFuture<'static, VortexResult<BufferHandle>>> {
-        let host_buffer = handle
-            .as_host_opt()
-            .ok_or_else(|| vortex_err!("Buffer is not on host"))?;
-
-        self.copy_to_device(host_buffer.clone())
-    }
 }
 
 /// Registers a callback and asynchronously waits for its completion.
@@ -126,7 +103,7 @@ impl VortexCudaStream {
 ///
 /// Returns an error if registering the stream callback fails or if the callback
 /// channel closes unexpectedly.
-pub async fn await_stream_callback(stream: &CudaStream) -> VortexResult<()> {
+pub(crate) async fn await_stream_callback(stream: &CudaStream) -> VortexResult<()> {
     let rx = register_stream_callback(stream)?;
 
     rx.recv()


### PR DESCRIPTION
## Summary

Besides adding docs for the execution model, this includes notes on pageable and pinned physical memory. Further, `move_to_device` is dropped in favor of `copy_to_device`.