### PR TITLE
Update public-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7129,9 +7129,9 @@ dependencies = [
 
 [[package]]
 name = "public-api"
-version = "0.50.3"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40883c1581e900daa2cc4bc1ac50858f83a8563dd2e3c55b70bba44f57db7b35"
+checksum = "b4597eaaa646a5df48e5f37924b58bd4b2e2a3746d4665195d03538846784858"
 dependencies = [
  "hashbag",
  "rustdoc-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ proc-macro2 = "1.0.95"
 prost = "0.14"
 prost-build = "0.14"
 prost-types = "0.14"
-public-api = "0.50"
+public-api = "0.51"
 pyo3 = { version = "0.27.0" }
 pyo3-bytes = "0.5"
 pyo3-log = "0.13.0"

--- a/encodings/alp/public-api.lock
+++ b/encodings/alp/public-api.lock
@@ -432,6 +432,32 @@ pub const f32::SWEET: Self
 
 pub fn f32::as_int(self) -> Self::ALPInt
 
+pub fn f32::decode(encoded: &[Self::ALPInt], exponents: vortex_alp::Exponents) -> alloc::vec::Vec<Self>
+
+pub fn f32::decode_buffer(encoded: vortex_buffer::buffer_mut::BufferMut<Self::ALPInt>, exponents: vortex_alp::Exponents) -> vortex_buffer::buffer_mut::BufferMut<Self>
+
+pub fn f32::decode_into(encoded: &[Self::ALPInt], exponents: vortex_alp::Exponents, output: &mut [Self])
+
+pub fn f32::decode_single(encoded: Self::ALPInt, exponents: vortex_alp::Exponents) -> Self
+
+pub fn f32::decode_slice_inplace(encoded: &mut [Self::ALPInt], exponents: vortex_alp::Exponents)
+
+pub fn f32::encode(values: &[Self], exponents: core::option::Option<vortex_alp::Exponents>) -> (vortex_alp::Exponents, vortex_buffer::buffer::Buffer<Self::ALPInt>, vortex_buffer::buffer::Buffer<u64>, vortex_buffer::buffer::Buffer<Self>, vortex_buffer::buffer_mut::BufferMut<u64>)
+
+pub fn f32::encode_above(value: Self, exponents: vortex_alp::Exponents) -> Self::ALPInt
+
+pub fn f32::encode_below(value: Self, exponents: vortex_alp::Exponents) -> Self::ALPInt
+
+pub fn f32::encode_single(value: Self, exponents: vortex_alp::Exponents) -> core::option::Option<Self::ALPInt>
+
+pub fn f32::encode_single_unchecked(value: Self, exponents: vortex_alp::Exponents) -> Self::ALPInt
+
+pub fn f32::estimate_encoded_size(encoded: &[Self::ALPInt], patches: &[Self]) -> usize
+
+pub fn f32::fast_round(self) -> Self
+
+pub fn f32::find_best_exponents(values: &[Self]) -> vortex_alp::Exponents
+
 pub fn f32::from_int(n: Self::ALPInt) -> Self
 
 impl vortex_alp::ALPFloat for f64
@@ -449,6 +475,32 @@ pub const f64::MAX_EXPONENT: u8
 pub const f64::SWEET: Self
 
 pub fn f64::as_int(self) -> Self::ALPInt
+
+pub fn f64::decode(encoded: &[Self::ALPInt], exponents: vortex_alp::Exponents) -> alloc::vec::Vec<Self>
+
+pub fn f64::decode_buffer(encoded: vortex_buffer::buffer_mut::BufferMut<Self::ALPInt>, exponents: vortex_alp::Exponents) -> vortex_buffer::buffer_mut::BufferMut<Self>
+
+pub fn f64::decode_into(encoded: &[Self::ALPInt], exponents: vortex_alp::Exponents, output: &mut [Self])
+
+pub fn f64::decode_single(encoded: Self::ALPInt, exponents: vortex_alp::Exponents) -> Self
+
+pub fn f64::decode_slice_inplace(encoded: &mut [Self::ALPInt], exponents: vortex_alp::Exponents)
+
+pub fn f64::encode(values: &[Self], exponents: core::option::Option<vortex_alp::Exponents>) -> (vortex_alp::Exponents, vortex_buffer::buffer::Buffer<Self::ALPInt>, vortex_buffer::buffer::Buffer<u64>, vortex_buffer::buffer::Buffer<Self>, vortex_buffer::buffer_mut::BufferMut<u64>)
+
+pub fn f64::encode_above(value: Self, exponents: vortex_alp::Exponents) -> Self::ALPInt
+
+pub fn f64::encode_below(value: Self, exponents: vortex_alp::Exponents) -> Self::ALPInt
+
+pub fn f64::encode_single(value: Self, exponents: vortex_alp::Exponents) -> core::option::Option<Self::ALPInt>
+
+pub fn f64::encode_single_unchecked(value: Self, exponents: vortex_alp::Exponents) -> Self::ALPInt
+
+pub fn f64::estimate_encoded_size(encoded: &[Self::ALPInt], patches: &[Self]) -> usize
+
+pub fn f64::fast_round(self) -> Self
+
+pub fn f64::find_best_exponents(values: &[Self]) -> vortex_alp::Exponents
 
 pub fn f64::from_int(n: Self::ALPInt) -> Self
 
@@ -470,6 +522,8 @@ impl vortex_alp::ALPRDFloat for f32
 
 pub type f32::UINT = u32
 
+pub const f32::BITS: usize
+
 pub fn f32::from_bits(bits: Self::UINT) -> Self
 
 pub fn f32::from_u16(value: u16) -> Self::UINT
@@ -481,6 +535,8 @@ pub fn f32::to_u16(bits: Self::UINT) -> u16
 impl vortex_alp::ALPRDFloat for f64
 
 pub type f64::UINT = u64
+
+pub const f64::BITS: usize
 
 pub fn f64::from_bits(bits: Self::UINT) -> Self
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -194,6 +194,8 @@ pub type vortex_array::arrays::DictVTable::ValidityVTable = vortex_array::arrays
 
 pub type vortex_array::arrays::DictVTable::VisitorVTable = vortex_array::arrays::DictVTable
 
+pub fn vortex_array::arrays::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::DictVTable::array_eq(array: &vortex_array::arrays::DictArray, other: &vortex_array::arrays::DictArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DictArray, state: &mut H, precision: vortex_array::Precision)
@@ -214,6 +216,8 @@ pub fn vortex_array::arrays::DictVTable::len(array: &vortex_array::arrays::DictA
 
 pub fn vortex_array::arrays::DictVTable::metadata(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -228,6 +232,8 @@ pub fn vortex_array::arrays::DictVTable::validity(array: &vortex_array::arrays::
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
 
+pub fn vortex_array::arrays::DictVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::DictVTable::nbuffers(_array: &vortex_array::arrays::DictArray) -> usize
 
 pub fn vortex_array::arrays::DictVTable::nchildren(_array: &vortex_array::arrays::DictArray) -> usize
@@ -237,6 +243,8 @@ pub fn vortex_array::arrays::DictVTable::nth_child(array: &vortex_array::arrays:
 pub fn vortex_array::arrays::DictVTable::visit_buffers(_array: &vortex_array::arrays::DictArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::DictVTable::visit_children(array: &vortex_array::arrays::DictArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::DictVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub enum vortex_array::arrays::ListViewRebuildMode
 
@@ -315,6 +323,8 @@ pub fn vortex_array::arrays::AnyScalarFn::fmt(&self, f: &mut core::fmt::Formatte
 impl vortex_array::matcher::Matcher for vortex_array::arrays::AnyScalarFn
 
 pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
+
+pub fn vortex_array::arrays::AnyScalarFn::matches(array: &dyn vortex_array::Array) -> bool
 
 pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
@@ -498,6 +508,8 @@ pub type vortex_array::arrays::BoolVTable::ValidityVTable = vortex_array::vtable
 
 pub type vortex_array::arrays::BoolVTable::VisitorVTable = vortex_array::arrays::BoolVTable
 
+pub fn vortex_array::arrays::BoolVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::BoolVTable::array_eq(array: &vortex_array::arrays::BoolArray, other: &vortex_array::arrays::BoolArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::BoolVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::BoolArray, state: &mut H, precision: vortex_array::Precision)
@@ -518,6 +530,8 @@ pub fn vortex_array::arrays::BoolVTable::len(array: &vortex_array::arrays::BoolA
 
 pub fn vortex_array::arrays::BoolVTable::metadata(array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::BoolVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::BoolVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::BoolVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -528,6 +542,8 @@ pub fn vortex_array::arrays::BoolVTable::with_children(array: &mut Self::Array, 
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolVTable
 
+pub fn vortex_array::arrays::BoolVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::BoolVTable::nbuffers(_array: &vortex_array::arrays::BoolArray) -> usize
 
 pub fn vortex_array::arrays::BoolVTable::nchildren(array: &vortex_array::arrays::BoolArray) -> usize
@@ -537,6 +553,8 @@ pub fn vortex_array::arrays::BoolVTable::nth_child(array: &vortex_array::arrays:
 pub fn vortex_array::arrays::BoolVTable::visit_buffers(array: &vortex_array::arrays::BoolArray, visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::BoolVTable::visit_children(array: &vortex_array::arrays::BoolArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::BoolVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::ChunkedArray
 
@@ -704,6 +722,8 @@ pub fn vortex_array::arrays::ChunkedVTable::validity(array: &vortex_array::array
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
 
+pub fn vortex_array::arrays::ChunkedVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::ChunkedVTable::nbuffers(_array: &vortex_array::arrays::ChunkedArray) -> usize
 
 pub fn vortex_array::arrays::ChunkedVTable::nchildren(array: &vortex_array::arrays::ChunkedArray) -> usize
@@ -818,6 +838,8 @@ pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::ar
 
 pub type vortex_array::arrays::ConstantVTable::VisitorVTable = vortex_array::arrays::ConstantVTable
 
+pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::ConstantVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ConstantArray, state: &mut H, _precision: vortex_array::Precision)
@@ -830,11 +852,15 @@ pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays:
 
 pub fn vortex_array::arrays::ConstantVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::arrays::ConstantVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
 pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
 
 pub fn vortex_array::arrays::ConstantVTable::metadata(_array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ConstantVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::ConstantVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -850,6 +876,8 @@ pub fn vortex_array::arrays::ConstantVTable::validity(array: &vortex_array::arra
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
 
+pub fn vortex_array::arrays::ConstantVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
 
 pub fn vortex_array::arrays::ConstantVTable::nchildren(_array: &vortex_array::arrays::ConstantArray) -> usize
@@ -859,6 +887,8 @@ pub fn vortex_array::arrays::ConstantVTable::nth_child(_array: &vortex_array::ar
 pub fn vortex_array::arrays::ConstantVTable::visit_buffers(array: &vortex_array::arrays::ConstantArray, visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::ConstantVTable::visit_children(_array: &vortex_array::arrays::ConstantArray, _visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::ConstantVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::DecimalArray
 
@@ -1032,6 +1062,8 @@ pub type vortex_array::arrays::DecimalVTable::ValidityVTable = vortex_array::vta
 
 pub type vortex_array::arrays::DecimalVTable::VisitorVTable = vortex_array::arrays::DecimalVTable
 
+pub fn vortex_array::arrays::DecimalVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::DecimalVTable::array_eq(array: &vortex_array::arrays::DecimalArray, other: &vortex_array::arrays::DecimalArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::DecimalVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DecimalArray, state: &mut H, precision: vortex_array::Precision)
@@ -1052,6 +1084,8 @@ pub fn vortex_array::arrays::DecimalVTable::len(array: &vortex_array::arrays::De
 
 pub fn vortex_array::arrays::DecimalVTable::metadata(array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::DecimalVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::DecimalVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::DecimalVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -1062,6 +1096,8 @@ pub fn vortex_array::arrays::DecimalVTable::with_children(array: &mut Self::Arra
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalVTable
 
+pub fn vortex_array::arrays::DecimalVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::DecimalVTable::nbuffers(_array: &vortex_array::arrays::DecimalArray) -> usize
 
 pub fn vortex_array::arrays::DecimalVTable::nchildren(array: &vortex_array::arrays::DecimalArray) -> usize
@@ -1071,6 +1107,8 @@ pub fn vortex_array::arrays::DecimalVTable::nth_child(array: &vortex_array::arra
 pub fn vortex_array::arrays::DecimalVTable::visit_buffers(array: &vortex_array::arrays::DecimalArray, visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::DecimalVTable::visit_children(array: &vortex_array::arrays::DecimalArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::DecimalVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::DictArray
 
@@ -1236,6 +1274,8 @@ pub type vortex_array::arrays::DictVTable::ValidityVTable = vortex_array::arrays
 
 pub type vortex_array::arrays::DictVTable::VisitorVTable = vortex_array::arrays::DictVTable
 
+pub fn vortex_array::arrays::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::DictVTable::array_eq(array: &vortex_array::arrays::DictArray, other: &vortex_array::arrays::DictArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DictArray, state: &mut H, precision: vortex_array::Precision)
@@ -1256,6 +1296,8 @@ pub fn vortex_array::arrays::DictVTable::len(array: &vortex_array::arrays::DictA
 
 pub fn vortex_array::arrays::DictVTable::metadata(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -1270,6 +1312,8 @@ pub fn vortex_array::arrays::DictVTable::validity(array: &vortex_array::arrays::
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
 
+pub fn vortex_array::arrays::DictVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::DictVTable::nbuffers(_array: &vortex_array::arrays::DictArray) -> usize
 
 pub fn vortex_array::arrays::DictVTable::nchildren(_array: &vortex_array::arrays::DictArray) -> usize
@@ -1279,6 +1323,8 @@ pub fn vortex_array::arrays::DictVTable::nth_child(array: &vortex_array::arrays:
 pub fn vortex_array::arrays::DictVTable::visit_buffers(_array: &vortex_array::arrays::DictArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::DictVTable::visit_children(array: &vortex_array::arrays::DictArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::DictVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::ExactScalarFn<F: vortex_array::scalar_fn::ScalarFnVTable>(_)
 
@@ -1422,6 +1468,8 @@ pub type vortex_array::arrays::ExtensionVTable::ValidityVTable = vortex_array::v
 
 pub type vortex_array::arrays::ExtensionVTable::VisitorVTable = vortex_array::arrays::ExtensionVTable
 
+pub fn vortex_array::arrays::ExtensionVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::ExtensionVTable::array_eq(array: &vortex_array::arrays::ExtensionArray, other: &vortex_array::arrays::ExtensionArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::ExtensionVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ExtensionArray, state: &mut H, precision: vortex_array::Precision)
@@ -1442,6 +1490,8 @@ pub fn vortex_array::arrays::ExtensionVTable::len(array: &vortex_array::arrays::
 
 pub fn vortex_array::arrays::ExtensionVTable::metadata(_array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::ExtensionVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::ExtensionVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::ExtensionVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -1456,6 +1506,8 @@ pub fn vortex_array::arrays::ExtensionVTable::validity_child(array: &vortex_arra
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
 
+pub fn vortex_array::arrays::ExtensionVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::ExtensionVTable::nbuffers(_array: &vortex_array::arrays::ExtensionArray) -> usize
 
 pub fn vortex_array::arrays::ExtensionVTable::nchildren(_array: &vortex_array::arrays::ExtensionArray) -> usize
@@ -1465,6 +1517,8 @@ pub fn vortex_array::arrays::ExtensionVTable::nth_child(array: &vortex_array::ar
 pub fn vortex_array::arrays::ExtensionVTable::visit_buffers(_array: &vortex_array::arrays::ExtensionArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::ExtensionVTable::visit_children(array: &vortex_array::arrays::ExtensionArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::ExtensionVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::FilterArray
 
@@ -1570,6 +1624,8 @@ pub type vortex_array::arrays::FilterVTable::ValidityVTable = vortex_array::arra
 
 pub type vortex_array::arrays::FilterVTable::VisitorVTable = vortex_array::arrays::FilterVTable
 
+pub fn vortex_array::arrays::FilterVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::FilterVTable::array_eq(array: &vortex_array::arrays::FilterArray, other: &vortex_array::arrays::FilterArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::FilterVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FilterArray, state: &mut H, precision: vortex_array::Precision)
@@ -1581,6 +1637,8 @@ pub fn vortex_array::arrays::FilterVTable::deserialize(_bytes: &[u8], _dtype: &v
 pub fn vortex_array::arrays::FilterVTable::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::arrays::FilterVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::FilterVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::FilterVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
@@ -1604,6 +1662,10 @@ pub fn vortex_array::arrays::FilterVTable::validity(array: &vortex_array::arrays
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
 
+pub fn vortex_array::arrays::FilterVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrays::FilterVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
+
 pub fn vortex_array::arrays::FilterVTable::nchildren(_array: &vortex_array::arrays::FilterArray) -> usize
 
 pub fn vortex_array::arrays::FilterVTable::nth_child(array: &vortex_array::arrays::FilterArray, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
@@ -1611,6 +1673,8 @@ pub fn vortex_array::arrays::FilterVTable::nth_child(array: &vortex_array::array
 pub fn vortex_array::arrays::FilterVTable::visit_buffers(_array: &vortex_array::arrays::FilterArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::FilterVTable::visit_children(array: &vortex_array::arrays::FilterArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::FilterVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::FixedSizeListArray
 
@@ -1722,6 +1786,8 @@ pub type vortex_array::arrays::FixedSizeListVTable::ValidityVTable = vortex_arra
 
 pub type vortex_array::arrays::FixedSizeListVTable::VisitorVTable = vortex_array::arrays::FixedSizeListVTable
 
+pub fn vortex_array::arrays::FixedSizeListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::FixedSizeListVTable::array_eq(array: &vortex_array::arrays::FixedSizeListArray, other: &vortex_array::arrays::FixedSizeListArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::FixedSizeListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FixedSizeListArray, state: &mut H, precision: vortex_array::Precision)
@@ -1742,6 +1808,8 @@ pub fn vortex_array::arrays::FixedSizeListVTable::len(array: &vortex_array::arra
 
 pub fn vortex_array::arrays::FixedSizeListVTable::metadata(_array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::FixedSizeListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::FixedSizeListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::FixedSizeListVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -1752,6 +1820,8 @@ pub fn vortex_array::arrays::FixedSizeListVTable::with_children(array: &mut Self
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::FixedSizeListVTable> for vortex_array::arrays::FixedSizeListVTable
 
+pub fn vortex_array::arrays::FixedSizeListVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::FixedSizeListVTable::nbuffers(_array: &vortex_array::arrays::FixedSizeListArray) -> usize
 
 pub fn vortex_array::arrays::FixedSizeListVTable::nchildren(array: &vortex_array::arrays::FixedSizeListArray) -> usize
@@ -1761,6 +1831,8 @@ pub fn vortex_array::arrays::FixedSizeListVTable::nth_child(array: &vortex_array
 pub fn vortex_array::arrays::FixedSizeListVTable::visit_buffers(_array: &vortex_array::arrays::FixedSizeListArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::FixedSizeListVTable::visit_children(array: &vortex_array::arrays::FixedSizeListArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::FixedSizeListVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 #[repr(C, align(8))] pub struct vortex_array::arrays::Inlined
 
@@ -1918,6 +1990,8 @@ pub type vortex_array::arrays::ListVTable::ValidityVTable = vortex_array::vtable
 
 pub type vortex_array::arrays::ListVTable::VisitorVTable = vortex_array::arrays::ListVTable
 
+pub fn vortex_array::arrays::ListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::ListVTable::array_eq(array: &vortex_array::arrays::ListArray, other: &vortex_array::arrays::ListArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::ListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListArray, state: &mut H, precision: vortex_array::Precision)
@@ -1938,6 +2012,8 @@ pub fn vortex_array::arrays::ListVTable::len(array: &vortex_array::arrays::ListA
 
 pub fn vortex_array::arrays::ListVTable::metadata(array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::ListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::ListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::ListVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -1948,6 +2024,8 @@ pub fn vortex_array::arrays::ListVTable::with_children(array: &mut Self::Array, 
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ListVTable> for vortex_array::arrays::ListVTable
 
+pub fn vortex_array::arrays::ListVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::ListVTable::nbuffers(_array: &vortex_array::arrays::ListArray) -> usize
 
 pub fn vortex_array::arrays::ListVTable::nchildren(array: &vortex_array::arrays::ListArray) -> usize
@@ -1957,6 +2035,8 @@ pub fn vortex_array::arrays::ListVTable::nth_child(array: &vortex_array::arrays:
 pub fn vortex_array::arrays::ListVTable::visit_buffers(_array: &vortex_array::arrays::ListArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::ListVTable::visit_children(array: &vortex_array::arrays::ListArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::ListVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::ListViewArray
 
@@ -2096,6 +2176,8 @@ pub type vortex_array::arrays::ListViewVTable::ValidityVTable = vortex_array::vt
 
 pub type vortex_array::arrays::ListViewVTable::VisitorVTable = vortex_array::arrays::ListViewVTable
 
+pub fn vortex_array::arrays::ListViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::ListViewVTable::array_eq(array: &vortex_array::arrays::ListViewArray, other: &vortex_array::arrays::ListViewArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::ListViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListViewArray, state: &mut H, precision: vortex_array::Precision)
@@ -2116,6 +2198,8 @@ pub fn vortex_array::arrays::ListViewVTable::len(array: &vortex_array::arrays::L
 
 pub fn vortex_array::arrays::ListViewVTable::metadata(array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::ListViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::ListViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::ListViewVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -2126,6 +2210,8 @@ pub fn vortex_array::arrays::ListViewVTable::with_children(array: &mut Self::Arr
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ListViewVTable> for vortex_array::arrays::ListViewVTable
 
+pub fn vortex_array::arrays::ListViewVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::ListViewVTable::nbuffers(_array: &vortex_array::arrays::ListViewArray) -> usize
 
 pub fn vortex_array::arrays::ListViewVTable::nchildren(array: &vortex_array::arrays::ListViewArray) -> usize
@@ -2135,6 +2221,8 @@ pub fn vortex_array::arrays::ListViewVTable::nth_child(array: &vortex_array::arr
 pub fn vortex_array::arrays::ListViewVTable::visit_buffers(_array: &vortex_array::arrays::ListViewArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::ListViewVTable::visit_children(array: &vortex_array::arrays::ListViewArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::ListViewVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::MaskedArray
 
@@ -2216,6 +2304,8 @@ pub type vortex_array::arrays::MaskedVTable::ValidityVTable = vortex_array::vtab
 
 pub type vortex_array::arrays::MaskedVTable::VisitorVTable = vortex_array::arrays::MaskedVTable
 
+pub fn vortex_array::arrays::MaskedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::MaskedVTable::array_eq(array: &vortex_array::arrays::MaskedArray, other: &vortex_array::arrays::MaskedArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::MaskedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::MaskedArray, state: &mut H, precision: vortex_array::Precision)
@@ -2236,6 +2326,8 @@ pub fn vortex_array::arrays::MaskedVTable::len(array: &vortex_array::arrays::Mas
 
 pub fn vortex_array::arrays::MaskedVTable::metadata(_array: &vortex_array::arrays::MaskedArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::MaskedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::MaskedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::MaskedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -2246,6 +2338,10 @@ pub fn vortex_array::arrays::MaskedVTable::with_children(array: &mut Self::Array
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::MaskedVTable> for vortex_array::arrays::MaskedVTable
 
+pub fn vortex_array::arrays::MaskedVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrays::MaskedVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
+
 pub fn vortex_array::arrays::MaskedVTable::nchildren(array: &vortex_array::arrays::MaskedArray) -> usize
 
 pub fn vortex_array::arrays::MaskedVTable::nth_child(array: &vortex_array::arrays::MaskedArray, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
@@ -2253,6 +2349,8 @@ pub fn vortex_array::arrays::MaskedVTable::nth_child(array: &vortex_array::array
 pub fn vortex_array::arrays::MaskedVTable::visit_buffers(_array: &vortex_array::arrays::MaskedArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::MaskedVTable::visit_children(array: &vortex_array::arrays::MaskedArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::MaskedVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 #[repr(transparent)] pub struct vortex_array::arrays::NativeValue<T>(pub T)
 
@@ -2410,6 +2508,8 @@ pub type vortex_array::arrays::NullVTable::ValidityVTable = vortex_array::arrays
 
 pub type vortex_array::arrays::NullVTable::VisitorVTable = vortex_array::arrays::NullVTable
 
+pub fn vortex_array::arrays::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::NullVTable::array_eq(array: &vortex_array::arrays::NullArray, other: &vortex_array::arrays::NullArray, _precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::NullArray, state: &mut H, _precision: vortex_array::Precision)
@@ -2422,11 +2522,15 @@ pub fn vortex_array::arrays::NullVTable::dtype(_array: &vortex_array::arrays::Nu
 
 pub fn vortex_array::arrays::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::arrays::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
 pub fn vortex_array::arrays::NullVTable::len(array: &vortex_array::arrays::NullArray) -> usize
 
 pub fn vortex_array::arrays::NullVTable::metadata(_array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -2442,6 +2546,10 @@ pub fn vortex_array::arrays::NullVTable::validity(_array: &vortex_array::arrays:
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::NullVTable> for vortex_array::arrays::NullVTable
 
+pub fn vortex_array::arrays::NullVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrays::NullVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
+
 pub fn vortex_array::arrays::NullVTable::nchildren(_array: &vortex_array::arrays::NullArray) -> usize
 
 pub fn vortex_array::arrays::NullVTable::nth_child(_array: &vortex_array::arrays::NullArray, _idx: usize) -> core::option::Option<vortex_array::ArrayRef>
@@ -2449,6 +2557,8 @@ pub fn vortex_array::arrays::NullVTable::nth_child(_array: &vortex_array::arrays
 pub fn vortex_array::arrays::NullVTable::visit_buffers(_array: &vortex_array::arrays::NullArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::NullVTable::visit_children(_array: &vortex_array::arrays::NullArray, _visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::NullVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::PrimitiveArray
 
@@ -2658,6 +2768,8 @@ pub type vortex_array::arrays::PrimitiveVTable::ValidityVTable = vortex_array::v
 
 pub type vortex_array::arrays::PrimitiveVTable::VisitorVTable = vortex_array::arrays::PrimitiveVTable
 
+pub fn vortex_array::arrays::PrimitiveVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::PrimitiveVTable::array_eq(array: &vortex_array::arrays::PrimitiveArray, other: &vortex_array::arrays::PrimitiveArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::PrimitiveVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::PrimitiveArray, state: &mut H, precision: vortex_array::Precision)
@@ -2678,6 +2790,8 @@ pub fn vortex_array::arrays::PrimitiveVTable::len(array: &vortex_array::arrays::
 
 pub fn vortex_array::arrays::PrimitiveVTable::metadata(_array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::PrimitiveVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::PrimitiveVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::PrimitiveVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -2688,6 +2802,8 @@ pub fn vortex_array::arrays::PrimitiveVTable::with_children(array: &mut Self::Ar
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveVTable
 
+pub fn vortex_array::arrays::PrimitiveVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::PrimitiveVTable::nbuffers(_array: &vortex_array::arrays::PrimitiveArray) -> usize
 
 pub fn vortex_array::arrays::PrimitiveVTable::nchildren(array: &vortex_array::arrays::PrimitiveArray) -> usize
@@ -2697,6 +2813,8 @@ pub fn vortex_array::arrays::PrimitiveVTable::nth_child(array: &vortex_array::ar
 pub fn vortex_array::arrays::PrimitiveVTable::visit_buffers(array: &vortex_array::arrays::PrimitiveArray, visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::PrimitiveVTable::visit_children(array: &vortex_array::arrays::PrimitiveArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::PrimitiveVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 #[repr(C, align(8))] pub struct vortex_array::arrays::Ref
 
@@ -2818,6 +2936,8 @@ pub type vortex_array::arrays::ScalarFnVTable::ValidityVTable = vortex_array::ar
 
 pub type vortex_array::arrays::ScalarFnVTable::VisitorVTable = vortex_array::arrays::ScalarFnVTable
 
+pub fn vortex_array::arrays::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::ScalarFnVTable::array_eq(array: &vortex_array::arrays::ScalarFnArray, other: &vortex_array::arrays::ScalarFnArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
@@ -2829,6 +2949,8 @@ pub fn vortex_array::arrays::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: 
 pub fn vortex_array::arrays::ScalarFnVTable::dtype(array: &vortex_array::arrays::ScalarFnArray) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::arrays::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
 
@@ -2851,6 +2973,8 @@ impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ScalarFnVTable> 
 pub fn vortex_array::arrays::ScalarFnVTable::validity(array: &vortex_array::arrays::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ScalarFnVTable> for vortex_array::arrays::ScalarFnVTable
+
+pub fn vortex_array::arrays::ScalarFnVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::ScalarFnArray) -> usize
 
@@ -2926,6 +3050,8 @@ pub type vortex_array::arrays::SharedVTable::ValidityVTable = vortex_array::arra
 
 pub type vortex_array::arrays::SharedVTable::VisitorVTable = vortex_array::arrays::SharedVTable
 
+pub fn vortex_array::arrays::SharedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::SharedVTable::array_eq(array: &vortex_array::arrays::SharedArray, other: &vortex_array::arrays::SharedArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::SharedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SharedArray, state: &mut H, precision: vortex_array::Precision)
@@ -2938,11 +3064,17 @@ pub fn vortex_array::arrays::SharedVTable::dtype(array: &vortex_array::arrays::S
 
 pub fn vortex_array::arrays::SharedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::arrays::SharedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::SharedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
 pub fn vortex_array::arrays::SharedVTable::len(array: &vortex_array::arrays::SharedArray) -> usize
 
 pub fn vortex_array::arrays::SharedVTable::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::SharedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::SharedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::SharedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
@@ -2956,6 +3088,10 @@ pub fn vortex_array::arrays::SharedVTable::validity(array: &vortex_array::arrays
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
 
+pub fn vortex_array::arrays::SharedVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrays::SharedVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
+
 pub fn vortex_array::arrays::SharedVTable::nchildren(_array: &vortex_array::arrays::SharedArray) -> usize
 
 pub fn vortex_array::arrays::SharedVTable::nth_child(array: &vortex_array::arrays::SharedArray, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
@@ -2963,6 +3099,8 @@ pub fn vortex_array::arrays::SharedVTable::nth_child(array: &vortex_array::array
 pub fn vortex_array::arrays::SharedVTable::visit_buffers(_array: &vortex_array::arrays::SharedArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::SharedVTable::visit_children(array: &vortex_array::arrays::SharedArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::SharedVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::SliceArray
 
@@ -3078,6 +3216,8 @@ pub type vortex_array::arrays::SliceVTable::ValidityVTable = vortex_array::array
 
 pub type vortex_array::arrays::SliceVTable::VisitorVTable = vortex_array::arrays::SliceVTable
 
+pub fn vortex_array::arrays::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::SliceVTable::array_eq(array: &vortex_array::arrays::SliceArray, other: &vortex_array::arrays::SliceArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SliceArray, state: &mut H, precision: vortex_array::Precision)
@@ -3090,11 +3230,15 @@ pub fn vortex_array::arrays::SliceVTable::dtype(array: &vortex_array::arrays::Sl
 
 pub fn vortex_array::arrays::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::arrays::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
 pub fn vortex_array::arrays::SliceVTable::len(array: &vortex_array::arrays::SliceArray) -> usize
 
 pub fn vortex_array::arrays::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -3110,6 +3254,10 @@ pub fn vortex_array::arrays::SliceVTable::validity(array: &vortex_array::arrays:
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::SliceVTable> for vortex_array::arrays::SliceVTable
 
+pub fn vortex_array::arrays::SliceVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrays::SliceVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
+
 pub fn vortex_array::arrays::SliceVTable::nchildren(_array: &vortex_array::arrays::SliceArray) -> usize
 
 pub fn vortex_array::arrays::SliceVTable::nth_child(array: &vortex_array::arrays::SliceArray, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
@@ -3117,6 +3265,8 @@ pub fn vortex_array::arrays::SliceVTable::nth_child(array: &vortex_array::arrays
 pub fn vortex_array::arrays::SliceVTable::visit_buffers(_array: &vortex_array::arrays::SliceArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::SliceVTable::visit_children(array: &vortex_array::arrays::SliceArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::SliceVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::StructArray
 
@@ -3260,6 +3410,8 @@ pub type vortex_array::arrays::StructVTable::ValidityVTable = vortex_array::vtab
 
 pub type vortex_array::arrays::StructVTable::VisitorVTable = vortex_array::arrays::StructVTable
 
+pub fn vortex_array::arrays::StructVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::StructVTable::array_eq(array: &vortex_array::arrays::StructArray, other: &vortex_array::arrays::StructArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::StructVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::StructArray, state: &mut H, precision: vortex_array::Precision)
@@ -3280,6 +3432,8 @@ pub fn vortex_array::arrays::StructVTable::len(array: &vortex_array::arrays::Str
 
 pub fn vortex_array::arrays::StructVTable::metadata(_array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::StructVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::StructVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::StructVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -3289,6 +3443,8 @@ pub fn vortex_array::arrays::StructVTable::stats(array: &vortex_array::arrays::S
 pub fn vortex_array::arrays::StructVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::StructVTable::nbuffers(_array: &vortex_array::arrays::StructArray) -> usize
 
@@ -3586,6 +3742,8 @@ pub type vortex_array::arrays::VarBinVTable::ValidityVTable = vortex_array::vtab
 
 pub type vortex_array::arrays::VarBinVTable::VisitorVTable = vortex_array::arrays::VarBinVTable
 
+pub fn vortex_array::arrays::VarBinVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::VarBinVTable::array_eq(array: &vortex_array::arrays::VarBinArray, other: &vortex_array::arrays::VarBinArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::VarBinVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinArray, state: &mut H, precision: vortex_array::Precision)
@@ -3606,6 +3764,8 @@ pub fn vortex_array::arrays::VarBinVTable::len(array: &vortex_array::arrays::Var
 
 pub fn vortex_array::arrays::VarBinVTable::metadata(array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::VarBinVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::VarBinVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::VarBinVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -3616,6 +3776,8 @@ pub fn vortex_array::arrays::VarBinVTable::with_children(array: &mut Self::Array
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::VarBinVTable> for vortex_array::arrays::VarBinVTable
 
+pub fn vortex_array::arrays::VarBinVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::VarBinVTable::nbuffers(_array: &vortex_array::arrays::VarBinArray) -> usize
 
 pub fn vortex_array::arrays::VarBinVTable::nchildren(array: &vortex_array::arrays::VarBinArray) -> usize
@@ -3625,6 +3787,8 @@ pub fn vortex_array::arrays::VarBinVTable::nth_child(array: &vortex_array::array
 pub fn vortex_array::arrays::VarBinVTable::visit_buffers(array: &vortex_array::arrays::VarBinArray, visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::VarBinVTable::visit_children(array: &vortex_array::arrays::VarBinArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::VarBinVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrays::VarBinViewArray
 
@@ -3802,6 +3966,8 @@ pub type vortex_array::arrays::VarBinViewVTable::ValidityVTable = vortex_array::
 
 pub type vortex_array::arrays::VarBinViewVTable::VisitorVTable = vortex_array::arrays::VarBinViewVTable
 
+pub fn vortex_array::arrays::VarBinViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::VarBinViewVTable::array_eq(array: &vortex_array::arrays::VarBinViewArray, other: &vortex_array::arrays::VarBinViewArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::VarBinViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinViewArray, state: &mut H, precision: vortex_array::Precision)
@@ -3822,6 +3988,8 @@ pub fn vortex_array::arrays::VarBinViewVTable::len(array: &vortex_array::arrays:
 
 pub fn vortex_array::arrays::VarBinViewVTable::metadata(_array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::arrays::VarBinViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::VarBinViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::VarBinViewVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -3832,6 +4000,8 @@ pub fn vortex_array::arrays::VarBinViewVTable::with_children(array: &mut Self::A
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::VarBinViewVTable> for vortex_array::arrays::VarBinViewVTable
 
+pub fn vortex_array::arrays::VarBinViewVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::VarBinViewVTable::nbuffers(array: &vortex_array::arrays::VarBinViewArray) -> usize
 
 pub fn vortex_array::arrays::VarBinViewVTable::nchildren(array: &vortex_array::arrays::VarBinViewArray) -> usize
@@ -3841,6 +4011,8 @@ pub fn vortex_array::arrays::VarBinViewVTable::nth_child(array: &vortex_array::a
 pub fn vortex_array::arrays::VarBinViewVTable::visit_buffers(array: &vortex_array::arrays::VarBinViewArray, visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrays::VarBinViewVTable::visit_children(array: &vortex_array::arrays::VarBinViewArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrays::VarBinViewVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub const vortex_array::arrays::IS_CONST_LANE_WIDTH: usize
 
@@ -3893,6 +4065,8 @@ pub trait vortex_array::arrays::ScalarFnArrayExt: vortex_array::scalar_fn::Scala
 pub fn vortex_array::arrays::ScalarFnArrayExt::try_new_array(&self, len: usize, options: Self::Options, children: impl core::convert::Into<alloc::vec::Vec<vortex_array::ArrayRef>>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 impl<V: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::arrays::ScalarFnArrayExt for V
+
+pub fn V::try_new_array(&self, len: usize, options: Self::Options, children: impl core::convert::Into<alloc::vec::Vec<vortex_array::ArrayRef>>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub trait vortex_array::arrays::SliceKernel: vortex_array::vtable::VTable
 
@@ -4170,6 +4344,8 @@ pub type vortex_array::arrow::ArrowVTable::ValidityVTable = vortex_array::arrow:
 
 pub type vortex_array::arrow::ArrowVTable::VisitorVTable = vortex_array::arrow::ArrowVTable
 
+pub fn vortex_array::arrow::ArrowVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrow::ArrowVTable::array_eq(array: &vortex_array::arrow::ArrowArray, other: &vortex_array::arrow::ArrowArray, _precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrow::ArrowVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrow::ArrowArray, state: &mut H, _precision: vortex_array::Precision)
@@ -4182,11 +4358,17 @@ pub fn vortex_array::arrow::ArrowVTable::dtype(array: &vortex_array::arrow::Arro
 
 pub fn vortex_array::arrow::ArrowVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::arrow::ArrowVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrow::ArrowVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
 pub fn vortex_array::arrow::ArrowVTable::len(array: &vortex_array::arrow::ArrowArray) -> usize
 
 pub fn vortex_array::arrow::ArrowVTable::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrow::ArrowVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrow::ArrowVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrow::ArrowVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
@@ -4200,6 +4382,10 @@ pub fn vortex_array::arrow::ArrowVTable::validity(array: &vortex_array::arrow::A
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrow::ArrowVTable> for vortex_array::arrow::ArrowVTable
 
+pub fn vortex_array::arrow::ArrowVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrow::ArrowVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
+
 pub fn vortex_array::arrow::ArrowVTable::nchildren(_array: &vortex_array::arrow::ArrowArray) -> usize
 
 pub fn vortex_array::arrow::ArrowVTable::nth_child(_array: &vortex_array::arrow::ArrowArray, _idx: usize) -> core::option::Option<vortex_array::ArrayRef>
@@ -4207,6 +4393,8 @@ pub fn vortex_array::arrow::ArrowVTable::nth_child(_array: &vortex_array::arrow:
 pub fn vortex_array::arrow::ArrowVTable::visit_buffers(_array: &vortex_array::arrow::ArrowArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrow::ArrowVTable::visit_children(_array: &vortex_array::arrow::ArrowArray, _visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrow::ArrowVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub struct vortex_array::arrow::Datum
 
@@ -4239,6 +4427,8 @@ pub fn vortex_array::arrow::ArrowArrayExecutor::execute_record_batches(self, sch
 impl vortex_array::arrow::ArrowArrayExecutor for vortex_array::ArrayRef
 
 pub fn vortex_array::ArrayRef::execute_arrow(self, data_type: core::option::Option<&arrow_schema::datatype::DataType>, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<arrow_array::array::ArrayRef>
+
+pub fn vortex_array::ArrayRef::execute_record_batch(self, schema: &arrow_schema::schema::Schema, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<arrow_array::record_batch::RecordBatch>
 
 pub fn vortex_array::ArrayRef::execute_record_batches(self, schema: &arrow_schema::schema::Schema, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<alloc::vec::Vec<arrow_array::record_batch::RecordBatch>>
 
@@ -4602,9 +4792,19 @@ pub fn vortex_array::builders::BoolBuilder::with_capacity(nullability: vortex_ar
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::BoolBuilder
 
+pub fn vortex_array::builders::BoolBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::BoolBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::BoolBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::BoolBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::BoolBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::BoolBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::BoolBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::BoolBuilder::append_zeros(&mut self, n: usize)
 
@@ -4614,15 +4814,21 @@ pub fn vortex_array::builders::BoolBuilder::as_any_mut(&mut self) -> &mut dyn co
 
 pub fn vortex_array::builders::BoolBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::BoolBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::BoolBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::BoolBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::BoolBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::BoolBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::BoolBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::BoolBuilder::reserve_exact(&mut self, additional: usize)
+
+pub fn vortex_array::builders::BoolBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::BoolBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
@@ -4642,9 +4848,19 @@ pub fn vortex_array::builders::DecimalBuilder::with_capacity<T: vortex_array::dt
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::DecimalBuilder
 
+pub fn vortex_array::builders::DecimalBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::DecimalBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::DecimalBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::DecimalBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::DecimalBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::DecimalBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::DecimalBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::DecimalBuilder::append_zeros(&mut self, n: usize)
 
@@ -4654,15 +4870,21 @@ pub fn vortex_array::builders::DecimalBuilder::as_any_mut(&mut self) -> &mut dyn
 
 pub fn vortex_array::builders::DecimalBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::DecimalBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::DecimalBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::DecimalBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::DecimalBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::DecimalBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::DecimalBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::DecimalBuilder::reserve_exact(&mut self, additional: usize)
+
+pub fn vortex_array::builders::DecimalBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::DecimalBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
@@ -4686,9 +4908,19 @@ pub fn vortex_array::builders::ExtensionBuilder::with_capacity(ext_dtype: vortex
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::ExtensionBuilder
 
+pub fn vortex_array::builders::ExtensionBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::ExtensionBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::ExtensionBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::ExtensionBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::ExtensionBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::ExtensionBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::ExtensionBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::ExtensionBuilder::append_zeros(&mut self, n: usize)
 
@@ -4698,15 +4930,21 @@ pub fn vortex_array::builders::ExtensionBuilder::as_any_mut(&mut self) -> &mut d
 
 pub fn vortex_array::builders::ExtensionBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::ExtensionBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::ExtensionBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::ExtensionBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::ExtensionBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::ExtensionBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::ExtensionBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::ExtensionBuilder::reserve_exact(&mut self, capacity: usize)
+
+pub fn vortex_array::builders::ExtensionBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::ExtensionBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
@@ -4730,9 +4968,19 @@ pub fn vortex_array::builders::FixedSizeListBuilder::with_capacity(element_dtype
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::FixedSizeListBuilder
 
+pub fn vortex_array::builders::FixedSizeListBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::FixedSizeListBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::FixedSizeListBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::FixedSizeListBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::FixedSizeListBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::FixedSizeListBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::FixedSizeListBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::FixedSizeListBuilder::append_zeros(&mut self, n: usize)
 
@@ -4742,15 +4990,21 @@ pub fn vortex_array::builders::FixedSizeListBuilder::as_any_mut(&mut self) -> &m
 
 pub fn vortex_array::builders::FixedSizeListBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::FixedSizeListBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::FixedSizeListBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::FixedSizeListBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::FixedSizeListBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::FixedSizeListBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::FixedSizeListBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::FixedSizeListBuilder::reserve_exact(&mut self, additional: usize)
+
+pub fn vortex_array::builders::FixedSizeListBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::FixedSizeListBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
@@ -4772,9 +5026,19 @@ pub fn vortex_array::builders::ListBuilder<O>::with_capacity(value_dtype: alloc:
 
 impl<O: vortex_array::dtype::IntegerPType> vortex_array::builders::ArrayBuilder for vortex_array::builders::ListBuilder<O>
 
+pub fn vortex_array::builders::ListBuilder<O>::append_default(&mut self)
+
+pub fn vortex_array::builders::ListBuilder<O>::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::ListBuilder<O>::append_null(&mut self)
+
+pub fn vortex_array::builders::ListBuilder<O>::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::ListBuilder<O>::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::ListBuilder<O>::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::ListBuilder<O>::append_zero(&mut self)
 
 pub fn vortex_array::builders::ListBuilder<O>::append_zeros(&mut self, n: usize)
 
@@ -4784,13 +5048,21 @@ pub fn vortex_array::builders::ListBuilder<O>::as_any_mut(&mut self) -> &mut dyn
 
 pub fn vortex_array::builders::ListBuilder<O>::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::ListBuilder<O>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::ListBuilder<O>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::ListBuilder<O>::finish(&mut self) -> vortex_array::ArrayRef
 
+pub fn vortex_array::builders::ListBuilder<O>::finish_into_canonical(&mut self) -> vortex_array::Canonical
+
+pub fn vortex_array::builders::ListBuilder<O>::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::ListBuilder<O>::len(&self) -> usize
 
 pub fn vortex_array::builders::ListBuilder<O>::reserve_exact(&mut self, additional: usize)
+
+pub fn vortex_array::builders::ListBuilder<O>::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::ListBuilder<O>::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
@@ -4812,9 +5084,19 @@ pub fn vortex_array::builders::ListViewBuilder<O, S>::with_capacity(element_dtyp
 
 impl<O: vortex_array::dtype::IntegerPType, S: vortex_array::dtype::IntegerPType> vortex_array::builders::ArrayBuilder for vortex_array::builders::ListViewBuilder<O, S>
 
+pub fn vortex_array::builders::ListViewBuilder<O, S>::append_default(&mut self)
+
+pub fn vortex_array::builders::ListViewBuilder<O, S>::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::ListViewBuilder<O, S>::append_null(&mut self)
+
+pub fn vortex_array::builders::ListViewBuilder<O, S>::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::ListViewBuilder<O, S>::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::ListViewBuilder<O, S>::append_zero(&mut self)
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::append_zeros(&mut self, n: usize)
 
@@ -4824,15 +5106,21 @@ pub fn vortex_array::builders::ListViewBuilder<O, S>::as_any_mut(&mut self) -> &
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::ListViewBuilder<O, S>::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::ListViewBuilder<O, S>::len(&self) -> usize
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::reserve_exact(&mut self, capacity: usize)
+
+pub fn vortex_array::builders::ListViewBuilder<O, S>::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::ListViewBuilder<O, S>::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
@@ -4848,9 +5136,19 @@ pub fn vortex_array::builders::NullBuilder::default() -> Self
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::NullBuilder
 
+pub fn vortex_array::builders::NullBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::NullBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::NullBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::NullBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::NullBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::NullBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::NullBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::NullBuilder::append_zeros(&mut self, n: usize)
 
@@ -4860,15 +5158,21 @@ pub fn vortex_array::builders::NullBuilder::as_any_mut(&mut self) -> &mut dyn co
 
 pub fn vortex_array::builders::NullBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::NullBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::NullBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::NullBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::NullBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::NullBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::NullBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::NullBuilder::reserve_exact(&mut self, _additional: usize)
+
+pub fn vortex_array::builders::NullBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::NullBuilder::set_validity_unchecked(&mut self, _validity: vortex_mask::Mask)
 
@@ -4892,9 +5196,19 @@ pub fn vortex_array::builders::PrimitiveBuilder<T>::with_capacity(nullability: v
 
 impl<T: vortex_array::dtype::NativePType> vortex_array::builders::ArrayBuilder for vortex_array::builders::PrimitiveBuilder<T>
 
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_default(&mut self)
+
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_null(&mut self)
+
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::PrimitiveBuilder<T>::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_zero(&mut self)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::append_zeros(&mut self, n: usize)
 
@@ -4904,15 +5218,21 @@ pub fn vortex_array::builders::PrimitiveBuilder<T>::as_any_mut(&mut self) -> &mu
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::PrimitiveBuilder<T>::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::PrimitiveBuilder<T>::len(&self) -> usize
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::reserve_exact(&mut self, additional: usize)
+
+pub fn vortex_array::builders::PrimitiveBuilder<T>::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::PrimitiveBuilder<T>::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
@@ -4932,9 +5252,19 @@ pub fn vortex_array::builders::StructBuilder::with_capacity(struct_dtype: vortex
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::StructBuilder
 
+pub fn vortex_array::builders::StructBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::StructBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::StructBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::StructBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::StructBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::StructBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::StructBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::StructBuilder::append_zeros(&mut self, n: usize)
 
@@ -4944,15 +5274,21 @@ pub fn vortex_array::builders::StructBuilder::as_any_mut(&mut self) -> &mut dyn 
 
 pub fn vortex_array::builders::StructBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::StructBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::StructBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::StructBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::StructBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::StructBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::StructBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::StructBuilder::reserve_exact(&mut self, capacity: usize)
+
+pub fn vortex_array::builders::StructBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::StructBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
@@ -4998,9 +5334,19 @@ pub fn vortex_array::builders::VarBinViewBuilder::with_compaction(dtype: vortex_
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::VarBinViewBuilder
 
+pub fn vortex_array::builders::VarBinViewBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::VarBinViewBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::VarBinViewBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::VarBinViewBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::VarBinViewBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::VarBinViewBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::VarBinViewBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::VarBinViewBuilder::append_zeros(&mut self, n: usize)
 
@@ -5010,15 +5356,21 @@ pub fn vortex_array::builders::VarBinViewBuilder::as_any_mut(&mut self) -> &mut 
 
 pub fn vortex_array::builders::VarBinViewBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::VarBinViewBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::VarBinViewBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::VarBinViewBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::VarBinViewBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::VarBinViewBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::VarBinViewBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::VarBinViewBuilder::reserve_exact(&mut self, additional: usize)
+
+pub fn vortex_array::builders::VarBinViewBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::VarBinViewBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
@@ -5068,9 +5420,19 @@ pub unsafe fn vortex_array::builders::ArrayBuilder::set_validity_unchecked(&mut 
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::BoolBuilder
 
+pub fn vortex_array::builders::BoolBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::BoolBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::BoolBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::BoolBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::BoolBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::BoolBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::BoolBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::BoolBuilder::append_zeros(&mut self, n: usize)
 
@@ -5080,23 +5442,39 @@ pub fn vortex_array::builders::BoolBuilder::as_any_mut(&mut self) -> &mut dyn co
 
 pub fn vortex_array::builders::BoolBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::BoolBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::BoolBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::BoolBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::BoolBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::BoolBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::BoolBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::BoolBuilder::reserve_exact(&mut self, additional: usize)
+
+pub fn vortex_array::builders::BoolBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::BoolBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::DecimalBuilder
 
+pub fn vortex_array::builders::DecimalBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::DecimalBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::DecimalBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::DecimalBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::DecimalBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::DecimalBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::DecimalBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::DecimalBuilder::append_zeros(&mut self, n: usize)
 
@@ -5106,23 +5484,39 @@ pub fn vortex_array::builders::DecimalBuilder::as_any_mut(&mut self) -> &mut dyn
 
 pub fn vortex_array::builders::DecimalBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::DecimalBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::DecimalBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::DecimalBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::DecimalBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::DecimalBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::DecimalBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::DecimalBuilder::reserve_exact(&mut self, additional: usize)
+
+pub fn vortex_array::builders::DecimalBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::DecimalBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::ExtensionBuilder
 
+pub fn vortex_array::builders::ExtensionBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::ExtensionBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::ExtensionBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::ExtensionBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::ExtensionBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::ExtensionBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::ExtensionBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::ExtensionBuilder::append_zeros(&mut self, n: usize)
 
@@ -5132,23 +5526,39 @@ pub fn vortex_array::builders::ExtensionBuilder::as_any_mut(&mut self) -> &mut d
 
 pub fn vortex_array::builders::ExtensionBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::ExtensionBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::ExtensionBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::ExtensionBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::ExtensionBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::ExtensionBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::ExtensionBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::ExtensionBuilder::reserve_exact(&mut self, capacity: usize)
+
+pub fn vortex_array::builders::ExtensionBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::ExtensionBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::FixedSizeListBuilder
 
+pub fn vortex_array::builders::FixedSizeListBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::FixedSizeListBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::FixedSizeListBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::FixedSizeListBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::FixedSizeListBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::FixedSizeListBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::FixedSizeListBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::FixedSizeListBuilder::append_zeros(&mut self, n: usize)
 
@@ -5158,23 +5568,39 @@ pub fn vortex_array::builders::FixedSizeListBuilder::as_any_mut(&mut self) -> &m
 
 pub fn vortex_array::builders::FixedSizeListBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::FixedSizeListBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::FixedSizeListBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::FixedSizeListBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::FixedSizeListBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::FixedSizeListBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::FixedSizeListBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::FixedSizeListBuilder::reserve_exact(&mut self, additional: usize)
+
+pub fn vortex_array::builders::FixedSizeListBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::FixedSizeListBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::NullBuilder
 
+pub fn vortex_array::builders::NullBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::NullBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::NullBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::NullBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::NullBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::NullBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::NullBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::NullBuilder::append_zeros(&mut self, n: usize)
 
@@ -5184,23 +5610,39 @@ pub fn vortex_array::builders::NullBuilder::as_any_mut(&mut self) -> &mut dyn co
 
 pub fn vortex_array::builders::NullBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::NullBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::NullBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::NullBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::NullBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::NullBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::NullBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::NullBuilder::reserve_exact(&mut self, _additional: usize)
+
+pub fn vortex_array::builders::NullBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::NullBuilder::set_validity_unchecked(&mut self, _validity: vortex_mask::Mask)
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::StructBuilder
 
+pub fn vortex_array::builders::StructBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::StructBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::StructBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::StructBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::StructBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::StructBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::StructBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::StructBuilder::append_zeros(&mut self, n: usize)
 
@@ -5210,23 +5652,39 @@ pub fn vortex_array::builders::StructBuilder::as_any_mut(&mut self) -> &mut dyn 
 
 pub fn vortex_array::builders::StructBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::StructBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::StructBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::StructBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::StructBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::StructBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::StructBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::StructBuilder::reserve_exact(&mut self, capacity: usize)
+
+pub fn vortex_array::builders::StructBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::StructBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
 impl vortex_array::builders::ArrayBuilder for vortex_array::builders::VarBinViewBuilder
 
+pub fn vortex_array::builders::VarBinViewBuilder::append_default(&mut self)
+
+pub fn vortex_array::builders::VarBinViewBuilder::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::VarBinViewBuilder::append_null(&mut self)
+
+pub fn vortex_array::builders::VarBinViewBuilder::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::VarBinViewBuilder::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::VarBinViewBuilder::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::VarBinViewBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::VarBinViewBuilder::append_zeros(&mut self, n: usize)
 
@@ -5236,23 +5694,39 @@ pub fn vortex_array::builders::VarBinViewBuilder::as_any_mut(&mut self) -> &mut 
 
 pub fn vortex_array::builders::VarBinViewBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::VarBinViewBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::VarBinViewBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::VarBinViewBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::VarBinViewBuilder::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::VarBinViewBuilder::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::VarBinViewBuilder::len(&self) -> usize
 
 pub fn vortex_array::builders::VarBinViewBuilder::reserve_exact(&mut self, additional: usize)
+
+pub fn vortex_array::builders::VarBinViewBuilder::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::VarBinViewBuilder::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
 impl<O: vortex_array::dtype::IntegerPType, S: vortex_array::dtype::IntegerPType> vortex_array::builders::ArrayBuilder for vortex_array::builders::ListViewBuilder<O, S>
 
+pub fn vortex_array::builders::ListViewBuilder<O, S>::append_default(&mut self)
+
+pub fn vortex_array::builders::ListViewBuilder<O, S>::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::ListViewBuilder<O, S>::append_null(&mut self)
+
+pub fn vortex_array::builders::ListViewBuilder<O, S>::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::ListViewBuilder<O, S>::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::ListViewBuilder<O, S>::append_zero(&mut self)
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::append_zeros(&mut self, n: usize)
 
@@ -5262,23 +5736,39 @@ pub fn vortex_array::builders::ListViewBuilder<O, S>::as_any_mut(&mut self) -> &
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::ListViewBuilder<O, S>::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::ListViewBuilder<O, S>::len(&self) -> usize
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::reserve_exact(&mut self, capacity: usize)
+
+pub fn vortex_array::builders::ListViewBuilder<O, S>::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::ListViewBuilder<O, S>::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
 impl<O: vortex_array::dtype::IntegerPType> vortex_array::builders::ArrayBuilder for vortex_array::builders::ListBuilder<O>
 
+pub fn vortex_array::builders::ListBuilder<O>::append_default(&mut self)
+
+pub fn vortex_array::builders::ListBuilder<O>::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::ListBuilder<O>::append_null(&mut self)
+
+pub fn vortex_array::builders::ListBuilder<O>::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::ListBuilder<O>::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::ListBuilder<O>::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::ListBuilder<O>::append_zero(&mut self)
 
 pub fn vortex_array::builders::ListBuilder<O>::append_zeros(&mut self, n: usize)
 
@@ -5288,21 +5778,39 @@ pub fn vortex_array::builders::ListBuilder<O>::as_any_mut(&mut self) -> &mut dyn
 
 pub fn vortex_array::builders::ListBuilder<O>::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::ListBuilder<O>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::ListBuilder<O>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::ListBuilder<O>::finish(&mut self) -> vortex_array::ArrayRef
+
+pub fn vortex_array::builders::ListBuilder<O>::finish_into_canonical(&mut self) -> vortex_array::Canonical
+
+pub fn vortex_array::builders::ListBuilder<O>::is_empty(&self) -> bool
 
 pub fn vortex_array::builders::ListBuilder<O>::len(&self) -> usize
 
 pub fn vortex_array::builders::ListBuilder<O>::reserve_exact(&mut self, additional: usize)
 
+pub fn vortex_array::builders::ListBuilder<O>::set_validity(&mut self, validity: vortex_mask::Mask)
+
 pub unsafe fn vortex_array::builders::ListBuilder<O>::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
 impl<T: vortex_array::dtype::NativePType> vortex_array::builders::ArrayBuilder for vortex_array::builders::PrimitiveBuilder<T>
 
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_default(&mut self)
+
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_defaults(&mut self, n: usize)
+
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_null(&mut self)
+
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_nulls(&mut self, n: usize)
+
 pub unsafe fn vortex_array::builders::PrimitiveBuilder<T>::append_nulls_unchecked(&mut self, n: usize)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::append_scalar(&mut self, scalar: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_zero(&mut self)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::append_zeros(&mut self, n: usize)
 
@@ -5312,15 +5820,21 @@ pub fn vortex_array::builders::PrimitiveBuilder<T>::as_any_mut(&mut self) -> &mu
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::dtype(&self) -> &vortex_array::dtype::DType
 
+pub fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+
 pub unsafe fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::finish(&mut self) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::finish_into_canonical(&mut self) -> vortex_array::Canonical
 
+pub fn vortex_array::builders::PrimitiveBuilder<T>::is_empty(&self) -> bool
+
 pub fn vortex_array::builders::PrimitiveBuilder<T>::len(&self) -> usize
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::reserve_exact(&mut self, additional: usize)
+
+pub fn vortex_array::builders::PrimitiveBuilder<T>::set_validity(&mut self, validity: vortex_mask::Mask)
 
 pub unsafe fn vortex_array::builders::PrimitiveBuilder<T>::set_validity_unchecked(&mut self, validity: vortex_mask::Mask)
 
@@ -5828,6 +6342,8 @@ pub fn vortex_array::compute::IsSortedIteratorExt::is_strict_sorted(self) -> boo
 
 impl<T> vortex_array::compute::IsSortedIteratorExt for T where T: core::iter::traits::iterator::Iterator + ?core::marker::Sized, <T as core::iter::traits::iterator::Iterator>::Item: core::cmp::PartialOrd
 
+pub fn T::is_strict_sorted(self) -> bool where Self: core::marker::Sized, Self::Item: core::cmp::PartialOrd
+
 pub trait vortex_array::compute::IsSortedKernel: vortex_array::vtable::VTable
 
 pub fn vortex_array::compute::IsSortedKernel::is_sorted(&self, array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<bool>>
@@ -6316,6 +6832,8 @@ pub fn vortex_array::extension::datetime::Date::unpack_native(&self, metadata: &
 
 pub fn vortex_array::extension::datetime::Date::validate_dtype(&self, metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::extension::datetime::Date::validate_scalar_value(&self, metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType, storage_value: &vortex_array::scalar::ScalarValue) -> vortex_error::VortexResult<()>
+
 impl vortex_array::dtype::extension::ExtVTable for vortex_array::extension::datetime::Time
 
 pub type vortex_array::extension::datetime::Time::Metadata = vortex_array::extension::datetime::TimeUnit
@@ -6331,6 +6849,8 @@ pub fn vortex_array::extension::datetime::Time::serialize_metadata(&self, metada
 pub fn vortex_array::extension::datetime::Time::unpack_native(&self, metadata: &Self::Metadata, _storage_dtype: &vortex_array::dtype::DType, storage_value: &vortex_array::scalar::ScalarValue) -> vortex_error::VortexResult<Self::NativeValue>
 
 pub fn vortex_array::extension::datetime::Time::validate_dtype(&self, metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::extension::datetime::Time::validate_scalar_value(&self, metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType, storage_value: &vortex_array::scalar::ScalarValue) -> vortex_error::VortexResult<()>
 
 impl vortex_array::dtype::extension::ExtVTable for vortex_array::extension::datetime::Timestamp
 
@@ -6348,6 +6868,8 @@ pub fn vortex_array::extension::datetime::Timestamp::unpack_native<'a>(&self, me
 
 pub fn vortex_array::extension::datetime::Timestamp::validate_dtype(&self, _metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::extension::datetime::Timestamp::validate_scalar_value(&self, metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType, storage_value: &vortex_array::scalar::ScalarValue) -> vortex_error::VortexResult<()>
+
 pub trait vortex_array::dtype::extension::Matcher
 
 pub type vortex_array::dtype::extension::Matcher::Match<'a>
@@ -6359,6 +6881,8 @@ pub fn vortex_array::dtype::extension::Matcher::try_match<'a>(item: &'a vortex_a
 impl vortex_array::dtype::extension::Matcher for vortex_array::extension::datetime::AnyTemporal
 
 pub type vortex_array::extension::datetime::AnyTemporal::Match<'a> = vortex_array::extension::datetime::TemporalMetadata<'a>
+
+pub fn vortex_array::extension::datetime::AnyTemporal::matches(item: &vortex_array::dtype::extension::ExtDTypeRef) -> bool
 
 pub fn vortex_array::extension::datetime::AnyTemporal::try_match<'a>(item: &'a vortex_array::dtype::extension::ExtDTypeRef) -> core::option::Option<Self::Match>
 
@@ -7980,6 +8504,8 @@ pub fn vortex_array::dtype::IntegerPType::max_value_as_u64() -> u64
 
 impl<T> vortex_array::dtype::IntegerPType for T where T: vortex_array::dtype::NativePType + num_traits::int::PrimInt + num_traits::cast::ToPrimitive + num_traits::bounds::Bounded + core::ops::arith::AddAssign + num_traits::cast::AsPrimitive<usize>
 
+pub fn T::max_value_as_u64() -> u64
+
 pub trait vortex_array::dtype::NativeDType
 
 pub fn vortex_array::dtype::NativeDType::dtype() -> vortex_array::dtype::DType
@@ -8200,7 +8726,15 @@ pub fn f32::downcast<V: vortex_array::dtype::PTypeDowncast>(visitor: V) -> <V as
 
 pub fn f32::is_eq(self, other: Self) -> bool
 
+pub fn f32::is_ge(self, other: Self) -> bool
+
+pub fn f32::is_gt(self, other: Self) -> bool
+
 pub fn f32::is_infinite(self) -> bool
+
+pub fn f32::is_le(self, other: Self) -> bool
+
+pub fn f32::is_lt(self, other: Self) -> bool
 
 pub fn f32::is_nan(self) -> bool
 
@@ -8216,7 +8750,15 @@ pub fn f64::downcast<V: vortex_array::dtype::PTypeDowncast>(visitor: V) -> <V as
 
 pub fn f64::is_eq(self, other: Self) -> bool
 
+pub fn f64::is_ge(self, other: Self) -> bool
+
+pub fn f64::is_gt(self, other: Self) -> bool
+
 pub fn f64::is_infinite(self) -> bool
+
+pub fn f64::is_le(self, other: Self) -> bool
+
+pub fn f64::is_lt(self, other: Self) -> bool
 
 pub fn f64::is_nan(self) -> bool
 
@@ -8232,7 +8774,15 @@ pub fn half::binary16::f16::downcast<V: vortex_array::dtype::PTypeDowncast>(visi
 
 pub fn half::binary16::f16::is_eq(self, other: Self) -> bool
 
+pub fn half::binary16::f16::is_ge(self, other: Self) -> bool
+
+pub fn half::binary16::f16::is_gt(self, other: Self) -> bool
+
 pub fn half::binary16::f16::is_infinite(self) -> bool
+
+pub fn half::binary16::f16::is_le(self, other: Self) -> bool
+
+pub fn half::binary16::f16::is_lt(self, other: Self) -> bool
 
 pub fn half::binary16::f16::is_nan(self) -> bool
 
@@ -8248,7 +8798,15 @@ pub fn i16::downcast<V: vortex_array::dtype::PTypeDowncast>(visitor: V) -> <V as
 
 pub fn i16::is_eq(self, other: Self) -> bool
 
+pub fn i16::is_ge(self, other: Self) -> bool
+
+pub fn i16::is_gt(self, other: Self) -> bool
+
 pub fn i16::is_infinite(self) -> bool
+
+pub fn i16::is_le(self, other: Self) -> bool
+
+pub fn i16::is_lt(self, other: Self) -> bool
 
 pub fn i16::is_nan(self) -> bool
 
@@ -8264,7 +8822,15 @@ pub fn i32::downcast<V: vortex_array::dtype::PTypeDowncast>(visitor: V) -> <V as
 
 pub fn i32::is_eq(self, other: Self) -> bool
 
+pub fn i32::is_ge(self, other: Self) -> bool
+
+pub fn i32::is_gt(self, other: Self) -> bool
+
 pub fn i32::is_infinite(self) -> bool
+
+pub fn i32::is_le(self, other: Self) -> bool
+
+pub fn i32::is_lt(self, other: Self) -> bool
 
 pub fn i32::is_nan(self) -> bool
 
@@ -8280,7 +8846,15 @@ pub fn i64::downcast<V: vortex_array::dtype::PTypeDowncast>(visitor: V) -> <V as
 
 pub fn i64::is_eq(self, other: Self) -> bool
 
+pub fn i64::is_ge(self, other: Self) -> bool
+
+pub fn i64::is_gt(self, other: Self) -> bool
+
 pub fn i64::is_infinite(self) -> bool
+
+pub fn i64::is_le(self, other: Self) -> bool
+
+pub fn i64::is_lt(self, other: Self) -> bool
 
 pub fn i64::is_nan(self) -> bool
 
@@ -8296,7 +8870,15 @@ pub fn i8::downcast<V: vortex_array::dtype::PTypeDowncast>(visitor: V) -> <V as 
 
 pub fn i8::is_eq(self, other: Self) -> bool
 
+pub fn i8::is_ge(self, other: Self) -> bool
+
+pub fn i8::is_gt(self, other: Self) -> bool
+
 pub fn i8::is_infinite(self) -> bool
+
+pub fn i8::is_le(self, other: Self) -> bool
+
+pub fn i8::is_lt(self, other: Self) -> bool
 
 pub fn i8::is_nan(self) -> bool
 
@@ -8312,7 +8894,15 @@ pub fn u16::downcast<V: vortex_array::dtype::PTypeDowncast>(visitor: V) -> <V as
 
 pub fn u16::is_eq(self, other: Self) -> bool
 
+pub fn u16::is_ge(self, other: Self) -> bool
+
+pub fn u16::is_gt(self, other: Self) -> bool
+
 pub fn u16::is_infinite(self) -> bool
+
+pub fn u16::is_le(self, other: Self) -> bool
+
+pub fn u16::is_lt(self, other: Self) -> bool
 
 pub fn u16::is_nan(self) -> bool
 
@@ -8328,7 +8918,15 @@ pub fn u32::downcast<V: vortex_array::dtype::PTypeDowncast>(visitor: V) -> <V as
 
 pub fn u32::is_eq(self, other: Self) -> bool
 
+pub fn u32::is_ge(self, other: Self) -> bool
+
+pub fn u32::is_gt(self, other: Self) -> bool
+
 pub fn u32::is_infinite(self) -> bool
+
+pub fn u32::is_le(self, other: Self) -> bool
+
+pub fn u32::is_lt(self, other: Self) -> bool
 
 pub fn u32::is_nan(self) -> bool
 
@@ -8344,7 +8942,15 @@ pub fn u64::downcast<V: vortex_array::dtype::PTypeDowncast>(visitor: V) -> <V as
 
 pub fn u64::is_eq(self, other: Self) -> bool
 
+pub fn u64::is_ge(self, other: Self) -> bool
+
+pub fn u64::is_gt(self, other: Self) -> bool
+
 pub fn u64::is_infinite(self) -> bool
+
+pub fn u64::is_le(self, other: Self) -> bool
+
+pub fn u64::is_lt(self, other: Self) -> bool
 
 pub fn u64::is_nan(self) -> bool
 
@@ -8360,7 +8966,15 @@ pub fn u8::downcast<V: vortex_array::dtype::PTypeDowncast>(visitor: V) -> <V as 
 
 pub fn u8::is_eq(self, other: Self) -> bool
 
+pub fn u8::is_ge(self, other: Self) -> bool
+
+pub fn u8::is_gt(self, other: Self) -> bool
+
 pub fn u8::is_infinite(self) -> bool
+
+pub fn u8::is_le(self, other: Self) -> bool
+
+pub fn u8::is_lt(self, other: Self) -> bool
 
 pub fn u8::is_nan(self) -> bool
 
@@ -8399,6 +9013,8 @@ pub trait vortex_array::dtype::PTypeDowncastExt: vortex_array::dtype::PTypeDownc
 pub fn vortex_array::dtype::PTypeDowncastExt::downcast<T: vortex_array::dtype::NativePType>(self) -> Self::Output where Self: core::marker::Sized
 
 impl<T: vortex_array::dtype::PTypeDowncast> vortex_array::dtype::PTypeDowncastExt for T
+
+pub fn T::downcast<T: vortex_array::dtype::NativePType>(self) -> Self::Output where Self: core::marker::Sized
 
 pub trait vortex_array::dtype::PTypeUpcast
 
@@ -9272,17 +9888,23 @@ impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::MutTypedS
 
 pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::get(&self, stat: vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
 
+pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::is_empty(&self) -> bool
+
 pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::len(&self) -> usize
 
 impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::StatsSetRef<'_>
 
 pub fn vortex_array::stats::StatsSetRef<'_>::get(&self, stat: vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
 
+pub fn vortex_array::stats::StatsSetRef<'_>::is_empty(&self) -> bool
+
 pub fn vortex_array::stats::StatsSetRef<'_>::len(&self) -> usize
 
 impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::TypedStatsSetRef<'_, '_>
 
 pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::get(&self, stat: vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
+
+pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::is_empty(&self) -> bool
 
 pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::len(&self) -> usize
 
@@ -9295,6 +9917,12 @@ pub fn vortex_array::expr::stats::StatsProviderExt::get_as_bound<S, U>(&self) ->
 pub fn vortex_array::expr::stats::StatsProviderExt::get_scalar_bound<S: vortex_array::expr::stats::StatType<vortex_array::scalar::Scalar>>(&self) -> core::option::Option<<S as vortex_array::expr::stats::StatType>::Bound>
 
 impl<S> vortex_array::expr::stats::StatsProviderExt for S where S: vortex_array::expr::stats::StatsProvider
+
+pub fn S::get_as<T: for<'a> core::convert::TryFrom<&'a vortex_array::scalar::Scalar, Error = vortex_error::VortexError>>(&self, stat: vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<T>>
+
+pub fn S::get_as_bound<S, U>(&self) -> core::option::Option<<S as vortex_array::expr::stats::StatType>::Bound> where S: vortex_array::expr::stats::StatType<U>, U: for<'a> core::convert::TryFrom<&'a vortex_array::scalar::Scalar, Error = vortex_error::VortexError>
+
+pub fn S::get_scalar_bound<S: vortex_array::expr::stats::StatType<vortex_array::scalar::Scalar>>(&self) -> core::option::Option<<S as vortex_array::expr::stats::StatType>::Bound>
 
 pub mod vortex_array::expr::transform
 
@@ -9416,6 +10044,8 @@ impl vortex_array::expr::traversal::NodeVisitor<'_> for vortex_array::expr::trav
 
 pub type vortex_array::expr::traversal::ReferenceCollector::NodeTy = vortex_array::expr::Expression
 
+pub fn vortex_array::expr::traversal::ReferenceCollector::visit_down(&mut self, node: &'a Self::NodeTy) -> vortex_error::VortexResult<vortex_array::expr::traversal::TraversalOrder>
+
 pub fn vortex_array::expr::traversal::ReferenceCollector::visit_up(&mut self, node: &vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::traversal::TraversalOrder>
 
 pub struct vortex_array::expr::traversal::Transformed<T>
@@ -9518,6 +10148,20 @@ pub fn vortex_array::expr::traversal::NodeExt::transform_up<F: core::ops::functi
 
 impl<T: vortex_array::expr::traversal::Node> vortex_array::expr::traversal::NodeExt for T
 
+pub fn T::accept<'a, V: vortex_array::expr::traversal::NodeVisitor<'a, NodeTy = Self>>(&'a self, visitor: &mut V) -> vortex_error::VortexResult<vortex_array::expr::traversal::TraversalOrder>
+
+pub fn T::fold<R, F: vortex_array::expr::traversal::NodeFolder<NodeTy = Self, Result = R>>(self, folder: &mut F) -> vortex_error::VortexResult<vortex_array::expr::traversal::FoldUp<R>>
+
+pub fn T::fold_context<R, F: vortex_array::expr::traversal::NodeFolderContext<NodeTy = Self, Result = R>>(self, ctx: &<F as vortex_array::expr::traversal::NodeFolderContext>::Context, folder: &mut F) -> vortex_error::VortexResult<vortex_array::expr::traversal::FoldUp<R>>
+
+pub fn T::rewrite<R: vortex_array::expr::traversal::NodeRewriter<NodeTy = Self>>(self, rewriter: &mut R) -> vortex_error::VortexResult<vortex_array::expr::traversal::Transformed<Self>>
+
+pub fn T::transform<F, G>(self, down: F, up: G) -> vortex_error::VortexResult<vortex_array::expr::traversal::Transformed<Self>> where F: core::ops::function::FnMut(Self) -> vortex_error::VortexResult<vortex_array::expr::traversal::Transformed<Self>>, G: core::ops::function::FnMut(Self) -> vortex_error::VortexResult<vortex_array::expr::traversal::Transformed<Self>>
+
+pub fn T::transform_down<F: core::ops::function::FnMut(Self) -> vortex_error::VortexResult<vortex_array::expr::traversal::Transformed<Self>>>(self, f: F) -> vortex_error::VortexResult<vortex_array::expr::traversal::Transformed<Self>>
+
+pub fn T::transform_up<F: core::ops::function::FnMut(Self) -> vortex_error::VortexResult<vortex_array::expr::traversal::Transformed<Self>>>(self, f: F) -> vortex_error::VortexResult<vortex_array::expr::traversal::Transformed<Self>>
+
 pub trait vortex_array::expr::traversal::NodeFolder
 
 pub type vortex_array::expr::traversal::NodeFolder::NodeTy: vortex_array::expr::traversal::Node
@@ -9567,6 +10211,8 @@ pub fn vortex_array::expr::traversal::NodeVisitor::visit_up(&mut self, node: &'a
 impl vortex_array::expr::traversal::NodeVisitor<'_> for vortex_array::expr::traversal::ReferenceCollector
 
 pub type vortex_array::expr::traversal::ReferenceCollector::NodeTy = vortex_array::expr::Expression
+
+pub fn vortex_array::expr::traversal::ReferenceCollector::visit_down(&mut self, node: &'a Self::NodeTy) -> vortex_error::VortexResult<vortex_array::expr::traversal::TraversalOrder>
 
 pub fn vortex_array::expr::traversal::ReferenceCollector::visit_up(&mut self, node: &vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::traversal::TraversalOrder>
 
@@ -9992,6 +10638,8 @@ impl vortex_array::dtype::extension::Matcher for vortex_array::extension::dateti
 
 pub type vortex_array::extension::datetime::AnyTemporal::Match<'a> = vortex_array::extension::datetime::TemporalMetadata<'a>
 
+pub fn vortex_array::extension::datetime::AnyTemporal::matches(item: &vortex_array::dtype::extension::ExtDTypeRef) -> bool
+
 pub fn vortex_array::extension::datetime::AnyTemporal::try_match<'a>(item: &'a vortex_array::dtype::extension::ExtDTypeRef) -> core::option::Option<Self::Match>
 
 pub struct vortex_array::extension::datetime::Date
@@ -10042,6 +10690,8 @@ pub fn vortex_array::extension::datetime::Date::unpack_native(&self, metadata: &
 
 pub fn vortex_array::extension::datetime::Date::validate_dtype(&self, metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
 
+pub fn vortex_array::extension::datetime::Date::validate_scalar_value(&self, metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType, storage_value: &vortex_array::scalar::ScalarValue) -> vortex_error::VortexResult<()>
+
 pub struct vortex_array::extension::datetime::Time
 
 impl vortex_array::extension::datetime::Time
@@ -10089,6 +10739,8 @@ pub fn vortex_array::extension::datetime::Time::serialize_metadata(&self, metada
 pub fn vortex_array::extension::datetime::Time::unpack_native(&self, metadata: &Self::Metadata, _storage_dtype: &vortex_array::dtype::DType, storage_value: &vortex_array::scalar::ScalarValue) -> vortex_error::VortexResult<Self::NativeValue>
 
 pub fn vortex_array::extension::datetime::Time::validate_dtype(&self, metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::extension::datetime::Time::validate_scalar_value(&self, metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType, storage_value: &vortex_array::scalar::ScalarValue) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::extension::datetime::Timestamp
 
@@ -10139,6 +10791,8 @@ pub fn vortex_array::extension::datetime::Timestamp::serialize_metadata(&self, m
 pub fn vortex_array::extension::datetime::Timestamp::unpack_native<'a>(&self, metadata: &'a Self::Metadata, _storage_dtype: &'a vortex_array::dtype::DType, storage_value: &'a vortex_array::scalar::ScalarValue) -> vortex_error::VortexResult<Self::NativeValue>
 
 pub fn vortex_array::extension::datetime::Timestamp::validate_dtype(&self, _metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::extension::datetime::Timestamp::validate_scalar_value(&self, metadata: &Self::Metadata, storage_dtype: &vortex_array::dtype::DType, storage_value: &vortex_array::scalar::ScalarValue) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::extension::datetime::TimestampOptions
 
@@ -10241,6 +10895,10 @@ pub fn vortex_array::iter::ArrayIteratorExt::into_array_stream(self) -> impl vor
 pub fn vortex_array::iter::ArrayIteratorExt::read_all(self) -> vortex_error::VortexResult<vortex_array::ArrayRef> where Self: core::marker::Sized
 
 impl<I: vortex_array::iter::ArrayIterator> vortex_array::iter::ArrayIteratorExt for I
+
+pub fn I::into_array_stream(self) -> impl vortex_array::stream::ArrayStream where Self: core::marker::Sized
+
+pub fn I::read_all(self) -> vortex_error::VortexResult<vortex_array::ArrayRef> where Self: core::marker::Sized
 
 pub mod vortex_array::kernel
 
@@ -10394,11 +11052,15 @@ impl vortex_array::matcher::Matcher for vortex_array::AnyColumnar
 
 pub type vortex_array::AnyColumnar::Match<'a> = vortex_array::ColumnarView<'a>
 
+pub fn vortex_array::AnyColumnar::matches(array: &dyn vortex_array::Array) -> bool
+
 pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 impl vortex_array::matcher::Matcher for vortex_array::arrays::AnyScalarFn
 
 pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
+
+pub fn vortex_array::arrays::AnyScalarFn::matches(array: &dyn vortex_array::Array) -> bool
 
 pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
@@ -11192,7 +11854,15 @@ impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::PValue> for vor
 
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::PValue) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_len(&self) -> usize
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 pub enum vortex_array::scalar::ScalarValue
 
@@ -12386,7 +13056,15 @@ impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::Scalar> for (dy
 
 pub fn (dyn vortex_array::Array + '_)::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
+pub fn (dyn vortex_array::Array + '_)::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn (dyn vortex_array::Array + '_)::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn (dyn vortex_array::Array + '_)::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
 pub fn (dyn vortex_array::Array + '_)::index_len(&self) -> usize
+
+pub fn (dyn vortex_array::Array + '_)::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 impl<'a, T> core::convert::TryFrom<&'a vortex_array::scalar::Scalar> for alloc::vec::Vec<T> where T: for<'b> core::convert::TryFrom<&'b vortex_array::scalar::Scalar, Error = vortex_error::VortexError>
 
@@ -12714,11 +13392,21 @@ pub fn vortex_array::scalar_fn::fns::between::Between::is_fallible(&self, _optio
 
 pub fn vortex_array::scalar_fn::fns::between::Between::is_null_sensitive(&self, _instance: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::between::Between::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::between::Between::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::between::Between::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::between::Between::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::between::Between::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::between::Between::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
 pub fn vortex_array::scalar_fn::fns::between::Between::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::between::Between::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub struct vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>(pub V)
 
@@ -12834,9 +13522,17 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::is_fallible(&self, operator
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::is_null_sensitive(&self, _operator: &vortex_array::scalar_fn::fns::operators::Operator) -> bool
 
+pub fn vortex_array::scalar_fn::fns::binary::Binary::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::binary::Binary::return_dtype(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::binary::Binary::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::binary::Binary::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_falsification(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
@@ -12904,6 +13600,8 @@ pub fn vortex_array::scalar_fn::fns::cast::Cast::fmt_sql(&self, dtype: &vortex_a
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::id(&self) -> vortex_array::scalar_fn::ScalarFnId
 
+pub fn vortex_array::scalar_fn::fns::cast::Cast::is_fallible(&self, options: &Self::Options) -> bool
+
 pub fn vortex_array::scalar_fn::fns::cast::Cast::is_null_sensitive(&self, _instance: &vortex_array::dtype::DType) -> bool
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::reduce(&self, target_dtype: &vortex_array::dtype::DType, node: &dyn vortex_array::scalar_fn::ReduceNode, _ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
@@ -12912,7 +13610,13 @@ pub fn vortex_array::scalar_fn::fns::cast::Cast::return_dtype(&self, dtype: &vor
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::serialize(&self, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::cast::Cast::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::cast::Cast::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
 pub fn vortex_array::scalar_fn::fns::cast::Cast::stat_expression(&self, dtype: &vortex_array::dtype::DType, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::cast::Cast::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::validity(&self, dtype: &vortex_array::dtype::DType, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
@@ -13028,17 +13732,33 @@ pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::arity(&self, _o
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::child_name(&self, _instance: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
+
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::execute(&self, data: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::fmt_sql(&self, dynamic: &vortex_array::scalar_fn::fns::dynamic::DynamicComparisonExpr, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::id(&self) -> vortex_array::scalar_fn::ScalarFnId
 
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::is_fallible(&self, options: &Self::Options) -> bool
+
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::is_null_sensitive(&self, _instance: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::return_dtype(&self, dynamic: &vortex_array::scalar_fn::fns::dynamic::DynamicComparisonExpr, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::stat_falsification(&self, dynamic: &vortex_array::scalar_fn::fns::dynamic::DynamicComparisonExpr, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub struct vortex_array::scalar_fn::fns::dynamic::DynamicComparisonExpr
 
@@ -13104,11 +13824,19 @@ pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::is_fallible(&self, _op
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::is_null_sensitive(&self, _options: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::simplify(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::validity(&self, _options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
@@ -13210,9 +13938,15 @@ pub fn vortex_array::scalar_fn::fns::get_item::GetItem::return_dtype(&self, fiel
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::get_item::GetItem::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::simplify_untyped(&self, field_name: &vortex_array::dtype::FieldName, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::stat_expression(&self, field_name: &vortex_array::dtype::FieldName, _expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::get_item::GetItem::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::get_item::GetItem::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub mod vortex_array::scalar_fn::fns::is_null
 
@@ -13242,11 +13976,21 @@ pub fn vortex_array::scalar_fn::fns::is_null::IsNull::is_fallible(&self, _instan
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::is_null_sensitive(&self, _instance: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::return_dtype(&self, _options: &Self::Options, _arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::serialize(&self, _instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::stat_falsification(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub mod vortex_array::scalar_fn::fns::like
 
@@ -13272,11 +14016,21 @@ pub fn vortex_array::scalar_fn::fns::like::Like::fmt_sql(&self, options: &Self::
 
 pub fn vortex_array::scalar_fn::fns::like::Like::id(&self) -> vortex_array::scalar_fn::ScalarFnId
 
+pub fn vortex_array::scalar_fn::fns::like::Like::is_fallible(&self, options: &Self::Options) -> bool
+
 pub fn vortex_array::scalar_fn::fns::like::Like::is_null_sensitive(&self, _instance: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::like::Like::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::like::Like::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::like::Like::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::like::Like::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::stat_falsification(&self, like_opts: &vortex_array::scalar_fn::fns::like::LikeOptions, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
@@ -13390,11 +14144,21 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::is_fallible(&s
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::is_null_sensitive(&self, _instance: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::serialize(&self, _instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::stat_falsification(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub struct vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>(pub V)
 
@@ -13464,11 +14228,19 @@ pub fn vortex_array::scalar_fn::fns::literal::Literal::is_fallible(&self, _insta
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::is_null_sensitive(&self, _instance: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::literal::Literal::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::literal::Literal::return_dtype(&self, options: &Self::Options, _arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::literal::Literal::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::literal::Literal::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
 pub fn vortex_array::scalar_fn::fns::literal::Literal::stat_expression(&self, scalar: &vortex_array::scalar::Scalar, _expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, _catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::literal::Literal::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::validity(&self, scalar: &vortex_array::scalar::Scalar, _expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
@@ -13496,11 +14268,23 @@ pub fn vortex_array::scalar_fn::fns::mask::Mask::fmt_sql(&self, _options: &Self:
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::id(&self) -> vortex_array::scalar_fn::ScalarFnId
 
+pub fn vortex_array::scalar_fn::fns::mask::Mask::is_fallible(&self, options: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::mask::Mask::is_null_sensitive(&self, options: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::mask::Mask::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::mask::Mask::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::simplify(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::mask::Mask::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::mask::Mask::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::mask::Mask::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::validity(&self, _options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
@@ -13670,6 +14454,14 @@ pub fn vortex_array::scalar_fn::fns::merge::Merge::return_dtype(&self, options: 
 
 pub fn vortex_array::scalar_fn::fns::merge::Merge::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::merge::Merge::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::merge::Merge::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::merge::Merge::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::merge::Merge::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
 pub fn vortex_array::scalar_fn::fns::merge::Merge::validity(&self, _options: &Self::Options, _expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub mod vortex_array::scalar_fn::fns::not
@@ -13700,9 +14492,21 @@ pub fn vortex_array::scalar_fn::fns::not::Not::is_fallible(&self, _options: &Sel
 
 pub fn vortex_array::scalar_fn::fns::not::Not::is_null_sensitive(&self, _options: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::not::Not::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::not::Not::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::not::Not::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::not::Not::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::not::Not::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::not::Not::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::not::Not::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::not::Not::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub struct vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>(pub V)
 
@@ -13938,9 +14742,19 @@ pub fn vortex_array::scalar_fn::fns::pack::Pack::is_fallible(&self, _instance: &
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::is_null_sensitive(&self, _instance: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::pack::Pack::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::pack::Pack::return_dtype(&self, options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::pack::Pack::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::pack::Pack::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::pack::Pack::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::pack::Pack::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::validity(&self, _options: &Self::Options, _expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
@@ -14002,11 +14816,21 @@ pub fn vortex_array::scalar_fn::fns::root::Root::is_fallible(&self, _options: &S
 
 pub fn vortex_array::scalar_fn::fns::root::Root::is_null_sensitive(&self, _options: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::root::Root::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::root::Root::return_dtype(&self, _options: &Self::Options, _arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::root::Root::serialize(&self, _instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::root::Root::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::root::Root::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
 pub fn vortex_array::scalar_fn::fns::root::Root::stat_expression(&self, _options: &Self::Options, _expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::root::Root::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::root::Root::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub mod vortex_array::scalar_fn::fns::select
 
@@ -14080,11 +14904,21 @@ pub fn vortex_array::scalar_fn::fns::select::Select::is_fallible(&self, _instanc
 
 pub fn vortex_array::scalar_fn::fns::select::Select::is_null_sensitive(&self, _instance: &vortex_array::scalar_fn::fns::select::FieldSelection) -> bool
 
+pub fn vortex_array::scalar_fn::fns::select::Select::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::select::Select::return_dtype(&self, selection: &vortex_array::scalar_fn::fns::select::FieldSelection, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::select::Select::serialize(&self, instance: &vortex_array::scalar_fn::fns::select::FieldSelection) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 pub fn vortex_array::scalar_fn::fns::select::Select::simplify(&self, selection: &vortex_array::scalar_fn::fns::select::FieldSelection, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::select::Select::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::select::Select::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::select::Select::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::select::Select::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub mod vortex_array::scalar_fn::fns::zip
 
@@ -14114,11 +14948,21 @@ pub fn vortex_array::scalar_fn::fns::zip::Zip::is_fallible(&self, _options: &Sel
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::is_null_sensitive(&self, _options: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::zip::Zip::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::zip::Zip::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::simplify(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, _ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::zip::Zip::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::zip::Zip::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::zip::Zip::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::zip::Zip::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub struct vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>(pub V)
 
@@ -14195,6 +15039,8 @@ pub trait vortex_array::scalar_fn::session::ScalarFnSessionExt: vortex_session::
 pub fn vortex_array::scalar_fn::session::ScalarFnSessionExt::scalar_fns(&self) -> vortex_session::Ref<'_, vortex_array::scalar_fn::session::ScalarFnSession>
 
 impl<S: vortex_session::SessionExt> vortex_array::scalar_fn::session::ScalarFnSessionExt for S
+
+pub fn S::scalar_fns(&self) -> vortex_session::Ref<'_, vortex_array::scalar_fn::session::ScalarFnSession>
 
 pub type vortex_array::scalar_fn::session::ScalarFnRegistry = vortex_session::registry::Registry<vortex_array::scalar_fn::ScalarFnPluginRef>
 
@@ -14488,11 +15334,21 @@ pub fn vortex_array::scalar_fn::fns::between::Between::is_fallible(&self, _optio
 
 pub fn vortex_array::scalar_fn::fns::between::Between::is_null_sensitive(&self, _instance: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::between::Between::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::between::Between::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::between::Between::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::between::Between::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::between::Between::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::between::Between::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
 pub fn vortex_array::scalar_fn::fns::between::Between::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::between::Between::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::binary::Binary
 
@@ -14514,9 +15370,17 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::is_fallible(&self, operator
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::is_null_sensitive(&self, _operator: &vortex_array::scalar_fn::fns::operators::Operator) -> bool
 
+pub fn vortex_array::scalar_fn::fns::binary::Binary::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::binary::Binary::return_dtype(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::binary::Binary::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::binary::Binary::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_falsification(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
@@ -14538,6 +15402,8 @@ pub fn vortex_array::scalar_fn::fns::cast::Cast::fmt_sql(&self, dtype: &vortex_a
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::id(&self) -> vortex_array::scalar_fn::ScalarFnId
 
+pub fn vortex_array::scalar_fn::fns::cast::Cast::is_fallible(&self, options: &Self::Options) -> bool
+
 pub fn vortex_array::scalar_fn::fns::cast::Cast::is_null_sensitive(&self, _instance: &vortex_array::dtype::DType) -> bool
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::reduce(&self, target_dtype: &vortex_array::dtype::DType, node: &dyn vortex_array::scalar_fn::ReduceNode, _ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
@@ -14546,7 +15412,13 @@ pub fn vortex_array::scalar_fn::fns::cast::Cast::return_dtype(&self, dtype: &vor
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::serialize(&self, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::cast::Cast::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::cast::Cast::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
 pub fn vortex_array::scalar_fn::fns::cast::Cast::stat_expression(&self, dtype: &vortex_array::dtype::DType, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::cast::Cast::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::validity(&self, dtype: &vortex_array::dtype::DType, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
@@ -14558,17 +15430,33 @@ pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::arity(&self, _o
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::child_name(&self, _instance: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
 
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
+
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::execute(&self, data: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::fmt_sql(&self, dynamic: &vortex_array::scalar_fn::fns::dynamic::DynamicComparisonExpr, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::id(&self) -> vortex_array::scalar_fn::ScalarFnId
 
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::is_fallible(&self, options: &Self::Options) -> bool
+
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::is_null_sensitive(&self, _instance: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::return_dtype(&self, dynamic: &vortex_array::scalar_fn::fns::dynamic::DynamicComparisonExpr, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::stat_falsification(&self, dynamic: &vortex_array::scalar_fn::fns::dynamic::DynamicComparisonExpr, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::fill_null::FillNull
 
@@ -14590,11 +15478,19 @@ pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::is_fallible(&self, _op
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::is_null_sensitive(&self, _options: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::simplify(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::validity(&self, _options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
@@ -14624,9 +15520,15 @@ pub fn vortex_array::scalar_fn::fns::get_item::GetItem::return_dtype(&self, fiel
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::get_item::GetItem::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::simplify_untyped(&self, field_name: &vortex_array::dtype::FieldName, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::stat_expression(&self, field_name: &vortex_array::dtype::FieldName, _expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::get_item::GetItem::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::get_item::GetItem::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::is_null::IsNull
 
@@ -14648,11 +15550,21 @@ pub fn vortex_array::scalar_fn::fns::is_null::IsNull::is_fallible(&self, _instan
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::is_null_sensitive(&self, _instance: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::return_dtype(&self, _options: &Self::Options, _arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::serialize(&self, _instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::stat_falsification(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::like::Like
 
@@ -14670,11 +15582,21 @@ pub fn vortex_array::scalar_fn::fns::like::Like::fmt_sql(&self, options: &Self::
 
 pub fn vortex_array::scalar_fn::fns::like::Like::id(&self) -> vortex_array::scalar_fn::ScalarFnId
 
+pub fn vortex_array::scalar_fn::fns::like::Like::is_fallible(&self, options: &Self::Options) -> bool
+
 pub fn vortex_array::scalar_fn::fns::like::Like::is_null_sensitive(&self, _instance: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::like::Like::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::like::Like::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::like::Like::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::like::Like::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::stat_falsification(&self, like_opts: &vortex_array::scalar_fn::fns::like::LikeOptions, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
@@ -14700,11 +15622,21 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::is_fallible(&s
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::is_null_sensitive(&self, _instance: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::serialize(&self, _instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::stat_falsification(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::literal::Literal
 
@@ -14726,11 +15658,19 @@ pub fn vortex_array::scalar_fn::fns::literal::Literal::is_fallible(&self, _insta
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::is_null_sensitive(&self, _instance: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::literal::Literal::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::literal::Literal::return_dtype(&self, options: &Self::Options, _arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::literal::Literal::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::literal::Literal::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
 pub fn vortex_array::scalar_fn::fns::literal::Literal::stat_expression(&self, scalar: &vortex_array::scalar::Scalar, _expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, _catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::literal::Literal::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::validity(&self, scalar: &vortex_array::scalar::Scalar, _expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
@@ -14750,11 +15690,23 @@ pub fn vortex_array::scalar_fn::fns::mask::Mask::fmt_sql(&self, _options: &Self:
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::id(&self) -> vortex_array::scalar_fn::ScalarFnId
 
+pub fn vortex_array::scalar_fn::fns::mask::Mask::is_fallible(&self, options: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::mask::Mask::is_null_sensitive(&self, options: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::mask::Mask::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::mask::Mask::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::simplify(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::mask::Mask::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::mask::Mask::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::mask::Mask::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::validity(&self, _options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
@@ -14784,6 +15736,14 @@ pub fn vortex_array::scalar_fn::fns::merge::Merge::return_dtype(&self, options: 
 
 pub fn vortex_array::scalar_fn::fns::merge::Merge::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::merge::Merge::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::merge::Merge::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::merge::Merge::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::merge::Merge::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
 pub fn vortex_array::scalar_fn::fns::merge::Merge::validity(&self, _options: &Self::Options, _expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::not::Not
@@ -14806,9 +15766,21 @@ pub fn vortex_array::scalar_fn::fns::not::Not::is_fallible(&self, _options: &Sel
 
 pub fn vortex_array::scalar_fn::fns::not::Not::is_null_sensitive(&self, _options: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::not::Not::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::not::Not::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::not::Not::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::not::Not::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::not::Not::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::not::Not::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::not::Not::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::not::Not::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::pack::Pack
 
@@ -14830,9 +15802,19 @@ pub fn vortex_array::scalar_fn::fns::pack::Pack::is_fallible(&self, _instance: &
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::is_null_sensitive(&self, _instance: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::pack::Pack::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::pack::Pack::return_dtype(&self, options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::serialize(&self, instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::pack::Pack::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::pack::Pack::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::pack::Pack::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::pack::Pack::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::validity(&self, _options: &Self::Options, _expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
@@ -14856,11 +15838,21 @@ pub fn vortex_array::scalar_fn::fns::root::Root::is_fallible(&self, _options: &S
 
 pub fn vortex_array::scalar_fn::fns::root::Root::is_null_sensitive(&self, _options: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::root::Root::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::root::Root::return_dtype(&self, _options: &Self::Options, _arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::root::Root::serialize(&self, _instance: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::scalar_fn::fns::root::Root::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::root::Root::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
 pub fn vortex_array::scalar_fn::fns::root::Root::stat_expression(&self, _options: &Self::Options, _expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::root::Root::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::root::Root::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::select::Select
 
@@ -14882,11 +15874,21 @@ pub fn vortex_array::scalar_fn::fns::select::Select::is_fallible(&self, _instanc
 
 pub fn vortex_array::scalar_fn::fns::select::Select::is_null_sensitive(&self, _instance: &vortex_array::scalar_fn::fns::select::FieldSelection) -> bool
 
+pub fn vortex_array::scalar_fn::fns::select::Select::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::select::Select::return_dtype(&self, selection: &vortex_array::scalar_fn::fns::select::FieldSelection, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::select::Select::serialize(&self, instance: &vortex_array::scalar_fn::fns::select::FieldSelection) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 pub fn vortex_array::scalar_fn::fns::select::Select::simplify(&self, selection: &vortex_array::scalar_fn::fns::select::FieldSelection, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::select::Select::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::select::Select::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::select::Select::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::select::Select::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::zip::Zip
 
@@ -14908,11 +15910,21 @@ pub fn vortex_array::scalar_fn::fns::zip::Zip::is_fallible(&self, _options: &Sel
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::is_null_sensitive(&self, _options: &Self::Options) -> bool
 
+pub fn vortex_array::scalar_fn::fns::zip::Zip::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
 pub fn vortex_array::scalar_fn::fns::zip::Zip::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::simplify(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, _ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::zip::Zip::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::zip::Zip::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::zip::Zip::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::zip::Zip::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub trait vortex_array::scalar_fn::ScalarFnVTableExt: vortex_array::scalar_fn::ScalarFnVTable
 
@@ -14923,6 +15935,12 @@ pub fn vortex_array::scalar_fn::ScalarFnVTableExt::new_expr(&self, options: Self
 pub fn vortex_array::scalar_fn::ScalarFnVTableExt::try_new_expr(&self, options: Self::Options, children: impl core::iter::traits::collect::IntoIterator<Item = vortex_array::expr::Expression>) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 impl<V: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::scalar_fn::ScalarFnVTableExt for V
+
+pub fn V::bind(&self, options: Self::Options) -> vortex_array::scalar_fn::ScalarFnRef
+
+pub fn V::new_expr(&self, options: Self::Options, children: impl core::iter::traits::collect::IntoIterator<Item = vortex_array::expr::Expression>) -> vortex_array::expr::Expression
+
+pub fn V::try_new_expr(&self, options: Self::Options, children: impl core::iter::traits::collect::IntoIterator<Item = vortex_array::expr::Expression>) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub trait vortex_array::scalar_fn::SimplifyCtx
 
@@ -15022,25 +16040,57 @@ impl vortex_array::search_sorted::IndexOrd<core::option::Option<vortex_array::sc
 
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_cmp(&self, idx: usize, elem: &core::option::Option<vortex_array::scalar::PValue>) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_len(&self) -> usize
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::PValue> for vortex_array::variants::PrimitiveTyped<'_>
 
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::PValue) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_len(&self) -> usize
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::Scalar> for (dyn vortex_array::Array + '_)
 
 pub fn (dyn vortex_array::Array + '_)::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
+pub fn (dyn vortex_array::Array + '_)::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn (dyn vortex_array::Array + '_)::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn (dyn vortex_array::Array + '_)::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
 pub fn (dyn vortex_array::Array + '_)::index_len(&self) -> usize
+
+pub fn (dyn vortex_array::Array + '_)::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 impl<T: core::cmp::PartialOrd> vortex_array::search_sorted::IndexOrd<T> for [T]
 
 pub fn [T]::index_cmp(&self, idx: usize, elem: &T) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
+pub fn [T]::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn [T]::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn [T]::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
 pub fn [T]::index_len(&self) -> usize
+
+pub fn [T]::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 pub trait vortex_array::search_sorted::SearchSorted<T>
 
@@ -15049,6 +16099,8 @@ pub fn vortex_array::search_sorted::SearchSorted::search_sorted(&self, value: &T
 pub fn vortex_array::search_sorted::SearchSorted::search_sorted_by<F: core::ops::function::FnMut(usize) -> vortex_error::VortexResult<core::cmp::Ordering>, N: core::ops::function::FnMut(usize) -> vortex_error::VortexResult<core::cmp::Ordering>>(&self, find: F, side_find: N, side: vortex_array::search_sorted::SearchSortedSide) -> vortex_error::VortexResult<vortex_array::search_sorted::SearchResult>
 
 impl<S, T> vortex_array::search_sorted::SearchSorted<T> for S where S: vortex_array::search_sorted::IndexOrd<T> + ?core::marker::Sized
+
+pub fn S::search_sorted(&self, value: &T, side: vortex_array::search_sorted::SearchSortedSide) -> vortex_error::VortexResult<vortex_array::search_sorted::SearchResult> where Self: vortex_array::search_sorted::IndexOrd<T>
 
 pub fn S::search_sorted_by<F, N>(&self, find: F, side_find: N, side: vortex_array::search_sorted::SearchSortedSide) -> core::result::Result<vortex_array::search_sorted::SearchResult, vortex_error::VortexError> where F: core::ops::function::FnMut(usize) -> core::result::Result<core::cmp::Ordering, vortex_error::VortexError>, N: core::ops::function::FnMut(usize) -> core::result::Result<core::cmp::Ordering, vortex_error::VortexError>
 
@@ -15136,6 +16188,8 @@ impl vortex_array::serde::ArrayChildren for &[vortex_array::ArrayRef]
 
 pub fn &[vortex_array::ArrayRef]::get(&self, index: usize, dtype: &vortex_array::dtype::DType, len: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn &[vortex_array::ArrayRef]::is_empty(&self) -> bool
+
 pub fn &[vortex_array::ArrayRef]::len(&self) -> usize
 
 pub mod vortex_array::session
@@ -15161,6 +16215,8 @@ pub trait vortex_array::session::ArraySessionExt: vortex_session::SessionExt
 pub fn vortex_array::session::ArraySessionExt::arrays(&self) -> vortex_session::Ref<'_, vortex_array::session::ArraySession>
 
 impl<S: vortex_session::SessionExt> vortex_array::session::ArraySessionExt for S
+
+pub fn S::arrays(&self) -> vortex_session::Ref<'_, vortex_array::session::ArraySession>
 
 pub type vortex_array::session::ArrayRegistry = vortex_session::registry::Registry<&'static dyn vortex_array::vtable::DynVTable>
 
@@ -15223,6 +16279,8 @@ pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::merge_unordered(self, o
 impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::MutTypedStatsSetRef<'_, '_>
 
 pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::get(&self, stat: vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
+
+pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::is_empty(&self) -> bool
 
 pub fn vortex_array::stats::MutTypedStatsSetRef<'_, '_>::len(&self) -> usize
 
@@ -15366,6 +16424,8 @@ impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::StatsSetR
 
 pub fn vortex_array::stats::StatsSetRef<'_>::get(&self, stat: vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
 
+pub fn vortex_array::stats::StatsSetRef<'_>::is_empty(&self) -> bool
+
 pub fn vortex_array::stats::StatsSetRef<'_>::len(&self) -> usize
 
 impl vortex_flatbuffers::WriteFlatBuffer for vortex_array::stats::StatsSetRef<'_>
@@ -15383,6 +16443,8 @@ pub vortex_array::stats::TypedStatsSetRef::values: &'a vortex_array::stats::Stat
 impl vortex_array::expr::stats::StatsProvider for vortex_array::stats::TypedStatsSetRef<'_, '_>
 
 pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::get(&self, stat: vortex_array::expr::stats::Stat) -> core::option::Option<vortex_array::expr::stats::Precision<vortex_array::scalar::Scalar>>
+
+pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::is_empty(&self) -> bool
 
 pub fn vortex_array::stats::TypedStatsSetRef<'_, '_>::len(&self) -> usize
 
@@ -15433,6 +16495,10 @@ pub fn vortex_array::stream::ArrayStreamExt::boxed(self) -> vortex_array::stream
 pub fn vortex_array::stream::ArrayStreamExt::read_all(self) -> impl core::future::future::Future<Output = vortex_error::VortexResult<vortex_array::ArrayRef>> where Self: core::marker::Sized
 
 impl<S: vortex_array::stream::ArrayStream> vortex_array::stream::ArrayStreamExt for S
+
+pub fn S::boxed(self) -> vortex_array::stream::SendableArrayStream where Self: core::marker::Sized + core::marker::Send + 'static
+
+pub fn S::read_all(self) -> impl core::future::future::Future<Output = vortex_error::VortexResult<vortex_array::ArrayRef>> where Self: core::marker::Sized
 
 pub type vortex_array::stream::SendableArrayStream = core::pin::Pin<alloc::boxed::Box<(dyn vortex_array::stream::ArrayStream + core::marker::Send)>>
 
@@ -15582,13 +16648,29 @@ impl vortex_array::search_sorted::IndexOrd<core::option::Option<vortex_array::sc
 
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_cmp(&self, idx: usize, elem: &core::option::Option<vortex_array::scalar::PValue>) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_len(&self) -> usize
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::PValue> for vortex_array::variants::PrimitiveTyped<'_>
 
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::PValue) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_len(&self) -> usize
+
+pub fn vortex_array::variants::PrimitiveTyped<'_>::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 pub struct vortex_array::variants::StructTyped<'a>(_)
 
@@ -15800,6 +16882,8 @@ pub type vortex_array::arrays::BoolVTable::ValidityVTable = vortex_array::vtable
 
 pub type vortex_array::arrays::BoolVTable::VisitorVTable = vortex_array::arrays::BoolVTable
 
+pub fn vortex_array::arrays::BoolVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::BoolVTable::array_eq(array: &vortex_array::arrays::BoolArray, other: &vortex_array::arrays::BoolArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::BoolVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::BoolArray, state: &mut H, precision: vortex_array::Precision)
@@ -15819,6 +16903,8 @@ pub fn vortex_array::arrays::BoolVTable::id(_array: &Self::Array) -> vortex_arra
 pub fn vortex_array::arrays::BoolVTable::len(array: &vortex_array::arrays::BoolArray) -> usize
 
 pub fn vortex_array::arrays::BoolVTable::metadata(array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::BoolVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::BoolVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -15884,6 +16970,8 @@ pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::ar
 
 pub type vortex_array::arrays::ConstantVTable::VisitorVTable = vortex_array::arrays::ConstantVTable
 
+pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::ConstantVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ConstantArray, state: &mut H, _precision: vortex_array::Precision)
@@ -15896,11 +16984,15 @@ pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays:
 
 pub fn vortex_array::arrays::ConstantVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::arrays::ConstantVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
 pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
 
 pub fn vortex_array::arrays::ConstantVTable::metadata(_array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ConstantVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::ConstantVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -15922,6 +17014,8 @@ pub type vortex_array::arrays::DecimalVTable::ValidityVTable = vortex_array::vta
 
 pub type vortex_array::arrays::DecimalVTable::VisitorVTable = vortex_array::arrays::DecimalVTable
 
+pub fn vortex_array::arrays::DecimalVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::DecimalVTable::array_eq(array: &vortex_array::arrays::DecimalArray, other: &vortex_array::arrays::DecimalArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::DecimalVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DecimalArray, state: &mut H, precision: vortex_array::Precision)
@@ -15941,6 +17035,8 @@ pub fn vortex_array::arrays::DecimalVTable::id(_array: &Self::Array) -> vortex_a
 pub fn vortex_array::arrays::DecimalVTable::len(array: &vortex_array::arrays::DecimalArray) -> usize
 
 pub fn vortex_array::arrays::DecimalVTable::metadata(array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::DecimalVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::DecimalVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -15962,6 +17058,8 @@ pub type vortex_array::arrays::DictVTable::ValidityVTable = vortex_array::arrays
 
 pub type vortex_array::arrays::DictVTable::VisitorVTable = vortex_array::arrays::DictVTable
 
+pub fn vortex_array::arrays::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::DictVTable::array_eq(array: &vortex_array::arrays::DictArray, other: &vortex_array::arrays::DictArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DictArray, state: &mut H, precision: vortex_array::Precision)
@@ -15981,6 +17079,8 @@ pub fn vortex_array::arrays::DictVTable::id(_array: &Self::Array) -> vortex_arra
 pub fn vortex_array::arrays::DictVTable::len(array: &vortex_array::arrays::DictArray) -> usize
 
 pub fn vortex_array::arrays::DictVTable::metadata(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16002,6 +17102,8 @@ pub type vortex_array::arrays::ExtensionVTable::ValidityVTable = vortex_array::v
 
 pub type vortex_array::arrays::ExtensionVTable::VisitorVTable = vortex_array::arrays::ExtensionVTable
 
+pub fn vortex_array::arrays::ExtensionVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::ExtensionVTable::array_eq(array: &vortex_array::arrays::ExtensionArray, other: &vortex_array::arrays::ExtensionArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::ExtensionVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ExtensionArray, state: &mut H, precision: vortex_array::Precision)
@@ -16021,6 +17123,8 @@ pub fn vortex_array::arrays::ExtensionVTable::id(_array: &Self::Array) -> vortex
 pub fn vortex_array::arrays::ExtensionVTable::len(array: &vortex_array::arrays::ExtensionArray) -> usize
 
 pub fn vortex_array::arrays::ExtensionVTable::metadata(_array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ExtensionVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::ExtensionVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16042,6 +17146,8 @@ pub type vortex_array::arrays::FilterVTable::ValidityVTable = vortex_array::arra
 
 pub type vortex_array::arrays::FilterVTable::VisitorVTable = vortex_array::arrays::FilterVTable
 
+pub fn vortex_array::arrays::FilterVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::FilterVTable::array_eq(array: &vortex_array::arrays::FilterArray, other: &vortex_array::arrays::FilterArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::FilterVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FilterArray, state: &mut H, precision: vortex_array::Precision)
@@ -16053,6 +17159,8 @@ pub fn vortex_array::arrays::FilterVTable::deserialize(_bytes: &[u8], _dtype: &v
 pub fn vortex_array::arrays::FilterVTable::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::arrays::FilterVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::FilterVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::FilterVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
@@ -16082,6 +17190,8 @@ pub type vortex_array::arrays::FixedSizeListVTable::ValidityVTable = vortex_arra
 
 pub type vortex_array::arrays::FixedSizeListVTable::VisitorVTable = vortex_array::arrays::FixedSizeListVTable
 
+pub fn vortex_array::arrays::FixedSizeListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::FixedSizeListVTable::array_eq(array: &vortex_array::arrays::FixedSizeListArray, other: &vortex_array::arrays::FixedSizeListArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::FixedSizeListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FixedSizeListArray, state: &mut H, precision: vortex_array::Precision)
@@ -16101,6 +17211,8 @@ pub fn vortex_array::arrays::FixedSizeListVTable::id(_array: &Self::Array) -> vo
 pub fn vortex_array::arrays::FixedSizeListVTable::len(array: &vortex_array::arrays::FixedSizeListArray) -> usize
 
 pub fn vortex_array::arrays::FixedSizeListVTable::metadata(_array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::FixedSizeListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16122,6 +17234,8 @@ pub type vortex_array::arrays::ListVTable::ValidityVTable = vortex_array::vtable
 
 pub type vortex_array::arrays::ListVTable::VisitorVTable = vortex_array::arrays::ListVTable
 
+pub fn vortex_array::arrays::ListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::ListVTable::array_eq(array: &vortex_array::arrays::ListArray, other: &vortex_array::arrays::ListArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::ListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListArray, state: &mut H, precision: vortex_array::Precision)
@@ -16141,6 +17255,8 @@ pub fn vortex_array::arrays::ListVTable::id(_array: &Self::Array) -> vortex_arra
 pub fn vortex_array::arrays::ListVTable::len(array: &vortex_array::arrays::ListArray) -> usize
 
 pub fn vortex_array::arrays::ListVTable::metadata(array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::ListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16162,6 +17278,8 @@ pub type vortex_array::arrays::ListViewVTable::ValidityVTable = vortex_array::vt
 
 pub type vortex_array::arrays::ListViewVTable::VisitorVTable = vortex_array::arrays::ListViewVTable
 
+pub fn vortex_array::arrays::ListViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::ListViewVTable::array_eq(array: &vortex_array::arrays::ListViewArray, other: &vortex_array::arrays::ListViewArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::ListViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListViewArray, state: &mut H, precision: vortex_array::Precision)
@@ -16181,6 +17299,8 @@ pub fn vortex_array::arrays::ListViewVTable::id(_array: &Self::Array) -> vortex_
 pub fn vortex_array::arrays::ListViewVTable::len(array: &vortex_array::arrays::ListViewArray) -> usize
 
 pub fn vortex_array::arrays::ListViewVTable::metadata(array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ListViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::ListViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16202,6 +17322,8 @@ pub type vortex_array::arrays::MaskedVTable::ValidityVTable = vortex_array::vtab
 
 pub type vortex_array::arrays::MaskedVTable::VisitorVTable = vortex_array::arrays::MaskedVTable
 
+pub fn vortex_array::arrays::MaskedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::MaskedVTable::array_eq(array: &vortex_array::arrays::MaskedArray, other: &vortex_array::arrays::MaskedArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::MaskedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::MaskedArray, state: &mut H, precision: vortex_array::Precision)
@@ -16221,6 +17343,8 @@ pub fn vortex_array::arrays::MaskedVTable::id(_array: &Self::Array) -> vortex_ar
 pub fn vortex_array::arrays::MaskedVTable::len(array: &vortex_array::arrays::MaskedArray) -> usize
 
 pub fn vortex_array::arrays::MaskedVTable::metadata(_array: &vortex_array::arrays::MaskedArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::MaskedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::MaskedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16242,6 +17366,8 @@ pub type vortex_array::arrays::NullVTable::ValidityVTable = vortex_array::arrays
 
 pub type vortex_array::arrays::NullVTable::VisitorVTable = vortex_array::arrays::NullVTable
 
+pub fn vortex_array::arrays::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::NullVTable::array_eq(array: &vortex_array::arrays::NullArray, other: &vortex_array::arrays::NullArray, _precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::NullArray, state: &mut H, _precision: vortex_array::Precision)
@@ -16254,11 +17380,15 @@ pub fn vortex_array::arrays::NullVTable::dtype(_array: &vortex_array::arrays::Nu
 
 pub fn vortex_array::arrays::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::arrays::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
 pub fn vortex_array::arrays::NullVTable::len(array: &vortex_array::arrays::NullArray) -> usize
 
 pub fn vortex_array::arrays::NullVTable::metadata(_array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16280,6 +17410,8 @@ pub type vortex_array::arrays::PrimitiveVTable::ValidityVTable = vortex_array::v
 
 pub type vortex_array::arrays::PrimitiveVTable::VisitorVTable = vortex_array::arrays::PrimitiveVTable
 
+pub fn vortex_array::arrays::PrimitiveVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::PrimitiveVTable::array_eq(array: &vortex_array::arrays::PrimitiveArray, other: &vortex_array::arrays::PrimitiveArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::PrimitiveVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::PrimitiveArray, state: &mut H, precision: vortex_array::Precision)
@@ -16299,6 +17431,8 @@ pub fn vortex_array::arrays::PrimitiveVTable::id(_array: &Self::Array) -> vortex
 pub fn vortex_array::arrays::PrimitiveVTable::len(array: &vortex_array::arrays::PrimitiveArray) -> usize
 
 pub fn vortex_array::arrays::PrimitiveVTable::metadata(_array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::PrimitiveVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::PrimitiveVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16320,6 +17454,8 @@ pub type vortex_array::arrays::ScalarFnVTable::ValidityVTable = vortex_array::ar
 
 pub type vortex_array::arrays::ScalarFnVTable::VisitorVTable = vortex_array::arrays::ScalarFnVTable
 
+pub fn vortex_array::arrays::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::ScalarFnVTable::array_eq(array: &vortex_array::arrays::ScalarFnArray, other: &vortex_array::arrays::ScalarFnArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
@@ -16331,6 +17467,8 @@ pub fn vortex_array::arrays::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: 
 pub fn vortex_array::arrays::ScalarFnVTable::dtype(array: &vortex_array::arrays::ScalarFnArray) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::arrays::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
 
@@ -16360,6 +17498,8 @@ pub type vortex_array::arrays::SharedVTable::ValidityVTable = vortex_array::arra
 
 pub type vortex_array::arrays::SharedVTable::VisitorVTable = vortex_array::arrays::SharedVTable
 
+pub fn vortex_array::arrays::SharedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::SharedVTable::array_eq(array: &vortex_array::arrays::SharedArray, other: &vortex_array::arrays::SharedArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::SharedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SharedArray, state: &mut H, precision: vortex_array::Precision)
@@ -16372,11 +17512,17 @@ pub fn vortex_array::arrays::SharedVTable::dtype(array: &vortex_array::arrays::S
 
 pub fn vortex_array::arrays::SharedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::arrays::SharedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::SharedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
 pub fn vortex_array::arrays::SharedVTable::len(array: &vortex_array::arrays::SharedArray) -> usize
 
 pub fn vortex_array::arrays::SharedVTable::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::SharedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::SharedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::SharedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
@@ -16396,6 +17542,8 @@ pub type vortex_array::arrays::SliceVTable::ValidityVTable = vortex_array::array
 
 pub type vortex_array::arrays::SliceVTable::VisitorVTable = vortex_array::arrays::SliceVTable
 
+pub fn vortex_array::arrays::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::SliceVTable::array_eq(array: &vortex_array::arrays::SliceArray, other: &vortex_array::arrays::SliceArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SliceArray, state: &mut H, precision: vortex_array::Precision)
@@ -16408,11 +17556,15 @@ pub fn vortex_array::arrays::SliceVTable::dtype(array: &vortex_array::arrays::Sl
 
 pub fn vortex_array::arrays::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::arrays::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrays::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
 pub fn vortex_array::arrays::SliceVTable::len(array: &vortex_array::arrays::SliceArray) -> usize
 
 pub fn vortex_array::arrays::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16434,6 +17586,8 @@ pub type vortex_array::arrays::StructVTable::ValidityVTable = vortex_array::vtab
 
 pub type vortex_array::arrays::StructVTable::VisitorVTable = vortex_array::arrays::StructVTable
 
+pub fn vortex_array::arrays::StructVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::StructVTable::array_eq(array: &vortex_array::arrays::StructArray, other: &vortex_array::arrays::StructArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::StructVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::StructArray, state: &mut H, precision: vortex_array::Precision)
@@ -16453,6 +17607,8 @@ pub fn vortex_array::arrays::StructVTable::id(_array: &Self::Array) -> vortex_ar
 pub fn vortex_array::arrays::StructVTable::len(array: &vortex_array::arrays::StructArray) -> usize
 
 pub fn vortex_array::arrays::StructVTable::metadata(_array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::StructVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::StructVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16474,6 +17630,8 @@ pub type vortex_array::arrays::VarBinVTable::ValidityVTable = vortex_array::vtab
 
 pub type vortex_array::arrays::VarBinVTable::VisitorVTable = vortex_array::arrays::VarBinVTable
 
+pub fn vortex_array::arrays::VarBinVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::VarBinVTable::array_eq(array: &vortex_array::arrays::VarBinArray, other: &vortex_array::arrays::VarBinArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::VarBinVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinArray, state: &mut H, precision: vortex_array::Precision)
@@ -16493,6 +17651,8 @@ pub fn vortex_array::arrays::VarBinVTable::id(_array: &Self::Array) -> vortex_ar
 pub fn vortex_array::arrays::VarBinVTable::len(array: &vortex_array::arrays::VarBinArray) -> usize
 
 pub fn vortex_array::arrays::VarBinVTable::metadata(array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBinVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::VarBinVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16514,6 +17674,8 @@ pub type vortex_array::arrays::VarBinViewVTable::ValidityVTable = vortex_array::
 
 pub type vortex_array::arrays::VarBinViewVTable::VisitorVTable = vortex_array::arrays::VarBinViewVTable
 
+pub fn vortex_array::arrays::VarBinViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrays::VarBinViewVTable::array_eq(array: &vortex_array::arrays::VarBinViewArray, other: &vortex_array::arrays::VarBinViewArray, precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrays::VarBinViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinViewArray, state: &mut H, precision: vortex_array::Precision)
@@ -16533,6 +17695,8 @@ pub fn vortex_array::arrays::VarBinViewVTable::id(_array: &Self::Array) -> vorte
 pub fn vortex_array::arrays::VarBinViewVTable::len(array: &vortex_array::arrays::VarBinViewArray) -> usize
 
 pub fn vortex_array::arrays::VarBinViewVTable::metadata(_array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBinViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::VarBinViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16554,6 +17718,8 @@ pub type vortex_array::arrow::ArrowVTable::ValidityVTable = vortex_array::arrow:
 
 pub type vortex_array::arrow::ArrowVTable::VisitorVTable = vortex_array::arrow::ArrowVTable
 
+pub fn vortex_array::arrow::ArrowVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::arrow::ArrowVTable::array_eq(array: &vortex_array::arrow::ArrowArray, other: &vortex_array::arrow::ArrowArray, _precision: vortex_array::Precision) -> bool
 
 pub fn vortex_array::arrow::ArrowVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrow::ArrowArray, state: &mut H, _precision: vortex_array::Precision)
@@ -16566,11 +17732,17 @@ pub fn vortex_array::arrow::ArrowVTable::dtype(array: &vortex_array::arrow::Arro
 
 pub fn vortex_array::arrow::ArrowVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::arrow::ArrowVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::arrow::ArrowVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
 pub fn vortex_array::arrow::ArrowVTable::len(array: &vortex_array::arrow::ArrowArray) -> usize
 
 pub fn vortex_array::arrow::ArrowVTable::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrow::ArrowVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrow::ArrowVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrow::ArrowVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
@@ -16716,6 +17888,8 @@ pub fn vortex_array::vtable::VisitorVTable::visit_children_unnamed(array: &<V as
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolVTable
 
+pub fn vortex_array::arrays::BoolVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::BoolVTable::nbuffers(_array: &vortex_array::arrays::BoolArray) -> usize
 
 pub fn vortex_array::arrays::BoolVTable::nchildren(array: &vortex_array::arrays::BoolArray) -> usize
@@ -16726,7 +17900,11 @@ pub fn vortex_array::arrays::BoolVTable::visit_buffers(array: &vortex_array::arr
 
 pub fn vortex_array::arrays::BoolVTable::visit_children(array: &vortex_array::arrays::BoolArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::BoolVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::ChunkedVTable::nbuffers(_array: &vortex_array::arrays::ChunkedArray) -> usize
 
@@ -16742,6 +17920,8 @@ pub fn vortex_array::arrays::ChunkedVTable::visit_children_unnamed(array: &vorte
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
 
+pub fn vortex_array::arrays::ConstantVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
 
 pub fn vortex_array::arrays::ConstantVTable::nchildren(_array: &vortex_array::arrays::ConstantArray) -> usize
@@ -16752,7 +17932,11 @@ pub fn vortex_array::arrays::ConstantVTable::visit_buffers(array: &vortex_array:
 
 pub fn vortex_array::arrays::ConstantVTable::visit_children(_array: &vortex_array::arrays::ConstantArray, _visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::ConstantVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::DecimalVTable::nbuffers(_array: &vortex_array::arrays::DecimalArray) -> usize
 
@@ -16764,7 +17948,11 @@ pub fn vortex_array::arrays::DecimalVTable::visit_buffers(array: &vortex_array::
 
 pub fn vortex_array::arrays::DecimalVTable::visit_children(array: &vortex_array::arrays::DecimalArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::DecimalVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::DictVTable::nbuffers(_array: &vortex_array::arrays::DictArray) -> usize
 
@@ -16776,7 +17964,11 @@ pub fn vortex_array::arrays::DictVTable::visit_buffers(_array: &vortex_array::ar
 
 pub fn vortex_array::arrays::DictVTable::visit_children(array: &vortex_array::arrays::DictArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::DictVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::ExtensionVTable::nbuffers(_array: &vortex_array::arrays::ExtensionArray) -> usize
 
@@ -16788,7 +17980,13 @@ pub fn vortex_array::arrays::ExtensionVTable::visit_buffers(_array: &vortex_arra
 
 pub fn vortex_array::arrays::ExtensionVTable::visit_children(array: &vortex_array::arrays::ExtensionArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::ExtensionVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
+
+pub fn vortex_array::arrays::FilterVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrays::FilterVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
 
 pub fn vortex_array::arrays::FilterVTable::nchildren(_array: &vortex_array::arrays::FilterArray) -> usize
 
@@ -16798,7 +17996,11 @@ pub fn vortex_array::arrays::FilterVTable::visit_buffers(_array: &vortex_array::
 
 pub fn vortex_array::arrays::FilterVTable::visit_children(array: &vortex_array::arrays::FilterArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::FilterVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::FixedSizeListVTable> for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::FixedSizeListVTable::nbuffers(_array: &vortex_array::arrays::FixedSizeListArray) -> usize
 
@@ -16810,7 +18012,11 @@ pub fn vortex_array::arrays::FixedSizeListVTable::visit_buffers(_array: &vortex_
 
 pub fn vortex_array::arrays::FixedSizeListVTable::visit_children(array: &vortex_array::arrays::FixedSizeListArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::FixedSizeListVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ListVTable> for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::ListVTable::nbuffers(_array: &vortex_array::arrays::ListArray) -> usize
 
@@ -16822,7 +18028,11 @@ pub fn vortex_array::arrays::ListVTable::visit_buffers(_array: &vortex_array::ar
 
 pub fn vortex_array::arrays::ListVTable::visit_children(array: &vortex_array::arrays::ListArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::ListVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ListViewVTable> for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::ListViewVTable::nbuffers(_array: &vortex_array::arrays::ListViewArray) -> usize
 
@@ -16834,7 +18044,13 @@ pub fn vortex_array::arrays::ListViewVTable::visit_buffers(_array: &vortex_array
 
 pub fn vortex_array::arrays::ListViewVTable::visit_children(array: &vortex_array::arrays::ListViewArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::ListViewVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::MaskedVTable> for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrays::MaskedVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
 
 pub fn vortex_array::arrays::MaskedVTable::nchildren(array: &vortex_array::arrays::MaskedArray) -> usize
 
@@ -16844,7 +18060,13 @@ pub fn vortex_array::arrays::MaskedVTable::visit_buffers(_array: &vortex_array::
 
 pub fn vortex_array::arrays::MaskedVTable::visit_children(array: &vortex_array::arrays::MaskedArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::MaskedVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::NullVTable> for vortex_array::arrays::NullVTable
+
+pub fn vortex_array::arrays::NullVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrays::NullVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
 
 pub fn vortex_array::arrays::NullVTable::nchildren(_array: &vortex_array::arrays::NullArray) -> usize
 
@@ -16854,7 +18076,11 @@ pub fn vortex_array::arrays::NullVTable::visit_buffers(_array: &vortex_array::ar
 
 pub fn vortex_array::arrays::NullVTable::visit_children(_array: &vortex_array::arrays::NullArray, _visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::NullVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::PrimitiveVTable::nbuffers(_array: &vortex_array::arrays::PrimitiveArray) -> usize
 
@@ -16866,7 +18092,11 @@ pub fn vortex_array::arrays::PrimitiveVTable::visit_buffers(array: &vortex_array
 
 pub fn vortex_array::arrays::PrimitiveVTable::visit_children(array: &vortex_array::arrays::PrimitiveArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::PrimitiveVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::ScalarFnVTable> for vortex_array::arrays::ScalarFnVTable
+
+pub fn vortex_array::arrays::ScalarFnVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::ScalarFnArray) -> usize
 
@@ -16882,6 +18112,10 @@ pub fn vortex_array::arrays::ScalarFnVTable::visit_children_unnamed(array: &vort
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
 
+pub fn vortex_array::arrays::SharedVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrays::SharedVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
+
 pub fn vortex_array::arrays::SharedVTable::nchildren(_array: &vortex_array::arrays::SharedArray) -> usize
 
 pub fn vortex_array::arrays::SharedVTable::nth_child(array: &vortex_array::arrays::SharedArray, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
@@ -16890,7 +18124,13 @@ pub fn vortex_array::arrays::SharedVTable::visit_buffers(_array: &vortex_array::
 
 pub fn vortex_array::arrays::SharedVTable::visit_children(array: &vortex_array::arrays::SharedArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::SharedVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::SliceVTable> for vortex_array::arrays::SliceVTable
+
+pub fn vortex_array::arrays::SliceVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrays::SliceVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
 
 pub fn vortex_array::arrays::SliceVTable::nchildren(_array: &vortex_array::arrays::SliceArray) -> usize
 
@@ -16900,7 +18140,11 @@ pub fn vortex_array::arrays::SliceVTable::visit_buffers(_array: &vortex_array::a
 
 pub fn vortex_array::arrays::SliceVTable::visit_children(array: &vortex_array::arrays::SliceArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::SliceVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::StructVTable::nbuffers(_array: &vortex_array::arrays::StructArray) -> usize
 
@@ -16916,6 +18160,8 @@ pub fn vortex_array::arrays::StructVTable::visit_children_unnamed(array: &vortex
 
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::VarBinVTable> for vortex_array::arrays::VarBinVTable
 
+pub fn vortex_array::arrays::VarBinVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
 pub fn vortex_array::arrays::VarBinVTable::nbuffers(_array: &vortex_array::arrays::VarBinArray) -> usize
 
 pub fn vortex_array::arrays::VarBinVTable::nchildren(array: &vortex_array::arrays::VarBinArray) -> usize
@@ -16926,7 +18172,11 @@ pub fn vortex_array::arrays::VarBinVTable::visit_buffers(array: &vortex_array::a
 
 pub fn vortex_array::arrays::VarBinVTable::visit_children(array: &vortex_array::arrays::VarBinArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::VarBinVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrays::VarBinViewVTable> for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
 
 pub fn vortex_array::arrays::VarBinViewVTable::nbuffers(array: &vortex_array::arrays::VarBinViewArray) -> usize
 
@@ -16938,7 +18188,13 @@ pub fn vortex_array::arrays::VarBinViewVTable::visit_buffers(array: &vortex_arra
 
 pub fn vortex_array::arrays::VarBinViewVTable::visit_children(array: &vortex_array::arrays::VarBinViewArray, visitor: &mut dyn vortex_array::ArrayChildVisitor)
 
+pub fn vortex_array::arrays::VarBinViewVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
+
 impl vortex_array::vtable::VisitorVTable<vortex_array::arrow::ArrowVTable> for vortex_array::arrow::ArrowVTable
+
+pub fn vortex_array::arrow::ArrowVTable::buffer_names(array: &<V as vortex_array::vtable::VTable>::Array) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::arrow::ArrowVTable::nbuffers(array: &<V as vortex_array::vtable::VTable>::Array) -> usize
 
 pub fn vortex_array::arrow::ArrowVTable::nchildren(_array: &vortex_array::arrow::ArrowArray) -> usize
 
@@ -16947,6 +18203,8 @@ pub fn vortex_array::arrow::ArrowVTable::nth_child(_array: &vortex_array::arrow:
 pub fn vortex_array::arrow::ArrowVTable::visit_buffers(_array: &vortex_array::arrow::ArrowArray, _visitor: &mut dyn vortex_array::ArrayBufferVisitor)
 
 pub fn vortex_array::arrow::ArrowVTable::visit_children(_array: &vortex_array::arrow::ArrowArray, _visitor: &mut dyn vortex_array::ArrayChildVisitor)
+
+pub fn vortex_array::arrow::ArrowVTable::visit_children_unnamed(array: &<V as vortex_array::vtable::VTable>::Array, visitor: &mut dyn vortex_array::ArrayChildVisitorUnnamed)
 
 pub fn vortex_array::vtable::validity_nchildren(validity: &vortex_array::validity::Validity) -> usize
 
@@ -17182,6 +18440,8 @@ impl vortex_array::matcher::Matcher for vortex_array::AnyColumnar
 
 pub type vortex_array::AnyColumnar::Match<'a> = vortex_array::ColumnarView<'a>
 
+pub fn vortex_array::AnyColumnar::matches(array: &dyn vortex_array::Array) -> bool
+
 pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 #[repr(transparent)] pub struct vortex_array::ArrayAdapter<V: vortex_array::vtable::VTable>(_)
@@ -17213,6 +18473,8 @@ pub fn vortex_array::ArrayAdapter<V>::encoding_id(&self) -> vortex_array::vtable
 pub fn vortex_array::ArrayAdapter<V>::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::ArrayAdapter<V>::invalid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::ArrayAdapter<V>::is_empty(&self) -> bool
 
 pub fn vortex_array::ArrayAdapter<V>::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
 
@@ -17474,6 +18736,8 @@ pub fn alloc::sync::Arc<dyn vortex_array::Array>::filter(&self, mask: vortex_mas
 
 pub fn alloc::sync::Arc<dyn vortex_array::Array>::invalid_count(&self) -> vortex_error::VortexResult<usize>
 
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::is_empty(&self) -> bool
+
 pub fn alloc::sync::Arc<dyn vortex_array::Array>::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
 
 pub fn alloc::sync::Arc<dyn vortex_array::Array>::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
@@ -17521,6 +18785,8 @@ pub fn vortex_array::ArrayAdapter<V>::encoding_id(&self) -> vortex_array::vtable
 pub fn vortex_array::ArrayAdapter<V>::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::ArrayAdapter<V>::invalid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::ArrayAdapter<V>::is_empty(&self) -> bool
 
 pub fn vortex_array::ArrayAdapter<V>::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
 
@@ -17749,6 +19015,10 @@ pub fn vortex_array::ArrayVisitorExt::depth_first_traversal(&self) -> impl core:
 pub fn vortex_array::ArrayVisitorExt::nbuffers_recursive(&self) -> usize
 
 impl<A: vortex_array::Array + ?core::marker::Sized> vortex_array::ArrayVisitorExt for A
+
+pub fn A::depth_first_traversal(&self) -> impl core::iter::traits::iterator::Iterator<Item = vortex_array::ArrayRef>
+
+pub fn A::nbuffers_recursive(&self) -> usize
 
 pub trait vortex_array::DeserializeMetadata where Self: core::marker::Sized
 

--- a/vortex-btrblocks/public-api.lock
+++ b/vortex-btrblocks/public-api.lock
@@ -270,7 +270,11 @@ impl vortex_btrblocks::CompressorStats for vortex_btrblocks::IntegerStats
 
 pub type vortex_btrblocks::IntegerStats::ArrayVTable = vortex_array::arrays::primitive::vtable::PrimitiveVTable
 
+pub fn vortex_btrblocks::IntegerStats::generate(input: &<Self::ArrayVTable as vortex_array::vtable::VTable>::Array) -> Self
+
 pub fn vortex_btrblocks::IntegerStats::generate_opts(input: &vortex_array::arrays::primitive::array::PrimitiveArray, opts: vortex_btrblocks::GenerateStatsOptions) -> Self
+
+pub fn vortex_btrblocks::IntegerStats::sample(&self, sample_size: u32, sample_count: u32) -> Self
 
 pub fn vortex_btrblocks::IntegerStats::sample_opts(&self, sample_size: u32, sample_count: u32, opts: vortex_btrblocks::GenerateStatsOptions) -> Self
 
@@ -314,7 +318,11 @@ impl vortex_btrblocks::CompressorStats for vortex_btrblocks::IntegerStats
 
 pub type vortex_btrblocks::IntegerStats::ArrayVTable = vortex_array::arrays::primitive::vtable::PrimitiveVTable
 
+pub fn vortex_btrblocks::IntegerStats::generate(input: &<Self::ArrayVTable as vortex_array::vtable::VTable>::Array) -> Self
+
 pub fn vortex_btrblocks::IntegerStats::generate_opts(input: &vortex_array::arrays::primitive::array::PrimitiveArray, opts: vortex_btrblocks::GenerateStatsOptions) -> Self
+
+pub fn vortex_btrblocks::IntegerStats::sample(&self, sample_size: u32, sample_count: u32) -> Self
 
 pub fn vortex_btrblocks::IntegerStats::sample_opts(&self, sample_size: u32, sample_count: u32, opts: vortex_btrblocks::GenerateStatsOptions) -> Self
 

--- a/vortex-buffer/public-api.lock
+++ b/vortex-buffer/public-api.lock
@@ -930,6 +930,10 @@ pub fn vortex_buffer::AlignedBuf::copy_to_const_aligned<const A: usize>(&mut sel
 
 impl<B: bytes::buf::buf_impl::Buf> vortex_buffer::AlignedBuf for B
 
+pub fn B::copy_to_aligned(&mut self, len: usize, alignment: vortex_buffer::Alignment) -> vortex_buffer::ByteBuffer
+
+pub fn B::copy_to_const_aligned<const A: usize>(&mut self, len: usize) -> vortex_buffer::ConstByteBuffer<A>
+
 pub fn vortex_buffer::get_bit(buf: &[u8], index: usize) -> bool
 
 pub unsafe fn vortex_buffer::get_bit_unchecked(buf: *const u8, index: usize) -> bool

--- a/vortex-file/public-api.lock
+++ b/vortex-file/public-api.lock
@@ -404,10 +404,14 @@ pub fn vortex_file::OpenOptionsSessionExt::open_options(&self) -> vortex_file::V
 
 impl<S: vortex_array::session::ArraySessionExt + vortex_layout::session::LayoutSessionExt + vortex_io::session::RuntimeSessionExt> vortex_file::OpenOptionsSessionExt for S
 
+pub fn S::open_options(&self) -> vortex_file::VortexOpenOptions
+
 pub trait vortex_file::WriteOptionsSessionExt: vortex_session::SessionExt
 
 pub fn vortex_file::WriteOptionsSessionExt::write_options(&self) -> vortex_file::VortexWriteOptions
 
 impl<S: vortex_session::SessionExt> vortex_file::WriteOptionsSessionExt for S
+
+pub fn S::write_options(&self) -> vortex_file::VortexWriteOptions
 
 pub fn vortex_file::register_default_encodings(session: &mut vortex_session::VortexSession)

--- a/vortex-io/public-api.lock
+++ b/vortex-io/public-api.lock
@@ -454,6 +454,12 @@ pub fn vortex_io::session::RuntimeSessionExt::with_tokio(self) -> Self
 
 impl<S: vortex_session::SessionExt> vortex_io::session::RuntimeSessionExt for S
 
+pub fn S::handle(&self) -> vortex_io::runtime::Handle
+
+pub fn S::with_handle(self, handle: vortex_io::runtime::Handle) -> Self
+
+pub fn S::with_tokio(self) -> Self
+
 pub mod vortex_io::std_file
 
 pub struct vortex_io::std_file::FileReadAt
@@ -552,6 +558,8 @@ pub fn vortex_io::OwnedSlice<T>::bytes_init(&self) -> usize
 
 pub fn vortex_io::OwnedSlice<T>::read_ptr(&self) -> *const u8
 
+pub fn vortex_io::OwnedSlice<T>::slice_owned(self, range: core::ops::range::Range<usize>) -> vortex_io::OwnedSlice<Self> where Self: core::marker::Sized
+
 pub struct vortex_io::SizeLimitedStream<Fut>
 
 impl<Fut> vortex_io::SizeLimitedStream<Fut> where Fut: core::future::future::Future
@@ -592,6 +600,8 @@ pub fn &'static [u8]::bytes_init(&self) -> usize
 
 pub fn &'static [u8]::read_ptr(&self) -> *const u8
 
+pub fn &'static [u8]::slice_owned(self, range: core::ops::range::Range<usize>) -> vortex_io::OwnedSlice<Self> where Self: core::marker::Sized
+
 impl vortex_io::IoBuf for alloc::vec::Vec<u8>
 
 pub fn alloc::vec::Vec<u8>::as_slice(&self) -> &[u8]
@@ -599,6 +609,8 @@ pub fn alloc::vec::Vec<u8>::as_slice(&self) -> &[u8]
 pub fn alloc::vec::Vec<u8>::bytes_init(&self) -> usize
 
 pub fn alloc::vec::Vec<u8>::read_ptr(&self) -> *const u8
+
+pub fn alloc::vec::Vec<u8>::slice_owned(self, range: core::ops::range::Range<usize>) -> vortex_io::OwnedSlice<Self> where Self: core::marker::Sized
 
 impl vortex_io::IoBuf for bytes::bytes::Bytes
 
@@ -608,6 +620,8 @@ pub fn bytes::bytes::Bytes::bytes_init(&self) -> usize
 
 pub fn bytes::bytes::Bytes::read_ptr(&self) -> *const u8
 
+pub fn bytes::bytes::Bytes::slice_owned(self, range: core::ops::range::Range<usize>) -> vortex_io::OwnedSlice<Self> where Self: core::marker::Sized
+
 impl<T: core::marker::Unpin + core::marker::Send + 'static> vortex_io::IoBuf for vortex_buffer::buffer::Buffer<T>
 
 pub fn vortex_buffer::buffer::Buffer<T>::as_slice(&self) -> &[u8]
@@ -615,6 +629,8 @@ pub fn vortex_buffer::buffer::Buffer<T>::as_slice(&self) -> &[u8]
 pub fn vortex_buffer::buffer::Buffer<T>::bytes_init(&self) -> usize
 
 pub fn vortex_buffer::buffer::Buffer<T>::read_ptr(&self) -> *const u8
+
+pub fn vortex_buffer::buffer::Buffer<T>::slice_owned(self, range: core::ops::range::Range<usize>) -> vortex_io::OwnedSlice<Self> where Self: core::marker::Sized
 
 impl<T: vortex_io::IoBuf> vortex_io::IoBuf for vortex_io::OwnedSlice<T>
 
@@ -624,6 +640,8 @@ pub fn vortex_io::OwnedSlice<T>::bytes_init(&self) -> usize
 
 pub fn vortex_io::OwnedSlice<T>::read_ptr(&self) -> *const u8
 
+pub fn vortex_io::OwnedSlice<T>::slice_owned(self, range: core::ops::range::Range<usize>) -> vortex_io::OwnedSlice<Self> where Self: core::marker::Sized
+
 impl<const A: usize> vortex_io::IoBuf for vortex_buffer::ConstByteBuffer<A>
 
 pub fn vortex_buffer::ConstByteBuffer<A>::as_slice(&self) -> &[u8]
@@ -632,6 +650,8 @@ pub fn vortex_buffer::ConstByteBuffer<A>::bytes_init(&self) -> usize
 
 pub fn vortex_buffer::ConstByteBuffer<A>::read_ptr(&self) -> *const u8
 
+pub fn vortex_buffer::ConstByteBuffer<A>::slice_owned(self, range: core::ops::range::Range<usize>) -> vortex_io::OwnedSlice<Self> where Self: core::marker::Sized
+
 impl<const N: usize> vortex_io::IoBuf for [u8; N]
 
 pub fn [u8; N]::as_slice(&self) -> &[u8]
@@ -639,6 +659,8 @@ pub fn [u8; N]::as_slice(&self) -> &[u8]
 pub fn [u8; N]::bytes_init(&self) -> usize
 
 pub fn [u8; N]::read_ptr(&self) -> *const u8
+
+pub fn [u8; N]::slice_owned(self, range: core::ops::range::Range<usize>) -> vortex_io::OwnedSlice<Self> where Self: core::marker::Sized
 
 pub trait vortex_io::VortexReadAt: core::marker::Send + core::marker::Sync + 'static
 
@@ -666,11 +688,15 @@ pub fn alloc::sync::Arc<dyn vortex_io::VortexReadAt>::uri(&self) -> core::option
 
 impl vortex_io::VortexReadAt for vortex_buffer::ByteBuffer
 
+pub fn vortex_buffer::ByteBuffer::coalesce_config(&self) -> core::option::Option<vortex_io::CoalesceConfig>
+
 pub fn vortex_buffer::ByteBuffer::concurrency(&self) -> usize
 
 pub fn vortex_buffer::ByteBuffer::read_at(&self, offset: u64, length: usize, alignment: vortex_buffer::alignment::Alignment) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_array::buffer::BufferHandle>>
 
 pub fn vortex_buffer::ByteBuffer::size(&self) -> futures_core::future::BoxFuture<'static, vortex_error::VortexResult<u64>>
+
+pub fn vortex_buffer::ByteBuffer::uri(&self) -> core::option::Option<&alloc::sync::Arc<str>>
 
 impl vortex_io::VortexReadAt for vortex_io::object_store::ObjectStoreReadAt
 

--- a/vortex-layout/public-api.lock
+++ b/vortex-layout/public-api.lock
@@ -772,6 +772,8 @@ pub fn vortex_layout::layouts::table::TableStrategy::with_validity_strategy(self
 
 impl vortex_layout::LayoutStrategy for vortex_layout::layouts::table::TableStrategy
 
+pub fn vortex_layout::layouts::table::TableStrategy::buffered_bytes(&self) -> u64
+
 pub fn vortex_layout::layouts::table::TableStrategy::write_stream<'life0, 'async_trait>(&'life0 self, ctx: vortex_array::context::ArrayContext, segment_sink: vortex_layout::segments::SegmentSinkRef, stream: vortex_layout::sequence::SendableSequentialStream, eof: vortex_layout::sequence::SequencePointer, handle: vortex_io::runtime::handle::Handle) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_layout::LayoutRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 
 pub mod vortex_layout::layouts::zoned
@@ -1200,6 +1202,8 @@ pub fn vortex_layout::sequence::SequentialArrayStreamExt::sequenced(self, pointe
 
 impl<S: vortex_array::stream::ArrayStream> vortex_layout::sequence::SequentialArrayStreamExt for S
 
+pub fn S::sequenced(self, pointer: vortex_layout::sequence::SequencePointer) -> vortex_layout::sequence::SendableSequentialStream where Self: core::marker::Sized + core::marker::Send + 'static
+
 pub trait vortex_layout::sequence::SequentialStream: futures_core::stream::Stream<Item = vortex_error::VortexResult<(vortex_layout::sequence::SequenceId, vortex_array::array::ArrayRef)>>
 
 pub fn vortex_layout::sequence::SequentialStream::dtype(&self) -> &vortex_array::dtype::DType
@@ -1217,6 +1221,8 @@ pub trait vortex_layout::sequence::SequentialStreamExt: vortex_layout::sequence:
 pub fn vortex_layout::sequence::SequentialStreamExt::sendable(self) -> vortex_layout::sequence::SendableSequentialStream where Self: core::marker::Sized + core::marker::Send + 'static
 
 impl<S: vortex_layout::sequence::SequentialStream> vortex_layout::sequence::SequentialStreamExt for S
+
+pub fn S::sendable(self) -> vortex_layout::sequence::SendableSequentialStream where Self: core::marker::Sized + core::marker::Send + 'static
 
 pub type vortex_layout::sequence::SendableSequentialStream = core::pin::Pin<alloc::boxed::Box<(dyn vortex_layout::sequence::SequentialStream + core::marker::Send)>>
 
@@ -1245,6 +1251,8 @@ pub trait vortex_layout::session::LayoutSessionExt: vortex_session::SessionExt
 pub fn vortex_layout::session::LayoutSessionExt::layouts(&self) -> vortex_session::Ref<'_, vortex_layout::session::LayoutSession>
 
 impl<S: vortex_session::SessionExt> vortex_layout::session::LayoutSessionExt for S
+
+pub fn S::layouts(&self) -> vortex_session::Ref<'_, vortex_layout::session::LayoutSession>
 
 pub type vortex_layout::session::LayoutRegistry = vortex_session::registry::Registry<vortex_layout::LayoutEncodingRef>
 
@@ -1743,6 +1751,8 @@ pub fn vortex_layout::layouts::struct_::writer::StructStrategy::buffered_bytes(&
 pub fn vortex_layout::layouts::struct_::writer::StructStrategy::write_stream<'life0, 'async_trait>(&'life0 self, ctx: vortex_array::context::ArrayContext, segment_sink: vortex_layout::segments::SegmentSinkRef, stream: vortex_layout::sequence::SendableSequentialStream, eof: vortex_layout::sequence::SequencePointer, handle: vortex_io::runtime::handle::Handle) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_layout::LayoutRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 
 impl vortex_layout::LayoutStrategy for vortex_layout::layouts::table::TableStrategy
+
+pub fn vortex_layout::layouts::table::TableStrategy::buffered_bytes(&self) -> u64
 
 pub fn vortex_layout::layouts::table::TableStrategy::write_stream<'life0, 'async_trait>(&'life0 self, ctx: vortex_array::context::ArrayContext, segment_sink: vortex_layout::segments::SegmentSinkRef, stream: vortex_layout::sequence::SendableSequentialStream, eof: vortex_layout::sequence::SequencePointer, handle: vortex_io::runtime::handle::Handle) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_layout::LayoutRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 

--- a/vortex-scan/public-api.lock
+++ b/vortex-scan/public-api.lock
@@ -58,7 +58,11 @@ pub fn vortex_scan::layout::LayoutReaderDataSource::row_count(&self) -> core::op
 
 pub fn vortex_scan::layout::LayoutReaderDataSource::scan<'life0, 'async_trait>(&'life0 self, scan_request: vortex_scan::api::ScanRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_scan::api::DataSourceScanRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 
+pub fn vortex_scan::layout::LayoutReaderDataSource::serialize(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
 impl vortex_scan::api::DataSource for vortex_scan::multi::MultiLayoutDataSource
+
+pub fn vortex_scan::multi::MultiLayoutDataSource::byte_size(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<u64>>
 
 pub fn vortex_scan::multi::MultiLayoutDataSource::deserialize_partition(&self, _data: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_scan::api::PartitionRef>
 
@@ -69,6 +73,8 @@ pub fn vortex_scan::multi::MultiLayoutDataSource::field_statistics<'life0, 'life
 pub fn vortex_scan::multi::MultiLayoutDataSource::row_count(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<u64>>
 
 pub fn vortex_scan::multi::MultiLayoutDataSource::scan<'life0, 'async_trait>(&'life0 self, scan_request: vortex_scan::api::ScanRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_scan::api::DataSourceScanRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+
+pub fn vortex_scan::multi::MultiLayoutDataSource::serialize(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 pub trait vortex_scan::api::DataSourceOpener: 'static
 
@@ -156,6 +162,8 @@ pub fn vortex_scan::layout::LayoutReaderDataSource::row_count(&self) -> core::op
 
 pub fn vortex_scan::layout::LayoutReaderDataSource::scan<'life0, 'async_trait>(&'life0 self, scan_request: vortex_scan::api::ScanRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_scan::api::DataSourceScanRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 
+pub fn vortex_scan::layout::LayoutReaderDataSource::serialize(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
 pub mod vortex_scan::multi
 
 pub struct vortex_scan::multi::MultiLayoutDataSource
@@ -170,6 +178,8 @@ pub fn vortex_scan::multi::MultiLayoutDataSource::with_concurrency(self, concurr
 
 impl vortex_scan::api::DataSource for vortex_scan::multi::MultiLayoutDataSource
 
+pub fn vortex_scan::multi::MultiLayoutDataSource::byte_size(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<u64>>
+
 pub fn vortex_scan::multi::MultiLayoutDataSource::deserialize_partition(&self, _data: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_scan::api::PartitionRef>
 
 pub fn vortex_scan::multi::MultiLayoutDataSource::dtype(&self) -> &vortex_array::dtype::DType
@@ -179,6 +189,8 @@ pub fn vortex_scan::multi::MultiLayoutDataSource::field_statistics<'life0, 'life
 pub fn vortex_scan::multi::MultiLayoutDataSource::row_count(&self) -> core::option::Option<vortex_array::expr::stats::precision::Precision<u64>>
 
 pub fn vortex_scan::multi::MultiLayoutDataSource::scan<'life0, 'async_trait>(&'life0 self, scan_request: vortex_scan::api::ScanRequest) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_scan::api::DataSourceScanRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+
+pub fn vortex_scan::multi::MultiLayoutDataSource::serialize(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 pub trait vortex_scan::multi::LayoutReaderFactory: 'static + core::marker::Send + core::marker::Sync
 


### PR DESCRIPTION
Upgrades public-api crate.

This version of the crate generates an API entry for every trait function, even if it is not overridden by the implementation.