### PR TITLE
Fix S3 globbing for duckdbfs with httplib

### DIFF
--- a/vortex-duckdb/cpp/include/duckdb_vx/file_system.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/file_system.h
@@ -39,7 +39,7 @@ duckdb_state duckdb_vx_fs_read(duckdb_vx_file_handle handle,
 
 /// Callback invoked for each entry returned by `duckdb_vx_fs_list_files`.
 ///
-/// @param name  The entry name (not a full path).
+/// @param name  The entry's path, full for remote files, relative for local files
 /// @param is_dir  Whether the entry is a directory.
 /// @param user_data  Opaque pointer forwarded from the caller.
 typedef void (*duckdb_vx_list_files_callback)(const char *name, bool is_dir, void *user_data);

--- a/vortex-duckdb/src/duckdb/file_system.rs
+++ b/vortex-duckdb/src/duckdb/file_system.rs
@@ -39,14 +39,15 @@ pub(crate) fn fs_error(err: cpp::duckdb_vx_error) -> VortexError {
 
 /// An entry returned by [`duckdb_fs_list_dir`].
 pub(crate) struct DirEntry {
+    /// Full path for S3 files, relative path for local files
     pub name: String,
     pub is_dir: bool,
 }
 
 /// Non-recursively list entries in `directory` via DuckDB's filesystem.
 ///
-/// Returns file and subdirectory names (not full paths). The caller is
-/// responsible for joining paths and recursing into subdirectories.
+/// Returns full paths. The caller is responsible for joining paths and
+/// recursing into subdirectories.
 pub(crate) fn duckdb_fs_list_dir(
     ctx: &ClientContextRef,
     directory: &str,

--- a/vortex-duckdb/src/filesystem.rs
+++ b/vortex-duckdb/src/filesystem.rs
@@ -127,27 +127,13 @@ impl FileSystem for DuckDbFileSystem {
             directory_url.set_path(&format!("{}/{}", directory_url.path(), prefix));
         }
 
-        // DuckDB's ListFiles expects bare paths for local files, but full URLs
-        // for remote schemes (s3://, etc.).
-        let directory = if directory_url.scheme() == "file" {
-            directory_url.path().to_string()
-        } else {
-            directory_url.to_string()
-        };
-
-        tracing::debug!(
-            "Listing files from {} with prefix {}",
-            self.base_url,
-            directory
-        );
-
         let ctx = self.ctx;
-        let base_path = self.base_url.path().to_string();
 
+        let base_url = self.base_url.clone();
         stream::once(async move {
             RUNTIME
                 .handle()
-                .spawn_blocking(move || list_recursive(ctx, &directory, &base_path))
+                .spawn_blocking(move || list_recursive(ctx, &directory_url, &base_url))
                 .await
         })
         .flat_map(|result| match result {
@@ -169,20 +155,46 @@ impl FileSystem for DuckDbFileSystem {
 /// returned URL to produce relative paths.
 fn list_recursive(
     ctx: &ClientContextRef,
-    directory: &str,
-    base_path: &str,
+    directory_url: &Url,
+    base_url: &Url,
 ) -> VortexResult<Vec<FileListing>> {
+    // DuckDB's ListFiles expects bare paths for local files, but full URLs
+    // for remote schemes (s3://, etc.).
+    let directory = if directory_url.scheme() == "file" {
+        directory_url.path().to_string()
+    } else {
+        directory_url.to_string()
+    };
+
+    let (base_path, is_remote_path) = if base_url.scheme() == "file" {
+        (base_url.path().to_string(), false)
+    } else {
+        // This is really ugly. As we operate on Strings and not on urls, we
+        // must produce a base path with / so as relative url would not have
+        // the / and thus match the glob
+        (format!("{base_url}/"), true)
+    };
+
     let mut results = Vec::new();
-    let mut stack = vec![directory.to_string()];
+    let mut stack = vec![directory];
 
     while let Some(dir) = stack.pop() {
+        // TODO(myrrc) this doesn't work with curl backend in v1.4, producing
+        // "URL using bad/illegal format or missing URL error", see
+        // https://github.com/duckdb/duckdb-httpfs/pull/265
         for entry in duckdb_fs_list_dir(ctx, &dir)? {
-            let full_path = format!("{}/{}", dir.trim_end_matches('/'), entry.name);
+            // duckdb_fs_list_dir returns relative paths for local files but full
+            // paths for s3 files.
+            let full_path = if is_remote_path {
+                entry.name
+            } else {
+                format!("{}/{}", dir.trim_end_matches('/'), entry.name)
+            };
             if entry.is_dir {
                 stack.push(full_path);
             } else {
                 let relative_path = full_path
-                    .strip_prefix(base_path)
+                    .strip_prefix(&base_path)
                     .unwrap_or_else(|| &full_path)
                     .to_string();
                 results.push(FileListing {


### PR DESCRIPTION
Using vortex_filesystem=duckdb, both of httpfs backends are broken
when using globs on S3 files:

1. httplib was broken because duckdb folder list API returns full paths for
   S3 files, and we assumed relative paths. This PR fixes this behavior
2. curl was broken because of https://github.com/duckdb/duckdb-httpfs/pull/265
   in 1.4. Up until upstream fixes this, globbing won't work.
   This issue is not present in 1.5 anymore

Because of this bug, our benchmarks fail to run with curl backend, see https://github.com/vortex-data/vortex/pull/6685