### PR TITLE
Rename spawn_blocking -> spawn_blocking_io

### DIFF
--- a/vortex-io/public-api.lock
+++ b/vortex-io/public-api.lock
@@ -410,7 +410,7 @@ pub trait vortex_io::runtime::Executor: core::marker::Send + core::marker::Sync
 
 pub fn vortex_io::runtime::Executor::spawn(&self, fut: futures_core::future::BoxFuture<'static, ()>) -> vortex_io::runtime::AbortHandleRef
 
-pub fn vortex_io::runtime::Executor::spawn_blocking(&self, task: alloc::boxed::Box<(dyn core::ops::function::FnOnce() + core::marker::Send + 'static)>) -> vortex_io::runtime::AbortHandleRef
+pub fn vortex_io::runtime::Executor::spawn_blocking_io(&self, task: alloc::boxed::Box<(dyn core::ops::function::FnOnce() + core::marker::Send + 'static)>) -> vortex_io::runtime::AbortHandleRef
 
 pub fn vortex_io::runtime::Executor::spawn_cpu(&self, task: alloc::boxed::Box<(dyn core::ops::function::FnOnce() + core::marker::Send + 'static)>) -> vortex_io::runtime::AbortHandleRef
 
@@ -418,7 +418,7 @@ impl vortex_io::runtime::Executor for async_executor::Executor<'static>
 
 pub fn async_executor::Executor<'static>::spawn(&self, fut: futures_core::future::BoxFuture<'static, ()>) -> vortex_io::runtime::AbortHandleRef
 
-pub fn async_executor::Executor<'static>::spawn_blocking(&self, task: alloc::boxed::Box<(dyn core::ops::function::FnOnce() + core::marker::Send + 'static)>) -> vortex_io::runtime::AbortHandleRef
+pub fn async_executor::Executor<'static>::spawn_blocking_io(&self, task: alloc::boxed::Box<(dyn core::ops::function::FnOnce() + core::marker::Send + 'static)>) -> vortex_io::runtime::AbortHandleRef
 
 pub fn async_executor::Executor<'static>::spawn_cpu(&self, task: alloc::boxed::Box<(dyn core::ops::function::FnOnce() + core::marker::Send + 'static)>) -> vortex_io::runtime::AbortHandleRef
 
@@ -426,7 +426,7 @@ impl vortex_io::runtime::Executor for tokio::runtime::handle::Handle
 
 pub fn tokio::runtime::handle::Handle::spawn(&self, fut: futures_core::future::BoxFuture<'static, ()>) -> vortex_io::runtime::AbortHandleRef
 
-pub fn tokio::runtime::handle::Handle::spawn_blocking(&self, task: alloc::boxed::Box<(dyn core::ops::function::FnOnce() + core::marker::Send + 'static)>) -> vortex_io::runtime::AbortHandleRef
+pub fn tokio::runtime::handle::Handle::spawn_blocking_io(&self, task: alloc::boxed::Box<(dyn core::ops::function::FnOnce() + core::marker::Send + 'static)>) -> vortex_io::runtime::AbortHandleRef
 
 pub fn tokio::runtime::handle::Handle::spawn_cpu(&self, cpu: alloc::boxed::Box<(dyn core::ops::function::FnOnce() + core::marker::Send + 'static)>) -> vortex_io::runtime::AbortHandleRef
 

--- a/vortex-io/src/runtime/handle.rs
+++ b/vortex-io/src/runtime/handle.rs
@@ -123,7 +123,7 @@ impl Handle {
         R: Send + 'static,
     {
         let (send, recv) = oneshot::channel();
-        let abort_handle = self.runtime().spawn_blocking(Box::new(move || {
+        let abort_handle = self.runtime().spawn_blocking_io(Box::new(move || {
             // Optimistically avoid the work if the result won't be used.
             if !send.is_closed() {
                 // Task::detach allows the receiver to be dropped, so we ignore send errors.

--- a/vortex-io/src/runtime/mod.rs
+++ b/vortex-io/src/runtime/mod.rs
@@ -53,7 +53,7 @@ pub trait Executor: Send + Sync {
     ///
     /// The returned `AbortHandle` may be used to optimistically cancel the task if it has not
     /// yet started executing.
-    fn spawn_blocking(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef;
+    fn spawn_blocking_io(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef;
 }
 
 /// A handle that may be used to optimistically abort a spawned task.

--- a/vortex-io/src/runtime/single.rs
+++ b/vortex-io/src/runtime/single.rs
@@ -140,7 +140,7 @@ impl Executor for Sender {
         })
     }
 
-    fn spawn_blocking(&self, work: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
+    fn spawn_blocking_io(&self, work: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
         let (send, recv) = oneshot::channel();
         if let Err(e) = self.blocking.send(SpawnSync {
             sync: work,

--- a/vortex-io/src/runtime/smol.rs
+++ b/vortex-io/src/runtime/smol.rs
@@ -19,7 +19,7 @@ impl Executor for smol::Executor<'static> {
         SmolAbortHandle::new_handle(smol::Executor::spawn(self, async move { task() }))
     }
 
-    fn spawn_blocking(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
+    fn spawn_blocking_io(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
         SmolAbortHandle::new_handle(smol::unblock(task))
     }
 }

--- a/vortex-io/src/runtime/tokio.rs
+++ b/vortex-io/src/runtime/tokio.rs
@@ -72,7 +72,7 @@ impl Executor for tokio::runtime::Handle {
         }
     }
 
-    fn spawn_blocking(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
+    fn spawn_blocking_io(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
         #[cfg(unix)]
         {
             use custom_labels::Labelset;
@@ -106,7 +106,7 @@ impl Executor for CurrentTokioRuntime {
         )
     }
 
-    fn spawn_blocking(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
+    fn spawn_blocking_io(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
         Box::new(
             tokio::runtime::Handle::current()
                 .spawn_blocking(task)

--- a/vortex-io/src/runtime/wasm.rs
+++ b/vortex-io/src/runtime/wasm.rs
@@ -36,7 +36,7 @@ impl Executor for WasmRuntime {
         Box::new(NoOpAbortHandle)
     }
 
-    fn spawn_blocking(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
+    fn spawn_blocking_io(&self, task: Box<dyn FnOnce() + Send + 'static>) -> AbortHandleRef {
         spawn_local(async move { task() });
         Box::new(NoOpAbortHandle)
     }


### PR DESCRIPTION
Things go really badly if we accidentally spawn CPU-heavy work onto the blocking pool. This name clarifies it.

Fixes #6672 