### PR TITLE
Generic Matchers

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -316,11 +316,13 @@ impl core::fmt::Debug for vortex_array::arrays::AnyScalarFn
 
 pub fn vortex_array::arrays::AnyScalarFn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::matcher::Matcher for vortex_array::arrays::AnyScalarFn
-
-pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
+impl vortex_array::matcher::Matcher<dyn vortex_array::Array> for vortex_array::arrays::AnyScalarFn
 
 pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
+
+impl vortex_array::matcher::MatcherType<dyn vortex_array::Array> for vortex_array::arrays::AnyScalarFn
+
+pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
 
 pub struct vortex_array::arrays::BoolArray
 
@@ -1310,13 +1312,15 @@ impl<F: core::fmt::Debug + vortex_array::expr::VTable> core::fmt::Debug for vort
 
 pub fn vortex_array::arrays::ExactScalarFn<F>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl<F: vortex_array::expr::VTable> vortex_array::matcher::Matcher for vortex_array::arrays::ExactScalarFn<F>
-
-pub type vortex_array::arrays::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::ScalarFnArrayView<'a, F>
+impl<F: vortex_array::expr::VTable> vortex_array::matcher::Matcher<dyn vortex_array::Array> for vortex_array::arrays::ExactScalarFn<F>
 
 pub fn vortex_array::arrays::ExactScalarFn<F>::matches(array: &dyn vortex_array::Array) -> bool
 
 pub fn vortex_array::arrays::ExactScalarFn<F>::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
+
+impl<F: vortex_array::expr::VTable> vortex_array::matcher::MatcherType<dyn vortex_array::Array> for vortex_array::arrays::ExactScalarFn<F>
+
+pub type vortex_array::arrays::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::ScalarFnArrayView<'a, F>
 
 pub struct vortex_array::arrays::ExtensionArray
 
@@ -1550,7 +1554,7 @@ impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::F
 
 pub type vortex_array::arrays::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
 
-pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::arrays::FilterReduceAdaptor<V>(pub V)
 
@@ -3084,7 +3088,7 @@ impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::S
 
 pub type vortex_array::arrays::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::arrays::SliceMetadata(_)
 
@@ -3106,7 +3110,7 @@ impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_arra
 
 pub type vortex_array::arrays::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::arrays::SliceVTable
 
@@ -3384,7 +3388,7 @@ impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::T
 
 pub type vortex_array::arrays::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::arrays::TakeReduceAdaptor<V>(pub V)
 
@@ -6320,11 +6324,11 @@ impl vortex_array::dtype::extension::ExtDTypeRef
 
 pub fn vortex_array::dtype::extension::ExtDTypeRef::downcast<V: vortex_array::dtype::extension::ExtVTable>(self) -> vortex_array::dtype::extension::ExtDType<V>
 
-pub fn vortex_array::dtype::extension::ExtDTypeRef::is<M: vortex_array::dtype::extension::Matcher>(&self) -> bool
+pub fn vortex_array::dtype::extension::ExtDTypeRef::is<M: vortex_array::matcher::Matcher<Self>>(&self) -> bool
 
-pub fn vortex_array::dtype::extension::ExtDTypeRef::metadata<M: vortex_array::dtype::extension::Matcher>(&self) -> <M as vortex_array::dtype::extension::Matcher>::Match
+pub fn vortex_array::dtype::extension::ExtDTypeRef::metadata<M: vortex_array::matcher::Matcher<Self>>(&self) -> <M as vortex_array::matcher::MatcherType>::Match
 
-pub fn vortex_array::dtype::extension::ExtDTypeRef::metadata_opt<M: vortex_array::dtype::extension::Matcher>(&self) -> core::option::Option<<M as vortex_array::dtype::extension::Matcher>::Match>
+pub fn vortex_array::dtype::extension::ExtDTypeRef::metadata_opt<M: vortex_array::matcher::Matcher<Self>>(&self) -> core::option::Option<<M as vortex_array::matcher::MatcherType>::Match>
 
 pub fn vortex_array::dtype::extension::ExtDTypeRef::try_downcast<V: vortex_array::dtype::extension::ExtVTable>(self) -> core::result::Result<vortex_array::dtype::extension::ExtDType<V>, vortex_array::dtype::extension::ExtDTypeRef>
 
@@ -6349,6 +6353,14 @@ pub fn vortex_array::dtype::extension::ExtDTypeRef::fmt(&self, f: &mut core::fmt
 impl core::hash::Hash for vortex_array::dtype::extension::ExtDTypeRef
 
 pub fn vortex_array::dtype::extension::ExtDTypeRef::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl vortex_array::matcher::Matcher<vortex_array::dtype::extension::ExtDTypeRef> for vortex_array::extension::datetime::AnyTemporal
+
+pub fn vortex_array::extension::datetime::AnyTemporal::try_match<'a>(item: &'a vortex_array::dtype::extension::ExtDTypeRef) -> core::option::Option<Self::Match>
+
+impl vortex_array::matcher::MatcherType<vortex_array::dtype::extension::ExtDTypeRef> for vortex_array::extension::datetime::AnyTemporal
+
+pub type vortex_array::extension::datetime::AnyTemporal::Match<'a> = vortex_array::extension::datetime::TemporalMetadata<'a>
 
 pub trait vortex_array::dtype::extension::ExtDTypePlugin: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug
 
@@ -6409,28 +6421,6 @@ pub fn vortex_array::extension::datetime::Timestamp::id(&self) -> vortex_array::
 pub fn vortex_array::extension::datetime::Timestamp::serialize(&self, metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
 pub fn vortex_array::extension::datetime::Timestamp::validate_dtype(&self, _metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
-
-pub trait vortex_array::dtype::extension::Matcher
-
-pub type vortex_array::dtype::extension::Matcher::Match<'a>
-
-pub fn vortex_array::dtype::extension::Matcher::matches(item: &vortex_array::dtype::extension::ExtDTypeRef) -> bool
-
-pub fn vortex_array::dtype::extension::Matcher::try_match<'a>(item: &'a vortex_array::dtype::extension::ExtDTypeRef) -> core::option::Option<Self::Match>
-
-impl vortex_array::dtype::extension::Matcher for vortex_array::extension::datetime::AnyTemporal
-
-pub type vortex_array::extension::datetime::AnyTemporal::Match<'a> = vortex_array::extension::datetime::TemporalMetadata<'a>
-
-pub fn vortex_array::extension::datetime::AnyTemporal::try_match<'a>(item: &'a vortex_array::dtype::extension::ExtDTypeRef) -> core::option::Option<Self::Match>
-
-impl<V: vortex_array::dtype::extension::ExtVTable> vortex_array::dtype::extension::Matcher for V
-
-pub type V::Match<'a> = &'a <V as vortex_array::dtype::extension::ExtVTable>::Metadata
-
-pub fn V::matches(item: &vortex_array::dtype::extension::ExtDTypeRef) -> bool
-
-pub fn V::try_match<'a>(item: &'a vortex_array::dtype::extension::ExtDTypeRef) -> core::option::Option<<V as vortex_array::dtype::extension::Matcher>::Match>
 
 pub type vortex_array::dtype::extension::ExtId = arcref::ArcRef<str>
 
@@ -10142,7 +10132,7 @@ impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::expr::Cas
 
 pub type vortex_array::expr::CastExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::expr::Cast>
 
-pub fn vortex_array::expr::CastExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::expr::CastExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::expr::CastReduceAdaptor<V>(pub V)
 
@@ -12308,11 +12298,13 @@ impl core::marker::StructuralPartialEq for vortex_array::extension::datetime::Ti
 
 pub struct vortex_array::extension::datetime::AnyTemporal
 
-impl vortex_array::dtype::extension::Matcher for vortex_array::extension::datetime::AnyTemporal
-
-pub type vortex_array::extension::datetime::AnyTemporal::Match<'a> = vortex_array::extension::datetime::TemporalMetadata<'a>
+impl vortex_array::matcher::Matcher<vortex_array::dtype::extension::ExtDTypeRef> for vortex_array::extension::datetime::AnyTemporal
 
 pub fn vortex_array::extension::datetime::AnyTemporal::try_match<'a>(item: &'a vortex_array::dtype::extension::ExtDTypeRef) -> core::option::Option<Self::Match>
+
+impl vortex_array::matcher::MatcherType<vortex_array::dtype::extension::ExtDTypeRef> for vortex_array::extension::datetime::AnyTemporal
+
+pub type vortex_array::extension::datetime::AnyTemporal::Match<'a> = vortex_array::extension::datetime::TemporalMetadata<'a>
 
 pub struct vortex_array::extension::datetime::Date
 
@@ -12588,27 +12580,27 @@ pub fn vortex_array::kernel::ParentKernelAdapter<V, K>::matches(&self, parent: &
 
 pub trait vortex_array::kernel::ExecuteParentKernel<V: vortex_array::vtable::VTable>: core::fmt::Debug + core::marker::Send + core::marker::Sync + 'static
 
-pub type vortex_array::kernel::ExecuteParentKernel::Parent: vortex_array::matcher::Matcher
+pub type vortex_array::kernel::ExecuteParentKernel::Parent: vortex_array::matcher::Matcher<dyn vortex_array::Array>
 
-pub fn vortex_array::kernel::ExecuteParentKernel::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::kernel::ExecuteParentKernel::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::FilterExecuteAdaptor<V> where V: vortex_array::arrays::FilterKernel
 
 pub type vortex_array::arrays::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
 
-pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::SliceExecuteAdaptor<V> where V: vortex_array::arrays::SliceKernel
 
 pub type vortex_array::arrays::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::TakeExecuteAdaptor<V> where V: vortex_array::arrays::TakeExecute
 
 pub type vortex_array::arrays::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::expr::BetweenExecuteAdaptor<V> where V: vortex_array::expr::BetweenKernel
 
@@ -12620,7 +12612,7 @@ impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::expr::Cas
 
 pub type vortex_array::expr::CastExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::expr::Cast>
 
-pub fn vortex_array::expr::CastExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::expr::CastExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::expr::CompareExecuteAdaptor<V> where V: vortex_array::expr::CompareKernel
 
@@ -12674,65 +12666,99 @@ impl core::fmt::Debug for vortex_array::matcher::AnyArray
 
 pub fn vortex_array::matcher::AnyArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::matcher::Matcher for vortex_array::matcher::AnyArray
-
-pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::Array + 'static)
+impl vortex_array::matcher::Matcher<dyn vortex_array::Array> for vortex_array::matcher::AnyArray
 
 pub fn vortex_array::matcher::AnyArray::matches(_array: &dyn vortex_array::Array) -> bool
 
 pub fn vortex_array::matcher::AnyArray::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
-pub trait vortex_array::matcher::Matcher
+impl vortex_array::matcher::MatcherType<dyn vortex_array::Array> for vortex_array::matcher::AnyArray
 
-pub type vortex_array::matcher::Matcher::Match<'a>
+pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::Array + 'static)
 
-pub fn vortex_array::matcher::Matcher::matches(array: &dyn vortex_array::Array) -> bool
+pub trait vortex_array::matcher::Matcher<Over: ?core::marker::Sized>: vortex_array::matcher::MatcherType<Over>
 
-pub fn vortex_array::matcher::Matcher::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn vortex_array::matcher::Matcher::matches(item: &Over) -> bool
 
-impl vortex_array::matcher::Matcher for vortex_array::AnyCanonical
+pub fn vortex_array::matcher::Matcher::try_match<'a>(item: &'a Over) -> core::option::Option<Self::Match>
 
-pub type vortex_array::AnyCanonical::Match<'a> = vortex_array::CanonicalView<'a>
+impl vortex_array::matcher::Matcher<dyn vortex_array::Array> for vortex_array::AnyCanonical
 
 pub fn vortex_array::AnyCanonical::matches(array: &dyn vortex_array::Array) -> bool
 
 pub fn vortex_array::AnyCanonical::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
-impl vortex_array::matcher::Matcher for vortex_array::AnyColumnar
-
-pub type vortex_array::AnyColumnar::Match<'a> = vortex_array::ColumnarView<'a>
+impl vortex_array::matcher::Matcher<dyn vortex_array::Array> for vortex_array::AnyColumnar
 
 pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
-impl vortex_array::matcher::Matcher for vortex_array::arrays::AnyScalarFn
-
-pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
+impl vortex_array::matcher::Matcher<dyn vortex_array::Array> for vortex_array::arrays::AnyScalarFn
 
 pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
-impl vortex_array::matcher::Matcher for vortex_array::matcher::AnyArray
-
-pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::Array + 'static)
+impl vortex_array::matcher::Matcher<dyn vortex_array::Array> for vortex_array::matcher::AnyArray
 
 pub fn vortex_array::matcher::AnyArray::matches(_array: &dyn vortex_array::Array) -> bool
 
 pub fn vortex_array::matcher::AnyArray::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
-impl<F: vortex_array::expr::VTable> vortex_array::matcher::Matcher for vortex_array::arrays::ExactScalarFn<F>
+impl vortex_array::matcher::Matcher<vortex_array::dtype::extension::ExtDTypeRef> for vortex_array::extension::datetime::AnyTemporal
 
-pub type vortex_array::arrays::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::ScalarFnArrayView<'a, F>
+pub fn vortex_array::extension::datetime::AnyTemporal::try_match<'a>(item: &'a vortex_array::dtype::extension::ExtDTypeRef) -> core::option::Option<Self::Match>
+
+impl<F: vortex_array::expr::VTable> vortex_array::matcher::Matcher<dyn vortex_array::Array> for vortex_array::arrays::ExactScalarFn<F>
 
 pub fn vortex_array::arrays::ExactScalarFn<F>::matches(array: &dyn vortex_array::Array) -> bool
 
 pub fn vortex_array::arrays::ExactScalarFn<F>::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
-impl<V: vortex_array::vtable::VTable> vortex_array::matcher::Matcher for V
+impl<V: vortex_array::dtype::extension::ExtVTable> vortex_array::matcher::Matcher<vortex_array::dtype::extension::ExtDTypeRef> for V
 
-pub type V::Match<'a> = &'a <V as vortex_array::vtable::VTable>::Array
+pub fn V::matches(item: &vortex_array::dtype::extension::ExtDTypeRef) -> bool
+
+pub fn V::try_match<'a>(item: &'a vortex_array::dtype::extension::ExtDTypeRef) -> core::option::Option<Self::Match>
+
+impl<V: vortex_array::vtable::VTable> vortex_array::matcher::Matcher<dyn vortex_array::Array> for V
 
 pub fn V::matches(array: &dyn vortex_array::Array) -> bool
 
 pub fn V::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
+
+pub trait vortex_array::matcher::MatcherType<Over: ?core::marker::Sized>
+
+pub type vortex_array::matcher::MatcherType::Match<'a>
+
+impl vortex_array::matcher::MatcherType<dyn vortex_array::Array> for vortex_array::AnyCanonical
+
+pub type vortex_array::AnyCanonical::Match<'a> = vortex_array::CanonicalView<'a>
+
+impl vortex_array::matcher::MatcherType<dyn vortex_array::Array> for vortex_array::AnyColumnar
+
+pub type vortex_array::AnyColumnar::Match<'a> = vortex_array::ColumnarView<'a>
+
+impl vortex_array::matcher::MatcherType<dyn vortex_array::Array> for vortex_array::arrays::AnyScalarFn
+
+pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
+
+impl vortex_array::matcher::MatcherType<dyn vortex_array::Array> for vortex_array::matcher::AnyArray
+
+pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::Array + 'static)
+
+impl vortex_array::matcher::MatcherType<vortex_array::dtype::extension::ExtDTypeRef> for vortex_array::extension::datetime::AnyTemporal
+
+pub type vortex_array::extension::datetime::AnyTemporal::Match<'a> = vortex_array::extension::datetime::TemporalMetadata<'a>
+
+impl<F: vortex_array::expr::VTable> vortex_array::matcher::MatcherType<dyn vortex_array::Array> for vortex_array::arrays::ExactScalarFn<F>
+
+pub type vortex_array::arrays::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::ScalarFnArrayView<'a, F>
+
+impl<V: vortex_array::dtype::extension::ExtVTable> vortex_array::matcher::MatcherType<vortex_array::dtype::extension::ExtDTypeRef> for V
+
+pub type V::Match<'a> = &'a <V as vortex_array::dtype::extension::ExtVTable>::Metadata
+
+impl<V: vortex_array::vtable::VTable> vortex_array::matcher::MatcherType<dyn vortex_array::Array> for V
+
+pub type V::Match<'a> = &'a <V as vortex_array::vtable::VTable>::Array
 
 pub mod vortex_array::normalize
 
@@ -12782,9 +12808,9 @@ pub const fn vortex_array::optimizer::rules::ReduceRuleSet<V>::new(rules: &'stat
 
 pub trait vortex_array::optimizer::rules::ArrayParentReduceRule<V: vortex_array::vtable::VTable>: core::fmt::Debug + core::marker::Send + core::marker::Sync + 'static
 
-pub type vortex_array::optimizer::rules::ArrayParentReduceRule::Parent: vortex_array::matcher::Matcher
+pub type vortex_array::optimizer::rules::ArrayParentReduceRule::Parent: vortex_array::matcher::Matcher<dyn vortex_array::Array>
 
-pub fn vortex_array::optimizer::rules::ArrayParentReduceRule::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::optimizer::rules::ArrayParentReduceRule::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolMaskedValidityRule
 
@@ -12814,7 +12840,7 @@ impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_arra
 
 pub type vortex_array::arrays::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::MatcherType<dyn vortex_array::Array>>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::TakeReduceAdaptor<V> where V: vortex_array::arrays::TakeReduce
 
@@ -17196,21 +17222,25 @@ impl core::marker::Copy for vortex_array::Precision
 
 pub struct vortex_array::AnyCanonical
 
-impl vortex_array::matcher::Matcher for vortex_array::AnyCanonical
-
-pub type vortex_array::AnyCanonical::Match<'a> = vortex_array::CanonicalView<'a>
+impl vortex_array::matcher::Matcher<dyn vortex_array::Array> for vortex_array::AnyCanonical
 
 pub fn vortex_array::AnyCanonical::matches(array: &dyn vortex_array::Array) -> bool
 
 pub fn vortex_array::AnyCanonical::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
+impl vortex_array::matcher::MatcherType<dyn vortex_array::Array> for vortex_array::AnyCanonical
+
+pub type vortex_array::AnyCanonical::Match<'a> = vortex_array::CanonicalView<'a>
+
 pub struct vortex_array::AnyColumnar
 
-impl vortex_array::matcher::Matcher for vortex_array::AnyColumnar
-
-pub type vortex_array::AnyColumnar::Match<'a> = vortex_array::ColumnarView<'a>
+impl vortex_array::matcher::Matcher<dyn vortex_array::Array> for vortex_array::AnyColumnar
 
 pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
+
+impl vortex_array::matcher::MatcherType<dyn vortex_array::Array> for vortex_array::AnyColumnar
+
+pub type vortex_array::AnyColumnar::Match<'a> = vortex_array::ColumnarView<'a>
 
 #[repr(transparent)] pub struct vortex_array::ArrayAdapter<V: vortex_array::vtable::VTable>(_)
 

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -53,6 +53,7 @@ use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProviderExt;
 use crate::hash;
 use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
 use crate::stats::StatsSetRef;
@@ -294,17 +295,17 @@ impl ToOwned for dyn Array {
 
 impl dyn Array + '_ {
     /// Does the array match the given matcher.
-    pub fn is<M: Matcher>(&self) -> bool {
+    pub fn is<M: Matcher<Self>>(&self) -> bool {
         M::matches(self)
     }
 
     /// Returns the array downcast by the given matcher.
-    pub fn as_<M: Matcher>(&self) -> M::Match<'_> {
+    pub fn as_<M: Matcher<Self>>(&self) -> M::Match<'_> {
         self.as_opt::<M>().vortex_expect("Failed to downcast")
     }
 
     /// Returns the array downcast by the given matcher.
-    pub fn as_opt<M: Matcher>(&self) -> Option<M::Match<'_>> {
+    pub fn as_opt<M: Matcher<Self>>(&self) -> Option<M::Match<'_>> {
         M::try_match(self)
     }
 
@@ -809,10 +810,12 @@ impl<V: VTable> ArrayVisitor for ArrayAdapter<V> {
     }
 }
 
-/// Implement a matcher for a specific VTable type
-impl<V: VTable> Matcher for V {
+impl<V: VTable> MatcherType<dyn Array> for V {
     type Match<'a> = &'a V::Array;
+}
 
+/// Implement a matcher for a specific VTable type
+impl<V: VTable> Matcher<dyn Array> for V {
     fn matches(array: &dyn Array) -> bool {
         Array::as_any(array).is::<ArrayAdapter<V>>()
     }

--- a/vortex-array/src/arrays/dict/take.rs
+++ b/vortex-array/src/arrays/dict/take.rs
@@ -16,7 +16,7 @@ use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProvider;
 use crate::expr::stats::StatsProviderExt;
 use crate::kernel::ExecuteParentKernel;
-use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::scalar::Scalar;
 use crate::stats::StatsSet;
@@ -118,7 +118,7 @@ where
     fn execute_parent(
         &self,
         array: &V::Array,
-        parent: <Self::Parent as Matcher>::Match<'_>,
+        parent: <Self::Parent as MatcherType<dyn Array>>::Match<'_>,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/filter/kernel.rs
+++ b/vortex-array/src/arrays/filter/kernel.rs
@@ -4,6 +4,7 @@
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::Array;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
@@ -11,7 +12,7 @@ use crate::IntoArray;
 use crate::arrays::FilterArray;
 use crate::arrays::FilterVTable;
 use crate::kernel::ExecuteParentKernel;
-use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::vtable::VTable;
 
@@ -105,7 +106,7 @@ where
     fn execute_parent(
         &self,
         array: &V::Array,
-        parent: <Self::Parent as Matcher>::Match<'_>,
+        parent: <Self::Parent as MatcherType<dyn Array>>::Match<'_>,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -39,6 +39,7 @@ use crate::expr::Expression;
 use crate::expr::ScalarFn;
 use crate::expr::VTableExt;
 use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 use crate::serde::ArrayChildren;
 use crate::vtable;
 use crate::vtable::ArrayId;
@@ -185,9 +186,12 @@ impl<V: expr::VTable> ScalarFnArrayExt for V {}
 /// A matcher that matches any scalar function expression.
 #[derive(Debug)]
 pub struct AnyScalarFn;
-impl Matcher for AnyScalarFn {
-    type Match<'a> = &'a ScalarFnArray;
 
+impl MatcherType<dyn Array> for AnyScalarFn {
+    type Match<'a> = &'a ScalarFnArray;
+}
+
+impl Matcher<dyn Array> for AnyScalarFn {
     fn try_match(array: &dyn Array) -> Option<Self::Match<'_>> {
         array.as_opt::<ScalarFnVTable>()
     }
@@ -197,9 +201,11 @@ impl Matcher for AnyScalarFn {
 #[derive(Debug, Default)]
 pub struct ExactScalarFn<F: expr::VTable>(PhantomData<F>);
 
-impl<F: expr::VTable> Matcher for ExactScalarFn<F> {
+impl<F: expr::VTable> MatcherType<dyn Array> for ExactScalarFn<F> {
     type Match<'a> = ScalarFnArrayView<'a, F>;
+}
 
+impl<F: expr::VTable> Matcher<dyn Array> for ExactScalarFn<F> {
     fn matches(array: &dyn Array) -> bool {
         if let Some(scalar_fn_array) = array.as_opt::<ScalarFnVTable>() {
             scalar_fn_array.scalar_fn().is::<F>()

--- a/vortex-array/src/arrays/slice/mod.rs
+++ b/vortex-array/src/arrays/slice/mod.rs
@@ -12,12 +12,13 @@ pub use array::*;
 use vortex_error::VortexResult;
 pub use vtable::*;
 
+use crate::Array;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::kernel::ExecuteParentKernel;
-use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::vtable::VTable;
 
@@ -76,7 +77,7 @@ where
     fn reduce_parent(
         &self,
         array: &V::Array,
-        parent: <Self::Parent as Matcher>::Match<'_>,
+        parent: <Self::Parent as MatcherType<dyn Array>>::Match<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         assert_eq!(child_idx, 0);
@@ -99,7 +100,7 @@ where
     fn execute_parent(
         &self,
         array: &V::Array,
-        parent: <Self::Parent as Matcher>::Match<'_>,
+        parent: <Self::Parent as MatcherType<dyn Array>>::Match<'_>,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -47,6 +47,7 @@ use crate::builders::builder_with_capacity;
 use crate::dtype::DType;
 use crate::dtype::NativePType;
 use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 
 /// An enum capturing the default uncompressed encodings for each [Vortex type](DType).
 ///
@@ -871,9 +872,12 @@ impl AsRef<dyn Array> for CanonicalView<'_> {
 
 /// A matcher for any canonical array type.
 pub struct AnyCanonical;
-impl Matcher for AnyCanonical {
-    type Match<'a> = CanonicalView<'a>;
 
+impl MatcherType<dyn Array> for AnyCanonical {
+    type Match<'a> = CanonicalView<'a>;
+}
+
+impl Matcher<dyn Array> for AnyCanonical {
     fn matches(array: &dyn Array) -> bool {
         array.is::<NullVTable>()
             || array.is::<BoolVTable>()

--- a/vortex-array/src/columnar.rs
+++ b/vortex-array/src/columnar.rs
@@ -20,6 +20,7 @@ use crate::arrays::ConstantArray;
 use crate::arrays::ConstantVTable;
 use crate::dtype::DType;
 use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 use crate::scalar::Scalar;
 
 /// Represents a columnnar array of data, either in canonical form or as a constant array.
@@ -125,9 +126,12 @@ impl<'a> AsRef<dyn Array> for ColumnarView<'a> {
 }
 
 pub struct AnyColumnar;
-impl Matcher for AnyColumnar {
-    type Match<'a> = ColumnarView<'a>;
 
+impl MatcherType<dyn Array> for AnyColumnar {
+    type Match<'a> = ColumnarView<'a>;
+}
+
+impl Matcher<dyn Array> for AnyColumnar {
     fn try_match<'a>(array: &'a dyn Array) -> Option<Self::Match<'a>> {
         if let Some(constant) = array.as_opt::<ConstantVTable>() {
             Some(ColumnarView::Constant(constant))

--- a/vortex-array/src/dtype/extension/erased.rs
+++ b/vortex-array/src/dtype/extension/erased.rs
@@ -20,9 +20,9 @@ use crate::dtype::Nullability;
 use crate::dtype::extension::ExtDType;
 use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ExtVTable;
-use crate::dtype::extension::Matcher;
 use crate::dtype::extension::typed::DynExtDType;
 use crate::dtype::extension::typed::ExtDTypeInner;
+use crate::matcher::Matcher;
 
 /// A type-erased extension dtype.
 ///

--- a/vortex-array/src/dtype/extension/erased.rs
+++ b/vortex-array/src/dtype/extension/erased.rs
@@ -91,12 +91,12 @@ impl ExtDTypeRef {
 /// Methods for downcasting type-erased extension dtypes.
 impl ExtDTypeRef {
     /// Check if the extension dtype is of the concrete type.
-    pub fn is<M: Matcher>(&self) -> bool {
+    pub fn is<M: Matcher<Self>>(&self) -> bool {
         M::matches(self)
     }
 
     /// Extract the metadata of the ExtDType per the given [`Matcher`].
-    pub fn metadata_opt<M: Matcher>(&self) -> Option<M::Match<'_>> {
+    pub fn metadata_opt<M: Matcher<Self>>(&self) -> Option<M::Match<'_>> {
         M::try_match(self)
     }
 
@@ -105,7 +105,7 @@ impl ExtDTypeRef {
     /// # Panics
     ///
     /// Panics if the match fails.
-    pub fn metadata<M: Matcher>(&self) -> M::Match<'_> {
+    pub fn metadata<M: Matcher<Self>>(&self) -> M::Match<'_> {
         self.metadata_opt::<M>()
             .vortex_expect("Failed to downcast ExtDTypeRef")
     }

--- a/vortex-array/src/dtype/extension/matcher.rs
+++ b/vortex-array/src/dtype/extension/matcher.rs
@@ -5,23 +5,30 @@ use crate::dtype::extension::ExtDTypeRef;
 use crate::dtype::extension::ExtVTable;
 use crate::dtype::extension::typed::ExtDTypeInner;
 
-/// A trait for matching extension dtypes.
-pub trait Matcher {
+/// A super trait that allows us to define a generic associated type on `Matcher`.
+///
+/// We need to have this because of https://github.com/rust-lang/rust/issues/87479
+pub trait MatcherType {
     /// The matched view type.
     type Match<'a>;
+}
 
+/// A trait for matching extension dtypes.
+pub trait Matcher<Over>: MatcherType {
     /// Check if the given extension dtype matches this matcher.
-    fn matches(item: &ExtDTypeRef) -> bool {
+    fn matches(item: &Over) -> bool {
         Self::try_match(item).is_some()
     }
 
     /// Try to match the given extension type, returning the matched dtype if successful.
-    fn try_match<'a>(item: &'a ExtDTypeRef) -> Option<Self::Match<'a>>;
+    fn try_match<'a>(item: &'a Over) -> Option<Self::Match<'a>>;
 }
 
-impl<V: ExtVTable> Matcher for V {
+impl<V: ExtVTable> MatcherType for V {
     type Match<'a> = &'a V::Metadata;
+}
 
+impl<V: ExtVTable> Matcher<ExtDTypeRef> for V {
     fn matches(item: &ExtDTypeRef) -> bool {
         item.0.as_any().is::<ExtDTypeInner<V>>()
     }

--- a/vortex-array/src/dtype/extension/matcher.rs
+++ b/vortex-array/src/dtype/extension/matcher.rs
@@ -4,27 +4,10 @@
 use crate::dtype::extension::ExtDTypeRef;
 use crate::dtype::extension::ExtVTable;
 use crate::dtype::extension::typed::ExtDTypeInner;
+use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 
-/// A super trait that allows us to define a generic associated type on `Matcher`.
-///
-/// We need to have this because of https://github.com/rust-lang/rust/issues/87479
-pub trait MatcherType {
-    /// The matched view type.
-    type Match<'a>;
-}
-
-/// A trait for matching extension dtypes.
-pub trait Matcher<Over>: MatcherType {
-    /// Check if the given extension dtype matches this matcher.
-    fn matches(item: &Over) -> bool {
-        Self::try_match(item).is_some()
-    }
-
-    /// Try to match the given extension type, returning the matched dtype if successful.
-    fn try_match<'a>(item: &'a Over) -> Option<Self::Match<'a>>;
-}
-
-impl<V: ExtVTable> MatcherType for V {
+impl<V: ExtVTable> MatcherType<ExtDTypeRef> for V {
     type Match<'a> = &'a V::Metadata;
 }
 

--- a/vortex-array/src/dtype/extension/mod.rs
+++ b/vortex-array/src/dtype/extension/mod.rs
@@ -26,8 +26,6 @@ mod erased;
 pub use erased::ExtDTypeRef;
 
 mod matcher;
-pub use matcher::Matcher;
-pub use matcher::MatcherType;
 
 /// A unique identifier for an extension type
 pub type ExtId = arcref::ArcRef<str>;

--- a/vortex-array/src/dtype/extension/mod.rs
+++ b/vortex-array/src/dtype/extension/mod.rs
@@ -27,6 +27,7 @@ pub use erased::ExtDTypeRef;
 
 mod matcher;
 pub use matcher::Matcher;
+pub use matcher::MatcherType;
 
 /// A unique identifier for an extension type
 pub type ExtId = arcref::ArcRef<str>;

--- a/vortex-array/src/expr/exprs/cast/kernel.rs
+++ b/vortex-array/src/expr/exprs/cast/kernel.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 
+use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::arrays::ExactScalarFn;
@@ -10,7 +11,7 @@ use crate::arrays::ScalarFnArrayView;
 use crate::dtype::DType;
 use crate::expr::Cast;
 use crate::kernel::ExecuteParentKernel;
-use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::vtable::VTable;
 
@@ -76,7 +77,7 @@ where
     fn execute_parent(
         &self,
         array: &V::Array,
-        parent: <Self::Parent as Matcher>::Match<'_>,
+        parent: <Self::Parent as MatcherType<dyn Array>>::Match<'_>,
         _child_idx: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/extension/datetime/matcher.rs
+++ b/vortex-array/src/extension/datetime/matcher.rs
@@ -8,17 +8,17 @@ use vortex_error::VortexResult;
 
 use crate::dtype::extension::ExtDTypeRef;
 use crate::dtype::extension::ExtVTable;
-use crate::dtype::extension::Matcher;
-use crate::dtype::extension::MatcherType;
 use crate::extension::datetime::Date;
 use crate::extension::datetime::Time;
 use crate::extension::datetime::TimeUnit;
 use crate::extension::datetime::Timestamp;
+use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 
 /// Matcher for temporal extension data types.
 pub struct AnyTemporal;
 
-impl MatcherType for AnyTemporal {
+impl MatcherType<ExtDTypeRef> for AnyTemporal {
     type Match<'a> = TemporalMetadata<'a>;
 }
 

--- a/vortex-array/src/extension/datetime/matcher.rs
+++ b/vortex-array/src/extension/datetime/matcher.rs
@@ -9,6 +9,7 @@ use vortex_error::VortexResult;
 use crate::dtype::extension::ExtDTypeRef;
 use crate::dtype::extension::ExtVTable;
 use crate::dtype::extension::Matcher;
+use crate::dtype::extension::MatcherType;
 use crate::extension::datetime::Date;
 use crate::extension::datetime::Time;
 use crate::extension::datetime::TimeUnit;
@@ -17,9 +18,11 @@ use crate::extension::datetime::Timestamp;
 /// Matcher for temporal extension data types.
 pub struct AnyTemporal;
 
-impl Matcher for AnyTemporal {
+impl MatcherType for AnyTemporal {
     type Match<'a> = TemporalMetadata<'a>;
+}
 
+impl Matcher<ExtDTypeRef> for AnyTemporal {
     fn try_match<'a>(item: &'a ExtDTypeRef) -> Option<Self::Match<'a>> {
         if let Some(opts) = item.metadata_opt::<Timestamp>() {
             return Some(TemporalMetadata::Timestamp(&opts.unit, &opts.tz));

--- a/vortex-array/src/kernel.rs
+++ b/vortex-array/src/kernel.rs
@@ -7,9 +7,11 @@ use std::marker::PhantomData;
 
 use vortex_error::VortexResult;
 
+use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 use crate::vtable::VTable;
 
 pub struct ParentKernelSet<V: VTable> {
@@ -59,13 +61,13 @@ impl<V: VTable> ParentKernelSet<V> {
 }
 
 pub trait ExecuteParentKernel<V: VTable>: Debug + Send + Sync + 'static {
-    type Parent: Matcher;
+    type Parent: Matcher<dyn Array>;
 
     /// Attempt to execute the parent array fused with the child array.
     fn execute_parent(
         &self,
         array: &V::Array,
-        parent: <Self::Parent as Matcher>::Match<'_>,
+        parent: <Self::Parent as MatcherType<dyn Array>>::Match<'_>,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>>;

--- a/vortex-array/src/matcher.rs
+++ b/vortex-array/src/matcher.rs
@@ -3,26 +3,35 @@
 
 use crate::Array;
 
-/// Trait for matching array types.
-pub trait Matcher {
+/// A super trait that allows us to define a generic associated type on `Matcher`.
+///
+/// We need to do this in this manner because of rust needs to keep forward compatibility.
+/// See [this](https://github.com/rust-lang/rust/issues/87479) GitHub issue for more information.
+pub trait MatcherType<Over: ?Sized> {
+    /// The matched view type.
     type Match<'a>;
+}
 
-    /// Check if the given array matches this matcher type
-    fn matches(array: &dyn Array) -> bool {
-        Self::try_match(array).is_some()
+/// A trait for matching types.
+pub trait Matcher<Over: ?Sized>: MatcherType<Over> {
+    /// Check if the given item matches this matcher.
+    fn matches(item: &Over) -> bool {
+        Self::try_match(item).is_some()
     }
 
-    /// Try to match the given array, returning the matched view type if successful.
-    fn try_match<'a>(array: &'a dyn Array) -> Option<Self::Match<'a>>;
+    /// Try to match the given item, returning the matched type if successful.
+    fn try_match<'a>(item: &'a Over) -> Option<Self::Match<'a>>;
 }
 
 /// Matches any array type (wildcard matcher)
 #[derive(Debug)]
 pub struct AnyArray;
 
-impl Matcher for AnyArray {
+impl MatcherType<dyn Array> for AnyArray {
     type Match<'a> = &'a dyn Array;
+}
 
+impl Matcher<dyn Array> for AnyArray {
     #[inline(always)]
     fn matches(_array: &dyn Array) -> bool {
         true

--- a/vortex-array/src/optimizer/rules.rs
+++ b/vortex-array/src/optimizer/rules.rs
@@ -7,8 +7,10 @@ use std::marker::PhantomData;
 
 use vortex_error::VortexResult;
 
+use crate::Array;
 use crate::array::ArrayRef;
 use crate::matcher::Matcher;
+use crate::matcher::MatcherType;
 use crate::vtable::VTable;
 
 /// A rewrite rule that transforms arrays based on their own content
@@ -24,7 +26,7 @@ pub trait ArrayReduceRule<V: VTable>: Debug + Send + Sync + 'static {
 
 /// A rewrite rule that transforms arrays based on parent context
 pub trait ArrayParentReduceRule<V: VTable>: Debug + Send + Sync + 'static {
-    type Parent: Matcher;
+    type Parent: Matcher<dyn Array>;
 
     /// Attempt to rewrite this child array given information about its parent.
     ///
@@ -35,7 +37,7 @@ pub trait ArrayParentReduceRule<V: VTable>: Debug + Send + Sync + 'static {
     fn reduce_parent(
         &self,
         array: &V::Array,
-        parent: <Self::Parent as Matcher>::Match<'_>,
+        parent: <Self::Parent as MatcherType<dyn Array>>::Match<'_>,
         child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>>;
 }


### PR DESCRIPTION
## Summary

This PR pakes the `Matcher` pattern we have been using generic, and replaces the existing duplicated traits. The changes can be roughly seen in this order by the 2 commits.

We want this because we will be adding matchers for the extension scalars and arrays in the future, and having 4 duplicated traits that are exactly the same except for 1 parameter is a bit much.

---

The old trait(s) was this before:

```rust
pub trait Matcher {
    type Match<'a>;

    /// Check if the given array matches this matcher type
    //                 vvvvvvvvv This is hardcoded!
    fn matches(array: &dyn Array) -> bool {
        Self::try_match(array).is_some()
    }

    /// Try to match the given array, returning the matched view type if successful.
    //                          vvvvvvvvv This is hardcoded!
    fn try_match<'a>(array: &'a dyn Array) -> Option<Self::Match<'a>>;
}
```

The new trait(s) is now:

```rust
/// A super trait that allows us to define a generic associated type on `Matcher`.
///
/// We need to do this in this manner because of rust needs to keep forward compatibility.
/// See [this](https://github.com/rust-lang/rust/issues/87479) GitHub issue for more information.
pub trait MatcherType<Over: ?Sized> {
    /// The matched view type.
    type Match<'a>;
}

/// A trait for matching types.
pub trait Matcher<Over: ?Sized>: MatcherType<Over> {
    /// Check if the given item matches this matcher.
    fn matches(item: &Over) -> bool {
        Self::try_match(item).is_some()
    }

    /// Try to match the given item, returning the matched type if successful.
    fn try_match<'a>(item: &'a Over) -> Option<Self::Match<'a>>;
}
```

### Why 2 traits?

Note that the issue in https://github.com/rust-lang/rust/issues/87479 is the reason we need to split this out into 2 traits. This meant changing some fully qualified paths, but that is just a cosmetic change.

### Why generic `MatcherType<Over: ?Sized>`?

Also, you might wonder why the `MatcherType` also has a generic parameter. This is because we have both a `impl<V: VTable> MatcherType<dyn Array> for V` and a `impl<V: ExtVTable> MatcherType<ExtDTypeRef> for V`, and without that generic parameter the trait solver cannot distinguish that `VTable` is mutually exclusive from `ExtVTable`.

## Unresolved Questions

It might be good to also type alias the `Matcher<dyn Array>` to an `ArrayMatcher`? Not sure if that's any better.

## API Changes

Technically there are API changes here but it is mostly related to extension types which nobody should be using right now anyways.

## Testing

Since this is a generics change there is not logical difference.