### PR TITLE
feat: teach ALPRDArray how to append_to_builder

### DIFF
--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -17,6 +17,8 @@ use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
+use vortex_array::builders::ArrayBuilder;
+use vortex_array::builders::PrimitiveBuilder;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
@@ -35,6 +37,7 @@ use vortex_array::vtable::patches_child;
 use vortex_array::vtable::patches_child_name;
 use vortex_array::vtable::patches_nchildren;
 use vortex_buffer::Buffer;
+use vortex_error::VortexExpect as _;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
@@ -43,6 +46,8 @@ use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
+use crate::ALPRDFloat;
+use crate::alp_rd::alp_rd_decode_inplace;
 use crate::alp_rd::kernel::PARENT_KERNELS;
 use crate::alp_rd::rules::RULES;
 use crate::alp_rd_decode;
@@ -295,6 +300,18 @@ impl VTable for ALPRDVTable {
         Ok(())
     }
 
+    fn append_to_builder(
+        array: &Self::Array,
+        builder: &mut dyn ArrayBuilder,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<()> {
+        if array.is_f32() {
+            append_to_builder_typed::<f32>(array, builder, ctx)
+        } else {
+            append_to_builder_typed::<f64>(array, builder, ctx)
+        }
+    }
+
     fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
         let left_parts = array.left_parts().clone().execute::<PrimitiveArray>(ctx)?;
         let right_parts = array.right_parts().clone().execute::<PrimitiveArray>(ctx)?;
@@ -353,6 +370,58 @@ impl VTable for ALPRDVTable {
     ) -> VortexResult<Option<ArrayRef>> {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
+}
+
+fn append_to_builder_typed<T: ALPRDFloat>(
+    array: &ALPRDArray,
+    builder: &mut dyn ArrayBuilder,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<()> {
+    let left_parts = array.left_parts().clone().execute::<PrimitiveArray>(ctx)?;
+    let validity = array
+        .left_parts()
+        .validity()?
+        .to_array(array.len())
+        .execute::<Mask>(ctx)?;
+
+    let builder: &mut PrimitiveBuilder<T> = builder
+        .as_any_mut()
+        .downcast_mut()
+        .vortex_expect("ALPRD array must canonicalize into a primitive array");
+
+    let cursor = builder.len();
+    let n = array.len();
+    builder.reserve_exact(n);
+
+    builder.as_values_and_nulls(|non_nullable_builder, nulls| -> VortexResult<()> {
+        // SAFETY: T and T::UINT have the same size/alignment (f32↔u32, f64↔u64).
+        unsafe {
+            non_nullable_builder.as_transmuted::<T::UINT, VortexResult<()>>(|uint_builder| {
+                // BitPacked can downcast uint_builder to PrimitiveBuilder<T::UINT>.
+                array.right_parts().append_to_builder(uint_builder, ctx)?;
+
+                // Decode in-place: combine left+right bits.
+                let right_parts_slice = &mut uint_builder.values_mut()[cursor..cursor + n];
+                alp_rd_decode_inplace::<T>(
+                    left_parts.into_buffer::<u16>(),
+                    array.left_parts_dictionary(),
+                    array.right_bit_width,
+                    right_parts_slice,
+                    array.left_parts_patches(),
+                    ctx,
+                )?;
+
+                Ok(())
+            })?;
+        }
+
+        // Set the correct validity from left_parts.
+        nulls.append_validity_mask(validity);
+
+        Ok(())
+    })?;
+
+    Ok(())
 }
 
 #[derive(Clone, Debug)]

--- a/encodings/alp/src/alp_rd/mod.rs
+++ b/encodings/alp/src/alp_rd/mod.rs
@@ -294,13 +294,46 @@ pub fn alp_rd_decode<T: ALPRDFloat>(
     left_parts: Buffer<u16>,
     left_parts_dict: &[u16],
     right_bit_width: u8,
-    right_parts: BufferMut<T::UINT>,
+    mut right_parts: BufferMut<T::UINT>,
     left_parts_patches: Option<&Patches>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Buffer<T>> {
-    if left_parts.len() != right_parts.len() {
-        vortex_panic!("alp_rd_decode: left_parts.len != right_parts.len");
-    }
+    alp_rd_decode_inplace::<T>(
+        left_parts,
+        left_parts_dict,
+        right_bit_width,
+        right_parts.as_mut_slice(),
+        left_parts_patches,
+        ctx,
+    )?;
+
+    // SAFETY: alp_rd_decode_inplace combined left+right bits in-place.
+    // The buffer now contains valid T bit patterns stored as T::UINT.
+    Ok(unsafe { right_parts.transmute::<T>() }.freeze())
+}
+
+/// Decode ALP-RD encoded values in-place into a mutable slice of right parts.
+///
+/// After this function returns, `right_parts` contains valid `T` bit patterns
+/// (stored as `T::UINT`). Each element is the combination of the dictionary-decoded
+/// left part shifted left by `right_bit_width` bits, OR'd with the original right part.
+///
+/// # Panics
+///
+/// Panics if `left_parts.len() != right_parts.len()`.
+pub fn alp_rd_decode_inplace<T: ALPRDFloat>(
+    left_parts: Buffer<u16>,
+    left_parts_dict: &[u16],
+    right_bit_width: u8,
+    right_parts: &mut [T::UINT],
+    left_parts_patches: Option<&Patches>,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<()> {
+    assert_eq!(
+        left_parts.len(),
+        right_parts.len(),
+        "alp_rd_decode_inplace: left_parts.len != right_parts.len"
+    );
 
     // Decode the left-parts dictionary
     let mut values = BufferMut::<u16>::from_iter(
@@ -316,13 +349,13 @@ pub fn alp_rd_decode<T: ALPRDFloat>(
         alp_rd_apply_patches(&mut values, &indices, &patch_values, patches.offset());
     }
 
-    // Shift the left-parts and add in the right-parts.
-    Ok(alp_rd_decode_core(
-        left_parts_dict,
-        right_bit_width,
-        right_parts,
-        values,
-    ))
+    // Combine left + right in-place: *right = (left << rbw) | *right
+    for (right, left) in right_parts.iter_mut().zip(values.iter()) {
+        let left_uint = <T as ALPRDFloat>::from_u16(*left);
+        *right = (left_uint << (right_bit_width as usize)) | *right;
+    }
+
+    Ok(())
 }
 
 /// Apply patches to the decoded left-parts values.
@@ -341,25 +374,6 @@ fn alp_rd_apply_patches(
             .zip(patch_values.as_slice::<u16>().iter())
             .for_each(|(idx, v)| values[idx as usize] = *v);
     })
-}
-
-/// Core decode logic shared between `alp_rd_decode` and `execute_alp_rd_decode`.
-fn alp_rd_decode_core<T: ALPRDFloat>(
-    _left_parts_dict: &[u16],
-    right_bit_width: u8,
-    right_parts: BufferMut<T::UINT>,
-    values: BufferMut<u16>,
-) -> Buffer<T> {
-    // Shift the left-parts and add in the right-parts.
-    let mut index = 0;
-    right_parts
-        .map_each_in_place(|right| {
-            let left = values[index];
-            index += 1;
-            let left = <T as ALPRDFloat>::from_u16(left);
-            T::from_bits((left << (right_bit_width as usize)) | right)
-        })
-        .freeze()
 }
 
 /// Find the best "cut point" for a set of floating point values such that we can

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -17,6 +17,7 @@ use crate::Precision;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::fixed_size_list::compute::rules::PARENT_RULES;
 use crate::buffer::BufferHandle;
+use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
 use crate::hash::ArrayEq;
 use crate::hash::ArrayHash;

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -217,6 +217,14 @@ impl VTable for FixedSizeListVTable {
         Ok(())
     }
 
+    fn append_to_builder(
+        array: &Self::Array,
+        builder: &mut dyn ArrayBuilder,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<()> {
+        array.append_to_builder(builder, ctx)
+    }
+
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
         Ok(array.to_array())
     }

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -28,6 +28,7 @@ use crate::arrays::scalar_fn::metadata::ScalarFnMetadata;
 use crate::arrays::scalar_fn::rules::PARENT_RULES;
 use crate::arrays::scalar_fn::rules::RULES;
 use crate::buffer::BufferHandle;
+use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
 use crate::executor::ExecutionCtx;
 use crate::expr::Expression;
@@ -193,6 +194,20 @@ impl VTable for ScalarFnVTable {
         Ok(())
     }
 
+    fn append_to_builder(
+        array: &Self::Array,
+        builder: &mut dyn ArrayBuilder,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<()> {
+        ctx.log(format_args!("scalar_fn({}): executing", array.scalar_fn));
+        let args = ExecutionArgs {
+            inputs: array.children.clone(),
+            row_count: array.len,
+            ctx,
+        };
+        array.scalar_fn.append_to_builder(args, builder)
+    }
+
     fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
         ctx.log(format_args!("scalar_fn({}): executing", array.scalar_fn));
         let args = ExecutionArgs {
@@ -356,6 +371,15 @@ impl scalar_fn::ScalarFnVTable for ArrayExpr {
 
     fn return_dtype(&self, options: &Self::Options, _arg_dtypes: &[DType]) -> VortexResult<DType> {
         Ok(options.0.dtype().clone())
+    }
+
+    fn append_to_builder(
+        &self,
+        options: &Self::Options,
+        args: ExecutionArgs,
+        builder: &mut dyn ArrayBuilder,
+    ) -> VortexResult<()> {
+        options.0.append_to_builder(builder, args.ctx)
     }
 
     fn execute(&self, options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -26,7 +26,7 @@ use crate::scalar::Scalar;
 pub struct BoolBuilder {
     dtype: DType,
     inner: BitBufferMut,
-    nulls: LazyBitBufferBuilder,
+    pub nulls: LazyBitBufferBuilder,
 }
 
 impl BoolBuilder {

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -39,7 +39,7 @@ pub struct FixedSizeListBuilder {
     /// The null map builder of the [`FixedSizeListArray`].
     ///
     /// We also use this type to store the length of the final output array.
-    nulls: LazyBitBufferBuilder,
+    pub nulls: LazyBitBufferBuilder,
 }
 
 impl FixedSizeListBuilder {

--- a/vortex-array/src/builders/lazy_null_builder.rs
+++ b/vortex-array/src/builders/lazy_null_builder.rs
@@ -31,6 +31,10 @@ impl LazyBitBufferBuilder {
         }
     }
 
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
     /// Appends `n` non-null values to the builder.
     #[inline]
     pub fn append_n_non_nulls(&mut self, n: usize) {
@@ -103,6 +107,11 @@ impl LazyBitBufferBuilder {
     pub fn len(&self) -> usize {
         // self.len is the length of the builder if the inner buffer is not materialized
         self.inner.as_ref().map(|i| i.len()).unwrap_or(self.len)
+    }
+
+    /// Returns true if this builder contains no bits.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     fn finish(&mut self) -> Option<BitBuffer> {

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -44,7 +44,7 @@ use crate::match_each_native_ptype;
 use crate::scalar::Scalar;
 
 mod lazy_null_builder;
-pub(crate) use lazy_null_builder::LazyBitBufferBuilder;
+pub use lazy_null_builder::LazyBitBufferBuilder;
 
 mod bool;
 mod decimal;

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -28,7 +28,7 @@ use crate::scalar::Scalar;
 pub struct PrimitiveBuilder<T> {
     dtype: DType,
     values: BufferMut<T>,
-    nulls: LazyBitBufferBuilder,
+    pub nulls: LazyBitBufferBuilder,
 }
 
 impl<T: NativePType> PrimitiveBuilder<T> {

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -118,6 +118,97 @@ impl<T: NativePType> PrimitiveBuilder<T> {
         self.values.extend(iter);
         self.nulls.append_validity_mask(mask);
     }
+
+    /// Returns a mutable slice of the initialized values in this builder.
+    pub fn values_mut(&mut self) -> &mut [T] {
+        self.values.as_mut_slice()
+    }
+
+    /// Temporarily detaches the nulls buffer, making this builder non-nullable
+    /// for the duration of the closure.
+    ///
+    /// The closure receives:
+    /// - `&mut self` with dtype changed to non-nullable and nulls swapped out
+    /// - The detached [`LazyBitBufferBuilder`] for managing validity separately
+    ///
+    /// After the closure returns, the original nullability and nulls are restored.
+    pub fn as_values_and_nulls<R>(
+        &mut self,
+        f: impl FnOnce(&mut Self, &mut LazyBitBufferBuilder) -> R,
+    ) -> R {
+        let original_dtype = self.dtype.clone();
+
+        // Make the builder non-nullable.
+        self.dtype = DType::Primitive(T::PTYPE, Nullability::NonNullable);
+
+        // Swap nulls out.
+        let mut nulls = LazyBitBufferBuilder::new(0);
+        std::mem::swap(&mut self.nulls, &mut nulls);
+
+        let result = f(self, &mut nulls);
+
+        // Restore dtype and nulls.
+        self.dtype = original_dtype;
+        std::mem::swap(&mut self.nulls, &mut nulls);
+
+        result
+    }
+
+    /// Temporarily transmutes the values buffer from `T` to `U` and runs a
+    /// closure with a `PrimitiveBuilder<U>`.
+    ///
+    /// The temporary builder preserves this builder's nullability, and the nulls
+    /// buffer is moved into it for the duration of the closure.
+    ///
+    /// After the closure returns, values are transmuted back to `T` and the
+    /// nulls buffer is restored.
+    ///
+    /// # Safety
+    ///
+    /// - `T` and `U` must have the same size and alignment.
+    /// - After this call, any newly appended values contain `U` bit patterns.
+    ///   The caller must ensure these are valid `T` bit patterns before reading
+    ///   them as `T`.
+    pub unsafe fn as_transmuted<U: NativePType, R>(
+        &mut self,
+        f: impl FnOnce(&mut PrimitiveBuilder<U>) -> R,
+    ) -> R {
+        assert_eq!(
+            size_of::<T>(),
+            size_of::<U>(),
+            "T and U must have the same size"
+        );
+        assert_eq!(
+            align_of::<T>(),
+            align_of::<U>(),
+            "T and U must have the same alignment"
+        );
+
+        let values = std::mem::take(&mut self.values);
+        // SAFETY: We have verified that T and U have the same size and alignment.
+        let retyped_values: BufferMut<U> = unsafe { values.transmute() };
+
+        // Swap nulls into the temp builder so it inherits our validity state.
+        let mut nulls = LazyBitBufferBuilder::new(0);
+        std::mem::swap(&mut self.nulls, &mut nulls);
+
+        let mut temp_builder = PrimitiveBuilder {
+            dtype: DType::Primitive(U::PTYPE, self.dtype.nullability()),
+            values: retyped_values,
+            nulls,
+        };
+
+        let result = f(&mut temp_builder);
+
+        // Restore values (transmute back to T).
+        // SAFETY: Same size/alignment guarantee as above.
+        self.values = unsafe { std::mem::take(&mut temp_builder.values).transmute() };
+
+        // Restore nulls.
+        std::mem::swap(&mut self.nulls, &mut temp_builder.nulls);
+
+        result
+    }
 }
 
 impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {

--- a/vortex-array/src/scalar_fn/erased.rs
+++ b/vortex-array/src/scalar_fn/erased.rs
@@ -15,6 +15,7 @@ use vortex_error::VortexResult;
 use vortex_utils::debug_with::DebugWith;
 
 use crate::ArrayRef;
+use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
 use crate::expr::Expression;
 use crate::expr::StatsCatalog;
@@ -106,6 +107,15 @@ impl ScalarFnRef {
                 [IsNull.new_expr(EmptyOptions, [expr.clone()])],
             )
         }))
+    }
+
+    /// Execute the expression given the input arguments.
+    pub fn append_to_builder(
+        &self,
+        ctx: ExecutionArgs,
+        builder: &mut dyn ArrayBuilder,
+    ) -> VortexResult<()> {
+        self.0.append_to_builder(ctx, builder)
     }
 
     /// Execute the expression given the input arguments.

--- a/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
@@ -92,6 +92,8 @@ impl ScalarFnVTable for FillNull {
             .with_nullability(arg_dtypes[1].nullability()))
     }
 
+    // TODO(DK): append_to_builder and then mutate in-place.
+
     fn execute(&self, _options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
         let [input, fill_value]: [ArrayRef; _] = args
             .inputs

--- a/vortex-array/src/scalar_fn/fns/get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/get_item.rs
@@ -12,6 +12,7 @@ use vortex_session::VortexSession;
 
 use crate::ArrayRef;
 use crate::arrays::StructArray;
+use crate::builders::ArrayBuilder;
 use crate::builtins::ArrayBuiltins;
 use crate::builtins::ExprBuiltins;
 use crate::dtype::DType;
@@ -103,6 +104,30 @@ impl ScalarFnVTable for GetItem {
         }
 
         Ok(field_dtype)
+    }
+
+    fn append_to_builder(
+        &self,
+        field_name: &FieldName,
+        mut args: ExecutionArgs,
+        builder: &mut dyn ArrayBuilder,
+    ) -> VortexResult<()> {
+        let input = args
+            .inputs
+            .pop()
+            .vortex_expect("missing input for GetItem expression")
+            .execute::<StructArray>(args.ctx)?;
+        let field = input.unmasked_field_by_name(field_name).cloned()?;
+
+        match input.dtype().nullability() {
+            Nullability::NonNullable => builder.extend_from_array(&field),
+            Nullability::Nullable => {
+                // TODO(DK): use extend_from_array and then mutate the validity with input.validity().
+                builder.extend_from_array(&field.mask(input.validity()?.to_array(input.len()))?)
+            }
+        }
+
+        Ok(())
     }
 
     fn execute(&self, field_name: &FieldName, mut args: ExecutionArgs) -> VortexResult<ArrayRef> {

--- a/vortex-array/src/scalar_fn/fns/mask/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/mask/mod.rs
@@ -5,6 +5,7 @@ mod kernel;
 use std::fmt::Formatter;
 
 pub use kernel::*;
+use std::ops::Not;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
@@ -18,12 +19,17 @@ use crate::arrays::BoolArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::ConstantVTable;
 use crate::arrays::mask_validity_canonical;
+use crate::builders::ArrayBuilder;
+use crate::builders::BoolBuilder;
+use crate::builders::FixedSizeListBuilder;
+use crate::builders::PrimitiveBuilder;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::expr::Expression;
 use crate::expr::and;
 use crate::expr::lit;
+use crate::match_each_native_ptype;
 use crate::scalar::Scalar;
 use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
@@ -92,6 +98,72 @@ impl ScalarFnVTable for Mask {
             arg_dtypes[1]
         );
         Ok(arg_dtypes[0].as_nullable())
+    }
+
+    fn append_to_builder(
+        &self,
+        _options: &Self::Options,
+        args: ExecutionArgs,
+        builder: &mut dyn ArrayBuilder,
+    ) -> VortexResult<()> {
+        let [input, mask_array]: [ArrayRef; _] = args
+            .inputs
+            .try_into()
+            .map_err(|_| vortex_err!("Wrong arg count"))?;
+
+        if let Some(result) = execute_constant(&input, &mask_array)? {
+            builder.extend_from_array(&result);
+            return Ok(());
+        }
+
+        let cursor = builder.len();
+        builder.extend_from_array(&input);
+
+        let mask_bool = mask_array.execute::<BoolArray>(args.ctx)?;
+        let invalidity_buffer = mask_bool.to_bit_buffer().not();
+
+        match builder.dtype() {
+            DType::Null => {}
+            DType::Bool(..) => {
+                let builder = builder
+                    .as_any_mut()
+                    .downcast_mut::<BoolBuilder>()
+                    .vortex_expect("boolbuilder");
+                let nulls = &mut builder.nulls;
+                for index in invalidity_buffer.set_indices() {
+                    nulls.set_bit(cursor + index, false);
+                }
+            }
+            DType::Primitive(ptype, ..) => {
+                match_each_native_ptype!(ptype, |T| {
+                    let builder = builder
+                        .as_any_mut()
+                        .downcast_mut::<PrimitiveBuilder<T>>()
+                        .vortex_expect("boolbuilder");
+                    let nulls = &mut builder.nulls;
+                    for index in invalidity_buffer.set_indices() {
+                        nulls.set_bit(cursor + index, false);
+                    }
+                })
+            }
+            DType::Decimal(..) => todo!(),
+            DType::Utf8(..) => todo!(),
+            DType::Binary(..) => todo!(),
+            DType::List(..) => todo!(),
+            DType::FixedSizeList(..) => {
+                let builder = builder
+                    .as_any_mut()
+                    .downcast_mut::<FixedSizeListBuilder>()
+                    .vortex_expect("boolbuilder");
+                let nulls = &mut builder.nulls;
+                for index in invalidity_buffer.set_indices() {
+                    nulls.set_bit(cursor + index, false);
+                }
+            }
+            DType::Struct(..) => todo!(),
+            DType::Extension(..) => todo!(),
+        }
+        Ok(())
     }
 
     fn execute(&self, _options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {

--- a/vortex-array/src/scalar_fn/fns/mask/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/mask/mod.rs
@@ -111,16 +111,22 @@ impl ScalarFnVTable for Mask {
             .try_into()
             .map_err(|_| vortex_err!("Wrong arg count"))?;
 
-        if let Some(result) = execute_constant(&input, &mask_array)? {
-            builder.extend_from_array(&result);
+        if let Some(constant_mask) = mask_array.as_opt::<ConstantVTable>() {
+            let mask_value = constant_mask.scalar().as_bool().value().unwrap_or(false);
+            if mask_value {
+                builder.extend_from_array(&input);
+            } else {
+                ConstantArray::new(Scalar::null(input.dtype().as_nullable()), input.len())
+                    .append_to_builder(builder, args.ctx)?;
+            };
             return Ok(());
         }
 
-        let cursor = builder.len();
-        builder.extend_from_array(&input);
-
         let mask_bool = mask_array.execute::<BoolArray>(args.ctx)?;
         let invalidity_buffer = mask_bool.to_bit_buffer().not();
+
+        let cursor = builder.len();
+        builder.extend_from_array(&input);
 
         match builder.dtype() {
             DType::Null => {}

--- a/vortex-array/src/scalar_fn/fns/mask/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/mask/mod.rs
@@ -114,7 +114,7 @@ impl ScalarFnVTable for Mask {
         if let Some(constant_mask) = mask_array.as_opt::<ConstantVTable>() {
             let mask_value = constant_mask.scalar().as_bool().value().unwrap_or(false);
             if mask_value {
-                builder.extend_from_array(&input);
+                input.append_to_builder(builder, args.ctx)?;
             } else {
                 ConstantArray::new(Scalar::null(input.dtype().as_nullable()), input.len())
                     .append_to_builder(builder, args.ctx)?;

--- a/vortex-array/src/scalar_fn/fns/pack.rs
+++ b/vortex-array/src/scalar_fn/fns/pack.rs
@@ -130,6 +130,8 @@ impl ScalarFnVTable for Pack {
         Ok(Some(lit(true)))
     }
 
+    // TODO(DK): append_to_builder: split the builder into its parts and append_to_builder each child
+
     fn execute(&self, options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
         let len = args.row_count;
         let value_arrays = args.inputs;

--- a/vortex-array/src/scalar_fn/fns/select.rs
+++ b/vortex-array/src/scalar_fn/fns/select.rs
@@ -138,6 +138,8 @@ impl ScalarFnVTable for Select {
         Ok(DType::Struct(projected, child_dtype.nullability()))
     }
 
+    // TODO(DK): append_to_builder: downcast the builder and append_to_builder each field
+
     fn execute(
         &self,
         selection: &FieldSelection,

--- a/vortex-array/src/scalar_fn/typed.rs
+++ b/vortex-array/src/scalar_fn/typed.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
 use crate::expr::Expression;
 use crate::expr::StatsCatalog;
@@ -44,6 +45,11 @@ pub(super) trait DynScalarFn: 'static + Send + Sync + super::sealed::Sealed {
     fn options_any(&self) -> &dyn Any;
 
     // Bound methods — options accessed from self
+    fn append_to_builder(
+        &self,
+        ctx: ExecutionArgs,
+        builder: &mut dyn ArrayBuilder,
+    ) -> VortexResult<()>;
     fn execute(&self, args: ExecutionArgs) -> VortexResult<ArrayRef>;
     fn return_dtype(&self, arg_types: &[DType]) -> VortexResult<DType>;
     fn reduce(
@@ -107,6 +113,47 @@ impl<V: ScalarFnVTable> DynScalarFn for ScalarFnInner<V> {
 
     fn options_any(&self) -> &dyn Any {
         &self.options
+    }
+
+    fn append_to_builder(
+        &self,
+        args: ExecutionArgs,
+        builder: &mut dyn ArrayBuilder,
+    ) -> VortexResult<()> {
+        // let expected_row_count = args.row_count;
+        // #[cfg(debug_assertions)]
+        // let expected_dtype = {
+        //     let args_dtypes: Vec<DType> = args
+        //         .inputs
+        //         .iter()
+        //         .map(|array| array.dtype().clone())
+        //         .collect();
+        //     V::return_dtype(&self.vtable, &self.options, &args_dtypes)
+        // }?;
+
+        V::append_to_builder(&self.vtable, &self.options, args, builder)?;
+
+        // assert_eq!(
+        //     result.len(),
+        //     expected_row_count,
+        //     "Expression execution {} returned vector of length {}, but expected {}",
+        //     self.vtable.id(),
+        //     result.len(),
+        //     expected_row_count,
+        // );
+
+        // #[cfg(debug_assertions)]
+        // {
+        //     vortex_error::vortex_ensure!(
+        //         result.dtype() == &expected_dtype,
+        //         "Expression execution {} returned vector of invalid dtype. Expected {}, got {}",
+        //         self.vtable.id(),
+        //         expected_dtype,
+        //         result.dtype(),
+        //     );
+        // }
+
+        Ok(())
     }
 
     fn execute(&self, args: ExecutionArgs) -> VortexResult<ArrayRef> {

--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -17,6 +17,7 @@ use vortex_session::VortexSession;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
 use crate::expr::Expression;
 use crate::expr::StatsCatalog;
@@ -80,6 +81,16 @@ pub trait ScalarFnVTable: 'static + Sized + Clone + Send + Sync {
 
     /// Compute the return [`DType`] of the expression if evaluated over the given input types.
     fn return_dtype(&self, options: &Self::Options, arg_dtypes: &[DType]) -> VortexResult<DType>;
+
+    fn append_to_builder(
+        &self,
+        options: &Self::Options,
+        args: ExecutionArgs,
+        builder: &mut dyn ArrayBuilder,
+    ) -> VortexResult<()> {
+        self.execute(options, args)
+            .map(|a| builder.extend_from_array(&a))
+    }
 
     /// Execute the expression over the input arguments.
     ///


### PR DESCRIPTION
The PrimitiveBuilder API is a bit awkward for this. I needed two key things:

1. I want to treat a trailing slice of the builder's values as a different type. In particular, ALPRD decodes u32s (respectively u64s) and then converts them to f32s (resp. f64s).

2. I want to separately update the nulls and the values. In particular, ALPRD stores the nulls on the left parts whereas the right parts hold the values.

All of this is copacetic *when done on the UninitRange*, but I do it on the whole PrimitiveBuilder. I kinda think PrimitiveBuilder should be able to split itself into the initialized and uninitialized parts. In my opinion, it seems reasonable to transmute the builder of uninitialized parts since no one else is looking at that data anyway.
