### PR TITLE
Add explain feature to DF benchmarks

### DIFF
--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -39,6 +39,8 @@ use vortex_bench::conversions::convert_parquet_directory_to_vortex;
 use vortex_bench::create_benchmark;
 use vortex_bench::create_output_writer;
 use vortex_bench::display::DisplayFormat;
+use vortex_bench::runner::BenchmarkMode;
+use vortex_bench::runner::BenchmarkQueryResult;
 use vortex_bench::runner::SqlBenchmarkRunner;
 use vortex_bench::runner::filter_queries;
 use vortex_bench::setup_logging_and_tracing;
@@ -159,46 +161,18 @@ async fn main() -> anyhow::Result<()> {
         Arc::new(Mutex::new(Vec::new()));
     let show_metrics = args.show_metrics;
 
-    if args.explain {
-        runner
-            .explain_all_async(
-                &filtered_queries,
-                |format| {
-                    let benchmark = &*benchmark;
-                    async move {
-                        let session = datafusion_bench::get_session_context();
-                        datafusion_bench::make_object_store(&session, benchmark.data_url())?;
-                        register_benchmark_tables(&session, benchmark, format).await?;
-                        Ok(session)
-                    }
-                },
-                |session, _query_idx, _format, query| {
-                    let explain_query = format!("EXPLAIN {query}");
-                    Box::pin(async move {
-                        let df = session.sql(&explain_query).await?;
-                        let batches = df.collect().await?;
-                        let mut output = String::new();
-                        for batch in &batches {
-                            output.push_str(
-                                &datafusion::arrow::util::pretty::pretty_format_batches(
-                                    std::slice::from_ref(batch),
-                                )?
-                                .to_string(),
-                            );
-                        }
-                        Ok(output)
-                    })
-                },
-            )
-            .await?;
-
-        return Ok(());
-    }
+    let mode = if args.explain {
+        BenchmarkMode::Explain
+    } else {
+        BenchmarkMode::Run {
+            iterations: args.iterations,
+        }
+    };
 
     runner
         .run_all_async(
             &filtered_queries,
-            args.iterations,
+            mode,
             |format| {
                 let benchmark = &*benchmark;
                 async move {
@@ -220,7 +194,6 @@ async fn main() -> anyhow::Result<()> {
                             .with_labelset(get_labelset_from_global())
                             .await?;
                         let time = timer.elapsed();
-                        let row_count = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
                         // Store plan for metrics (only store once per query/format combination)
                         if show_metrics {
@@ -234,7 +207,7 @@ async fn main() -> anyhow::Result<()> {
                             }
                         }
 
-                        anyhow::Ok((row_count, Some(time), plan))
+                        anyhow::Ok((Some(time), DataFusionQueryResult(batches)))
                     }
                     .with_labelset(labelset),
                 )
@@ -242,15 +215,17 @@ async fn main() -> anyhow::Result<()> {
         )
         .await?;
 
-    // Print metrics if requested
-    if show_metrics {
-        let plans = collected_plans.lock();
-        print_metrics(plans.as_ref());
-    }
+    if !args.explain {
+        // Print metrics if requested
+        if show_metrics {
+            let plans = collected_plans.lock();
+            print_metrics(plans.as_ref());
+        }
 
-    let benchmark_id = format!("datafusion-{}", benchmark.dataset_name());
-    let writer = create_output_writer(&args.display_format, args.output_path, &benchmark_id)?;
-    runner.export_to(&args.display_format, writer)?;
+        let benchmark_id = format!("datafusion-{}", benchmark.dataset_name());
+        let writer = create_output_writer(&args.display_format, args.output_path, &benchmark_id)?;
+        runner.export_to(&args.display_format, writer)?;
+    }
 
     Ok(())
 }
@@ -410,6 +385,21 @@ async fn register_arrow_tables<B: Benchmark + ?Sized>(
     }
 
     Ok(())
+}
+
+/// Wrapper around DataFusion record batches implementing `BenchmarkQueryResult`.
+pub struct DataFusionQueryResult(pub Vec<RecordBatch>);
+
+impl BenchmarkQueryResult for DataFusionQueryResult {
+    fn row_count(&self) -> usize {
+        self.0.iter().map(|batch| batch.num_rows()).sum()
+    }
+
+    fn display(self) -> String {
+        datafusion::arrow::util::pretty::pretty_format_batches(&self.0)
+            .map(|d| d.to_string())
+            .unwrap_or_else(|e| format!("<error: {e}>"))
+    }
 }
 
 pub async fn execute_query(

--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -95,9 +95,6 @@ struct Args {
     #[arg(long, default_value_t = false)]
     explain: bool,
 
-    #[arg(long, default_value_t = false)]
-    explain_analyze: bool,
-
     #[arg(long, value_delimiter = ',', value_parser = value_parser!(Format))]
     formats: Vec<Format>,
 
@@ -161,6 +158,42 @@ async fn main() -> anyhow::Result<()> {
     let collected_plans: Arc<Mutex<Vec<(usize, Format, Arc<dyn ExecutionPlan>)>>> =
         Arc::new(Mutex::new(Vec::new()));
     let show_metrics = args.show_metrics;
+
+    if args.explain {
+        runner
+            .explain_all_async(
+                &filtered_queries,
+                |format| {
+                    let benchmark = &*benchmark;
+                    async move {
+                        let session = datafusion_bench::get_session_context();
+                        datafusion_bench::make_object_store(&session, benchmark.data_url())?;
+                        register_benchmark_tables(&session, benchmark, format).await?;
+                        Ok(session)
+                    }
+                },
+                |session, _query_idx, _format, query| {
+                    let explain_query = format!("EXPLAIN {query}");
+                    Box::pin(async move {
+                        let df = session.sql(&explain_query).await?;
+                        let batches = df.collect().await?;
+                        let mut output = String::new();
+                        for batch in &batches {
+                            output.push_str(
+                                &datafusion::arrow::util::pretty::pretty_format_batches(
+                                    std::slice::from_ref(batch),
+                                )?
+                                .to_string(),
+                            );
+                        }
+                        Ok(output)
+                    })
+                },
+            )
+            .await?;
+
+        return Ok(());
+    }
 
     runner
         .run_all_async(

--- a/benchmarks/duckdb-bench/src/lib.rs
+++ b/benchmarks/duckdb-bench/src/lib.rs
@@ -3,6 +3,7 @@
 
 //! DuckDB context for benchmarks.
 
+use std::ops::Deref;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::time::Instant;
@@ -14,9 +15,11 @@ use vortex_bench::Benchmark;
 use vortex_bench::Format;
 use vortex_bench::IdempotentPath;
 use vortex_bench::generate_duckdb_registration_sql;
+use vortex_bench::runner::BenchmarkQueryResult;
 use vortex_duckdb::duckdb::Config;
 use vortex_duckdb::duckdb::Connection;
 use vortex_duckdb::duckdb::Database;
+use vortex_duckdb::duckdb::QueryResult;
 
 /// DuckDB context for benchmarks.
 pub struct DuckClient {
@@ -188,5 +191,33 @@ impl DuckClient {
         }
 
         Ok(())
+    }
+
+    /// Execute a query and return a `DuckQueryResult` wrapper.
+    pub fn execute_query_result(&self, query: &str) -> Result<(Option<Duration>, DuckQueryResult)> {
+        trace!("execute duckdb query: {query}");
+        let time_instant = Instant::now();
+        let result = self.connection().query(query)?;
+        let query_time = time_instant.elapsed();
+        Ok((Some(query_time), DuckQueryResult(result)))
+    }
+}
+
+/// Wrapper around DuckDB's `QueryResult` implementing `BenchmarkQueryResult`.
+pub struct DuckQueryResult(pub QueryResult);
+
+impl BenchmarkQueryResult for DuckQueryResult {
+    fn row_count(&self) -> usize {
+        usize::try_from(self.0.row_count()).unwrap_or(0)
+    }
+
+    fn display(self) -> String {
+        let mut output = String::new();
+        for chunk in self.0 {
+            let chunk_str =
+                String::try_from(chunk.deref()).unwrap_or_else(|_| "<error>".to_string());
+            output.push_str(&chunk_str);
+        }
+        output
     }
 }

--- a/benchmarks/duckdb-bench/src/main.rs
+++ b/benchmarks/duckdb-bench/src/main.rs
@@ -3,7 +3,6 @@
 
 mod validation;
 
-use std::ops::Deref;
 use std::path::PathBuf;
 
 use clap::Parser;
@@ -21,6 +20,7 @@ use vortex_bench::conversions::convert_parquet_directory_to_vortex;
 use vortex_bench::create_benchmark;
 use vortex_bench::create_output_writer;
 use vortex_bench::display::DisplayFormat;
+use vortex_bench::runner::BenchmarkMode;
 use vortex_bench::runner::SqlBenchmarkRunner;
 use vortex_bench::runner::filter_queries;
 use vortex_bench::setup_logging_and_tracing;
@@ -149,37 +149,17 @@ fn main() -> anyhow::Result<()> {
 
     let benchmark_name = benchmark.dataset().to_string();
 
-    if args.explain {
-        runner.explain_all(
-            &filtered_queries,
-            |format| {
-                let ctx = DuckClient::new(
-                    &*benchmark,
-                    format,
-                    args.delete_duckdb_database,
-                    args.threads,
-                )?;
-                ctx.register_tables(&*benchmark, format)?;
-                Ok(ctx)
-            },
-            |ctx, _query_idx, _format, query| {
-                let result = ctx.connection().query(&format!("EXPLAIN {query}"))?;
-                let mut output = String::new();
-                for chunk in result {
-                    let chunk_str =
-                        String::try_from(chunk.deref()).unwrap_or_else(|_| "<error>".to_string());
-                    output.push_str(&chunk_str);
-                }
-                Ok(output)
-            },
-        )?;
-
-        return Ok(());
-    }
+    let mode = if args.explain {
+        BenchmarkMode::Explain
+    } else {
+        BenchmarkMode::Run {
+            iterations: args.iterations,
+        }
+    };
 
     runner.run_all(
         &filtered_queries,
-        args.iterations,
+        mode,
         |format| {
             let ctx = DuckClient::new(
                 &*benchmark,
@@ -201,13 +181,15 @@ fn main() -> anyhow::Result<()> {
             if !args.reuse {
                 ctx.reopen()?;
             }
-            ctx.execute_query(query)
+            ctx.execute_query_result(query)
         },
     )?;
 
-    let benchmark_id = format!("duckdb-{}", benchmark.dataset_name());
-    let writer = create_output_writer(&args.display_format, args.output_path, &benchmark_id)?;
-    runner.export_to(&args.display_format, writer)?;
+    if !args.explain {
+        let benchmark_id = format!("duckdb-{}", benchmark.dataset_name());
+        let writer = create_output_writer(&args.display_format, args.output_path, &benchmark_id)?;
+        runner.export_to(&args.display_format, writer)?;
+    }
 
     Ok(())
 }

--- a/benchmarks/duckdb-bench/src/main.rs
+++ b/benchmarks/duckdb-bench/src/main.rs
@@ -139,33 +139,6 @@ fn main() -> anyhow::Result<()> {
         })?;
     }
 
-    if args.explain {
-        for format in &args.formats {
-            let ctx = DuckClient::new(
-                &*benchmark,
-                *format,
-                args.delete_duckdb_database,
-                args.threads,
-            )?;
-            ctx.register_tables(&*benchmark, *format)?;
-
-            for (query_idx, query) in &filtered_queries {
-                println!("=== Q{query_idx} [{format}] ===");
-                println!("{query}");
-                println!();
-                let result = ctx.connection().query(&format!("EXPLAIN {query}"))?;
-                for chunk in result {
-                    let chunk_str =
-                        String::try_from(chunk.deref()).unwrap_or_else(|_| "<error>".to_string());
-                    println!("{chunk_str}");
-                }
-                println!();
-            }
-        }
-
-        return Ok(());
-    }
-
     let mut runner = SqlBenchmarkRunner::new(
         &*benchmark,
         Engine::DuckDB,
@@ -175,6 +148,34 @@ fn main() -> anyhow::Result<()> {
     )?;
 
     let benchmark_name = benchmark.dataset().to_string();
+
+    if args.explain {
+        runner.explain_all(
+            &filtered_queries,
+            |format| {
+                let ctx = DuckClient::new(
+                    &*benchmark,
+                    format,
+                    args.delete_duckdb_database,
+                    args.threads,
+                )?;
+                ctx.register_tables(&*benchmark, format)?;
+                Ok(ctx)
+            },
+            |ctx, _query_idx, _format, query| {
+                let result = ctx.connection().query(&format!("EXPLAIN {query}"))?;
+                let mut output = String::new();
+                for chunk in result {
+                    let chunk_str =
+                        String::try_from(chunk.deref()).unwrap_or_else(|_| "<error>".to_string());
+                    output.push_str(&chunk_str);
+                }
+                Ok(output)
+            },
+        )?;
+
+        return Ok(());
+    }
 
     runner.run_all(
         &filtered_queries,

--- a/benchmarks/lance-bench/src/main.rs
+++ b/benchmarks/lance-bench/src/main.rs
@@ -23,6 +23,8 @@ use vortex_bench::Opts;
 use vortex_bench::create_benchmark;
 use vortex_bench::create_output_writer;
 use vortex_bench::display::DisplayFormat;
+use vortex_bench::runner::BenchmarkMode;
+use vortex_bench::runner::BenchmarkQueryResult;
 use vortex_bench::runner::SqlBenchmarkRunner;
 use vortex_bench::runner::filter_queries;
 use vortex_bench::setup_logging_and_tracing;
@@ -99,7 +101,9 @@ async fn main() -> anyhow::Result<()> {
     runner
         .run_all_async(
             &filtered_queries,
-            args.iterations,
+            BenchmarkMode::Run {
+                iterations: args.iterations,
+            },
             |_format| async {
                 let session = SessionContext::new();
                 register_lance_tables(&session, &*benchmark).await?;
@@ -108,10 +112,9 @@ async fn main() -> anyhow::Result<()> {
             |_query_idx, session, query| {
                 Box::pin(async move {
                     let timer = Instant::now();
-                    let (batches, plan) = execute_query(session, query).await?;
+                    let (batches, _plan) = execute_query(session, query).await?;
                     let time = timer.elapsed();
-                    let row_count = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
-                    anyhow::Ok((row_count, Some(time), plan))
+                    anyhow::Ok((Some(time), LanceQueryResult(batches)))
                 })
             },
         )
@@ -146,6 +149,22 @@ async fn register_lance_tables<B: Benchmark + ?Sized>(
     }
 
     Ok(())
+}
+
+/// Wrapper around Lance/DataFusion record batches implementing `BenchmarkQueryResult`.
+struct LanceQueryResult(Vec<RecordBatch>);
+
+impl BenchmarkQueryResult for LanceQueryResult {
+    fn row_count(&self) -> usize {
+        self.0.iter().map(|batch| batch.num_rows()).sum()
+    }
+
+    fn display(self) -> String {
+        // Lance uses the same Arrow RecordBatch type
+        lance::deps::datafusion::arrow::util::pretty::pretty_format_batches(&self.0)
+            .map(|d| d.to_string())
+            .unwrap_or_else(|e| format!("<error: {e}>"))
+    }
 }
 
 pub async fn execute_query(

--- a/vortex-bench/src/runner.rs
+++ b/vortex-bench/src/runner.rs
@@ -19,6 +19,24 @@ use crate::BenchmarkDataset;
 use crate::Engine;
 use crate::Format;
 use crate::Target;
+
+/// Controls whether queries are benchmarked or explained.
+pub enum BenchmarkMode {
+    /// Run each query `iterations` times, collecting timing.
+    Run { iterations: usize },
+    /// Prepend `EXPLAIN` to each query, print the result, skip timing.
+    Explain,
+}
+
+/// Trait implemented by engine-specific query results so the runner can
+/// extract row counts (for validation in Run mode) and display text
+/// (for Explain mode).
+pub trait BenchmarkQueryResult {
+    /// Number of result rows (used for row-count validation).
+    fn row_count(&self) -> usize;
+    /// Human-readable representation of the result (used by Explain mode).
+    fn display(self) -> String;
+}
 use crate::display::DisplayFormat;
 use crate::display::print_measurements_json;
 use crate::display::render_table;
@@ -97,38 +115,32 @@ impl SqlBenchmarkRunner {
     /// Run a synchronous query benchmark.
     ///
     /// Executes the query function `iterations` times, collecting timing information.
-    /// The function should return `(row_count, optional_timing, result)` where:
-    /// - `row_count` is used for validation
-    /// - `optional_timing` can be `Some(Duration)` if the callback wants to report its own timing
+    /// The function should return `(Option<Duration>, R)` where:
+    /// - `Option<Duration>` can be `Some(Duration)` if the callback wants to report its own timing
     ///   (e.g., DuckDB's internal timing), or `None` to use external wall-clock measurement
-    ///
-    /// This handles:
-    /// - Memory tracking (start/end)
-    /// - Timing each iteration
-    /// - Recording measurements
-    /// - Row count validation
-    /// - Progress bar updates
-    fn run_query<F>(&mut self, query_idx: usize, format: Format, iterations: usize, mut f: F)
+    /// - `R` implements `BenchmarkQueryResult` for row count and display
+    fn run_query<R, F>(&mut self, query_idx: usize, format: Format, iterations: usize, mut f: F)
     where
-        F: FnMut() -> (usize, Option<Duration>),
+        R: BenchmarkQueryResult,
+        F: FnMut() -> (Option<Duration>, R),
     {
         self.start_query();
 
         let mut runs = Vec::with_capacity(iterations);
-        let mut result = None;
+        let mut row_count = None;
 
         for _ in 0..iterations {
             let start = Instant::now();
-            let (row_count, timing) = f();
+            let (timing, result) = f();
             let elapsed = timing.unwrap_or_else(|| start.elapsed());
             runs.push(elapsed);
 
-            if result.is_none() {
-                result = Some(row_count);
+            if row_count.is_none() {
+                row_count = Some(result.row_count());
             }
         }
 
-        let row_count = result.expect("iterations must be > 0");
+        let row_count = row_count.expect("iterations must be > 0");
         self.record_query(query_idx, format, runs, row_count);
     }
 
@@ -235,148 +247,89 @@ impl SqlBenchmarkRunner {
         }
     }
 
-    /// Print EXPLAIN output for all queries across all formats.
+    /// Run (or explain) all queries for all formats synchronously.
     ///
-    /// For each format:
-    /// 1. Calls `setup` to create a context for that format
-    /// 2. Iterates over all queries, calling `explain` for each
+    /// In `Run` mode, executes each query `iterations` times, collecting timing.
+    /// In `Explain` mode, prepends `EXPLAIN` to each query, executes once, and
+    /// prints `R::display()`. No progress bar or timing in Explain mode.
     ///
-    /// The `explain` callback receives the context, query index, format, and query string,
-    /// and should return the explain output as a String.
-    pub fn explain_all<Ctx, S, E>(
-        &self,
-        queries: &[(usize, String)],
-        mut setup: S,
-        mut explain: E,
-    ) -> anyhow::Result<()>
-    where
-        S: FnMut(Format) -> anyhow::Result<Ctx>,
-        E: FnMut(&Ctx, usize, Format, &str) -> anyhow::Result<String>,
-    {
-        for format in self.formats.clone() {
-            let ctx = setup(format)?;
-
-            for (query_idx, query) in queries.iter() {
-                println!("=== Q{query_idx} [{format}] ===");
-                println!("{query}");
-                println!();
-                let output = explain(&ctx, *query_idx, format, query.as_str())?;
-                println!("{output}");
-                println!();
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Print EXPLAIN output for all queries across all formats asynchronously.
-    ///
-    /// For each format:
-    /// 1. Calls `setup` to create a context for that format
-    /// 2. Iterates over all queries, calling `explain` for each
-    ///
-    /// The `explain` callback receives the context, query index, format, and query string,
-    /// and should return the explain output as a String.
-    pub async fn explain_all_async<Ctx, S, SFut, E>(
-        &self,
-        queries: &[(usize, String)],
-        setup: S,
-        mut explain: E,
-    ) -> anyhow::Result<()>
-    where
-        S: Fn(Format) -> SFut,
-        SFut: Future<Output = anyhow::Result<Ctx>>,
-        E: for<'c> FnMut(
-            &'c Ctx,
-            usize,
-            Format,
-            &'c str,
-        ) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + 'c>>,
-    {
-        for format in self.formats.clone() {
-            let ctx = setup(format).await?;
-
-            for (query_idx, query) in queries.iter() {
-                println!("=== Q{query_idx} [{format}] ===");
-                println!("{query}");
-                println!();
-                let output = explain(&ctx, *query_idx, format, query.as_str()).await?;
-                println!("{output}");
-                println!();
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Run all queries for all formats synchronously.
-    ///
-    /// For each format:
-    /// 1. Calls `setup` to create a context for that format
-    /// 2. Iterates over all queries, calling `execute` for each
-    ///
-    /// The `execute` callback receives the context, query index, and query string,
-    /// and should return `(row_count, optional_timing)` where `optional_timing` can be
-    /// `Some(Duration)` if the callback wants to report its own timing.
-    pub fn run_all<Ctx, S, E>(
+    /// The `execute` callback returns `(Option<Duration>, R)` where
+    /// `Option<Duration>` overrides wall-clock timing, and `R` implements
+    /// `BenchmarkQueryResult`.
+    pub fn run_all<Ctx, R, S, E>(
         &mut self,
         queries: &[(usize, String)],
-        iterations: usize,
+        mode: BenchmarkMode,
         mut setup: S,
         mut execute: E,
     ) -> anyhow::Result<()>
     where
+        R: BenchmarkQueryResult,
         S: FnMut(Format) -> anyhow::Result<Ctx>,
-        E: FnMut(&mut Ctx, usize, Format, &str) -> anyhow::Result<(usize, Option<Duration>)>,
+        E: FnMut(&mut Ctx, usize, Format, &str) -> anyhow::Result<(Option<Duration>, R)>,
     {
-        let bar_length = queries.len() * self.formats.len();
-        let progress_bar = if self.hide_progress_bar || bar_length == 0 {
-            ProgressBar::hidden()
-        } else {
-            ProgressBar::new(bar_length as u64)
-        };
+        match mode {
+            BenchmarkMode::Run { iterations } => {
+                let bar_length = queries.len() * self.formats.len();
+                let progress_bar = if self.hide_progress_bar || bar_length == 0 {
+                    ProgressBar::hidden()
+                } else {
+                    ProgressBar::new(bar_length as u64)
+                };
 
-        for format in self.formats.clone() {
-            let mut ctx = setup(format)?;
+                for format in self.formats.clone() {
+                    let mut ctx = setup(format)?;
 
-            for (query_idx, query) in queries.iter() {
-                let query_idx = *query_idx;
-                tracing::debug!(%format, query_idx, "Running query");
-                self.run_query(query_idx, format, iterations, || {
-                    let (row_count, timing) = execute(&mut ctx, query_idx, format, query.as_str())
-                        .unwrap_or_else(|err| {
-                            vortex_panic!("query {query_idx} failed: {err}");
+                    for (query_idx, query) in queries.iter() {
+                        let query_idx = *query_idx;
+                        tracing::debug!(%format, query_idx, "Running query");
+                        self.run_query(query_idx, format, iterations, || {
+                            execute(&mut ctx, query_idx, format, query.as_str()).unwrap_or_else(
+                                |err| {
+                                    vortex_panic!("query {query_idx} failed: {err}");
+                                },
+                            )
                         });
-                    (row_count, timing)
-                });
 
-                progress_bar.inc(1);
+                        progress_bar.inc(1);
+                    }
+                }
+
+                progress_bar.finish();
+            }
+            BenchmarkMode::Explain => {
+                for format in self.formats.clone() {
+                    let mut ctx = setup(format)?;
+
+                    for (query_idx, query) in queries.iter() {
+                        let explain_query = format!("EXPLAIN {query}");
+                        let (_, result) = execute(&mut ctx, *query_idx, format, &explain_query)?;
+                        println!("=== Q{query_idx} [{format}] ===");
+                        println!("{query}");
+                        println!();
+                        println!("{}", result.display());
+                        println!();
+                    }
+                }
             }
         }
-
-        progress_bar.finish();
 
         Ok(())
     }
 
-    /// Run all queries for all formats asynchronously.
+    /// Run (or explain) all queries for all formats asynchronously.
     ///
-    /// For each format:
-    /// 1. Calls `setup` to create a context for that format
-    /// 2. Iterates over all queries, calling `execute` for each
-    ///
-    /// The `execute` callback receives the context, query index, and query string,
-    /// and should return `(row_count, optional_timing, result)` where `optional_timing` can be
-    /// `Some(Duration)` if the callback wants to report its own timing.
+    /// Same semantics as `run_all` but for async execute callbacks.
     /// Use `Box::pin(async move { ... })` in the closure.
-    pub async fn run_all_async<Ctx, S, SFut, E, T>(
+    pub async fn run_all_async<Ctx, R, S, SFut, E>(
         &mut self,
         queries: &[(usize, String)],
-        iterations: usize,
+        mode: BenchmarkMode,
         setup: S,
         mut execute: E,
     ) -> anyhow::Result<()>
     where
+        R: BenchmarkQueryResult,
         S: Fn(Format) -> SFut,
         SFut: Future<Output = anyhow::Result<Ctx>>,
         E: for<'c> FnMut(
@@ -384,52 +337,71 @@ impl SqlBenchmarkRunner {
             &'c Ctx,
             &'c str,
         ) -> Pin<
-            Box<dyn Future<Output = anyhow::Result<(usize, Option<Duration>, T)>> + 'c>,
+            Box<dyn Future<Output = anyhow::Result<(Option<Duration>, R)>> + 'c>,
         >,
     {
-        let bar_length = queries.len() * self.formats.len();
-        let progress_bar = if self.hide_progress_bar || bar_length == 0 {
-            ProgressBar::hidden()
-        } else {
-            ProgressBar::new(bar_length as u64)
-        };
+        match mode {
+            BenchmarkMode::Run { iterations } => {
+                let bar_length = queries.len() * self.formats.len();
+                let progress_bar = if self.hide_progress_bar || bar_length == 0 {
+                    ProgressBar::hidden()
+                } else {
+                    ProgressBar::new(bar_length as u64)
+                };
 
-        for format in self.formats.clone() {
-            let ctx = setup(format).await?;
+                for format in self.formats.clone() {
+                    let ctx = setup(format).await?;
 
-            for (query_idx, query) in queries.iter() {
-                let query_idx = *query_idx;
+                    for (query_idx, query) in queries.iter() {
+                        let query_idx = *query_idx;
 
-                self.start_query();
+                        self.start_query();
 
-                let mut runs = Vec::with_capacity(iterations);
-                let mut result = None;
+                        let mut runs = Vec::with_capacity(iterations);
+                        let mut row_count = None;
 
-                tracing::debug!(%format, query_idx, "Running query");
+                        tracing::debug!(%format, query_idx, "Running query");
 
-                for _ in 0..iterations {
-                    let start = Instant::now();
-                    let (row_count, timing, iter_result) = execute(query_idx, &ctx, query.as_str())
-                        .await
-                        .unwrap_or_else(|err| {
-                            vortex_panic!("query {query_idx} failed: {err}");
-                        });
-                    let elapsed = timing.unwrap_or_else(|| start.elapsed());
-                    runs.push(elapsed);
+                        for _ in 0..iterations {
+                            let start = Instant::now();
+                            let (timing, result) = execute(query_idx, &ctx, query.as_str())
+                                .await
+                                .unwrap_or_else(|err| {
+                                    vortex_panic!("query {query_idx} failed: {err}");
+                                });
+                            let elapsed = timing.unwrap_or_else(|| start.elapsed());
+                            runs.push(elapsed);
 
-                    if result.is_none() {
-                        result = Some((row_count, iter_result));
+                            if row_count.is_none() {
+                                row_count = Some(result.row_count());
+                            }
+                        }
+
+                        let row_count = row_count.expect("iterations must be > 0");
+                        self.record_query(query_idx, format, runs, row_count);
+
+                        progress_bar.inc(1);
                     }
                 }
 
-                let (row_count, _) = result.expect("iterations must be > 0");
-                self.record_query(query_idx, format, runs, row_count);
+                progress_bar.finish();
+            }
+            BenchmarkMode::Explain => {
+                for format in self.formats.clone() {
+                    let ctx = setup(format).await?;
 
-                progress_bar.inc(1);
+                    for (query_idx, query) in queries.iter() {
+                        let explain_query = format!("EXPLAIN {query}");
+                        let (_, result) = execute(*query_idx, &ctx, &explain_query).await?;
+                        println!("=== Q{query_idx} [{format}] ===");
+                        println!("{query}");
+                        println!();
+                        println!("{}", result.display());
+                        println!();
+                    }
+                }
             }
         }
-
-        progress_bar.finish();
 
         Ok(())
     }

--- a/vortex-bench/src/runner.rs
+++ b/vortex-bench/src/runner.rs
@@ -235,6 +235,80 @@ impl SqlBenchmarkRunner {
         }
     }
 
+    /// Print EXPLAIN output for all queries across all formats.
+    ///
+    /// For each format:
+    /// 1. Calls `setup` to create a context for that format
+    /// 2. Iterates over all queries, calling `explain` for each
+    ///
+    /// The `explain` callback receives the context, query index, format, and query string,
+    /// and should return the explain output as a String.
+    pub fn explain_all<Ctx, S, E>(
+        &self,
+        queries: &[(usize, String)],
+        mut setup: S,
+        mut explain: E,
+    ) -> anyhow::Result<()>
+    where
+        S: FnMut(Format) -> anyhow::Result<Ctx>,
+        E: FnMut(&Ctx, usize, Format, &str) -> anyhow::Result<String>,
+    {
+        for format in self.formats.clone() {
+            let ctx = setup(format)?;
+
+            for (query_idx, query) in queries.iter() {
+                println!("=== Q{query_idx} [{format}] ===");
+                println!("{query}");
+                println!();
+                let output = explain(&ctx, *query_idx, format, query.as_str())?;
+                println!("{output}");
+                println!();
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Print EXPLAIN output for all queries across all formats asynchronously.
+    ///
+    /// For each format:
+    /// 1. Calls `setup` to create a context for that format
+    /// 2. Iterates over all queries, calling `explain` for each
+    ///
+    /// The `explain` callback receives the context, query index, format, and query string,
+    /// and should return the explain output as a String.
+    pub async fn explain_all_async<Ctx, S, SFut, E>(
+        &self,
+        queries: &[(usize, String)],
+        setup: S,
+        mut explain: E,
+    ) -> anyhow::Result<()>
+    where
+        S: Fn(Format) -> SFut,
+        SFut: Future<Output = anyhow::Result<Ctx>>,
+        E: for<'c> FnMut(
+            &'c Ctx,
+            usize,
+            Format,
+            &'c str,
+        ) -> Pin<Box<dyn Future<Output = anyhow::Result<String>> + 'c>>,
+    {
+        for format in self.formats.clone() {
+            let ctx = setup(format).await?;
+
+            for (query_idx, query) in queries.iter() {
+                println!("=== Q{query_idx} [{format}] ===");
+                println!("{query}");
+                println!();
+                let output = explain(&ctx, *query_idx, format, query.as_str()).await?;
+                println!("{output}");
+                println!();
+            }
+        }
+
+        Ok(())
+    }
+
     /// Run all queries for all formats synchronously.
     ///
     /// For each format:


### PR DESCRIPTION
## Summary

I've added this in an ad-hoc ways multiple times during development, and now I feel called out by @gatesn, so added it to both engines.

When using `--explain`, it prints the query plan instead of running the query