### PR TITLE
oncelock shared array for zero cost access after materialisation

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -2924,9 +2924,9 @@ pub struct vortex_array::arrays::SharedArray
 
 impl vortex_array::arrays::SharedArray
 
-pub fn vortex_array::arrays::SharedArray::get_or_compute(&self, f: impl core::ops::function::FnOnce(&vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::Canonical>) -> vortex_error::VortexResult<vortex_array::Canonical>
+pub fn vortex_array::arrays::SharedArray::get_or_compute(&self, f: impl core::ops::function::FnOnce(&vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::Canonical>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub async fn vortex_array::arrays::SharedArray::get_or_compute_async<F, Fut>(&self, f: F) -> vortex_error::VortexResult<vortex_array::Canonical> where F: core::ops::function::FnOnce(vortex_array::ArrayRef) -> Fut, Fut: core::future::future::Future<Output = vortex_error::VortexResult<vortex_array::Canonical>>
+pub async fn vortex_array::arrays::SharedArray::get_or_compute_async<F, Fut>(&self, f: F) -> vortex_error::VortexResult<vortex_array::ArrayRef> where F: core::ops::function::FnOnce(vortex_array::ArrayRef) -> Fut, Fut: core::future::future::Future<Output = vortex_error::VortexResult<vortex_array::Canonical>>
 
 pub fn vortex_array::arrays::SharedArray::new(source: vortex_array::ArrayRef) -> Self
 

--- a/vortex-array/src/arrays/shared/array.rs
+++ b/vortex-array/src/arrays/shared/array.rs
@@ -3,10 +3,10 @@
 
 use std::future::Future;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
-use async_lock::RwLock;
-use async_lock::RwLockReadGuard;
-use async_lock::RwLockWriteGuard;
+use async_lock::Mutex as AsyncMutex;
+use vortex_error::SharedVortexResult;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
@@ -15,97 +15,86 @@ use crate::IntoArray;
 use crate::dtype::DType;
 use crate::stats::ArrayStats;
 
+/// A lazily-executing array wrapper with a one-way transition from source to cached form.
+///
+/// Before materialization, operations delegate to the source array.
+/// After materialization (via `get_or_compute`), operations delegate to the cached result.
 #[derive(Debug, Clone)]
 pub struct SharedArray {
-    pub(super) state: Arc<RwLock<SharedState>>,
+    source: ArrayRef,
+    cached: Arc<OnceLock<SharedVortexResult<ArrayRef>>>,
+    async_compute_lock: Arc<AsyncMutex<()>>,
     pub(super) dtype: DType,
     pub(super) stats: ArrayStats,
 }
 
-#[derive(Debug, Clone)]
-pub(super) enum SharedState {
-    Source(ArrayRef),
-    Cached(Canonical),
-}
-
 impl SharedArray {
-    /// Creates a new `SharedArray` wrapping the given source array.
     pub fn new(source: ArrayRef) -> Self {
         Self {
             dtype: source.dtype().clone(),
-            state: Arc::new(RwLock::new(SharedState::Source(source))),
+            source,
+            cached: Arc::new(OnceLock::new()),
+            async_compute_lock: Arc::new(AsyncMutex::new(())),
             stats: ArrayStats::default(),
         }
     }
 
-    #[cfg(not(target_family = "wasm"))]
-    fn write_lock_sync(&self) -> RwLockWriteGuard<'_, SharedState> {
-        self.state.write_blocking()
-    }
-
-    #[cfg(target_family = "wasm")]
-    fn write_lock_sync(&self) -> RwLockWriteGuard<'_, SharedState> {
-        // this should mirror how parking_lot compiles to wasm
-        self.state
-            .try_write()
-            .expect("SharedArray: mutex contention on single-threaded wasm target")
-    }
-
-    #[cfg(not(target_family = "wasm"))]
-    fn read_lock_sync(&self) -> RwLockReadGuard<'_, SharedState> {
-        self.state.read_blocking()
-    }
-
-    #[cfg(target_family = "wasm")]
-    fn read_lock_sync(&self) -> RwLockReadGuard<'_, SharedState> {
-        // this should mirror how parking_lot compiles to wasm
-        self.state
-            .try_read()
-            .expect("SharedArray: mutex contention on single-threaded wasm target")
-    }
-
-    pub fn get_or_compute(
-        &self,
-        f: impl FnOnce(&ArrayRef) -> VortexResult<Canonical>,
-    ) -> VortexResult<Canonical> {
-        let mut state = self.write_lock_sync();
-        match &*state {
-            SharedState::Cached(canonical) => Ok(canonical.clone()),
-            SharedState::Source(source) => {
-                let canonical = f(source)?;
-                *state = SharedState::Cached(canonical.clone());
-                Ok(canonical)
-            }
+    /// Returns the current array reference.
+    ///
+    /// After materialization, returns the cached result. Otherwise, returns the source.
+    /// If materialization failed, falls back to the source.
+    pub(super) fn current_array_ref(&self) -> &ArrayRef {
+        match self.cached.get() {
+            Some(Ok(arr)) => arr,
+            _ => &self.source,
         }
     }
 
-    pub async fn get_or_compute_async<F, Fut>(&self, f: F) -> VortexResult<Canonical>
+    /// Compute and cache the result. The computation runs exactly once via `OnceLock`.
+    ///
+    /// If the computation fails, the error is cached and returned on all subsequent calls.
+    pub fn get_or_compute(
+        &self,
+        f: impl FnOnce(&ArrayRef) -> VortexResult<Canonical>,
+    ) -> VortexResult<ArrayRef> {
+        let result = self
+            .cached
+            .get_or_init(|| f(&self.source).map(|c| c.into_array()).map_err(Arc::new));
+        result.clone().map_err(Into::into)
+    }
+
+    /// Async version of `get_or_compute`.
+    pub async fn get_or_compute_async<F, Fut>(&self, f: F) -> VortexResult<ArrayRef>
     where
         F: FnOnce(ArrayRef) -> Fut,
         Fut: Future<Output = VortexResult<Canonical>>,
     {
-        let mut state = self.state.write().await;
-        match &*state {
-            SharedState::Cached(canonical) => Ok(canonical.clone()),
-            SharedState::Source(source) => {
-                let source = source.clone();
-                let canonical = f(source).await?;
-                *state = SharedState::Cached(canonical.clone());
-                Ok(canonical)
-            }
+        // Fast path: already computed.
+        if let Some(result) = self.cached.get() {
+            return result.clone().map_err(Into::into);
         }
-    }
 
-    pub(super) fn current_array_ref(&self) -> ArrayRef {
-        let state = self.read_lock_sync();
-        match &*state {
-            SharedState::Source(source) => source.clone(),
-            SharedState::Cached(canonical) => canonical.clone().into_array(),
+        // Serialize async computation to prevent redundant work.
+        let _guard = self.async_compute_lock.lock().await;
+
+        // Double-check after acquiring the lock.
+        if let Some(result) = self.cached.get() {
+            return result.clone().map_err(Into::into);
         }
+
+        let computed = f(self.source.clone())
+            .await
+            .map(|c| c.into_array())
+            .map_err(Arc::new);
+
+        let result = self.cached.get_or_init(|| computed);
+        result.clone().map_err(Into::into)
     }
 
     pub(super) fn set_source(&mut self, source: ArrayRef) {
         self.dtype = source.dtype().clone();
-        *self.write_lock_sync() = SharedState::Source(source);
+        self.source = source;
+        self.cached = Arc::new(OnceLock::new());
+        self.async_compute_lock = Arc::new(AsyncMutex::new(()));
     }
 }

--- a/vortex-array/src/arrays/shared/tests.rs
+++ b/vortex-array/src/arrays/shared/tests.rs
@@ -28,11 +28,7 @@ fn shared_array_caches_on_canonicalize() -> VortexResult<()> {
     // Second call should return cached without invoking the closure.
     let second = shared.get_or_compute(|_| panic!("should not execute twice"))?;
 
-    assert!(
-        first
-            .as_ref()
-            .array_eq(second.as_ref(), HashPrecision::Value)
-    );
+    assert!(first.array_eq(&second, HashPrecision::Value));
 
     Ok(())
 }

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -13,7 +13,6 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
-use crate::IntoArray;
 use crate::Precision;
 use crate::arrays::shared::SharedArray;
 use crate::buffer::BufferHandle;
@@ -99,9 +98,7 @@ impl VTable for SharedVTable {
     }
 
     fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array
-            .get_or_compute(|source| source.clone().execute::<Canonical>(ctx))?
-            .into_array())
+        array.get_or_compute(|source| source.clone().execute::<Canonical>(ctx))
     }
 }
 
@@ -127,7 +124,7 @@ impl BaseArrayVTable<SharedVTable> for SharedVTable {
     fn array_eq(array: &SharedArray, other: &SharedArray, precision: Precision) -> bool {
         let current = array.current_array_ref();
         let other_current = other.current_array_ref();
-        current.array_eq(&other_current, precision) && array.dtype == other.dtype
+        current.array_eq(other_current, precision) && array.dtype == other.dtype
     }
 }
 
@@ -147,7 +144,7 @@ impl VisitorVTable<SharedVTable> for SharedVTable {
     fn visit_buffers(_array: &SharedArray, _visitor: &mut dyn ArrayBufferVisitor) {}
 
     fn visit_children(array: &SharedArray, visitor: &mut dyn ArrayChildVisitor) {
-        visitor.visit_child("source", &array.current_array_ref());
+        visitor.visit_child("source", array.current_array_ref());
     }
 
     fn nchildren(_array: &SharedArray) -> usize {
@@ -156,7 +153,7 @@ impl VisitorVTable<SharedVTable> for SharedVTable {
 
     fn nth_child(array: &SharedArray, idx: usize) -> Option<ArrayRef> {
         match idx {
-            0 => Some(array.current_array_ref()),
+            0 => Some(array.current_array_ref().clone()),
             _ => None,
         }
     }

--- a/vortex-cuda/src/kernel/arrays/shared.rs
+++ b/vortex-cuda/src/kernel/arrays/shared.rs
@@ -32,6 +32,7 @@ impl CudaExecute for SharedExecutor {
 
         shared
             .get_or_compute_async(|source| source.execute_cuda(ctx))
-            .await
+            .await?
+            .to_canonical()
     }
 }


### PR DESCRIPTION
## Summary

lighterweight shared array implementation to lend refs instead of Arcs after materialisation, using oncelock to bypass locking after canonicalisation
