### PR TITLE
Close DuckDB database before re-opening

### DIFF
--- a/benchmarks/duckdb-bench/src/lib.rs
+++ b/benchmarks/duckdb-bench/src/lib.rs
@@ -20,13 +20,19 @@ use vortex_duckdb::duckdb::Database;
 
 /// DuckDB context for benchmarks.
 pub struct DuckClient {
-    pub db: Database,
-    pub connection: Connection,
+    db: Option<Database>,
+    connection: Option<Connection>,
     pub db_path: PathBuf,
     pub threads: Option<usize>,
 }
 
 impl DuckClient {
+    pub fn connection(&self) -> &Connection {
+        self.connection
+            .as_ref()
+            .vortex_expect("DuckClient connection accessed after close")
+    }
+
     /// Create a new DuckDB context with a database at `{data_url}/{format}/duckdb.db`.
     pub fn new(
         benchmark: &dyn Benchmark,
@@ -55,8 +61,8 @@ impl DuckClient {
         let (db, connection) = Self::open_and_setup_database(Some(db_path.clone()), threads)?;
 
         Ok(Self {
-            db,
-            connection,
+            db: Some(db),
+            connection: Some(connection),
             db_path,
             threads,
         })
@@ -100,11 +106,18 @@ impl DuckClient {
     }
 
     pub fn reopen(&mut self) -> Result<()> {
-        let (mut db, mut connection) =
+        // Close the old database before opening a new one on the same file path.
+        // DuckDB cannot have two instances on the same file simultaneously — the new
+        // instance may read an inconsistent state, causing deserialization
+        // errors. Drop connection before database (connection depends on database).
+        self.connection.take();
+        self.db.take();
+
+        let (db, connection) =
             Self::open_and_setup_database(Some(self.db_path.clone()), self.threads)?;
 
-        std::mem::swap(&mut self.connection, &mut connection);
-        std::mem::swap(&mut self.db, &mut db);
+        self.db = Some(db);
+        self.connection = Some(connection);
 
         Ok(())
     }
@@ -117,8 +130,8 @@ impl DuckClient {
         let db_path = dir.join("duckdb.db");
         let (db, connection) = Self::open_and_setup_database(Some(db_path.clone()), None)?;
         Ok(Self {
-            db,
-            connection,
+            db: Some(db),
+            connection: Some(connection),
             db_path,
             threads: None,
         })
@@ -130,7 +143,7 @@ impl DuckClient {
     pub fn execute_query(&self, query: &str) -> Result<(usize, Option<Duration>)> {
         trace!("execute duckdb query: {query}");
         let time_instant = Instant::now();
-        let result = self.connection.query(query)?;
+        let result = self.connection().query(query)?;
         let query_time = time_instant.elapsed();
 
         let row_count = usize::try_from(result.row_count()).vortex_expect("row count overflow");

--- a/benchmarks/duckdb-bench/src/main.rs
+++ b/benchmarks/duckdb-bench/src/main.rs
@@ -145,7 +145,7 @@ fn main() -> anyhow::Result<()> {
                 println!("=== Q{query_idx} [{format}] ===");
                 println!("{query}");
                 println!();
-                let result = ctx.connection.query(&format!("EXPLAIN {query}"))?;
+                let result = ctx.connection().query(&format!("EXPLAIN {query}"))?;
                 for chunk in result {
                     let chunk_str =
                         String::try_from(chunk.deref()).unwrap_or_else(|_| "<error>".to_string());


### PR DESCRIPTION
The TPCH NVME SF=10 benchmarks were failing specifically for duckdb:duckdb. I'm not too sure why, but the #6581 PR introduced this bug. Before, we would re-open the DB using dangling pointers. This PR does it in a safe way by holding options and dropping prior to re-opening.