### PR TITLE
Implement BetweenReduceRule for ConstantArray

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -798,6 +798,10 @@ impl vortex_array::compute::SumKernel for vortex_array::arrays::ConstantVTable
 
 pub fn vortex_array::arrays::ConstantVTable::sum(&self, array: &vortex_array::arrays::ConstantArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
+impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::between(array: &vortex_array::arrays::ConstantArray, lower: &dyn vortex_array::Array, upper: &dyn vortex_array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ConstantVTable
 
 pub fn vortex_array::arrays::ConstantVTable::cast(array: &vortex_array::arrays::ConstantArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
@@ -12881,6 +12885,10 @@ pub fn vortex_array::arrays::PrimitiveVTable::between(arr: &vortex_array::arrays
 pub trait vortex_array::scalar_fn::fns::between::BetweenReduce: vortex_array::vtable::VTable
 
 pub fn vortex_array::scalar_fn::fns::between::BetweenReduce::between(array: &Self::Array, lower: &dyn vortex_array::Array, upper: &dyn vortex_array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::between(array: &vortex_array::arrays::ConstantArray, lower: &dyn vortex_array::Array, upper: &dyn vortex_array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::binary
 

--- a/vortex-array/src/arrays/constant/compute/between.rs
+++ b/vortex-array/src/arrays/constant/compute/between.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_error::VortexResult;
+
+use crate::Array;
+use crate::ArrayRef;
+use crate::IntoArray;
+use crate::arrays::ConstantArray;
+use crate::arrays::ConstantVTable;
+use crate::scalar::Scalar;
+use crate::scalar_fn::fns::between::BetweenOptions;
+use crate::scalar_fn::fns::between::BetweenReduce;
+
+impl BetweenReduce for ConstantVTable {
+    fn between(
+        array: &ConstantArray,
+        lower: &dyn Array,
+        upper: &dyn Array,
+        options: &BetweenOptions,
+    ) -> VortexResult<Option<ArrayRef>> {
+        // Can reduce if everything is constant
+        if let Some(((constant, lower), upper)) = array
+            .as_constant()
+            .zip(lower.as_constant())
+            .zip(upper.as_constant())
+        {
+            let BetweenOptions {
+                lower_strict,
+                upper_strict,
+            } = options;
+
+            let lower_result = if lower_strict.is_strict() {
+                lower < constant
+            } else {
+                lower <= constant
+            };
+
+            let upper_result = if upper_strict.is_strict() {
+                constant < upper
+            } else {
+                constant <= upper
+            };
+
+            let result = lower_result && upper_result;
+
+            let scalar = Scalar::bool(
+                result,
+                lower.dtype().nullability() | upper.dtype().nullability(),
+            );
+            return Ok(Some(ConstantArray::new(scalar, array.len()).into_array()));
+        }
+
+        Ok(None)
+    }
+}

--- a/vortex-array/src/arrays/constant/compute/mod.rs
+++ b/vortex-array/src/arrays/constant/compute/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+mod between;
 mod cast;
 mod fill_null;
 mod filter;
@@ -10,7 +11,6 @@ pub(crate) mod rules;
 mod slice;
 mod sum;
 mod take;
-mod between;
 
 #[cfg(test)]
 mod test {

--- a/vortex-array/src/arrays/constant/compute/mod.rs
+++ b/vortex-array/src/arrays/constant/compute/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod rules;
 mod slice;
 mod sum;
 mod take;
+mod between;
 
 #[cfg(test)]
 mod test {

--- a/vortex-array/src/arrays/constant/compute/rules.rs
+++ b/vortex-array/src/arrays/constant/compute/rules.rs
@@ -14,16 +14,18 @@ use crate::arrays::SliceReduceAdaptor;
 use crate::arrays::TakeReduceAdaptor;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
+use crate::scalar_fn::fns::between::BetweenReduceAdaptor;
 use crate::scalar_fn::fns::cast::CastReduceAdaptor;
 use crate::scalar_fn::fns::fill_null::FillNullReduceAdaptor;
 use crate::scalar_fn::fns::not::NotReduceAdaptor;
 
 pub(crate) const PARENT_RULES: ParentRuleSet<ConstantVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&ConstantFilterRule),
+    ParentRuleSet::lift(&BetweenReduceAdaptor(ConstantVTable)),
     ParentRuleSet::lift(&CastReduceAdaptor(ConstantVTable)),
-    ParentRuleSet::lift(&NotReduceAdaptor(ConstantVTable)),
+    ParentRuleSet::lift(&ConstantFilterRule),
     ParentRuleSet::lift(&FillNullReduceAdaptor(ConstantVTable)),
     ParentRuleSet::lift(&FilterReduceAdaptor(ConstantVTable)),
+    ParentRuleSet::lift(&NotReduceAdaptor(ConstantVTable)),
     ParentRuleSet::lift(&SliceReduceAdaptor(ConstantVTable)),
     ParentRuleSet::lift(&TakeReduceAdaptor(ConstantVTable)),
 ]);


### PR DESCRIPTION
This seems to be missing after migration and it's obviously valuable. Avoids
having to canonicalise result of between on constant array.

Signed-off-by: Robert Kruszewski <github@robertk.io>
