### PR TITLE
chore: delete commented out metadata tests

### DIFF
--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -276,17 +276,6 @@ impl From<Vec<Option<bool>>> for ByteBoolArray {
 mod tests {
     use super::*;
 
-    // #[cfg_attr(miri, ignore)]
-    // #[test]
-    // fn test_bytebool_metadata() {
-    //     check_metadata(
-    //         "bytebool.metadata",
-    //         SerdeMetadata(ByteBoolMetadata {
-    //             validity: ValidityMetadata::AllValid,
-    //         }),
-    //     );
-    // }
-
     #[test]
     fn test_validity_construction() {
         let v = vec![true, false];

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -307,20 +307,6 @@ mod test {
 
     use crate::BitPackedArray;
 
-    // #[cfg_attr(miri, ignore)]
-    // #[test]
-    // fn test_bitpacked_metadata() {
-    //     check_metadata(
-    //         "bitpacked.metadata",
-    //         RkyvMetadata(BitPackedMetadata {
-    //             patches: Some(PatchesMetadata::new(usize::MAX, usize::MAX, PType::U64)),
-    //             validity: ValidityMetadata::AllValid,
-    //             offset: u16::MAX,
-    //             bit_width: u8::MAX,
-    //         }),
-    //     );
-    // }
-
     #[test]
     fn test_encode() {
         let values = [


### PR DESCRIPTION
## Summary

Remove two commented-out test functions that reference a `check_metadata` helper that no longer exists:

- `test_bitpacked_metadata` in `encodings/fastlanes/src/bitpacking/array/mod.rs`
- `test_bytebool_metadata` in `encodings/bytebool/src/array.rs`

Both tests were fully commented out (including their `#[test]` and `#[cfg_attr(miri, ignore)]` attributes) and referenced removed types (`RkyvMetadata`, `SerdeMetadata`). They were dead code.

## Testing

No behavioral change — only dead code removal.

Signed-off-by: Vignesh Sankaran <developer@sankaran.io>