### PR TITLE
cudarc use 12.5 instead of 12.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,10 +113,10 @@ clap = "4.5"
 criterion = "0.7"
 crossterm = "0.29"
 cudarc = { version = "0.18.2", features = [
-    # 12.8 matches the CUDA toolkit version pre-installed on the lambda.ai GPU base
-    # image. The version does not have to match exactly. Lower toolkit versions can
-    # be specified if a later toolkit version is installed on the system.
-    "cuda-12080",
+    # The NSight Compute version available on lambda.ai hosts does not inject a symbol for
+    # several functions that cudarc expects to load when this is set to "cuda-12080". We
+    # don't use any CUDA 12.8 specific features currently so this is fine.
+    "cuda-12050",
 ] }
 custom-labels = "0.4.4"
 dashmap = "6.1.0"


### PR DESCRIPTION
When running on lambda.ai boxes, we have CUDA Toolkit 12.8 installed. The NSight Compute version that they ship does not seem to inject libs that include several of the symbols `cudarc` marks as available on 12.8, for example:


```
(base) ubuntu@132-145-211-165:~/vortex$ RUST_LOG=vortex_cuda=trace,info FLAT_LAYOUT_INLINE_ARRAY_NODE=true ncu ./target/samply/gpu-scan-cli ./vortex-bench/data/tpch/1.0/vortex-file-compressed/lineitem_0.vortex

thread 'main' panicked at /home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cudarc-0.18.2/src/driver/sys/mod.rs:24528:18:
Expected symbol in library: DlSym { desc: "/usr/lib/x86_64-linux-gnu/nsight-compute/target/linux-desktop-glibc_2_11_3-x64/./libcuda-injection.so: undefined symbol: cuTensorMapEncodeIm2colWide" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
==ERROR== The application returned an error code (101).
```

`cudarc` eagerly loads all symbols it believes should be available at startup, even if they aren't used by the program.

We don't use any recently added CUDA symbols, so to keep this compatible with NSight Compute execution, we should downgrade cudarc to build with only the CUDA 12.5 symbols.

This runs without issue.

<img width="863" height="343" alt="image" src="https://github.com/user-attachments/assets/69d27d13-ced5-43df-8841-1830de40bda1" />
