### PR TITLE
separate in_memory vs file coalescing config

### DIFF
--- a/vortex-duckdb/src/filesystem.rs
+++ b/vortex-duckdb/src/filesystem.rs
@@ -234,7 +234,7 @@ impl VortexReadAt for DuckDbFsReader {
 
     fn coalesce_config(&self) -> Option<CoalesceConfig> {
         Some(if self.is_local {
-            CoalesceConfig::local()
+            CoalesceConfig::file()
         } else {
             CoalesceConfig::object_storage()
         })

--- a/vortex-io/public-api.lock
+++ b/vortex-io/public-api.lock
@@ -494,7 +494,9 @@ pub vortex_io::CoalesceConfig::max_size: u64
 
 impl vortex_io::CoalesceConfig
 
-pub const fn vortex_io::CoalesceConfig::local() -> Self
+pub const fn vortex_io::CoalesceConfig::file() -> Self
+
+pub const fn vortex_io::CoalesceConfig::in_memory() -> Self
 
 pub const fn vortex_io::CoalesceConfig::new(distance: u64, max_size: u64) -> Self
 

--- a/vortex-io/src/read_at.rs
+++ b/vortex-io/src/read_at.rs
@@ -33,9 +33,14 @@ impl CoalesceConfig {
         Self { distance, max_size }
     }
 
-    /// Configuration appropriate for fast local storage (memory, NVMe).
-    pub const fn local() -> Self {
+    /// Configuration appropriate for in-memory / low-latency sources.
+    pub const fn in_memory() -> Self {
         Self::new(8 * 1024, 8 * 1024) // 8KB
+    }
+
+    /// Configuration appropriate for local filesystem access.
+    pub const fn file() -> Self {
+        Self::new(1 << 20, 4 << 20) // 1MB distance, 4MB max
     }
 
     /// Configuration appropriate for object storage (S3, GCS, etc.).
@@ -317,10 +322,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_coalesce_config_local() {
-        let config = CoalesceConfig::local();
+    fn test_coalesce_config_in_memory() {
+        let config = CoalesceConfig::in_memory();
         assert_eq!(config.distance, 8 * 1024);
         assert_eq!(config.max_size, 8 * 1024);
+    }
+
+    #[test]
+    fn test_coalesce_config_file() {
+        let config = CoalesceConfig::file();
+        assert_eq!(config.distance, 1 << 20); // 1MB
+        assert_eq!(config.max_size, 4 << 20); // 4MB
     }
 
     #[test]

--- a/vortex-io/src/std_file/read_at.rs
+++ b/vortex-io/src/std_file/read_at.rs
@@ -57,10 +57,6 @@ pub(crate) fn read_exact_at(file: &File, buffer: &mut [u8], offset: u64) -> io::
     }
 }
 
-const COALESCING_CONFIG: CoalesceConfig = CoalesceConfig {
-    distance: 1024 * 1024,     // 1MB
-    max_size: 4 * 1024 * 1024, // 4MB
-};
 /// Default number of concurrent requests to allow for local file I/O.
 pub const DEFAULT_CONCURRENCY: usize = 32;
 
@@ -87,7 +83,7 @@ impl VortexReadAt for FileReadAt {
     }
 
     fn coalesce_config(&self) -> Option<CoalesceConfig> {
-        Some(COALESCING_CONFIG)
+        Some(CoalesceConfig::file())
     }
 
     fn concurrency(&self) -> usize {


### PR DESCRIPTION
rename local CoalescingConfig to in_memory, get all nvme read_at impls to use the same coalescing config as std-file, which is slightly more aggressive than in_memory, but not as much as object store. 

If we end up removing the spawn_blocking overhead from our cpu work then we should use the in_memory config for nvme