### PR TITLE
allocators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10480,6 +10480,7 @@ dependencies = [
  "vortex-error",
  "vortex-metrics",
  "vortex-session",
+ "vortex-utils",
  "wasm-bindgen-futures",
 ]
 

--- a/vortex-io/Cargo.toml
+++ b/vortex-io/Cargo.toml
@@ -41,6 +41,7 @@ vortex-buffer = { workspace = true }
 vortex-error = { workspace = true }
 vortex-metrics = { workspace = true }
 vortex-session = { workspace = true }
+vortex-utils = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 custom-labels = { workspace = true }

--- a/vortex-io/public-api.lock
+++ b/vortex-io/public-api.lock
@@ -144,29 +144,17 @@ pub fn vortex_io::object_store::ObjectStoreFileSystem::list(&self, prefix: &str)
 
 pub fn vortex_io::object_store::ObjectStoreFileSystem::open_read<'life0, 'life1, 'async_trait>(&'life0 self, path: &'life1 str) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<alloc::sync::Arc<dyn vortex_io::VortexReadAt>>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait, 'life1: 'async_trait
 
-pub struct vortex_io::object_store::ObjectStoreReadAt
+pub struct vortex_io::object_store::ObjectStoreReader
 
-impl vortex_io::object_store::ObjectStoreReadAt
+impl vortex_io::object_store::ObjectStoreReader
 
-pub fn vortex_io::object_store::ObjectStoreReadAt::new(store: alloc::sync::Arc<dyn object_store::ObjectStore>, path: object_store::path::Path, handle: vortex_io::runtime::Handle) -> Self
+pub fn vortex_io::object_store::ObjectStoreReader::new(store: alloc::sync::Arc<dyn object_store::ObjectStore>, path: object_store::path::Path, handle: vortex_io::runtime::Handle) -> Self
 
-pub fn vortex_io::object_store::ObjectStoreReadAt::with_coalesce_config(self, config: vortex_io::CoalesceConfig) -> Self
+impl vortex_io::ReadInto for vortex_io::object_store::ObjectStoreReader
 
-pub fn vortex_io::object_store::ObjectStoreReadAt::with_concurrency(self, concurrency: usize) -> Self
+pub fn vortex_io::object_store::ObjectStoreReader::read_into(&self, target: alloc::boxed::Box<dyn vortex_io::WriteTarget>, offset: u64) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<alloc::boxed::Box<dyn vortex_io::WriteTarget>>>
 
-pub fn vortex_io::object_store::ObjectStoreReadAt::with_some_coalesce_config(self, config: core::option::Option<vortex_io::CoalesceConfig>) -> Self
-
-impl vortex_io::VortexReadAt for vortex_io::object_store::ObjectStoreReadAt
-
-pub fn vortex_io::object_store::ObjectStoreReadAt::coalesce_config(&self) -> core::option::Option<vortex_io::CoalesceConfig>
-
-pub fn vortex_io::object_store::ObjectStoreReadAt::concurrency(&self) -> usize
-
-pub fn vortex_io::object_store::ObjectStoreReadAt::read_at(&self, offset: u64, length: usize, alignment: vortex_buffer::alignment::Alignment) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_array::buffer::BufferHandle>>
-
-pub fn vortex_io::object_store::ObjectStoreReadAt::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
-
-pub fn vortex_io::object_store::ObjectStoreReadAt::uri(&self) -> core::option::Option<&alloc::sync::Arc<str>>
+pub fn vortex_io::object_store::ObjectStoreReader::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
 
 pub struct vortex_io::object_store::ObjectStoreWrite
 
@@ -185,6 +173,8 @@ pub async fn vortex_io::object_store::ObjectStoreWrite::shutdown(&mut self) -> s
 pub async fn vortex_io::object_store::ObjectStoreWrite::write_all<B: vortex_io::IoBuf>(&mut self, buffer: B) -> std::io::error::Result<B>
 
 pub const vortex_io::object_store::DEFAULT_CONCURRENCY: usize
+
+pub type vortex_io::object_store::ObjectStoreReadAt = vortex_io::AllocatingReader<vortex_io::object_store::ObjectStoreReader>
 
 pub mod vortex_io::runtime
 
@@ -456,25 +446,59 @@ impl<S: vortex_session::SessionExt> vortex_io::session::RuntimeSessionExt for S
 
 pub mod vortex_io::std_file
 
-pub struct vortex_io::std_file::FileReadAt
+pub struct vortex_io::std_file::FileReader
 
-impl vortex_io::std_file::FileReadAt
+impl vortex_io::std_file::FileReader
 
-pub fn vortex_io::std_file::FileReadAt::open(path: impl core::convert::AsRef<std::path::Path>, handle: vortex_io::runtime::Handle) -> vortex_error::VortexResult<Self>
+pub fn vortex_io::std_file::FileReader::open(path: impl core::convert::AsRef<std::path::Path>, handle: vortex_io::runtime::Handle) -> vortex_error::VortexResult<Self>
 
-impl vortex_io::VortexReadAt for vortex_io::std_file::FileReadAt
+impl vortex_io::ReadInto for vortex_io::std_file::FileReader
 
-pub fn vortex_io::std_file::FileReadAt::coalesce_config(&self) -> core::option::Option<vortex_io::CoalesceConfig>
+pub fn vortex_io::std_file::FileReader::read_into(&self, target: alloc::boxed::Box<dyn vortex_io::WriteTarget>, offset: u64) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<alloc::boxed::Box<dyn vortex_io::WriteTarget>>>
 
-pub fn vortex_io::std_file::FileReadAt::concurrency(&self) -> usize
-
-pub fn vortex_io::std_file::FileReadAt::read_at(&self, offset: u64, length: usize, alignment: vortex_buffer::alignment::Alignment) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_array::buffer::BufferHandle>>
-
-pub fn vortex_io::std_file::FileReadAt::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
-
-pub fn vortex_io::std_file::FileReadAt::uri(&self) -> core::option::Option<&alloc::sync::Arc<str>>
+pub fn vortex_io::std_file::FileReader::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
 
 pub const vortex_io::std_file::DEFAULT_CONCURRENCY: usize
+
+pub type vortex_io::std_file::FileReadAt = vortex_io::AllocatingReader<vortex_io::std_file::FileReader>
+
+pub struct vortex_io::AllocatingReader<R: vortex_io::ReadInto>
+
+pub vortex_io::AllocatingReader::reader: R
+
+impl vortex_io::AllocatingReader<vortex_io::object_store::ObjectStoreReader>
+
+pub fn vortex_io::AllocatingReader<vortex_io::object_store::ObjectStoreReader>::new(store: alloc::sync::Arc<dyn object_store::ObjectStore>, path: object_store::path::Path, handle: vortex_io::runtime::Handle) -> Self
+
+impl vortex_io::AllocatingReader<vortex_io::std_file::FileReader>
+
+pub fn vortex_io::AllocatingReader<vortex_io::std_file::FileReader>::open(path: impl core::convert::AsRef<std::path::Path>, handle: vortex_io::runtime::Handle) -> vortex_error::VortexResult<Self>
+
+impl<R: vortex_io::ReadInto> vortex_io::AllocatingReader<R>
+
+pub fn vortex_io::AllocatingReader<R>::with_allocator(reader: R, allocator: alloc::sync::Arc<dyn vortex_io::BufferAllocator>, concurrency: usize) -> Self
+
+pub fn vortex_io::AllocatingReader<R>::with_coalesce_config(self, config: vortex_io::CoalesceConfig) -> Self
+
+pub fn vortex_io::AllocatingReader<R>::with_concurrency(self, concurrency: usize) -> Self
+
+pub fn vortex_io::AllocatingReader<R>::with_default_allocator(reader: R, concurrency: usize) -> Self
+
+pub fn vortex_io::AllocatingReader<R>::with_some_coalesce_config(self, config: core::option::Option<vortex_io::CoalesceConfig>) -> Self
+
+pub fn vortex_io::AllocatingReader<R>::with_uri(self, uri: alloc::sync::Arc<str>) -> Self
+
+impl<R: vortex_io::ReadInto> vortex_io::VortexReadAt for vortex_io::AllocatingReader<R>
+
+pub fn vortex_io::AllocatingReader<R>::coalesce_config(&self) -> core::option::Option<vortex_io::CoalesceConfig>
+
+pub fn vortex_io::AllocatingReader<R>::concurrency(&self) -> usize
+
+pub fn vortex_io::AllocatingReader<R>::read_at(&self, offset: u64, length: usize, alignment: vortex_buffer::alignment::Alignment) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_array::buffer::BufferHandle>>
+
+pub fn vortex_io::AllocatingReader<R>::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
+
+pub fn vortex_io::AllocatingReader<R>::uri(&self) -> core::option::Option<&alloc::sync::Arc<str>>
 
 pub struct vortex_io::AsyncWriteAdapter<W: futures_io::if_std::AsyncWrite>(pub W)
 
@@ -509,6 +533,48 @@ impl core::fmt::Debug for vortex_io::CoalesceConfig
 pub fn vortex_io::CoalesceConfig::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
 impl core::marker::Copy for vortex_io::CoalesceConfig
+
+pub struct vortex_io::DefaultAllocator
+
+impl vortex_io::BufferAllocator for vortex_io::DefaultAllocator
+
+pub fn vortex_io::DefaultAllocator::allocate(&self, len: usize, alignment: vortex_buffer::alignment::Alignment) -> vortex_error::VortexResult<alloc::boxed::Box<dyn vortex_io::WriteTarget>>
+
+pub struct vortex_io::HostByteBufferPool
+
+impl vortex_io::HostByteBufferPool
+
+pub fn vortex_io::HostByteBufferPool::get(self: &alloc::sync::Arc<Self>, len: usize) -> vortex_error::VortexResult<vortex_io::PooledHostBuffer>
+
+pub fn vortex_io::HostByteBufferPool::stats(&self) -> vortex_io::HostPoolStats
+
+pub fn vortex_io::HostByteBufferPool::with_max_buffers_per_bucket(max_buffers_per_bucket: usize) -> Self
+
+impl core::default::Default for vortex_io::HostByteBufferPool
+
+pub fn vortex_io::HostByteBufferPool::default() -> Self
+
+pub struct vortex_io::HostPoolStats
+
+pub vortex_io::HostPoolStats::hits: u64
+
+pub vortex_io::HostPoolStats::misses: u64
+
+pub vortex_io::HostPoolStats::returns: u64
+
+impl core::clone::Clone for vortex_io::HostPoolStats
+
+pub fn vortex_io::HostPoolStats::clone(&self) -> vortex_io::HostPoolStats
+
+impl core::default::Default for vortex_io::HostPoolStats
+
+pub fn vortex_io::HostPoolStats::default() -> vortex_io::HostPoolStats
+
+impl core::fmt::Debug for vortex_io::HostPoolStats
+
+pub fn vortex_io::HostPoolStats::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::marker::Copy for vortex_io::HostPoolStats
 
 pub struct vortex_io::InstrumentedReadAt<T: vortex_io::VortexReadAt + core::clone::Clone>
 
@@ -548,6 +614,26 @@ pub fn vortex_io::OwnedSlice<T>::bytes_init(&self) -> usize
 
 pub fn vortex_io::OwnedSlice<T>::read_ptr(&self) -> *const u8
 
+pub struct vortex_io::PooledHostAllocator
+
+impl vortex_io::PooledHostAllocator
+
+pub fn vortex_io::PooledHostAllocator::new(pool: alloc::sync::Arc<vortex_io::HostByteBufferPool>) -> Self
+
+impl vortex_io::BufferAllocator for vortex_io::PooledHostAllocator
+
+pub fn vortex_io::PooledHostAllocator::allocate(&self, len: usize, alignment: vortex_buffer::alignment::Alignment) -> vortex_error::VortexResult<alloc::boxed::Box<dyn vortex_io::WriteTarget>>
+
+pub struct vortex_io::PooledHostBuffer
+
+impl vortex_io::WriteTarget for vortex_io::PooledHostBuffer
+
+pub fn vortex_io::PooledHostBuffer::as_mut_slice(&mut self) -> &mut [u8]
+
+pub fn vortex_io::PooledHostBuffer::into_handle(self: alloc::boxed::Box<Self>) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_array::buffer::BufferHandle>>
+
+pub fn vortex_io::PooledHostBuffer::len(&self) -> usize
+
 pub struct vortex_io::SizeLimitedStream<Fut>
 
 impl<Fut> vortex_io::SizeLimitedStream<Fut> where Fut: core::future::future::Future
@@ -569,6 +655,18 @@ impl<Fut> futures_core::stream::Stream for vortex_io::SizeLimitedStream<Fut> whe
 pub type vortex_io::SizeLimitedStream<Fut>::Item = <Fut as core::future::future::Future>::Output
 
 pub fn vortex_io::SizeLimitedStream<Fut>::poll_next(self: core::pin::Pin<&mut Self>, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::option::Option<Self::Item>>
+
+pub trait vortex_io::BufferAllocator: core::marker::Send + core::marker::Sync + 'static
+
+pub fn vortex_io::BufferAllocator::allocate(&self, len: usize, alignment: vortex_buffer::alignment::Alignment) -> vortex_error::VortexResult<alloc::boxed::Box<dyn vortex_io::WriteTarget>>
+
+impl vortex_io::BufferAllocator for vortex_io::DefaultAllocator
+
+pub fn vortex_io::DefaultAllocator::allocate(&self, len: usize, alignment: vortex_buffer::alignment::Alignment) -> vortex_error::VortexResult<alloc::boxed::Box<dyn vortex_io::WriteTarget>>
+
+impl vortex_io::BufferAllocator for vortex_io::PooledHostAllocator
+
+pub fn vortex_io::PooledHostAllocator::allocate(&self, len: usize, alignment: vortex_buffer::alignment::Alignment) -> vortex_error::VortexResult<alloc::boxed::Box<dyn vortex_io::WriteTarget>>
 
 pub unsafe trait vortex_io::IoBuf: core::marker::Unpin + core::marker::Send + 'static
 
@@ -636,6 +734,24 @@ pub fn [u8; N]::bytes_init(&self) -> usize
 
 pub fn [u8; N]::read_ptr(&self) -> *const u8
 
+pub trait vortex_io::ReadInto: core::marker::Send + core::marker::Sync + 'static
+
+pub fn vortex_io::ReadInto::read_into(&self, target: alloc::boxed::Box<dyn vortex_io::WriteTarget>, offset: u64) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<alloc::boxed::Box<dyn vortex_io::WriteTarget>>>
+
+pub fn vortex_io::ReadInto::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
+
+impl vortex_io::ReadInto for vortex_io::object_store::ObjectStoreReader
+
+pub fn vortex_io::object_store::ObjectStoreReader::read_into(&self, target: alloc::boxed::Box<dyn vortex_io::WriteTarget>, offset: u64) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<alloc::boxed::Box<dyn vortex_io::WriteTarget>>>
+
+pub fn vortex_io::object_store::ObjectStoreReader::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
+
+impl vortex_io::ReadInto for vortex_io::std_file::FileReader
+
+pub fn vortex_io::std_file::FileReader::read_into(&self, target: alloc::boxed::Box<dyn vortex_io::WriteTarget>, offset: u64) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<alloc::boxed::Box<dyn vortex_io::WriteTarget>>>
+
+pub fn vortex_io::std_file::FileReader::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
+
 pub trait vortex_io::VortexReadAt: core::marker::Send + core::marker::Sync + 'static
 
 pub fn vortex_io::VortexReadAt::coalesce_config(&self) -> core::option::Option<vortex_io::CoalesceConfig>
@@ -668,29 +784,17 @@ pub fn vortex_buffer::ByteBuffer::read_at(&self, offset: u64, length: usize, ali
 
 pub fn vortex_buffer::ByteBuffer::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
 
-impl vortex_io::VortexReadAt for vortex_io::object_store::ObjectStoreReadAt
+impl<R: vortex_io::ReadInto> vortex_io::VortexReadAt for vortex_io::AllocatingReader<R>
 
-pub fn vortex_io::object_store::ObjectStoreReadAt::coalesce_config(&self) -> core::option::Option<vortex_io::CoalesceConfig>
+pub fn vortex_io::AllocatingReader<R>::coalesce_config(&self) -> core::option::Option<vortex_io::CoalesceConfig>
 
-pub fn vortex_io::object_store::ObjectStoreReadAt::concurrency(&self) -> usize
+pub fn vortex_io::AllocatingReader<R>::concurrency(&self) -> usize
 
-pub fn vortex_io::object_store::ObjectStoreReadAt::read_at(&self, offset: u64, length: usize, alignment: vortex_buffer::alignment::Alignment) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_array::buffer::BufferHandle>>
+pub fn vortex_io::AllocatingReader<R>::read_at(&self, offset: u64, length: usize, alignment: vortex_buffer::alignment::Alignment) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_array::buffer::BufferHandle>>
 
-pub fn vortex_io::object_store::ObjectStoreReadAt::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
+pub fn vortex_io::AllocatingReader<R>::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
 
-pub fn vortex_io::object_store::ObjectStoreReadAt::uri(&self) -> core::option::Option<&alloc::sync::Arc<str>>
-
-impl vortex_io::VortexReadAt for vortex_io::std_file::FileReadAt
-
-pub fn vortex_io::std_file::FileReadAt::coalesce_config(&self) -> core::option::Option<vortex_io::CoalesceConfig>
-
-pub fn vortex_io::std_file::FileReadAt::concurrency(&self) -> usize
-
-pub fn vortex_io::std_file::FileReadAt::read_at(&self, offset: u64, length: usize, alignment: vortex_buffer::alignment::Alignment) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_array::buffer::BufferHandle>>
-
-pub fn vortex_io::std_file::FileReadAt::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
-
-pub fn vortex_io::std_file::FileReadAt::uri(&self) -> core::option::Option<&alloc::sync::Arc<str>>
+pub fn vortex_io::AllocatingReader<R>::uri(&self) -> core::option::Option<&alloc::sync::Arc<str>>
 
 impl<R: vortex_io::VortexReadAt> vortex_io::VortexReadAt for alloc::sync::Arc<R>
 
@@ -815,3 +919,29 @@ pub fn vortex_io::compat::Compat<W>::flush(&mut self) -> impl core::future::futu
 pub fn vortex_io::compat::Compat<W>::shutdown(&mut self) -> impl core::future::future::Future<Output = std::io::error::Result<()>>
 
 pub fn vortex_io::compat::Compat<W>::write_all<B: vortex_io::IoBuf>(&mut self, buffer: B) -> impl core::future::future::Future<Output = std::io::error::Result<B>>
+
+pub trait vortex_io::WriteTarget: core::marker::Send + 'static
+
+pub fn vortex_io::WriteTarget::as_mut_slice(&mut self) -> &mut [u8]
+
+pub fn vortex_io::WriteTarget::into_handle(self: alloc::boxed::Box<Self>) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_array::buffer::BufferHandle>>
+
+pub fn vortex_io::WriteTarget::is_empty(&self) -> bool
+
+pub fn vortex_io::WriteTarget::len(&self) -> usize
+
+impl vortex_io::WriteTarget for vortex_buffer::ByteBufferMut
+
+pub fn vortex_buffer::ByteBufferMut::as_mut_slice(&mut self) -> &mut [u8]
+
+pub fn vortex_buffer::ByteBufferMut::into_handle(self: alloc::boxed::Box<Self>) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_array::buffer::BufferHandle>>
+
+pub fn vortex_buffer::ByteBufferMut::len(&self) -> usize
+
+impl vortex_io::WriteTarget for vortex_io::PooledHostBuffer
+
+pub fn vortex_io::PooledHostBuffer::as_mut_slice(&mut self) -> &mut [u8]
+
+pub fn vortex_io::PooledHostBuffer::into_handle(self: alloc::boxed::Box<Self>) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_array::buffer::BufferHandle>>
+
+pub fn vortex_io::PooledHostBuffer::len(&self) -> usize

--- a/vortex-io/src/allocator.rs
+++ b/vortex-io/src/allocator.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use bytes::Bytes;
+use futures::FutureExt;
+use futures::future::BoxFuture;
+use parking_lot::Mutex;
+use vortex_array::buffer::BufferHandle;
+use vortex_buffer::Alignment;
+use vortex_buffer::ByteBufferMut;
+use vortex_error::VortexResult;
+use vortex_error::vortex_panic;
+use vortex_utils::aliases::hash_map::HashMap;
+
+use crate::WriteTarget;
+
+/// Page size used as the minimum allocation size and fixed alignment for pooled buffers.
+const PAGE_SIZE: usize = 4096;
+const PAGE_ALIGNMENT: Alignment = Alignment::new(PAGE_SIZE);
+
+pub trait BufferAllocator: Send + Sync + 'static {
+    /// Allocate a buffer for the requested length and alignment.
+    fn allocate(&self, len: usize, alignment: Alignment) -> VortexResult<Box<dyn WriteTarget>>;
+}
+
+/// A simple allocator that uses `ByteBufferMut`.
+pub struct DefaultAllocator;
+
+impl BufferAllocator for DefaultAllocator {
+    fn allocate(&self, len: usize, alignment: Alignment) -> VortexResult<Box<dyn WriteTarget>> {
+        let mut buffer = ByteBufferMut::with_capacity_aligned(len, alignment);
+        unsafe { buffer.set_len(len) };
+        Ok(Box::new(buffer))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HostPoolStats {
+    /// Number of allocation requests satisfied from the pool.
+    pub hits: u64,
+    /// Number of allocation requests that required a new allocation.
+    pub misses: u64,
+    /// Number of buffers returned to the pool.
+    pub returns: u64,
+}
+
+/// A host buffer pool with power of two size classes and page alignment.
+///
+/// All buffers are page-aligned (4096 bytes). Requested lengths are rounded up to the next
+/// power of two (minimum one page).
+pub struct HostByteBufferPool {
+    max_buffers_per_bucket: usize,
+    buckets: Mutex<HashMap<usize, Vec<ByteBufferMut>>>,
+    hits: AtomicU64,
+    misses: AtomicU64,
+    returns: AtomicU64,
+}
+
+impl HostByteBufferPool {
+    /// Create a new pool with a maximum number of cached buffers per size class.
+    pub fn with_max_buffers_per_bucket(max_buffers_per_bucket: usize) -> Self {
+        Self {
+            max_buffers_per_bucket: max_buffers_per_bucket.max(1),
+            buckets: Mutex::new(HashMap::new()),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            returns: AtomicU64::new(0),
+        }
+    }
+
+    pub fn stats(&self) -> HostPoolStats {
+        HostPoolStats {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            returns: self.returns.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Get a pooled buffer that returns to the pool on drop.
+    pub fn get(self: &Arc<Self>, len: usize) -> VortexResult<PooledHostBuffer> {
+        let size_class = len.next_power_of_two().max(PAGE_SIZE);
+        let inner = self.get_inner(size_class, len)?;
+        Ok(PooledHostBuffer {
+            inner,
+            size_class,
+            pool: self.clone(),
+        })
+    }
+
+    fn get_inner(&self, size_class: usize, len: usize) -> VortexResult<ByteBufferMut> {
+        let mut buckets = self.buckets.lock();
+        if let Some(bucket) = buckets.get_mut(&size_class)
+            && let Some(mut buf) = bucket.pop()
+        {
+            // Has to hold, capacity is size_class, which is larger than len>
+            assert!(buf.capacity() >= len);
+            unsafe { buf.set_len(len) };
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            return Ok(buf);
+        }
+        self.misses.fetch_add(1, Ordering::Relaxed);
+        let mut buf = ByteBufferMut::with_capacity_aligned(size_class, PAGE_ALIGNMENT);
+        assert!(buf.capacity() >= len);
+        unsafe { buf.set_len(len) };
+        Ok(buf)
+    }
+
+    fn put(&self, size_class: usize, buf: ByteBufferMut) {
+        let mut buckets = self.buckets.lock();
+        let bucket = buckets.entry(size_class).or_default();
+        if bucket.len() < self.max_buffers_per_bucket {
+            bucket.push(buf);
+        }
+        self.returns.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl Default for HostByteBufferPool {
+    fn default() -> Self {
+        Self::with_max_buffers_per_bucket(4)
+    }
+}
+
+/// A pooled host buffer that returns to its pool on drop.
+pub struct PooledHostBuffer {
+    inner: ByteBufferMut,
+    size_class: usize,
+    pool: Arc<HostByteBufferPool>,
+}
+
+impl WriteTarget for PooledHostBuffer {
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.inner.as_mut_slice()
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn into_handle(self: Box<Self>) -> BoxFuture<'static, VortexResult<BufferHandle>> {
+        async move {
+            let this = *self;
+            let owner = PooledHostBufferHandle {
+                inner: Some(this.inner),
+                size_class: this.size_class,
+                pool: this.pool,
+            };
+            let bytes = Bytes::from_owner(owner);
+            Ok(BufferHandle::new_host(bytes.into()))
+        }
+        .boxed()
+    }
+}
+
+// Read only view of a pooled host buffer, returns the underlying
+// buffer into the pool on drop.
+struct PooledHostBufferHandle {
+    inner: Option<ByteBufferMut>,
+    size_class: usize,
+    pool: Arc<HostByteBufferPool>,
+}
+
+impl AsRef<[u8]> for PooledHostBufferHandle {
+    fn as_ref(&self) -> &[u8] {
+        self.inner
+            .as_ref()
+            .unwrap_or_else(|| vortex_panic!("pooled buffer already consumed"))
+            .as_slice()
+    }
+}
+
+impl Drop for PooledHostBufferHandle {
+    fn drop(&mut self) {
+        if let Some(mut buffer) = self.inner.take() {
+            // Restore to size-class capacity so the pool bucket key matches.
+            unsafe { buffer.set_len(self.size_class) };
+            self.pool.put(self.size_class, buffer);
+        }
+    }
+}
+
+/// Allocator backed by a [`HostByteBufferPool`].
+pub struct PooledHostAllocator {
+    pool: Arc<HostByteBufferPool>,
+}
+
+impl PooledHostAllocator {
+    pub fn new(pool: Arc<HostByteBufferPool>) -> Self {
+        Self { pool }
+    }
+}
+
+impl BufferAllocator for PooledHostAllocator {
+    fn allocate(&self, len: usize, alignment: Alignment) -> VortexResult<Box<dyn WriteTarget>> {
+        assert!(
+            PAGE_ALIGNMENT.is_aligned_to(alignment),
+            "PooledHostAllocator uses page alignment ({PAGE_SIZE}), \
+             which does not satisfy requested alignment {alignment}"
+        );
+        let buffer = self.pool.get(len)?;
+        Ok(Box::new(buffer))
+    }
+}

--- a/vortex-io/src/lib.rs
+++ b/vortex-io/src/lib.rs
@@ -10,11 +10,14 @@
 //! This crate provides core traits for positioned and streaming IO, and via feature
 //! flags implements the core traits for several common async runtimes and backing stores.
 
+pub use allocator::*;
 pub use io_buf::*;
 pub use limit::*;
 pub use read_at::*;
 pub use write::*;
+pub use write_target::*;
 
+mod allocator;
 pub mod compat;
 pub mod filesystem;
 mod io_buf;
@@ -30,3 +33,4 @@ pub mod std_file;
 #[cfg(feature = "tokio")]
 mod tokio;
 mod write;
+mod write_target;

--- a/vortex-io/src/object_store/read_at.rs
+++ b/vortex-io/src/object_store/read_at.rs
@@ -12,15 +12,14 @@ use object_store::GetRange;
 use object_store::GetResultPayload;
 use object_store::ObjectStore;
 use object_store::path::Path as ObjectPath;
-use vortex_array::buffer::BufferHandle;
-use vortex_buffer::Alignment;
-use vortex_buffer::ByteBufferMut;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 
 use crate::CoalesceConfig;
-use crate::VortexReadAt;
+use crate::ReadInto;
+use crate::WriteTarget;
+use crate::read_at::AllocatingReader;
 use crate::runtime::Handle;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::std_file::read_exact_at;
@@ -28,62 +27,25 @@ use crate::std_file::read_exact_at;
 /// Default number of concurrent requests to allow.
 pub const DEFAULT_CONCURRENCY: usize = 192;
 
-/// An object store backed I/O source.
-pub struct ObjectStoreReadAt {
+/// Low-level object store reader that implements [`ReadInto`].
+pub struct ObjectStoreReader {
     store: Arc<dyn ObjectStore>,
     path: ObjectPath,
-    uri: Arc<str>,
     handle: Handle,
-    concurrency: usize,
-    coalesce_config: Option<CoalesceConfig>,
 }
 
-impl ObjectStoreReadAt {
-    /// Create a new object store source.
+impl ObjectStoreReader {
+    /// Create a new object store reader.
     pub fn new(store: Arc<dyn ObjectStore>, path: ObjectPath, handle: Handle) -> Self {
-        let uri = Arc::from(path.to_string());
         Self {
             store,
             path,
-            uri,
             handle,
-            concurrency: DEFAULT_CONCURRENCY,
-            coalesce_config: Some(CoalesceConfig::object_storage()),
         }
-    }
-
-    /// Set the concurrency for this source.
-    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
-        self.concurrency = concurrency;
-        self
-    }
-
-    /// Set the coalesce config for this source.
-    pub fn with_coalesce_config(mut self, config: CoalesceConfig) -> Self {
-        self.coalesce_config = Some(config);
-        self
-    }
-
-    /// Set an optional coalesce config for this source.
-    pub fn with_some_coalesce_config(mut self, config: Option<CoalesceConfig>) -> Self {
-        self.coalesce_config = config;
-        self
     }
 }
 
-impl VortexReadAt for ObjectStoreReadAt {
-    fn uri(&self) -> Option<&Arc<str>> {
-        Some(&self.uri)
-    }
-
-    fn coalesce_config(&self) -> Option<CoalesceConfig> {
-        self.coalesce_config
-    }
-
-    fn concurrency(&self) -> usize {
-        self.concurrency
-    }
-
+impl ReadInto for ObjectStoreReader {
     fn size(&self) -> BoxFuture<'static, VortexResult<u64>> {
         let store = self.store.clone();
         let path = self.path.clone();
@@ -97,20 +59,18 @@ impl VortexReadAt for ObjectStoreReadAt {
         .boxed()
     }
 
-    fn read_at(
+    fn read_into(
         &self,
+        mut target: Box<dyn WriteTarget>,
         offset: u64,
-        length: usize,
-        alignment: Alignment,
-    ) -> BoxFuture<'static, VortexResult<BufferHandle>> {
+    ) -> BoxFuture<'static, VortexResult<Box<dyn WriteTarget>>> {
         let store = self.store.clone();
         let path = self.path.clone();
         let handle = self.handle.clone();
+        let length = target.len();
         let range = offset..(offset + length as u64);
 
         async move {
-            let mut buffer = ByteBufferMut::with_capacity_aligned(length, alignment);
-
             let response = store
                 .get_opts(
                     &path,
@@ -121,42 +81,67 @@ impl VortexReadAt for ObjectStoreReadAt {
                 )
                 .await?;
 
-            let buffer = match response.payload {
+            match response.payload {
                 #[cfg(not(target_arch = "wasm32"))]
                 GetResultPayload::File(file, _) => {
-                    unsafe { buffer.set_len(length) };
-
-                    handle
+                    target = handle
                         .spawn_blocking(move || {
-                            read_exact_at(&file, &mut buffer, range.start)?;
-                            Ok::<_, io::Error>(buffer)
+                            let mut target = target;
+                            read_exact_at(&file, target.as_mut_slice(), range.start)?;
+                            Ok::<_, io::Error>(target)
                         })
                         .await
-                        .map_err(io::Error::other)?
+                        .map_err(io::Error::other)?;
                 }
                 #[cfg(target_arch = "wasm32")]
                 GetResultPayload::File(..) => {
                     unreachable!("File payload not supported on wasm32")
                 }
                 GetResultPayload::Stream(mut byte_stream) => {
+                    let mut filled = 0usize;
                     while let Some(bytes) = byte_stream.next().await {
-                        buffer.extend_from_slice(&bytes?);
+                        let bytes = bytes?;
+                        let end = filled + bytes.len();
+                        vortex_ensure!(
+                            end <= length,
+                            "Object store stream returned more bytes than expected (expected {} bytes, got at least {} bytes, range: {:?})",
+                            length,
+                            end,
+                            range
+                        );
+                        target.as_mut_slice()[filled..end].copy_from_slice(&bytes);
+                        filled = end;
                     }
 
                     vortex_ensure!(
-                        buffer.len() == length,
+                        filled == length,
                         "Object store stream returned {} bytes but expected {} bytes (range: {:?})",
-                        buffer.len(),
+                        filled,
                         length,
                         range
                     );
-
-                    buffer
                 }
-            };
+            }
 
-            Ok(BufferHandle::new_host(buffer.freeze()))
+            Ok(target)
         }
         .boxed()
+    }
+}
+
+/// An object store backed I/O source.
+///
+/// This is a convenience alias for [`AllocatingReader<ObjectStoreReader>`] using the default
+/// allocator.
+pub type ObjectStoreReadAt = AllocatingReader<ObjectStoreReader>;
+
+impl ObjectStoreReadAt {
+    /// Create a new object store source with the default allocator.
+    pub fn new(store: Arc<dyn ObjectStore>, path: ObjectPath, handle: Handle) -> Self {
+        let uri: Arc<str> = Arc::from(path.to_string());
+        let reader = ObjectStoreReader::new(store, path, handle);
+        AllocatingReader::with_default_allocator(reader, DEFAULT_CONCURRENCY)
+            .with_uri(uri)
+            .with_coalesce_config(CoalesceConfig::object_storage())
     }
 }

--- a/vortex-io/src/read_at.rs
+++ b/vortex-io/src/read_at.rs
@@ -18,6 +18,10 @@ use vortex_metrics::MetricBuilder;
 use vortex_metrics::MetricsRegistry;
 use vortex_metrics::Timer;
 
+use crate::BufferAllocator;
+use crate::DefaultAllocator;
+use crate::WriteTarget;
+
 /// Configuration for coalescing nearby I/O requests into single operations.
 #[derive(Clone, Copy, Debug)]
 pub struct CoalesceConfig {
@@ -172,6 +176,130 @@ impl VortexReadAt for ByteBuffer {
             Ok(BufferHandle::new_host(
                 buffer.slice_unaligned(start..end).aligned(alignment),
             ))
+        }
+        .boxed()
+    }
+}
+
+/// Low-level trait for reading bytes at an offset into a provided [`WriteTarget`].
+///
+/// This trait decouples "where to read from" (file, object store, etc.) from
+/// "how to allocate the destination buffer" ([`BufferAllocator`]).
+///
+/// Compose a `ReadInto` with a [`BufferAllocator`] via [`AllocatingReader`] to
+/// produce a [`VortexReadAt`]. Source metadata (URI, concurrency, coalesce config)
+/// is configured on [`AllocatingReader`] directly, keeping this trait minimal.
+///
+/// [`WriteTarget`]: crate::WriteTarget
+pub trait ReadInto: Send + Sync + 'static {
+    /// Asynchronously get the number of bytes of the underlying source.
+    fn size(&self) -> BoxFuture<'static, VortexResult<u64>>;
+
+    /// Read from `offset` into the provided [`WriteTarget`](crate::WriteTarget).
+    ///
+    /// The target is consumed and returned on success so it can be moved across
+    /// thread boundaries (e.g. into `spawn_blocking`).
+    fn read_into(
+        &self,
+        target: Box<dyn WriteTarget>,
+        offset: u64,
+    ) -> BoxFuture<'static, VortexResult<Box<dyn WriteTarget>>>;
+}
+
+/// Composes a [`ReadInto`] with a [`BufferAllocator`] to produce a [`VortexReadAt`].
+///
+/// On each `read_at` call, the allocator provides a buffer, the reader fills it,
+/// and the buffer is finalized into a [`BufferHandle`].
+///
+/// Source metadata (URI, concurrency, coalesce config) is stored here rather than
+/// on the [`ReadInto`] trait, so that `ReadInto` stays focused on I/O.
+pub struct AllocatingReader<R: ReadInto> {
+    /// The underlying reader.
+    pub reader: R,
+    allocator: Arc<dyn BufferAllocator>,
+    pub(crate) uri: Option<Arc<str>>,
+    pub(crate) coalesce_config: Option<CoalesceConfig>,
+    pub(crate) concurrency: usize,
+}
+
+impl<R: ReadInto> AllocatingReader<R> {
+    /// Create a new allocating reader with the given reader and allocator.
+    pub fn with_allocator(
+        reader: R,
+        allocator: Arc<dyn BufferAllocator>,
+        concurrency: usize,
+    ) -> Self {
+        Self {
+            reader,
+            allocator,
+            uri: None,
+            coalesce_config: None,
+            concurrency,
+        }
+    }
+
+    /// Create a new allocating reader using the [`DefaultAllocator`].
+    pub fn with_default_allocator(reader: R, concurrency: usize) -> Self {
+        Self::with_allocator(reader, Arc::new(DefaultAllocator), concurrency)
+    }
+
+    /// Set the URI for this reader.
+    pub fn with_uri(mut self, uri: Arc<str>) -> Self {
+        self.uri = Some(uri);
+        self
+    }
+
+    /// Set the coalesce config for this reader.
+    pub fn with_coalesce_config(mut self, config: CoalesceConfig) -> Self {
+        self.coalesce_config = Some(config);
+        self
+    }
+
+    /// Set an optional coalesce config for this reader.
+    pub fn with_some_coalesce_config(mut self, config: Option<CoalesceConfig>) -> Self {
+        self.coalesce_config = config;
+        self
+    }
+
+    /// Set the concurrency for this reader.
+    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = concurrency;
+        self
+    }
+}
+
+impl<R: ReadInto> VortexReadAt for AllocatingReader<R> {
+    fn uri(&self) -> Option<&Arc<str>> {
+        self.uri.as_ref()
+    }
+
+    fn coalesce_config(&self) -> Option<CoalesceConfig> {
+        self.coalesce_config
+    }
+
+    fn concurrency(&self) -> usize {
+        self.concurrency
+    }
+
+    fn size(&self) -> BoxFuture<'static, VortexResult<u64>> {
+        self.reader.size()
+    }
+
+    fn read_at(
+        &self,
+        offset: u64,
+        length: usize,
+        alignment: Alignment,
+    ) -> BoxFuture<'static, VortexResult<BufferHandle>> {
+        let target = match self.allocator.allocate(length, alignment) {
+            Ok(target) => target,
+            Err(e) => return async move { Err(e) }.boxed(),
+        };
+
+        let fut = self.reader.read_into(target, offset);
+        async move {
+            let target = fut.await?;
+            target.into_handle().await
         }
         .boxed()
     }

--- a/vortex-io/src/std_file/read_at.rs
+++ b/vortex-io/src/std_file/read_at.rs
@@ -16,13 +16,12 @@ use std::sync::Arc;
 
 use futures::FutureExt;
 use futures::future::BoxFuture;
-use vortex_array::buffer::BufferHandle;
-use vortex_buffer::Alignment;
-use vortex_buffer::ByteBufferMut;
 use vortex_error::VortexResult;
 
 use crate::CoalesceConfig;
-use crate::VortexReadAt;
+use crate::ReadInto;
+use crate::WriteTarget;
+use crate::read_at::AllocatingReader;
 use crate::runtime::Handle;
 
 /// Read exactly `buffer.len()` bytes from `file` starting at `offset`.
@@ -64,36 +63,21 @@ const COALESCING_CONFIG: CoalesceConfig = CoalesceConfig {
 /// Default number of concurrent requests to allow for local file I/O.
 pub const DEFAULT_CONCURRENCY: usize = 32;
 
-/// An adapter type wrapping a [`File`] to implement [`VortexReadAt`].
-pub struct FileReadAt {
-    uri: Arc<str>,
+/// Low-level file reader that implements [`ReadInto`].
+pub struct FileReader {
     file: Arc<File>,
     handle: Handle,
 }
 
-impl FileReadAt {
+impl FileReader {
     /// Open a file for reading.
     pub fn open(path: impl AsRef<Path>, handle: Handle) -> VortexResult<Self> {
-        let path = path.as_ref();
-        let uri = path.to_string_lossy().to_string().into();
-        let file = Arc::new(File::open(path)?);
-        Ok(Self { uri, file, handle })
+        let file = Arc::new(File::open(path.as_ref())?);
+        Ok(Self { file, handle })
     }
 }
 
-impl VortexReadAt for FileReadAt {
-    fn uri(&self) -> Option<&Arc<str>> {
-        Some(&self.uri)
-    }
-
-    fn coalesce_config(&self) -> Option<CoalesceConfig> {
-        Some(COALESCING_CONFIG)
-    }
-
-    fn concurrency(&self) -> usize {
-        DEFAULT_CONCURRENCY
-    }
-
+impl ReadInto for FileReader {
     fn size(&self) -> BoxFuture<'static, VortexResult<u64>> {
         let file = self.file.clone();
         async move {
@@ -103,24 +87,40 @@ impl VortexReadAt for FileReadAt {
         .boxed()
     }
 
-    fn read_at(
+    fn read_into(
         &self,
+        mut target: Box<dyn WriteTarget>,
         offset: u64,
-        length: usize,
-        alignment: Alignment,
-    ) -> BoxFuture<'static, VortexResult<BufferHandle>> {
+    ) -> BoxFuture<'static, VortexResult<Box<dyn WriteTarget>>> {
         let file = self.file.clone();
         let handle = self.handle.clone();
         async move {
             handle
                 .spawn_blocking(move || {
-                    let mut buffer = ByteBufferMut::with_capacity_aligned(length, alignment);
-                    unsafe { buffer.set_len(length) };
-                    read_exact_at(&file, &mut buffer, offset)?;
-                    Ok(BufferHandle::new_host(buffer.freeze()))
+                    read_exact_at(&file, target.as_mut_slice(), offset)?;
+                    Ok(target)
                 })
                 .await
         }
         .boxed()
+    }
+}
+
+/// An adapter type wrapping a [`File`] to implement [`VortexReadAt`](crate::VortexReadAt).
+///
+/// This is a convenience alias for [`AllocatingReader<FileReader>`] using the default allocator.
+pub type FileReadAt = AllocatingReader<FileReader>;
+
+impl FileReadAt {
+    /// Open a file for reading with the default allocator.
+    pub fn open(path: impl AsRef<Path>, handle: Handle) -> VortexResult<Self> {
+        let path = path.as_ref();
+        let uri: Arc<str> = path.to_string_lossy().to_string().into();
+        let reader = FileReader::open(path, handle)?;
+        Ok(
+            AllocatingReader::with_default_allocator(reader, DEFAULT_CONCURRENCY)
+                .with_uri(uri)
+                .with_coalesce_config(COALESCING_CONFIG),
+        )
     }
 }

--- a/vortex-io/src/write_target.rs
+++ b/vortex-io/src/write_target.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use futures::FutureExt;
+use futures::future::BoxFuture;
+use vortex_array::buffer::BufferHandle;
+use vortex_buffer::ByteBufferMut;
+use vortex_error::VortexResult;
+
+/// A destination for I/O reads that can be finalized into a [`BufferHandle`].
+pub trait WriteTarget: Send + 'static {
+    /// Returns the buffer as a mutable slice.
+    fn as_mut_slice(&mut self) -> &mut [u8];
+
+    /// Returns the length of the buffer in bytes.
+    fn len(&self) -> usize;
+
+    /// Returns true if the buffer is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Finalize the target into a buffer handle.
+    fn into_handle(self: Box<Self>) -> BoxFuture<'static, VortexResult<BufferHandle>>;
+}
+
+impl WriteTarget for ByteBufferMut {
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.as_mut_slice()
+    }
+
+    fn len(&self) -> usize {
+        ByteBufferMut::len(self)
+    }
+
+    fn into_handle(self: Box<Self>) -> BoxFuture<'static, VortexResult<BufferHandle>> {
+        async move { Ok(BufferHandle::new_host(self.freeze())) }.boxed()
+    }
+}


### PR DESCRIPTION
## Summary

Add buffer allocator trait and a simple cpu buffer pool. `VortexReadAt` now can own a buffer pool through a lower level trait `ReadInto`, and AllocatingReader will bridge them. 

This PR adds the types, but doesn't wire the buffer pool in yet. The existing ReadAt implementors currently use the default allocator, which allocates a fresh new BufferMut per call