### PR TITLE
Eliminate redundant decompressions in VarBinArray canonicalization

### DIFF
--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use num_traits::AsPrimitive;
-use vortex_buffer::Buffer;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -11,7 +10,6 @@ use vortex_error::vortex_err;
 
 use crate::Array;
 use crate::ArrayRef;
-use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::varbin::builder::VarBinBuilder;
 use crate::buffer::BufferHandle;
@@ -374,39 +372,6 @@ impl VarBinArray {
     /// the `offsets` array, and the `validity`.
     pub fn into_parts(self) -> (DType, BufferHandle, ArrayRef, Validity) {
         (self.dtype, self.bytes, self.offsets, self.validity)
-    }
-}
-
-impl VarBinArray {
-    /// Return an array containing the same data, but where the internal `offsets` start at zero
-    /// and all wasted space in the bytes child has been clipped.
-    #[doc(hidden)]
-    pub fn zero_offsets(self) -> Self {
-        if self.is_empty() {
-            return self;
-        }
-
-        let first = self.offset_at(0);
-
-        let bytes = self.sliced_bytes();
-        let dtype = self.dtype;
-        let validity = self.validity;
-        let offsets = self.offsets;
-
-        let offsets = if first == 0 {
-            offsets
-        } else {
-            let offsets = offsets.to_primitive();
-            match_each_integer_ptype!(offsets.ptype(), |P| {
-                let offsets = offsets.as_slice::<P>();
-                let buffer: Buffer<P> = offsets.iter().map(|index| index - offsets[0]).collect();
-                buffer.into_array()
-            })
-        };
-
-        // SAFETY: we make the first offset start at zero, and slice the bytes accordingly,
-        //  so all offsets stay valid.
-        unsafe { Self::new_unchecked(offsets, bytes, dtype, validity) }
     }
 }
 

--- a/vortex-array/src/arrays/varbin/tests.rs
+++ b/vortex-array/src/arrays/varbin/tests.rs
@@ -47,21 +47,3 @@ pub fn slice_array(binary_array: ArrayRef) {
         VarBinViewArray::from_iter_str(["hello world this is a long string"])
     );
 }
-
-#[test]
-fn test_zero_offsets() -> vortex_error::VortexResult<()> {
-    use crate::arrays::VarBinVTable;
-    use crate::dtype::Nullability::NonNullable;
-
-    let items = VarBinArray::from_iter_nonnull(["abc", "def", "ghi"], DType::Utf8(NonNullable));
-    let sliced = items.slice(1..3)?.as_::<VarBinVTable>().clone();
-
-    // After slicing, there is some unused data at the front of the bytes.
-    assert_eq!(sliced.offset_at(0), 3);
-
-    // But after zeroing the offsets, the extraneous data is gone.
-    let truncated = sliced.zero_offsets();
-    assert_eq!(truncated.offset_at(0), 0);
-    assert_eq!(truncated.len(), 2);
-    Ok(())
-}

--- a/vortex-array/src/arrays/varbin/vtable/canonical.rs
+++ b/vortex-array/src/arrays/varbin/vtable/canonical.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use num_traits::AsPrimitive;
 use vortex_error::VortexResult;
 
 use crate::ExecutionCtx;
@@ -21,24 +22,21 @@ pub(crate) fn varbin_to_canonical(
     array: &VarBinArray,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<VarBinViewArray> {
-    // Zero the offsets first to ensure the bytes buffer starts at 0
-    let array = array.clone().zero_offsets();
-    let (dtype, bytes, offsets, validity) = array.into_parts();
+    let (dtype, bytes, offsets, validity) = array.clone().into_parts();
 
-    // offsets_to_lengths
     let offsets = offsets.execute::<PrimitiveArray>(ctx)?;
-    let bytes = bytes.unwrap_host().into_mut();
 
     match_each_integer_ptype!(offsets.ptype(), |P| {
-        let lens = offsets_to_lengths(offsets.as_slice::<P>());
+        let offsets_slice = offsets.as_slice::<P>();
+        let first: usize = offsets_slice[0].as_();
+        let last: usize = offsets_slice[offsets_slice.len() - 1].as_();
+        let bytes = bytes.unwrap_host().slice(first..last).into_mut();
+
+        let lens = offsets_to_lengths(offsets_slice);
         let (buffers, views) = build_views(0, MAX_BUFFER_LEN, bytes, lens.as_slice());
 
-        let varbinview =
-            unsafe { VarBinViewArray::new_unchecked(views, Arc::from(buffers), dtype, validity) };
-
-        // Create VarBinViewArray with the original bytes buffer and computed views
         // SAFETY: views are correctly computed from valid offsets
-        Ok(varbinview)
+        Ok(unsafe { VarBinViewArray::new_unchecked(views, Arc::from(buffers), dtype, validity) })
     })
 }
 
@@ -46,7 +44,10 @@ pub(crate) fn varbin_to_canonical(
 mod tests {
     use rstest::rstest;
 
+    use crate::arrays::VarBinViewArray;
+    use crate::arrays::varbin::VarBinArray;
     use crate::arrays::varbin::builder::VarBinBuilder;
+    use crate::assert_arrays_eq;
     use crate::canonical::ToCanonical;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
@@ -54,7 +55,7 @@ mod tests {
     #[rstest]
     #[case(DType::Utf8(Nullability::Nullable))]
     #[case(DType::Binary(Nullability::Nullable))]
-    fn test_canonical_varbin(#[case] dtype: DType) {
+    fn test_canonical_varbin_sliced(#[case] dtype: DType) {
         let mut varbin = VarBinBuilder::<i32>::with_capacity(10);
         varbin.append_null();
         varbin.append_null();
@@ -78,5 +79,27 @@ mod tests {
         // Second value is not inlined (13 bytes)
         assert!(!canonical.views()[2].is_inlined());
         assert_eq!(canonical.bytes_at(2).as_slice(), "1234567890123".as_bytes());
+    }
+
+    #[rstest]
+    #[case(DType::Utf8(Nullability::NonNullable))]
+    #[case(DType::Binary(Nullability::NonNullable))]
+    fn test_canonical_varbin_unsliced(#[case] dtype: DType) {
+        let varbin = VarBinArray::from_iter_nonnull(["foo", "bar", "baz"], dtype.clone());
+        let canonical = varbin.to_varbinview();
+        let expected = match dtype {
+            DType::Utf8(_) => VarBinViewArray::from_iter_str(["foo", "bar", "baz"]),
+            _ => VarBinViewArray::from_iter_bin(["foo", "bar", "baz"]),
+        };
+        assert_arrays_eq!(canonical, expected);
+    }
+
+    // Empty array: offsets has exactly one element; no elements to canonicalize.
+    #[test]
+    fn test_canonical_varbin_empty() {
+        let varbin =
+            VarBinArray::from_iter_nonnull([] as [&str; 0], DType::Utf8(Nullability::NonNullable));
+        let canonical = varbin.to_varbinview();
+        assert_eq!(canonical.len(), 0);
     }
 }


### PR DESCRIPTION
`varbin_to_canonical` is doing so many decompressions
- `zero_offsets -> offset_at -> offset_at`
- `zero_offsets -> slice_bytes -> offset_at(0)`
- `zero_offsets -> slice_bytes -> offset_at(self.len)`
- if first != 0 `zero_offsets -> to_primitive()` else `execute::<PrimitiveArray>`

This PR reduces it down to 1 and simplifies the function.