### PR TITLE
Use cache-cargo-install action instead of installing manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,7 +691,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./.github/actions/system-info
       - name: Install Codspeed
-        run: cargo install --force cargo-codspeed --locked
+        uses: taiki-e/cache-cargo-install-action@2bfc3cedaf2ee5e7fa5d0ae034ccd5fb50cf8e1f
+        with:
+          tool: cargo-codspeed
       - name: Build benchmarks
         env:
           RUSTFLAGS: "-C target-feature=+avx2 -C debug-assertions=yes"
@@ -874,6 +876,7 @@ jobs:
       - run: cargo build --package vortex-jni
 
   rust-publish-dry-run:
+    name: "Rust publish dry-run"
     timeout-minutes: 120
     runs-on:
       - runs-on=${{ github.run_id }}
@@ -891,10 +894,12 @@ jobs:
         uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cargo Set Version
+      - name: Install cargo-edit
+        uses: taiki-e/cache-cargo-install-action@2bfc3cedaf2ee5e7fa5d0ae034ccd5fb50cf8e1f
+        with:
+          tool: cargo-edit
+      - name: Set Version
         run: |
-          # Match publish toolchain
-          cargo install --locked cargo-edit
           # This is mostly a dummy version, we don't actually publish anything but it cannot exist in crates.io
           cargo set-version --workspace 0.100000.0
       - name: Test Release

--- a/.github/workflows/close-fixed-fuzzer-issues.yml
+++ b/.github/workflows/close-fixed-fuzzer-issues.yml
@@ -50,8 +50,10 @@ jobs:
         with:
           compiler: llvm
 
-      - name: Install cargo fuzz
-        run: cargo install --locked cargo-fuzz
+      - name: Install cargo-fuzz
+        uses: taiki-e/cache-cargo-install-action@2bfc3cedaf2ee5e7fa5d0ae034ccd5fb50cf8e1f
+        with:
+          tool: cargo-fuzz
 
       - name: Retest and close fixed fuzzer issues
         env:

--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -50,8 +50,10 @@ jobs:
           fi
           echo "Found llvm-profdata at $LLVM_PROFDATA"
 
-      - name: Install cargo fuzz
-        run: cargo install --locked cargo-fuzz
+      - name: Install cargo-fuzz
+        uses: taiki-e/cache-cargo-install-action@2bfc3cedaf2ee5e7fa5d0ae034ccd5fb50cf8e1f
+        with:
+          tool: cargo-fuzz
 
       - name: Download corpus from R2
         shell: bash

--- a/.github/workflows/fuzzer-fix-automation.yml
+++ b/.github/workflows/fuzzer-fix-automation.yml
@@ -68,8 +68,10 @@ jobs:
         with:
           compiler: llvm
 
-      - name: Install cargo fuzz
-        run: cargo install --locked cargo-fuzz
+      - name: Install cargo-fuzz
+        uses: taiki-e/cache-cargo-install-action@2bfc3cedaf2ee5e7fa5d0ae034ccd5fb50cf8e1f
+        with:
+          tool: cargo-fuzz
 
       - name: Extract crash details from issue
         id: extract

--- a/.github/workflows/minimize_fuzz_corpus_workflow.yml
+++ b/.github/workflows/minimize_fuzz_corpus_workflow.yml
@@ -59,8 +59,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
 
-      - name: Install cargo fuzz
-        run: cargo install --locked cargo-fuzz
+      - name: Install cargo-fuzz
+        uses: taiki-e/cache-cargo-install-action@2bfc3cedaf2ee5e7fa5d0ae034ccd5fb50cf8e1f
+        with:
+          tool: cargo-fuzz
 
       - name: Restore corpus
         shell: bash

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -41,9 +41,13 @@ jobs:
           targets: ${{ matrix.target.target }}
           enable-sccache: "false"
 
+      - name: Install cargo-edit
+        uses: taiki-e/cache-cargo-install-action@2bfc3cedaf2ee5e7fa5d0ae034ccd5fb50cf8e1f
+        with:
+          tool: cargo-edit
+
       - name: Cargo Set Version
         run: |
-          cargo install cargo-edit
           cargo set-version --workspace ${{ inputs.version }}
 
       - name: Set up Python

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,15 +26,17 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           enable-sccache: "false"
+      - name: Install cargo-edit
+        uses: taiki-e/cache-cargo-install-action@2bfc3cedaf2ee5e7fa5d0ae034ccd5fb50cf8e1f
+        with:
+          tool: cargo-edit
 
       - name: Cargo Set Version
         run: |
-          cargo install cargo-edit
           cargo set-version --workspace ${{ github.event.release.tag_name }}
 
       - name: Release

--- a/.github/workflows/run-fuzzer.yml
+++ b/.github/workflows/run-fuzzer.yml
@@ -78,8 +78,10 @@ jobs:
         with:
           compiler: llvm
 
-      - name: Install cargo fuzz
-        run: cargo install --locked cargo-fuzz
+      - name: Install cargo-fuzz
+        uses: taiki-e/cache-cargo-install-action@2bfc3cedaf2ee5e7fa5d0ae034ccd5fb50cf8e1f
+        with:
+          tool: cargo-fuzz
 
       - name: Restore corpus
         shell: bash


### PR DESCRIPTION
This will let us cache the installed binary which in a lot of cases is the
slowest part of the check

Signed-off-by: Robert Kruszewski <github@robertk.io>
