### PR TITLE
Fix compression benchmarks build

### DIFF
--- a/vortex-bench/Cargo.toml
+++ b/vortex-bench/Cargo.toml
@@ -39,7 +39,7 @@ parquet = { workspace = true, features = ["async"] }
 rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream"] }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sysinfo = { workspace = true }
 tabled = { workspace = true, features = ["std"] }


### PR DESCRIPTION
Some other crate stopped enabling this feature, which changed how the dependency is resolved, so now it doesn't build.