### PR TITLE
refactor: simplify Buffer creation from Vec

### DIFF
--- a/encodings/pco/src/test.rs
+++ b/encodings/pco/src/test.rs
@@ -88,7 +88,7 @@ fn test_validity_and_multiple_chunks_and_pages() {
     validity[7..15].fill(false);
     validity[101] = false;
     let array = PrimitiveArray::new(
-        data.iter().cloned().collect::<Buffer<_>>(),
+        Buffer::from(data),
         Validity::Array(BoolArray::from_iter(validity).to_array()),
     );
     let compression_level = 3;
@@ -128,7 +128,7 @@ fn test_validity_vtable() {
     let data: Vec<i32> = (0..5).collect();
     let mask_bools = vec![false, true, true, false, true];
     let array = PrimitiveArray::new(
-        data.iter().cloned().collect::<Buffer<_>>(),
+        Buffer::from(data),
         Validity::Array(BoolArray::from_iter(mask_bools.clone()).to_array()),
     );
     let compressed = PcoArray::from_primitive(&array, 3, 0).unwrap();

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -141,7 +141,7 @@ impl ZigZagVTable {
 
 impl ZigZagArray {
     pub fn new(encoded: ArrayRef) -> Self {
-        Self::try_new(encoded).vortex_expect("ZigZigArray new")
+        Self::try_new(encoded).vortex_expect("ZigZagArray new")
     }
 
     pub fn try_new(encoded: ArrayRef) -> VortexResult<Self> {

--- a/encodings/zstd/src/test.rs
+++ b/encodings/zstd/src/test.rs
@@ -63,7 +63,7 @@ fn test_zstd_with_validity_and_multi_frame() {
     validity[3] = true;
     validity[177] = true;
     let array = PrimitiveArray::new(
-        data.iter().cloned().collect::<Buffer<_>>(),
+        Buffer::from(data),
         Validity::Array(BoolArray::from_iter(validity).to_array()),
     );
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

Replace `vec.iter().cloned().collect::<Buffer<_>>()` with `Buffer::from(vec)`
for better performance and readability. 
<!--
If this PR is related to a tracked effort, please link to the relevant issue
here (e.g., `Closes: #123`). Otherwise, feel free to ignore / delete this.

In this section, please:

1. Explain the rationale for this change.
2. Summarize the changes included in this PR.

A general rule of thumb is that larger PRs should have larger summaries. If
there are a lot of changes, please help us review the code by explaining what
was changed and why.

If there is an issue or discussion attached, there is no need to duplicate all
the details, but clarity is always preferred over brevity.
-->


<!--
## API Changes

Uncomment this section if there are any user-facing changes.

Consider whether the change affects users in one of the following ways:

1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the engine integrations.
3. Should some documentation be updated to reflect this change?

If a public API is changed in a breaking manner, make sure to add the
appropriate label. You can run `./scripts/public-api.sh` locally to see if there
are any public API changes (and this also runs in our CI).
-->

## Testing
N/A
<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
3. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
