### PR TITLE
Make the tui an default optional dependecy of vortex-python

### DIFF
--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -22,11 +22,12 @@ workspace = true
 crate-type = ["rlib", "cdylib"]
 
 [features]
-default = ["extension-module"]
+default = ["extension-module", "tui"]
 # Enable this feature when building the standalone Python extension.
 # Disable it when using vortex-python as a library dependency to avoid
 # duplicate PyInit__lib symbols.
 extension-module = []
+tui = ["dep:vortex-tui"]
 
 [dependencies]
 arrow-array = { workspace = true }
@@ -52,7 +53,7 @@ tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 tracing = { workspace = true, features = ["std", "log"] }
 url = { workspace = true }
 vortex = { workspace = true, features = ["object_store", "tokio"] }
-vortex-tui = { workspace = true }
+vortex-tui = { workspace = true, optional = true }
 
 [dev-dependencies]
 vortex-array = { workspace = true, features = ["_test-harness"] }

--- a/vortex-python/src/lib.rs
+++ b/vortex-python/src/lib.rs
@@ -9,6 +9,7 @@ use pyo3::prelude::*;
 
 pub(crate) mod arrays;
 pub mod arrow;
+#[cfg(feature = "tui")]
 mod cli;
 mod compress;
 mod dataset;
@@ -62,6 +63,7 @@ fn _lib(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
 
     // Initialize our submodules, living under vortex._lib
     arrays::init(py, m)?;
+    #[cfg(feature = "tui")]
     cli::init(py, m)?;
     compress::init(py, m)?;
     dataset::init(py, m)?;


### PR DESCRIPTION
## Summary

When using vortex-python as a library, adding the tui isn't necessarily useful and pulls in many significant dependencies (Like DF, parquet)

