### PR TITLE
only a read lock for current_array_ref

### DIFF
--- a/vortex-array/src/arrays/shared/array.rs
+++ b/vortex-array/src/arrays/shared/array.rs
@@ -4,8 +4,9 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use async_lock::Mutex;
-use async_lock::MutexGuard;
+use async_lock::RwLock;
+use async_lock::RwLockReadGuard;
+use async_lock::RwLockWriteGuard;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
@@ -16,7 +17,7 @@ use crate::stats::ArrayStats;
 
 #[derive(Debug, Clone)]
 pub struct SharedArray {
-    pub(super) state: Arc<Mutex<SharedState>>,
+    pub(super) state: Arc<RwLock<SharedState>>,
     pub(super) dtype: DType,
     pub(super) stats: ArrayStats,
 }
@@ -32,21 +33,34 @@ impl SharedArray {
     pub fn new(source: ArrayRef) -> Self {
         Self {
             dtype: source.dtype().clone(),
-            state: Arc::new(Mutex::new(SharedState::Source(source))),
+            state: Arc::new(RwLock::new(SharedState::Source(source))),
             stats: ArrayStats::default(),
         }
     }
 
     #[cfg(not(target_family = "wasm"))]
-    fn lock_sync(&self) -> MutexGuard<'_, SharedState> {
-        self.state.lock_blocking()
+    fn write_lock_sync(&self) -> RwLockWriteGuard<'_, SharedState> {
+        self.state.write_blocking()
     }
 
     #[cfg(target_family = "wasm")]
-    fn lock_sync(&self) -> MutexGuard<'_, SharedState> {
+    fn write_lock_sync(&self) -> RwLockWriteGuard<'_, SharedState> {
         // this should mirror how parking_lot compiles to wasm
         self.state
-            .try_lock()
+            .try_write()
+            .expect("SharedArray: mutex contention on single-threaded wasm target")
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    fn read_lock_sync(&self) -> RwLockReadGuard<'_, SharedState> {
+        self.state.read_blocking()
+    }
+
+    #[cfg(target_family = "wasm")]
+    fn read_lock_sync(&self) -> RwLockReadGuard<'_, SharedState> {
+        // this should mirror how parking_lot compiles to wasm
+        self.state
+            .try_read()
             .expect("SharedArray: mutex contention on single-threaded wasm target")
     }
 
@@ -54,7 +68,7 @@ impl SharedArray {
         &self,
         f: impl FnOnce(&ArrayRef) -> VortexResult<Canonical>,
     ) -> VortexResult<Canonical> {
-        let mut state = self.lock_sync();
+        let mut state = self.write_lock_sync();
         match &*state {
             SharedState::Cached(canonical) => Ok(canonical.clone()),
             SharedState::Source(source) => {
@@ -70,7 +84,7 @@ impl SharedArray {
         F: FnOnce(ArrayRef) -> Fut,
         Fut: Future<Output = VortexResult<Canonical>>,
     {
-        let mut state = self.state.lock().await;
+        let mut state = self.state.write().await;
         match &*state {
             SharedState::Cached(canonical) => Ok(canonical.clone()),
             SharedState::Source(source) => {
@@ -83,7 +97,7 @@ impl SharedArray {
     }
 
     pub(super) fn current_array_ref(&self) -> ArrayRef {
-        let state = self.lock_sync();
+        let state = self.read_lock_sync();
         match &*state {
             SharedState::Source(source) => source.clone(),
             SharedState::Cached(canonical) => canonical.clone().into_array(),
@@ -92,6 +106,6 @@ impl SharedArray {
 
     pub(super) fn set_source(&mut self, source: ArrayRef) {
         self.dtype = source.dtype().clone();
-        *self.lock_sync() = SharedState::Source(source);
+        *self.write_lock_sync() = SharedState::Source(source);
     }
 }


### PR DESCRIPTION
## Summary

SharedArray uses a Mutex as of #6453. This interacts particularly badly with `scalar_at` by way of `is_valid`. In particular, all calls to `scalar_at` on the given array are serialized. It seems reasonable to allow multiple threads to simultaneously read the validity. This PR permits that by using an RwLock.

## Testing

I have a Vortex-based system which recently pulled in a version of Vortex that includes #6453. With that version, my profile looks like this:

https://share.firefox.dev/4tO94Ki
<img width="1920" height="1080" alt="Screenshot 2026-02-20 at 4 26 28 PM" src="https://github.com/user-attachments/assets/77f24c44-268e-4dd8-8bc7-ec2c193443b6" />


With this PR applied (i.e. with an RwLock in place of the Mutex), it looks like this:

https://share.firefox.dev/4aNPZzt
<img width="1920" height="1080" alt="Screenshot 2026-02-20 at 4 27 25 PM" src="https://github.com/user-attachments/assets/dcf2fde3-e35a-413b-a6e6-2b4053e05653" />

CPU utilization is high, and runtime is ~7s. By comparison, with a Mutex, CPU utilization is low and runtime is ~18s.