### PR TITLE
Make ExecutionArgs a dyn trait

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -13180,7 +13180,7 @@ pub fn vortex_array::scalar_fn::fns::between::Between::child_name(&self, _instan
 
 pub fn vortex_array::scalar_fn::fns::between::Between::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::between::Between::execute(&self, options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::between::Between::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::between::Between::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -13310,7 +13310,7 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::child_name(&self, _instance
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -13392,7 +13392,7 @@ pub fn vortex_array::scalar_fn::fns::cast::Cast::child_name(&self, _instance: &v
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::deserialize(&self, _metadata: &[u8], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::cast::Cast::execute(&self, target_dtype: &vortex_array::dtype::DType, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::cast::Cast::execute(&self, target_dtype: &vortex_array::dtype::DType, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::fmt_sql(&self, dtype: &vortex_array::dtype::DType, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -13532,7 +13532,7 @@ pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::child_name(&sel
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::execute(&self, data: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::execute(&self, data: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::fmt_sql(&self, dynamic: &vortex_array::scalar_fn::fns::dynamic::DynamicComparisonExpr, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -13612,7 +13612,7 @@ pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::child_name(&self, _opt
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::execute(&self, _options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -13720,7 +13720,7 @@ pub fn vortex_array::scalar_fn::fns::get_item::GetItem::child_name(&self, _insta
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::get_item::GetItem::execute(&self, field_name: &vortex_array::dtype::FieldName, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::get_item::GetItem::execute(&self, field_name: &vortex_array::dtype::FieldName, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::fmt_sql(&self, field_name: &vortex_array::dtype::FieldName, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -13764,7 +13764,7 @@ pub fn vortex_array::scalar_fn::fns::is_null::IsNull::child_name(&self, _instanc
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::is_null::IsNull::execute(&self, _data: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::execute(&self, _data: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -13808,7 +13808,7 @@ pub fn vortex_array::scalar_fn::fns::like::Like::child_name(&self, _instance: &S
 
 pub fn vortex_array::scalar_fn::fns::like::Like::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::like::Like::execute(&self, options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::like::Like::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -13932,7 +13932,7 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::child_name(&se
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -14016,7 +14016,7 @@ pub fn vortex_array::scalar_fn::fns::literal::Literal::child_name(&self, _instan
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::deserialize(&self, _metadata: &[u8], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::literal::Literal::execute(&self, scalar: &vortex_array::scalar::Scalar, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::literal::Literal::execute(&self, scalar: &vortex_array::scalar::Scalar, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::fmt_sql(&self, scalar: &vortex_array::scalar::Scalar, _expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -14060,7 +14060,7 @@ pub fn vortex_array::scalar_fn::fns::mask::Mask::child_name(&self, _options: &Se
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::mask::Mask::execute(&self, _options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::mask::Mask::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -14236,7 +14236,7 @@ pub fn vortex_array::scalar_fn::fns::merge::Merge::child_name(&self, _instance: 
 
 pub fn vortex_array::scalar_fn::fns::merge::Merge::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::merge::Merge::execute(&self, options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::merge::Merge::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::merge::Merge::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -14280,7 +14280,7 @@ pub fn vortex_array::scalar_fn::fns::not::Not::child_name(&self, _options: &Self
 
 pub fn vortex_array::scalar_fn::fns::not::Not::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::not::Not::execute(&self, _data: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::not::Not::execute(&self, _data: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::not::Not::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -14530,7 +14530,7 @@ pub fn vortex_array::scalar_fn::fns::pack::Pack::child_name(&self, instance: &Se
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::pack::Pack::execute(&self, options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::pack::Pack::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -14604,7 +14604,7 @@ pub fn vortex_array::scalar_fn::fns::root::Root::child_name(&self, _instance: &S
 
 pub fn vortex_array::scalar_fn::fns::root::Root::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::root::Root::execute(&self, _data: &Self::Options, _args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::root::Root::execute(&self, _data: &Self::Options, _args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::root::Root::fmt_sql(&self, _options: &Self::Options, _expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -14692,7 +14692,7 @@ pub fn vortex_array::scalar_fn::fns::select::Select::child_name(&self, _instance
 
 pub fn vortex_array::scalar_fn::fns::select::Select::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_array::scalar_fn::fns::select::FieldSelection>
 
-pub fn vortex_array::scalar_fn::fns::select::Select::execute(&self, selection: &vortex_array::scalar_fn::fns::select::FieldSelection, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::select::Select::execute(&self, selection: &vortex_array::scalar_fn::fns::select::FieldSelection, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::select::Select::fmt_sql(&self, selection: &vortex_array::scalar_fn::fns::select::FieldSelection, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -14736,7 +14736,7 @@ pub fn vortex_array::scalar_fn::fns::zip::Zip::child_name(&self, _options: &Self
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::zip::Zip::execute(&self, _options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::zip::Zip::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -14904,14 +14904,6 @@ pub fn vortex_array::scalar_fn::EmptyOptions::hash<__H: core::hash::Hasher>(&sel
 
 impl core::marker::StructuralPartialEq for vortex_array::scalar_fn::EmptyOptions
 
-pub struct vortex_array::scalar_fn::ExecutionArgs<'a>
-
-pub vortex_array::scalar_fn::ExecutionArgs::ctx: &'a mut vortex_array::ExecutionCtx
-
-pub vortex_array::scalar_fn::ExecutionArgs::inputs: alloc::vec::Vec<vortex_array::ArrayRef>
-
-pub vortex_array::scalar_fn::ExecutionArgs::row_count: usize
-
 pub struct vortex_array::scalar_fn::ScalarFn<V: vortex_array::scalar_fn::ScalarFnVTable>(_)
 
 impl<V: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::scalar_fn::ScalarFn<V>
@@ -14960,7 +14952,7 @@ pub fn vortex_array::scalar_fn::ScalarFnRef::as_<V: vortex_array::scalar_fn::Sca
 
 pub fn vortex_array::scalar_fn::ScalarFnRef::as_opt<V: vortex_array::scalar_fn::ScalarFnVTable>(&self) -> core::option::Option<&<V as vortex_array::scalar_fn::ScalarFnVTable>::Options>
 
-pub fn vortex_array::scalar_fn::ScalarFnRef::execute(&self, ctx: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::ScalarFnRef::execute(&self, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::ScalarFnRef::id(&self) -> vortex_array::scalar_fn::ScalarFnId
 
@@ -15011,6 +15003,36 @@ pub fn vortex_array::scalar_fn::ScalarFnSignature<'_>::child_name(&self, index: 
 pub fn vortex_array::scalar_fn::ScalarFnSignature<'_>::is_fallible(&self) -> bool
 
 pub fn vortex_array::scalar_fn::ScalarFnSignature<'_>::is_null_sensitive(&self) -> bool
+
+pub struct vortex_array::scalar_fn::VecExecutionArgs
+
+impl vortex_array::scalar_fn::VecExecutionArgs
+
+pub fn vortex_array::scalar_fn::VecExecutionArgs::new(inputs: alloc::vec::Vec<vortex_array::ArrayRef>, row_count: usize) -> Self
+
+impl vortex_array::scalar_fn::ExecutionArgs for vortex_array::scalar_fn::VecExecutionArgs
+
+pub fn vortex_array::scalar_fn::VecExecutionArgs::get(&self, index: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::scalar_fn::VecExecutionArgs::num_inputs(&self) -> usize
+
+pub fn vortex_array::scalar_fn::VecExecutionArgs::row_count(&self) -> usize
+
+pub trait vortex_array::scalar_fn::ExecutionArgs
+
+pub fn vortex_array::scalar_fn::ExecutionArgs::get(&self, index: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::scalar_fn::ExecutionArgs::num_inputs(&self) -> usize
+
+pub fn vortex_array::scalar_fn::ExecutionArgs::row_count(&self) -> usize
+
+impl vortex_array::scalar_fn::ExecutionArgs for vortex_array::scalar_fn::VecExecutionArgs
+
+pub fn vortex_array::scalar_fn::VecExecutionArgs::get(&self, index: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::scalar_fn::VecExecutionArgs::num_inputs(&self) -> usize
+
+pub fn vortex_array::scalar_fn::VecExecutionArgs::row_count(&self) -> usize
 
 pub trait vortex_array::scalar_fn::ReduceCtx
 
@@ -15086,7 +15108,7 @@ pub fn vortex_array::scalar_fn::ScalarFnVTable::child_name(&self, options: &Self
 
 pub fn vortex_array::scalar_fn::ScalarFnVTable::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::ScalarFnVTable::execute(&self, options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::ScalarFnVTable::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::ScalarFnVTable::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15122,7 +15144,7 @@ pub fn vortex_array::scalar_fn::fns::between::Between::child_name(&self, _instan
 
 pub fn vortex_array::scalar_fn::fns::between::Between::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::between::Between::execute(&self, options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::between::Between::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::between::Between::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15158,7 +15180,7 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::child_name(&self, _instance
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15194,7 +15216,7 @@ pub fn vortex_array::scalar_fn::fns::cast::Cast::child_name(&self, _instance: &v
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::deserialize(&self, _metadata: &[u8], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::cast::Cast::execute(&self, target_dtype: &vortex_array::dtype::DType, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::cast::Cast::execute(&self, target_dtype: &vortex_array::dtype::DType, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::fmt_sql(&self, dtype: &vortex_array::dtype::DType, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15230,7 +15252,7 @@ pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::child_name(&sel
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::execute(&self, data: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::execute(&self, data: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::dynamic::DynamicComparison::fmt_sql(&self, dynamic: &vortex_array::scalar_fn::fns::dynamic::DynamicComparisonExpr, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15266,7 +15288,7 @@ pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::child_name(&self, _opt
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::execute(&self, _options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNull::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15302,7 +15324,7 @@ pub fn vortex_array::scalar_fn::fns::get_item::GetItem::child_name(&self, _insta
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::get_item::GetItem::execute(&self, field_name: &vortex_array::dtype::FieldName, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::get_item::GetItem::execute(&self, field_name: &vortex_array::dtype::FieldName, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::get_item::GetItem::fmt_sql(&self, field_name: &vortex_array::dtype::FieldName, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15338,7 +15360,7 @@ pub fn vortex_array::scalar_fn::fns::is_null::IsNull::child_name(&self, _instanc
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::is_null::IsNull::execute(&self, _data: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::is_null::IsNull::execute(&self, _data: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::is_null::IsNull::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15374,7 +15396,7 @@ pub fn vortex_array::scalar_fn::fns::like::Like::child_name(&self, _instance: &S
 
 pub fn vortex_array::scalar_fn::fns::like::Like::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::like::Like::execute(&self, options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::like::Like::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::like::Like::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15410,7 +15432,7 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::child_name(&se
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15446,7 +15468,7 @@ pub fn vortex_array::scalar_fn::fns::literal::Literal::child_name(&self, _instan
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::deserialize(&self, _metadata: &[u8], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::literal::Literal::execute(&self, scalar: &vortex_array::scalar::Scalar, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::literal::Literal::execute(&self, scalar: &vortex_array::scalar::Scalar, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::fmt_sql(&self, scalar: &vortex_array::scalar::Scalar, _expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15482,7 +15504,7 @@ pub fn vortex_array::scalar_fn::fns::mask::Mask::child_name(&self, _options: &Se
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::mask::Mask::execute(&self, _options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::mask::Mask::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::mask::Mask::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15518,7 +15540,7 @@ pub fn vortex_array::scalar_fn::fns::merge::Merge::child_name(&self, _instance: 
 
 pub fn vortex_array::scalar_fn::fns::merge::Merge::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::merge::Merge::execute(&self, options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::merge::Merge::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::merge::Merge::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15554,7 +15576,7 @@ pub fn vortex_array::scalar_fn::fns::not::Not::child_name(&self, _options: &Self
 
 pub fn vortex_array::scalar_fn::fns::not::Not::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::not::Not::execute(&self, _data: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::not::Not::execute(&self, _data: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::not::Not::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15590,7 +15612,7 @@ pub fn vortex_array::scalar_fn::fns::pack::Pack::child_name(&self, instance: &Se
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::pack::Pack::execute(&self, options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::pack::Pack::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::pack::Pack::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15626,7 +15648,7 @@ pub fn vortex_array::scalar_fn::fns::root::Root::child_name(&self, _instance: &S
 
 pub fn vortex_array::scalar_fn::fns::root::Root::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::root::Root::execute(&self, _data: &Self::Options, _args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::root::Root::execute(&self, _data: &Self::Options, _args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::root::Root::fmt_sql(&self, _options: &Self::Options, _expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15662,7 +15684,7 @@ pub fn vortex_array::scalar_fn::fns::select::Select::child_name(&self, _instance
 
 pub fn vortex_array::scalar_fn::fns::select::Select::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_array::scalar_fn::fns::select::FieldSelection>
 
-pub fn vortex_array::scalar_fn::fns::select::Select::execute(&self, selection: &vortex_array::scalar_fn::fns::select::FieldSelection, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::select::Select::execute(&self, selection: &vortex_array::scalar_fn::fns::select::FieldSelection, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::select::Select::fmt_sql(&self, selection: &vortex_array::scalar_fn::fns::select::FieldSelection, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15698,7 +15720,7 @@ pub fn vortex_array::scalar_fn::fns::zip::Zip::child_name(&self, _options: &Self
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::zip::Zip::execute(&self, _options: &Self::Options, args: vortex_array::scalar_fn::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::zip::Zip::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::zip::Zip::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -38,6 +38,7 @@ use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTableExt;
+use crate::scalar_fn::VecExecutionArgs;
 use crate::serde::ArrayChildren;
 use crate::stats::StatsSetRef;
 use crate::vtable;
@@ -195,12 +196,8 @@ impl VTable for ScalarFnVTable {
 
     fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
         ctx.log(format_args!("scalar_fn({}): executing", array.scalar_fn));
-        let args = ExecutionArgs {
-            inputs: array.children.clone(),
-            row_count: array.len,
-            ctx,
-        };
-        array.scalar_fn.execute(args)
+        let args = VecExecutionArgs::new(array.children.clone(), array.len);
+        array.scalar_fn.execute(&args, ctx)
     }
 
     fn reduce(array: &Self::Array) -> VortexResult<Option<ArrayRef>> {
@@ -358,8 +355,13 @@ impl scalar_fn::ScalarFnVTable for ArrayExpr {
         Ok(options.0.dtype().clone())
     }
 
-    fn execute(&self, options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        crate::Executable::execute(options.0.clone(), args.ctx)
+    fn execute(
+        &self,
+        options: &Self::Options,
+        _args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        crate::Executable::execute(options.0.clone(), ctx)
     }
 
     fn validity(

--- a/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
@@ -12,7 +12,7 @@ use crate::arrays::scalar_fn::array::ScalarFnArray;
 use crate::arrays::scalar_fn::vtable::ScalarFnVTable;
 use crate::columnar::Columnar;
 use crate::scalar::Scalar;
-use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::VecExecutionArgs;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<ScalarFnVTable> for ScalarFnVTable {
@@ -24,12 +24,8 @@ impl OperationsVTable<ScalarFnVTable> for ScalarFnVTable {
             .collect::<VortexResult<_>>()?;
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let args = ExecutionArgs {
-            inputs,
-            row_count: 1,
-            ctx: &mut ctx,
-        };
-        let result = array.scalar_fn.execute(args)?;
+        let args = VecExecutionArgs::new(inputs, 1);
+        let result = array.scalar_fn.execute(&args, &mut ctx)?;
 
         let scalar = match result.execute::<Columnar>(&mut ctx)? {
             Columnar::Canonical(arr) => {

--- a/vortex-array/src/arrays/scalar_fn/vtable/validity.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/validity.rs
@@ -13,8 +13,8 @@ use crate::arrays::scalar_fn::vtable::FakeEq;
 use crate::arrays::scalar_fn::vtable::ScalarFnVTable;
 use crate::expr::Expression;
 use crate::expr::lit;
-use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFn;
+use crate::scalar_fn::VecExecutionArgs;
 use crate::scalar_fn::fns::literal::Literal;
 use crate::scalar_fn::fns::root::Root;
 use crate::validity::Validity;
@@ -44,13 +44,9 @@ fn execute_expr(expr: &Expression, row_count: usize) -> VortexResult<ArrayRef> {
         .map(|child| execute_expr(child, row_count))
         .collect::<VortexResult<_>>()?;
 
-    let args = ExecutionArgs {
-        inputs,
-        row_count,
-        ctx: &mut ctx,
-    };
+    let args = VecExecutionArgs::new(inputs, row_count);
 
-    Ok(expr.scalar_fn().execute(args)?.into_array())
+    Ok(expr.scalar_fn().execute(&args, &mut ctx)?.into_array())
 }
 
 impl ValidityVTable<ScalarFnVTable> for ScalarFnVTable {

--- a/vortex-array/src/scalar_fn/erased.rs
+++ b/vortex-array/src/scalar_fn/erased.rs
@@ -15,6 +15,7 @@ use vortex_error::VortexResult;
 use vortex_utils::debug_with::DebugWith;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::dtype::DType;
 use crate::expr::Expression;
 use crate::expr::StatsCatalog;
@@ -109,8 +110,12 @@ impl ScalarFnRef {
     }
 
     /// Execute the expression given the input arguments.
-    pub fn execute(&self, ctx: ExecutionArgs) -> VortexResult<ArrayRef> {
-        self.0.execute(ctx)
+    pub fn execute(
+        &self,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        self.0.execute(args, ctx)
     }
 
     /// Perform abstract reduction on this scalar function node.

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -11,7 +11,6 @@ pub use kernel::*;
 use prost::Message;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
-use vortex_error::vortex_err;
 use vortex_proto::expr as pb;
 use vortex_session::VortexSession;
 
@@ -294,28 +293,26 @@ impl ScalarFnVTable for Between {
         ))
     }
 
-    fn execute(&self, options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let [arr, lower, upper]: [ArrayRef; _] = args
-            .inputs
-            .try_into()
-            .map_err(|_| vortex_err!("Expected 3 arguments for Between expression",))?;
+    fn execute(
+        &self,
+        options: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let arr = args.get(0)?;
+        let lower = args.get(1)?;
+        let upper = args.get(2)?;
 
         // canonicalize the arr and we might be able to run a between kernels over that.
         if !arr.is_canonical() {
-            return arr.execute::<Canonical>(args.ctx)?.into_array().between(
+            return arr.execute::<Canonical>(ctx)?.into_array().between(
                 lower,
                 upper,
                 options.clone(),
             );
         }
 
-        between_canonical(
-            arr.as_ref(),
-            lower.as_ref(),
-            upper.as_ref(),
-            options,
-            args.ctx,
-        )
+        between_canonical(arr.as_ref(), lower.as_ref(), upper.as_ref(), options, ctx)
     }
 
     fn stat_falsification(

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -14,6 +14,7 @@ use vortex_proto::expr as pb;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::dtype::DType;
 use crate::expr::StatsCatalog;
 use crate::expr::and;
@@ -121,24 +122,28 @@ impl ScalarFnVTable for Binary {
         Ok(DType::Bool((lhs.is_nullable() || rhs.is_nullable()).into()))
     }
 
-    fn execute(&self, op: &Operator, args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let [lhs, rhs] = &args.inputs[..] else {
-            vortex_bail!("Wrong arg count")
-        };
+    fn execute(
+        &self,
+        op: &Operator,
+        args: &dyn ExecutionArgs,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let lhs = args.get(0)?;
+        let rhs = args.get(1)?;
 
         match op {
-            Operator::Eq => execute_compare(lhs, rhs, CompareOperator::Eq),
-            Operator::NotEq => execute_compare(lhs, rhs, CompareOperator::NotEq),
-            Operator::Lt => execute_compare(lhs, rhs, CompareOperator::Lt),
-            Operator::Lte => execute_compare(lhs, rhs, CompareOperator::Lte),
-            Operator::Gt => execute_compare(lhs, rhs, CompareOperator::Gt),
-            Operator::Gte => execute_compare(lhs, rhs, CompareOperator::Gte),
-            Operator::And => execute_boolean(lhs, rhs, Operator::And),
-            Operator::Or => execute_boolean(lhs, rhs, Operator::Or),
-            Operator::Add => execute_numeric(lhs, rhs, crate::scalar::NumericOperator::Add),
-            Operator::Sub => execute_numeric(lhs, rhs, crate::scalar::NumericOperator::Sub),
-            Operator::Mul => execute_numeric(lhs, rhs, crate::scalar::NumericOperator::Mul),
-            Operator::Div => execute_numeric(lhs, rhs, crate::scalar::NumericOperator::Div),
+            Operator::Eq => execute_compare(&lhs, &rhs, CompareOperator::Eq),
+            Operator::NotEq => execute_compare(&lhs, &rhs, CompareOperator::NotEq),
+            Operator::Lt => execute_compare(&lhs, &rhs, CompareOperator::Lt),
+            Operator::Lte => execute_compare(&lhs, &rhs, CompareOperator::Lte),
+            Operator::Gt => execute_compare(&lhs, &rhs, CompareOperator::Gt),
+            Operator::Gte => execute_compare(&lhs, &rhs, CompareOperator::Gte),
+            Operator::And => execute_boolean(&lhs, &rhs, Operator::And),
+            Operator::Or => execute_boolean(&lhs, &rhs, Operator::Or),
+            Operator::Add => execute_numeric(&lhs, &rhs, crate::scalar::NumericOperator::Add),
+            Operator::Sub => execute_numeric(&lhs, &rhs, crate::scalar::NumericOperator::Sub),
+            Operator::Mul => execute_numeric(&lhs, &rhs, crate::scalar::NumericOperator::Mul),
+            Operator::Div => execute_numeric(&lhs, &rhs, crate::scalar::NumericOperator::Div),
         }
     }
 

--- a/vortex-array/src/scalar_fn/fns/cast/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/cast/mod.rs
@@ -7,7 +7,6 @@ use std::fmt::Formatter;
 
 pub use kernel::*;
 use prost::Message;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
@@ -102,21 +101,21 @@ impl ScalarFnVTable for Cast {
         Ok(dtype.clone())
     }
 
-    fn execute(&self, target_dtype: &DType, mut args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let input = args
-            .inputs
-            .pop()
-            .vortex_expect("missing input for Cast expression");
+    fn execute(
+        &self,
+        target_dtype: &DType,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let input = args.get(0)?;
 
         let Some(columnar) = input.as_opt::<AnyColumnar>() else {
-            return input
-                .execute::<ArrayRef>(args.ctx)?
-                .cast(target_dtype.clone());
+            return input.execute::<ArrayRef>(ctx)?.cast(target_dtype.clone());
         };
 
         match columnar {
             ColumnarView::Canonical(canonical) => {
-                match cast_canonical(canonical.clone(), target_dtype, args.ctx)? {
+                match cast_canonical(canonical.clone(), target_dtype, ctx)? {
                     Some(result) => Ok(result),
                     None => vortex_bail!(
                         "No CastKernel to cast canonical array {} from {} to {}",

--- a/vortex-array/src/scalar_fn/fns/dynamic.rs
+++ b/vortex-array/src/scalar_fn/fns/dynamic.rs
@@ -15,6 +15,7 @@ use vortex_error::vortex_bail;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::dtype::DType;
@@ -31,6 +32,7 @@ use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
 use crate::scalar_fn::ScalarFnVTableExt;
+use crate::scalar_fn::VecExecutionArgs;
 use crate::scalar_fn::fns::binary::Binary;
 use crate::scalar_fn::fns::operators::CompareOperator;
 use crate::scalar_fn::fns::operators::Operator;
@@ -92,28 +94,27 @@ impl ScalarFnVTable for DynamicComparison {
         ))
     }
 
-    fn execute(&self, data: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
+    fn execute(
+        &self,
+        data: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
         if let Some(scalar) = data.rhs.scalar() {
-            let [lhs]: [ArrayRef; _] = args
-                .inputs
-                .try_into()
-                .map_err(|_| vortex_error::vortex_err!("Wrong arg count for DynamicComparison"))?;
-            let rhs = ConstantArray::new(scalar, args.row_count).into_array();
+            let lhs = args.get(0)?;
+            let rhs = ConstantArray::new(scalar, args.row_count()).into_array();
 
+            let delegate_args = VecExecutionArgs::new(vec![lhs, rhs], args.row_count());
             return Binary
                 .bind(Operator::from(data.operator))
-                .execute(ExecutionArgs {
-                    inputs: vec![lhs, rhs],
-                    row_count: args.row_count,
-                    ctx: args.ctx,
-                });
+                .execute(&delegate_args, ctx);
         }
         let ret_dtype =
-            DType::Bool(args.inputs[0].dtype().nullability() | data.rhs.dtype.nullability());
+            DType::Bool(args.get(0)?.dtype().nullability() | data.rhs.dtype.nullability());
 
         Ok(ConstantArray::new(
             Scalar::try_new(ret_dtype, Some(data.default.into()))?,
-            args.row_count,
+            args.row_count(),
         )
         .into_array())
     }

--- a/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
@@ -92,24 +92,25 @@ impl ScalarFnVTable for FillNull {
             .with_nullability(arg_dtypes[1].nullability()))
     }
 
-    fn execute(&self, _options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let [input, fill_value]: [ArrayRef; _] = args
-            .inputs
-            .try_into()
-            .map_err(|_| vortex_err!("Wrong arg count"))?;
+    fn execute(
+        &self,
+        _options: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let input = args.get(0)?;
+        let fill_value = args.get(1)?;
 
         let fill_scalar = fill_value
             .as_constant()
             .ok_or_else(|| vortex_err!("fill_null fill_value must be a constant/scalar"))?;
 
         let Some(columnar) = input.as_opt::<AnyColumnar>() else {
-            return input.execute::<ArrayRef>(args.ctx)?.fill_null(fill_scalar);
+            return input.execute::<ArrayRef>(ctx)?.fill_null(fill_scalar);
         };
 
         match columnar {
-            ColumnarView::Canonical(canonical) => {
-                fill_null_canonical(canonical, &fill_scalar, args.ctx)
-            }
+            ColumnarView::Canonical(canonical) => fill_null_canonical(canonical, &fill_scalar, ctx),
             ColumnarView::Constant(constant) => fill_null_constant(constant, &fill_scalar),
         }
     }

--- a/vortex-array/src/scalar_fn/fns/get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/get_item.rs
@@ -4,13 +4,13 @@
 use std::fmt::Formatter;
 
 use prost::Message;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 use vortex_proto::expr as pb;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::arrays::StructArray;
 use crate::builtins::ArrayBuiltins;
 use crate::builtins::ExprBuiltins;
@@ -105,12 +105,13 @@ impl ScalarFnVTable for GetItem {
         Ok(field_dtype)
     }
 
-    fn execute(&self, field_name: &FieldName, mut args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let input = args
-            .inputs
-            .pop()
-            .vortex_expect("missing input for GetItem expression")
-            .execute::<StructArray>(args.ctx)?;
+    fn execute(
+        &self,
+        field_name: &FieldName,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let input = args.get(0)?.execute::<StructArray>(ctx)?;
         let field = input.unmasked_field_by_name(field_name).cloned()?;
 
         match input.dtype().nullability() {

--- a/vortex-array/src/scalar_fn/fns/is_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_null.rs
@@ -3,11 +3,11 @@
 
 use std::fmt::Formatter;
 
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::builtins::ArrayBuiltins;
@@ -75,17 +75,22 @@ impl ScalarFnVTable for IsNull {
         Ok(DType::Bool(Nullability::NonNullable))
     }
 
-    fn execute(&self, _data: &Self::Options, mut args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let child = args.inputs.pop().vortex_expect("Missing input child");
+    fn execute(
+        &self,
+        _data: &Self::Options,
+        args: &dyn ExecutionArgs,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let child = args.get(0)?;
         if let Some(scalar) = child.as_constant() {
-            return Ok(ConstantArray::new(scalar.is_null(), args.row_count).into_array());
+            return Ok(ConstantArray::new(scalar.is_null(), args.row_count()).into_array());
         }
 
         match child.validity()? {
             Validity::NonNullable | Validity::AllValid => {
-                Ok(ConstantArray::new(false, args.row_count).into_array())
+                Ok(ConstantArray::new(false, args.row_count()).into_array())
             }
-            Validity::AllInvalid => Ok(ConstantArray::new(true, args.row_count).into_array()),
+            Validity::AllInvalid => Ok(ConstantArray::new(true, args.row_count()).into_array()),
             Validity::Array(a) => a.not(),
         }
     }

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -10,12 +10,12 @@ pub use kernel::*;
 use prost::Message;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
-use vortex_error::vortex_err;
 use vortex_proto::expr as pb;
 use vortex_session::VortexSession;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::arrow::Datum;
 use crate::arrow::from_arrow_array_with_len;
 use crate::dtype::DType;
@@ -137,11 +137,14 @@ impl ScalarFnVTable for Like {
         ))
     }
 
-    fn execute(&self, options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let [child, pattern]: [ArrayRef; _] = args
-            .inputs
-            .try_into()
-            .map_err(|_| vortex_err!("Wrong argument count"))?;
+    fn execute(
+        &self,
+        options: &Self::Options,
+        args: &dyn ExecutionArgs,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let child = args.get(0)?;
+        let pattern = args.get(1)?;
 
         arrow_like(&child, &pattern, *options)
     }

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -18,6 +18,7 @@ use vortex_session::VortexSession;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::BoolArray;
@@ -119,17 +120,20 @@ impl ScalarFnVTable for ListContains {
         Ok(DType::Bool(nullability))
     }
 
-    fn execute(&self, _options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let [list_array, value_array]: [ArrayRef; _] = args
-            .inputs
-            .try_into()
-            .map_err(|_| vortex_err!("Wrong number of arguments for ListContains expression"))?;
+    fn execute(
+        &self,
+        _options: &Self::Options,
+        args: &dyn ExecutionArgs,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let list_array = args.get(0)?;
+        let value_array = args.get(1)?;
 
         if let Some(list_scalar) = list_array.as_constant()
             && let Some(value_scalar) = value_array.as_constant()
         {
             let result = compute_contains_scalar(&list_scalar, &value_scalar)?;
-            return Ok(ConstantArray::new(result, args.row_count).into_array());
+            return Ok(ConstantArray::new(result, args.row_count()).into_array());
         }
 
         compute_list_contains(list_array.as_ref(), value_array.as_ref())

--- a/vortex-array/src/scalar_fn/fns/literal.rs
+++ b/vortex-array/src/scalar_fn/fns/literal.rs
@@ -10,6 +10,7 @@ use vortex_proto::expr as pb;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::dtype::DType;
@@ -84,8 +85,13 @@ impl ScalarFnVTable for Literal {
         Ok(options.dtype().clone())
     }
 
-    fn execute(&self, scalar: &Scalar, args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        Ok(ConstantArray::new(scalar.clone(), args.row_count).into_array())
+    fn execute(
+        &self,
+        scalar: &Scalar,
+        args: &dyn ExecutionArgs,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        Ok(ConstantArray::new(scalar.clone(), args.row_count()).into_array())
     }
 
     fn stat_expression(

--- a/vortex-array/src/scalar_fn/fns/mask/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/mask/mod.rs
@@ -8,11 +8,11 @@ pub use kernel::*;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
-use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
 use crate::Canonical;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
 use crate::arrays::ConstantArray;
@@ -94,17 +94,20 @@ impl ScalarFnVTable for Mask {
         Ok(arg_dtypes[0].as_nullable())
     }
 
-    fn execute(&self, _options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let [input, mask_array]: [ArrayRef; _] = args
-            .inputs
-            .try_into()
-            .map_err(|_| vortex_err!("Wrong arg count"))?;
+    fn execute(
+        &self,
+        _options: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let input = args.get(0)?;
+        let mask_array = args.get(1)?;
 
         if let Some(result) = execute_constant(&input, &mask_array)? {
             return Ok(result);
         }
 
-        execute_canonical(input, mask_array, args.ctx)
+        execute_canonical(input, mask_array, ctx)
     }
 
     fn simplify(
@@ -176,7 +179,7 @@ fn execute_constant(input: &ArrayRef, mask_array: &ArrayRef) -> VortexResult<Opt
 fn execute_canonical(
     input: ArrayRef,
     mask_array: ArrayRef,
-    ctx: &mut crate::executor::ExecutionCtx,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let mask_bool = mask_array.execute::<BoolArray>(ctx)?;
     let validity_mask = vortex_mask::Mask::from(mask_bool.to_bit_buffer());

--- a/vortex-array/src/scalar_fn/fns/merge.rs
+++ b/vortex-array/src/scalar_fn/fns/merge.rs
@@ -14,6 +14,7 @@ use vortex_session::VortexSession;
 use vortex_utils::aliases::hash_set::HashSet;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray as _;
 use crate::arrays::StructArray;
 use crate::dtype::DType;
@@ -138,14 +139,19 @@ impl ScalarFnVTable for Merge {
         ))
     }
 
-    fn execute(&self, options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
+    fn execute(
+        &self,
+        options: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
         // Collect fields in order of appearance. Later fields overwrite earlier fields.
         let mut field_names = Vec::new();
         let mut arrays = Vec::new();
         let mut duplicate_names = HashSet::<_>::new();
 
-        for input in args.inputs {
-            let array = input.execute::<StructArray>(args.ctx)?;
+        for i in 0..args.num_inputs() {
+            let array = args.get(i)?.execute::<StructArray>(ctx)?;
             if array.dtype().is_nullable() {
                 vortex_bail!("merge expects non-nullable input");
             }
@@ -175,7 +181,7 @@ impl ScalarFnVTable for Merge {
 
         // TODO(DK): When children are allowed to be nullable, this needs to change.
         let validity = Validity::NonNullable;
-        let len = args.row_count;
+        let len = args.row_count();
         Ok(
             StructArray::try_new(FieldNames::from(field_names), arrays, len, validity)?
                 .into_array(),

--- a/vortex-array/src/scalar_fn/fns/not/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/not/mod.rs
@@ -6,13 +6,13 @@ mod kernel;
 use std::fmt::Formatter;
 
 pub use kernel::*;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_session::VortexSession;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
 use crate::arrays::BoolVTable;
@@ -84,8 +84,13 @@ impl ScalarFnVTable for Not {
         Ok(child_dtype.clone())
     }
 
-    fn execute(&self, _data: &Self::Options, mut args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let child = args.inputs.pop().vortex_expect("Missing input child");
+    fn execute(
+        &self,
+        _data: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let child = args.get(0)?;
 
         // For constant boolean
         if let Some(scalar) = child.as_constant() {
@@ -93,7 +98,7 @@ impl ScalarFnVTable for Not {
                 Some(b) => Scalar::bool(!b, child.dtype().nullability()),
                 None => Scalar::null(child.dtype().clone()),
             };
-            return Ok(ConstantArray::new(value, args.row_count).into_array());
+            return Ok(ConstantArray::new(value, args.row_count()).into_array());
         }
 
         // For boolean array
@@ -102,7 +107,7 @@ impl ScalarFnVTable for Not {
         }
 
         // Otherwise, execute and try again
-        child.execute::<ArrayRef>(args.ctx)?.not()
+        child.execute::<ArrayRef>(ctx)?.not()
     }
 
     fn is_null_sensitive(&self, _options: &Self::Options) -> bool {

--- a/vortex-array/src/scalar_fn/fns/pack.rs
+++ b/vortex-array/src/scalar_fn/fns/pack.rs
@@ -12,6 +12,7 @@ use vortex_proto::expr as pb;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::StructArray;
 use crate::dtype::DType;
@@ -130,13 +131,20 @@ impl ScalarFnVTable for Pack {
         Ok(Some(lit(true)))
     }
 
-    fn execute(&self, options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let len = args.row_count;
-        let value_arrays = args.inputs;
+    fn execute(
+        &self,
+        options: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let len = args.row_count();
+        let value_arrays: Vec<ArrayRef> = (0..args.num_inputs())
+            .map(|i| args.get(i))
+            .collect::<VortexResult<_>>()?;
         let validity: Validity = options.nullability.into();
         StructArray::try_new(options.names.clone(), value_arrays, len, validity)?
             .into_array()
-            .execute(args.ctx)
+            .execute(ctx)
     }
 
     // This applies a nullability

--- a/vortex-array/src/scalar_fn/fns/root.rs
+++ b/vortex-array/src/scalar_fn/fns/root.rs
@@ -8,6 +8,7 @@ use vortex_error::vortex_bail;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::dtype::DType;
 use crate::dtype::FieldPath;
 use crate::expr::StatsCatalog;
@@ -68,7 +69,12 @@ impl ScalarFnVTable for Root {
         vortex_bail!("Root expression does not support return_dtype")
     }
 
-    fn execute(&self, _data: &Self::Options, _args: ExecutionArgs) -> VortexResult<ArrayRef> {
+    fn execute(
+        &self,
+        _data: &Self::Options,
+        _args: &dyn ExecutionArgs,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
         vortex_bail!("Root expression is not executable")
     }
 

--- a/vortex-array/src/scalar_fn/fns/select.rs
+++ b/vortex-array/src/scalar_fn/fns/select.rs
@@ -16,6 +16,7 @@ use vortex_proto::expr::select_opts::Opts;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::StructArray;
 use crate::dtype::DType;
@@ -141,13 +142,10 @@ impl ScalarFnVTable for Select {
     fn execute(
         &self,
         selection: &FieldSelection,
-        mut args: ExecutionArgs,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let child = args
-            .inputs
-            .pop()
-            .vortex_expect("Missing input child")
-            .execute::<StructArray>(args.ctx)?;
+        let child = args.get(0)?.execute::<StructArray>(ctx)?;
 
         let result = match selection {
             FieldSelection::Include(f) => child.project(f.as_ref()),
@@ -162,7 +160,7 @@ impl ScalarFnVTable for Select {
             }
         }?;
 
-        result.into_array().execute(args.ctx)
+        result.into_array().execute(ctx)
     }
 
     fn simplify(

--- a/vortex-array/src/scalar_fn/fns/zip/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/mod.rs
@@ -8,13 +8,13 @@ use std::fmt::Formatter;
 pub use kernel::*;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
-use vortex_error::vortex_err;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
 use crate::Array;
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::builders::ArrayBuilder;
 use crate::builders::builder_with_capacity;
@@ -104,11 +104,15 @@ impl ScalarFnVTable for Zip {
             .union_nullability(arg_dtypes[1].nullability()))
     }
 
-    fn execute(&self, _options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let [if_true, if_false, mask_array]: [ArrayRef; _] = args
-            .inputs
-            .try_into()
-            .map_err(|_| vortex_err!("Wrong arg count"))?;
+    fn execute(
+        &self,
+        _options: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let if_true = args.get(0)?;
+        let if_false = args.get(1)?;
+        let mask_array = args.get(2)?;
 
         let mask = mask_array.try_to_mask_fill_null_false()?;
 
@@ -118,7 +122,7 @@ impl ScalarFnVTable for Zip {
             .union_nullability(if_false.dtype().nullability());
 
         if mask.all_true() {
-            return if_true.cast(return_dtype)?.execute(args.ctx);
+            return if_true.cast(return_dtype)?.execute(ctx);
         }
 
         let return_dtype = if_true
@@ -127,12 +131,12 @@ impl ScalarFnVTable for Zip {
             .union_nullability(if_false.dtype().nullability());
 
         if mask.all_false() {
-            return if_false.cast(return_dtype)?.execute(args.ctx);
+            return if_false.cast(return_dtype)?.execute(ctx);
         }
 
         if !if_true.is_canonical() || !if_false.is_canonical() {
-            let if_true = if_true.execute::<ArrayRef>(args.ctx)?;
-            let if_false = if_false.execute::<ArrayRef>(args.ctx)?;
+            let if_true = if_true.execute::<ArrayRef>(ctx)?;
+            let if_false = if_false.execute::<ArrayRef>(ctx)?;
             return if_true.zip(if_false, mask.into_array());
         }
 

--- a/vortex-array/src/scalar_fn/typed.rs
+++ b/vortex-array/src/scalar_fn/typed.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::dtype::DType;
 use crate::expr::Expression;
 use crate::expr::StatsCatalog;
@@ -44,7 +45,7 @@ pub(super) trait DynScalarFn: 'static + Send + Sync + super::sealed::Sealed {
     fn options_any(&self) -> &dyn Any;
 
     // Bound methods — options accessed from self
-    fn execute(&self, args: ExecutionArgs) -> VortexResult<ArrayRef>;
+    fn execute(&self, args: &dyn ExecutionArgs, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef>;
     fn return_dtype(&self, arg_types: &[DType]) -> VortexResult<DType>;
     fn reduce(
         &self,
@@ -109,19 +110,17 @@ impl<V: ScalarFnVTable> DynScalarFn for ScalarFnInner<V> {
         &self.options
     }
 
-    fn execute(&self, args: ExecutionArgs) -> VortexResult<ArrayRef> {
-        let expected_row_count = args.row_count;
+    fn execute(&self, args: &dyn ExecutionArgs, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+        let expected_row_count = args.row_count();
         #[cfg(debug_assertions)]
         let expected_dtype = {
-            let args_dtypes: Vec<DType> = args
-                .inputs
-                .iter()
-                .map(|array| array.dtype().clone())
-                .collect();
+            let args_dtypes: Vec<DType> = (0..args.num_inputs())
+                .map(|i| args.get(i).map(|a| a.dtype().clone()))
+                .collect::<VortexResult<_>>()?;
             V::return_dtype(&self.vtable, &self.options, &args_dtypes)
         }?;
 
-        let result = V::execute(&self.vtable, &self.options, args)?;
+        let result = V::execute(&self.vtable, &self.options, args, ctx)?;
 
         assert_eq!(
             result.len(),

--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -13,6 +13,7 @@ use arcref::ArcRef;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_err;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
@@ -92,7 +93,12 @@ pub trait ScalarFnVTable: 'static + Sized + Clone + Send + Sync {
     ///
     /// This provides maximum opportunities for array-level optimizations using execute_parent
     /// kernels.
-    fn execute(&self, options: &Self::Options, args: ExecutionArgs) -> VortexResult<ArrayRef>;
+    fn execute(
+        &self,
+        options: &Self::Options,
+        args: &dyn ExecutionArgs,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef>;
 
     /// Implement an abstract reduction rule over a tree of scalar functions.
     ///
@@ -291,13 +297,48 @@ pub trait SimplifyCtx {
 }
 
 /// Arguments for expression execution.
-pub struct ExecutionArgs<'a> {
-    /// The inputs for the expression, one per child.
-    pub inputs: Vec<ArrayRef>,
-    /// The row count of the execution scope.
-    pub row_count: usize,
-    /// The execution context.
-    pub ctx: &'a mut ExecutionCtx,
+pub trait ExecutionArgs {
+    /// Returns the input array at the given index.
+    fn get(&self, index: usize) -> VortexResult<ArrayRef>;
+
+    /// Returns the number of inputs.
+    fn num_inputs(&self) -> usize;
+
+    /// Returns the row count of the execution scope.
+    fn row_count(&self) -> usize;
+}
+
+/// A concrete [`ExecutionArgs`] backed by a `Vec<ArrayRef>`.
+pub struct VecExecutionArgs {
+    inputs: Vec<ArrayRef>,
+    row_count: usize,
+}
+
+impl VecExecutionArgs {
+    /// Create a new `VecExecutionArgs`.
+    pub fn new(inputs: Vec<ArrayRef>, row_count: usize) -> Self {
+        Self { inputs, row_count }
+    }
+}
+
+impl ExecutionArgs for VecExecutionArgs {
+    fn get(&self, index: usize) -> VortexResult<ArrayRef> {
+        self.inputs.get(index).cloned().ok_or_else(|| {
+            vortex_err!(
+                "Input index {} out of bounds (num_inputs={})",
+                index,
+                self.inputs.len()
+            )
+        })
+    }
+
+    fn num_inputs(&self) -> usize {
+        self.inputs.len()
+    }
+
+    fn row_count(&self) -> usize {
+        self.row_count
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/vortex-layout/public-api.lock
+++ b/vortex-layout/public-api.lock
@@ -608,7 +608,7 @@ pub fn vortex_layout::layouts::row_idx::RowIdx::arity(&self, _options: &Self::Op
 
 pub fn vortex_layout::layouts::row_idx::RowIdx::child_name(&self, _instance: &Self::Options, _child_idx: usize) -> vortex_array::scalar_fn::vtable::ChildName
 
-pub fn vortex_layout::layouts::row_idx::RowIdx::execute(&self, _options: &Self::Options, _args: vortex_array::scalar_fn::vtable::ExecutionArgs<'_>) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_layout::layouts::row_idx::RowIdx::execute(&self, _options: &Self::Options, _args: &dyn vortex_array::scalar_fn::vtable::ExecutionArgs, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
 
 pub fn vortex_layout::layouts::row_idx::RowIdx::fmt_sql(&self, _options: &Self::Options, _expr: &vortex_array::expr::expression::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 

--- a/vortex-layout/src/layouts/row_idx/expr.rs
+++ b/vortex-layout/src/layouts/row_idx/expr.rs
@@ -49,7 +49,12 @@ impl ScalarFnVTable for RowIdx {
         Ok(DType::Primitive(PType::U64, Nullability::NonNullable))
     }
 
-    fn execute(&self, _options: &Self::Options, _args: ExecutionArgs) -> VortexResult<ArrayRef> {
+    fn execute(
+        &self,
+        _options: &Self::Options,
+        _args: &dyn ExecutionArgs,
+        _ctx: &mut vortex_array::ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
         vortex_bail!(
             "RowIdxExpr should not be executed directly, use it in the context of a Vortex scan and it will be substituted for a row index array"
         );


### PR DESCRIPTION
This allows implementations to short-circuit, and supports the next change where ExecutionArgs::get will return a Columnar value.