### PR TITLE
chore: trim unused crate deps with `cargo-machete`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1359,7 +1359,6 @@ dependencies = [
  "lance-bench",
  "parquet",
  "regex",
- "serde",
  "tokio",
  "tracing",
  "vortex",
@@ -1923,15 +1922,12 @@ name = "datafusion-bench"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-ipc",
- "async-trait",
  "clap",
  "custom-labels",
  "datafusion 52.1.0",
  "datafusion-common 52.1.0",
  "datafusion-physical-plan 52.1.0",
  "futures",
- "get_dir",
  "itertools 0.14.0",
  "object_store",
  "opentelemetry",
@@ -3290,7 +3286,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3342,12 +3338,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
- "custom-labels",
- "get_dir",
  "similar",
  "tokio",
  "tracing",
- "url",
  "vortex",
  "vortex-bench",
  "vortex-cuda",
@@ -3485,7 +3478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3906,8 +3899,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -4718,7 +4711,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4799,7 +4792,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5014,7 +5007,6 @@ dependencies = [
  "async-trait",
  "clap",
  "futures",
- "get_dir",
  "lance",
  "lance-encoding",
  "parquet",
@@ -5592,7 +5584,7 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.7.1",
+ "redox_syscall 0.7.2",
 ]
 
 [[package]]
@@ -6142,7 +6134,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7338,7 +7330,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7464,14 +7456,12 @@ name = "random-access-bench"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "indicatif",
  "lance-bench",
  "rand 0.9.2",
  "rand_distr 0.5.1",
  "tokio",
- "vortex",
  "vortex-bench",
 ]
 
@@ -7636,9 +7626,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35985aa610addc02e24fc232012c86fd11f14111180f902b67e2d5331f8ebf2b"
+checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -7984,7 +7974,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9077,7 +9067,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9907,10 +9897,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrow-array",
- "arrow-ipc",
  "codspeed-divan-compat",
  "fastlanes",
- "itertools 0.14.0",
  "mimalloc",
  "parquet",
  "rand 0.9.2",
@@ -10089,7 +10077,6 @@ dependencies = [
  "rustc-hash",
  "test-with",
  "tracing",
- "tracing-subscriber",
  "vortex-alp",
  "vortex-array",
  "vortex-buffer",
@@ -10135,7 +10122,6 @@ dependencies = [
  "vortex-array",
  "vortex-buffer",
  "vortex-error",
- "vortex-mask",
  "vortex-session",
 ]
 
@@ -10155,17 +10141,13 @@ name = "vortex-cuda"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
- "arrow-data",
- "arrow-schema",
  "async-trait",
  "bindgen",
  "codspeed-criterion-compat-walltime",
  "cudarc",
  "fastlanes",
- "flatbuffers",
  "futures",
  "kanal",
- "paste",
  "prost 0.14.3",
  "rstest",
  "tokio",
@@ -10183,7 +10165,6 @@ dependencies = [
 name = "vortex-cuda-macros"
 version = "0.1.0"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
@@ -10197,7 +10178,6 @@ dependencies = [
  "arrow-schema",
  "async-fs",
  "cxx",
- "cxx-build",
  "futures",
  "paste",
  "take_mut",
@@ -10211,7 +10191,6 @@ dependencies = [
  "anyhow",
  "arrow-schema",
  "async-trait",
- "chrono",
  "datafusion 52.1.0",
  "datafusion-catalog 52.1.0",
  "datafusion-common 52.1.0",
@@ -10237,7 +10216,6 @@ dependencies = [
  "url",
  "vortex",
  "vortex-utils",
- "walkdir",
 ]
 
 [[package]]
@@ -10281,7 +10259,6 @@ dependencies = [
  "cc",
  "custom-labels",
  "futures",
- "glob",
  "itertools 0.14.0",
  "jiff",
  "num-traits",
@@ -10312,7 +10289,6 @@ dependencies = [
  "jiff",
  "object_store",
  "prost 0.14.3",
- "pyo3",
  "serial_test",
  "temp-env",
  "tokio",
@@ -10368,7 +10344,6 @@ dependencies = [
  "flatbuffers",
  "futures",
  "getrandom 0.3.4",
- "glob",
  "itertools 0.14.0",
  "kanal",
  "moka",
@@ -10378,7 +10353,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
- "url",
  "uuid",
  "vortex-alp",
  "vortex-array",
@@ -10421,7 +10395,6 @@ version = "0.1.0"
 dependencies = [
  "codspeed-divan-compat",
  "fsst-rs",
- "num-traits",
  "prost 0.14.3",
  "rand 0.9.2",
  "rstest",
@@ -10552,7 +10525,6 @@ dependencies = [
  "vortex-array",
  "vortex-btrblocks",
  "vortex-buffer",
- "vortex-decimal-byte-parts",
  "vortex-error",
  "vortex-flatbuffers",
  "vortex-io",
@@ -10582,7 +10554,6 @@ dependencies = [
  "getrandom 0.3.4",
  "parking_lot",
  "sketches-ddsketch",
- "vortex-session",
 ]
 
 [[package]]
@@ -10601,11 +10572,8 @@ dependencies = [
 name = "vortex-pco"
 version = "0.1.0"
 dependencies = [
- "codspeed-divan-compat",
- "mimalloc",
  "pco",
  "prost 0.14.3",
- "rand 0.9.2",
  "rstest",
  "vortex-array",
  "vortex-buffer",
@@ -10639,10 +10607,8 @@ dependencies = [
  "pyo3-log",
  "pyo3-object_store",
  "tokio",
- "tracing",
  "url",
  "vortex",
- "vortex-array",
  "vortex-tui",
 ]
 
@@ -10676,7 +10642,6 @@ dependencies = [
  "bit-vec 0.8.0",
  "futures",
  "itertools 0.14.0",
- "kanal",
  "parking_lot",
  "roaring 0.11.3",
  "sketches-ddsketch",
@@ -10702,11 +10667,8 @@ dependencies = [
  "vortex-array",
  "vortex-buffer",
  "vortex-error",
- "vortex-file",
- "vortex-layout",
  "vortex-mask",
  "vortex-proto",
- "vortex-runend",
  "vortex-session",
 ]
 
@@ -10748,7 +10710,6 @@ dependencies = [
  "futures",
  "indicatif",
  "sqllogictest",
- "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "vortex",
@@ -10761,12 +10722,8 @@ name = "vortex-test-e2e"
 version = "0.1.0"
 dependencies = [
  "futures",
- "rstest",
  "tokio",
  "vortex",
- "vortex-array",
- "vortex-error",
- "vortex-file",
 ]
 
 [[package]]
@@ -11138,7 +11095,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/benchmarks/compress-bench/Cargo.toml
+++ b/benchmarks/compress-bench/Cargo.toml
@@ -27,7 +27,6 @@ itertools = { workspace = true }
 lance-bench = { path = "../lance-bench", optional = true }
 parquet = { workspace = true }
 regex = { workspace = true }
-serde = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 vortex = { workspace = true }

--- a/benchmarks/datafusion-bench/Cargo.toml
+++ b/benchmarks/datafusion-bench/Cargo.toml
@@ -16,8 +16,6 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-arrow-ipc.workspace = true
-async-trait = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 custom-labels = { workspace = true }
 datafusion = { workspace = true, features = [
@@ -44,7 +42,6 @@ vortex-datafusion = { workspace = true }
 vortex-metrics = { workspace = true }
 
 [build-dependencies]
-get_dir = { workspace = true }
 custom-labels = { workspace = true }
 
 [features]

--- a/benchmarks/duckdb-bench/Cargo.toml
+++ b/benchmarks/duckdb-bench/Cargo.toml
@@ -17,19 +17,13 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-custom-labels = { workspace = true }
 similar = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-url = { workspace = true }
 vortex = { workspace = true }
 vortex-bench = { workspace = true }
 vortex-cuda = { workspace = true, optional = true }
 vortex-duckdb = { workspace = true }
-
-[build-dependencies]
-get_dir = { workspace = true }
-custom-labels = { workspace = true }
 
 [features]
 cuda = ["dep:vortex-cuda"]

--- a/benchmarks/lance-bench/Cargo.toml
+++ b/benchmarks/lance-bench/Cargo.toml
@@ -29,8 +29,5 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 vortex-bench = { workspace = true }
 
-[build-dependencies]
-get_dir = { workspace = true }
-
 [lints]
 workspace = true

--- a/benchmarks/random-access-bench/Cargo.toml
+++ b/benchmarks/random-access-bench/Cargo.toml
@@ -16,14 +16,12 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 indicatif = { workspace = true }
 lance-bench = { path = "../lance-bench", optional = true }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
-vortex = { workspace = true }
 vortex-bench = { workspace = true }
 
 [features]

--- a/encodings/bytebool/Cargo.toml
+++ b/encodings/bytebool/Cargo.toml
@@ -21,7 +21,6 @@ num-traits = { workspace = true }
 vortex-array = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-error = { workspace = true }
-vortex-mask = { workspace = true }
 vortex-session = { workspace = true }
 
 [dev-dependencies]

--- a/encodings/fsst/Cargo.toml
+++ b/encodings/fsst/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [dependencies]
 fsst-rs = { workspace = true }
-num-traits = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true, optional = true }
 vortex-array = { workspace = true }

--- a/encodings/pco/Cargo.toml
+++ b/encodings/pco/Cargo.toml
@@ -26,9 +26,6 @@ vortex-mask = { workspace = true }
 vortex-session = { workspace = true }
 
 [dev-dependencies]
-divan = { workspace = true }
-mimalloc = { workspace = true }
-rand = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }
 

--- a/encodings/sequence/Cargo.toml
+++ b/encodings/sequence/Cargo.toml
@@ -21,15 +21,12 @@ vortex-buffer = { workspace = true }
 vortex-error = { workspace = true }
 vortex-mask = { workspace = true }
 vortex-proto = { workspace = true }
-vortex-runend = { workspace = true }
 vortex-session = { workspace = true }
 
 [dev-dependencies]
 itertools = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { path = "../../vortex-array", features = ["_test-harness"] }
-vortex-file = { path = "../../vortex-file", features = ["tokio"] }
-vortex-layout = { path = "../../vortex-layout" }
 
 [lints]
 workspace = true

--- a/java/testfiles/Cargo.lock
+++ b/java/testfiles/Cargo.lock
@@ -436,6 +436,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6f81257d10a0f602a294ae4182251151ff97dbb504ef9afcdda4a64b24d9b4"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +600,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "dtype_dispatch"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,6 +754,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fsst-rs"
@@ -979,10 +1011,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1215,6 +1349,12 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -1460,6 +1600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1661,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1681,6 +1836,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "roaring"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,6 +2003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,6 +2034,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1906,6 +2088,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,6 +2134,24 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -2174,12 +2384,15 @@ dependencies = [
  "flatbuffers",
  "futures",
  "getrandom 0.3.4",
+ "glob",
  "itertools 0.14.0",
  "kanal",
+ "moka",
  "oneshot",
  "parking_lot",
  "pin-project-lite",
  "tracing",
+ "url",
  "uuid",
  "vortex-alp",
  "vortex-array",
@@ -2194,6 +2407,7 @@ dependencies = [
  "vortex-fsst",
  "vortex-io",
  "vortex-layout",
+ "vortex-mask",
  "vortex-metrics",
  "vortex-pco",
  "vortex-runend",
@@ -2374,7 +2588,9 @@ dependencies = [
  "bit-vec",
  "futures",
  "itertools 0.14.0",
+ "kanal",
  "parking_lot",
+ "roaring",
  "sketches-ddsketch",
  "tracing",
  "vortex-array",
@@ -2746,12 +2962,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+ "synstructure",
 ]
 
 [[package]]
@@ -2768,6 +3013,60 @@ name = "zerocopy-derive"
 version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/vortex-btrblocks/Cargo.toml
+++ b/vortex-btrblocks/Cargo.toml
@@ -43,7 +43,6 @@ vortex-zstd = { workspace = true, optional = true }
 divan = { workspace = true }
 rstest = { workspace = true }
 test-with = { workspace = true }
-tracing-subscriber = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }
 
 [features]

--- a/vortex-cuda/Cargo.toml
+++ b/vortex-cuda/Cargo.toml
@@ -24,22 +24,14 @@ unstable_encodings = ["vortex/unstable_encodings"]
 
 [dependencies]
 arc-swap = { workspace = true }
-arrow-data = { workspace = true, features = ["ffi"] }
-arrow-schema = { workspace = true, features = ["ffi"] }
 async-trait = { workspace = true }
 cudarc = { workspace = true, features = ["f16"] }
-fastlanes = { workspace = true }
-flatbuffers = { workspace = true }
 futures = { workspace = true, features = ["executor"] }
 kanal = { workspace = true }
-paste = { workspace = true }
 prost = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true, features = ["std", "attributes"] }
 vortex = { workspace = true, features = ["zstd"] }
-# Keep vortex-array and vortex-error as direct deps for macro hygiene: encoding
-# macros (e.g. `match_each_alp_float_ptype!`) expand to bare `vortex_array::`
-# and `vortex_error::` paths that must resolve as crate names at the call site.
 vortex-array = { workspace = true, features = ["cudarc"] }
 vortex-cub = { path = "cub" }
 vortex-cuda-macros = { workspace = true }

--- a/vortex-cuda/macros/Cargo.toml
+++ b/vortex-cuda/macros/Cargo.toml
@@ -20,6 +20,5 @@ workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }

--- a/vortex-cuda/nvcomp/Cargo.toml
+++ b/vortex-cuda/nvcomp/Cargo.toml
@@ -23,6 +23,6 @@ vortex-cuda-macros = { workspace = true }
 
 [build-dependencies]
 bindgen = { workspace = true }
+liblzma = { workspace = true }
 reqwest = { workspace = true }
 tar = { workspace = true }
-liblzma = { workspace = true }

--- a/vortex-cxx/Cargo.toml
+++ b/vortex-cxx/Cargo.toml
@@ -30,6 +30,3 @@ futures = { workspace = true }
 paste = { workspace = true }
 take_mut = { workspace = true }
 vortex = { workspace = true }
-
-[build-dependencies]
-cxx-build = "1.0"

--- a/vortex-datafusion/Cargo.toml
+++ b/vortex-datafusion/Cargo.toml
@@ -16,7 +16,6 @@ version = { workspace = true }
 [dependencies]
 arrow-schema = { workspace = true }
 async-trait = { workspace = true }
-chrono = { workspace = true }
 datafusion-catalog = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-common-runtime = { workspace = true }
@@ -46,7 +45,6 @@ rstest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "rt-multi-thread", "fs"] }
 url = { workspace = true }
-walkdir = { workspace = true }
 
 [lints]
 workspace = true

--- a/vortex-duckdb/Cargo.toml
+++ b/vortex-duckdb/Cargo.toml
@@ -30,7 +30,6 @@ async-trait = { workspace = true }
 bitvec = { workspace = true }
 custom-labels = { workspace = true }
 futures = { workspace = true }
-glob = { workspace = true }
 itertools = { workspace = true }
 num-traits = { workspace = true }
 object_store = { workspace = true, features = ["aws"] }

--- a/vortex-error/Cargo.toml
+++ b/vortex-error/Cargo.toml
@@ -25,7 +25,6 @@ flatbuffers = { workspace = true, optional = true }
 jiff = { workspace = true }
 object_store = { workspace = true, optional = true }
 prost = { workspace = true }
-pyo3 = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
 
 [dev-dependencies]

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -22,7 +22,6 @@ bytes = { workspace = true }
 flatbuffers = { workspace = true }
 futures = { workspace = true, features = ["std", "async-await"] }
 getrandom_v03 = { workspace = true }                              # Needed to pickup the "wasm_js" feature for wasm targets from the workspace configuration
-glob = { workspace = true }
 itertools = { workspace = true }
 kanal = { workspace = true }
 moka = { workspace = true, features = ["sync"] }
@@ -32,7 +31,6 @@ parking_lot = { workspace = true }
 pin-project-lite = { workspace = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
 tracing = { workspace = true }
-url = { workspace = true }
 uuid = { workspace = true }                                       # Needed to pickup the "js" feature for wasm targets from the workspace configuration
 vortex-alp = { workspace = true }
 vortex-array = { workspace = true }

--- a/vortex-layout/Cargo.toml
+++ b/vortex-layout/Cargo.toml
@@ -39,7 +39,6 @@ uuid = { workspace = true }
 vortex-array = { workspace = true }
 vortex-btrblocks = { workspace = true }
 vortex-buffer = { workspace = true }
-vortex-decimal-byte-parts = { workspace = true }
 vortex-error = { workspace = true }
 vortex-flatbuffers = { workspace = true, features = ["layout"] }
 vortex-io = { workspace = true }

--- a/vortex-metrics/Cargo.toml
+++ b/vortex-metrics/Cargo.toml
@@ -17,7 +17,6 @@ version = { workspace = true }
 getrandom_v03 = { workspace = true }
 parking_lot = { workspace = true }
 sketches-ddsketch = { workspace = true }
-vortex-session = { workspace = true }
 
 [lints]
 workspace = true

--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -49,11 +49,6 @@ pyo3-bytes = { workspace = true }
 pyo3-log = { workspace = true }
 pyo3-object_store = { version = "0.7" }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
-# This feature makes the underlying tracing logs to be emitted as `log` events
-tracing = { workspace = true, features = ["std", "log"] }
 url = { workspace = true }
 vortex = { workspace = true, features = ["object_store", "tokio"] }
 vortex-tui = { workspace = true, optional = true }
-
-[dev-dependencies]
-vortex-array = { workspace = true, features = ["_test-harness"] }

--- a/vortex-scan/Cargo.toml
+++ b/vortex-scan/Cargo.toml
@@ -32,7 +32,6 @@ async-trait = { workspace = true }
 bit-vec = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-kanal = { workspace = true }
 parking_lot = { workspace = true }
 roaring = { workspace = true }
 sketches-ddsketch = { workspace = true }

--- a/vortex-sqllogictest/Cargo.toml
+++ b/vortex-sqllogictest/Cargo.toml
@@ -22,7 +22,6 @@ datafusion-sqllogictest = { workspace = true }
 futures.workspace = true
 indicatif.workspace = true
 sqllogictest = "0.28"
-tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 vortex = { workspace = true, features = ["tokio"] }

--- a/vortex-test/e2e/Cargo.toml
+++ b/vortex-test/e2e/Cargo.toml
@@ -20,9 +20,5 @@ unstable_encodings = ["vortex/unstable_encodings"]
 
 [dependencies]
 futures = { workspace = true }
-rstest = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros"] }
 vortex = { workspace = true, features = ["files", "tokio"] }
-vortex-array = { workspace = true, features = ["_test-harness"] }
-vortex-error = { workspace = true }
-vortex-file = { workspace = true }

--- a/vortex/Cargo.toml
+++ b/vortex/Cargo.toml
@@ -51,10 +51,8 @@ vortex-zstd = { workspace = true, optional = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 arrow-array = { workspace = true }
-arrow-ipc = { workspace = true }
 divan = { workspace = true }
 fastlanes = { workspace = true }
-itertools = { workspace = true }
 mimalloc = { workspace = true }
 parquet = { workspace = true }
 rand = { workspace = true }


### PR DESCRIPTION
Trims unused crate dependencies based on:  `cargo-machete --with-metadata --fix`.