### PR TITLE
Pull RFCs into docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/_collections/
 
 # PyBuilder
 .pybuilder/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,11 +39,12 @@ extensions = [
     "sphinxcontrib.bibtex",
     "sphinxcontrib.mermaid",
     "sphinxext.opengraph",
+    "sphinx_collections",
 ]
 
 templates_path = ["_templates"]
 html_show_sourcelink = False
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md"]
+exclude_patterns = ["_build", "_collections/rfcs/README.md", "Thumbs.db", ".DS_Store", "README.md"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
@@ -52,6 +53,8 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable", None),
     "polars": ("https://docs.pola.rs/api/python/stable", "polars.objects.inv"),
 }
+
+collections = {"rfcs": {"driver": "git", "source": "https://github.com/vortex-data/rfcs.git"}}
 
 git_root = Path(__file__).parent.parent
 

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -38,3 +38,15 @@ integrations/datafusion
 integrations/duckdb
 integrations/spark
 ```
+
+if-collection:: rfcs
+```{toctree}
+---
+maxdepth: 2
+caption: RFCs
+glob:
+---
+
+../_collections/rfcs/proposals/*
+
+```

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "libclang>=18.1.1",
     # forced transitive bumps
     "starlette>=0.49.1",
+    "sphinx-collections>=0.3.1",
 ]
 requires-python = ">= 3.11"
 

--- a/uv.lock
+++ b/uv.lock
@@ -243,6 +243,7 @@ dependencies = [
     { name = "setuptools" },
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
+    { name = "sphinx-collections" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
     { name = "sphinx-inline-tabs" },
@@ -263,6 +264,7 @@ requires-dist = [
     { name = "setuptools", specifier = ">=75.8.0" },
     { name = "sphinx", specifier = ">=8.0.2" },
     { name = "sphinx-autobuild", specifier = ">=2024.10.3" },
+    { name = "sphinx-collections", specifier = ">=0.3.1" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.0" },
     { name = "sphinx-inline-tabs", specifier = ">=2023.4.21" },
@@ -333,6 +335,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.46"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
 ]
 
 [[package]]
@@ -1494,6 +1520,15 @@ wheels = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1563,6 +1598,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/3c/a59a3a453d4133777f7ed2e83c80b7dc817d43c74b74298ca0af869662ad/sphinx_autobuild-2025.8.25.tar.gz", hash = "sha256:9cf5aab32853c8c31af572e4fecdc09c997e2b8be5a07daf2a389e270e85b213", size = 15200, upload-time = "2025-08-25T18:44:55.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/20/56411b52f917696995f5ad27d2ea7e9492c84a043c5b49a3a3173573cd93/sphinx_autobuild-2025.8.25-py3-none-any.whl", hash = "sha256:b750ac7d5a18603e4665294323fd20f6dcc0a984117026d1986704fa68f0379a", size = 12535, upload-time = "2025-08-25T18:44:54.164Z" },
+]
+
+[[package]]
+name = "sphinx-collections"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitpython" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/18/2f258a70fb9059014d7dc589b4aab09ffd9a47ba6e4235b77b888d0220f8/sphinx_collections-0.3.1.tar.gz", hash = "sha256:4dda762479d2ad2163ccb074b15f36f72810d9cd08be4daa69854a6e34c99f92", size = 13031, upload-time = "2025-10-30T16:04:14.802Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/85/8f0de226be865c7bda58c46db8d27cee0be7f9125bbc21568e5d40699286/sphinx_collections-0.3.1-py3-none-any.whl", hash = "sha256:fb93b979cc9275bd2ad980a71fd57be5521c0f879f90f8189917a8f7ca0436ab", size = 16273, upload-time = "2025-10-30T16:04:13.28Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR pulls the new vortex-data/rfcs repo into the docs, under the `Developer Guide`.
Sidebar:
<img width="183" height="103" alt="Screenshot 2026-02-23 at 18 18 49" src="https://github.com/user-attachments/assets/31416ede-6980-420a-a2b1-9678f3156341" />

Doc (empty template):
<img width="971" height="273" alt="Screenshot 2026-02-23 at 18 19 22" src="https://github.com/user-attachments/assets/6bad134e-90b2-419a-853b-6c40f37f6c42" />

We need to force some structure on the RFCs, that's my next thing to add to that repo.
