### PR TITLE
use PublicBI fork with R2 hosted dataset

### DIFF
--- a/vortex-bench/scripts/fetch_public_bi_schemas_and_queries.sh
+++ b/vortex-bench/scripts/fetch_public_bi_schemas_and_queries.sh
@@ -18,7 +18,7 @@ if [ -d ".git" ]; then
     git pull origin master
 else
     git init
-    git remote add origin "https://github.com/cwida/public_bi_benchmark.git"
+    git remote add origin "https://github.com/vortex-data/public_bi_benchmark.git"
     git config core.sparseCheckout true
     # checkout tables and queries under the benchmark folder only
     cat > .git/info/sparse-checkout << EOF


### PR DESCRIPTION
While CWI has been generous enough to host the PublicBI benchmark dataset on a web server for a few years now, in recent weeks it's been incredibly unstable.

In the background, I've been running a little `wget -r -np -nH -R "index.html*" -c --retry-connrefused --waitretry=5 -t 0 --timeout=30 https://event.cwi.nl/da/PublicBIbenchmark/` job for a few days to save off a copy of the dataset that I've then pushed up to an R2 bucket in our Cloudflare account.

I have a fork of PublicBI repo at https://github.com/vortex-data/public_bi_benchmark with all of the data URLs updated to point to the R2 bucket, this PR just changes our Public BI benchmark infra to use the fork instead of the upstream repo, which should bring in the updated R2 data URLs