### PR TITLE
Slice(ChunkedArray) canonicalizes all chunks instead of only relevant ones

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -3152,6 +3152,8 @@ pub type vortex_array::arrays::SliceVTable::ValidityVTable = vortex_array::array
 
 pub type vortex_array::arrays::SliceVTable::VisitorVTable = vortex_array::arrays::SliceVTable
 
+pub fn vortex_array::arrays::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
 
 pub fn vortex_array::arrays::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
@@ -16487,6 +16489,8 @@ pub type vortex_array::arrays::SliceVTable::OperationsVTable = vortex_array::arr
 pub type vortex_array::arrays::SliceVTable::ValidityVTable = vortex_array::arrays::SliceVTable
 
 pub type vortex_array::arrays::SliceVTable::VisitorVTable = vortex_array::arrays::SliceVTable
+
+pub fn vortex_array::arrays::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
 

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -25,6 +25,7 @@ use crate::Precision;
 use crate::arrays::slice::array::SliceArray;
 use crate::arrays::slice::rules::PARENT_RULES;
 use crate::buffer::BufferHandle;
+use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
 use crate::executor::ExecutionCtx;
 use crate::scalar::Scalar;
@@ -105,6 +106,18 @@ impl VTable for SliceVTable {
             .into_iter()
             .next()
             .vortex_expect("children length already validated");
+        Ok(())
+    }
+
+    fn append_to_builder(
+        array: &Self::Array,
+        builder: &mut dyn ArrayBuilder,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<()> {
+        // Execute through the full loop so that execute_parent optimizations (e.g.
+        // SliceExecuteAdaptor for ChunkedArray) can fire before we canonicalize.
+        let canonical = array.to_array().execute::<Canonical>(ctx)?;
+        builder.extend_from_array(canonical.as_ref());
         Ok(())
     }
 

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -114,8 +114,8 @@ impl VTable for SliceVTable {
         builder: &mut dyn ArrayBuilder,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
-        // Execute through the full loop so that execute_parent optimizations (e.g.
-        // SliceExecuteAdaptor for ChunkedArray) can fire before we canonicalize.
+        // Execute through the full loop so that execute_parent optimizations
+        // can fire before we canonicalize.
         let canonical = array.to_array().execute::<Canonical>(ctx)?;
         builder.extend_from_array(canonical.as_ref());
         Ok(())


### PR DESCRIPTION
SliceVTable was using the default append_to_builder, which calls SliceVTable::execute directly. This bypasses the execution loop, so execute_parent optimizations like SliceExecuteAdaptor(ChunkedVTable) never fire.

For Slice(ChunkedArray), this means the entire chunked array gets canonicalized before slicing — instead of using find_chunk_idx to select only the relevant chunks first.