### PR TITLE
chore: exclude cuda gen files from auto-formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,7 @@ jobs:
         run: |
           git ls-files vortex-cuda vortex-cxx vortex-duckdb vortex-ffi \
             | grep -E '\.(cpp|hpp|cu|cuh|h)$' \
+            | grep -v 'kernels/src/bit_unpack_.*\.cu$' \
             | xargs clang-format --dry-run --Werror --style=file
 
   rust-lint-no-default:

--- a/vortex-cuda/build.rs
+++ b/vortex-cuda/build.rs
@@ -49,25 +49,10 @@ fn main() {
     {
         println!("cargo:rerun-if-changed={}", entry.path().display());
     }
-    let unpack_files = [
-        generate_unpack::<u8>(&kernels_src, 32).expect("Failed to generate unpack for u8"),
-        generate_unpack::<u16>(&kernels_src, 32).expect("Failed to generate unpack for u16"),
-        generate_unpack::<u32>(&kernels_src, 32).expect("Failed to generate unpack for u32"),
-        generate_unpack::<u64>(&kernels_src, 16).expect("Failed to generate unpack for u64"),
-    ];
-    // Run clang-format on the generated files.
-    if let Ok(status) = Command::new("clang-format")
-        .arg("-i")
-        .arg("--style=file")
-        .args(&unpack_files)
-        .status()
-    {
-        if !status.success() {
-            println!("cargo:warning=clang-format exited with status {status}");
-        }
-    } else {
-        println!("cargo:warning=clang-format not found, skipping formatting of generated files");
-    }
+    generate_unpack::<u8>(&kernels_src, 32).expect("Failed to generate unpack for u8");
+    generate_unpack::<u16>(&kernels_src, 32).expect("Failed to generate unpack for u16");
+    generate_unpack::<u32>(&kernels_src, 32).expect("Failed to generate unpack for u32");
+    generate_unpack::<u64>(&kernels_src, 16).expect("Failed to generate unpack for u64");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
     generate_dynamic_dispatch_bindings(&kernels_src, &out_dir);

--- a/vortex-cuda/kernels/src/bit_unpack_16.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_16.cu
@@ -4,12 +4,9 @@
 #include <stdint.h>
 #include "fastlanes_common.cuh"
 
-__device__ void _bit_unpack_16_0bw_lane(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_16_0bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
-
+    
     out[INDEX(0, lane)] = reference;
     out[INDEX(1, lane)] = reference;
     out[INDEX(2, lane)] = reference;
@@ -28,14 +25,11 @@ __device__ void _bit_unpack_16_0bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = reference;
 }
 
-__device__ void _bit_unpack_16_1bw_lane(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_16_1bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 1);
     out[INDEX(0, lane)] = tmp + reference;
@@ -71,14 +65,11 @@ __device__ void _bit_unpack_16_1bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_2bw_lane(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_16_2bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 2);
     out[INDEX(0, lane)] = tmp + reference;
@@ -116,14 +107,11 @@ __device__ void _bit_unpack_16_2bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_3bw_lane(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_16_3bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 3);
     out[INDEX(0, lane)] = tmp + reference;
@@ -163,14 +151,11 @@ __device__ void _bit_unpack_16_3bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_4bw_lane(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_16_4bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 4);
     out[INDEX(0, lane)] = tmp + reference;
@@ -212,14 +197,11 @@ __device__ void _bit_unpack_16_4bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_5bw_lane(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_16_5bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 5);
     out[INDEX(0, lane)] = tmp + reference;
@@ -263,14 +245,11 @@ __device__ void _bit_unpack_16_5bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_6bw_lane(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_16_6bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 6);
     out[INDEX(0, lane)] = tmp + reference;
@@ -316,14 +295,11 @@ __device__ void _bit_unpack_16_6bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_7bw_lane(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_16_7bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 7);
     out[INDEX(0, lane)] = tmp + reference;
@@ -371,14 +347,11 @@ __device__ void _bit_unpack_16_7bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_8bw_lane(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_16_8bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 8);
     out[INDEX(0, lane)] = tmp + reference;
@@ -428,14 +401,11 @@ __device__ void _bit_unpack_16_8bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_9bw_lane(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_16_9bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 9);
     out[INDEX(0, lane)] = tmp + reference;
@@ -487,14 +457,11 @@ __device__ void _bit_unpack_16_9bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_10bw_lane(const uint16_t *__restrict in,
-                                         uint16_t *__restrict out,
-                                         uint16_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_16_10bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 10);
     out[INDEX(0, lane)] = tmp + reference;
@@ -548,14 +515,11 @@ __device__ void _bit_unpack_16_10bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_11bw_lane(const uint16_t *__restrict in,
-                                         uint16_t *__restrict out,
-                                         uint16_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_16_11bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 11);
     out[INDEX(0, lane)] = tmp + reference;
@@ -611,14 +575,11 @@ __device__ void _bit_unpack_16_11bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_12bw_lane(const uint16_t *__restrict in,
-                                         uint16_t *__restrict out,
-                                         uint16_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_16_12bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 12);
     out[INDEX(0, lane)] = tmp + reference;
@@ -676,14 +637,11 @@ __device__ void _bit_unpack_16_12bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_13bw_lane(const uint16_t *__restrict in,
-                                         uint16_t *__restrict out,
-                                         uint16_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_16_13bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 13);
     out[INDEX(0, lane)] = tmp + reference;
@@ -743,14 +701,11 @@ __device__ void _bit_unpack_16_13bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_14bw_lane(const uint16_t *__restrict in,
-                                         uint16_t *__restrict out,
-                                         uint16_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_16_14bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 14);
     out[INDEX(0, lane)] = tmp + reference;
@@ -812,14 +767,11 @@ __device__ void _bit_unpack_16_14bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_15bw_lane(const uint16_t *__restrict in,
-                                         uint16_t *__restrict out,
-                                         uint16_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_16_15bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
     uint16_t src;
     uint16_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint16_t, 15);
     out[INDEX(0, lane)] = tmp + reference;
@@ -883,12 +835,9 @@ __device__ void _bit_unpack_16_15bw_lane(const uint16_t *__restrict in,
     out[INDEX(15, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_16_16bw_lane(const uint16_t *__restrict in,
-                                         uint16_t *__restrict out,
-                                         uint16_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_16_16bw_lane(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 64;
-
+    
     out[INDEX(0, lane)] = in[LANE_COUNT * 0 + lane] + reference;
     out[INDEX(1, lane)] = in[LANE_COUNT * 1 + lane] + reference;
     out[INDEX(2, lane)] = in[LANE_COUNT * 2 + lane] + reference;
@@ -908,70 +857,35 @@ __device__ void _bit_unpack_16_16bw_lane(const uint16_t *__restrict in,
 }
 
 /// Runtime dispatch to the optimized lane decoder for the given bit width.
-__device__ inline void bit_unpack_16_lane(const uint16_t *__restrict in,
-                                          uint16_t *__restrict out,
-                                          uint16_t reference,
-                                          unsigned int lane,
-                                          uint32_t bit_width) {
+__device__ inline void bit_unpack_16_lane(
+    const uint16_t *__restrict in,
+    uint16_t *__restrict out,
+    uint16_t reference,
+    unsigned int lane,
+    uint32_t bit_width
+) {
     switch (bit_width) {
-    case 0:
-        _bit_unpack_16_0bw_lane(in, out, reference, lane);
-        break;
-    case 1:
-        _bit_unpack_16_1bw_lane(in, out, reference, lane);
-        break;
-    case 2:
-        _bit_unpack_16_2bw_lane(in, out, reference, lane);
-        break;
-    case 3:
-        _bit_unpack_16_3bw_lane(in, out, reference, lane);
-        break;
-    case 4:
-        _bit_unpack_16_4bw_lane(in, out, reference, lane);
-        break;
-    case 5:
-        _bit_unpack_16_5bw_lane(in, out, reference, lane);
-        break;
-    case 6:
-        _bit_unpack_16_6bw_lane(in, out, reference, lane);
-        break;
-    case 7:
-        _bit_unpack_16_7bw_lane(in, out, reference, lane);
-        break;
-    case 8:
-        _bit_unpack_16_8bw_lane(in, out, reference, lane);
-        break;
-    case 9:
-        _bit_unpack_16_9bw_lane(in, out, reference, lane);
-        break;
-    case 10:
-        _bit_unpack_16_10bw_lane(in, out, reference, lane);
-        break;
-    case 11:
-        _bit_unpack_16_11bw_lane(in, out, reference, lane);
-        break;
-    case 12:
-        _bit_unpack_16_12bw_lane(in, out, reference, lane);
-        break;
-    case 13:
-        _bit_unpack_16_13bw_lane(in, out, reference, lane);
-        break;
-    case 14:
-        _bit_unpack_16_14bw_lane(in, out, reference, lane);
-        break;
-    case 15:
-        _bit_unpack_16_15bw_lane(in, out, reference, lane);
-        break;
-    case 16:
-        _bit_unpack_16_16bw_lane(in, out, reference, lane);
-        break;
+        case 0: _bit_unpack_16_0bw_lane(in, out, reference, lane); break;
+        case 1: _bit_unpack_16_1bw_lane(in, out, reference, lane); break;
+        case 2: _bit_unpack_16_2bw_lane(in, out, reference, lane); break;
+        case 3: _bit_unpack_16_3bw_lane(in, out, reference, lane); break;
+        case 4: _bit_unpack_16_4bw_lane(in, out, reference, lane); break;
+        case 5: _bit_unpack_16_5bw_lane(in, out, reference, lane); break;
+        case 6: _bit_unpack_16_6bw_lane(in, out, reference, lane); break;
+        case 7: _bit_unpack_16_7bw_lane(in, out, reference, lane); break;
+        case 8: _bit_unpack_16_8bw_lane(in, out, reference, lane); break;
+        case 9: _bit_unpack_16_9bw_lane(in, out, reference, lane); break;
+        case 10: _bit_unpack_16_10bw_lane(in, out, reference, lane); break;
+        case 11: _bit_unpack_16_11bw_lane(in, out, reference, lane); break;
+        case 12: _bit_unpack_16_12bw_lane(in, out, reference, lane); break;
+        case 13: _bit_unpack_16_13bw_lane(in, out, reference, lane); break;
+        case 14: _bit_unpack_16_14bw_lane(in, out, reference, lane); break;
+        case 15: _bit_unpack_16_15bw_lane(in, out, reference, lane); break;
+        case 16: _bit_unpack_16_16bw_lane(in, out, reference, lane); break;
     }
 }
 
-__device__ void _bit_unpack_16_0bw_32t(const uint16_t *__restrict in,
-                                       uint16_t *__restrict out,
-                                       uint16_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_16_0bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_0bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_0bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -981,18 +895,14 @@ __device__ void _bit_unpack_16_0bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_16_0bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_0bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 0 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_0bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_1bw_32t(const uint16_t *__restrict in,
-                                       uint16_t *__restrict out,
-                                       uint16_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_16_1bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_1bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_1bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1002,18 +912,14 @@ __device__ void _bit_unpack_16_1bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_16_1bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_1bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 1 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_1bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_2bw_32t(const uint16_t *__restrict in,
-                                       uint16_t *__restrict out,
-                                       uint16_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_16_2bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_2bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_2bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1023,18 +929,14 @@ __device__ void _bit_unpack_16_2bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_16_2bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_2bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 2 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_2bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_3bw_32t(const uint16_t *__restrict in,
-                                       uint16_t *__restrict out,
-                                       uint16_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_16_3bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_3bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_3bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1044,18 +946,14 @@ __device__ void _bit_unpack_16_3bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_16_3bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_3bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 3 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_3bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_4bw_32t(const uint16_t *__restrict in,
-                                       uint16_t *__restrict out,
-                                       uint16_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_16_4bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_4bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_4bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1065,18 +963,14 @@ __device__ void _bit_unpack_16_4bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_16_4bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_4bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 4 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_4bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_5bw_32t(const uint16_t *__restrict in,
-                                       uint16_t *__restrict out,
-                                       uint16_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_16_5bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_5bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_5bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1086,18 +980,14 @@ __device__ void _bit_unpack_16_5bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_16_5bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_5bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 5 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_5bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_6bw_32t(const uint16_t *__restrict in,
-                                       uint16_t *__restrict out,
-                                       uint16_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_16_6bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_6bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_6bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1107,18 +997,14 @@ __device__ void _bit_unpack_16_6bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_16_6bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_6bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 6 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_6bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_7bw_32t(const uint16_t *__restrict in,
-                                       uint16_t *__restrict out,
-                                       uint16_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_16_7bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_7bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_7bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1128,18 +1014,14 @@ __device__ void _bit_unpack_16_7bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_16_7bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_7bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 7 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_7bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_8bw_32t(const uint16_t *__restrict in,
-                                       uint16_t *__restrict out,
-                                       uint16_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_16_8bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_8bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_8bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1149,18 +1031,14 @@ __device__ void _bit_unpack_16_8bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_16_8bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_8bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 8 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_8bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_9bw_32t(const uint16_t *__restrict in,
-                                       uint16_t *__restrict out,
-                                       uint16_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_16_9bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_9bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_9bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1170,18 +1048,14 @@ __device__ void _bit_unpack_16_9bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_16_9bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_9bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 9 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_9bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_10bw_32t(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_16_10bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_10bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_10bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1191,19 +1065,14 @@ __device__ void _bit_unpack_16_10bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_16_10bw_32t(const uint16_t *__restrict full_in,
-                                                  uint16_t *__restrict full_out,
-                                                  uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_10bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 10 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_10bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_11bw_32t(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_16_11bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_11bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_11bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1213,19 +1082,14 @@ __device__ void _bit_unpack_16_11bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_16_11bw_32t(const uint16_t *__restrict full_in,
-                                                  uint16_t *__restrict full_out,
-                                                  uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_11bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 11 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_11bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_12bw_32t(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_16_12bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_12bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_12bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1235,19 +1099,14 @@ __device__ void _bit_unpack_16_12bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_16_12bw_32t(const uint16_t *__restrict full_in,
-                                                  uint16_t *__restrict full_out,
-                                                  uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_12bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 12 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_12bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_13bw_32t(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_16_13bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_13bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_13bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1257,19 +1116,14 @@ __device__ void _bit_unpack_16_13bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_16_13bw_32t(const uint16_t *__restrict full_in,
-                                                  uint16_t *__restrict full_out,
-                                                  uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_13bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 13 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_13bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_14bw_32t(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_16_14bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_14bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_14bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1279,19 +1133,14 @@ __device__ void _bit_unpack_16_14bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_16_14bw_32t(const uint16_t *__restrict full_in,
-                                                  uint16_t *__restrict full_out,
-                                                  uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_14bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 14 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_14bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_15bw_32t(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_16_15bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_15bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_15bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1301,19 +1150,14 @@ __device__ void _bit_unpack_16_15bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_16_15bw_32t(const uint16_t *__restrict full_in,
-                                                  uint16_t *__restrict full_out,
-                                                  uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_15bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 15 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_15bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_16_16bw_32t(const uint16_t *__restrict in,
-                                        uint16_t *__restrict out,
-                                        uint16_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_16_16bw_32t(const uint16_t *__restrict in, uint16_t *__restrict out, uint16_t reference, int thread_idx) {
     __shared__ uint16_t shared_out[1024];
     _bit_unpack_16_16bw_lane(in, shared_out, reference, thread_idx * 2 + 0);
     _bit_unpack_16_16bw_lane(in, shared_out, reference, thread_idx * 2 + 1);
@@ -1323,11 +1167,10 @@ __device__ void _bit_unpack_16_16bw_32t(const uint16_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_16_16bw_32t(const uint16_t *__restrict full_in,
-                                                  uint16_t *__restrict full_out,
-                                                  uint16_t reference) {
+extern "C" __global__ void bit_unpack_16_16bw_32t(const uint16_t *__restrict full_in, uint16_t *__restrict full_out, uint16_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 16 / sizeof(uint16_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_16_16bw_32t(in, out, reference, thread_idx);
 }
+

--- a/vortex-cuda/kernels/src/bit_unpack_32.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_32.cu
@@ -4,12 +4,9 @@
 #include <stdint.h>
 #include "fastlanes_common.cuh"
 
-__device__ void _bit_unpack_32_0bw_lane(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_32_0bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
-
+    
     out[INDEX(0, lane)] = reference;
     out[INDEX(1, lane)] = reference;
     out[INDEX(2, lane)] = reference;
@@ -44,14 +41,11 @@ __device__ void _bit_unpack_32_0bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = reference;
 }
 
-__device__ void _bit_unpack_32_1bw_lane(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_32_1bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 1);
     out[INDEX(0, lane)] = tmp + reference;
@@ -119,14 +113,11 @@ __device__ void _bit_unpack_32_1bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_2bw_lane(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_32_2bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 2);
     out[INDEX(0, lane)] = tmp + reference;
@@ -196,14 +187,11 @@ __device__ void _bit_unpack_32_2bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_3bw_lane(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_32_3bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 3);
     out[INDEX(0, lane)] = tmp + reference;
@@ -275,14 +263,11 @@ __device__ void _bit_unpack_32_3bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_4bw_lane(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_32_4bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 4);
     out[INDEX(0, lane)] = tmp + reference;
@@ -356,14 +341,11 @@ __device__ void _bit_unpack_32_4bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_5bw_lane(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_32_5bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 5);
     out[INDEX(0, lane)] = tmp + reference;
@@ -439,14 +421,11 @@ __device__ void _bit_unpack_32_5bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_6bw_lane(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_32_6bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 6);
     out[INDEX(0, lane)] = tmp + reference;
@@ -524,14 +503,11 @@ __device__ void _bit_unpack_32_6bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_7bw_lane(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_32_7bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 7);
     out[INDEX(0, lane)] = tmp + reference;
@@ -611,14 +587,11 @@ __device__ void _bit_unpack_32_7bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_8bw_lane(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_32_8bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 8);
     out[INDEX(0, lane)] = tmp + reference;
@@ -700,14 +673,11 @@ __device__ void _bit_unpack_32_8bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_9bw_lane(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_32_9bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 9);
     out[INDEX(0, lane)] = tmp + reference;
@@ -791,14 +761,11 @@ __device__ void _bit_unpack_32_9bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_10bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_10bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 10);
     out[INDEX(0, lane)] = tmp + reference;
@@ -884,14 +851,11 @@ __device__ void _bit_unpack_32_10bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_11bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_11bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 11);
     out[INDEX(0, lane)] = tmp + reference;
@@ -979,14 +943,11 @@ __device__ void _bit_unpack_32_11bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_12bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_12bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 12);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1076,14 +1037,11 @@ __device__ void _bit_unpack_32_12bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_13bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_13bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 13);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1175,14 +1133,11 @@ __device__ void _bit_unpack_32_13bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_14bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_14bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 14);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1276,14 +1231,11 @@ __device__ void _bit_unpack_32_14bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_15bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_15bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 15);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1379,14 +1331,11 @@ __device__ void _bit_unpack_32_15bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_16bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_16bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 16);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1484,14 +1433,11 @@ __device__ void _bit_unpack_32_16bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_17bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_17bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 17);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1591,14 +1537,11 @@ __device__ void _bit_unpack_32_17bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_18bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_18bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 18);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1700,14 +1643,11 @@ __device__ void _bit_unpack_32_18bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_19bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_19bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 19);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1811,14 +1751,11 @@ __device__ void _bit_unpack_32_19bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_20bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_20bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 20);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1924,14 +1861,11 @@ __device__ void _bit_unpack_32_20bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_21bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_21bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 21);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2039,14 +1973,11 @@ __device__ void _bit_unpack_32_21bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_22bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_22bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 22);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2156,14 +2087,11 @@ __device__ void _bit_unpack_32_22bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_23bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_23bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 23);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2275,14 +2203,11 @@ __device__ void _bit_unpack_32_23bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_24bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_24bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 24);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2396,14 +2321,11 @@ __device__ void _bit_unpack_32_24bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_25bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_25bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 25);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2519,14 +2441,11 @@ __device__ void _bit_unpack_32_25bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_26bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_26bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 26);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2644,14 +2563,11 @@ __device__ void _bit_unpack_32_26bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_27bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_27bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 27);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2771,14 +2687,11 @@ __device__ void _bit_unpack_32_27bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_28bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_28bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 28);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2900,14 +2813,11 @@ __device__ void _bit_unpack_32_28bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_29bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_29bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 29);
     out[INDEX(0, lane)] = tmp + reference;
@@ -3031,14 +2941,11 @@ __device__ void _bit_unpack_32_29bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_30bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_30bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 30);
     out[INDEX(0, lane)] = tmp + reference;
@@ -3164,14 +3071,11 @@ __device__ void _bit_unpack_32_30bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_31bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_31bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
     uint32_t src;
     uint32_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint32_t, 31);
     out[INDEX(0, lane)] = tmp + reference;
@@ -3299,12 +3203,9 @@ __device__ void _bit_unpack_32_31bw_lane(const uint32_t *__restrict in,
     out[INDEX(31, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_32_32bw_lane(const uint32_t *__restrict in,
-                                         uint32_t *__restrict out,
-                                         uint32_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_32_32bw_lane(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 32;
-
+    
     out[INDEX(0, lane)] = in[LANE_COUNT * 0 + lane] + reference;
     out[INDEX(1, lane)] = in[LANE_COUNT * 1 + lane] + reference;
     out[INDEX(2, lane)] = in[LANE_COUNT * 2 + lane] + reference;
@@ -3340,118 +3241,51 @@ __device__ void _bit_unpack_32_32bw_lane(const uint32_t *__restrict in,
 }
 
 /// Runtime dispatch to the optimized lane decoder for the given bit width.
-__device__ inline void bit_unpack_32_lane(const uint32_t *__restrict in,
-                                          uint32_t *__restrict out,
-                                          uint32_t reference,
-                                          unsigned int lane,
-                                          uint32_t bit_width) {
+__device__ inline void bit_unpack_32_lane(
+    const uint32_t *__restrict in,
+    uint32_t *__restrict out,
+    uint32_t reference,
+    unsigned int lane,
+    uint32_t bit_width
+) {
     switch (bit_width) {
-    case 0:
-        _bit_unpack_32_0bw_lane(in, out, reference, lane);
-        break;
-    case 1:
-        _bit_unpack_32_1bw_lane(in, out, reference, lane);
-        break;
-    case 2:
-        _bit_unpack_32_2bw_lane(in, out, reference, lane);
-        break;
-    case 3:
-        _bit_unpack_32_3bw_lane(in, out, reference, lane);
-        break;
-    case 4:
-        _bit_unpack_32_4bw_lane(in, out, reference, lane);
-        break;
-    case 5:
-        _bit_unpack_32_5bw_lane(in, out, reference, lane);
-        break;
-    case 6:
-        _bit_unpack_32_6bw_lane(in, out, reference, lane);
-        break;
-    case 7:
-        _bit_unpack_32_7bw_lane(in, out, reference, lane);
-        break;
-    case 8:
-        _bit_unpack_32_8bw_lane(in, out, reference, lane);
-        break;
-    case 9:
-        _bit_unpack_32_9bw_lane(in, out, reference, lane);
-        break;
-    case 10:
-        _bit_unpack_32_10bw_lane(in, out, reference, lane);
-        break;
-    case 11:
-        _bit_unpack_32_11bw_lane(in, out, reference, lane);
-        break;
-    case 12:
-        _bit_unpack_32_12bw_lane(in, out, reference, lane);
-        break;
-    case 13:
-        _bit_unpack_32_13bw_lane(in, out, reference, lane);
-        break;
-    case 14:
-        _bit_unpack_32_14bw_lane(in, out, reference, lane);
-        break;
-    case 15:
-        _bit_unpack_32_15bw_lane(in, out, reference, lane);
-        break;
-    case 16:
-        _bit_unpack_32_16bw_lane(in, out, reference, lane);
-        break;
-    case 17:
-        _bit_unpack_32_17bw_lane(in, out, reference, lane);
-        break;
-    case 18:
-        _bit_unpack_32_18bw_lane(in, out, reference, lane);
-        break;
-    case 19:
-        _bit_unpack_32_19bw_lane(in, out, reference, lane);
-        break;
-    case 20:
-        _bit_unpack_32_20bw_lane(in, out, reference, lane);
-        break;
-    case 21:
-        _bit_unpack_32_21bw_lane(in, out, reference, lane);
-        break;
-    case 22:
-        _bit_unpack_32_22bw_lane(in, out, reference, lane);
-        break;
-    case 23:
-        _bit_unpack_32_23bw_lane(in, out, reference, lane);
-        break;
-    case 24:
-        _bit_unpack_32_24bw_lane(in, out, reference, lane);
-        break;
-    case 25:
-        _bit_unpack_32_25bw_lane(in, out, reference, lane);
-        break;
-    case 26:
-        _bit_unpack_32_26bw_lane(in, out, reference, lane);
-        break;
-    case 27:
-        _bit_unpack_32_27bw_lane(in, out, reference, lane);
-        break;
-    case 28:
-        _bit_unpack_32_28bw_lane(in, out, reference, lane);
-        break;
-    case 29:
-        _bit_unpack_32_29bw_lane(in, out, reference, lane);
-        break;
-    case 30:
-        _bit_unpack_32_30bw_lane(in, out, reference, lane);
-        break;
-    case 31:
-        _bit_unpack_32_31bw_lane(in, out, reference, lane);
-        break;
-    case 32:
-        _bit_unpack_32_32bw_lane(in, out, reference, lane);
-        break;
+        case 0: _bit_unpack_32_0bw_lane(in, out, reference, lane); break;
+        case 1: _bit_unpack_32_1bw_lane(in, out, reference, lane); break;
+        case 2: _bit_unpack_32_2bw_lane(in, out, reference, lane); break;
+        case 3: _bit_unpack_32_3bw_lane(in, out, reference, lane); break;
+        case 4: _bit_unpack_32_4bw_lane(in, out, reference, lane); break;
+        case 5: _bit_unpack_32_5bw_lane(in, out, reference, lane); break;
+        case 6: _bit_unpack_32_6bw_lane(in, out, reference, lane); break;
+        case 7: _bit_unpack_32_7bw_lane(in, out, reference, lane); break;
+        case 8: _bit_unpack_32_8bw_lane(in, out, reference, lane); break;
+        case 9: _bit_unpack_32_9bw_lane(in, out, reference, lane); break;
+        case 10: _bit_unpack_32_10bw_lane(in, out, reference, lane); break;
+        case 11: _bit_unpack_32_11bw_lane(in, out, reference, lane); break;
+        case 12: _bit_unpack_32_12bw_lane(in, out, reference, lane); break;
+        case 13: _bit_unpack_32_13bw_lane(in, out, reference, lane); break;
+        case 14: _bit_unpack_32_14bw_lane(in, out, reference, lane); break;
+        case 15: _bit_unpack_32_15bw_lane(in, out, reference, lane); break;
+        case 16: _bit_unpack_32_16bw_lane(in, out, reference, lane); break;
+        case 17: _bit_unpack_32_17bw_lane(in, out, reference, lane); break;
+        case 18: _bit_unpack_32_18bw_lane(in, out, reference, lane); break;
+        case 19: _bit_unpack_32_19bw_lane(in, out, reference, lane); break;
+        case 20: _bit_unpack_32_20bw_lane(in, out, reference, lane); break;
+        case 21: _bit_unpack_32_21bw_lane(in, out, reference, lane); break;
+        case 22: _bit_unpack_32_22bw_lane(in, out, reference, lane); break;
+        case 23: _bit_unpack_32_23bw_lane(in, out, reference, lane); break;
+        case 24: _bit_unpack_32_24bw_lane(in, out, reference, lane); break;
+        case 25: _bit_unpack_32_25bw_lane(in, out, reference, lane); break;
+        case 26: _bit_unpack_32_26bw_lane(in, out, reference, lane); break;
+        case 27: _bit_unpack_32_27bw_lane(in, out, reference, lane); break;
+        case 28: _bit_unpack_32_28bw_lane(in, out, reference, lane); break;
+        case 29: _bit_unpack_32_29bw_lane(in, out, reference, lane); break;
+        case 30: _bit_unpack_32_30bw_lane(in, out, reference, lane); break;
+        case 31: _bit_unpack_32_31bw_lane(in, out, reference, lane); break;
+        case 32: _bit_unpack_32_32bw_lane(in, out, reference, lane); break;
     }
 }
 
-__device__ void _bit_unpack_32_0bw_32t(const uint32_t *__restrict in,
-                                       uint32_t *__restrict out,
-                                       uint32_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_32_0bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_0bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3460,18 +3294,14 @@ __device__ void _bit_unpack_32_0bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_32_0bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_0bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 0 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_0bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_1bw_32t(const uint32_t *__restrict in,
-                                       uint32_t *__restrict out,
-                                       uint32_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_32_1bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_1bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3480,18 +3310,14 @@ __device__ void _bit_unpack_32_1bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_32_1bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_1bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 1 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_1bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_2bw_32t(const uint32_t *__restrict in,
-                                       uint32_t *__restrict out,
-                                       uint32_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_32_2bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_2bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3500,18 +3326,14 @@ __device__ void _bit_unpack_32_2bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_32_2bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_2bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 2 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_2bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_3bw_32t(const uint32_t *__restrict in,
-                                       uint32_t *__restrict out,
-                                       uint32_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_32_3bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_3bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3520,18 +3342,14 @@ __device__ void _bit_unpack_32_3bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_32_3bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_3bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 3 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_3bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_4bw_32t(const uint32_t *__restrict in,
-                                       uint32_t *__restrict out,
-                                       uint32_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_32_4bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_4bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3540,18 +3358,14 @@ __device__ void _bit_unpack_32_4bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_32_4bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_4bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 4 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_4bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_5bw_32t(const uint32_t *__restrict in,
-                                       uint32_t *__restrict out,
-                                       uint32_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_32_5bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_5bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3560,18 +3374,14 @@ __device__ void _bit_unpack_32_5bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_32_5bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_5bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 5 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_5bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_6bw_32t(const uint32_t *__restrict in,
-                                       uint32_t *__restrict out,
-                                       uint32_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_32_6bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_6bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3580,18 +3390,14 @@ __device__ void _bit_unpack_32_6bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_32_6bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_6bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 6 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_6bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_7bw_32t(const uint32_t *__restrict in,
-                                       uint32_t *__restrict out,
-                                       uint32_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_32_7bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_7bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3600,18 +3406,14 @@ __device__ void _bit_unpack_32_7bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_32_7bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_7bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 7 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_7bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_8bw_32t(const uint32_t *__restrict in,
-                                       uint32_t *__restrict out,
-                                       uint32_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_32_8bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_8bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3620,18 +3422,14 @@ __device__ void _bit_unpack_32_8bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_32_8bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_8bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 8 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_8bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_9bw_32t(const uint32_t *__restrict in,
-                                       uint32_t *__restrict out,
-                                       uint32_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_32_9bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_9bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3640,18 +3438,14 @@ __device__ void _bit_unpack_32_9bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_32_9bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_9bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 9 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_9bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_10bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_10bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_10bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3660,19 +3454,14 @@ __device__ void _bit_unpack_32_10bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_10bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_10bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 10 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_10bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_11bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_11bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_11bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3681,19 +3470,14 @@ __device__ void _bit_unpack_32_11bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_11bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_11bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 11 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_11bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_12bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_12bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_12bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3702,19 +3486,14 @@ __device__ void _bit_unpack_32_12bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_12bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_12bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 12 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_12bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_13bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_13bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_13bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3723,19 +3502,14 @@ __device__ void _bit_unpack_32_13bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_13bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_13bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 13 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_13bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_14bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_14bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_14bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3744,19 +3518,14 @@ __device__ void _bit_unpack_32_14bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_14bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_14bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 14 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_14bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_15bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_15bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_15bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3765,19 +3534,14 @@ __device__ void _bit_unpack_32_15bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_15bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_15bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 15 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_15bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_16bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_16bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_16bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3786,19 +3550,14 @@ __device__ void _bit_unpack_32_16bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_16bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_16bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 16 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_16bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_17bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_17bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_17bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3807,19 +3566,14 @@ __device__ void _bit_unpack_32_17bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_17bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_17bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 17 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_17bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_18bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_18bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_18bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3828,19 +3582,14 @@ __device__ void _bit_unpack_32_18bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_18bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_18bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 18 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_18bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_19bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_19bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_19bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3849,19 +3598,14 @@ __device__ void _bit_unpack_32_19bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_19bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_19bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 19 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_19bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_20bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_20bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_20bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3870,19 +3614,14 @@ __device__ void _bit_unpack_32_20bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_20bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_20bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 20 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_20bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_21bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_21bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_21bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3891,19 +3630,14 @@ __device__ void _bit_unpack_32_21bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_21bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_21bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 21 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_21bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_22bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_22bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_22bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3912,19 +3646,14 @@ __device__ void _bit_unpack_32_22bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_22bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_22bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 22 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_22bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_23bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_23bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_23bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3933,19 +3662,14 @@ __device__ void _bit_unpack_32_23bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_23bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_23bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 23 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_23bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_24bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_24bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_24bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3954,19 +3678,14 @@ __device__ void _bit_unpack_32_24bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_24bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_24bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 24 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_24bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_25bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_25bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_25bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3975,19 +3694,14 @@ __device__ void _bit_unpack_32_25bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_25bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_25bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 25 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_25bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_26bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_26bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_26bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -3996,19 +3710,14 @@ __device__ void _bit_unpack_32_26bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_26bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_26bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 26 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_26bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_27bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_27bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_27bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -4017,19 +3726,14 @@ __device__ void _bit_unpack_32_27bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_27bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_27bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 27 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_27bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_28bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_28bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_28bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -4038,19 +3742,14 @@ __device__ void _bit_unpack_32_28bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_28bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_28bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 28 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_28bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_29bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_29bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_29bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -4059,19 +3758,14 @@ __device__ void _bit_unpack_32_29bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_29bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_29bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 29 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_29bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_30bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_30bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_30bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -4080,19 +3774,14 @@ __device__ void _bit_unpack_32_30bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_30bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_30bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 30 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_30bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_31bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_31bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_31bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -4101,19 +3790,14 @@ __device__ void _bit_unpack_32_31bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_31bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_31bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 31 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_31bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_32_32bw_32t(const uint32_t *__restrict in,
-                                        uint32_t *__restrict out,
-                                        uint32_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_32_32bw_32t(const uint32_t *__restrict in, uint32_t *__restrict out, uint32_t reference, int thread_idx) {
     __shared__ uint32_t shared_out[1024];
     _bit_unpack_32_32bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 32; i++) {
@@ -4122,11 +3806,10 @@ __device__ void _bit_unpack_32_32bw_32t(const uint32_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_32_32bw_32t(const uint32_t *__restrict full_in,
-                                                  uint32_t *__restrict full_out,
-                                                  uint32_t reference) {
+extern "C" __global__ void bit_unpack_32_32bw_32t(const uint32_t *__restrict full_in, uint32_t *__restrict full_out, uint32_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 32 / sizeof(uint32_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_32_32bw_32t(in, out, reference, thread_idx);
 }
+

--- a/vortex-cuda/kernels/src/bit_unpack_64.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_64.cu
@@ -4,12 +4,9 @@
 #include <stdint.h>
 #include "fastlanes_common.cuh"
 
-__device__ void _bit_unpack_64_0bw_lane(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_64_0bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
-
+    
     out[INDEX(0, lane)] = reference;
     out[INDEX(1, lane)] = reference;
     out[INDEX(2, lane)] = reference;
@@ -76,14 +73,11 @@ __device__ void _bit_unpack_64_0bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = reference;
 }
 
-__device__ void _bit_unpack_64_1bw_lane(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_64_1bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 1);
     out[INDEX(0, lane)] = tmp + reference;
@@ -215,14 +209,11 @@ __device__ void _bit_unpack_64_1bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_2bw_lane(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_64_2bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 2);
     out[INDEX(0, lane)] = tmp + reference;
@@ -356,14 +347,11 @@ __device__ void _bit_unpack_64_2bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_3bw_lane(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_64_3bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 3);
     out[INDEX(0, lane)] = tmp + reference;
@@ -499,14 +487,11 @@ __device__ void _bit_unpack_64_3bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_4bw_lane(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_64_4bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 4);
     out[INDEX(0, lane)] = tmp + reference;
@@ -644,14 +629,11 @@ __device__ void _bit_unpack_64_4bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_5bw_lane(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_64_5bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 5);
     out[INDEX(0, lane)] = tmp + reference;
@@ -791,14 +773,11 @@ __device__ void _bit_unpack_64_5bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_6bw_lane(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_64_6bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 6);
     out[INDEX(0, lane)] = tmp + reference;
@@ -940,14 +919,11 @@ __device__ void _bit_unpack_64_6bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_7bw_lane(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_64_7bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 7);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1091,14 +1067,11 @@ __device__ void _bit_unpack_64_7bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_8bw_lane(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_64_8bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 8);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1244,14 +1217,11 @@ __device__ void _bit_unpack_64_8bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_9bw_lane(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        unsigned int lane) {
+__device__ void _bit_unpack_64_9bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 9);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1399,14 +1369,11 @@ __device__ void _bit_unpack_64_9bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_10bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_10bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 10);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1556,14 +1523,11 @@ __device__ void _bit_unpack_64_10bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_11bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_11bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 11);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1715,14 +1679,11 @@ __device__ void _bit_unpack_64_11bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_12bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_12bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 12);
     out[INDEX(0, lane)] = tmp + reference;
@@ -1876,14 +1837,11 @@ __device__ void _bit_unpack_64_12bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_13bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_13bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 13);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2039,14 +1997,11 @@ __device__ void _bit_unpack_64_13bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_14bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_14bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 14);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2204,14 +2159,11 @@ __device__ void _bit_unpack_64_14bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_15bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_15bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 15);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2371,14 +2323,11 @@ __device__ void _bit_unpack_64_15bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_16bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_16bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 16);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2540,14 +2489,11 @@ __device__ void _bit_unpack_64_16bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_17bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_17bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 17);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2711,14 +2657,11 @@ __device__ void _bit_unpack_64_17bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_18bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_18bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 18);
     out[INDEX(0, lane)] = tmp + reference;
@@ -2884,14 +2827,11 @@ __device__ void _bit_unpack_64_18bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_19bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_19bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 19);
     out[INDEX(0, lane)] = tmp + reference;
@@ -3059,14 +2999,11 @@ __device__ void _bit_unpack_64_19bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_20bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_20bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 20);
     out[INDEX(0, lane)] = tmp + reference;
@@ -3236,14 +3173,11 @@ __device__ void _bit_unpack_64_20bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_21bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_21bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 21);
     out[INDEX(0, lane)] = tmp + reference;
@@ -3415,14 +3349,11 @@ __device__ void _bit_unpack_64_21bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_22bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_22bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 22);
     out[INDEX(0, lane)] = tmp + reference;
@@ -3596,14 +3527,11 @@ __device__ void _bit_unpack_64_22bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_23bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_23bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 23);
     out[INDEX(0, lane)] = tmp + reference;
@@ -3779,14 +3707,11 @@ __device__ void _bit_unpack_64_23bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_24bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_24bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 24);
     out[INDEX(0, lane)] = tmp + reference;
@@ -3964,14 +3889,11 @@ __device__ void _bit_unpack_64_24bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_25bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_25bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 25);
     out[INDEX(0, lane)] = tmp + reference;
@@ -4151,14 +4073,11 @@ __device__ void _bit_unpack_64_25bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_26bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_26bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 26);
     out[INDEX(0, lane)] = tmp + reference;
@@ -4340,14 +4259,11 @@ __device__ void _bit_unpack_64_26bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_27bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_27bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 27);
     out[INDEX(0, lane)] = tmp + reference;
@@ -4531,14 +4447,11 @@ __device__ void _bit_unpack_64_27bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_28bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_28bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 28);
     out[INDEX(0, lane)] = tmp + reference;
@@ -4724,14 +4637,11 @@ __device__ void _bit_unpack_64_28bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_29bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_29bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 29);
     out[INDEX(0, lane)] = tmp + reference;
@@ -4919,14 +4829,11 @@ __device__ void _bit_unpack_64_29bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_30bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_30bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 30);
     out[INDEX(0, lane)] = tmp + reference;
@@ -5116,14 +5023,11 @@ __device__ void _bit_unpack_64_30bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_31bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_31bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 31);
     out[INDEX(0, lane)] = tmp + reference;
@@ -5315,14 +5219,11 @@ __device__ void _bit_unpack_64_31bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_32bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_32bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 32);
     out[INDEX(0, lane)] = tmp + reference;
@@ -5516,14 +5417,11 @@ __device__ void _bit_unpack_64_32bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_33bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_33bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 33);
     out[INDEX(0, lane)] = tmp + reference;
@@ -5719,14 +5617,11 @@ __device__ void _bit_unpack_64_33bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_34bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_34bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 34);
     out[INDEX(0, lane)] = tmp + reference;
@@ -5924,14 +5819,11 @@ __device__ void _bit_unpack_64_34bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_35bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_35bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 35);
     out[INDEX(0, lane)] = tmp + reference;
@@ -6131,14 +6023,11 @@ __device__ void _bit_unpack_64_35bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_36bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_36bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 36);
     out[INDEX(0, lane)] = tmp + reference;
@@ -6340,14 +6229,11 @@ __device__ void _bit_unpack_64_36bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_37bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_37bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 37);
     out[INDEX(0, lane)] = tmp + reference;
@@ -6551,14 +6437,11 @@ __device__ void _bit_unpack_64_37bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_38bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_38bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 38);
     out[INDEX(0, lane)] = tmp + reference;
@@ -6764,14 +6647,11 @@ __device__ void _bit_unpack_64_38bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_39bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_39bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 39);
     out[INDEX(0, lane)] = tmp + reference;
@@ -6979,14 +6859,11 @@ __device__ void _bit_unpack_64_39bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_40bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_40bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 40);
     out[INDEX(0, lane)] = tmp + reference;
@@ -7196,14 +7073,11 @@ __device__ void _bit_unpack_64_40bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_41bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_41bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 41);
     out[INDEX(0, lane)] = tmp + reference;
@@ -7415,14 +7289,11 @@ __device__ void _bit_unpack_64_41bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_42bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_42bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 42);
     out[INDEX(0, lane)] = tmp + reference;
@@ -7636,14 +7507,11 @@ __device__ void _bit_unpack_64_42bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_43bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_43bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 43);
     out[INDEX(0, lane)] = tmp + reference;
@@ -7859,14 +7727,11 @@ __device__ void _bit_unpack_64_43bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_44bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_44bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 44);
     out[INDEX(0, lane)] = tmp + reference;
@@ -8084,14 +7949,11 @@ __device__ void _bit_unpack_64_44bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_45bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_45bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 45);
     out[INDEX(0, lane)] = tmp + reference;
@@ -8311,14 +8173,11 @@ __device__ void _bit_unpack_64_45bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_46bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_46bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 46);
     out[INDEX(0, lane)] = tmp + reference;
@@ -8540,14 +8399,11 @@ __device__ void _bit_unpack_64_46bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_47bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_47bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 47);
     out[INDEX(0, lane)] = tmp + reference;
@@ -8771,14 +8627,11 @@ __device__ void _bit_unpack_64_47bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_48bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_48bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 48);
     out[INDEX(0, lane)] = tmp + reference;
@@ -9004,14 +8857,11 @@ __device__ void _bit_unpack_64_48bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_49bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_49bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 49);
     out[INDEX(0, lane)] = tmp + reference;
@@ -9239,14 +9089,11 @@ __device__ void _bit_unpack_64_49bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_50bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_50bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 50);
     out[INDEX(0, lane)] = tmp + reference;
@@ -9476,14 +9323,11 @@ __device__ void _bit_unpack_64_50bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_51bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_51bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 51);
     out[INDEX(0, lane)] = tmp + reference;
@@ -9715,14 +9559,11 @@ __device__ void _bit_unpack_64_51bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_52bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_52bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 52);
     out[INDEX(0, lane)] = tmp + reference;
@@ -9956,14 +9797,11 @@ __device__ void _bit_unpack_64_52bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_53bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_53bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 53);
     out[INDEX(0, lane)] = tmp + reference;
@@ -10199,14 +10037,11 @@ __device__ void _bit_unpack_64_53bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_54bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_54bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 54);
     out[INDEX(0, lane)] = tmp + reference;
@@ -10444,14 +10279,11 @@ __device__ void _bit_unpack_64_54bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_55bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_55bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 55);
     out[INDEX(0, lane)] = tmp + reference;
@@ -10691,14 +10523,11 @@ __device__ void _bit_unpack_64_55bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_56bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_56bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 56);
     out[INDEX(0, lane)] = tmp + reference;
@@ -10940,14 +10769,11 @@ __device__ void _bit_unpack_64_56bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_57bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_57bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 57);
     out[INDEX(0, lane)] = tmp + reference;
@@ -11191,14 +11017,11 @@ __device__ void _bit_unpack_64_57bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_58bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_58bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 58);
     out[INDEX(0, lane)] = tmp + reference;
@@ -11444,14 +11267,11 @@ __device__ void _bit_unpack_64_58bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_59bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_59bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 59);
     out[INDEX(0, lane)] = tmp + reference;
@@ -11699,14 +11519,11 @@ __device__ void _bit_unpack_64_59bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_60bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_60bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 60);
     out[INDEX(0, lane)] = tmp + reference;
@@ -11956,14 +11773,11 @@ __device__ void _bit_unpack_64_60bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_61bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_61bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 61);
     out[INDEX(0, lane)] = tmp + reference;
@@ -12215,14 +12029,11 @@ __device__ void _bit_unpack_64_61bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_62bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_62bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 62);
     out[INDEX(0, lane)] = tmp + reference;
@@ -12476,14 +12287,11 @@ __device__ void _bit_unpack_64_62bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_63bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_63bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
     uint64_t src;
     uint64_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint64_t, 63);
     out[INDEX(0, lane)] = tmp + reference;
@@ -12739,12 +12547,9 @@ __device__ void _bit_unpack_64_63bw_lane(const uint64_t *__restrict in,
     out[INDEX(63, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_64_64bw_lane(const uint64_t *__restrict in,
-                                         uint64_t *__restrict out,
-                                         uint64_t reference,
-                                         unsigned int lane) {
+__device__ void _bit_unpack_64_64bw_lane(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 16;
-
+    
     out[INDEX(0, lane)] = in[LANE_COUNT * 0 + lane] + reference;
     out[INDEX(1, lane)] = in[LANE_COUNT * 1 + lane] + reference;
     out[INDEX(2, lane)] = in[LANE_COUNT * 2 + lane] + reference;
@@ -12812,214 +12617,83 @@ __device__ void _bit_unpack_64_64bw_lane(const uint64_t *__restrict in,
 }
 
 /// Runtime dispatch to the optimized lane decoder for the given bit width.
-__device__ inline void bit_unpack_64_lane(const uint64_t *__restrict in,
-                                          uint64_t *__restrict out,
-                                          uint64_t reference,
-                                          unsigned int lane,
-                                          uint32_t bit_width) {
+__device__ inline void bit_unpack_64_lane(
+    const uint64_t *__restrict in,
+    uint64_t *__restrict out,
+    uint64_t reference,
+    unsigned int lane,
+    uint32_t bit_width
+) {
     switch (bit_width) {
-    case 0:
-        _bit_unpack_64_0bw_lane(in, out, reference, lane);
-        break;
-    case 1:
-        _bit_unpack_64_1bw_lane(in, out, reference, lane);
-        break;
-    case 2:
-        _bit_unpack_64_2bw_lane(in, out, reference, lane);
-        break;
-    case 3:
-        _bit_unpack_64_3bw_lane(in, out, reference, lane);
-        break;
-    case 4:
-        _bit_unpack_64_4bw_lane(in, out, reference, lane);
-        break;
-    case 5:
-        _bit_unpack_64_5bw_lane(in, out, reference, lane);
-        break;
-    case 6:
-        _bit_unpack_64_6bw_lane(in, out, reference, lane);
-        break;
-    case 7:
-        _bit_unpack_64_7bw_lane(in, out, reference, lane);
-        break;
-    case 8:
-        _bit_unpack_64_8bw_lane(in, out, reference, lane);
-        break;
-    case 9:
-        _bit_unpack_64_9bw_lane(in, out, reference, lane);
-        break;
-    case 10:
-        _bit_unpack_64_10bw_lane(in, out, reference, lane);
-        break;
-    case 11:
-        _bit_unpack_64_11bw_lane(in, out, reference, lane);
-        break;
-    case 12:
-        _bit_unpack_64_12bw_lane(in, out, reference, lane);
-        break;
-    case 13:
-        _bit_unpack_64_13bw_lane(in, out, reference, lane);
-        break;
-    case 14:
-        _bit_unpack_64_14bw_lane(in, out, reference, lane);
-        break;
-    case 15:
-        _bit_unpack_64_15bw_lane(in, out, reference, lane);
-        break;
-    case 16:
-        _bit_unpack_64_16bw_lane(in, out, reference, lane);
-        break;
-    case 17:
-        _bit_unpack_64_17bw_lane(in, out, reference, lane);
-        break;
-    case 18:
-        _bit_unpack_64_18bw_lane(in, out, reference, lane);
-        break;
-    case 19:
-        _bit_unpack_64_19bw_lane(in, out, reference, lane);
-        break;
-    case 20:
-        _bit_unpack_64_20bw_lane(in, out, reference, lane);
-        break;
-    case 21:
-        _bit_unpack_64_21bw_lane(in, out, reference, lane);
-        break;
-    case 22:
-        _bit_unpack_64_22bw_lane(in, out, reference, lane);
-        break;
-    case 23:
-        _bit_unpack_64_23bw_lane(in, out, reference, lane);
-        break;
-    case 24:
-        _bit_unpack_64_24bw_lane(in, out, reference, lane);
-        break;
-    case 25:
-        _bit_unpack_64_25bw_lane(in, out, reference, lane);
-        break;
-    case 26:
-        _bit_unpack_64_26bw_lane(in, out, reference, lane);
-        break;
-    case 27:
-        _bit_unpack_64_27bw_lane(in, out, reference, lane);
-        break;
-    case 28:
-        _bit_unpack_64_28bw_lane(in, out, reference, lane);
-        break;
-    case 29:
-        _bit_unpack_64_29bw_lane(in, out, reference, lane);
-        break;
-    case 30:
-        _bit_unpack_64_30bw_lane(in, out, reference, lane);
-        break;
-    case 31:
-        _bit_unpack_64_31bw_lane(in, out, reference, lane);
-        break;
-    case 32:
-        _bit_unpack_64_32bw_lane(in, out, reference, lane);
-        break;
-    case 33:
-        _bit_unpack_64_33bw_lane(in, out, reference, lane);
-        break;
-    case 34:
-        _bit_unpack_64_34bw_lane(in, out, reference, lane);
-        break;
-    case 35:
-        _bit_unpack_64_35bw_lane(in, out, reference, lane);
-        break;
-    case 36:
-        _bit_unpack_64_36bw_lane(in, out, reference, lane);
-        break;
-    case 37:
-        _bit_unpack_64_37bw_lane(in, out, reference, lane);
-        break;
-    case 38:
-        _bit_unpack_64_38bw_lane(in, out, reference, lane);
-        break;
-    case 39:
-        _bit_unpack_64_39bw_lane(in, out, reference, lane);
-        break;
-    case 40:
-        _bit_unpack_64_40bw_lane(in, out, reference, lane);
-        break;
-    case 41:
-        _bit_unpack_64_41bw_lane(in, out, reference, lane);
-        break;
-    case 42:
-        _bit_unpack_64_42bw_lane(in, out, reference, lane);
-        break;
-    case 43:
-        _bit_unpack_64_43bw_lane(in, out, reference, lane);
-        break;
-    case 44:
-        _bit_unpack_64_44bw_lane(in, out, reference, lane);
-        break;
-    case 45:
-        _bit_unpack_64_45bw_lane(in, out, reference, lane);
-        break;
-    case 46:
-        _bit_unpack_64_46bw_lane(in, out, reference, lane);
-        break;
-    case 47:
-        _bit_unpack_64_47bw_lane(in, out, reference, lane);
-        break;
-    case 48:
-        _bit_unpack_64_48bw_lane(in, out, reference, lane);
-        break;
-    case 49:
-        _bit_unpack_64_49bw_lane(in, out, reference, lane);
-        break;
-    case 50:
-        _bit_unpack_64_50bw_lane(in, out, reference, lane);
-        break;
-    case 51:
-        _bit_unpack_64_51bw_lane(in, out, reference, lane);
-        break;
-    case 52:
-        _bit_unpack_64_52bw_lane(in, out, reference, lane);
-        break;
-    case 53:
-        _bit_unpack_64_53bw_lane(in, out, reference, lane);
-        break;
-    case 54:
-        _bit_unpack_64_54bw_lane(in, out, reference, lane);
-        break;
-    case 55:
-        _bit_unpack_64_55bw_lane(in, out, reference, lane);
-        break;
-    case 56:
-        _bit_unpack_64_56bw_lane(in, out, reference, lane);
-        break;
-    case 57:
-        _bit_unpack_64_57bw_lane(in, out, reference, lane);
-        break;
-    case 58:
-        _bit_unpack_64_58bw_lane(in, out, reference, lane);
-        break;
-    case 59:
-        _bit_unpack_64_59bw_lane(in, out, reference, lane);
-        break;
-    case 60:
-        _bit_unpack_64_60bw_lane(in, out, reference, lane);
-        break;
-    case 61:
-        _bit_unpack_64_61bw_lane(in, out, reference, lane);
-        break;
-    case 62:
-        _bit_unpack_64_62bw_lane(in, out, reference, lane);
-        break;
-    case 63:
-        _bit_unpack_64_63bw_lane(in, out, reference, lane);
-        break;
-    case 64:
-        _bit_unpack_64_64bw_lane(in, out, reference, lane);
-        break;
+        case 0: _bit_unpack_64_0bw_lane(in, out, reference, lane); break;
+        case 1: _bit_unpack_64_1bw_lane(in, out, reference, lane); break;
+        case 2: _bit_unpack_64_2bw_lane(in, out, reference, lane); break;
+        case 3: _bit_unpack_64_3bw_lane(in, out, reference, lane); break;
+        case 4: _bit_unpack_64_4bw_lane(in, out, reference, lane); break;
+        case 5: _bit_unpack_64_5bw_lane(in, out, reference, lane); break;
+        case 6: _bit_unpack_64_6bw_lane(in, out, reference, lane); break;
+        case 7: _bit_unpack_64_7bw_lane(in, out, reference, lane); break;
+        case 8: _bit_unpack_64_8bw_lane(in, out, reference, lane); break;
+        case 9: _bit_unpack_64_9bw_lane(in, out, reference, lane); break;
+        case 10: _bit_unpack_64_10bw_lane(in, out, reference, lane); break;
+        case 11: _bit_unpack_64_11bw_lane(in, out, reference, lane); break;
+        case 12: _bit_unpack_64_12bw_lane(in, out, reference, lane); break;
+        case 13: _bit_unpack_64_13bw_lane(in, out, reference, lane); break;
+        case 14: _bit_unpack_64_14bw_lane(in, out, reference, lane); break;
+        case 15: _bit_unpack_64_15bw_lane(in, out, reference, lane); break;
+        case 16: _bit_unpack_64_16bw_lane(in, out, reference, lane); break;
+        case 17: _bit_unpack_64_17bw_lane(in, out, reference, lane); break;
+        case 18: _bit_unpack_64_18bw_lane(in, out, reference, lane); break;
+        case 19: _bit_unpack_64_19bw_lane(in, out, reference, lane); break;
+        case 20: _bit_unpack_64_20bw_lane(in, out, reference, lane); break;
+        case 21: _bit_unpack_64_21bw_lane(in, out, reference, lane); break;
+        case 22: _bit_unpack_64_22bw_lane(in, out, reference, lane); break;
+        case 23: _bit_unpack_64_23bw_lane(in, out, reference, lane); break;
+        case 24: _bit_unpack_64_24bw_lane(in, out, reference, lane); break;
+        case 25: _bit_unpack_64_25bw_lane(in, out, reference, lane); break;
+        case 26: _bit_unpack_64_26bw_lane(in, out, reference, lane); break;
+        case 27: _bit_unpack_64_27bw_lane(in, out, reference, lane); break;
+        case 28: _bit_unpack_64_28bw_lane(in, out, reference, lane); break;
+        case 29: _bit_unpack_64_29bw_lane(in, out, reference, lane); break;
+        case 30: _bit_unpack_64_30bw_lane(in, out, reference, lane); break;
+        case 31: _bit_unpack_64_31bw_lane(in, out, reference, lane); break;
+        case 32: _bit_unpack_64_32bw_lane(in, out, reference, lane); break;
+        case 33: _bit_unpack_64_33bw_lane(in, out, reference, lane); break;
+        case 34: _bit_unpack_64_34bw_lane(in, out, reference, lane); break;
+        case 35: _bit_unpack_64_35bw_lane(in, out, reference, lane); break;
+        case 36: _bit_unpack_64_36bw_lane(in, out, reference, lane); break;
+        case 37: _bit_unpack_64_37bw_lane(in, out, reference, lane); break;
+        case 38: _bit_unpack_64_38bw_lane(in, out, reference, lane); break;
+        case 39: _bit_unpack_64_39bw_lane(in, out, reference, lane); break;
+        case 40: _bit_unpack_64_40bw_lane(in, out, reference, lane); break;
+        case 41: _bit_unpack_64_41bw_lane(in, out, reference, lane); break;
+        case 42: _bit_unpack_64_42bw_lane(in, out, reference, lane); break;
+        case 43: _bit_unpack_64_43bw_lane(in, out, reference, lane); break;
+        case 44: _bit_unpack_64_44bw_lane(in, out, reference, lane); break;
+        case 45: _bit_unpack_64_45bw_lane(in, out, reference, lane); break;
+        case 46: _bit_unpack_64_46bw_lane(in, out, reference, lane); break;
+        case 47: _bit_unpack_64_47bw_lane(in, out, reference, lane); break;
+        case 48: _bit_unpack_64_48bw_lane(in, out, reference, lane); break;
+        case 49: _bit_unpack_64_49bw_lane(in, out, reference, lane); break;
+        case 50: _bit_unpack_64_50bw_lane(in, out, reference, lane); break;
+        case 51: _bit_unpack_64_51bw_lane(in, out, reference, lane); break;
+        case 52: _bit_unpack_64_52bw_lane(in, out, reference, lane); break;
+        case 53: _bit_unpack_64_53bw_lane(in, out, reference, lane); break;
+        case 54: _bit_unpack_64_54bw_lane(in, out, reference, lane); break;
+        case 55: _bit_unpack_64_55bw_lane(in, out, reference, lane); break;
+        case 56: _bit_unpack_64_56bw_lane(in, out, reference, lane); break;
+        case 57: _bit_unpack_64_57bw_lane(in, out, reference, lane); break;
+        case 58: _bit_unpack_64_58bw_lane(in, out, reference, lane); break;
+        case 59: _bit_unpack_64_59bw_lane(in, out, reference, lane); break;
+        case 60: _bit_unpack_64_60bw_lane(in, out, reference, lane); break;
+        case 61: _bit_unpack_64_61bw_lane(in, out, reference, lane); break;
+        case 62: _bit_unpack_64_62bw_lane(in, out, reference, lane); break;
+        case 63: _bit_unpack_64_63bw_lane(in, out, reference, lane); break;
+        case 64: _bit_unpack_64_64bw_lane(in, out, reference, lane); break;
     }
 }
 
-__device__ void _bit_unpack_64_0bw_16t(const uint64_t *__restrict in,
-                                       uint64_t *__restrict out,
-                                       uint64_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_64_0bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_0bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13028,18 +12702,14 @@ __device__ void _bit_unpack_64_0bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_64_0bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_0bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 0 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_0bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_1bw_16t(const uint64_t *__restrict in,
-                                       uint64_t *__restrict out,
-                                       uint64_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_64_1bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_1bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13048,18 +12718,14 @@ __device__ void _bit_unpack_64_1bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_64_1bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_1bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 1 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_1bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_2bw_16t(const uint64_t *__restrict in,
-                                       uint64_t *__restrict out,
-                                       uint64_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_64_2bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_2bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13068,18 +12734,14 @@ __device__ void _bit_unpack_64_2bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_64_2bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_2bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 2 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_2bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_3bw_16t(const uint64_t *__restrict in,
-                                       uint64_t *__restrict out,
-                                       uint64_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_64_3bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_3bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13088,18 +12750,14 @@ __device__ void _bit_unpack_64_3bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_64_3bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_3bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 3 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_3bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_4bw_16t(const uint64_t *__restrict in,
-                                       uint64_t *__restrict out,
-                                       uint64_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_64_4bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_4bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13108,18 +12766,14 @@ __device__ void _bit_unpack_64_4bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_64_4bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_4bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 4 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_4bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_5bw_16t(const uint64_t *__restrict in,
-                                       uint64_t *__restrict out,
-                                       uint64_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_64_5bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_5bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13128,18 +12782,14 @@ __device__ void _bit_unpack_64_5bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_64_5bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_5bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 5 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_5bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_6bw_16t(const uint64_t *__restrict in,
-                                       uint64_t *__restrict out,
-                                       uint64_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_64_6bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_6bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13148,18 +12798,14 @@ __device__ void _bit_unpack_64_6bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_64_6bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_6bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 6 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_6bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_7bw_16t(const uint64_t *__restrict in,
-                                       uint64_t *__restrict out,
-                                       uint64_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_64_7bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_7bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13168,18 +12814,14 @@ __device__ void _bit_unpack_64_7bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_64_7bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_7bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 7 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_7bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_8bw_16t(const uint64_t *__restrict in,
-                                       uint64_t *__restrict out,
-                                       uint64_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_64_8bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_8bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13188,18 +12830,14 @@ __device__ void _bit_unpack_64_8bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_64_8bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_8bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 8 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_8bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_9bw_16t(const uint64_t *__restrict in,
-                                       uint64_t *__restrict out,
-                                       uint64_t reference,
-                                       int thread_idx) {
+__device__ void _bit_unpack_64_9bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_9bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13208,18 +12846,14 @@ __device__ void _bit_unpack_64_9bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_64_9bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_9bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 9 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_9bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_10bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_10bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_10bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13228,19 +12862,14 @@ __device__ void _bit_unpack_64_10bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_10bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_10bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 10 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_10bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_11bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_11bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_11bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13249,19 +12878,14 @@ __device__ void _bit_unpack_64_11bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_11bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_11bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 11 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_11bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_12bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_12bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_12bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13270,19 +12894,14 @@ __device__ void _bit_unpack_64_12bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_12bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_12bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 12 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_12bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_13bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_13bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_13bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13291,19 +12910,14 @@ __device__ void _bit_unpack_64_13bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_13bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_13bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 13 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_13bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_14bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_14bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_14bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13312,19 +12926,14 @@ __device__ void _bit_unpack_64_14bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_14bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_14bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 14 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_14bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_15bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_15bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_15bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13333,19 +12942,14 @@ __device__ void _bit_unpack_64_15bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_15bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_15bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 15 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_15bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_16bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_16bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_16bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13354,19 +12958,14 @@ __device__ void _bit_unpack_64_16bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_16bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_16bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 16 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_16bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_17bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_17bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_17bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13375,19 +12974,14 @@ __device__ void _bit_unpack_64_17bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_17bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_17bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 17 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_17bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_18bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_18bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_18bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13396,19 +12990,14 @@ __device__ void _bit_unpack_64_18bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_18bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_18bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 18 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_18bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_19bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_19bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_19bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13417,19 +13006,14 @@ __device__ void _bit_unpack_64_19bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_19bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_19bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 19 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_19bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_20bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_20bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_20bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13438,19 +13022,14 @@ __device__ void _bit_unpack_64_20bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_20bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_20bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 20 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_20bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_21bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_21bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_21bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13459,19 +13038,14 @@ __device__ void _bit_unpack_64_21bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_21bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_21bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 21 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_21bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_22bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_22bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_22bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13480,19 +13054,14 @@ __device__ void _bit_unpack_64_22bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_22bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_22bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 22 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_22bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_23bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_23bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_23bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13501,19 +13070,14 @@ __device__ void _bit_unpack_64_23bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_23bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_23bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 23 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_23bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_24bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_24bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_24bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13522,19 +13086,14 @@ __device__ void _bit_unpack_64_24bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_24bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_24bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 24 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_24bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_25bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_25bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_25bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13543,19 +13102,14 @@ __device__ void _bit_unpack_64_25bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_25bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_25bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 25 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_25bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_26bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_26bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_26bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13564,19 +13118,14 @@ __device__ void _bit_unpack_64_26bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_26bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_26bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 26 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_26bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_27bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_27bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_27bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13585,19 +13134,14 @@ __device__ void _bit_unpack_64_27bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_27bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_27bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 27 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_27bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_28bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_28bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_28bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13606,19 +13150,14 @@ __device__ void _bit_unpack_64_28bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_28bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_28bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 28 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_28bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_29bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_29bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_29bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13627,19 +13166,14 @@ __device__ void _bit_unpack_64_29bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_29bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_29bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 29 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_29bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_30bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_30bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_30bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13648,19 +13182,14 @@ __device__ void _bit_unpack_64_30bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_30bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_30bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 30 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_30bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_31bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_31bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_31bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13669,19 +13198,14 @@ __device__ void _bit_unpack_64_31bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_31bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_31bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 31 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_31bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_32bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_32bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_32bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13690,19 +13214,14 @@ __device__ void _bit_unpack_64_32bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_32bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_32bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 32 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_32bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_33bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_33bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_33bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13711,19 +13230,14 @@ __device__ void _bit_unpack_64_33bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_33bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_33bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 33 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_33bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_34bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_34bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_34bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13732,19 +13246,14 @@ __device__ void _bit_unpack_64_34bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_34bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_34bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 34 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_34bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_35bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_35bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_35bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13753,19 +13262,14 @@ __device__ void _bit_unpack_64_35bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_35bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_35bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 35 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_35bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_36bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_36bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_36bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13774,19 +13278,14 @@ __device__ void _bit_unpack_64_36bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_36bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_36bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 36 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_36bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_37bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_37bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_37bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13795,19 +13294,14 @@ __device__ void _bit_unpack_64_37bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_37bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_37bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 37 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_37bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_38bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_38bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_38bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13816,19 +13310,14 @@ __device__ void _bit_unpack_64_38bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_38bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_38bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 38 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_38bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_39bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_39bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_39bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13837,19 +13326,14 @@ __device__ void _bit_unpack_64_39bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_39bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_39bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 39 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_39bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_40bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_40bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_40bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13858,19 +13342,14 @@ __device__ void _bit_unpack_64_40bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_40bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_40bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 40 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_40bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_41bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_41bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_41bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13879,19 +13358,14 @@ __device__ void _bit_unpack_64_41bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_41bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_41bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 41 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_41bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_42bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_42bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_42bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13900,19 +13374,14 @@ __device__ void _bit_unpack_64_42bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_42bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_42bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 42 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_42bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_43bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_43bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_43bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13921,19 +13390,14 @@ __device__ void _bit_unpack_64_43bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_43bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_43bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 43 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_43bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_44bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_44bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_44bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13942,19 +13406,14 @@ __device__ void _bit_unpack_64_44bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_44bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_44bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 44 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_44bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_45bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_45bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_45bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13963,19 +13422,14 @@ __device__ void _bit_unpack_64_45bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_45bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_45bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 45 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_45bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_46bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_46bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_46bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -13984,19 +13438,14 @@ __device__ void _bit_unpack_64_46bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_46bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_46bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 46 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_46bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_47bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_47bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_47bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14005,19 +13454,14 @@ __device__ void _bit_unpack_64_47bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_47bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_47bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 47 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_47bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_48bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_48bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_48bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14026,19 +13470,14 @@ __device__ void _bit_unpack_64_48bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_48bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_48bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 48 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_48bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_49bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_49bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_49bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14047,19 +13486,14 @@ __device__ void _bit_unpack_64_49bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_49bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_49bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 49 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_49bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_50bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_50bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_50bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14068,19 +13502,14 @@ __device__ void _bit_unpack_64_50bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_50bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_50bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 50 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_50bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_51bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_51bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_51bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14089,19 +13518,14 @@ __device__ void _bit_unpack_64_51bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_51bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_51bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 51 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_51bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_52bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_52bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_52bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14110,19 +13534,14 @@ __device__ void _bit_unpack_64_52bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_52bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_52bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 52 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_52bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_53bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_53bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_53bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14131,19 +13550,14 @@ __device__ void _bit_unpack_64_53bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_53bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_53bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 53 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_53bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_54bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_54bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_54bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14152,19 +13566,14 @@ __device__ void _bit_unpack_64_54bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_54bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_54bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 54 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_54bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_55bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_55bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_55bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14173,19 +13582,14 @@ __device__ void _bit_unpack_64_55bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_55bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_55bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 55 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_55bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_56bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_56bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_56bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14194,19 +13598,14 @@ __device__ void _bit_unpack_64_56bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_56bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_56bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 56 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_56bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_57bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_57bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_57bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14215,19 +13614,14 @@ __device__ void _bit_unpack_64_57bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_57bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_57bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 57 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_57bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_58bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_58bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_58bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14236,19 +13630,14 @@ __device__ void _bit_unpack_64_58bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_58bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_58bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 58 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_58bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_59bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_59bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_59bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14257,19 +13646,14 @@ __device__ void _bit_unpack_64_59bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_59bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_59bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 59 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_59bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_60bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_60bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_60bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14278,19 +13662,14 @@ __device__ void _bit_unpack_64_60bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_60bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_60bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 60 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_60bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_61bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_61bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_61bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14299,19 +13678,14 @@ __device__ void _bit_unpack_64_61bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_61bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_61bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 61 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_61bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_62bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_62bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_62bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14320,19 +13694,14 @@ __device__ void _bit_unpack_64_62bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_62bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_62bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 62 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_62bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_63bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_63bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_63bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14341,19 +13710,14 @@ __device__ void _bit_unpack_64_63bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_63bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_63bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 63 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_63bw_16t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_64_64bw_16t(const uint64_t *__restrict in,
-                                        uint64_t *__restrict out,
-                                        uint64_t reference,
-                                        int thread_idx) {
+__device__ void _bit_unpack_64_64bw_16t(const uint64_t *__restrict in, uint64_t *__restrict out, uint64_t reference, int thread_idx) {
     __shared__ uint64_t shared_out[1024];
     _bit_unpack_64_64bw_lane(in, shared_out, reference, thread_idx * 1 + 0);
     for (int i = 0; i < 64; i++) {
@@ -14362,11 +13726,10 @@ __device__ void _bit_unpack_64_64bw_16t(const uint64_t *__restrict in,
     }
 }
 
-extern "C" __global__ void bit_unpack_64_64bw_16t(const uint64_t *__restrict full_in,
-                                                  uint64_t *__restrict full_out,
-                                                  uint64_t reference) {
+extern "C" __global__ void bit_unpack_64_64bw_16t(const uint64_t *__restrict full_in, uint64_t *__restrict full_out, uint64_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 64 / sizeof(uint64_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_64_64bw_16t(in, out, reference, thread_idx);
 }
+

--- a/vortex-cuda/kernels/src/bit_unpack_8.cu
+++ b/vortex-cuda/kernels/src/bit_unpack_8.cu
@@ -4,12 +4,9 @@
 #include <stdint.h>
 #include "fastlanes_common.cuh"
 
-__device__ void _bit_unpack_8_0bw_lane(const uint8_t *__restrict in,
-                                       uint8_t *__restrict out,
-                                       uint8_t reference,
-                                       unsigned int lane) {
+__device__ void _bit_unpack_8_0bw_lane(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 128;
-
+    
     out[INDEX(0, lane)] = reference;
     out[INDEX(1, lane)] = reference;
     out[INDEX(2, lane)] = reference;
@@ -20,14 +17,11 @@ __device__ void _bit_unpack_8_0bw_lane(const uint8_t *__restrict in,
     out[INDEX(7, lane)] = reference;
 }
 
-__device__ void _bit_unpack_8_1bw_lane(const uint8_t *__restrict in,
-                                       uint8_t *__restrict out,
-                                       uint8_t reference,
-                                       unsigned int lane) {
+__device__ void _bit_unpack_8_1bw_lane(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 128;
     uint8_t src;
     uint8_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint8_t, 1);
     out[INDEX(0, lane)] = tmp + reference;
@@ -47,14 +41,11 @@ __device__ void _bit_unpack_8_1bw_lane(const uint8_t *__restrict in,
     out[INDEX(7, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_8_2bw_lane(const uint8_t *__restrict in,
-                                       uint8_t *__restrict out,
-                                       uint8_t reference,
-                                       unsigned int lane) {
+__device__ void _bit_unpack_8_2bw_lane(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 128;
     uint8_t src;
     uint8_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint8_t, 2);
     out[INDEX(0, lane)] = tmp + reference;
@@ -76,14 +67,11 @@ __device__ void _bit_unpack_8_2bw_lane(const uint8_t *__restrict in,
     out[INDEX(7, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_8_3bw_lane(const uint8_t *__restrict in,
-                                       uint8_t *__restrict out,
-                                       uint8_t reference,
-                                       unsigned int lane) {
+__device__ void _bit_unpack_8_3bw_lane(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 128;
     uint8_t src;
     uint8_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint8_t, 3);
     out[INDEX(0, lane)] = tmp + reference;
@@ -107,14 +95,11 @@ __device__ void _bit_unpack_8_3bw_lane(const uint8_t *__restrict in,
     out[INDEX(7, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_8_4bw_lane(const uint8_t *__restrict in,
-                                       uint8_t *__restrict out,
-                                       uint8_t reference,
-                                       unsigned int lane) {
+__device__ void _bit_unpack_8_4bw_lane(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 128;
     uint8_t src;
     uint8_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint8_t, 4);
     out[INDEX(0, lane)] = tmp + reference;
@@ -140,14 +125,11 @@ __device__ void _bit_unpack_8_4bw_lane(const uint8_t *__restrict in,
     out[INDEX(7, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_8_5bw_lane(const uint8_t *__restrict in,
-                                       uint8_t *__restrict out,
-                                       uint8_t reference,
-                                       unsigned int lane) {
+__device__ void _bit_unpack_8_5bw_lane(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 128;
     uint8_t src;
     uint8_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint8_t, 5);
     out[INDEX(0, lane)] = tmp + reference;
@@ -175,14 +157,11 @@ __device__ void _bit_unpack_8_5bw_lane(const uint8_t *__restrict in,
     out[INDEX(7, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_8_6bw_lane(const uint8_t *__restrict in,
-                                       uint8_t *__restrict out,
-                                       uint8_t reference,
-                                       unsigned int lane) {
+__device__ void _bit_unpack_8_6bw_lane(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 128;
     uint8_t src;
     uint8_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint8_t, 6);
     out[INDEX(0, lane)] = tmp + reference;
@@ -212,14 +191,11 @@ __device__ void _bit_unpack_8_6bw_lane(const uint8_t *__restrict in,
     out[INDEX(7, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_8_7bw_lane(const uint8_t *__restrict in,
-                                       uint8_t *__restrict out,
-                                       uint8_t reference,
-                                       unsigned int lane) {
+__device__ void _bit_unpack_8_7bw_lane(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 128;
     uint8_t src;
     uint8_t tmp;
-
+    
     src = in[lane];
     tmp = (src >> 0) & MASK(uint8_t, 7);
     out[INDEX(0, lane)] = tmp + reference;
@@ -251,12 +227,9 @@ __device__ void _bit_unpack_8_7bw_lane(const uint8_t *__restrict in,
     out[INDEX(7, lane)] = tmp + reference;
 }
 
-__device__ void _bit_unpack_8_8bw_lane(const uint8_t *__restrict in,
-                                       uint8_t *__restrict out,
-                                       uint8_t reference,
-                                       unsigned int lane) {
+__device__ void _bit_unpack_8_8bw_lane(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, unsigned int lane) {
     unsigned int LANE_COUNT = 128;
-
+    
     out[INDEX(0, lane)] = in[LANE_COUNT * 0 + lane] + reference;
     out[INDEX(1, lane)] = in[LANE_COUNT * 1 + lane] + reference;
     out[INDEX(2, lane)] = in[LANE_COUNT * 2 + lane] + reference;
@@ -268,46 +241,27 @@ __device__ void _bit_unpack_8_8bw_lane(const uint8_t *__restrict in,
 }
 
 /// Runtime dispatch to the optimized lane decoder for the given bit width.
-__device__ inline void bit_unpack_8_lane(const uint8_t *__restrict in,
-                                         uint8_t *__restrict out,
-                                         uint8_t reference,
-                                         unsigned int lane,
-                                         uint32_t bit_width) {
+__device__ inline void bit_unpack_8_lane(
+    const uint8_t *__restrict in,
+    uint8_t *__restrict out,
+    uint8_t reference,
+    unsigned int lane,
+    uint32_t bit_width
+) {
     switch (bit_width) {
-    case 0:
-        _bit_unpack_8_0bw_lane(in, out, reference, lane);
-        break;
-    case 1:
-        _bit_unpack_8_1bw_lane(in, out, reference, lane);
-        break;
-    case 2:
-        _bit_unpack_8_2bw_lane(in, out, reference, lane);
-        break;
-    case 3:
-        _bit_unpack_8_3bw_lane(in, out, reference, lane);
-        break;
-    case 4:
-        _bit_unpack_8_4bw_lane(in, out, reference, lane);
-        break;
-    case 5:
-        _bit_unpack_8_5bw_lane(in, out, reference, lane);
-        break;
-    case 6:
-        _bit_unpack_8_6bw_lane(in, out, reference, lane);
-        break;
-    case 7:
-        _bit_unpack_8_7bw_lane(in, out, reference, lane);
-        break;
-    case 8:
-        _bit_unpack_8_8bw_lane(in, out, reference, lane);
-        break;
+        case 0: _bit_unpack_8_0bw_lane(in, out, reference, lane); break;
+        case 1: _bit_unpack_8_1bw_lane(in, out, reference, lane); break;
+        case 2: _bit_unpack_8_2bw_lane(in, out, reference, lane); break;
+        case 3: _bit_unpack_8_3bw_lane(in, out, reference, lane); break;
+        case 4: _bit_unpack_8_4bw_lane(in, out, reference, lane); break;
+        case 5: _bit_unpack_8_5bw_lane(in, out, reference, lane); break;
+        case 6: _bit_unpack_8_6bw_lane(in, out, reference, lane); break;
+        case 7: _bit_unpack_8_7bw_lane(in, out, reference, lane); break;
+        case 8: _bit_unpack_8_8bw_lane(in, out, reference, lane); break;
     }
 }
 
-__device__ void _bit_unpack_8_0bw_32t(const uint8_t *__restrict in,
-                                      uint8_t *__restrict out,
-                                      uint8_t reference,
-                                      int thread_idx) {
+__device__ void _bit_unpack_8_0bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, int thread_idx) {
     __shared__ uint8_t shared_out[1024];
     _bit_unpack_8_0bw_lane(in, shared_out, reference, thread_idx * 4 + 0);
     _bit_unpack_8_0bw_lane(in, shared_out, reference, thread_idx * 4 + 1);
@@ -319,18 +273,14 @@ __device__ void _bit_unpack_8_0bw_32t(const uint8_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_8_0bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
+extern "C" __global__ void bit_unpack_8_0bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 0 / sizeof(uint8_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_8_0bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_8_1bw_32t(const uint8_t *__restrict in,
-                                      uint8_t *__restrict out,
-                                      uint8_t reference,
-                                      int thread_idx) {
+__device__ void _bit_unpack_8_1bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, int thread_idx) {
     __shared__ uint8_t shared_out[1024];
     _bit_unpack_8_1bw_lane(in, shared_out, reference, thread_idx * 4 + 0);
     _bit_unpack_8_1bw_lane(in, shared_out, reference, thread_idx * 4 + 1);
@@ -342,18 +292,14 @@ __device__ void _bit_unpack_8_1bw_32t(const uint8_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_8_1bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
+extern "C" __global__ void bit_unpack_8_1bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 1 / sizeof(uint8_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_8_1bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_8_2bw_32t(const uint8_t *__restrict in,
-                                      uint8_t *__restrict out,
-                                      uint8_t reference,
-                                      int thread_idx) {
+__device__ void _bit_unpack_8_2bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, int thread_idx) {
     __shared__ uint8_t shared_out[1024];
     _bit_unpack_8_2bw_lane(in, shared_out, reference, thread_idx * 4 + 0);
     _bit_unpack_8_2bw_lane(in, shared_out, reference, thread_idx * 4 + 1);
@@ -365,18 +311,14 @@ __device__ void _bit_unpack_8_2bw_32t(const uint8_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_8_2bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
+extern "C" __global__ void bit_unpack_8_2bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 2 / sizeof(uint8_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_8_2bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_8_3bw_32t(const uint8_t *__restrict in,
-                                      uint8_t *__restrict out,
-                                      uint8_t reference,
-                                      int thread_idx) {
+__device__ void _bit_unpack_8_3bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, int thread_idx) {
     __shared__ uint8_t shared_out[1024];
     _bit_unpack_8_3bw_lane(in, shared_out, reference, thread_idx * 4 + 0);
     _bit_unpack_8_3bw_lane(in, shared_out, reference, thread_idx * 4 + 1);
@@ -388,18 +330,14 @@ __device__ void _bit_unpack_8_3bw_32t(const uint8_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_8_3bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
+extern "C" __global__ void bit_unpack_8_3bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 3 / sizeof(uint8_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_8_3bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_8_4bw_32t(const uint8_t *__restrict in,
-                                      uint8_t *__restrict out,
-                                      uint8_t reference,
-                                      int thread_idx) {
+__device__ void _bit_unpack_8_4bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, int thread_idx) {
     __shared__ uint8_t shared_out[1024];
     _bit_unpack_8_4bw_lane(in, shared_out, reference, thread_idx * 4 + 0);
     _bit_unpack_8_4bw_lane(in, shared_out, reference, thread_idx * 4 + 1);
@@ -411,18 +349,14 @@ __device__ void _bit_unpack_8_4bw_32t(const uint8_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_8_4bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
+extern "C" __global__ void bit_unpack_8_4bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 4 / sizeof(uint8_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_8_4bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_8_5bw_32t(const uint8_t *__restrict in,
-                                      uint8_t *__restrict out,
-                                      uint8_t reference,
-                                      int thread_idx) {
+__device__ void _bit_unpack_8_5bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, int thread_idx) {
     __shared__ uint8_t shared_out[1024];
     _bit_unpack_8_5bw_lane(in, shared_out, reference, thread_idx * 4 + 0);
     _bit_unpack_8_5bw_lane(in, shared_out, reference, thread_idx * 4 + 1);
@@ -434,18 +368,14 @@ __device__ void _bit_unpack_8_5bw_32t(const uint8_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_8_5bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
+extern "C" __global__ void bit_unpack_8_5bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 5 / sizeof(uint8_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_8_5bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_8_6bw_32t(const uint8_t *__restrict in,
-                                      uint8_t *__restrict out,
-                                      uint8_t reference,
-                                      int thread_idx) {
+__device__ void _bit_unpack_8_6bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, int thread_idx) {
     __shared__ uint8_t shared_out[1024];
     _bit_unpack_8_6bw_lane(in, shared_out, reference, thread_idx * 4 + 0);
     _bit_unpack_8_6bw_lane(in, shared_out, reference, thread_idx * 4 + 1);
@@ -457,18 +387,14 @@ __device__ void _bit_unpack_8_6bw_32t(const uint8_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_8_6bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
+extern "C" __global__ void bit_unpack_8_6bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 6 / sizeof(uint8_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_8_6bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_8_7bw_32t(const uint8_t *__restrict in,
-                                      uint8_t *__restrict out,
-                                      uint8_t reference,
-                                      int thread_idx) {
+__device__ void _bit_unpack_8_7bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, int thread_idx) {
     __shared__ uint8_t shared_out[1024];
     _bit_unpack_8_7bw_lane(in, shared_out, reference, thread_idx * 4 + 0);
     _bit_unpack_8_7bw_lane(in, shared_out, reference, thread_idx * 4 + 1);
@@ -480,18 +406,14 @@ __device__ void _bit_unpack_8_7bw_32t(const uint8_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_8_7bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
+extern "C" __global__ void bit_unpack_8_7bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 7 / sizeof(uint8_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_8_7bw_32t(in, out, reference, thread_idx);
 }
 
-__device__ void _bit_unpack_8_8bw_32t(const uint8_t *__restrict in,
-                                      uint8_t *__restrict out,
-                                      uint8_t reference,
-                                      int thread_idx) {
+__device__ void _bit_unpack_8_8bw_32t(const uint8_t *__restrict in, uint8_t *__restrict out, uint8_t reference, int thread_idx) {
     __shared__ uint8_t shared_out[1024];
     _bit_unpack_8_8bw_lane(in, shared_out, reference, thread_idx * 4 + 0);
     _bit_unpack_8_8bw_lane(in, shared_out, reference, thread_idx * 4 + 1);
@@ -503,10 +425,10 @@ __device__ void _bit_unpack_8_8bw_32t(const uint8_t *__restrict in,
     }
 }
 
-extern "C" __global__ void
-bit_unpack_8_8bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
+extern "C" __global__ void bit_unpack_8_8bw_32t(const uint8_t *__restrict full_in, uint8_t *__restrict full_out, uint8_t reference) {
     int thread_idx = threadIdx.x;
     auto in = full_in + (blockIdx.x * (128 * 8 / sizeof(uint8_t)));
     auto out = full_out + (blockIdx.x * 1024);
     _bit_unpack_8_8bw_32t(in, out, reference, thread_idx);
 }
+


### PR DESCRIPTION
Exclude auto-formatting for gen CUDA files as they otherwise show up changed in case clang-format is not installed.