### PR TITLE
Remove info log in execution path

### DIFF
--- a/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
@@ -33,7 +33,7 @@ impl OperationsVTable<ScalarFnVTable> for ScalarFnVTable {
 
         let scalar = match result.execute::<Columnar>(&mut ctx)? {
             Columnar::Canonical(arr) => {
-                tracing::info!(
+                tracing::trace!(
                     "Scalar function {} returned non-constant array from execution over all scalar inputs",
                     array.scalar_fn,
                 );


### PR DESCRIPTION
Just a small touch up I noticed in benchmarks, doesn't seem very useful