### PR TITLE
Remove &dyn Array call sites

### DIFF
--- a/encodings/alp/public-api.lock
+++ b/encodings/alp/public-api.lock
@@ -150,7 +150,7 @@ pub fn vortex_alp::ALPRDVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> 
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_alp::ALPRDVTable
 
-pub fn vortex_alp::ALPRDVTable::take(array: &vortex_alp::ALPRDArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_alp::ALPRDVTable::take(array: &vortex_alp::ALPRDArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_alp::ALPRDVTable
 
@@ -238,7 +238,7 @@ pub fn vortex_alp::ALPVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> co
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_alp::ALPVTable
 
-pub fn vortex_alp::ALPVTable::take(array: &vortex_alp::ALPArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_alp::ALPVTable::take(array: &vortex_alp::ALPArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_alp::ALPVTable
 
@@ -254,11 +254,11 @@ pub fn vortex_alp::ALPVTable::nan_count(&self, array: &vortex_alp::ALPArray) -> 
 
 impl vortex_array::scalar_fn::fns::between::kernel::BetweenReduce for vortex_alp::ALPVTable
 
-pub fn vortex_alp::ALPVTable::between(array: &vortex_alp::ALPArray, lower: &dyn vortex_array::array::Array, upper: &dyn vortex_array::array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_alp::ALPVTable::between(array: &vortex_alp::ALPArray, lower: &vortex_array::array::ArrayRef, upper: &vortex_array::array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_alp::ALPVTable
 
-pub fn vortex_alp::ALPVTable::compare(lhs: &vortex_alp::ALPArray, rhs: &dyn vortex_array::array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_alp::ALPVTable::compare(lhs: &vortex_alp::ALPArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_alp::ALPVTable
 

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -285,7 +285,7 @@ pub struct ALPMetadata {
 
 impl ALPArray {
     fn validate(
-        encoded: &dyn Array,
+        encoded: &ArrayRef,
         exponents: Exponents,
         patches: Option<&Patches>,
     ) -> VortexResult<()> {
@@ -336,7 +336,7 @@ impl ALPArray {
     }
 
     /// Validate that any patches provided are valid for the ALPArray.
-    fn validate_patches<T: ALPFloat>(patches: &Patches, encoded: &dyn Array) -> VortexResult<()> {
+    fn validate_patches<T: ALPFloat>(patches: &Patches, encoded: &ArrayRef) -> VortexResult<()> {
         vortex_ensure!(
             patches.array_len() == encoded.len(),
             "patches array_len != encoded len: {} != {}",

--- a/encodings/alp/src/alp/compute/between.rs
+++ b/encodings/alp/src/alp/compute/between.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Debug;
 
-use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::arrays::ConstantArray;
@@ -25,8 +24,8 @@ use crate::match_each_alp_float_ptype;
 impl BetweenReduce for ALPVTable {
     fn between(
         array: &ALPArray,
-        lower: &dyn Array,
-        upper: &dyn Array,
+        lower: &ArrayRef,
+        upper: &ArrayRef,
         options: &BetweenOptions,
     ) -> VortexResult<Option<ArrayRef>> {
         let (Some(lower), Some(upper)) = (lower.as_constant(), upper.as_constant()) else {

--- a/encodings/alp/src/alp/compute/cast.rs
+++ b/encodings/alp/src/alp/compute/cast.rs
@@ -147,7 +147,7 @@ mod tests {
     #[case(buffer![0.0f32, -1.5, 2.5, -3.5, 4.5].into_array())]
     fn test_cast_alp_conformance(#[case] array: vortex_array::ArrayRef) -> VortexResult<()> {
         let alp = alp_encode(&array.to_primitive(), None).vortex_expect("cannot fail");
-        test_cast_conformance(alp.as_ref());
+        test_cast_conformance(&alp.to_array());
 
         Ok(())
     }

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -28,7 +28,7 @@ use crate::match_each_alp_float_ptype;
 impl CompareKernel for ALPVTable {
     fn compare(
         lhs: &ALPArray,
-        rhs: &dyn Array,
+        rhs: &ArrayRef,
         operator: CompareOperator,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/encodings/alp/src/alp/compute/filter.rs
+++ b/encodings/alp/src/alp/compute/filter.rs
@@ -60,6 +60,6 @@ mod test {
     ].into_array())]
     fn test_filter_alp_conformance(#[case] array: ArrayRef) {
         let alp = alp_encode(&array.to_primitive(), None).unwrap();
-        test_filter_conformance(alp.as_ref());
+        test_filter_conformance(&alp.to_array());
     }
 }

--- a/encodings/alp/src/alp/compute/mask.rs
+++ b/encodings/alp/src/alp/compute/mask.rs
@@ -66,7 +66,7 @@ mod test {
     ].into_array())]
     fn test_mask_alp_conformance(#[case] array: vortex_array::ArrayRef) {
         let alp = alp_encode(&array.to_primitive(), None).unwrap();
-        test_mask_conformance(alp.as_ref());
+        test_mask_conformance(&alp.to_array());
     }
 
     #[test]
@@ -79,6 +79,6 @@ mod test {
         let array = PrimitiveArray::from_iter(values);
         let alp = alp_encode(&array, None).unwrap();
         assert!(alp.patches().is_some(), "expected patches");
-        test_mask_conformance(alp.as_ref());
+        test_mask_conformance(&alp.to_array());
     }
 }

--- a/encodings/alp/src/alp/compute/mod.rs
+++ b/encodings/alp/src/alp/compute/mod.rs
@@ -36,7 +36,7 @@ mod tests {
     #[case::repeating_pattern(alp_encode(&PrimitiveArray::from_iter([1.1f32, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3]), None).unwrap())]
     #[case::close_values(alp_encode(&PrimitiveArray::from_iter([100.001f64, 100.002, 100.003, 100.004, 100.005]), None).unwrap())]
     fn test_alp_consistency(#[case] array: ALPArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 
     #[rstest]

--- a/encodings/alp/src/alp/compute/take.rs
+++ b/encodings/alp/src/alp/compute/take.rs
@@ -14,7 +14,7 @@ use crate::ALPVTable;
 impl TakeExecute for ALPVTable {
     fn take(
         array: &ALPArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let taken_encoded = array.encoded().take(indices.to_array())?;
@@ -55,6 +55,6 @@ mod test {
     #[case(buffer![42.42f64].into_array())]
     fn test_take_alp_conformance(#[case] array: vortex_array::ArrayRef) {
         let alp = alp_encode(&array.to_primitive(), None).unwrap();
-        test_take_conformance(alp.as_ref());
+        test_take_conformance(&alp.to_array());
     }
 }

--- a/encodings/alp/src/alp_rd/compute/cast.rs
+++ b/encodings/alp/src/alp_rd/compute/cast.rs
@@ -138,6 +138,6 @@ mod tests {
         encoder.encode(&arr)
     })]
     fn test_cast_alprd_conformance(#[case] alprd: crate::alp_rd::ALPRDArray) {
-        test_cast_conformance(alprd.as_ref());
+        test_cast_conformance(&alprd.to_array());
     }
 }

--- a/encodings/alp/src/alp_rd/compute/mod.rs
+++ b/encodings/alp/src/alp_rd/compute/mod.rs
@@ -66,7 +66,7 @@ mod tests {
         encoder.encode(&arr)
     })]
     fn test_alp_rd_consistency(#[case] array: ALPRDArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 
     #[rstest]

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -16,7 +16,7 @@ use crate::ALPRDVTable;
 impl TakeExecute for ALPRDVTable {
     fn take(
         array: &ALPRDArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let taken_left_parts = array.left_parts().take(indices.to_array())?;

--- a/encodings/bytebool/public-api.lock
+++ b/encodings/bytebool/public-api.lock
@@ -62,7 +62,7 @@ pub fn vortex_bytebool::ByteBoolVTable::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_bytebool::ByteBoolVTable
 
-pub fn vortex_bytebool::ByteBoolVTable::take(array: &vortex_bytebool::ByteBoolArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_bytebool::ByteBoolVTable::take(array: &vortex_bytebool::ByteBoolArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::slice::SliceReduce for vortex_bytebool::ByteBoolVTable
 

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use num_traits::AsPrimitive;
-use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -60,14 +59,14 @@ impl MaskReduce for ByteBoolVTable {
 impl TakeExecute for ByteBoolVTable {
     fn take(
         array: &ByteBoolArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let indices = indices.to_primitive();
         let bools = array.as_slice();
 
         // This handles combining validity from both source array and nullable indices
-        let validity = array.validity().take(indices.as_ref())?;
+        let validity = array.validity().take(&indices.to_array())?;
 
         let taken_bools = match_each_integer_ptype!(indices.ptype(), |I| {
             indices
@@ -149,17 +148,21 @@ mod tests {
 
     #[test]
     fn test_mask_byte_bool() {
-        test_mask_conformance(ByteBoolArray::from(vec![true, false, true, true, false]).as_ref());
         test_mask_conformance(
-            ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None]).as_ref(),
+            &ByteBoolArray::from(vec![true, false, true, true, false]).to_array(),
+        );
+        test_mask_conformance(
+            &ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None]).to_array(),
         );
     }
 
     #[test]
     fn test_filter_byte_bool() {
-        test_filter_conformance(ByteBoolArray::from(vec![true, false, true, true, false]).as_ref());
         test_filter_conformance(
-            ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None]).as_ref(),
+            &ByteBoolArray::from(vec![true, false, true, true, false]).to_array(),
+        );
+        test_filter_conformance(
+            &ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None]).to_array(),
         );
     }
 
@@ -169,7 +172,7 @@ mod tests {
     #[case(ByteBoolArray::from(vec![true, false]))]
     #[case(ByteBoolArray::from(vec![true]))]
     fn test_take_byte_bool_conformance(#[case] array: ByteBoolArray) {
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 
     #[test]
@@ -190,7 +193,7 @@ mod tests {
     #[case(ByteBoolArray::from(vec![true]))]
     #[case(ByteBoolArray::from(vec![Some(true), None]))]
     fn test_cast_bytebool_conformance(#[case] array: ByteBoolArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 
     #[rstest]
@@ -203,6 +206,6 @@ mod tests {
     #[case::single_null(ByteBoolArray::from(vec![None]))]
     #[case::mixed_with_nulls(ByteBoolArray::from(vec![Some(true), None, Some(false), None, Some(true)]))]
     fn test_bytebool_consistency(#[case] array: ByteBoolArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/encodings/datetime-parts/public-api.lock
+++ b/encodings/datetime-parts/public-api.lock
@@ -124,7 +124,7 @@ pub fn vortex_datetime_parts::DateTimePartsVTable::fmt(&self, f: &mut core::fmt:
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_datetime_parts::DateTimePartsVTable
 
-pub fn vortex_datetime_parts::DateTimePartsVTable::take(array: &vortex_datetime_parts::DateTimePartsArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_datetime_parts::DateTimePartsVTable::take(array: &vortex_datetime_parts::DateTimePartsArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_datetime_parts::DateTimePartsVTable
 
@@ -140,7 +140,7 @@ pub fn vortex_datetime_parts::DateTimePartsVTable::is_constant(&self, array: &vo
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_datetime_parts::DateTimePartsVTable
 
-pub fn vortex_datetime_parts::DateTimePartsVTable::compare(lhs: &vortex_datetime_parts::DateTimePartsArray, rhs: &dyn vortex_array::array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_datetime_parts::DateTimePartsVTable::compare(lhs: &vortex_datetime_parts::DateTimePartsArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_datetime_parts::DateTimePartsVTable
 

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -95,8 +95,11 @@ pub fn decode_to_temporal(
     }
 
     Ok(TemporalArray::new_timestamp(
-        PrimitiveArray::new(values.freeze(), Validity::copy_from_array(array.as_ref())?)
-            .into_array(),
+        PrimitiveArray::new(
+            values.freeze(),
+            Validity::copy_from_array(&array.to_array())?,
+        )
+        .into_array(),
         options.unit,
         options.tz.clone(),
     ))

--- a/encodings/datetime-parts/src/compute/cast.rs
+++ b/encodings/datetime-parts/src/compute/cast.rs
@@ -134,6 +134,6 @@ mod tests {
     )).unwrap())]
     fn test_cast_datetime_parts_conformance(#[case] array: DateTimePartsArray) {
         use vortex_array::compute::conformance::cast::test_cast_conformance;
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -23,7 +23,7 @@ use crate::timestamp;
 impl CompareKernel for DateTimePartsVTable {
     fn compare(
         lhs: &DateTimePartsArray,
-        rhs: &dyn Array,
+        rhs: &ArrayRef,
         operator: CompareOperator,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
@@ -170,7 +170,7 @@ fn compare_gt(
 }
 
 fn compare_dtp(
-    lhs: &dyn Array,
+    lhs: &ArrayRef,
     rhs: i64,
     operator: CompareOperator,
     nullability: Nullability,

--- a/encodings/datetime-parts/src/compute/filter.rs
+++ b/encodings/datetime-parts/src/compute/filter.rs
@@ -51,7 +51,7 @@ mod test {
             TemporalArray::new_timestamp(timestamps, TimeUnit::Milliseconds, Some("UTC".into()));
 
         let array = DateTimePartsArray::try_from(temporal).unwrap();
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
 
         // Test with nullable values
         let timestamps = PrimitiveArray::from_option_iter([
@@ -67,6 +67,6 @@ mod test {
             TemporalArray::new_timestamp(timestamps, TimeUnit::Milliseconds, Some("UTC".into()));
 
         let array = DateTimePartsArray::try_from(temporal).unwrap();
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 }

--- a/encodings/datetime-parts/src/compute/is_constant.rs
+++ b/encodings/datetime-parts/src/compute/is_constant.rs
@@ -17,21 +17,21 @@ impl IsConstantKernel for DateTimePartsVTable {
         array: &DateTimePartsArray,
         opts: &IsConstantOpts,
     ) -> VortexResult<Option<bool>> {
-        let Some(days) = is_constant_opts(array.days().as_ref(), opts)? else {
+        let Some(days) = is_constant_opts(array.days(), opts)? else {
             return Ok(None);
         };
         if !days {
             return Ok(Some(false));
         }
 
-        let Some(seconds) = is_constant_opts(array.seconds().as_ref(), opts)? else {
+        let Some(seconds) = is_constant_opts(array.seconds(), opts)? else {
             return Ok(None);
         };
         if !seconds {
             return Ok(Some(false));
         }
 
-        let Some(subseconds) = is_constant_opts(array.subseconds().as_ref(), opts)? else {
+        let Some(subseconds) = is_constant_opts(array.subseconds(), opts)? else {
             return Ok(None);
         };
         if !subseconds {

--- a/encodings/datetime-parts/src/compute/mod.rs
+++ b/encodings/datetime-parts/src/compute/mod.rs
@@ -71,6 +71,6 @@ mod tests {
     )).unwrap())]
 
     fn test_datetime_parts_consistency(#[case] array: DateTimePartsArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/encodings/datetime-parts/src/compute/take.rs
+++ b/encodings/datetime-parts/src/compute/take.rs
@@ -18,7 +18,7 @@ use vortex_error::vortex_panic;
 use crate::DateTimePartsArray;
 use crate::DateTimePartsVTable;
 
-fn take_datetime_parts(array: &DateTimePartsArray, indices: &dyn Array) -> VortexResult<ArrayRef> {
+fn take_datetime_parts(array: &DateTimePartsArray, indices: &ArrayRef) -> VortexResult<ArrayRef> {
     // we go ahead and canonicalize here to avoid worst-case canonicalizing 3 separate times
     let indices = indices.to_primitive();
 
@@ -88,7 +88,7 @@ fn take_datetime_parts(array: &DateTimePartsArray, indices: &dyn Array) -> Vorte
 impl TakeExecute for DateTimePartsVTable {
     fn take(
         array: &DateTimePartsArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         take_datetime_parts(array, indices).map(Some)
@@ -136,6 +136,6 @@ mod tests {
         Some("UTC".into())
     )).unwrap())]
     fn test_take_datetime_parts_conformance(#[case] array: DateTimePartsArray) {
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 }

--- a/encodings/decimal-byte-parts/public-api.lock
+++ b/encodings/decimal-byte-parts/public-api.lock
@@ -54,7 +54,7 @@ pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::fmt(&self, f: &mut cor
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_decimal_byte_parts::DecimalBytePartsVTable
 
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::take(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::take(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_decimal_byte_parts::DecimalBytePartsVTable
 
@@ -70,7 +70,7 @@ pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::is_constant(&self, arr
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_decimal_byte_parts::DecimalBytePartsVTable
 
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::compare(lhs: &Self::Array, rhs: &dyn vortex_array::array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::compare(lhs: &Self::Array, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_decimal_byte_parts::DecimalBytePartsVTable
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/cast.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/cast.rs
@@ -118,6 +118,6 @@ mod tests {
         DecimalDType::new(10, 2),
     ).unwrap())]
     fn test_cast_decimal_byte_parts_conformance(#[case] array: DecimalBytePartsArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
@@ -29,7 +29,7 @@ use crate::decimal_byte_parts::compute::compare::Sign::Positive;
 impl CompareKernel for DecimalBytePartsVTable {
     fn compare(
         lhs: &Self::Array,
-        rhs: &dyn Array,
+        rhs: &ArrayRef,
         operator: CompareOperator,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
@@ -33,7 +33,7 @@ mod test {
 
         let decimal_dtype = DecimalDType::new(8, 2);
         let array = DecimalBytePartsArray::try_new(msp, decimal_dtype).unwrap();
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
 
         // Test with nullable values
         let msp = PrimitiveArray::from_option_iter([Some(10i64), None, Some(30), Some(40), None])
@@ -41,6 +41,6 @@ mod test {
 
         let decimal_dtype = DecimalDType::new(18, 4);
         let array = DecimalBytePartsArray::try_new(msp, decimal_dtype).unwrap();
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/mod.rs
@@ -68,6 +68,6 @@ mod tests {
     ).unwrap())]
 
     fn test_decimal_byte_parts_consistency(#[case] array: DecimalBytePartsArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/take.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/take.rs
@@ -13,7 +13,7 @@ use crate::DecimalBytePartsVTable;
 impl TakeExecute for DecimalBytePartsVTable {
     fn take(
         array: &DecimalBytePartsArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         DecimalBytePartsArray::try_new(array.msp.take(indices.to_array())?, *array.decimal_dtype())

--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -112,7 +112,7 @@ impl vortex_fastlanes::BitPackedArray
 
 pub fn vortex_fastlanes::BitPackedArray::bit_width(&self) -> u8
 
-pub fn vortex_fastlanes::BitPackedArray::encode(array: &dyn vortex_array::array::Array, bit_width: u8) -> vortex_error::VortexResult<Self>
+pub fn vortex_fastlanes::BitPackedArray::encode(array: &vortex_array::array::ArrayRef, bit_width: u8) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_fastlanes::BitPackedArray::into_parts(self) -> vortex_fastlanes::BitPackedArrayParts
 
@@ -190,7 +190,7 @@ pub fn vortex_fastlanes::BitPackedVTable::fmt(&self, f: &mut core::fmt::Formatte
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_fastlanes::BitPackedVTable
 
-pub fn vortex_fastlanes::BitPackedVTable::take(array: &vortex_fastlanes::BitPackedArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::BitPackedVTable::take(array: &vortex_fastlanes::BitPackedArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_fastlanes::BitPackedVTable
 
@@ -442,7 +442,7 @@ pub fn vortex_fastlanes::FoRVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>)
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_fastlanes::FoRVTable
 
-pub fn vortex_fastlanes::FoRVTable::take(array: &vortex_fastlanes::FoRArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::FoRVTable::take(array: &vortex_fastlanes::FoRArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_fastlanes::FoRVTable
 
@@ -464,7 +464,7 @@ pub fn vortex_fastlanes::FoRVTable::is_strict_sorted(&self, array: &vortex_fastl
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_fastlanes::FoRVTable
 
-pub fn vortex_fastlanes::FoRVTable::compare(lhs: &vortex_fastlanes::FoRArray, rhs: &dyn vortex_array::array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::FoRVTable::compare(lhs: &vortex_fastlanes::FoRArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::FoRVTable
 

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -461,7 +461,7 @@ mod test {
             Validity::from_iter(valid_values),
         );
         assert!(values.ptype().is_unsigned_int());
-        let compressed = BitPackedArray::encode(values.as_ref(), 4).unwrap();
+        let compressed = BitPackedArray::encode(&values.to_array(), 4).unwrap();
         assert!(compressed.patches().is_none());
         assert_eq!(
             (0..(1 << 4)).collect::<Vec<_>>(),
@@ -480,7 +480,7 @@ mod test {
         let array = PrimitiveArray::new(values, Validity::AllValid);
         assert!(array.ptype().is_signed_int());
 
-        let err = BitPackedArray::encode(array.as_ref(), 1024u32.ilog2() as u8).unwrap_err();
+        let err = BitPackedArray::encode(&array.to_array(), 1024u32.ilog2() as u8).unwrap_err();
         assert!(matches!(err, VortexError::InvalidArgument(_, _)));
     }
 

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -254,7 +254,7 @@ mod tests {
 
     fn compression_roundtrip(n: usize) {
         let values = PrimitiveArray::from_iter((0..n).map(|i| (i % 2047) as u16));
-        let compressed = BitPackedArray::encode(values.as_ref(), 11).unwrap();
+        let compressed = BitPackedArray::encode(&values.to_array(), 11).unwrap();
         assert_arrays_eq!(compressed, values);
 
         values

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use fastlanes::BitPacking;
-use vortex_array::Array;
+use vortex_array::ArrayRef;
 use vortex_array::arrays::PrimitiveVTable;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
@@ -269,7 +269,7 @@ impl BitPackedArray {
     /// If the requested bit-width for packing is larger than the array's native width, an
     /// error will be returned.
     // FIXME(ngates): take a PrimitiveArray
-    pub fn encode(array: &dyn Array, bit_width: u8) -> VortexResult<Self> {
+    pub fn encode(array: &ArrayRef, bit_width: u8) -> VortexResult<Self> {
         if let Some(parray) = array.as_opt::<PrimitiveVTable>() {
             bitpack_encode(parray, bit_width, None)
         } else {
@@ -319,7 +319,7 @@ mod test {
             Some(u64::MAX),
         ];
         let uncompressed = PrimitiveArray::from_option_iter(values);
-        let packed = BitPackedArray::encode(uncompressed.as_ref(), 1).unwrap();
+        let packed = BitPackedArray::encode(&uncompressed.to_array(), 1).unwrap();
         let expected = PrimitiveArray::from_option_iter(values);
         assert_arrays_eq!(packed.to_primitive(), expected);
     }
@@ -328,9 +328,9 @@ mod test {
     fn test_encode_too_wide() {
         let values = [Some(1u8), None, Some(1), None, Some(1), None];
         let uncompressed = PrimitiveArray::from_option_iter(values);
-        let _packed = BitPackedArray::encode(uncompressed.as_ref(), 8)
+        let _packed = BitPackedArray::encode(&uncompressed.to_array(), 8)
             .expect_err("Cannot pack value into the same width");
-        let _packed = BitPackedArray::encode(uncompressed.as_ref(), 9)
+        let _packed = BitPackedArray::encode(&uncompressed.to_array(), 9)
             .expect_err("Cannot pack value into larger width");
     }
 

--- a/encodings/fastlanes/src/bitpacking/compute/cast.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/cast.rs
@@ -68,8 +68,7 @@ mod tests {
     #[test]
     fn test_cast_bitpacked_u8_to_u32() {
         let packed =
-            BitPackedArray::encode(buffer![10u8, 20, 30, 40, 50, 60].into_array().as_ref(), 6)
-                .unwrap();
+            BitPackedArray::encode(&buffer![10u8, 20, 30, 40, 50, 60].into_array(), 6).unwrap();
 
         let casted = packed
             .to_array()
@@ -89,7 +88,7 @@ mod tests {
     #[test]
     fn test_cast_bitpacked_nullable() {
         let values = PrimitiveArray::from_option_iter([Some(5u16), None, Some(10), Some(15), None]);
-        let packed = BitPackedArray::encode(values.as_ref(), 4).unwrap();
+        let packed = BitPackedArray::encode(&values.to_array(), 4).unwrap();
 
         let casted = packed
             .to_array()
@@ -102,11 +101,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case(BitPackedArray::encode(buffer![0u8, 10, 20, 30, 40, 50, 60, 63].into_array().as_ref(), 6).unwrap())]
-    #[case(BitPackedArray::encode(buffer![0u16, 100, 200, 300, 400, 500].into_array().as_ref(), 9).unwrap())]
-    #[case(BitPackedArray::encode(buffer![0u32, 1000, 2000, 3000, 4000].into_array().as_ref(), 12).unwrap())]
-    #[case(BitPackedArray::encode(PrimitiveArray::from_option_iter([Some(1u32), None, Some(7), Some(15), None]).as_ref(), 4).unwrap())]
+    #[case(BitPackedArray::encode(&buffer![0u8, 10, 20, 30, 40, 50, 60, 63].into_array(), 6).unwrap())]
+    #[case(BitPackedArray::encode(&buffer![0u16, 100, 200, 300, 400, 500].into_array(), 9).unwrap())]
+    #[case(BitPackedArray::encode(&buffer![0u32, 1000, 2000, 3000, 4000].into_array(), 12).unwrap())]
+    #[case(BitPackedArray::encode(&PrimitiveArray::from_option_iter([Some(1u32), None, Some(7), Some(15), None]).to_array(), 4).unwrap())]
     fn test_cast_bitpacked_conformance(#[case] array: BitPackedArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -178,7 +178,7 @@ mod test {
     fn take_indices() {
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 6).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 6).unwrap();
 
         let mask = Mask::from_indices(bitpacked.len(), vec![0, 125, 2047, 2049, 2151, 2790]);
 
@@ -193,7 +193,7 @@ mod test {
     fn take_sliced_indices() {
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 6).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 6).unwrap();
         let sliced = bitpacked.slice(128..2050).unwrap();
 
         let mask = Mask::from_indices(sliced.len(), vec![1919, 1921]);
@@ -205,7 +205,7 @@ mod test {
     #[test]
     fn filter_bitpacked() {
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 6).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 6).unwrap();
         let filtered = bitpacked
             .filter(Mask::from_indices(4096, (0..1024).collect()))
             .unwrap();
@@ -219,7 +219,7 @@ mod test {
     fn filter_bitpacked_signed() {
         let values: Buffer<i64> = (0..500).collect();
         let unpacked = PrimitiveArray::new(values.clone(), Validity::NonNullable);
-        let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 9).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 9).unwrap();
         let filtered = bitpacked
             .filter(Mask::from_indices(values.len(), (0..250).collect()))
             .unwrap()
@@ -235,18 +235,18 @@ mod test {
     fn test_filter_bitpacked_conformance() {
         // Test with u8 values
         let unpacked = buffer![1u8, 2, 3, 4, 5].into_array();
-        let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 3).unwrap();
-        test_filter_conformance(bitpacked.as_ref());
+        let bitpacked = BitPackedArray::encode(&unpacked, 3).unwrap();
+        test_filter_conformance(&bitpacked.to_array());
 
         // Test with u32 values
         let unpacked = buffer![100u32, 200, 300, 400, 500].into_array();
-        let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 9).unwrap();
-        test_filter_conformance(bitpacked.as_ref());
+        let bitpacked = BitPackedArray::encode(&unpacked, 9).unwrap();
+        test_filter_conformance(&bitpacked.to_array());
 
         // Test with nullable values
         let unpacked = PrimitiveArray::from_option_iter([Some(1u16), None, Some(3), Some(4), None]);
-        let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 3).unwrap();
-        test_filter_conformance(bitpacked.as_ref());
+        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 3).unwrap();
+        test_filter_conformance(&bitpacked.to_array());
     }
 
     /// Regression test for signed integers with patches.
@@ -260,7 +260,7 @@ mod test {
         // Values 0-127 fit in 7 bits, but 1000 and 2000 do not.
         let values: Vec<i32> = vec![0, 10, 1000, 20, 30, 2000, 40, 50, 60, 70];
         let unpacked = PrimitiveArray::from_iter(values.clone());
-        let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 7).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 7).unwrap();
         assert!(
             bitpacked.patches().is_some(),
             "Expected patches for values exceeding bit width"
@@ -292,7 +292,7 @@ mod test {
             })
             .collect();
         let unpacked = PrimitiveArray::from_iter(values.clone());
-        let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 7).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 7).unwrap();
         assert!(
             bitpacked.patches().is_some(),
             "Expected patches for values exceeding bit width"

--- a/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
@@ -178,6 +178,6 @@ mod tests {
     #[test]
     fn is_constant_with_patches() {
         let array = BitPackedArray::encode(&buffer![4; 1025].into_array(), 2).unwrap();
-        assert!(is_constant(array.as_ref()).unwrap().unwrap());
+        assert!(is_constant(&array.to_array()).unwrap().unwrap());
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compute/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/mod.rs
@@ -82,7 +82,7 @@ mod tests {
     #[case::alternating_bits(bitpack_encode(&PrimitiveArray::from_iter([0u16, 255, 0, 255, 0, 255]), 8, None).unwrap())]
 
     fn test_bitpacked_consistency(#[case] array: BitPackedArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 
     #[rstest]

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -38,7 +38,7 @@ pub(super) const UNPACK_CHUNK_THRESHOLD: usize = 8;
 impl TakeExecute for BitPackedVTable {
     fn take(
         array: &BitPackedArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         // If the indices are large enough, it's faster to flatten and take the primitive array.
@@ -134,7 +134,7 @@ fn take_primitive<T: NativePType + BitPacking, I: IntegerPType>(
         unpatched_taken = unpatched_taken.reinterpret_cast(array.ptype());
     }
     if let Some(patches) = array.patches()
-        && let Some(patches) = patches.take(indices.as_ref())?
+        && let Some(patches) = patches.take(&indices.to_array())?
     {
         let cast_patches = patches.cast_values(unpatched_taken.dtype())?;
         return unpatched_taken.patch(&cast_patches);
@@ -168,7 +168,7 @@ mod test {
 
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 6).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 6).unwrap();
 
         let primitive_result = bitpacked.take(indices.to_array()).unwrap();
         assert_arrays_eq!(
@@ -194,7 +194,7 @@ mod test {
 
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedArray::encode(unpacked.as_ref(), 6).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 6).unwrap();
         let sliced = bitpacked.slice(128..2050).unwrap();
 
         let primitive_result = sliced.take(indices.to_array()).unwrap();
@@ -207,7 +207,7 @@ mod test {
         let num_patches: usize = 128;
         let values = (0..u16::MAX as u32 + num_patches as u32).collect::<Buffer<_>>();
         let uncompressed = PrimitiveArray::new(values.clone(), Validity::NonNullable);
-        let packed = BitPackedArray::encode(uncompressed.as_ref(), 16).unwrap();
+        let packed = BitPackedArray::encode(&uncompressed.to_array(), 16).unwrap();
         assert!(packed.patches().is_some());
 
         let rng = rng();
@@ -264,17 +264,17 @@ mod test {
     }
 
     #[rstest]
-    #[case(BitPackedArray::encode(PrimitiveArray::from_iter((0..100).map(|i| (i % 63) as u8)).as_ref(), 6).unwrap())]
-    #[case(BitPackedArray::encode(PrimitiveArray::from_iter((0..256).map(|i| i as u32)).as_ref(), 8).unwrap())]
-    #[case(BitPackedArray::encode(buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array().as_ref(), 3).unwrap())]
+    #[case(BitPackedArray::encode(&PrimitiveArray::from_iter((0..100).map(|i| (i % 63) as u8)).to_array(), 6).unwrap())]
+    #[case(BitPackedArray::encode(&PrimitiveArray::from_iter((0..256).map(|i| i as u32)).to_array(), 8).unwrap())]
+    #[case(BitPackedArray::encode(&buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array(), 3).unwrap())]
     #[case(BitPackedArray::encode(
-        PrimitiveArray::from_option_iter([Some(10u16), None, Some(20), Some(30), None]).as_ref(),
+        &PrimitiveArray::from_option_iter([Some(10u16), None, Some(20), Some(30), None]).to_array(),
         5
     ).unwrap())]
-    #[case(BitPackedArray::encode(buffer![42u32].into_array().as_ref(), 6).unwrap())]
-    #[case(BitPackedArray::encode(PrimitiveArray::from_iter((0..1024).map(|i| i as u32)).as_ref(), 8).unwrap())]
+    #[case(BitPackedArray::encode(&buffer![42u32].into_array(), 6).unwrap())]
+    #[case(BitPackedArray::encode(&PrimitiveArray::from_iter((0..1024).map(|i| i as u32)).to_array(), 8).unwrap())]
     fn test_take_bitpacked_conformance(#[case] bitpacked: BitPackedArray) {
         use vortex_array::compute::conformance::take::test_take_conformance;
-        test_take_conformance(bitpacked.as_ref());
+        test_take_conformance(&bitpacked.to_array());
     }
 }

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -72,7 +72,7 @@ mod test {
     #[test]
     pub fn slice_block() {
         let arr = BitPackedArray::encode(
-            PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).as_ref(),
+            &PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).to_array(),
             6,
         )
         .unwrap();
@@ -86,7 +86,7 @@ mod test {
     #[test]
     pub fn slice_within_block() {
         let arr = BitPackedArray::encode(
-            PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).as_ref(),
+            &PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).to_array(),
             6,
         )
         .unwrap();
@@ -100,7 +100,7 @@ mod test {
     #[test]
     fn slice_within_block_u8s() {
         let packed = BitPackedArray::encode(
-            PrimitiveArray::from_iter((0..10_000).map(|i| (i % 63) as u8)).as_ref(),
+            &PrimitiveArray::from_iter((0..10_000).map(|i| (i % 63) as u8)).to_array(),
             7,
         )
         .unwrap();
@@ -113,7 +113,7 @@ mod test {
     #[test]
     fn slice_block_boundary_u8s() {
         let packed = BitPackedArray::encode(
-            PrimitiveArray::from_iter((0..10_000).map(|i| (i % 63) as u8)).as_ref(),
+            &PrimitiveArray::from_iter((0..10_000).map(|i| (i % 63) as u8)).to_array(),
             7,
         )
         .unwrap();
@@ -126,7 +126,7 @@ mod test {
     #[test]
     fn double_slice_within_block() {
         let arr = BitPackedArray::encode(
-            PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).as_ref(),
+            &PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).to_array(),
             6,
         )
         .unwrap();
@@ -161,9 +161,11 @@ mod test {
     fn take_after_slice() {
         // Check that our take implementation respects the offsets applied after slicing.
 
-        let array =
-            BitPackedArray::encode(PrimitiveArray::from_iter((63u32..).take(3072)).as_ref(), 6)
-                .unwrap();
+        let array = BitPackedArray::encode(
+            &PrimitiveArray::from_iter((63u32..).take(3072)).to_array(),
+            6,
+        )
+        .unwrap();
 
         // Slice the array.
         // The resulting array will still have 3 1024-element chunks.

--- a/encodings/fastlanes/src/delta/compute/cast.rs
+++ b/encodings/fastlanes/src/delta/compute/cast.rs
@@ -125,6 +125,6 @@ mod tests {
     )]
     fn test_cast_delta_conformance(#[case] primitive: PrimitiveArray) {
         let delta_array = DeltaArray::try_from_primitive_array(&primitive).unwrap();
-        test_cast_conformance(delta_array.as_ref());
+        test_cast_conformance(&delta_array.to_array());
     }
 }

--- a/encodings/fastlanes/src/delta/vtable/operations.rs
+++ b/encodings/fastlanes/src/delta/vtable/operations.rs
@@ -228,7 +228,7 @@ mod tests {
     // Single element
     #[case::delta_single(DeltaArray::try_from_vec(vec![42u32]).unwrap())]
     fn test_delta_consistency(#[case] array: DeltaArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 
     #[rstest]

--- a/encodings/fastlanes/src/for/array/for_compress.rs
+++ b/encodings/fastlanes/src/for/array/for_compress.rs
@@ -130,7 +130,7 @@ mod test {
         // Create a range offset by a million.
         let expect = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7 + 10));
         let array = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7));
-        let bp = BitPackedArray::encode(array.as_ref(), 3).unwrap();
+        let bp = BitPackedArray::encode(&array.to_array(), 3).unwrap();
         let compressed = FoRArray::try_new(bp.into_array(), 10u32.into()).unwrap();
         assert_arrays_eq!(compressed, expect);
     }
@@ -140,7 +140,7 @@ mod test {
         // Create a range offset by a million.
         let expect = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7 + 10));
         let array = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7));
-        let bp = BitPackedArray::encode(array.as_ref(), 2).unwrap();
+        let bp = BitPackedArray::encode(&array.to_array(), 2).unwrap();
         let compressed = FoRArray::try_new(bp.clone().into_array(), 10u32.into()).unwrap();
         let decompressed =
             fused_decompress::<u32>(&compressed, &bp, &mut SESSION.create_execution_ctx())?;

--- a/encodings/fastlanes/src/for/compute/cast.rs
+++ b/encodings/fastlanes/src/for/compute/cast.rs
@@ -101,6 +101,6 @@ mod tests {
         Scalar::from(-100i32)
     ).unwrap())]
     fn test_cast_for_conformance(#[case] array: FoRArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/encodings/fastlanes/src/for/compute/compare.rs
+++ b/encodings/fastlanes/src/for/compute/compare.rs
@@ -28,7 +28,7 @@ use crate::FoRVTable;
 impl CompareKernel for FoRVTable {
     fn compare(
         lhs: &FoRArray,
-        rhs: &dyn Array,
+        rhs: &ArrayRef,
         operator: CompareOperator,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/encodings/fastlanes/src/for/compute/mod.rs
+++ b/encodings/fastlanes/src/for/compute/mod.rs
@@ -21,7 +21,7 @@ use crate::FoRVTable;
 impl TakeExecute for FoRVTable {
     fn take(
         array: &FoRArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
@@ -61,20 +61,20 @@ mod test {
         let values = buffer![100i32, 101, 102, 103, 104].into_array();
         let reference = Scalar::from(100i32);
         let for_array = FoRArray::try_new(values, reference).unwrap();
-        test_filter_conformance(for_array.as_ref());
+        test_filter_conformance(&for_array.to_array());
 
         // Test with u64 values
         let values = buffer![1000u64, 1001, 1002, 1003, 1004].into_array();
         let reference = Scalar::from(1000u64);
         let for_array = FoRArray::try_new(values, reference).unwrap();
-        test_filter_conformance(for_array.as_ref());
+        test_filter_conformance(&for_array.to_array());
 
         // Test with nullable values
         let values =
             PrimitiveArray::from_option_iter([Some(50i16), None, Some(52), Some(53), None]);
         let reference = Scalar::from(50i16);
         let for_array = FoRArray::try_new(values.into_array(), reference).unwrap();
-        test_filter_conformance(for_array.as_ref());
+        test_filter_conformance(&for_array.to_array());
     }
 
     #[rstest]
@@ -88,7 +88,7 @@ mod test {
     #[case(FoRArray::try_new(buffer![42i64].into_array(), Scalar::from(40i64)).unwrap())]
     fn test_take_for_conformance(#[case] for_array: FoRArray) {
         use vortex_array::compute::conformance::take::test_take_conformance;
-        test_take_conformance(for_array.as_ref());
+        test_take_conformance(&for_array.to_array());
     }
 }
 
@@ -157,7 +157,7 @@ mod tests {
     ).unwrap())]
 
     fn test_for_consistency(#[case] array: FoRArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 
     #[rstest]

--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -40,9 +40,9 @@ pub struct RLEArray {
 
 impl RLEArray {
     fn validate(
-        values: &dyn Array,
-        indices: &dyn Array,
-        value_idx_offsets: &dyn Array,
+        values: &ArrayRef,
+        indices: &ArrayRef,
+        value_idx_offsets: &ArrayRef,
         offset: usize,
     ) -> VortexResult<()> {
         vortex_ensure!(

--- a/encodings/fastlanes/src/rle/array/rle_decompress.rs
+++ b/encodings/fastlanes/src/rle/array/rle_decompress.rs
@@ -102,6 +102,6 @@ where
         buffer
             .freeze()
             .slice(offset_within_chunk..(offset_within_chunk + array.len())),
-        Validity::copy_from_array(array.as_ref())?,
+        Validity::copy_from_array(&array.to_array())?,
     ))
 }

--- a/encodings/fastlanes/src/rle/compute/cast.rs
+++ b/encodings/fastlanes/src/rle/compute/cast.rs
@@ -139,6 +139,6 @@ mod tests {
     )]
     fn test_cast_rle_conformance(#[case] primitive: PrimitiveArray) {
         let rle_array = RLEArray::encode(&primitive).unwrap();
-        test_cast_conformance(rle_array.as_ref());
+        test_cast_conformance(&rle_array.to_array());
     }
 }

--- a/encodings/fsst/public-api.lock
+++ b/encodings/fsst/public-api.lock
@@ -94,7 +94,7 @@ pub fn vortex_fsst::FSSTVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> 
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_fsst::FSSTVTable
 
-pub fn vortex_fsst::FSSTVTable::take(array: &vortex_fsst::FSSTArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fsst::FSSTVTable::take(array: &vortex_fsst::FSSTArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_fsst::FSSTVTable
 
@@ -106,7 +106,7 @@ pub fn vortex_fsst::FSSTVTable::slice(array: &Self::Array, range: core::ops::ran
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_fsst::FSSTVTable
 
-pub fn vortex_fsst::FSSTVTable::compare(lhs: &vortex_fsst::FSSTArray, rhs: &dyn vortex_array::array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fsst::FSSTVTable::compare(lhs: &vortex_fsst::FSSTArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fsst::FSSTVTable
 

--- a/encodings/fsst/src/compute/cast.rs
+++ b/encodings/fsst/src/compute/cast.rs
@@ -85,6 +85,6 @@ mod tests {
     fn test_cast_fsst_conformance(#[case] array: VarBinArray) {
         let compressor = fsst_train_compressor(&array);
         let fsst = fsst_compress(&array, &compressor);
-        test_cast_conformance(fsst.as_ref());
+        test_cast_conformance(&fsst.to_array());
     }
 }

--- a/encodings/fsst/src/compute/compare.rs
+++ b/encodings/fsst/src/compute/compare.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_array::Array;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
@@ -29,7 +28,7 @@ use crate::FSSTVTable;
 impl CompareKernel for FSSTVTable {
     fn compare(
         lhs: &FSSTArray,
-        rhs: &dyn Array,
+        rhs: &ArrayRef,
         operator: CompareOperator,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
@@ -78,7 +77,7 @@ fn compare_fsst_constant(
         return Ok(Some(
             BoolArray::new(
                 buffer,
-                Validity::copy_from_array(left.as_ref())?
+                Validity::copy_from_array(&left.to_array())?
                     .union_nullability(right.dtype().nullability()),
             )
             .into_array(),

--- a/encodings/fsst/src/compute/filter.rs
+++ b/encodings/fsst/src/compute/filter.rs
@@ -61,7 +61,7 @@ mod test {
 
         let compressor = fsst_train_compressor(&varbin);
         let array = fsst_compress(&varbin, &compressor);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
 
         // Test with longer strings that benefit from compression
         let mut builder = VarBinBuilder::<i32>::with_capacity(5);
@@ -74,7 +74,7 @@ mod test {
 
         let compressor = fsst_train_compressor(&varbin);
         let array = fsst_compress(&varbin, &compressor);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
 
         // Test with nullable strings
         let mut builder = VarBinBuilder::<i32>::with_capacity(5);
@@ -87,6 +87,6 @@ mod test {
 
         let compressor = fsst_train_compressor(&varbin);
         let array = fsst_compress(&varbin, &compressor);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 }

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -23,7 +23,7 @@ use crate::FSSTVTable;
 impl TakeExecute for FSSTVTable {
     fn take(
         array: &FSSTArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
@@ -102,7 +102,7 @@ mod tests {
     fn test_take_fsst_conformance(#[case] varbin: VarBinArray) {
         let compressor = fsst_train_compressor(&varbin);
         let array = fsst_compress(&varbin, &compressor);
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 
     #[rstest]
@@ -172,6 +172,6 @@ mod tests {
     })]
 
     fn test_fsst_consistency(#[case] array: FSSTArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/encodings/pco/src/compute/cast.rs
+++ b/encodings/pco/src/compute/cast.rs
@@ -169,6 +169,6 @@ mod tests {
     ))]
     fn test_cast_pco_conformance(#[case] values: PrimitiveArray) {
         let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
-        test_cast_conformance(pco.as_ref());
+        test_cast_conformance(&pco.to_array());
     }
 }

--- a/encodings/pco/src/compute/mod.rs
+++ b/encodings/pco/src/compute/mod.rs
@@ -86,6 +86,6 @@ mod tests {
     #[case::single(pco_single())]
     #[case::large(pco_large())]
     fn test_pco_consistency(#[case] array: PcoArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/encodings/runend/public-api.lock
+++ b/encodings/runend/public-api.lock
@@ -116,7 +116,7 @@ pub fn vortex_runend::RunEndVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>)
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_runend::RunEndVTable
 
-pub fn vortex_runend::RunEndVTable::take(array: &vortex_runend::RunEndArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_runend::RunEndVTable::take(array: &vortex_runend::RunEndArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_runend::RunEndVTable
 
@@ -138,7 +138,7 @@ pub fn vortex_runend::RunEndVTable::min_max(&self, array: &vortex_runend::RunEnd
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_runend::RunEndVTable
 
-pub fn vortex_runend::RunEndVTable::compare(lhs: &vortex_runend::RunEndArray, rhs: &dyn vortex_array::array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_runend::RunEndVTable::compare(lhs: &vortex_runend::RunEndArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_runend::RunEndVTable
 

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -228,8 +228,8 @@ impl RunEndVTable {
 
 impl RunEndArray {
     fn validate(
-        ends: &dyn Array,
-        values: &dyn Array,
+        ends: &ArrayRef,
+        values: &ArrayRef,
         offset: usize,
         length: usize,
     ) -> VortexResult<()> {

--- a/encodings/runend/src/arrow.rs
+++ b/encodings/runend/src/arrow.rs
@@ -38,7 +38,7 @@ where
                 .as_primitive_typed()
                 .search_sorted(&PValue::from(offset), SearchSortedSide::Right)?
                 .to_ends_index(ends.len());
-            let slice_end = find_slice_end_index(ends.as_ref(), offset + len)?;
+            let slice_end = find_slice_end_index(&ends.to_array(), offset + len)?;
 
             (
                 ends.slice(slice_begin..slice_end)?,

--- a/encodings/runend/src/compute/cast.rs
+++ b/encodings/runend/src/compute/cast.rs
@@ -155,6 +155,6 @@ mod tests {
         BoolArray::from_iter(vec![true, false, true, false, true]).into_array()
     ).unwrap())]
     fn test_cast_runend_conformance(#[case] array: RunEndArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/encodings/runend/src/compute/compare.rs
+++ b/encodings/runend/src/compute/compare.rs
@@ -20,7 +20,7 @@ use crate::compress::runend_decode_bools;
 impl CompareKernel for RunEndVTable {
     fn compare(
         lhs: &RunEndArray,
-        rhs: &dyn Array,
+        rhs: &ArrayRef,
         operator: CompareOperator,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/encodings/runend/src/compute/is_sorted.rs
+++ b/encodings/runend/src/compute/is_sorted.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::IntoArray as _;
 use vortex_array::compute::IsSortedKernel;
 use vortex_array::compute::IsSortedKernelAdapter;
 use vortex_array::compute::is_sorted;
@@ -17,7 +18,7 @@ impl IsSortedKernel for RunEndVTable {
     }
 
     fn is_strict_sorted(&self, array: &RunEndArray) -> VortexResult<Option<bool>> {
-        is_strict_sorted(array.to_canonical()?.as_ref())
+        is_strict_sorted(&array.to_canonical()?.into_array())
     }
 }
 

--- a/encodings/runend/src/compute/mod.rs
+++ b/encodings/runend/src/compute/mod.rs
@@ -45,6 +45,6 @@ mod tests {
     ).unwrap())]
 
     fn test_runend_consistency(#[case] array: RunEndArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/encodings/runend/src/compute/take.rs
+++ b/encodings/runend/src/compute/take.rs
@@ -29,7 +29,7 @@ impl TakeExecute for RunEndVTable {
     )]
     fn take(
         array: &RunEndArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let primitive_indices = indices.to_primitive();
@@ -182,7 +182,7 @@ mod test {
         RunEndArray::encode(PrimitiveArray::from_iter(values).into_array()).unwrap()
     })]
     fn test_take_runend_conformance(#[case] array: RunEndArray) {
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 
     #[rstest]
@@ -195,6 +195,6 @@ mod test {
         array.slice(2..8).unwrap()
     })]
     fn test_take_sliced_runend_conformance(#[case] sliced: ArrayRef) {
-        test_take_conformance(sliced.as_ref());
+        test_take_conformance(&sliced);
     }
 }

--- a/encodings/runend/src/ops.rs
+++ b/encodings/runend/src/ops.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use vortex_array::Array;
+use vortex_array::ArrayRef;
 use vortex_array::scalar::PValue;
 use vortex_array::scalar::Scalar;
 use vortex_array::search_sorted::SearchResult;
@@ -23,7 +23,7 @@ impl OperationsVTable<RunEndVTable> for RunEndVTable {
 ///
 /// If the index exists in the array we want to take that position (as we are searching from the right)
 /// otherwise we want to take the next one
-pub(crate) fn find_slice_end_index(array: &dyn Array, index: usize) -> VortexResult<usize> {
+pub(crate) fn find_slice_end_index(array: &ArrayRef, index: usize) -> VortexResult<usize> {
     let result = array
         .as_primitive_typed()
         .search_sorted(&PValue::from(index), SearchSortedSide::Right)?;

--- a/encodings/sequence/public-api.lock
+++ b/encodings/sequence/public-api.lock
@@ -68,7 +68,7 @@ pub fn vortex_sequence::SequenceVTable::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_sequence::SequenceVTable
 
-pub fn vortex_sequence::SequenceVTable::take(array: &vortex_sequence::SequenceArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_sequence::SequenceVTable::take(array: &vortex_sequence::SequenceArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_sequence::SequenceVTable
 
@@ -90,7 +90,7 @@ pub fn vortex_sequence::SequenceVTable::min_max(&self, array: &vortex_sequence::
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_sequence::SequenceVTable
 
-pub fn vortex_sequence::SequenceVTable::compare(lhs: &vortex_sequence::SequenceArray, rhs: &dyn vortex_array::array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_sequence::SequenceVTable::compare(lhs: &vortex_sequence::SequenceArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_sequence::SequenceVTable
 
@@ -98,7 +98,7 @@ pub fn vortex_sequence::SequenceVTable::cast(array: &vortex_sequence::SequenceAr
 
 impl vortex_array::scalar_fn::fns::list_contains::kernel::ListContainsElementReduce for vortex_sequence::SequenceVTable
 
-pub fn vortex_sequence::SequenceVTable::list_contains(list: &dyn vortex_array::array::Array, element: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_sequence::SequenceVTable::list_contains(list: &vortex_array::array::ArrayRef, element: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::vtable::VTable for vortex_sequence::SequenceVTable
 

--- a/encodings/sequence/src/compute/cast.rs
+++ b/encodings/sequence/src/compute/cast.rs
@@ -195,6 +195,6 @@ mod tests {
         5,
     ).unwrap())]
     fn test_cast_sequence_conformance(#[case] sequence: SequenceArray) {
-        test_cast_conformance(sequence.as_ref());
+        test_cast_conformance(&sequence.to_array());
     }
 }

--- a/encodings/sequence/src/compute/compare.rs
+++ b/encodings/sequence/src/compute/compare.rs
@@ -25,7 +25,7 @@ use crate::array::SequenceVTable;
 impl CompareKernel for SequenceVTable {
     fn compare(
         lhs: &SequenceArray,
-        rhs: &dyn Array,
+        rhs: &ArrayRef,
         operator: CompareOperator,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/encodings/sequence/src/compute/filter.rs
+++ b/encodings/sequence/src/compute/filter.rs
@@ -68,6 +68,6 @@ mod tests {
     #[case(SequenceArray::typed_new(0u32, 5, Nullability::NonNullable, MEDIUM_SIZE).unwrap())]
     #[case(SequenceArray::typed_new(0u64, 1, Nullability::NonNullable, LARGE_SIZE).unwrap())]
     fn test_filter_sequence_conformance(#[case] array: SequenceArray) {
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 }

--- a/encodings/sequence/src/compute/list_contains.rs
+++ b/encodings/sequence/src/compute/list_contains.rs
@@ -12,7 +12,7 @@ use crate::array::SequenceVTable;
 use crate::compute::compare::find_intersection_scalar;
 
 impl ListContainsElementReduce for SequenceVTable {
-    fn list_contains(list: &dyn Array, element: &Self::Array) -> VortexResult<Option<ArrayRef>> {
+    fn list_contains(list: &ArrayRef, element: &Self::Array) -> VortexResult<Option<ArrayRef>> {
         let Some(list_scalar) = list.as_constant() else {
             return Ok(None);
         };

--- a/encodings/sequence/src/compute/mod.rs
+++ b/encodings/sequence/src/compute/mod.rs
@@ -82,6 +82,6 @@ mod tests {
     ).unwrap())] // Results in [1000, 1100, 1200, ..., 150900]
 
     fn test_sequence_consistency(#[case] array: SequenceArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/encodings/sequence/src/compute/take.rs
+++ b/encodings/sequence/src/compute/take.rs
@@ -76,7 +76,7 @@ fn take_inner<T: IntegerPType, S: NativePType>(
 impl TakeExecute for SequenceVTable {
     fn take(
         array: &SequenceArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let mask = indices.validity_mask()?;
@@ -162,7 +162,7 @@ mod test {
     ).unwrap())]
     fn test_take_conformance(#[case] sequence: SequenceArray) {
         use vortex_array::compute::conformance::take::test_take_conformance;
-        test_take_conformance(sequence.as_ref());
+        test_take_conformance(&sequence.to_array());
     }
 
     #[test]

--- a/encodings/sparse/public-api.lock
+++ b/encodings/sparse/public-api.lock
@@ -4,7 +4,7 @@ pub struct vortex_sparse::SparseArray
 
 impl vortex_sparse::SparseArray
 
-pub fn vortex_sparse::SparseArray::encode(array: &dyn vortex_array::array::Array, fill_value: core::option::Option<vortex_array::scalar::Scalar>) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_sparse::SparseArray::encode(array: &vortex_array::array::ArrayRef, fill_value: core::option::Option<vortex_array::scalar::Scalar>) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
 
 pub fn vortex_sparse::SparseArray::fill_scalar(&self) -> &vortex_array::scalar::Scalar
 
@@ -74,7 +74,7 @@ pub fn vortex_sparse::SparseVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>)
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_sparse::SparseVTable
 
-pub fn vortex_sparse::SparseVTable::take(array: &vortex_sparse::SparseArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_sparse::SparseVTable::take(array: &vortex_sparse::SparseArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_sparse::SparseVTable
 

--- a/encodings/sparse/src/compute/cast.rs
+++ b/encodings/sparse/src/compute/cast.rs
@@ -112,6 +112,6 @@ mod tests {
         Scalar::from(0u8)
     ).unwrap())]
     fn test_cast_sparse_conformance(#[case] array: SparseArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/encodings/sparse/src/compute/filter.rs
+++ b/encodings/sparse/src/compute/filter.rs
@@ -120,7 +120,7 @@ mod tests {
     fn test_filter_sparse_array() {
         let null_fill_value = Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable));
         test_filter_conformance(
-            SparseArray::try_new(
+            &SparseArray::try_new(
                 buffer![1u64, 2, 4].into_array(),
                 buffer![100i32, 200, 300]
                     .into_array()
@@ -130,19 +130,19 @@ mod tests {
                 null_fill_value,
             )
             .unwrap()
-            .as_ref(),
+            .to_array(),
         );
 
         let ten_fill_value = Scalar::from(10i32);
         test_filter_conformance(
-            SparseArray::try_new(
+            &SparseArray::try_new(
                 buffer![1u64, 2, 4].into_array(),
                 buffer![100i32, 200, 300].into_array(),
                 5,
                 ten_fill_value,
             )
             .unwrap()
-            .as_ref(),
+            .to_array(),
         )
     }
 }

--- a/encodings/sparse/src/compute/mod.rs
+++ b/encodings/sparse/src/compute/mod.rs
@@ -97,7 +97,7 @@ mod test {
     fn test_mask_sparse_array() {
         let null_fill_value = Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable));
         test_mask_conformance(
-            SparseArray::try_new(
+            &SparseArray::try_new(
                 buffer![1u64, 2, 4].into_array(),
                 buffer![100i32, 200, 300]
                     .into_array()
@@ -107,19 +107,19 @@ mod test {
                 null_fill_value,
             )
             .unwrap()
-            .as_ref(),
+            .to_array(),
         );
 
         let ten_fill_value = Scalar::from(10i32);
         test_mask_conformance(
-            SparseArray::try_new(
+            &SparseArray::try_new(
                 buffer![1u64, 2, 4].into_array(),
                 buffer![100i32, 200, 300].into_array(),
                 5,
                 ten_fill_value,
             )
             .unwrap()
-            .as_ref(),
+            .to_array(),
         )
     }
 }
@@ -202,7 +202,7 @@ mod tests {
     })]
 
     fn test_sparse_consistency(#[case] array: SparseArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 
     #[rstest]

--- a/encodings/sparse/src/compute/take.rs
+++ b/encodings/sparse/src/compute/take.rs
@@ -15,7 +15,7 @@ use crate::SparseVTable;
 impl TakeExecute for SparseVTable {
     fn take(
         array: &SparseArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let patches_take = if array.fill_scalar().is_null() {
@@ -199,6 +199,6 @@ mod test {
     ).unwrap())]
     fn test_take_sparse_conformance(#[case] sparse: SparseArray) {
         use vortex_array::compute::conformance::take::test_take_conformance;
-        test_take_conformance(sparse.as_ref());
+        test_take_conformance(&sparse.to_array());
     }
 }

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -345,7 +345,7 @@ impl SparseArray {
     /// Encode given array as a SparseArray.
     ///
     /// Optionally provided fill value will be respected if the array is less than 90% null.
-    pub fn encode(array: &dyn Array, fill_value: Option<Scalar>) -> VortexResult<ArrayRef> {
+    pub fn encode(array: &ArrayRef, fill_value: Option<Scalar>) -> VortexResult<ArrayRef> {
         if let Some(fill_value) = fill_value.as_ref()
             && array.dtype() != fill_value.dtype()
         {

--- a/encodings/zigzag/public-api.lock
+++ b/encodings/zigzag/public-api.lock
@@ -50,7 +50,7 @@ pub fn vortex_zigzag::ZigZagVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>)
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_zigzag::ZigZagVTable
 
-pub fn vortex_zigzag::ZigZagVTable::take(array: &vortex_zigzag::ZigZagArray, indices: &dyn vortex_array::array::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_zigzag::ZigZagVTable::take(array: &vortex_zigzag::ZigZagArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_zigzag::ZigZagVTable
 

--- a/encodings/zigzag/src/compute/cast.rs
+++ b/encodings/zigzag/src/compute/cast.rs
@@ -127,6 +127,6 @@ mod tests {
     #[case(zigzag_encode(PrimitiveArray::from_option_iter([Some(-5i16), None, Some(0), Some(5), None])).unwrap())]
     #[case(zigzag_encode(PrimitiveArray::from_iter([i32::MIN, -1, 0, 1, i32::MAX])).unwrap())]
     fn test_cast_zigzag_conformance(#[case] array: ZigZagArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/encodings/zigzag/src/compute/mod.rs
+++ b/encodings/zigzag/src/compute/mod.rs
@@ -29,7 +29,7 @@ impl FilterReduce for ZigZagVTable {
 impl TakeExecute for ZigZagVTable {
     fn take(
         array: &ZigZagArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let encoded = array.encoded().take(indices.to_array())?;
@@ -140,20 +140,20 @@ mod tests {
             buffer![-189i32, -160, 1, 42, -73],
             Validity::AllValid,
         ))?;
-        test_filter_conformance(zigzag.as_ref());
+        test_filter_conformance(&zigzag.to_array());
 
         // Test with i64 values
         let zigzag = zigzag_encode(PrimitiveArray::new(
             buffer![1000i64, -2000, 3000, -4000, 5000],
             Validity::AllValid,
         ))?;
-        test_filter_conformance(zigzag.as_ref());
+        test_filter_conformance(&zigzag.to_array());
 
         // Test with nullable values
         let array =
             PrimitiveArray::from_option_iter([Some(-10i16), None, Some(20), Some(-30), None]);
         let zigzag = zigzag_encode(array)?;
-        test_filter_conformance(zigzag.as_ref());
+        test_filter_conformance(&zigzag.to_array());
         Ok(())
     }
 
@@ -166,14 +166,14 @@ mod tests {
             buffer![-100i32, 200, -300, 400, -500],
             Validity::AllValid,
         ))?;
-        test_mask_conformance(zigzag.as_ref());
+        test_mask_conformance(&zigzag.to_array());
 
         // Test with i8 values
         let zigzag = zigzag_encode(PrimitiveArray::new(
             buffer![-127i8, 0, 127, -1, 1],
             Validity::AllValid,
         ))?;
-        test_mask_conformance(zigzag.as_ref());
+        test_mask_conformance(&zigzag.to_array());
         Ok(())
     }
 
@@ -187,7 +187,7 @@ mod tests {
         use vortex_array::compute::conformance::take::test_take_conformance;
 
         let zigzag = zigzag_encode(array.to_primitive())?;
-        test_take_conformance(zigzag.as_ref());
+        test_take_conformance(&zigzag.to_array());
         Ok(())
     }
 
@@ -214,7 +214,7 @@ mod tests {
     #[case::zigzag_large_i64(zigzag_encode(PrimitiveArray::from_iter((-1000..1000).map(|i| i as i64 * 100))).unwrap()
     )]
     fn test_zigzag_consistency(#[case] array: ZigZagArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 
     #[rstest]

--- a/encodings/zstd/src/compute/cast.rs
+++ b/encodings/zstd/src/compute/cast.rs
@@ -188,6 +188,6 @@ mod tests {
     ))]
     fn test_cast_zstd_conformance(#[case] values: PrimitiveArray) {
         let zstd = ZstdArray::from_primitive(&values, 0, 0).unwrap();
-        test_cast_conformance(zstd.as_ref());
+        test_cast_conformance(&zstd.to_array());
     }
 }

--- a/encodings/zstd/src/compute/mod.rs
+++ b/encodings/zstd/src/compute/mod.rs
@@ -84,6 +84,6 @@ mod tests {
     #[case::all_same(zstd_all_same())]
     #[case::negative(zstd_negative())]
     fn test_zstd_consistency(#[case] array: ZstdArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/fuzz/src/array/compare.rs
+++ b/fuzz/src/array/compare.rs
@@ -21,7 +21,7 @@ use vortex_error::VortexExpect;
 use vortex_error::vortex_panic;
 
 pub fn compare_canonical_array(
-    array: &dyn Array,
+    array: &ArrayRef,
     value: &Scalar,
     operator: CompareOperator,
 ) -> ArrayRef {

--- a/fuzz/src/array/filter.rs
+++ b/fuzz/src/array/filter.rs
@@ -21,7 +21,7 @@ use vortex_error::VortexResult;
 
 use crate::array::take_canonical_array_non_nullable_indices;
 
-pub fn filter_canonical_array(array: &dyn Array, filter: &[bool]) -> VortexResult<ArrayRef> {
+pub fn filter_canonical_array(array: &ArrayRef, filter: &[bool]) -> VortexResult<ArrayRef> {
     let validity = if array.dtype().is_nullable() {
         let validity_buff = array.validity_mask()?.to_bit_buffer();
         Validity::from_iter(

--- a/fuzz/src/array/min_max.rs
+++ b/fuzz/src/array/min_max.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::Canonical;
+use vortex_array::IntoArray as _;
 use vortex_array::compute::MinMaxResult;
 use vortex_array::compute::min_max;
 use vortex_error::VortexResult;
@@ -9,5 +10,5 @@ use vortex_error::VortexResult;
 /// Compute min_max on the canonical form of the array to get a consistent baseline.
 pub fn min_max_canonical_array(canonical: Canonical) -> VortexResult<Option<MinMaxResult>> {
     // TODO(joe): replace with baseline not using canonical
-    min_max(canonical.as_ref())
+    min_max(&canonical.into_array())
 }

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -516,7 +516,7 @@ fn random_action_from_list(
 
 /// Compress an array using the given strategy.
 #[cfg(feature = "zstd")]
-pub fn compress_array(array: &dyn Array, strategy: CompressorStrategy) -> ArrayRef {
+pub fn compress_array(array: &ArrayRef, strategy: CompressorStrategy) -> ArrayRef {
     use vortex_btrblocks::BtrBlocksCompressorBuilder;
     use vortex_btrblocks::FloatCode;
     use vortex_btrblocks::IntCode;
@@ -538,7 +538,7 @@ pub fn compress_array(array: &dyn Array, strategy: CompressorStrategy) -> ArrayR
 
 /// Compress an array using the given strategy (only Default).
 #[cfg(not(feature = "zstd"))]
-pub fn compress_array(array: &dyn Array, _strategy: CompressorStrategy) -> ArrayRef {
+pub fn compress_array(array: &ArrayRef, _strategy: CompressorStrategy) -> ArrayRef {
     BtrBlocksCompressor::default()
         .compress(array)
         .vortex_expect("BtrBlocksCompressor compress should succeed in fuzz test")
@@ -566,7 +566,7 @@ pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> crate::error::VortexFuzz
                 let canonical = current_array
                     .to_canonical()
                     .vortex_expect("to_canonical should succeed in fuzz test");
-                current_array = compress_array(canonical.as_ref(), strategy);
+                current_array = compress_array(&canonical.into_array(), strategy);
                 assert_array_eq(&expected.array(), &current_array, i)?;
             }
             Action::Slice(range) => {

--- a/fuzz/src/array/search_sorted.rs
+++ b/fuzz/src/array/search_sorted.rs
@@ -5,6 +5,7 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 
 use vortex_array::Array;
+use vortex_array::ArrayRef;
 use vortex_array::ToCanonical;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::dtype::DType;
@@ -56,7 +57,7 @@ impl<T: NativePType> IndexOrd<Option<T>> for SearchPrimitiveSlice<T> {
 }
 
 pub fn search_sorted_canonical_array(
-    array: &dyn Array,
+    array: &ArrayRef,
     scalar: &Scalar,
     side: SearchSortedSide,
 ) -> VortexResult<SearchResult> {

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -21,7 +21,7 @@ use vortex_error::VortexResult;
 
 #[allow(clippy::unnecessary_fallible_conversions)]
 pub fn slice_canonical_array(
-    array: &dyn Array,
+    array: &ArrayRef,
     start: usize,
     stop: usize,
 ) -> VortexResult<ArrayRef> {

--- a/fuzz/src/array/sort.rs
+++ b/fuzz/src/array/sort.rs
@@ -21,7 +21,7 @@ use vortex_error::VortexResult;
 
 use crate::array::take_canonical_array_non_nullable_indices;
 
-pub fn sort_canonical_array(array: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn sort_canonical_array(array: &ArrayRef) -> VortexResult<ArrayRef> {
     match array.dtype() {
         DType::Bool(_) => {
             let bool_array = array.to_bool();

--- a/fuzz/src/array/sum.rs
+++ b/fuzz/src/array/sum.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::Canonical;
+use vortex_array::IntoArray as _;
 use vortex_array::compute::sum;
 use vortex_array::scalar::Scalar;
 use vortex_error::VortexResult;
@@ -9,5 +10,5 @@ use vortex_error::VortexResult;
 /// Compute sum on the canonical form of the array to get a consistent baseline.
 pub fn sum_canonical_array(canonical: Canonical) -> VortexResult<Scalar> {
     // TODO(joe): replace with baseline not using canonical
-    sum(canonical.as_ref())
+    sum(&canonical.into_array())
 }

--- a/fuzz/src/array/take.rs
+++ b/fuzz/src/array/take.rs
@@ -25,7 +25,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 pub fn take_canonical_array_non_nullable_indices(
-    array: &dyn Array,
+    array: &ArrayRef,
     indices: &[usize],
 ) -> VortexResult<ArrayRef> {
     take_canonical_array(
@@ -38,10 +38,7 @@ pub fn take_canonical_array_non_nullable_indices(
     )
 }
 
-pub fn take_canonical_array(
-    array: &dyn Array,
-    indices: &[Option<usize>],
-) -> VortexResult<ArrayRef> {
+pub fn take_canonical_array(array: &ArrayRef, indices: &[Option<usize>]) -> VortexResult<ArrayRef> {
     let nullable: Nullability = indices.contains(&None).into();
 
     let validity = if array.dtype().is_nullable() || nullable == Nullability::Nullable {

--- a/vortex-array/benches/dict_compare.rs
+++ b/vortex-array/benches/dict_compare.rs
@@ -49,7 +49,7 @@ const LENGTH_AND_UNIQUE_VALUES: &[(usize, usize)] = &[
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let primitive_arr = gen_primitive_for_dict::<i32>(len, uniqueness);
-    let dict = dict_encode(primitive_arr.as_ref()).unwrap();
+    let dict = dict_encode(&primitive_arr.to_array()).unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
     let session = VortexSession::empty();
 
@@ -67,7 +67,7 @@ fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, u
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(len, uniqueness));
-    let dict = dict_encode(varbin_arr.as_ref()).unwrap();
+    let dict = dict_encode(&varbin_arr.to_array()).unwrap();
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
     let session = VortexSession::empty();
@@ -86,7 +86,7 @@ fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usiz
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_varbinview(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(len, uniqueness));
-    let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
+    let dict = dict_encode(&varbinview_arr.to_array()).unwrap();
     let bytes = varbinview_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
     let session = VortexSession::empty();
@@ -120,7 +120,7 @@ fn bench_compare_sliced_dict_primitive(
     (codes_len, values_len): (usize, usize),
 ) {
     let primitive_arr = gen_primitive_for_dict::<i32>(codes_len.max(values_len), values_len);
-    let dict = dict_encode(primitive_arr.as_ref()).unwrap();
+    let dict = dict_encode(&primitive_arr.to_array()).unwrap();
     let dict = dict.slice(0..codes_len).unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
     let session = VortexSession::empty();
@@ -141,7 +141,7 @@ fn bench_compare_sliced_dict_varbinview(
     (codes_len, values_len): (usize, usize),
 ) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(codes_len.max(values_len), values_len));
-    let dict = dict_encode(varbin_arr.as_ref()).unwrap();
+    let dict = dict_encode(&varbin_arr.to_array()).unwrap();
     let dict = dict.slice(0..codes_len).unwrap();
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();

--- a/vortex-array/benches/dict_compress.rs
+++ b/vortex-array/benches/dict_compress.rs
@@ -43,7 +43,7 @@ where
 
     bencher
         .with_inputs(|| &primitive_arr)
-        .bench_refs(|arr| dict_encode(arr.as_ref()));
+        .bench_refs(|arr| dict_encode(&arr.to_array()));
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -52,7 +52,7 @@ fn encode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
 
     bencher
         .with_inputs(|| &varbin_arr)
-        .bench_refs(|arr| dict_encode(arr.as_ref()));
+        .bench_refs(|arr| dict_encode(&arr.to_array()));
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -61,7 +61,7 @@ fn encode_varbinview(bencher: Bencher, (len, unique_values): (usize, usize)) {
 
     bencher
         .with_inputs(|| &varbinview_arr)
-        .bench_refs(|arr| dict_encode(arr.as_ref()));
+        .bench_refs(|arr| dict_encode(&arr.to_array()));
 }
 
 #[divan::bench(types = [u8, f32, i64], args = BENCH_ARGS)]
@@ -71,7 +71,7 @@ where
     StandardUniform: Distribution<T>,
 {
     let primitive_arr = gen_primitive_for_dict::<T>(len, unique_values);
-    let dict = dict_encode(primitive_arr.as_ref()).unwrap();
+    let dict = dict_encode(&primitive_arr.to_array()).unwrap();
 
     bencher
         .with_inputs(|| &dict)
@@ -81,7 +81,7 @@ where
 #[divan::bench(args = BENCH_ARGS)]
 fn decode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(len, unique_values));
-    let dict = dict_encode(varbin_arr.as_ref()).unwrap();
+    let dict = dict_encode(&varbin_arr.to_array()).unwrap();
 
     bencher
         .with_inputs(|| &dict)
@@ -91,7 +91,7 @@ fn decode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
 #[divan::bench(args = BENCH_ARGS)]
 fn decode_varbinview(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(len, unique_values));
-    let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
+    let dict = dict_encode(&varbinview_arr.to_array()).unwrap();
 
     bencher
         .with_inputs(|| &dict)

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -142,7 +142,7 @@ pub fn vortex_array::arrays::DictVTable::slice(array: &Self::Array, range: core:
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DictVTable
 
@@ -160,7 +160,7 @@ pub fn vortex_array::arrays::DictVTable::min_max(&self, array: &vortex_array::ar
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &dyn vortex_array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::DictVTable
 
@@ -172,7 +172,7 @@ pub fn vortex_array::arrays::DictVTable::fill_null(array: &vortex_array::arrays:
 
 impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &dyn vortex_array::Array, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DictVTable
 
@@ -448,7 +448,7 @@ pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core:
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::BoolVTable
 
-pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::BoolVTable
 
@@ -620,7 +620,7 @@ pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: co
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ChunkedVTable
 
-pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &dyn vortex_array::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ChunkedVTable
 
@@ -654,7 +654,7 @@ pub fn vortex_array::arrays::ChunkedVTable::mask(array: &vortex_array::arrays::C
 
 impl vortex_array::scalar_fn::fns::zip::ZipReduce for vortex_array::arrays::ChunkedVTable
 
-pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &dyn vortex_array::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
 
@@ -778,7 +778,7 @@ pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: c
 
 impl vortex_array::arrays::TakeReduce for vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &dyn vortex_array::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ConstantVTable
 
@@ -790,7 +790,7 @@ pub fn vortex_array::arrays::ConstantVTable::sum(&self, array: &vortex_array::ar
 
 impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::between(array: &vortex_array::arrays::ConstantArray, lower: &dyn vortex_array::Array, upper: &dyn vortex_array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ConstantVTable::between(array: &vortex_array::arrays::ConstantArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ConstantVTable
 
@@ -980,7 +980,7 @@ pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: co
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DecimalVTable
 
-pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DecimalVTable
 
@@ -1008,7 +1008,7 @@ pub fn vortex_array::arrays::DecimalMaskedValidityRule::reduce_parent(&self, arr
 
 impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::DecimalVTable
 
-pub fn vortex_array::arrays::DecimalVTable::between(arr: &vortex_array::arrays::DecimalArray, lower: &dyn vortex_array::Array, upper: &dyn vortex_array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DecimalVTable::between(arr: &vortex_array::arrays::DecimalArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::DecimalVTable
 
@@ -1192,7 +1192,7 @@ pub fn vortex_array::arrays::DictVTable::slice(array: &Self::Array, range: core:
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DictVTable
 
@@ -1210,7 +1210,7 @@ pub fn vortex_array::arrays::DictVTable::min_max(&self, array: &vortex_array::ar
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &dyn vortex_array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::DictVTable
 
@@ -1222,7 +1222,7 @@ pub fn vortex_array::arrays::DictVTable::fill_null(array: &vortex_array::arrays:
 
 impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &dyn vortex_array::Array, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DictVTable
 
@@ -1384,7 +1384,7 @@ pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: 
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ExtensionVTable
 
-pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ExtensionVTable
 
@@ -1406,7 +1406,7 @@ pub fn vortex_array::arrays::ExtensionVTable::sum(&self, array: &vortex_array::a
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::ExtensionVTable
 
-pub fn vortex_array::arrays::ExtensionVTable::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &dyn vortex_array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ExtensionVTable::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ExtensionVTable
 
@@ -1646,7 +1646,7 @@ pub unsafe fn vortex_array::arrays::FixedSizeListArray::new_unchecked(elements: 
 
 pub fn vortex_array::arrays::FixedSizeListArray::try_new(elements: vortex_array::ArrayRef, list_size: u32, validity: vortex_array::validity::Validity, len: usize) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrays::FixedSizeListArray::validate(elements: &dyn vortex_array::Array, len: usize, list_size: u32, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::FixedSizeListArray::validate(elements: &vortex_array::ArrayRef, len: usize, list_size: u32, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
 impl core::clone::Clone for vortex_array::arrays::FixedSizeListArray
 
@@ -1698,7 +1698,7 @@ pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, ran
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::FixedSizeListVTable
 
-pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::FixedSizeListVTable
 
@@ -1834,7 +1834,7 @@ pub fn vortex_array::arrays::ListArray::sliced_elements(&self) -> vortex_error::
 
 pub fn vortex_array::arrays::ListArray::try_new(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrays::ListArray::validate(elements: &dyn vortex_array::Array, offsets: &dyn vortex_array::Array, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ListArray::validate(elements: &vortex_array::ArrayRef, offsets: &vortex_array::ArrayRef, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
 impl core::clone::Clone for vortex_array::arrays::ListArray
 
@@ -1896,7 +1896,7 @@ pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core:
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ListVTable
 
-pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListVTable
 
@@ -2004,7 +2004,7 @@ pub fn vortex_array::arrays::ListViewArray::sizes(&self) -> &vortex_array::Array
 
 pub fn vortex_array::arrays::ListViewArray::try_new(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, sizes: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrays::ListViewArray::validate(elements: &dyn vortex_array::Array, offsets: &dyn vortex_array::Array, sizes: &dyn vortex_array::Array, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ListViewArray::validate(elements: &vortex_array::ArrayRef, offsets: &vortex_array::ArrayRef, sizes: &vortex_array::ArrayRef, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::ListViewArray::verify_is_zero_copy_to_list(&self) -> bool
 
@@ -2076,7 +2076,7 @@ pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: c
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ListViewVTable
 
-pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListViewVTable
 
@@ -2216,7 +2216,7 @@ pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: cor
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::MaskedVTable
 
@@ -2406,7 +2406,7 @@ pub fn vortex_array::arrays::NullVTable::slice(_array: &Self::Array, range: core
 
 impl vortex_array::arrays::TakeReduce for vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::take(array: &vortex_array::arrays::NullArray, indices: &dyn vortex_array::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::NullVTable::take(array: &vortex_array::arrays::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::NullVTable
 
@@ -2628,7 +2628,7 @@ pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: 
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::PrimitiveVTable
 
-pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::PrimitiveVTable
 
@@ -2660,7 +2660,7 @@ pub fn vortex_array::arrays::PrimitiveMaskedValidityRule::reduce_parent(&self, a
 
 impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::PrimitiveVTable
 
-pub fn vortex_array::arrays::PrimitiveVTable::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &dyn vortex_array::Array, upper: &dyn vortex_array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::PrimitiveVTable::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::PrimitiveVTable
 
@@ -3270,7 +3270,7 @@ pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: cor
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::StructVTable
 
-pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::StructVTable
 
@@ -3290,7 +3290,7 @@ pub fn vortex_array::arrays::StructVTable::mask(array: &vortex_array::arrays::St
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::StructVTable
 
-pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &dyn vortex_array::Array, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
 
@@ -3478,7 +3478,7 @@ pub fn vortex_array::arrays::VarBinArray::try_new(offsets: vortex_array::ArrayRe
 
 pub fn vortex_array::arrays::VarBinArray::try_new_from_handle(offsets: vortex_array::ArrayRef, bytes: vortex_array::buffer::BufferHandle, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrays::VarBinArray::validate(offsets: &dyn vortex_array::Array, bytes: &vortex_array::buffer::BufferHandle, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::VarBinArray::validate(offsets: &vortex_array::ArrayRef, bytes: &vortex_array::buffer::BufferHandle, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
 impl core::clone::Clone for vortex_array::arrays::VarBinArray
 
@@ -3590,7 +3590,7 @@ pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: cor
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinVTable
 
-pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinVTable
 
@@ -3608,7 +3608,7 @@ pub fn vortex_array::arrays::VarBinVTable::min_max(&self, array: &vortex_array::
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBinVTable
 
-pub fn vortex_array::arrays::VarBinVTable::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &dyn vortex_array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinVTable::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinVTable
 
@@ -3808,7 +3808,7 @@ pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range:
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinViewVTable
 
-pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinViewVTable
 
@@ -3834,7 +3834,7 @@ pub fn vortex_array::arrays::VarBinViewVTable::mask(array: &vortex_array::arrays
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinViewVTable
 
-pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &dyn vortex_array::Array, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinViewVTable> for vortex_array::arrays::VarBinViewVTable
 
@@ -4026,71 +4026,71 @@ pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range:
 
 pub trait vortex_array::arrays::TakeExecute: vortex_array::vtable::VTable
 
-pub fn vortex_array::arrays::TakeExecute::take(array: &Self::Array, indices: &dyn vortex_array::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::TakeExecute::take(array: &Self::Array, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::BoolVTable
 
-pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ChunkedVTable
 
-pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &dyn vortex_array::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DecimalVTable
 
-pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ExtensionVTable
 
-pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::FixedSizeListVTable
 
-pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ListVTable
 
-pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ListViewVTable
 
-pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::PrimitiveVTable
 
-pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::StructVTable
 
-pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinVTable
 
-pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinViewVTable
 
-pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &dyn vortex_array::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::arrays::TakeReduce: vortex_array::vtable::VTable
 
-pub fn vortex_array::arrays::TakeReduce::take(array: &Self::Array, indices: &dyn vortex_array::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::TakeReduce::take(array: &Self::Array, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeReduce for vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &dyn vortex_array::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeReduce for vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::take(array: &vortex_array::arrays::NullArray, indices: &dyn vortex_array::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::NullVTable::take(array: &vortex_array::arrays::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::chunk_range(chunk_idx: usize, offset: usize, array_len: usize) -> core::ops::range::Range<usize>
 
@@ -4134,11 +4134,11 @@ impl vortex_array::compute::Options for vortex_array::arrow::compute::ToArrowOpt
 
 pub fn vortex_array::arrow::compute::ToArrowOptions::as_any(&self) -> &dyn core::any::Any
 
-pub fn vortex_array::arrow::compute::to_arrow(array: &dyn vortex_array::Array, arrow_type: &arrow_schema::datatype::DataType) -> vortex_error::VortexResult<arrow_array::array::ArrayRef>
+pub fn vortex_array::arrow::compute::to_arrow(array: &vortex_array::ArrayRef, arrow_type: &arrow_schema::datatype::DataType) -> vortex_error::VortexResult<arrow_array::array::ArrayRef>
 
-pub fn vortex_array::arrow::compute::to_arrow_opts(array: &dyn vortex_array::Array, options: &vortex_array::arrow::compute::ToArrowOptions) -> vortex_error::VortexResult<arrow_array::array::ArrayRef>
+pub fn vortex_array::arrow::compute::to_arrow_opts(array: &vortex_array::ArrayRef, options: &vortex_array::arrow::compute::ToArrowOptions) -> vortex_error::VortexResult<arrow_array::array::ArrayRef>
 
-pub fn vortex_array::arrow::compute::to_arrow_preferred(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<arrow_array::array::ArrayRef>
+pub fn vortex_array::arrow::compute::to_arrow_preferred(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<arrow_array::array::ArrayRef>
 
 pub mod vortex_array::arrow::null
 
@@ -4276,11 +4276,11 @@ impl vortex_array::arrow::Datum
 
 pub fn vortex_array::arrow::Datum::data_type(&self) -> &arrow_schema::datatype::DataType
 
-pub fn vortex_array::arrow::Datum::try_new(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrow::Datum::try_new(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrow::Datum::try_new_array(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrow::Datum::try_new_array(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrow::Datum::try_new_with_target_datatype(array: &dyn vortex_array::Array, target_datatype: &arrow_schema::datatype::DataType) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrow::Datum::try_new_with_target_datatype(array: &vortex_array::ArrayRef, target_datatype: &arrow_schema::datatype::DataType) -> vortex_error::VortexResult<Self>
 
 impl arrow_array::scalar::Datum for vortex_array::arrow::Datum
 
@@ -4598,15 +4598,15 @@ pub trait vortex_array::builders::dict::DictEncoder: core::marker::Send
 
 pub fn vortex_array::builders::dict::DictEncoder::codes_ptype(&self) -> vortex_array::dtype::PType
 
-pub fn vortex_array::builders::dict::DictEncoder::encode(&mut self, array: &dyn vortex_array::Array) -> vortex_array::ArrayRef
+pub fn vortex_array::builders::dict::DictEncoder::encode(&mut self, array: &vortex_array::ArrayRef) -> vortex_array::ArrayRef
 
 pub fn vortex_array::builders::dict::DictEncoder::reset(&mut self) -> vortex_array::ArrayRef
 
-pub fn vortex_array::builders::dict::dict_encode(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
+pub fn vortex_array::builders::dict::dict_encode(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
 
-pub fn vortex_array::builders::dict::dict_encode_with_constraints(array: &dyn vortex_array::Array, constraints: &vortex_array::builders::dict::DictConstraints) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
+pub fn vortex_array::builders::dict::dict_encode_with_constraints(array: &vortex_array::ArrayRef, constraints: &vortex_array::builders::dict::DictConstraints) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
 
-pub fn vortex_array::builders::dict::dict_encoder(array: &dyn vortex_array::Array, constraints: &vortex_array::builders::dict::DictConstraints) -> alloc::boxed::Box<dyn vortex_array::builders::dict::DictEncoder>
+pub fn vortex_array::builders::dict::dict_encoder(array: &vortex_array::ArrayRef, constraints: &vortex_array::builders::dict::DictConstraints) -> alloc::boxed::Box<dyn vortex_array::builders::dict::DictEncoder>
 
 pub enum vortex_array::builders::BufferGrowthStrategy
 
@@ -4688,9 +4688,9 @@ pub fn vortex_array::builders::BoolBuilder::as_any_mut(&mut self) -> &mut dyn co
 
 pub fn vortex_array::builders::BoolBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::BoolBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::BoolBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::BoolBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::BoolBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::BoolBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -4744,9 +4744,9 @@ pub fn vortex_array::builders::DecimalBuilder::as_any_mut(&mut self) -> &mut dyn
 
 pub fn vortex_array::builders::DecimalBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::DecimalBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::DecimalBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::DecimalBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::DecimalBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::DecimalBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -4804,9 +4804,9 @@ pub fn vortex_array::builders::ExtensionBuilder::as_any_mut(&mut self) -> &mut d
 
 pub fn vortex_array::builders::ExtensionBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::ExtensionBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::ExtensionBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::ExtensionBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::ExtensionBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::ExtensionBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -4826,7 +4826,7 @@ pub struct vortex_array::builders::FixedSizeListBuilder
 
 impl vortex_array::builders::FixedSizeListBuilder
 
-pub fn vortex_array::builders::FixedSizeListBuilder::append_array_as_list(&mut self, array: &dyn vortex_array::Array) -> vortex_error::VortexResult<()>
+pub fn vortex_array::builders::FixedSizeListBuilder::append_array_as_list(&mut self, array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::builders::FixedSizeListBuilder::append_value(&mut self, value: vortex_array::scalar::ListScalar<'_>) -> vortex_error::VortexResult<()>
 
@@ -4864,9 +4864,9 @@ pub fn vortex_array::builders::FixedSizeListBuilder::as_any_mut(&mut self) -> &m
 
 pub fn vortex_array::builders::FixedSizeListBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::FixedSizeListBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::FixedSizeListBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::FixedSizeListBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::FixedSizeListBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::FixedSizeListBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -4886,7 +4886,7 @@ pub struct vortex_array::builders::ListBuilder<O: vortex_array::dtype::IntegerPT
 
 impl<O: vortex_array::dtype::IntegerPType> vortex_array::builders::ListBuilder<O>
 
-pub fn vortex_array::builders::ListBuilder<O>::append_array_as_list(&mut self, array: &dyn vortex_array::Array) -> vortex_error::VortexResult<()>
+pub fn vortex_array::builders::ListBuilder<O>::append_array_as_list(&mut self, array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::builders::ListBuilder<O>::append_value(&mut self, value: vortex_array::scalar::ListScalar<'_>) -> vortex_error::VortexResult<()>
 
@@ -4922,9 +4922,9 @@ pub fn vortex_array::builders::ListBuilder<O>::as_any_mut(&mut self) -> &mut dyn
 
 pub fn vortex_array::builders::ListBuilder<O>::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::ListBuilder<O>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::ListBuilder<O>::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::ListBuilder<O>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::ListBuilder<O>::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::ListBuilder<O>::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -4944,7 +4944,7 @@ pub struct vortex_array::builders::ListViewBuilder<O: vortex_array::dtype::Integ
 
 impl<O: vortex_array::dtype::IntegerPType, S: vortex_array::dtype::IntegerPType> vortex_array::builders::ListViewBuilder<O, S>
 
-pub fn vortex_array::builders::ListViewBuilder<O, S>::append_array_as_list(&mut self, array: &dyn vortex_array::Array) -> vortex_error::VortexResult<()>
+pub fn vortex_array::builders::ListViewBuilder<O, S>::append_array_as_list(&mut self, array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::append_value(&mut self, value: vortex_array::scalar::ListScalar<'_>) -> vortex_error::VortexResult<()>
 
@@ -4980,9 +4980,9 @@ pub fn vortex_array::builders::ListViewBuilder<O, S>::as_any_mut(&mut self) -> &
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5032,9 +5032,9 @@ pub fn vortex_array::builders::NullBuilder::as_any_mut(&mut self) -> &mut dyn co
 
 pub fn vortex_array::builders::NullBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::NullBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::NullBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::NullBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::NullBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::NullBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5092,9 +5092,9 @@ pub fn vortex_array::builders::PrimitiveBuilder<T>::as_any_mut(&mut self) -> &mu
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5148,9 +5148,9 @@ pub fn vortex_array::builders::StructBuilder::as_any_mut(&mut self) -> &mut dyn 
 
 pub fn vortex_array::builders::StructBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::StructBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::StructBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::StructBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::StructBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::StructBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5230,9 +5230,9 @@ pub fn vortex_array::builders::VarBinViewBuilder::as_any_mut(&mut self) -> &mut 
 
 pub fn vortex_array::builders::VarBinViewBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::VarBinViewBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::VarBinViewBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::VarBinViewBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::VarBinViewBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::VarBinViewBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5274,9 +5274,9 @@ pub fn vortex_array::builders::ArrayBuilder::as_any_mut(&mut self) -> &mut dyn c
 
 pub fn vortex_array::builders::ArrayBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::ArrayBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::ArrayBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::ArrayBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::ArrayBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::ArrayBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5316,9 +5316,9 @@ pub fn vortex_array::builders::BoolBuilder::as_any_mut(&mut self) -> &mut dyn co
 
 pub fn vortex_array::builders::BoolBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::BoolBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::BoolBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::BoolBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::BoolBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::BoolBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5358,9 +5358,9 @@ pub fn vortex_array::builders::DecimalBuilder::as_any_mut(&mut self) -> &mut dyn
 
 pub fn vortex_array::builders::DecimalBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::DecimalBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::DecimalBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::DecimalBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::DecimalBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::DecimalBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5400,9 +5400,9 @@ pub fn vortex_array::builders::ExtensionBuilder::as_any_mut(&mut self) -> &mut d
 
 pub fn vortex_array::builders::ExtensionBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::ExtensionBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::ExtensionBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::ExtensionBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::ExtensionBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::ExtensionBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5442,9 +5442,9 @@ pub fn vortex_array::builders::FixedSizeListBuilder::as_any_mut(&mut self) -> &m
 
 pub fn vortex_array::builders::FixedSizeListBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::FixedSizeListBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::FixedSizeListBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::FixedSizeListBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::FixedSizeListBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::FixedSizeListBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5484,9 +5484,9 @@ pub fn vortex_array::builders::NullBuilder::as_any_mut(&mut self) -> &mut dyn co
 
 pub fn vortex_array::builders::NullBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::NullBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::NullBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::NullBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::NullBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::NullBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5526,9 +5526,9 @@ pub fn vortex_array::builders::StructBuilder::as_any_mut(&mut self) -> &mut dyn 
 
 pub fn vortex_array::builders::StructBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::StructBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::StructBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::StructBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::StructBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::StructBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5568,9 +5568,9 @@ pub fn vortex_array::builders::VarBinViewBuilder::as_any_mut(&mut self) -> &mut 
 
 pub fn vortex_array::builders::VarBinViewBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::VarBinViewBuilder::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::VarBinViewBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::VarBinViewBuilder::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::VarBinViewBuilder::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::VarBinViewBuilder::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5610,9 +5610,9 @@ pub fn vortex_array::builders::ListViewBuilder<O, S>::as_any_mut(&mut self) -> &
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5652,9 +5652,9 @@ pub fn vortex_array::builders::ListBuilder<O>::as_any_mut(&mut self) -> &mut dyn
 
 pub fn vortex_array::builders::ListBuilder<O>::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::ListBuilder<O>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::ListBuilder<O>::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::ListBuilder<O>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::ListBuilder<O>::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::ListBuilder<O>::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5694,9 +5694,9 @@ pub fn vortex_array::builders::PrimitiveBuilder<T>::as_any_mut(&mut self) -> &mu
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array(&mut self, array: &dyn vortex_array::Array)
+pub fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
 
-pub unsafe fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array_unchecked(&mut self, array: &dyn vortex_array::Array)
+pub unsafe fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array_unchecked(&mut self, array: &vortex_array::ArrayRef)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::finish(&mut self) -> vortex_array::ArrayRef
 
@@ -5859,6 +5859,10 @@ pub fn vortex_array::compute::Input<'_>::fmt(&self, f: &mut core::fmt::Formatter
 impl<'a> core::convert::From<&'a (dyn vortex_array::Array + 'static)> for vortex_array::compute::Input<'a>
 
 pub fn vortex_array::compute::Input<'a>::from(value: &'a dyn vortex_array::Array) -> Self
+
+impl<'a> core::convert::From<&'a alloc::sync::Arc<dyn vortex_array::Array>> for vortex_array::compute::Input<'a>
+
+pub fn vortex_array::compute::Input<'a>::from(value: &'a vortex_array::ArrayRef) -> Self
 
 impl<'a> core::convert::From<&'a vortex_array::dtype::DType> for vortex_array::compute::Input<'a>
 
@@ -6434,65 +6438,65 @@ impl vortex_array::compute::SumKernel for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::compute::add(lhs: &dyn vortex_array::Array, rhs: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::add(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::add_scalar(lhs: &dyn vortex_array::Array, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::add_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::and_kleene(lhs: &dyn vortex_array::Array, rhs: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::and_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::arrow_filter_fn(array: &dyn vortex_array::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::arrow_filter_fn(array: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::compute::cast(array: &dyn vortex_array::Array, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::compute::compare_lengths_to_empty<P, I>(lengths: I, op: vortex_array::scalar_fn::fns::operators::CompareOperator) -> vortex_buffer::bit::buf::BitBuffer where P: vortex_array::dtype::IntegerPType, I: core::iter::traits::iterator::Iterator<Item = P>
 
-pub fn vortex_array::compute::div(lhs: &dyn vortex_array::Array, rhs: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::div(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::div_scalar(lhs: &dyn vortex_array::Array, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::div_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::fill_null(array: &dyn vortex_array::Array, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::fill_null(array: &vortex_array::ArrayRef, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::filter(array: &dyn vortex_array::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::filter(array: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::invert(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::invert(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::is_constant(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::compute::is_constant(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::compute::is_constant_opts(array: &dyn vortex_array::Array, options: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::compute::is_constant_opts(array: &vortex_array::ArrayRef, options: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::compute::is_sorted(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::compute::is_sorted(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::compute::is_sorted_opts(array: &dyn vortex_array::Array, strict: bool) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::compute::is_sorted_opts(array: &vortex_array::ArrayRef, strict: bool) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::compute::is_strict_sorted(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::compute::is_strict_sorted(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::compute::list_contains(array: &dyn vortex_array::Array, value: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::list_contains(array: &vortex_array::ArrayRef, value: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::mask(array: &dyn vortex_array::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::mask(array: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::min_max(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::compute::min_max(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-pub fn vortex_array::compute::mul(lhs: &dyn vortex_array::Array, rhs: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::mul(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::mul_scalar(lhs: &dyn vortex_array::Array, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::mul_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::nan_count(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<usize>
+pub fn vortex_array::compute::nan_count(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<usize>
 
-pub fn vortex_array::compute::numeric(lhs: &dyn vortex_array::Array, rhs: &dyn vortex_array::Array, op: vortex_array::scalar::NumericOperator) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::numeric(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef, op: vortex_array::scalar::NumericOperator) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::or_kleene(lhs: &dyn vortex_array::Array, rhs: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::or_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::sub(lhs: &dyn vortex_array::Array, rhs: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::sub(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::sub_scalar(lhs: &dyn vortex_array::Array, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::sub_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::compute::sum(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::compute::sum(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::compute::sum_impl(array: &dyn vortex_array::Array, accumulator: &vortex_array::scalar::Scalar, kernels: &[arcref::ArcRef<dyn vortex_array::compute::Kernel>]) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::compute::sum_impl(array: &vortex_array::ArrayRef, accumulator: &vortex_array::scalar::Scalar, kernels: &[arcref::ArcRef<dyn vortex_array::compute::Kernel>]) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::compute::warm_up_vtables()
 
-pub fn vortex_array::compute::zip(if_true: &dyn vortex_array::Array, if_false: &dyn vortex_array::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::compute::zip(if_true: &vortex_array::ArrayRef, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub mod vortex_array::display
 
@@ -11180,13 +11184,13 @@ pub fn vortex_array::patches::Patches::search_index(&self, index: usize) -> vort
 
 pub fn vortex_array::patches::Patches::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<Self>>
 
-pub fn vortex_array::patches::Patches::take(&self, take_indices: &dyn vortex_array::Array) -> vortex_error::VortexResult<core::option::Option<Self>>
+pub fn vortex_array::patches::Patches::take(&self, take_indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<Self>>
 
 pub fn vortex_array::patches::Patches::take_map(&self, take_indices: vortex_array::arrays::PrimitiveArray, include_nulls: bool) -> vortex_error::VortexResult<core::option::Option<Self>>
 
 pub fn vortex_array::patches::Patches::take_search(&self, take_indices: vortex_array::arrays::PrimitiveArray, include_nulls: bool) -> vortex_error::VortexResult<core::option::Option<Self>>
 
-pub fn vortex_array::patches::Patches::take_with_nulls(&self, take_indices: &dyn vortex_array::Array) -> vortex_error::VortexResult<core::option::Option<Self>>
+pub fn vortex_array::patches::Patches::take_with_nulls(&self, take_indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<Self>>
 
 pub fn vortex_array::patches::Patches::to_metadata(&self, len: usize, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::patches::PatchesMetadata>
 
@@ -13270,23 +13274,23 @@ pub fn vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::reduce_pa
 
 pub trait vortex_array::scalar_fn::fns::between::BetweenKernel: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::between::BetweenKernel::between(array: &Self::Array, lower: &dyn vortex_array::Array, upper: &dyn vortex_array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::between::BetweenKernel::between(array: &Self::Array, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::DecimalVTable
 
-pub fn vortex_array::arrays::DecimalVTable::between(arr: &vortex_array::arrays::DecimalArray, lower: &dyn vortex_array::Array, upper: &dyn vortex_array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DecimalVTable::between(arr: &vortex_array::arrays::DecimalArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::PrimitiveVTable
 
-pub fn vortex_array::arrays::PrimitiveVTable::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &dyn vortex_array::Array, upper: &dyn vortex_array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::PrimitiveVTable::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::between::BetweenReduce: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::between::BetweenReduce::between(array: &Self::Array, lower: &dyn vortex_array::Array, upper: &dyn vortex_array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::between::BetweenReduce::between(array: &Self::Array, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::between(array: &vortex_array::arrays::ConstantArray, lower: &dyn vortex_array::Array, upper: &dyn vortex_array::Array, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ConstantVTable::between(array: &vortex_array::arrays::ConstantArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::binary
 
@@ -13350,23 +13354,23 @@ pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::execute_p
 
 pub trait vortex_array::scalar_fn::fns::binary::CompareKernel: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::binary::CompareKernel::compare(lhs: &Self::Array, rhs: &dyn vortex_array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::binary::CompareKernel::compare(lhs: &Self::Array, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &dyn vortex_array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::ExtensionVTable
 
-pub fn vortex_array::arrays::ExtensionVTable::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &dyn vortex_array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ExtensionVTable::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBinVTable
 
-pub fn vortex_array::arrays::VarBinVTable::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &dyn vortex_array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinVTable::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::scalar_fn::fns::binary::and_kleene(lhs: &dyn vortex_array::Array, rhs: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::binary::and_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::scalar_fn::fns::binary::or_kleene(lhs: &dyn vortex_array::Array, rhs: &dyn vortex_array::Array) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::binary::or_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::scalar_cmp(lhs: &vortex_array::scalar::Scalar, rhs: &vortex_array::scalar::Scalar, operator: vortex_array::scalar_fn::fns::operators::CompareOperator) -> vortex_array::scalar::Scalar
 
@@ -13900,15 +13904,15 @@ pub fn vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::reduce_parent(&
 
 pub trait vortex_array::scalar_fn::fns::like::LikeKernel: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::like::LikeKernel::like(array: &Self::Array, pattern: &dyn vortex_array::Array, options: vortex_array::scalar_fn::fns::like::LikeOptions, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::like::LikeKernel::like(array: &Self::Array, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::like::LikeReduce: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::like::LikeReduce::like(array: &Self::Array, pattern: &dyn vortex_array::Array, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::like::LikeReduce::like(array: &Self::Array, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &dyn vortex_array::Array, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::list_contains
 
@@ -13988,11 +13992,11 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAda
 
 pub trait vortex_array::scalar_fn::fns::list_contains::ListContainsElementKernel: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementKernel::list_contains(list: &dyn vortex_array::Array, element: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementKernel::list_contains(list: &vortex_array::ArrayRef, element: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduce: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduce::list_contains(list: &dyn vortex_array::Array, element: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduce::list_contains(list: &vortex_array::ArrayRef, element: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::literal
 
@@ -14792,23 +14796,23 @@ pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::reduce_parent(&se
 
 pub trait vortex_array::scalar_fn::fns::zip::ZipKernel: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipKernel::zip(array: &Self::Array, if_false: &dyn vortex_array::Array, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipKernel::zip(array: &Self::Array, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::StructVTable
 
-pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &dyn vortex_array::Array, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinViewVTable
 
-pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &dyn vortex_array::Array, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::zip::ZipReduce: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipReduce::zip(array: &Self::Array, if_false: &dyn vortex_array::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipReduce::zip(array: &Self::Array, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::zip::ZipReduce for vortex_array::arrays::ChunkedVTable
 
-pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &dyn vortex_array::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::session
 
@@ -16344,7 +16348,7 @@ pub fn vortex_array::validity::Validity::as_array(&self) -> core::option::Option
 
 pub fn vortex_array::validity::Validity::cast_nullability(self, nullability: vortex_array::dtype::Nullability, len: usize) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-pub fn vortex_array::validity::Validity::copy_from_array(array: &dyn vortex_array::Array) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::validity::Validity::copy_from_array(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_array::validity::Validity::filter(&self, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<Self>
 
@@ -16364,11 +16368,11 @@ pub fn vortex_array::validity::Validity::not(&self) -> vortex_error::VortexResul
 
 pub fn vortex_array::validity::Validity::nullability(&self) -> vortex_array::dtype::Nullability
 
-pub fn vortex_array::validity::Validity::patch(self, len: usize, indices_offset: usize, indices: &dyn vortex_array::Array, patches: &vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::validity::Validity::patch(self, len: usize, indices_offset: usize, indices: &vortex_array::ArrayRef, patches: &vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_array::validity::Validity::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::validity::Validity::take(&self, indices: &dyn vortex_array::Array) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::validity::Validity::take(&self, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_array::validity::Validity::to_array(&self, len: usize) -> vortex_array::ArrayRef
 
@@ -16552,7 +16556,7 @@ pub fn vortex_array::vtable::DynVTable::reduce(&self, array: &vortex_array::Arra
 
 pub fn vortex_array::vtable::DynVTable::reduce_parent(&self, array: &vortex_array::ArrayRef, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::vtable::DynVTable::with_children(&self, array: &dyn vortex_array::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::vtable::DynVTable::with_children(&self, array: &vortex_array::ArrayRef, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub trait vortex_array::vtable::OperationsVTable<V: vortex_array::vtable::VTable>
 

--- a/vortex-array/src/arrays/bool/compute/cast.rs
+++ b/vortex-array/src/arrays/bool/compute/cast.rs
@@ -61,6 +61,6 @@ mod tests {
     #[case(BoolArray::from_iter(vec![true]))]
     #[case(BoolArray::from_iter(vec![false, false]))]
     fn test_cast_bool_conformance(#[case] array: BoolArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/bool/compute/filter.rs
+++ b/vortex-array/src/arrays/bool/compute/filter.rs
@@ -125,6 +125,6 @@ mod test {
     #[case(BoolArray::from_iter((0..100).map(|i| i % 2 == 0)))]
     #[case(BoolArray::from_iter((0..1024).map(|i| i % 3 != 0)))]
     fn test_filter_bool_conformance(#[case] array: BoolArray) {
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/bool/compute/is_constant.rs
+++ b/vortex-array/src/arrays/bool/compute/is_constant.rs
@@ -41,6 +41,6 @@ mod tests {
     }, false)]
     fn test_is_constant(#[case] input: Vec<bool>, #[case] expected: bool) {
         let array = BoolArray::from_iter(input);
-        assert_eq!(is_constant(array.as_ref()).unwrap(), Some(expected));
+        assert_eq!(is_constant(&array.to_array()).unwrap(), Some(expected));
     }
 }

--- a/vortex-array/src/arrays/bool/compute/mask.rs
+++ b/vortex-array/src/arrays/bool/compute/mask.rs
@@ -40,6 +40,6 @@ mod test {
     #[case(BoolArray::from_iter([false, false]))]
     #[case(BoolArray::from_iter((0..100).map(|i| i % 2 == 0)))]
     fn test_mask_bool_conformance(#[case] array: BoolArray) {
-        test_mask_conformance(array.as_ref());
+        test_mask_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/bool/compute/min_max.rs
+++ b/vortex-array/src/arrays/bool/compute/min_max.rs
@@ -87,7 +87,7 @@ mod tests {
     #[test]
     fn test_min_max_nulls() {
         assert_eq!(
-            min_max(BoolArray::from_iter(vec![Some(true), Some(true), None, None]).as_ref())
+            min_max(&BoolArray::from_iter(vec![Some(true), Some(true), None, None]).to_array())
                 .unwrap(),
             Some(MinMaxResult {
                 min: Scalar::bool(true, NonNullable),
@@ -96,7 +96,7 @@ mod tests {
         );
 
         assert_eq!(
-            min_max(BoolArray::from_iter(vec![None, Some(true), Some(true)]).as_ref()).unwrap(),
+            min_max(&BoolArray::from_iter(vec![None, Some(true), Some(true)]).to_array()).unwrap(),
             Some(MinMaxResult {
                 min: Scalar::bool(true, NonNullable),
                 max: Scalar::bool(true, NonNullable),
@@ -104,7 +104,7 @@ mod tests {
         );
 
         assert_eq!(
-            min_max(BoolArray::from_iter(vec![None, Some(true), Some(true), None]).as_ref())
+            min_max(&BoolArray::from_iter(vec![None, Some(true), Some(true), None]).to_array())
                 .unwrap(),
             Some(MinMaxResult {
                 min: Scalar::bool(true, NonNullable),
@@ -113,7 +113,7 @@ mod tests {
         );
 
         assert_eq!(
-            min_max(BoolArray::from_iter(vec![Some(false), Some(false), None, None]).as_ref())
+            min_max(&BoolArray::from_iter(vec![Some(false), Some(false), None, None]).to_array())
                 .unwrap(),
             Some(MinMaxResult {
                 min: Scalar::bool(false, NonNullable),

--- a/vortex-array/src/arrays/bool/compute/mod.rs
+++ b/vortex-array/src/arrays/bool/compute/mod.rs
@@ -42,6 +42,6 @@ mod tests {
         None, None, Some(true), None, None, None, Some(false), None, None
     ]))]
     fn test_bool_consistency(#[case] array: BoolArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/bool/compute/take.rs
+++ b/vortex-array/src/arrays/bool/compute/take.rs
@@ -25,7 +25,7 @@ use crate::vtable::ValidityHelper;
 impl TakeExecute for BoolVTable {
     fn take(
         array: &BoolArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let indices_nulls_zeroed = match indices.validity_mask()? {
@@ -172,6 +172,6 @@ mod test {
     #[case(BoolArray::from_iter([true, false]))]
     #[case(BoolArray::from_iter([true]))]
     fn test_take_bool_conformance(#[case] array: BoolArray) {
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/bool/patch.rs
+++ b/vortex-array/src/arrays/bool/patch.rs
@@ -20,7 +20,7 @@ impl BoolArray {
         let patched_validity =
             self.validity()
                 .clone()
-                .patch(len, offset, indices.as_ref(), values.validity())?;
+                .patch(len, offset, &indices.to_array(), values.validity())?;
 
         let mut own_values = self.into_bit_buffer().into_mut();
         match_each_unsigned_integer_ptype!(indices.ptype(), |I| {

--- a/vortex-array/src/arrays/chunked/compute/cast.rs
+++ b/vortex-array/src/arrays/chunked/compute/cast.rs
@@ -92,6 +92,6 @@ mod test {
         DType::Primitive(PType::U8, Nullability::NonNullable)
     ).unwrap().into_array())]
     fn test_cast_chunked_conformance(#[case] array: crate::ArrayRef) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array);
     }
 }

--- a/vortex-array/src/arrays/chunked/compute/filter.rs
+++ b/vortex-array/src/arrays/chunked/compute/filter.rs
@@ -278,6 +278,6 @@ mod test {
         DType::Primitive(PType::I64, Nullability::NonNullable),
     ).unwrap())]
     fn test_filter_chunked_conformance(#[case] chunked: ChunkedArray) {
-        test_filter_conformance(chunked.as_ref());
+        test_filter_conformance(&chunked.to_array());
     }
 }

--- a/vortex-array/src/arrays/chunked/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/chunked/compute/is_sorted.rs
@@ -4,6 +4,7 @@
 use vortex_error::VortexResult;
 
 use crate::Array;
+use crate::ArrayRef;
 use crate::arrays::ChunkedArray;
 use crate::arrays::ChunkedVTable;
 use crate::compute::IsSortedKernel;
@@ -27,7 +28,7 @@ register_kernel!(IsSortedKernelAdapter(ChunkedVTable).lift());
 fn is_sorted_impl(
     array: &ChunkedArray,
     strict: bool,
-    reentry_fn: impl Fn(&dyn Array) -> VortexResult<Option<bool>>,
+    reentry_fn: impl Fn(&ArrayRef) -> VortexResult<Option<bool>>,
 ) -> VortexResult<Option<bool>> {
     let mut first_last = Vec::default();
 

--- a/vortex-array/src/arrays/chunked/compute/mask.rs
+++ b/vortex-array/src/arrays/chunked/compute/mask.rs
@@ -79,6 +79,6 @@ mod test {
         DType::Primitive(PType::F32, Nullability::NonNullable),
     ).unwrap())]
     fn test_mask_chunked_conformance(#[case] chunked: ChunkedArray) {
-        test_mask_conformance(chunked.as_ref());
+        test_mask_conformance(&chunked.to_array());
     }
 }

--- a/vortex-array/src/arrays/chunked/compute/mod.rs
+++ b/vortex-array/src/arrays/chunked/compute/mod.rs
@@ -82,7 +82,7 @@ mod tests {
     ).unwrap())]
 
     fn test_chunked_consistency(#[case] array: ChunkedArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 
     #[rstest]

--- a/vortex-array/src/arrays/chunked/compute/sum.rs
+++ b/vortex-array/src/arrays/chunked/compute/sum.rs
@@ -65,7 +65,7 @@ mod tests {
         .unwrap();
 
         // Compute sum
-        let result = sum(chunked.as_ref()).unwrap();
+        let result = sum(&chunked.to_array()).unwrap();
 
         // Expected sum: 1.5 + 3.2 + 4.8 + 2.1 + 5.7 + 1.0 + 2.5 = 20.8
         assert_eq!(result.as_primitive().as_::<f64>(), Some(20.8));
@@ -81,7 +81,7 @@ mod tests {
         let chunked =
             ChunkedArray::try_new(vec![chunk1.into_array(), chunk2.into_array()], dtype).unwrap();
         // Compute sum - should return null for all nulls
-        let result = sum(chunked.as_ref()).unwrap();
+        let result = sum(&chunked.to_array()).unwrap();
         assert_eq!(result, Scalar::primitive(0f64, Nullability::Nullable));
     }
 
@@ -104,7 +104,7 @@ mod tests {
         .unwrap();
 
         // Compute sum: 10.5 + 20.3 + 5.2 = 36.0
-        let result = sum(chunked.as_ref()).unwrap();
+        let result = sum(&chunked.to_array()).unwrap();
         assert_eq!(result.as_primitive().as_::<f64>(), Some(36.0));
     }
 
@@ -117,7 +117,7 @@ mod tests {
         let chunked =
             ChunkedArray::try_new(vec![chunk1.into_array(), chunk2.into_array()], dtype).unwrap();
 
-        let result = sum(chunked.as_ref()).unwrap();
+        let result = sum(&chunked.to_array()).unwrap();
         assert_eq!(result.as_primitive().as_::<u64>(), Some(1));
     }
 
@@ -149,7 +149,7 @@ mod tests {
         .unwrap();
 
         // Compute sum: 5*100 + 3*200 + 2*300 = 500 + 600 + 600 = 1700 (represents 17.00)
-        let result = sum(chunked.as_ref()).unwrap();
+        let result = sum(&chunked.to_array()).unwrap();
         let decimal_result = result.as_decimal();
         assert_eq!(
             decimal_result.decimal_value(),
@@ -186,7 +186,7 @@ mod tests {
         .unwrap();
 
         // Compute sum: 3*100 + 2*200 = 300 + 400 = 700 (nulls ignored)
-        let result = sum(chunked.as_ref()).unwrap();
+        let result = sum(&chunked.to_array()).unwrap();
         let decimal_result = result.as_decimal();
         assert_eq!(
             decimal_result.decimal_value(),
@@ -222,7 +222,7 @@ mod tests {
 
         // Compute sum: 500 + 600 = 1100
         // Result should have precision 13 (3+10), scale 0
-        let result = sum(chunked.as_ref()).unwrap();
+        let result = sum(&chunked.to_array()).unwrap();
         let decimal_result = result.as_decimal();
         assert_eq!(
             decimal_result.decimal_value(),

--- a/vortex-array/src/arrays/chunked/compute/take.rs
+++ b/vortex-array/src/arrays/chunked/compute/take.rs
@@ -24,7 +24,7 @@ use crate::validity::Validity;
 // we also want to return a chunked array ideally.
 fn take_chunked(
     array: &ChunkedArray,
-    indices: &dyn Array,
+    indices: &ArrayRef,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let indices = indices
@@ -103,7 +103,7 @@ fn take_chunked(
 impl TakeExecute for ChunkedVTable {
     fn take(
         array: &ChunkedArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         take_chunked(array, indices, ctx).map(Some)
@@ -325,14 +325,14 @@ mod test {
                 .clone(),
         )
         .unwrap();
-        test_take_conformance(arr.as_ref());
+        test_take_conformance(&arr.to_array());
 
         // Test with nullable chunked array
         let a = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]);
         let b = PrimitiveArray::from_option_iter([Some(4i32), Some(5)]);
         let dtype = a.dtype().clone();
         let arr = ChunkedArray::try_new(vec![a.into_array(), b.into_array()], dtype).unwrap();
-        test_take_conformance(arr.as_ref());
+        test_take_conformance(&arr.to_array());
 
         // Test with multiple identical chunks
         let chunk = buffer![10i32, 20, 30, 40, 50].into_array();
@@ -341,6 +341,6 @@ mod test {
             chunk.dtype().clone(),
         )
         .unwrap();
-        test_take_conformance(arr.as_ref());
+        test_take_conformance(&arr.to_array());
     }
 }

--- a/vortex-array/src/arrays/chunked/compute/zip.rs
+++ b/vortex-array/src/arrays/chunked/compute/zip.rs
@@ -18,7 +18,7 @@ use crate::scalar_fn::fns::zip::ZipReduce;
 impl ZipReduce for ChunkedVTable {
     fn zip(
         if_true: &ChunkedArray,
-        if_false: &dyn Array,
+        if_false: &ArrayRef,
         mask: &Mask,
     ) -> VortexResult<Option<ArrayRef>> {
         let Some(if_false) = if_false.as_opt::<ChunkedVTable>() else {
@@ -110,7 +110,7 @@ mod tests {
         let mask = Mask::from_iter([true, false, true, false, true]);
 
         #[expect(deprecated)]
-        let zipped = zip(if_true.as_ref(), if_false.as_ref(), &mask).unwrap();
+        let zipped = zip(&if_true.to_array(), &if_false.to_array(), &mask).unwrap();
         let zipped = zipped
             .as_opt::<ChunkedVTable>()
             .expect("zip should keep chunked encoding");

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -38,7 +38,7 @@ pub(super) fn _canonicalize(
         DType::Struct(struct_dtype, _) => {
             let struct_array = pack_struct_chunks(
                 array.chunks(),
-                Validity::copy_from_array(array.as_ref())?,
+                Validity::copy_from_array(&array.to_array())?,
                 struct_dtype,
                 ctx,
             )?;
@@ -46,7 +46,7 @@ pub(super) fn _canonicalize(
         }
         DType::List(elem_dtype, _) => Canonical::List(swizzle_list_chunks(
             array.chunks(),
-            Validity::copy_from_array(array.as_ref())?,
+            Validity::copy_from_array(&array.to_array())?,
             elem_dtype,
             ctx,
         )?),

--- a/vortex-array/src/arrays/constant/compute/between.rs
+++ b/vortex-array/src/arrays/constant/compute/between.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
@@ -15,8 +14,8 @@ use crate::scalar_fn::fns::between::BetweenReduce;
 impl BetweenReduce for ConstantVTable {
     fn between(
         array: &ConstantArray,
-        lower: &dyn Array,
-        upper: &dyn Array,
+        lower: &ArrayRef,
+        upper: &ArrayRef,
         options: &BetweenOptions,
     ) -> VortexResult<Option<ArrayRef>> {
         // Can reduce if everything is constant

--- a/vortex-array/src/arrays/constant/compute/cast.rs
+++ b/vortex-array/src/arrays/constant/compute/cast.rs
@@ -36,6 +36,6 @@ mod tests {
     #[case(ConstantArray::new(Scalar::null_native::<i32>(), 4).into_array())]
     #[case(ConstantArray::new(Scalar::from(255u8), 1).into_array())]
     fn test_cast_constant_conformance(#[case] array: crate::ArrayRef) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array);
     }
 }

--- a/vortex-array/src/arrays/constant/compute/mod.rs
+++ b/vortex-array/src/arrays/constant/compute/mod.rs
@@ -61,6 +61,6 @@ mod test {
     #[case::constant_single(ConstantArray::new(Scalar::from(99u64), 1))]
     #[case::constant_large(ConstantArray::new(Scalar::from("hello"), 1000))]
     fn test_constant_consistency(#[case] array: ConstantArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/constant/compute/sum.rs
+++ b/vortex-array/src/arrays/constant/compute/sum.rs
@@ -292,7 +292,7 @@ mod tests {
     fn test_sum_float_non_multiply() {
         let acc = -2048669276050936500000000000f64;
         let array = ConstantArray::new(6.1811675e16f64, 25);
-        let sum = sum_with_accumulator(array.as_ref(), &Scalar::primitive(acc, Nullable))
+        let sum = sum_with_accumulator(&array.to_array(), &Scalar::primitive(acc, Nullable))
             .vortex_expect("operation should succeed in test");
         assert_eq!(
             f64::try_from(&sum).vortex_expect("operation should succeed in test"),

--- a/vortex-array/src/arrays/constant/compute/take.rs
+++ b/vortex-array/src/arrays/constant/compute/take.rs
@@ -17,7 +17,7 @@ use crate::scalar::Scalar;
 use crate::validity::Validity;
 
 impl TakeReduce for ConstantVTable {
-    fn take(array: &ConstantArray, indices: &dyn Array) -> VortexResult<Option<ArrayRef>> {
+    fn take(array: &ConstantArray, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let result = match indices.validity_mask()?.bit_buffer() {
             AllOr::All => {
                 let scalar = Scalar::try_new(
@@ -128,6 +128,6 @@ mod tests {
     #[case(ConstantArray::new(Scalar::null_native::<i64>(), 5))]
     #[case(ConstantArray::new(true, 1))]
     fn test_take_constant_conformance(#[case] array: ConstantArray) {
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/decimal/array.rs
+++ b/vortex-array/src/arrays/decimal/array.rs
@@ -377,7 +377,7 @@ impl DecimalArray {
         let patched_validity = self.validity().clone().patch(
             self.len(),
             offset,
-            patch_indices.as_ref(),
+            &patch_indices.to_array(),
             patch_values.validity(),
         )?;
         assert_eq!(self.decimal_dtype(), patch_values.decimal_dtype());

--- a/vortex-array/src/arrays/decimal/compute/between.rs
+++ b/vortex-array/src/arrays/decimal/compute/between.rs
@@ -5,7 +5,6 @@ use vortex_buffer::BitBuffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
@@ -24,8 +23,8 @@ use crate::vtable::ValidityHelper;
 impl BetweenKernel for DecimalVTable {
     fn between(
         arr: &DecimalArray,
-        lower: &dyn Array,
-        upper: &dyn Array,
+        lower: &ArrayRef,
+        upper: &ArrayRef,
         options: &BetweenOptions,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/decimal/compute/cast.rs
+++ b/vortex-array/src/arrays/decimal/compute/cast.rs
@@ -311,7 +311,7 @@ mod tests {
     #[case(DecimalArray::from_option_iter([Some(100i32), None, Some(300)], DecimalDType::new(10, 2)))]
     #[case(DecimalArray::new(buffer![42i32], DecimalDType::new(5, 1), Validity::NonNullable))]
     fn test_cast_decimal_conformance(#[case] array: DecimalArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 
     #[test]

--- a/vortex-array/src/arrays/decimal/compute/is_constant.rs
+++ b/vortex-array/src/arrays/decimal/compute/is_constant.rs
@@ -44,7 +44,7 @@ mod tests {
             Validity::NonNullable,
         );
 
-        assert!(!is_constant(array.as_ref()).unwrap().unwrap());
+        assert!(!is_constant(&array.to_array()).unwrap().unwrap());
 
         let array = DecimalArray::new(
             buffer![100i128, 100i128, 100i128],
@@ -52,6 +52,6 @@ mod tests {
             Validity::NonNullable,
         );
 
-        assert!(is_constant(array.as_ref()).unwrap().unwrap());
+        assert!(is_constant(&array.to_array()).unwrap().unwrap());
     }
 }

--- a/vortex-array/src/arrays/decimal/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/decimal/compute/is_sorted.rs
@@ -91,8 +91,8 @@ mod tests {
         let sorted_array = DecimalArray::new(sorted, dtype, Validity::NonNullable);
         let unsorted_array = DecimalArray::new(unsorted, dtype, Validity::NonNullable);
 
-        assert!(is_sorted(sorted_array.as_ref()).unwrap().unwrap());
-        assert!(!is_sorted(unsorted_array.as_ref()).unwrap().unwrap());
+        assert!(is_sorted(&sorted_array.to_array()).unwrap().unwrap());
+        assert!(!is_sorted(&unsorted_array.to_array()).unwrap().unwrap());
     }
 
     #[test]
@@ -114,10 +114,10 @@ mod tests {
         let sorted_array = DecimalArray::new(sorted, dtype, Validity::NonNullable);
 
         assert!(
-            is_strict_sorted(strict_sorted_array.as_ref())
+            is_strict_sorted(&strict_sorted_array.to_array())
                 .unwrap()
                 .unwrap()
         );
-        assert!(!is_strict_sorted(sorted_array.as_ref()).unwrap().unwrap());
+        assert!(!is_strict_sorted(&sorted_array.to_array()).unwrap().unwrap());
     }
 }

--- a/vortex-array/src/arrays/decimal/compute/min_max.rs
+++ b/vortex-array/src/arrays/decimal/compute/min_max.rs
@@ -91,7 +91,7 @@ mod tests {
             Validity::from_iter([true, false, true]),
         );
 
-        let min_max = min_max(decimal.as_ref()).unwrap();
+        let min_max = min_max(&decimal.to_array()).unwrap();
 
         let non_nullable_dtype = decimal.dtype().as_nonnullable();
         let expected = MinMaxResult {

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -56,6 +56,6 @@ mod tests {
         Validity::NonNullable,
     ))]
     fn test_decimal_consistency(#[case] array: DecimalArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/decimal/compute/sum.rs
+++ b/vortex-array/src/arrays/decimal/compute/sum.rs
@@ -150,7 +150,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
 
         let expected = Scalar::try_new(
             DType::Decimal(DecimalDType::new(14, 2), Nullability::NonNullable),
@@ -169,7 +169,7 @@ mod tests {
             Validity::from_iter([true, false, true, true]),
         );
 
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
 
         let expected = Scalar::try_new(
             DType::Decimal(DecimalDType::new(14, 2), Nullability::Nullable),
@@ -188,7 +188,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
 
         let expected = Scalar::try_new(
             DType::Decimal(DecimalDType::new(14, 2), Nullability::NonNullable),
@@ -209,7 +209,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
 
         // Should use i64 for accumulation since precision increases
         let expected_sum = near_max as i64 + 500 + 400;
@@ -232,7 +232,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
 
         let expected_sum = (large_val as i128) * 4 + 1;
         let expected = Scalar::try_new(
@@ -257,7 +257,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
 
         // Should use i256 for accumulation
         let expected_sum =
@@ -282,7 +282,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
 
         let expected_sum = (large_pos as i128) + (large_neg as i128) + (large_pos as i128) + 1000;
         let expected = Scalar::try_new(
@@ -302,7 +302,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
 
         // Scale should be preserved, precision increased by 10
         let expected = Scalar::try_new(
@@ -319,7 +319,7 @@ mod tests {
         let decimal =
             DecimalArray::new(buffer![42i32], DecimalDType::new(3, 1), Validity::AllValid);
 
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
 
         let expected = Scalar::try_new(
             DType::Decimal(DecimalDType::new(13, 1), Nullability::NonNullable),
@@ -338,7 +338,7 @@ mod tests {
             Validity::from_iter([false, false, true, false]),
         );
 
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
 
         let expected = Scalar::try_new(
             DType::Decimal(DecimalDType::new(14, 2), Nullability::Nullable),
@@ -362,7 +362,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
 
         // Should use i256 for accumulation since 9 * (i128::MAX / 10) fits in i128 but we increase precision
         let expected_sum = i256::from_i128(large_i128).wrapping_pow(1) * i256::from_i128(9);
@@ -389,7 +389,7 @@ mod tests {
         let decimal = DecimalArray::new(buffer![val, val], decimal_dtype, Validity::AllValid);
 
         // Sum = 12 * 10^75 = 1.2 * 10^76, which exceeds precision 76 but fits in `i256`.
-        let result = sum(decimal.as_ref()).unwrap();
+        let result = sum(&decimal.to_array()).unwrap();
         assert_eq!(
             result,
             Scalar::null(DType::Decimal(decimal_dtype, Nullability::Nullable))
@@ -406,7 +406,7 @@ mod tests {
         );
 
         assert_eq!(
-            sum(decimal.as_ref()).vortex_expect("operation should succeed in test"),
+            sum(&decimal.to_array()).vortex_expect("operation should succeed in test"),
             Scalar::null(DType::Decimal(decimal_dtype, Nullability::Nullable))
         );
     }

--- a/vortex-array/src/arrays/decimal/compute/take.rs
+++ b/vortex-array/src/arrays/decimal/compute/take.rs
@@ -4,7 +4,6 @@
 use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::ToCanonical;
 use crate::arrays::DecimalArray;
@@ -20,11 +19,11 @@ use crate::vtable::ValidityHelper;
 impl TakeExecute for DecimalVTable {
     fn take(
         array: &DecimalArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let indices = indices.to_primitive();
-        let validity = array.validity().take(indices.as_ref())?;
+        let validity = array.validity().take(&indices.to_array())?;
 
         // TODO(joe): if the true count of take indices validity is low, only take array values with
         // valid indices.
@@ -128,6 +127,6 @@ mod tests {
         )
     })]
     fn test_take_decimal_conformance(#[case] array: DecimalArray) {
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/dict/compute/cast.rs
+++ b/vortex-array/src/arrays/dict/compute/cast.rs
@@ -84,7 +84,7 @@ mod tests {
     fn test_cast_dict_nullable() {
         let values =
             PrimitiveArray::from_option_iter([Some(10i32), None, Some(20), Some(10), None]);
-        let dict = dict_encode(values.as_ref()).unwrap();
+        let dict = dict_encode(&values.to_array()).unwrap();
 
         let casted = dict
             .to_array()
@@ -182,7 +182,7 @@ mod tests {
     #[case(dict_encode(&PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).into_array()).unwrap().into_array())]
     #[case(dict_encode(&buffer![1.5f32, 2.5, 1.5, 3.5].into_array()).unwrap().into_array())]
     fn test_cast_dict_conformance(#[case] array: crate::ArrayRef) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array);
     }
 
     #[test]

--- a/vortex-array/src/arrays/dict/compute/compare.rs
+++ b/vortex-array/src/arrays/dict/compute/compare.rs
@@ -18,7 +18,7 @@ use crate::scalar_fn::fns::operators::Operator;
 impl CompareKernel for DictVTable {
     fn compare(
         lhs: &DictArray,
-        rhs: &dyn Array,
+        rhs: &ArrayRef,
         operator: CompareOperator,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/dict/compute/like.rs
+++ b/vortex-array/src/arrays/dict/compute/like.rs
@@ -18,7 +18,7 @@ use crate::scalar_fn::fns::like::LikeReduce;
 impl LikeReduce for DictVTable {
     fn like(
         array: &DictArray,
-        pattern: &dyn Array,
+        pattern: &ArrayRef,
         options: LikeOptions,
     ) -> VortexResult<Option<ArrayRef>> {
         // If we have more values than codes, it is faster to canonicalize first.

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -47,13 +47,13 @@ mod tests {
     use vortex_buffer::buffer;
 
     use super::DictArray;
-    use crate::Array;
+    use crate::ArrayRef;
     use crate::IntoArray;
     use crate::arrays::PrimitiveArray;
     use crate::builders::dict::dict_encode;
     use crate::compute::min_max;
 
-    fn assert_min_max(array: &dyn Array, expected: Option<(i32, i32)>) {
+    fn assert_min_max(array: &ArrayRef, expected: Option<(i32, i32)>) {
         match (min_max(array).unwrap(), expected) {
             (Some(result), Some((expected_min, expected_max))) => {
                 assert_eq!(i32::try_from(&result.min).unwrap(), expected_min);
@@ -104,20 +104,20 @@ mod tests {
     )]
     #[case::nullable_values(
         dict_encode(
-            PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).as_ref()
+            &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).to_array()
         ).unwrap(),
         (1, 2)
     )]
     fn test_min_max(#[case] dict: DictArray, #[case] expected: (i32, i32)) {
-        assert_min_max(dict.as_ref(), Some(expected));
+        assert_min_max(&dict.to_array(), Some(expected));
     }
 
     #[test]
     fn test_sliced_dict() {
         let reference = PrimitiveArray::from_iter([1, 5, 10, 50, 100]);
-        let dict = dict_encode(reference.as_ref()).unwrap();
+        let dict = dict_encode(&reference.to_array()).unwrap();
         let sliced = dict.slice(1..3).unwrap();
-        assert_min_max(sliced.as_ref(), Some((5, 10)));
+        assert_min_max(&sliced, Some((5, 10)));
     }
 
     #[rstest]
@@ -134,6 +134,6 @@ mod tests {
         ).unwrap()
     )]
     fn test_min_max_none(#[case] dict: DictArray) {
-        assert_min_max(dict.as_ref(), None);
+        assert_min_max(&dict.to_array(), None);
     }
 }

--- a/vortex-array/src/arrays/dict/compute/mod.rs
+++ b/vortex-array/src/arrays/dict/compute/mod.rs
@@ -27,7 +27,7 @@ use crate::arrays::filter::FilterReduce;
 impl TakeExecute for DictVTable {
     fn take(
         array: &DictArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let codes = array.codes().take(indices.to_array())?;
@@ -87,7 +87,8 @@ mod test {
             })
             .collect();
 
-        let dict = dict_encode(PrimitiveArray::from_option_iter(values.clone()).as_ref()).unwrap();
+        let dict =
+            dict_encode(&PrimitiveArray::from_option_iter(values.clone()).to_array()).unwrap();
         let actual = dict.to_primitive();
 
         let expected = PrimitiveArray::from_option_iter(values);
@@ -100,7 +101,7 @@ mod test {
         let unique_values: Vec<i32> = (0..32).collect();
         let expected = PrimitiveArray::from_iter((0..1000).map(|i| unique_values[i % 32]));
 
-        let dict = dict_encode(expected.as_ref()).unwrap();
+        let dict = dict_encode(&expected.to_array()).unwrap();
         let actual = dict.to_primitive();
 
         assert_arrays_eq!(actual, expected);
@@ -111,7 +112,7 @@ mod test {
         let unique_values: Vec<i32> = (0..100).collect();
         let expected = PrimitiveArray::from_iter((0..1000).map(|i| unique_values[i % 100]));
 
-        let dict = dict_encode(expected.as_ref()).unwrap();
+        let dict = dict_encode(&expected.to_array()).unwrap();
         let actual = dict.to_primitive();
 
         assert_arrays_eq!(actual, expected);
@@ -124,7 +125,7 @@ mod test {
             DType::Utf8(Nullability::Nullable),
         );
         assert_eq!(reference.len(), 6);
-        let dict = dict_encode(reference.as_ref()).unwrap();
+        let dict = dict_encode(&reference.to_array()).unwrap();
         let flattened_dict = dict.to_varbinview();
         assert_eq!(
             flattened_dict.with_iterator(|iter| iter
@@ -145,7 +146,7 @@ mod test {
             Some(1),
             Some(5),
         ]);
-        let dict = dict_encode(reference.as_ref()).unwrap();
+        let dict = dict_encode(&reference.to_array()).unwrap();
         dict.slice(1..4).unwrap()
     }
 
@@ -164,13 +165,14 @@ mod test {
     #[test]
     fn test_mask_dict_array() {
         let array = dict_encode(&buffer![2, 0, 2, 0, 10].into_array()).unwrap();
-        test_mask_conformance(array.as_ref());
+        test_mask_conformance(&array.to_array());
 
         let array = dict_encode(
-            PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)]).as_ref(),
+            &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
+                .to_array(),
         )
         .unwrap();
-        test_mask_conformance(array.as_ref());
+        test_mask_conformance(&array.to_array());
 
         let array = dict_encode(
             &VarBinArray::from_iter(
@@ -186,19 +188,20 @@ mod test {
             .into_array(),
         )
         .unwrap();
-        test_mask_conformance(array.as_ref());
+        test_mask_conformance(&array.to_array());
     }
 
     #[test]
     fn test_filter_dict_array() {
         let array = dict_encode(&buffer![2, 0, 2, 0, 10].into_array()).unwrap();
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
 
         let array = dict_encode(
-            PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)]).as_ref(),
+            &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
+                .to_array(),
         )
         .unwrap();
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
 
         let array = dict_encode(
             &VarBinArray::from_iter(
@@ -214,12 +217,12 @@ mod test {
             .into_array(),
         )
         .unwrap();
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[test]
     fn test_take_dict() {
-        let array = dict_encode(buffer![1, 2].into_array().as_ref()).unwrap();
+        let array = dict_encode(&buffer![1, 2].into_array()).unwrap();
 
         assert_eq!(
             array
@@ -233,13 +236,14 @@ mod test {
     #[test]
     fn test_take_dict_conformance() {
         let array = dict_encode(&buffer![2, 0, 2, 0, 10].into_array()).unwrap();
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
 
         let array = dict_encode(
-            PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)]).as_ref(),
+            &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
+                .to_array(),
         )
         .unwrap();
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
 
         let array = dict_encode(
             &VarBinArray::from_iter(
@@ -255,7 +259,7 @@ mod test {
             .into_array(),
         )
         .unwrap();
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 }
 
@@ -281,7 +285,7 @@ mod tests {
         PrimitiveArray::from_option_iter([Some(10), Some(20), None]).into_array(),
     ).unwrap())]
     #[case::dict_nullable_values(dict_encode(
-        PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).as_ref()
+        &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).to_array()
     ).unwrap())]
     #[case::dict_u64(dict_encode(&buffer![100u64, 200, 100, 300, 200].into_array()).unwrap())]
     // String arrays
@@ -302,6 +306,6 @@ mod tests {
     #[case::dict_all_same(dict_encode(&buffer![5i32, 5, 5, 5, 5].into_array()).unwrap())]
     #[case::dict_large(dict_encode(&PrimitiveArray::from_iter((0..1000).map(|i| i % 10)).into_array()).unwrap())]
     fn test_dict_consistency(#[case] array: DictArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/dict/execute.rs
+++ b/vortex-array/src/arrays/dict/execute.rs
@@ -63,7 +63,7 @@ fn take_bool(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<BoolArray> {
     Ok(
-        <BoolVTable as TakeExecute>::take(array, codes.as_ref(), ctx)?
+        <BoolVTable as TakeExecute>::take(array, &codes.to_array(), ctx)?
             .vortex_expect("take bool should not return None")
             .as_::<BoolVTable>()
             .clone(),
@@ -75,7 +75,7 @@ fn take_primitive(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> PrimitiveArray {
-    <PrimitiveVTable as TakeExecute>::take(array, codes.as_ref(), ctx)
+    <PrimitiveVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
         .vortex_expect("take primitive array")
         .vortex_expect("take primitive should not return None")
         .as_::<PrimitiveVTable>()
@@ -87,7 +87,7 @@ fn take_decimal(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> DecimalArray {
-    <DecimalVTable as TakeExecute>::take(array, codes.as_ref(), ctx)
+    <DecimalVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
         .vortex_expect("take decimal array")
         .vortex_expect("take decimal should not return None")
         .as_::<DecimalVTable>()
@@ -99,7 +99,7 @@ fn take_varbinview(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> VarBinViewArray {
-    <VarBinViewVTable as TakeExecute>::take(array, codes.as_ref(), ctx)
+    <VarBinViewVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
         .vortex_expect("take varbinview array")
         .vortex_expect("take varbinview should not return None")
         .as_::<VarBinViewVTable>()
@@ -111,7 +111,7 @@ fn take_listview(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> ListViewArray {
-    <ListViewVTable as TakeExecute>::take(array, codes.as_ref(), ctx)
+    <ListViewVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
         .vortex_expect("take listview array")
         .vortex_expect("take listview should not return None")
         .as_::<ListViewVTable>()
@@ -123,7 +123,7 @@ fn take_fixed_size_list(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> FixedSizeListArray {
-    <FixedSizeListVTable as TakeExecute>::take(array, codes.as_ref(), ctx)
+    <FixedSizeListVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
         .vortex_expect("take fixed size list array")
         .vortex_expect("take fixed size list should not return None")
         .as_::<FixedSizeListVTable>()
@@ -131,7 +131,7 @@ fn take_fixed_size_list(
 }
 
 fn take_struct(array: &StructArray, codes: &PrimitiveArray, ctx: &mut ExecutionCtx) -> StructArray {
-    <StructVTable as TakeExecute>::take(array, codes.as_ref(), ctx)
+    <StructVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
         .vortex_expect("take struct array")
         .vortex_expect("take struct should not return None")
         .as_::<StructVTable>()
@@ -143,7 +143,7 @@ fn take_extension(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> ExtensionArray {
-    <ExtensionVTable as TakeExecute>::take(array, codes.as_ref(), ctx)
+    <ExtensionVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
         .vortex_expect("take extension storage")
         .vortex_expect("take extension should not return None")
         .as_::<ExtensionVTable>()

--- a/vortex-array/src/arrays/dict/take.rs
+++ b/vortex-array/src/arrays/dict/take.rs
@@ -32,7 +32,7 @@ pub trait TakeReduce: VTable {
     /// # Preconditions
     ///
     /// The indices are guaranteed to be non-empty.
-    fn take(array: &Self::Array, indices: &dyn Array) -> VortexResult<Option<ArrayRef>>;
+    fn take(array: &Self::Array, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>>;
 }
 
 pub trait TakeExecute: VTable {
@@ -46,7 +46,7 @@ pub trait TakeExecute: VTable {
     /// The indices are guaranteed to be non-empty.
     fn take(
         array: &Self::Array,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>>;
 }
@@ -55,7 +55,7 @@ pub trait TakeExecute: VTable {
 ///
 /// Returns `Some(result)` if the precondition short-circuits the take operation,
 /// or `None` if the take should proceed normally.
-fn precondition<V: VTable>(array: &V::Array, indices: &dyn Array) -> Option<ArrayRef> {
+fn precondition<V: VTable>(array: &V::Array, indices: &ArrayRef) -> Option<ArrayRef> {
     // Fast-path for empty indices.
     if indices.is_empty() {
         let result_dtype = array
@@ -100,7 +100,7 @@ where
         }
         let result = <V as TakeReduce>::take(array, parent.codes())?;
         if let Some(ref taken) = result {
-            propagate_take_stats(&**array, taken.as_ref(), parent.codes())?;
+            propagate_take_stats(&array.to_array(), taken, parent.codes())?;
         }
         Ok(result)
     }
@@ -131,16 +131,16 @@ where
         }
         let result = <V as TakeExecute>::take(array, parent.codes(), ctx)?;
         if let Some(ref taken) = result {
-            propagate_take_stats(&**array, taken.as_ref(), parent.codes())?;
+            propagate_take_stats(&array.to_array(), taken, parent.codes())?;
         }
         Ok(result)
     }
 }
 
 pub(crate) fn propagate_take_stats(
-    source: &dyn Array,
-    target: &dyn Array,
-    indices: &dyn Array,
+    source: &ArrayRef,
+    target: &ArrayRef,
+    indices: &ArrayRef,
 ) -> VortexResult<()> {
     target.statistics().with_mut_typed_stats_set(|mut st| {
         if indices.all_valid().unwrap_or(false) {

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -109,7 +109,7 @@ mod tests {
     #[case(create_timestamp_array(TimeUnit::Nanoseconds, false))]
     #[case(create_timestamp_array(TimeUnit::Seconds, true))]
     fn test_cast_extension_conformance(#[case] array: ExtensionArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 
     fn create_timestamp_array(time_unit: TimeUnit, nullable: bool) -> ExtensionArray {

--- a/vortex-array/src/arrays/extension/compute/compare.rs
+++ b/vortex-array/src/arrays/extension/compute/compare.rs
@@ -17,7 +17,7 @@ use crate::scalar_fn::fns::operators::Operator;
 impl CompareKernel for ExtensionVTable {
     fn compare(
         lhs: &ExtensionArray,
-        rhs: &dyn Array,
+        rhs: &ArrayRef,
         operator: CompareOperator,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/extension/compute/mod.rs
+++ b/vortex-array/src/arrays/extension/compute/mod.rs
@@ -35,14 +35,14 @@ mod test {
         // Create storage array
         let storage = buffer![1i32, 2, 3, 4, 5].into_array();
         let array = ExtensionArray::new(ext_dtype.clone(), storage);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
 
         // Test with nullable extension type
         let ext_dtype_nullable = ext_dtype.with_nullability(Nullability::Nullable);
         let storage = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), Some(4), None])
             .into_array();
         let array = ExtensionArray::new(ext_dtype_nullable, storage);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[rstest]
@@ -81,7 +81,7 @@ mod test {
         ExtensionArray::new(ext_dtype_large, storage)
     })]
     fn test_take_extension_array_conformance(#[case] array: ExtensionArray) {
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 }
 
@@ -118,6 +118,6 @@ mod tests {
         ExtensionArray::new(ext_dtype, storage)
     })]
     fn test_extension_consistency(#[case] array: ExtensionArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/extension/compute/take.rs
+++ b/vortex-array/src/arrays/extension/compute/take.rs
@@ -14,7 +14,7 @@ use crate::arrays::TakeExecute;
 impl TakeExecute for ExtensionVTable {
     fn take(
         array: &ExtensionArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let taken_storage = array.storage().take(indices.to_array())?;

--- a/vortex-array/src/arrays/filter/execute/bool.rs
+++ b/vortex-array/src/arrays/filter/execute/bool.rs
@@ -52,6 +52,6 @@ mod test {
     #[case(BoolArray::from_iter((0..100).map(|i| i % 2 == 0)))]
     #[case(BoolArray::from_iter((0..1024).map(|i| i % 3 != 0)))]
     fn test_filter_bool_conformance(#[case] array: BoolArray) {
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/filter/execute/decimal.rs
+++ b/vortex-array/src/arrays/filter/execute/decimal.rs
@@ -43,7 +43,7 @@ mod test {
             Some(99999),
         ];
         let array = DecimalArray::from_option_iter(values, decimal_dtype);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[test]
@@ -51,6 +51,6 @@ mod test {
         let decimal_dtype = DecimalDType::new(38, 4);
         let values = vec![Some(12345i128), None, Some(-12345), Some(0), None];
         let array = DecimalArray::from_option_iter(values, decimal_dtype);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/filter/execute/fixed_size_list.rs
+++ b/vortex-array/src/arrays/filter/execute/fixed_size_list.rs
@@ -130,7 +130,7 @@ mod test {
     fn test_filter_fixed_size_list_conformance() {
         let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6, 7, 8, 9]);
         let array = FixedSizeListArray::new(elements.into_array(), 3, Validity::NonNullable, 3);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[test]
@@ -139,7 +139,7 @@ mod test {
             PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), Some(4), Some(5), None]);
         let validity = Validity::from_iter([true, false, true]);
         let array = FixedSizeListArray::new(elements.into_array(), 2, validity, 3);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[test]

--- a/vortex-array/src/arrays/filter/execute/listview.rs
+++ b/vortex-array/src/arrays/filter/execute/listview.rs
@@ -96,7 +96,7 @@ mod test {
         let sizes = buffer![2u32, 2, 2].into_array();
         let array =
             ListViewArray::new(elements.into_array(), offsets, sizes, Validity::NonNullable);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[test]
@@ -107,7 +107,7 @@ mod test {
         let sizes = buffer![2u32, 2, 2].into_array();
         let validity = Validity::from_iter([true, false, true]);
         let array = ListViewArray::new(elements.into_array(), offsets, sizes, validity);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[test]
@@ -120,7 +120,7 @@ mod test {
             ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
                 .with_zero_copy_to_list(true)
         };
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[test]
@@ -131,7 +131,7 @@ mod test {
         let offsets = buffer![5u32, 2, 8, 0, 1].into_array();
         let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
         let array = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[test]
@@ -141,7 +141,7 @@ mod test {
         let offsets = buffer![0u32, 100, 200, 300, 400, 500, 600, 700, 800, 900].into_array();
         let sizes = buffer![50u32, 50, 50, 50, 50, 50, 50, 50, 50, 50].into_array();
         let array = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[test]

--- a/vortex-array/src/arrays/filter/execute/primitive.rs
+++ b/vortex-array/src/arrays/filter/execute/primitive.rs
@@ -73,6 +73,6 @@ mod test {
     #[case(PrimitiveArray::from_iter([0.1f32, 0.2, 0.3, 0.4, 0.5]))]
     #[case(PrimitiveArray::from_option_iter([Some(1.1f64), None, Some(2.2), Some(3.3), None]))]
     fn test_filter_primitive_conformance(#[case] array: PrimitiveArray) {
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/filter/execute/struct_.rs
+++ b/vortex-array/src/arrays/filter/execute/struct_.rs
@@ -64,7 +64,7 @@ mod test {
         ];
         let array =
             StructArray::try_new(["a", "b"].into(), fields, 5, Validity::NonNullable).unwrap();
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[test]
@@ -77,7 +77,7 @@ mod test {
         ];
         let array =
             StructArray::try_new(["a", "b"].into(), fields, 5, Validity::NonNullable).unwrap();
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[test]
@@ -138,9 +138,9 @@ mod test {
     #[test]
     fn test_filter_empty_struct_conformance() {
         test_filter_conformance(
-            StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
+            &StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
                 .unwrap()
-                .as_ref(),
+                .to_array(),
         );
     }
 
@@ -156,7 +156,7 @@ mod test {
             BoolArray::from_iter([Some(true), Some(true), None, None, Some(false)]).into_array();
 
         test_filter_conformance(
-            StructArray::try_new(
+            &StructArray::try_new(
                 ["xs", "ys", "zs"].into(),
                 vec![
                     StructArray::try_new(
@@ -174,7 +174,7 @@ mod test {
                 Validity::NonNullable,
             )
             .unwrap()
-            .as_ref(),
+            .to_array(),
         );
     }
 }

--- a/vortex-array/src/arrays/filter/execute/varbinview.rs
+++ b/vortex-array/src/arrays/filter/execute/varbinview.rs
@@ -13,7 +13,7 @@ use crate::compute::arrow_filter_fn;
 
 pub fn filter_varbinview(array: &VarBinViewArray, mask: &Arc<MaskValues>) -> VarBinViewArray {
     // Delegate to the Arrow implementation of filter over `VarBinView`.
-    arrow_filter_fn(array.as_ref(), &values_to_mask(mask))
+    arrow_filter_fn(&array.to_array(), &values_to_mask(mask))
         .vortex_expect("VarBinViewArray is Arrow-compatible and supports arrow_filter_fn")
         .as_::<VarBinViewVTable>()
         .clone()
@@ -27,18 +27,18 @@ mod test {
     #[test]
     fn test_filter_varbinview_conformance() {
         test_filter_conformance(
-            VarBinViewArray::from_iter_str(["one", "two", "three", "four", "five"]).as_ref(),
+            &VarBinViewArray::from_iter_str(["one", "two", "three", "four", "five"]).to_array(),
         );
 
         test_filter_conformance(
-            VarBinViewArray::from_iter_nullable_str([
+            &VarBinViewArray::from_iter_nullable_str([
                 Some("one"),
                 None,
                 Some("three"),
                 Some("four"),
                 Some("five"),
             ])
-            .as_ref(),
+            .to_array(),
         );
     }
 }

--- a/vortex-array/src/arrays/fixed_size_list/array.rs
+++ b/vortex-array/src/arrays/fixed_size_list/array.rs
@@ -177,7 +177,7 @@ impl FixedSizeListArray {
     ///
     /// This function checks all the invariants required by [`FixedSizeListArray::new_unchecked`].
     pub fn validate(
-        elements: &dyn Array,
+        elements: &ArrayRef,
         len: usize,
         list_size: u32,
         validity: &Validity,

--- a/vortex-array/src/arrays/fixed_size_list/compute/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/take.rs
@@ -29,7 +29,7 @@ use crate::vtable::ValidityHelper;
 impl TakeExecute for FixedSizeListVTable {
     fn take(
         array: &FixedSizeListArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         match_each_integer_ptype!(indices.dtype().as_ptype(), |I| {
@@ -42,7 +42,7 @@ impl TakeExecute for FixedSizeListVTable {
 /// Dispatches to the appropriate take implementation based on list size and nullability.
 fn take_with_indices<I: IntegerPType>(
     array: &FixedSizeListArray,
-    indices: &dyn Array,
+    indices: &ArrayRef,
 ) -> VortexResult<ArrayRef> {
     let list_size = array.list_size() as usize;
 

--- a/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/filter.rs
@@ -177,7 +177,7 @@ fn test_filter_nested_fixed_size_lists() {
 #[case(create_fsl_single_element())]
 #[case(create_fsl_empty())]
 fn test_filter_fsl_conformance(#[case] array: ArrayRef) {
-    test_filter_conformance(array.as_ref());
+    test_filter_conformance(&array);
 }
 
 // Helper functions for creating test arrays.

--- a/vortex-array/src/arrays/fixed_size_list/tests/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/take.rs
@@ -31,7 +31,7 @@ use crate::validity::Validity;
 #[case::single_element(create_single_element_fsl())]
 #[case::empty(create_empty_fsl())]
 fn test_take_fsl_conformance(#[case] fsl: FixedSizeListArray) {
-    test_take_conformance(fsl.as_ref());
+    test_take_conformance(&fsl.to_array());
 }
 
 // FSL-specific edge case tests that aren't covered by conformance.
@@ -85,7 +85,7 @@ fn test_take_degenerate_lists(
     let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
     let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, 5);
 
-    test_take_conformance(fsl.as_ref());
+    test_take_conformance(&fsl.to_array());
 
     // Also test the specific behavior.
     let indices_array = PrimitiveArray::from_option_iter(indices);

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -158,8 +158,8 @@ impl ListArray {
     ///
     /// This function checks all the invariants required by [`ListArray::new_unchecked`].
     pub fn validate(
-        elements: &dyn Array,
-        offsets: &dyn Array,
+        elements: &ArrayRef,
+        offsets: &ArrayRef,
         validity: &Validity,
     ) -> VortexResult<()> {
         // Offsets must have at least one element

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -141,7 +141,7 @@ mod tests {
     #[case(create_nested_list())]
     #[case(create_empty_lists())]
     fn test_cast_list_conformance(#[case] array: ListArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 
     fn create_simple_list() -> ListArray {

--- a/vortex-array/src/arrays/list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/list/compute/is_constant.rs
@@ -109,7 +109,7 @@ mod tests {
                 .unwrap()
         );
         assert!(
-            is_constant(struct_of_lists.as_ref())
+            is_constant(&struct_of_lists.to_array())
                 .unwrap()
                 .unwrap_or_default()
         );

--- a/vortex-array/src/arrays/list/compute/mod.rs
+++ b/vortex-array/src/arrays/list/compute/mod.rs
@@ -36,7 +36,7 @@ mod tests {
         let array =
             ListArray::try_new(elements.into_array(), offsets.into_array(), validity).unwrap();
 
-        test_mask_conformance(array.as_ref());
+        test_mask_conformance(&array.to_array());
     }
 
     #[test]
@@ -47,7 +47,7 @@ mod tests {
         let array =
             ListArray::try_new(elements.into_array(), offsets.into_array(), validity).unwrap();
 
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 
     #[rstest]
@@ -79,6 +79,6 @@ mod tests {
         Validity::NonNullable,
     ).unwrap())]
     fn test_list_consistency(#[case] array: ListArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -32,7 +32,7 @@ impl TakeExecute for ListVTable {
     #[expect(clippy::cognitive_complexity)]
     fn take(
         array: &ListArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let indices = indices.to_primitive();
@@ -105,7 +105,7 @@ fn _take<I: IntegerPType, O: IntegerPType, OutputOffsetType: IntegerPType>(
     Ok(ListArray::try_new(
         new_elements,
         new_offsets,
-        array.validity().clone().take(indices_array.as_ref())?,
+        array.validity().clone().take(&indices_array.to_array())?,
     )?
     .to_array())
 }
@@ -173,7 +173,7 @@ fn _take_nullable<I: IntegerPType, O: IntegerPType, OutputOffsetType: IntegerPTy
     Ok(ListArray::try_new(
         new_elements,
         new_offsets,
-        array.validity().clone().take(indices_array.as_ref())?,
+        array.validity().clone().take(&indices_array.to_array())?,
     )?
     .to_array())
 }
@@ -396,7 +396,7 @@ mod test {
         Validity::NonNullable,
     ).unwrap())]
     fn test_take_list_conformance(#[case] list: ListArray) {
-        test_take_conformance(list.as_ref());
+        test_take_conformance(&list.to_array());
     }
 
     #[test]

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -223,9 +223,9 @@ impl ListViewArray {
 
     /// Validates the components that would be used to create a [`ListViewArray`].
     pub fn validate(
-        elements: &dyn Array,
-        offsets: &dyn Array,
-        sizes: &dyn Array,
+        elements: &ArrayRef,
+        offsets: &ArrayRef,
+        sizes: &ArrayRef,
         validity: &Validity,
     ) -> VortexResult<()> {
         // Check that offsets and sizes are integer arrays and non-nullable.
@@ -494,7 +494,7 @@ where
 /// Helper function to validate if the [`ListViewArray`] components are actually zero-copyable to
 /// [`ListArray`](crate::arrays::ListArray).
 fn validate_zctl(
-    elements: &dyn Array,
+    elements: &ArrayRef,
     offsets_primitive: PrimitiveArray,
     sizes_primitive: PrimitiveArray,
 ) -> VortexResult<()> {

--- a/vortex-array/src/arrays/listview/compute/is_constant.rs
+++ b/vortex-array/src/arrays/listview/compute/is_constant.rs
@@ -22,7 +22,7 @@ impl IsConstantKernel for ListViewVTable {
         // - All elements are valid (no nulls)
 
         // First check if all list sizes are constant.
-        if !is_constant_opts(array.sizes().as_ref(), opts)?.unwrap_or_default() {
+        if !is_constant_opts(array.sizes(), opts)?.unwrap_or_default() {
             return Ok(Some(false));
         }
 

--- a/vortex-array/src/arrays/listview/compute/take.rs
+++ b/vortex-array/src/arrays/listview/compute/take.rs
@@ -45,7 +45,7 @@ const REBUILD_DENSITY_THRESHOLD: f64 = 0.1;
 impl TakeExecute for ListViewVTable {
     fn take(
         array: &ListViewArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let elements = array.elements();

--- a/vortex-array/src/arrays/listview/tests/filter.rs
+++ b/vortex-array/src/arrays/listview/tests/filter.rs
@@ -10,6 +10,7 @@ use super::common::create_empty_lists_listview;
 use super::common::create_large_listview;
 use super::common::create_nullable_listview;
 use super::common::create_overlapping_listview;
+use crate::Array;
 use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::ConstantArray;
@@ -27,7 +28,7 @@ use crate::validity::Validity;
 #[case::overlapping(create_overlapping_listview())]
 #[case::large(create_large_listview())]
 fn test_filter_listview_conformance(#[case] listview: ListViewArray) {
-    test_filter_conformance(listview.as_ref());
+    test_filter_conformance(&listview.to_array());
 }
 
 #[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `filter`"]

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -492,7 +492,7 @@ fn test_constant_repeated_same_lists() {
 #[case::nullable(create_nullable_listview())]
 #[case::large(create_large_listview())]
 fn test_mask_listview_conformance(#[case] listview: ListViewArray) {
-    test_mask_conformance(listview.as_ref());
+    test_mask_conformance(&listview.to_array());
 }
 
 #[test]

--- a/vortex-array/src/arrays/listview/tests/take.rs
+++ b/vortex-array/src/arrays/listview/tests/take.rs
@@ -27,7 +27,7 @@ use crate::validity::Validity;
 #[case::overlapping(create_overlapping_listview())]
 #[case::large(create_large_listview())]
 fn test_take_listview_conformance(#[case] listview: ListViewArray) {
-    test_take_conformance(listview.as_ref());
+    test_take_conformance(&listview.to_array());
 }
 
 // ListView-specific tests that aren't covered by conformance.

--- a/vortex-array/src/arrays/masked/compute/filter.rs
+++ b/vortex-array/src/arrays/masked/compute/filter.rs
@@ -57,6 +57,6 @@ mod tests {
         ).unwrap()
     )]
     fn test_filter_masked_conformance(#[case] array: MaskedArray) {
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/masked/compute/mask.rs
+++ b/vortex-array/src/arrays/masked/compute/mask.rs
@@ -60,6 +60,6 @@ mod tests {
         ).unwrap()
     )]
     fn test_mask_masked_conformance(#[case] array: MaskedArray) {
-        test_mask_conformance(array.as_ref());
+        test_mask_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/masked/compute/take.rs
+++ b/vortex-array/src/arrays/masked/compute/take.rs
@@ -17,7 +17,7 @@ use crate::vtable::ValidityHelper;
 impl TakeExecute for MaskedVTable {
     fn take(
         array: &MaskedArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let taken_child = if !indices.all_valid()? {
@@ -69,6 +69,6 @@ mod tests {
         ).unwrap()
     )]
     fn test_take_masked_conformance(#[case] array: MaskedArray) {
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/null/compute/cast.rs
+++ b/vortex-array/src/arrays/null/compute/cast.rs
@@ -82,6 +82,6 @@ mod tests {
     #[case(NullArray::new(100))]
     #[case(NullArray::new(0))]
     fn test_cast_null_conformance(#[case] array: NullArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/null/compute/mod.rs
+++ b/vortex-array/src/arrays/null/compute/mod.rs
@@ -56,21 +56,21 @@ mod test {
 
     #[test]
     fn test_filter_null_array() {
-        test_filter_conformance(NullArray::new(5).as_ref());
-        test_filter_conformance(NullArray::new(1).as_ref());
-        test_filter_conformance(NullArray::new(10).as_ref());
+        test_filter_conformance(&NullArray::new(5).to_array());
+        test_filter_conformance(&NullArray::new(1).to_array());
+        test_filter_conformance(&NullArray::new(10).to_array());
     }
 
     #[test]
     fn test_mask_null_array() {
-        test_mask_conformance(NullArray::new(5).as_ref());
+        test_mask_conformance(&NullArray::new(5).to_array());
     }
 
     #[test]
     fn test_take_null_array_conformance() {
-        test_take_conformance(NullArray::new(5).as_ref());
-        test_take_conformance(NullArray::new(1).as_ref());
-        test_take_conformance(NullArray::new(10).as_ref());
+        test_take_conformance(&NullArray::new(5).to_array());
+        test_take_conformance(&NullArray::new(1).to_array());
+        test_take_conformance(&NullArray::new(10).to_array());
     }
 
     #[rstest]
@@ -82,6 +82,6 @@ mod test {
     #[case::null_array_large(NullArray::new(1000))]
     #[case::null_array_empty(NullArray::new(0))]
     fn test_null_consistency(#[case] array: NullArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/null/compute/take.rs
+++ b/vortex-array/src/arrays/null/compute/take.rs
@@ -4,7 +4,6 @@
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::ToCanonical;
@@ -17,7 +16,7 @@ use crate::optimizer::rules::ParentRuleSet;
 
 impl TakeReduce for NullVTable {
     #[allow(clippy::cast_possible_truncation)]
-    fn take(array: &NullArray, indices: &dyn Array) -> VortexResult<Option<ArrayRef>> {
+    fn take(array: &NullArray, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let indices = indices.to_primitive();
 
         // Enforce all indices are valid

--- a/vortex-array/src/arrays/primitive/array/cast.rs
+++ b/vortex-array/src/arrays/primitive/array/cast.rs
@@ -66,7 +66,7 @@ impl PrimitiveArray {
             return Ok(self.clone());
         }
 
-        let Some(min_max) = min_max(self.as_ref())? else {
+        let Some(min_max) = min_max(&self.to_array())? else {
             return Ok(PrimitiveArray::new(
                 Buffer::<u8>::zeroed(self.len()),
                 self.validity.clone(),

--- a/vortex-array/src/arrays/primitive/array/mod.rs
+++ b/vortex-array/src/arrays/primitive/array/mod.rs
@@ -62,7 +62,8 @@ use crate::buffer::BufferHandle;
 /// assert_eq!(value, 2i32.into());
 ///
 /// // Convert into a type-erased array that can be passed to compute functions.
-/// let summed = sum(sliced.as_ref()).unwrap().as_primitive().typed_value::<i64>().unwrap();
+/// use vortex_array::IntoArray;
+/// let summed = sum(&sliced.into_array()).unwrap().as_primitive().typed_value::<i64>().unwrap();
 /// assert_eq!(summed, 5i64);
 /// # Ok(())
 /// # }

--- a/vortex-array/src/arrays/primitive/array/patch.rs
+++ b/vortex-array/src/arrays/primitive/array/patch.rs
@@ -5,7 +5,6 @@ use std::ops::Range;
 
 use vortex_error::VortexResult;
 
-use crate::Array;
 use crate::arrays::PrimitiveArray;
 use crate::dtype::IntegerPType;
 use crate::dtype::NativePType;
@@ -25,7 +24,7 @@ impl PrimitiveArray {
         let patched_validity = self.validity().clone().patch(
             self.len(),
             patches.offset(),
-            patch_indices.as_ref(),
+            &patch_indices.to_array(),
             patch_values.validity(),
         )?;
         Ok(match_each_integer_ptype!(patch_indices.ptype(), |I| {

--- a/vortex-array/src/arrays/primitive/compute/between.rs
+++ b/vortex-array/src/arrays/primitive/compute/between.rs
@@ -4,7 +4,6 @@
 use vortex_buffer::BitBuffer;
 use vortex_error::VortexResult;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
@@ -22,8 +21,8 @@ use crate::vtable::ValidityHelper;
 impl BetweenKernel for PrimitiveVTable {
     fn between(
         arr: &PrimitiveArray,
-        lower: &dyn Array,
-        upper: &dyn Array,
+        lower: &ArrayRef,
+        upper: &ArrayRef,
         options: &BetweenOptions,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -237,6 +237,6 @@ mod test {
     #[case(PrimitiveArray::from_option_iter([Some(1i32), None, Some(-100), Some(0), None]).into_array())]
     #[case(buffer![42u32].into_array())]
     fn test_cast_primitive_conformance(#[case] array: crate::ArrayRef) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array);
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/primitive/compute/is_sorted.rs
@@ -106,7 +106,7 @@ mod tests {
     #[case(PrimitiveArray::from_option_iter([None, Some(5_u8), None]), false)]
     fn test_primitive_is_sorted(#[case] array: PrimitiveArray, #[case] expected: bool) {
         assert_eq!(
-            is_sorted(array.as_ref()).vortex_expect("operation should succeed in test"),
+            is_sorted(&array.to_array()).vortex_expect("operation should succeed in test"),
             Some(expected)
         );
     }
@@ -119,7 +119,7 @@ mod tests {
     #[case(PrimitiveArray::from_option_iter([None, Some(5_u8), None]), false)]
     fn test_primitive_is_strict_sorted(#[case] array: PrimitiveArray, #[case] expected: bool) {
         assert_eq!(
-            is_strict_sorted(array.as_ref()).vortex_expect("operation should succeed in test"),
+            is_strict_sorted(&array.to_array()).vortex_expect("operation should succeed in test"),
             Some(expected)
         );
     }

--- a/vortex-array/src/arrays/primitive/compute/mask.rs
+++ b/vortex-array/src/arrays/primitive/compute/mask.rs
@@ -44,6 +44,6 @@ mod test {
     #[case(PrimitiveArray::from_iter([0.1f32, 0.2, 0.3, 0.4, 0.5]))]
     #[case(PrimitiveArray::from_option_iter([Some(1.1f64), None, Some(2.2), Some(3.3), None]))]
     fn test_mask_primitive_conformance(#[case] array: PrimitiveArray) {
-        test_mask_conformance(array.as_ref());
+        test_mask_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/min_max.rs
+++ b/vortex-array/src/arrays/primitive/compute/min_max.rs
@@ -86,7 +86,7 @@ mod tests {
             buffer![f32::NAN, -f32::NAN, -1.0, 1.0],
             Validity::NonNullable,
         );
-        let min_max = min_max(array.as_ref()).unwrap().unwrap();
+        let min_max = min_max(&array.to_array()).unwrap().unwrap();
         assert_eq!(f32::try_from(&min_max.min).unwrap(), -1.0);
         assert_eq!(f32::try_from(&min_max.max).unwrap(), 1.0);
     }
@@ -97,7 +97,7 @@ mod tests {
             buffer![f32::INFINITY, f32::NEG_INFINITY, -1.0, 1.0],
             Validity::NonNullable,
         );
-        let min_max = min_max(array.as_ref()).unwrap().unwrap();
+        let min_max = min_max(&array.to_array()).unwrap().unwrap();
         assert_eq!(f32::try_from(&min_max.min).unwrap(), f32::NEG_INFINITY);
         assert_eq!(f32::try_from(&min_max.max).unwrap(), f32::INFINITY);
     }

--- a/vortex-array/src/arrays/primitive/compute/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/mod.rs
@@ -42,7 +42,7 @@ mod tests {
     #[case::i16_negative(PrimitiveArray::from_iter([-100i16, -50, 0, 50, 100]))]
     #[case::f64_special(PrimitiveArray::from_iter([0.0f64, 1.0, -1.0, f64::INFINITY, f64::NEG_INFINITY]))]
     fn test_primitive_consistency(#[case] array: PrimitiveArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 
     #[rstest]

--- a/vortex-array/src/arrays/primitive/compute/nan_count.rs
+++ b/vortex-array/src/arrays/primitive/compute/nan_count.rs
@@ -58,6 +58,6 @@ mod tests {
             ],
             Validity::NonNullable,
         );
-        assert_eq!(nan_count(p.as_ref()).unwrap(), 2);
+        assert_eq!(nan_count(&p.to_array()).unwrap(), 2);
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/take/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/mod.rs
@@ -84,7 +84,7 @@ impl TakeImpl for TakeKernelScalar {
 impl TakeExecute for PrimitiveVTable {
     fn take(
         array: &PrimitiveArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let DType::Primitive(ptype, null) = indices.dtype() else {
@@ -101,7 +101,7 @@ impl TakeExecute for PrimitiveVTable {
                 .to_primitive()
         };
 
-        let validity = array.validity().take(unsigned_indices.as_ref())?;
+        let validity = array.validity().take(&unsigned_indices.to_array())?;
         // Delegate to the best kernel based on the target CPU
         PRIMITIVE_TAKE_KERNEL
             .take(array, &unsigned_indices, validity)
@@ -196,6 +196,6 @@ mod test {
     ))]
     #[case(PrimitiveArray::from_option_iter([Some(1), None, Some(3), Some(4), None]))]
     fn test_take_primitive_conformance(#[case] array: PrimitiveArray) {
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/primitive/tests.rs
+++ b/vortex-array/src/arrays/primitive/tests.rs
@@ -35,44 +35,50 @@ fn test_search_sorted_primitive(
 #[test]
 fn test_mask_primitive_array() {
     test_mask_conformance(
-        PrimitiveArray::new(buffer![0, 1, 2, 3, 4], Validity::NonNullable).as_ref(),
-    );
-    test_mask_conformance(PrimitiveArray::new(buffer![0, 1, 2, 3, 4], Validity::AllValid).as_ref());
-    test_mask_conformance(
-        PrimitiveArray::new(buffer![0, 1, 2, 3, 4], Validity::AllInvalid).as_ref(),
+        &PrimitiveArray::new(buffer![0, 1, 2, 3, 4], Validity::NonNullable).into_array(),
     );
     test_mask_conformance(
-        PrimitiveArray::new(
+        &PrimitiveArray::new(buffer![0, 1, 2, 3, 4], Validity::AllValid).into_array(),
+    );
+    test_mask_conformance(
+        &PrimitiveArray::new(buffer![0, 1, 2, 3, 4], Validity::AllInvalid).into_array(),
+    );
+    test_mask_conformance(
+        &PrimitiveArray::new(
             buffer![0, 1, 2, 3, 4],
             Validity::Array(BoolArray::from_iter([true, false, true, false, true]).into_array()),
         )
-        .as_ref(),
+        .into_array(),
     );
 }
 
 #[test]
 fn test_filter_primitive_array() {
     // Test various sizes
-    test_filter_conformance(PrimitiveArray::new(buffer![42i32], Validity::NonNullable).as_ref());
-    test_filter_conformance(PrimitiveArray::new(buffer![0, 1], Validity::NonNullable).as_ref());
     test_filter_conformance(
-        PrimitiveArray::new(buffer![0, 1, 2, 3, 4], Validity::NonNullable).as_ref(),
+        &PrimitiveArray::new(buffer![42i32], Validity::NonNullable).into_array(),
     );
     test_filter_conformance(
-        PrimitiveArray::new(buffer![0, 1, 2, 3, 4, 5, 6, 7], Validity::NonNullable).as_ref(),
+        &PrimitiveArray::new(buffer![0, 1], Validity::NonNullable).into_array(),
+    );
+    test_filter_conformance(
+        &PrimitiveArray::new(buffer![0, 1, 2, 3, 4], Validity::NonNullable).into_array(),
+    );
+    test_filter_conformance(
+        &PrimitiveArray::new(buffer![0, 1, 2, 3, 4, 5, 6, 7], Validity::NonNullable).into_array(),
     );
 
     // Test with validity
     test_filter_conformance(
-        PrimitiveArray::new(buffer![0, 1, 2, 3, 4], Validity::AllValid).as_ref(),
+        &PrimitiveArray::new(buffer![0, 1, 2, 3, 4], Validity::AllValid).into_array(),
     );
     test_filter_conformance(
-        PrimitiveArray::new(
+        &PrimitiveArray::new(
             buffer![0, 1, 2, 3, 4, 5],
             Validity::Array(
                 BoolArray::from_iter([true, false, true, false, true, true]).into_array(),
             ),
         )
-        .as_ref(),
+        .into_array(),
     );
 }

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -115,7 +115,7 @@ mod tests {
     #[case(create_nested_struct())]
     #[case(create_simple_struct())]
     fn test_cast_struct_conformance(#[case] array: StructArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 
     fn create_test_struct(nullable: bool) -> StructArray {

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -108,9 +108,9 @@ mod tests {
     #[test]
     fn test_mask_empty_struct() {
         test_mask_conformance(
-            StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
+            &StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
                 .unwrap()
-                .as_ref(),
+                .to_array(),
         );
     }
 
@@ -126,7 +126,7 @@ mod tests {
             BoolArray::from_iter([Some(true), Some(true), None, None, Some(false)]).into_array();
 
         test_mask_conformance(
-            StructArray::try_new(
+            &StructArray::try_new(
                 ["xs", "ys", "zs"].into(),
                 vec![
                     StructArray::try_new(
@@ -144,7 +144,7 @@ mod tests {
                 Validity::NonNullable,
             )
             .unwrap()
-            .as_ref(),
+            .to_array(),
         );
     }
 
@@ -253,16 +253,16 @@ mod tests {
     fn test_empty_struct_is_constant() {
         let array = StructArray::new_fieldless_with_len(2);
         let is_constant =
-            is_constant(array.as_ref()).vortex_expect("operation should succeed in test");
+            is_constant(&array.to_array()).vortex_expect("operation should succeed in test");
         assert_eq!(is_constant, Some(true));
     }
 
     #[test]
     fn test_take_empty_struct_conformance() {
         test_take_conformance(
-            StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
+            &StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
                 .unwrap()
-                .as_ref(),
+                .to_array(),
         );
     }
 
@@ -276,9 +276,9 @@ mod tests {
         .into_array();
 
         test_take_conformance(
-            StructArray::try_new(["xs", "ys"].into(), vec![xs, ys], 5, Validity::NonNullable)
+            &StructArray::try_new(["xs", "ys"].into(), vec![xs, ys], 5, Validity::NonNullable)
                 .unwrap()
-                .as_ref(),
+                .to_array(),
         );
     }
 
@@ -292,14 +292,14 @@ mod tests {
         );
 
         test_take_conformance(
-            StructArray::try_new(
+            &StructArray::try_new(
                 ["xs", "ys"].into(),
                 vec![xs.into_array(), ys.into_array()],
                 5,
                 Validity::NonNullable,
             )
             .unwrap()
-            .as_ref(),
+            .to_array(),
         );
     }
 
@@ -320,14 +320,14 @@ mod tests {
         let outer_zs = BoolArray::from_iter([true, false, true, false, true]).into_array();
 
         test_take_conformance(
-            StructArray::try_new(
+            &StructArray::try_new(
                 ["inner", "z"].into(),
                 vec![inner_struct, outer_zs],
                 5,
                 Validity::NonNullable,
             )
             .unwrap()
-            .as_ref(),
+            .to_array(),
         );
     }
 
@@ -337,9 +337,9 @@ mod tests {
         let ys = VarBinArray::from_iter(["hello"].map(Some), DType::Utf8(NonNullable)).into_array();
 
         test_take_conformance(
-            StructArray::try_new(["xs", "ys"].into(), vec![xs, ys], 1, Validity::NonNullable)
+            &StructArray::try_new(["xs", "ys"].into(), vec![xs, ys], 1, Validity::NonNullable)
                 .unwrap()
-                .as_ref(),
+                .to_array(),
         );
     }
 
@@ -355,14 +355,14 @@ mod tests {
         let zs = BoolArray::from_iter((0..100).map(|i| i % 2 == 0)).into_array();
 
         test_take_conformance(
-            StructArray::try_new(
+            &StructArray::try_new(
                 ["xs", "ys", "zs"].into(),
                 vec![xs, ys, zs],
                 100,
                 Validity::NonNullable,
             )
             .unwrap()
-            .as_ref(),
+            .to_array(),
         );
     }
 
@@ -412,6 +412,6 @@ mod tests {
         StructArray::try_new(["xs", "ys"].into(), vec![xs, ys], 100, Validity::NonNullable).unwrap()
     })]
     fn test_struct_consistency(#[case] array: StructArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/struct_/compute/take.rs
+++ b/vortex-array/src/arrays/struct_/compute/take.rs
@@ -18,7 +18,7 @@ use crate::vtable::ValidityHelper;
 impl TakeExecute for StructVTable {
     fn take(
         array: &StructArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         // If the struct array is empty then the indices must be all null, otherwise it will access

--- a/vortex-array/src/arrays/struct_/compute/zip.rs
+++ b/vortex-array/src/arrays/struct_/compute/zip.rs
@@ -8,7 +8,6 @@ use std::ops::Not;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
@@ -22,7 +21,7 @@ use crate::vtable::ValidityHelper;
 impl ZipKernel for StructVTable {
     fn zip(
         if_true: &StructArray,
-        if_false: &dyn Array,
+        if_false: &ArrayRef,
         mask: &Mask,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -167,7 +167,7 @@ impl VarBinArray {
     ///
     /// This function checks all the invariants required by [`VarBinArray::new_unchecked`].
     pub fn validate(
-        offsets: &dyn Array,
+        offsets: &ArrayRef,
         bytes: &BufferHandle,
         dtype: &DType,
         validity: &Validity,

--- a/vortex-array/src/arrays/varbin/compute/cast.rs
+++ b/vortex-array/src/arrays/varbin/compute/cast.rs
@@ -87,6 +87,6 @@ mod tests {
     #[case(VarBinArray::from_iter(vec![Some(b"test".as_slice()), None], DType::Binary(Nullability::Nullable)))]
     #[case(VarBinArray::from_iter(vec![Some("single")], DType::Utf8(Nullability::NonNullable)))]
     fn test_cast_varbin_conformance(#[case] array: VarBinArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -36,7 +36,7 @@ use crate::vtable::ValidityHelper;
 impl CompareKernel for VarBinVTable {
     fn compare(
         lhs: &VarBinArray,
-        rhs: &dyn Array,
+        rhs: &ArrayRef,
         operator: CompareOperator,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
@@ -82,7 +82,7 @@ impl CompareKernel for VarBinVTable {
                 ));
             }
 
-            let lhs = Datum::try_new(lhs.as_ref())?;
+            let lhs = Datum::try_new(&lhs.to_array())?;
 
             // Use StringViewArray/BinaryViewArray to match the Utf8View/BinaryView types
             // produced by Datum::try_new (which uses into_arrow_preferred())

--- a/vortex-array/src/arrays/varbin/compute/filter.rs
+++ b/vortex-array/src/arrays/varbin/compute/filter.rs
@@ -315,12 +315,12 @@ mod test {
             vec!["hello", "world", "filter", "good", "bye"],
             DType::Utf8(NonNullable),
         );
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
 
         let array = VarBinArray::from_iter(
             vec![Some("hello"), None, Some("filter"), Some("good"), None],
             DType::Utf8(Nullable),
         );
-        test_filter_conformance(array.as_ref());
+        test_filter_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/varbin/compute/mask.rs
+++ b/vortex-array/src/arrays/varbin/compute/mask.rs
@@ -41,12 +41,12 @@ mod test {
             vec!["hello", "world", "filter", "good", "bye"],
             DType::Utf8(Nullability::NonNullable),
         );
-        test_mask_conformance(array.as_ref());
+        test_mask_conformance(&array.to_array());
 
         let array = VarBinArray::from_iter(
             vec![Some("hello"), None, Some("filter"), Some("good"), None],
             DType::Utf8(Nullability::Nullable),
         );
-        test_mask_conformance(array.as_ref());
+        test_mask_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/varbin/compute/min_max.rs
+++ b/vortex-array/src/arrays/varbin/compute/min_max.rs
@@ -84,7 +84,7 @@ mod tests {
             ],
             Utf8(Nullable),
         );
-        let MinMaxResult { min, max } = min_max(array.as_ref()).unwrap().unwrap();
+        let MinMaxResult { min, max } = min_max(&array.to_array()).unwrap().unwrap();
 
         assert_eq!(
             min,

--- a/vortex-array/src/arrays/varbin/compute/mod.rs
+++ b/vortex-array/src/arrays/varbin/compute/mod.rs
@@ -63,6 +63,6 @@ mod tests {
         DType::Utf8(Nullability::NonNullable),
     ))]
     fn test_varbin_consistency(#[case] array: VarBinArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/varbin/compute/take.rs
+++ b/vortex-array/src/arrays/varbin/compute/take.rs
@@ -9,7 +9,6 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::ToCanonical;
@@ -26,7 +25,7 @@ use crate::validity::Validity;
 impl TakeExecute for VarBinVTable {
     fn take(
         array: &VarBinArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         // TODO(joe): Be lazy with execute
@@ -297,7 +296,7 @@ mod tests {
     ))]
     #[case(VarBinArray::from_iter(["single"].map(Some), DType::Utf8(Nullability::NonNullable)))]
     fn test_take_varbin_conformance(#[case] array: VarBinArray) {
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 
     #[test]

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -130,7 +130,7 @@ impl VarBinViewArray {
             self.len(),
             buffer_utilization_threshold,
         );
-        builder.extend_from_array(self.as_ref());
+        builder.extend_from_array(&self.to_array());
         Ok(builder.finish_into_varbinview())
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/cast.rs
+++ b/vortex-array/src/arrays/varbinview/compute/cast.rs
@@ -92,6 +92,6 @@ mod tests {
     #[case(VarBinViewArray::from_iter(vec![Some("single")], DType::Utf8(Nullability::NonNullable)))]
     #[case(VarBinViewArray::from_iter(vec![Some("very long string that exceeds the inline size to test view functionality with multiple buffers")], DType::Utf8(Nullability::NonNullable)))]
     fn test_cast_varbinview_conformance(#[case] array: VarBinViewArray) {
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/mask.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mask.rs
@@ -39,18 +39,18 @@ mod tests {
     #[test]
     fn take_mask_var_bin_view_array() {
         test_mask_conformance(
-            VarBinViewArray::from_iter_str(["one", "two", "three", "four", "five"]).as_ref(),
+            &VarBinViewArray::from_iter_str(["one", "two", "three", "four", "five"]).to_array(),
         );
 
         test_mask_conformance(
-            VarBinViewArray::from_iter_nullable_str([
+            &VarBinViewArray::from_iter_nullable_str([
                 Some("one"),
                 None,
                 Some("three"),
                 Some("four"),
                 Some("five"),
             ])
-            .as_ref(),
+            .to_array(),
         );
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/mod.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mod.rs
@@ -82,6 +82,6 @@ mod tests {
         None::<&str>, None, None, None
     ]))]
     fn test_varbinview_consistency(#[case] array: VarBinViewArray) {
-        test_array_consistency(array.as_ref());
+        test_array_consistency(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/take.rs
+++ b/vortex-array/src/arrays/varbinview/compute/take.rs
@@ -9,7 +9,6 @@ use vortex_error::VortexResult;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::ToCanonical;
@@ -26,7 +25,7 @@ impl TakeExecute for VarBinViewVTable {
     /// Take involves creating a new array that references the old array, just with the given set of views.
     fn take(
         array: &VarBinViewArray,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let validity = array.validity().take(indices)?;
@@ -160,6 +159,6 @@ mod tests {
     ))]
     #[case(VarBinViewArray::from_iter(["single"].map(Some), DType::Utf8(NonNullable)))]
     fn test_take_varbinview_conformance(#[case] array: VarBinViewArray) {
-        test_take_conformance(array.as_ref());
+        test_take_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/zip.rs
+++ b/vortex-array/src/arrays/varbinview/compute/zip.rs
@@ -9,7 +9,6 @@ use vortex_error::vortex_bail;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::arrays::BinaryView;
@@ -24,7 +23,7 @@ use crate::scalar_fn::fns::zip::ZipKernel;
 impl ZipKernel for VarBinViewVTable {
     fn zip(
         if_true: &VarBinViewArray,
-        if_false: &dyn Array,
+        if_false: &ArrayRef,
         mask: &Mask,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
@@ -244,7 +243,9 @@ mod tests {
         let mask = Mask::from_iter([true, false, true, false, false, true]);
 
         #[expect(deprecated)]
-        let zipped = zip(a.as_ref(), b.as_ref(), &mask).unwrap().to_varbinview();
+        let zipped = zip(&a.to_array(), &b.to_array(), &mask)
+            .unwrap()
+            .to_varbinview();
 
         let values = zipped.with_iterator(|it| {
             it.map(|v| v.map(|bytes| String::from_utf8(bytes.to_vec()).unwrap()))

--- a/vortex-array/src/arrow/compute/to_arrow/mod.rs
+++ b/vortex-array/src/arrow/compute/to_arrow/mod.rs
@@ -9,6 +9,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 
 use crate::Array;
+use crate::ArrayRef;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrow::ArrowArrayExecutor;
@@ -23,20 +24,20 @@ use crate::compute::Options;
 /// may have a different preferred Arrow type. Use [`to_arrow`] instead.
 #[deprecated(note = "Use ArrowArrayExecutor::execute_arrow instead")]
 #[expect(deprecated)]
-pub fn to_arrow_preferred(array: &dyn Array) -> VortexResult<ArrowArrayRef> {
+pub fn to_arrow_preferred(array: &ArrayRef) -> VortexResult<ArrowArrayRef> {
     to_arrow_opts(array, &ToArrowOptions { arrow_type: None })
 }
 
 /// Convert a Vortex array to an Arrow array of the given type.
 #[deprecated(note = "Use ArrowArrayExecutor::execute_arrow instead")]
-pub fn to_arrow(array: &dyn Array, arrow_type: &DataType) -> VortexResult<ArrowArrayRef> {
+pub fn to_arrow(array: &ArrayRef, arrow_type: &DataType) -> VortexResult<ArrowArrayRef> {
     let mut ctx = LEGACY_SESSION.create_execution_ctx();
     array.to_array().execute_arrow(Some(arrow_type), &mut ctx)
 }
 
 #[deprecated(note = "Use ArrowArrayExecutor::execute_arrow instead")]
 #[expect(deprecated)]
-pub fn to_arrow_opts(array: &dyn Array, options: &ToArrowOptions) -> VortexResult<ArrowArrayRef> {
+pub fn to_arrow_opts(array: &ArrayRef, options: &ToArrowOptions) -> VortexResult<ArrowArrayRef> {
     let data_type = if let Some(data_type) = &options.arrow_type {
         data_type.clone()
     } else {

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -26,7 +26,7 @@ pub struct Datum {
 
 impl Datum {
     /// Create a new [`Datum`] from an [`ArrayRef`], which can then be passed to Arrow compute.
-    pub fn try_new(array: &dyn Array) -> VortexResult<Self> {
+    pub fn try_new(array: &ArrayRef) -> VortexResult<Self> {
         if array.is::<ConstantVTable>() {
             Ok(Self {
                 array: array.slice(0..1)?.into_arrow_preferred()?,
@@ -42,7 +42,7 @@ impl Datum {
 
     /// Create a new [`Datum`] from an [`Array`], which can then be passed to Arrow compute.
     /// This not try and convert the array to a scalar if it is constant.
-    pub fn try_new_array(array: &dyn Array) -> VortexResult<Self> {
+    pub fn try_new_array(array: &ArrayRef) -> VortexResult<Self> {
         Ok(Self {
             array: array.to_array().into_arrow_preferred()?,
             is_scalar: false,
@@ -50,7 +50,7 @@ impl Datum {
     }
 
     pub fn try_new_with_target_datatype(
-        array: &dyn Array,
+        array: &ArrayRef,
         target_datatype: &DataType,
     ) -> VortexResult<Self> {
         if array.is::<ConstantVTable>() {

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -10,7 +10,6 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_mask::Mask;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
@@ -112,7 +111,7 @@ impl ArrayBuilder for BoolBuilder {
         Ok(())
     }
 
-    unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
+    unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         let bool_array = array.to_bool();
 
         self.inner.append_buffer(&bool_array.to_bit_buffer());

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -11,7 +11,6 @@ use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::ToCanonical;
@@ -187,7 +186,7 @@ impl ArrayBuilder for DecimalBuilder {
         Ok(())
     }
 
-    unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
+    unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         let decimal_array = array.to_decimal();
 
         match_each_decimal_value_type!(decimal_array.values_type(), |D| {

--- a/vortex-array/src/builders/dict/bytes.rs
+++ b/vortex-array/src/builders/dict/bytes.rs
@@ -158,7 +158,7 @@ impl<Code: UnsignedPType> BytesDictBuilder<Code> {
 }
 
 impl<Code: UnsignedPType> DictEncoder for BytesDictBuilder<Code> {
-    fn encode(&mut self, array: &dyn Array) -> ArrayRef {
+    fn encode(&mut self, array: &ArrayRef) -> ArrayRef {
         debug_assert_eq!(
             &self.dtype,
             array.dtype(),
@@ -214,7 +214,7 @@ mod test {
     #[test]
     fn encode_varbin() {
         let arr = VarBinArray::from(vec!["hello", "world", "hello", "again", "world"]);
-        let dict = dict_encode(arr.as_ref()).unwrap();
+        let dict = dict_encode(&arr.to_array()).unwrap();
         assert_eq!(
             dict.codes().to_primitive().as_slice::<u8>(),
             &[0, 1, 0, 2, 1]
@@ -243,7 +243,7 @@ mod test {
         ]
         .into_iter()
         .collect();
-        let dict = dict_encode(arr.as_ref()).unwrap();
+        let dict = dict_encode(&arr.to_array()).unwrap();
         assert_eq!(
             dict.codes().to_primitive().as_slice::<u8>(),
             &[0, 1, 2, 0, 1, 3, 2, 1]
@@ -260,7 +260,7 @@ mod test {
     #[test]
     fn repeated_values() {
         let arr = VarBinArray::from(vec!["a", "a", "b", "b", "a", "b", "a", "b"]);
-        let dict = dict_encode(arr.as_ref()).unwrap();
+        let dict = dict_encode(&arr.to_array()).unwrap();
         dict.values().to_varbinview().with_iterator(|iter| {
             assert_eq!(
                 iter.flatten()

--- a/vortex-array/src/builders/dict/mod.rs
+++ b/vortex-array/src/builders/dict/mod.rs
@@ -34,7 +34,7 @@ pub const UNCONSTRAINED: DictConstraints = DictConstraints {
 
 pub trait DictEncoder: Send {
     /// Assign dictionary codes to the given input array.
-    fn encode(&mut self, array: &dyn Array) -> ArrayRef;
+    fn encode(&mut self, array: &ArrayRef) -> ArrayRef;
 
     /// Clear the encoder state to make it ready for a new round of decoding.
     fn reset(&mut self) -> ArrayRef;
@@ -43,7 +43,7 @@ pub trait DictEncoder: Send {
     fn codes_ptype(&self) -> PType;
 }
 
-pub fn dict_encoder(array: &dyn Array, constraints: &DictConstraints) -> Box<dyn DictEncoder> {
+pub fn dict_encoder(array: &ArrayRef, constraints: &DictConstraints) -> Box<dyn DictEncoder> {
     let dict_builder: Box<dyn DictEncoder> = if let Some(pa) = array.as_opt::<PrimitiveVTable>() {
         match_each_native_ptype!(pa.ptype(), |P| {
             primitive_dict_builder::<P>(pa.dtype().nullability(), constraints)
@@ -62,7 +62,7 @@ pub fn dict_encoder(array: &dyn Array, constraints: &DictConstraints) -> Box<dyn
 ///
 /// Vortex encoders must always produce unsigned integer codes; signed codes are only accepted for external compatibility.
 pub fn dict_encode_with_constraints(
-    array: &dyn Array,
+    array: &ArrayRef,
     constraints: &DictConstraints,
 ) -> VortexResult<DictArray> {
     let mut encoder = dict_encoder(array, constraints);
@@ -78,7 +78,7 @@ pub fn dict_encode_with_constraints(
     }
 }
 
-pub fn dict_encode(array: &dyn Array) -> VortexResult<DictArray> {
+pub fn dict_encode(array: &ArrayRef) -> VortexResult<DictArray> {
     let dict_array = dict_encode_with_constraints(array, &UNCONSTRAINED)?;
     if dict_array.len() != array.len() {
         vortex_bail!(

--- a/vortex-array/src/builders/dict/primitive.rs
+++ b/vortex-array/src/builders/dict/primitive.rs
@@ -124,7 +124,7 @@ where
     NativeValue<T>: Hash + Eq,
     Code: UnsignedPType,
 {
-    fn encode(&mut self, array: &dyn Array) -> ArrayRef {
+    fn encode(&mut self, array: &ArrayRef) -> ArrayRef {
         let mut codes = BufferMut::<Code>::with_capacity(array.len());
 
         array.to_primitive().with_iterator(|it| {
@@ -167,7 +167,7 @@ mod test {
     #[test]
     fn encode_primitive() {
         let arr = buffer![1, 1, 3, 3, 3].into_array();
-        let dict = dict_encode(arr.as_ref()).unwrap();
+        let dict = dict_encode(&arr).unwrap();
 
         let expected_codes = buffer![0u8, 0, 1, 1, 1].into_array();
         assert_arrays_eq!(dict.codes(), expected_codes);
@@ -188,7 +188,7 @@ mod test {
             Some(3),
             None,
         ]);
-        let dict = dict_encode(arr.as_ref()).unwrap();
+        let dict = dict_encode(&arr.to_array()).unwrap();
 
         let expected_codes = buffer![0u8, 0, 1, 2, 2, 1, 2, 1].into_array();
         assert_arrays_eq!(dict.codes(), expected_codes);

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -7,7 +7,6 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_mask::Mask;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::ExtensionArray;
@@ -98,7 +97,7 @@ impl ArrayBuilder for ExtensionBuilder {
         self.append_value(scalar.as_extension())
     }
 
-    unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
+    unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         let ext_array = array.to_extension();
         self.storage.extend_from_array(ext_array.storage())
     }

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -80,7 +80,7 @@ impl FixedSizeListBuilder {
     ///
     /// Note that the list entry will be non-null but the elements themselves are allowed to be null
     /// (only if the elements [`DType`] is nullable, of course).
-    pub fn append_array_as_list(&mut self, array: &dyn Array) -> VortexResult<()> {
+    pub fn append_array_as_list(&mut self, array: &ArrayRef) -> VortexResult<()> {
         vortex_ensure!(
             array.dtype() == self.element_dtype(),
             "Array dtype {:?} does not match list element dtype {:?}",
@@ -234,7 +234,7 @@ impl ArrayBuilder for FixedSizeListBuilder {
 
     /// This will increase the capacity if extending with this `array` would go past the original
     /// capacity.
-    unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
+    unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         let fsl = array.to_fixed_size_list();
         if fsl.is_empty() {
             return;

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -91,7 +91,7 @@ impl<O: IntegerPType> ListBuilder<O> {
     ///
     /// Note that the list entry will be non-null but the elements themselves are allowed to be null
     /// (only if the elements [`DType`] in nullable, of course).
-    pub fn append_array_as_list(&mut self, array: &dyn Array) -> VortexResult<()> {
+    pub fn append_array_as_list(&mut self, array: &ArrayRef) -> VortexResult<()> {
         vortex_ensure!(
             array.dtype() == self.element_dtype(),
             "Array dtype {:?} does not match list element dtype {:?}",
@@ -213,7 +213,7 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
         self.append_value(scalar.as_list())
     }
 
-    unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
+    unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         let list = array.to_listview();
         if list.is_empty() {
             return;

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -116,7 +116,7 @@ impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
     ///
     /// Note that the list entry will be non-null but the elements themselves are allowed to be null
     /// (only if the elements [`DType`] is nullable, of course).
-    pub fn append_array_as_list(&mut self, array: &dyn Array) -> VortexResult<()> {
+    pub fn append_array_as_list(&mut self, array: &ArrayRef) -> VortexResult<()> {
         vortex_ensure!(
             array.dtype() == self.element_dtype(),
             "Array dtype {:?} does not match list element dtype {:?}",
@@ -290,7 +290,7 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
         self.append_value(list_scalar)
     }
 
-    unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
+    unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         let listview = array.to_listview();
         if listview.is_empty() {
             return;
@@ -344,7 +344,7 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
             .vortex_expect(
                 "was somehow unable to cast the new sizes to the type of the builder sizes",
             );
-        self.sizes_builder.extend_from_array(cast_sizes.as_ref());
+        self.sizes_builder.extend_from_array(&cast_sizes);
 
         // Now we need to adjust all of the offsets by adding the current number of elements in the
         // builder.

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -160,7 +160,7 @@ pub trait ArrayBuilder: Send {
 
     /// Extends the array with the provided array, canonicalizing if necessary.
     ///
-    /// Implementors must validate that the passed in [`Array`] has the correct [`DType`].
+    /// Implementors must validate that the passed in [`ArrayRef`] has the correct [`DType`].
     fn extend_from_array(&mut self, array: &ArrayRef) {
         if !self.dtype().eq_with_nullability_superset(array.dtype()) {
             vortex_panic!(
@@ -210,7 +210,7 @@ pub trait ArrayBuilder: Send {
     ///
     /// This method provides a default implementation that creates an [`ArrayRef`] via `finish` and
     /// then converts it to canonical form. Specific builders can override this with optimized
-    /// implementations that avoid the intermediate [`Array`] creation.
+    /// implementations that avoid the intermediate [`ArrayRef`] creation.
     fn finish_into_canonical(&mut self) -> Canonical {
         self.finish()
             .to_canonical()

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -35,7 +35,6 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::canonical::Canonical;
 use crate::dtype::DType;
@@ -157,12 +156,12 @@ pub trait ArrayBuilder: Send {
     ///
     /// The array that must have an equal [`DType`] to the array builder's `DType` (with nullability
     /// superset semantics).
-    unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array);
+    unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef);
 
     /// Extends the array with the provided array, canonicalizing if necessary.
     ///
     /// Implementors must validate that the passed in [`Array`] has the correct [`DType`].
-    fn extend_from_array(&mut self, array: &dyn Array) {
+    fn extend_from_array(&mut self, array: &ArrayRef) {
         if !self.dtype().eq_with_nullability_superset(array.dtype()) {
             vortex_panic!(
                 "tried to extend a builder with `DType` {} with an array with `DType {}",

--- a/vortex-array/src/builders/null.rs
+++ b/vortex-array/src/builders/null.rs
@@ -70,7 +70,7 @@ impl ArrayBuilder for NullBuilder {
         Ok(())
     }
 
-    unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
+    unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         self.append_nulls(array.len());
     }
 

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -10,7 +10,6 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_mask::Mask;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
@@ -164,7 +163,7 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
         Ok(())
     }
 
-    unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
+    unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         let array = array.to_primitive();
 
         // This should be checked in `extend_from_array` but we can check it again.

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -11,7 +11,6 @@ use vortex_error::vortex_ensure;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::StructArray;
@@ -165,7 +164,7 @@ impl ArrayBuilder for StructBuilder {
         self.append_value(scalar.as_struct())
     }
 
-    unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
+    unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         let array = array.to_struct();
 
         for (a, builder) in array
@@ -173,7 +172,7 @@ impl ArrayBuilder for StructBuilder {
             .iter()
             .zip_eq(self.builders.iter_mut())
         {
-            builder.extend_from_array(a.as_ref());
+            builder.extend_from_array(a);
         }
 
         self.nulls.append_validity_mask(

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -18,7 +18,6 @@ use vortex_mask::Mask;
 use vortex_utils::aliases::hash_map::Entry;
 use vortex_utils::aliases::hash_map::HashMap;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::BinaryView;
@@ -267,7 +266,7 @@ impl ArrayBuilder for VarBinViewBuilder {
         Ok(())
     }
 
-    unsafe fn extend_from_array_unchecked(&mut self, array: &dyn Array) {
+    unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         let array = array.to_varbinview();
         self.flush_in_progress();
 

--- a/vortex-array/src/compute/boolean.rs
+++ b/vortex-array/src/compute/boolean.rs
@@ -10,12 +10,12 @@ use crate::scalar_fn::fns::operators::Operator;
 
 /// Point-wise Kleene logical _and_ between two Boolean arrays.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn and_kleene(lhs: &dyn Array, rhs: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn and_kleene(lhs: &ArrayRef, rhs: &ArrayRef) -> VortexResult<ArrayRef> {
     lhs.to_array().binary(rhs.to_array(), Operator::And)
 }
 
 /// Point-wise Kleene logical _or_ between two Boolean arrays.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn or_kleene(lhs: &dyn Array, rhs: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn or_kleene(lhs: &ArrayRef, rhs: &ArrayRef) -> VortexResult<ArrayRef> {
     lhs.to_array().binary(rhs.to_array(), Operator::Or)
 }

--- a/vortex-array/src/compute/conformance/binary_numeric.rs
+++ b/vortex-array/src/compute/conformance/binary_numeric.rs
@@ -45,7 +45,7 @@ use crate::scalar::NumericOperator;
 use crate::scalar::PrimitiveScalar;
 use crate::scalar::Scalar;
 
-fn to_vec_of_scalar(array: &dyn Array) -> Vec<Scalar> {
+fn to_vec_of_scalar(array: &ArrayRef) -> Vec<Scalar> {
     // Not fast, but obviously correct
     (0..array.len())
         .map(|index| {

--- a/vortex-array/src/compute/conformance/cast.rs
+++ b/vortex-array/src/compute/conformance/cast.rs
@@ -30,7 +30,7 @@ fn cast_and_execute(array: &ArrayRef, dtype: DType) -> VortexResult<ArrayRef> {
 /// - Casting with nullability changes
 /// - Casting between string types (Utf8/Binary)
 /// - Edge cases like overflow behavior
-pub fn test_cast_conformance(array: &dyn Array) {
+pub fn test_cast_conformance(array: &ArrayRef) {
     let dtype = array.dtype();
 
     // Always test identity cast and nullability changes
@@ -57,7 +57,7 @@ pub fn test_cast_conformance(array: &dyn Array) {
     }
 }
 
-fn test_cast_identity(array: &dyn Array) {
+fn test_cast_identity(array: &ArrayRef) {
     // Casting to the same type should be a no-op
     let result = cast_and_execute(&array.to_array(), array.dtype().clone())
         .vortex_expect("cast should succeed in conformance test");
@@ -77,7 +77,7 @@ fn test_cast_identity(array: &dyn Array) {
     }
 }
 
-fn test_cast_from_null(array: &dyn Array) {
+fn test_cast_from_null(array: &ArrayRef) {
     // Null can be cast to itself
     let result = cast_and_execute(&array.to_array(), DType::Null)
         .vortex_expect("cast should succeed in conformance test");
@@ -121,7 +121,7 @@ fn test_cast_from_null(array: &dyn Array) {
     }
 }
 
-fn test_cast_to_non_nullable(array: &dyn Array) {
+fn test_cast_to_non_nullable(array: &ArrayRef) {
     if array
         .invalid_count()
         .vortex_expect("invalid_count should succeed in conformance test")
@@ -175,7 +175,7 @@ fn test_cast_to_non_nullable(array: &dyn Array) {
     }
 }
 
-fn test_cast_to_nullable(array: &dyn Array) {
+fn test_cast_to_nullable(array: &ArrayRef) {
     let nullable = cast_and_execute(&array.to_array(), array.dtype().as_nullable())
         .vortex_expect("arrays without nulls can cast to nullable");
     assert_eq!(nullable.dtype(), &array.dtype().as_nullable());
@@ -208,7 +208,7 @@ fn test_cast_to_nullable(array: &dyn Array) {
     }
 }
 
-fn test_cast_from_floating_point_types(array: &dyn Array) {
+fn test_cast_from_floating_point_types(array: &ArrayRef) {
     let ptype = array.as_primitive_typed().ptype();
     test_cast_to_primitive(array, PType::I8, false);
     test_cast_to_primitive(array, PType::U8, false);
@@ -223,7 +223,7 @@ fn test_cast_from_floating_point_types(array: &dyn Array) {
     test_cast_to_primitive(array, PType::F64, true);
 }
 
-fn test_cast_to_integral_types(array: &dyn Array) {
+fn test_cast_to_integral_types(array: &ArrayRef) {
     test_cast_to_primitive(array, PType::I8, true);
     test_cast_to_primitive(array, PType::U8, true);
     test_cast_to_primitive(array, PType::I16, true);
@@ -240,7 +240,7 @@ fn fits(value: &Scalar, ptype: PType) -> bool {
     value.cast(&dtype).is_ok()
 }
 
-fn test_cast_to_primitive(array: &dyn Array, target_ptype: PType, test_round_trip: bool) {
+fn test_cast_to_primitive(array: &ArrayRef, target_ptype: PType, test_round_trip: bool) {
     let maybe_min_max = min_max(array).vortex_expect("cast should succeed in conformance test");
 
     if let Some(MinMaxResult { min, max }) = maybe_min_max
@@ -329,37 +329,37 @@ mod tests {
     #[test]
     fn test_cast_conformance_u32() {
         let array = buffer![0u32, 100, 200, 65535, 1000000].into_array();
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array);
     }
 
     #[test]
     fn test_cast_conformance_i32() {
         let array = buffer![-100i32, -1, 0, 1, 100].into_array();
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array);
     }
 
     #[test]
     fn test_cast_conformance_f32() {
         let array = buffer![0.0f32, 1.5, -2.5, 100.0, 1e6].into_array();
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array);
     }
 
     #[test]
     fn test_cast_conformance_nullable() {
         let array = PrimitiveArray::from_option_iter([Some(1u8), None, Some(255), Some(0), None]);
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 
     #[test]
     fn test_cast_conformance_bool() {
         let array = BoolArray::from_iter(vec![true, false, true, false]);
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 
     #[test]
     fn test_cast_conformance_null() {
         let array = NullArray::new(5);
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 
     #[test]
@@ -368,7 +368,7 @@ mod tests {
             vec![Some("hello"), None, Some("world")],
             DType::Utf8(Nullability::Nullable),
         );
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 
     #[test]
@@ -377,7 +377,7 @@ mod tests {
             vec![Some(b"data".as_slice()), None, Some(b"bytes".as_slice())],
             DType::Binary(Nullability::Nullable),
         );
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 
     #[test]
@@ -394,7 +394,7 @@ mod tests {
         let array =
             StructArray::try_new(names, vec![a, b], 3, crate::validity::Validity::NonNullable)
                 .unwrap();
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 
     #[test]
@@ -404,6 +404,6 @@ mod tests {
 
         let array =
             ListArray::try_new(data, offsets, crate::validity::Validity::NonNullable).unwrap();
-        test_cast_conformance(array.as_ref());
+        test_cast_conformance(&array.to_array());
     }
 }

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -25,6 +25,7 @@ use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
 use crate::Array;
+use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
 use crate::arrays::PrimitiveArray;
@@ -47,7 +48,7 @@ use crate::scalar_fn::fns::operators::Operator;
 /// - Creates indices array containing positions where mask is true
 /// - Applies take with these indices
 /// - Verifies both results are identical
-fn test_filter_take_consistency(array: &dyn Array) {
+fn test_filter_take_consistency(array: &ArrayRef) {
     let len = array.len();
     if len == 0 {
         return;
@@ -115,7 +116,7 @@ fn test_filter_take_consistency(array: &dyn Array) {
 /// # Why This Matters
 /// This test ensures that mask operations compose correctly, which is critical for
 /// complex query operations that may apply multiple filters.
-fn test_double_mask_consistency(array: &dyn Array) {
+fn test_double_mask_consistency(array: &ArrayRef) {
     let len = array.len();
     if len == 0 {
         return;
@@ -182,7 +183,7 @@ fn test_double_mask_consistency(array: &dyn Array) {
 /// # Why This Matters
 /// This is an identity operation that should be optimized in implementations
 /// to avoid unnecessary copying.
-fn test_filter_identity(array: &dyn Array) {
+fn test_filter_identity(array: &ArrayRef) {
     let len = array.len();
     if len == 0 {
         return;
@@ -231,7 +232,7 @@ fn test_filter_identity(array: &dyn Array) {
 /// # Why This Matters
 /// Masking always produces a nullable array, even when no values are actually masked.
 /// This test ensures the type system handles this correctly.
-fn test_mask_identity(array: &dyn Array) {
+fn test_mask_identity(array: &ArrayRef) {
     let len = array.len();
     if len == 0 {
         return;
@@ -287,7 +288,7 @@ fn test_mask_identity(array: &dyn Array) {
 /// # Why This Matters
 /// When a filter mask represents a contiguous range, it should be equivalent to
 /// a slice operation. Some implementations may optimize this case.
-fn test_slice_filter_consistency(array: &dyn Array) {
+fn test_slice_filter_consistency(array: &ArrayRef) {
     let len = array.len();
     if len < 4 {
         return; // Need at least 4 elements for meaningful test
@@ -344,7 +345,7 @@ fn test_slice_filter_consistency(array: &dyn Array) {
 ///
 /// # Why This Matters
 /// Sequential takes are a common pattern that can be optimized to slice operations.
-fn test_take_slice_consistency(array: &dyn Array) {
+fn test_take_slice_consistency(array: &ArrayRef) {
     let len = array.len();
     if len < 3 {
         return; // Need at least 3 elements
@@ -387,7 +388,7 @@ fn test_take_slice_consistency(array: &dyn Array) {
 }
 
 /// Tests that filter preserves relative ordering
-fn test_filter_preserves_order(array: &dyn Array) {
+fn test_filter_preserves_order(array: &ArrayRef) {
     let len = array.len();
     if len < 4 {
         return;
@@ -432,7 +433,7 @@ fn test_filter_preserves_order(array: &dyn Array) {
 }
 
 /// Tests that take with repeated indices works correctly
-fn test_take_repeated_indices(array: &dyn Array) {
+fn test_take_repeated_indices(array: &ArrayRef) {
     let len = array.len();
     if len == 0 {
         return;
@@ -458,7 +459,7 @@ fn test_take_repeated_indices(array: &dyn Array) {
 }
 
 /// Tests mask and filter interaction with nulls
-fn test_mask_filter_null_consistency(array: &dyn Array) {
+fn test_mask_filter_null_consistency(array: &ArrayRef) {
     let len = array.len();
     if len < 3 {
         return;
@@ -495,7 +496,7 @@ fn test_mask_filter_null_consistency(array: &dyn Array) {
 }
 
 /// Tests that empty operations are consistent
-fn test_empty_operations_consistency(array: &dyn Array) {
+fn test_empty_operations_consistency(array: &ArrayRef) {
     let len = array.len();
 
     // Empty filter
@@ -524,7 +525,7 @@ fn test_empty_operations_consistency(array: &dyn Array) {
 }
 
 /// Tests that take preserves array properties
-fn test_take_preserves_properties(array: &dyn Array) {
+fn test_take_preserves_properties(array: &ArrayRef) {
     let len = array.len();
     if len == 0 {
         return;
@@ -568,7 +569,7 @@ fn test_take_preserves_properties(array: &dyn Array) {
 /// # Why This Matters
 /// Nullable indices are a powerful feature that allows introducing nulls during
 /// a take operation, which is useful for outer joins and similar operations.
-fn test_nullable_indices_consistency(array: &dyn Array) {
+fn test_nullable_indices_consistency(array: &ArrayRef) {
     let len = array.len();
     if len < 3 {
         return; // Need at least 3 elements to test indices 0 and 2
@@ -634,7 +635,7 @@ fn test_nullable_indices_consistency(array: &dyn Array) {
 }
 
 /// Tests large array consistency
-fn test_large_array_consistency(array: &dyn Array) {
+fn test_large_array_consistency(array: &ArrayRef) {
     let len = array.len();
     if len < 1000 {
         return;
@@ -685,7 +686,7 @@ fn test_large_array_consistency(array: &dyn Array) {
 /// This test catches bugs where an encoding might implement one comparison
 /// correctly but fail on its logical inverse.
 #[expect(deprecated)]
-fn test_comparison_inverse_consistency(array: &dyn Array) {
+fn test_comparison_inverse_consistency(array: &ArrayRef) {
     let len = array.len();
     if len == 0 {
         return;
@@ -810,7 +811,7 @@ fn test_comparison_inverse_consistency(array: &dyn Array) {
 /// # Why This Matters
 /// Ensures that comparison operations maintain mathematical ordering properties
 /// regardless of operand order.
-fn test_comparison_symmetry_consistency(array: &dyn Array) {
+fn test_comparison_symmetry_consistency(array: &ArrayRef) {
     let len = array.len();
     if len == 0 {
         return;
@@ -906,7 +907,7 @@ fn test_comparison_symmetry_consistency(array: &dyn Array) {
 /// This test catches bugs where encodings might optimize boolean operations
 /// incorrectly, breaking fundamental logical properties.
 #[expect(deprecated)]
-fn test_boolean_demorgan_consistency(array: &dyn Array) {
+fn test_boolean_demorgan_consistency(array: &ArrayRef) {
     if !matches!(array.dtype(), DType::Bool(_)) {
         return;
     }
@@ -915,13 +916,13 @@ fn test_boolean_demorgan_consistency(array: &dyn Array) {
         let mask_pattern: Vec<bool> = (0..array.len()).map(|i| i % 3 == 0).collect();
         BoolArray::from_iter(mask_pattern)
     };
-    let mask = mask.as_ref();
+    let mask = mask.to_array();
 
     // Test first De Morgan's law: NOT(A AND B) = (NOT A) OR (NOT B)
     if let (Ok(a_and_b), Ok(not_a), Ok(not_b)) = (
-        array.to_array().binary(mask.to_array(), Operator::And),
+        array.to_array().binary(mask.clone(), Operator::And),
         invert(array),
-        invert(mask),
+        invert(&mask),
     ) {
         let not_a_and_b =
             invert(&a_and_b).vortex_expect("invert should succeed in conformance test");
@@ -952,9 +953,9 @@ fn test_boolean_demorgan_consistency(array: &dyn Array) {
 
     // Test second De Morgan's law: NOT(A OR B) = (NOT A) AND (NOT B)
     if let (Ok(a_or_b), Ok(not_a), Ok(not_b)) = (
-        array.to_array().binary(mask.to_array(), Operator::Or),
+        array.to_array().binary(mask.clone(), Operator::Or),
         invert(array),
-        invert(mask),
+        invert(&mask),
     ) {
         let not_a_or_b = invert(&a_or_b).vortex_expect("invert should succeed in conformance test");
         let not_a_and_not_b = not_a
@@ -992,7 +993,7 @@ fn test_boolean_demorgan_consistency(array: &dyn Array) {
 /// # Why This Matters
 /// Aggregate operations on sliced arrays must produce correct results
 /// regardless of the underlying encoding's offset handling.
-fn test_slice_aggregate_consistency(array: &dyn Array) {
+fn test_slice_aggregate_consistency(array: &ArrayRef) {
     use crate::compute::min_max;
     use crate::compute::nan_count;
     use crate::compute::sum;
@@ -1095,7 +1096,7 @@ fn test_slice_aggregate_consistency(array: &dyn Array) {
 /// This test specifically catches bugs where encodings (like RunEndArray) fail to preserve
 /// offset information during cast operations. Such bugs can lead to incorrect data being
 /// returned after casting a sliced array.
-fn test_cast_slice_consistency(array: &dyn Array) {
+fn test_cast_slice_consistency(array: &ArrayRef) {
     let len = array.len();
     if len < 5 {
         return; // Need at least 5 elements for meaningful slice
@@ -1356,7 +1357,7 @@ fn test_cast_slice_consistency(array: &dyn Array) {
 /// ## Large Arrays
 /// - **Performance**: Operations scale correctly to large arrays (1000+ elements)
 /// ```text
-pub fn test_array_consistency(array: &dyn Array) {
+pub fn test_array_consistency(array: &ArrayRef) {
     // Core operation consistency
     test_filter_take_consistency(array);
     test_double_mask_consistency(array);

--- a/vortex-array/src/compute/conformance/filter.rs
+++ b/vortex-array/src/compute/conformance/filter.rs
@@ -5,6 +5,7 @@ use vortex_error::VortexExpect;
 use vortex_mask::Mask;
 
 use crate::Array;
+use crate::ArrayRef;
 use crate::IntoArray;
 use crate::assert_arrays_eq;
 use crate::dtype::DType;
@@ -16,7 +17,7 @@ pub const LARGE_SIZE: usize = 1024;
 
 /// Test filter compute function with various array sizes and patterns.
 /// The input array can be of any length.
-pub fn test_filter_conformance(array: &dyn Array) {
+pub fn test_filter_conformance(array: &ArrayRef) {
     let len = array.len();
 
     // Test with arrays of any size
@@ -59,7 +60,7 @@ pub fn create_runs_pattern(len: usize, run_length: usize) -> Vec<bool> {
 }
 
 /// Tests that filtering with an all-true mask returns all elements unchanged
-fn test_all_filter(array: &dyn Array) {
+fn test_all_filter(array: &ArrayRef) {
     let len = array.len();
     let mask = Mask::new_true(len);
     let filtered = array
@@ -69,7 +70,7 @@ fn test_all_filter(array: &dyn Array) {
 }
 
 /// Tests that filtering with an all-false mask returns an empty array with the same dtype
-fn test_none_filter(array: &dyn Array) {
+fn test_none_filter(array: &ArrayRef) {
     let len = array.len();
     let mask = Mask::new_false(len);
     let filtered = array
@@ -79,7 +80,7 @@ fn test_none_filter(array: &dyn Array) {
     assert_eq!(filtered.dtype(), array.dtype());
 }
 
-fn test_selective_filter(array: &dyn Array) {
+fn test_selective_filter(array: &ArrayRef) {
     let len = array.len();
     if len < 2 {
         return; // Skip for very small arrays
@@ -135,7 +136,7 @@ fn test_selective_filter(array: &dyn Array) {
     }
 }
 
-fn test_single_element_filter(array: &dyn Array) {
+fn test_single_element_filter(array: &ArrayRef) {
     let len = array.len();
     if len == 0 {
         return;
@@ -195,7 +196,7 @@ fn test_empty_array_filter(dtype: &DType) {
     assert_eq!(filtered.len(), 0);
 }
 
-fn test_mismatched_lengths(array: &dyn Array) {
+fn test_mismatched_lengths(array: &ArrayRef) {
     let len = array.len();
 
     // Test mask shorter than array
@@ -218,7 +219,7 @@ fn test_mismatched_lengths(array: &dyn Array) {
 }
 
 /// Tests filtering with alternating true/false pattern
-fn test_alternating_pattern_filter(array: &dyn Array) {
+fn test_alternating_pattern_filter(array: &ArrayRef) {
     let len = array.len();
     let pattern = create_alternating_pattern(len);
     let expected_count = pattern.iter().filter(|&&v| v).count();
@@ -247,7 +248,7 @@ fn test_alternating_pattern_filter(array: &dyn Array) {
 }
 
 /// Tests filtering with runs of true/false values
-fn test_runs_pattern_filter(array: &dyn Array) {
+fn test_runs_pattern_filter(array: &ArrayRef) {
     let len = array.len();
     if len < 4 {
         return; // Skip for very small arrays
@@ -265,7 +266,7 @@ fn test_runs_pattern_filter(array: &dyn Array) {
 }
 
 /// Tests filtering with sparse true values (mostly false)
-fn test_sparse_true_filter(array: &dyn Array) {
+fn test_sparse_true_filter(array: &ArrayRef) {
     let len = array.len();
     if len < 10 {
         return; // Skip for small arrays
@@ -283,7 +284,7 @@ fn test_sparse_true_filter(array: &dyn Array) {
 }
 
 /// Tests filtering with sparse false values (mostly true)
-fn test_sparse_false_filter(array: &dyn Array) {
+fn test_sparse_false_filter(array: &ArrayRef) {
     let len = array.len();
     if len < 10 {
         return; // Skip for small arrays
@@ -301,7 +302,7 @@ fn test_sparse_false_filter(array: &dyn Array) {
 }
 
 /// Tests filtering with random pattern
-fn test_random_pattern_filter(array: &dyn Array) {
+fn test_random_pattern_filter(array: &ArrayRef) {
     let len = array.len();
 
     // Create a pseudo-random pattern based on array length

--- a/vortex-array/src/compute/conformance/mask.rs
+++ b/vortex-array/src/compute/conformance/mask.rs
@@ -5,12 +5,13 @@ use vortex_error::VortexExpect;
 use vortex_mask::Mask;
 
 use crate::Array;
+use crate::ArrayRef;
 use crate::arrays::BoolArray;
 use crate::compute::mask;
 
 /// Test mask compute function with various array sizes and patterns.
 /// The mask operation sets elements to null where the mask is true.
-pub fn test_mask_conformance(array: &dyn Array) {
+pub fn test_mask_conformance(array: &ArrayRef) {
     let len = array.len();
 
     if len > 0 {
@@ -32,7 +33,7 @@ pub fn test_mask_conformance(array: &dyn Array) {
 }
 
 /// Tests masking with a heterogeneous pattern
-fn test_heterogenous_mask(array: &dyn Array) {
+fn test_heterogenous_mask(array: &ArrayRef) {
     let len = array.len();
 
     // Create a pattern where roughly half the values are masked
@@ -65,7 +66,7 @@ fn test_heterogenous_mask(array: &dyn Array) {
 }
 
 /// Tests that an empty mask (all false) preserves all elements
-fn test_empty_mask(array: &dyn Array) {
+fn test_empty_mask(array: &ArrayRef) {
     let len = array.len();
     let all_unmasked = vec![false; len];
     let mask_array = Mask::from_iter(all_unmasked);
@@ -88,7 +89,7 @@ fn test_empty_mask(array: &dyn Array) {
 }
 
 /// Tests that a full mask (all true) makes all elements null
-fn test_full_mask(array: &dyn Array) {
+fn test_full_mask(array: &ArrayRef) {
     let len = array.len();
     let all_masked = vec![true; len];
     let mask_array = Mask::from_iter(all_masked);
@@ -107,7 +108,7 @@ fn test_full_mask(array: &dyn Array) {
 }
 
 /// Tests alternating mask pattern
-fn test_alternating_mask(array: &dyn Array) {
+fn test_alternating_mask(array: &ArrayRef) {
     let len = array.len();
     let pattern: Vec<bool> = (0..len).map(|i| i % 2 == 0).collect();
     let mask_array = Mask::from_iter(pattern);
@@ -137,7 +138,7 @@ fn test_alternating_mask(array: &dyn Array) {
 }
 
 /// Tests sparse mask (only a few elements masked)
-fn test_sparse_mask(array: &dyn Array) {
+fn test_sparse_mask(array: &ArrayRef) {
     let len = array.len();
     if len < 10 {
         return; // Skip for small arrays
@@ -175,7 +176,7 @@ fn test_sparse_mask(array: &dyn Array) {
 }
 
 /// Tests masking a single element
-fn test_single_element_mask(array: &dyn Array) {
+fn test_single_element_mask(array: &ArrayRef) {
     let len = array.len();
 
     // Mask only the first element
@@ -204,7 +205,7 @@ fn test_single_element_mask(array: &dyn Array) {
 }
 
 /// Tests double masking operations
-fn test_double_mask(array: &dyn Array) {
+fn test_double_mask(array: &ArrayRef) {
     let len = array.len();
 
     // Create two different mask patterns
@@ -241,7 +242,7 @@ fn test_double_mask(array: &dyn Array) {
 }
 
 /// Tests masking with nullable mask (nulls treated as false)
-fn test_nullable_mask_input(array: &dyn Array) {
+fn test_nullable_mask_input(array: &ArrayRef) {
     let len = array.len();
     if len < 3 {
         return; // Skip for very small arrays

--- a/vortex-array/src/compute/conformance/take.rs
+++ b/vortex-array/src/compute/conformance/take.rs
@@ -5,6 +5,7 @@ use vortex_buffer::buffer;
 use vortex_error::VortexExpect;
 
 use crate::Array;
+use crate::ArrayRef;
 use crate::Canonical;
 use crate::IntoArray as _;
 use crate::arrays::PrimitiveArray;
@@ -19,7 +20,7 @@ use crate::dtype::Nullability;
 /// - Taking with out-of-bounds indices (should panic)
 /// - Taking with nullable indices
 /// - Edge cases like empty arrays
-pub fn test_take_conformance(array: &dyn Array) {
+pub fn test_take_conformance(array: &ArrayRef) {
     let len = array.len();
 
     if len > 0 {
@@ -51,7 +52,7 @@ pub fn test_take_conformance(array: &dyn Array) {
     }
 }
 
-fn test_take_all(array: &dyn Array) {
+fn test_take_all(array: &ArrayRef) {
     let len = array.len();
     let indices = PrimitiveArray::from_iter(0..len as u64);
     let result = array
@@ -92,7 +93,7 @@ fn test_take_all(array: &dyn Array) {
     }
 }
 
-fn test_take_none(array: &dyn Array) {
+fn test_take_none(array: &ArrayRef) {
     let indices: PrimitiveArray = PrimitiveArray::from_iter::<[u64; 0]>([]);
     let result = array
         .take(indices.to_array())
@@ -103,7 +104,7 @@ fn test_take_none(array: &dyn Array) {
 }
 
 #[allow(clippy::cast_possible_truncation)]
-fn test_take_selective(array: &dyn Array) {
+fn test_take_selective(array: &ArrayRef) {
     let len = array.len();
 
     // Take every other element
@@ -129,7 +130,7 @@ fn test_take_selective(array: &dyn Array) {
     }
 }
 
-fn test_take_first_and_last(array: &dyn Array) {
+fn test_take_first_and_last(array: &ArrayRef) {
     let len = array.len();
     let indices = PrimitiveArray::from_iter([0u64, (len - 1) as u64]);
     let result = array
@@ -156,7 +157,7 @@ fn test_take_first_and_last(array: &dyn Array) {
 }
 
 #[allow(clippy::cast_possible_truncation)]
-fn test_take_with_nullable_indices(array: &dyn Array) {
+fn test_take_with_nullable_indices(array: &ArrayRef) {
     let len = array.len();
 
     // Create indices with some null values
@@ -203,7 +204,7 @@ fn test_take_with_nullable_indices(array: &dyn Array) {
     }
 }
 
-fn test_take_repeated_indices(array: &dyn Array) {
+fn test_take_repeated_indices(array: &ArrayRef) {
     if array.is_empty() {
         return;
     }
@@ -228,7 +229,7 @@ fn test_take_repeated_indices(array: &dyn Array) {
     }
 }
 
-fn test_empty_indices(array: &dyn Array) {
+fn test_empty_indices(array: &ArrayRef) {
     let indices = PrimitiveArray::empty::<u64>(Nullability::NonNullable);
     let result = array
         .take(indices.to_array())
@@ -238,7 +239,7 @@ fn test_empty_indices(array: &dyn Array) {
     assert_eq!(result.dtype(), array.dtype());
 }
 
-fn test_take_reverse(array: &dyn Array) {
+fn test_take_reverse(array: &ArrayRef) {
     let len = array.len();
     // Take elements in reverse order
     let indices = PrimitiveArray::from_iter((0..len as u64).rev());
@@ -261,7 +262,7 @@ fn test_take_reverse(array: &dyn Array) {
     }
 }
 
-fn test_take_single_middle(array: &dyn Array) {
+fn test_take_single_middle(array: &ArrayRef) {
     let len = array.len();
     let middle_idx = len / 2;
 
@@ -282,7 +283,7 @@ fn test_take_single_middle(array: &dyn Array) {
 }
 
 #[allow(clippy::cast_possible_truncation)]
-fn test_take_random_unsorted(array: &dyn Array) {
+fn test_take_random_unsorted(array: &ArrayRef) {
     let len = array.len();
 
     // Create a pseudo-random but deterministic pattern
@@ -313,7 +314,7 @@ fn test_take_random_unsorted(array: &dyn Array) {
     }
 }
 
-fn test_take_contiguous_range(array: &dyn Array) {
+fn test_take_contiguous_range(array: &ArrayRef) {
     let len = array.len();
     let start = len / 4;
     let end = len / 2;
@@ -340,7 +341,7 @@ fn test_take_contiguous_range(array: &dyn Array) {
 }
 
 #[allow(clippy::cast_possible_truncation)]
-fn test_take_mixed_repeated(array: &dyn Array) {
+fn test_take_mixed_repeated(array: &ArrayRef) {
     let len = array.len();
 
     // Create pattern with some repeated indices
@@ -376,7 +377,7 @@ fn test_take_mixed_repeated(array: &dyn Array) {
 }
 
 #[allow(clippy::cast_possible_truncation)]
-fn test_take_large_indices(array: &dyn Array) {
+fn test_take_large_indices(array: &ArrayRef) {
     // Test with a large number of indices to stress test performance
     let len = array.len();
     let num_indices = 10000.min(len * 3);

--- a/vortex-array/src/compute/fill_null.rs
+++ b/vortex-array/src/compute/fill_null.rs
@@ -14,17 +14,18 @@ use crate::scalar::Scalar;
 /// # Examples
 ///
 /// ```
+/// use vortex_array::IntoArray;
 /// use vortex_array::arrays::{PrimitiveArray};
 /// use vortex_array::compute::{fill_null};
 /// use vortex_array::scalar::Scalar;
 ///
 /// let array =
 ///     PrimitiveArray::from_option_iter([Some(0i32), None, Some(1i32), None, Some(2i32)]);
-/// let array = fill_null(array.as_ref(), &Scalar::from(42i32)).unwrap();
+/// let array = fill_null(&array.into_array(), &Scalar::from(42i32)).unwrap();
 /// assert_eq!(array.display_values().to_string(), "[0i32, 42i32, 1i32, 42i32, 2i32]");
 /// ```
 #[deprecated(note = "use array.fill_null(scalar) via ArrayBuiltins instead")]
-pub fn fill_null(array: &dyn Array, fill_value: &Scalar) -> VortexResult<ArrayRef> {
+pub fn fill_null(array: &ArrayRef, fill_value: &Scalar) -> VortexResult<ArrayRef> {
     vortex_ensure!(
         !fill_value.is_null(),
         "fill_null requires a non-null fill value"

--- a/vortex-array/src/compute/filter.rs
+++ b/vortex-array/src/compute/filter.rs
@@ -32,10 +32,11 @@ use crate::scalar::Scalar;
 ///
 /// # fn main() -> VortexResult<()> {
 /// let array =
-///     PrimitiveArray::from_option_iter([Some(0i32), None, Some(1i32), None, Some(2i32)]);
+///     PrimitiveArray::from_option_iter([Some(0i32), None, Some(1i32), None, Some(2i32)])
+///         .into_array();
 /// let mask = Mask::from_iter([true, false, false, false, true]);
 ///
-/// let filtered = filter(array.as_ref(), &mask)?;
+/// let filtered = filter(&array, &mask)?;
 /// assert_eq!(filtered.len(), 2);
 /// assert_eq!(filtered.scalar_at(0)?, Scalar::from(Some(0_i32)));
 /// assert_eq!(filtered.scalar_at(1)?, Scalar::from(Some(2_i32)));
@@ -47,7 +48,7 @@ use crate::scalar::Scalar;
 ///
 /// The `predicate` must receive an Array with type non-nullable bool, and will panic if this is
 /// not the case.
-pub fn filter(array: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef> {
+pub fn filter(array: &ArrayRef, mask: &Mask) -> VortexResult<ArrayRef> {
     // TODO(connor): Remove this function completely!!!
     Ok(array.filter(mask.clone())?.to_canonical()?.into_array())
 }
@@ -68,7 +69,7 @@ impl dyn Array + '_ {
     }
 }
 
-pub fn arrow_filter_fn(array: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef> {
+pub fn arrow_filter_fn(array: &ArrayRef, mask: &Mask) -> VortexResult<ArrayRef> {
     let values = match &mask {
         Mask::Values(values) => values,
         Mask::AllTrue(_) | Mask::AllFalse(_) => unreachable!("check in filter invoke"),

--- a/vortex-array/src/compute/invert.rs
+++ b/vortex-array/src/compute/invert.rs
@@ -9,6 +9,6 @@ use crate::builtins::ArrayBuiltins;
 
 /// Logically invert a boolean array, preserving its validity.
 #[deprecated(note = "use array.not() via ArrayBuiltins instead")]
-pub fn invert(array: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn invert(array: &ArrayRef) -> VortexResult<ArrayRef> {
     array.to_array().not()
 }

--- a/vortex-array/src/compute/is_constant.rs
+++ b/vortex-array/src/compute/is_constant.rs
@@ -11,6 +11,8 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
 use crate::Array;
+use crate::ArrayRef;
+use crate::IntoArray as _;
 use crate::arrays::ConstantVTable;
 use crate::arrays::NullVTable;
 use crate::compute::ComputeFn;
@@ -54,7 +56,7 @@ pub(crate) fn warm_up_vtable() -> usize {
 ///
 /// Returns `Ok(None)` if we could not determine whether the array is constant, e.g. if
 /// canonicalization is disabled and the no kernel exists for the array's encoding.
-pub fn is_constant(array: &dyn Array) -> VortexResult<Option<bool>> {
+pub fn is_constant(array: &ArrayRef) -> VortexResult<Option<bool>> {
     let opts = IsConstantOpts::default();
     is_constant_opts(array, &opts)
 }
@@ -62,7 +64,7 @@ pub fn is_constant(array: &dyn Array) -> VortexResult<Option<bool>> {
 /// Computes whether an array has constant values. Configurable by [`IsConstantOpts`].
 ///
 /// Please see [`is_constant`] for a more detailed explanation of its behavior.
-pub fn is_constant_opts(array: &dyn Array, options: &IsConstantOpts) -> VortexResult<Option<bool>> {
+pub fn is_constant_opts(array: &ArrayRef, options: &IsConstantOpts) -> VortexResult<Option<bool>> {
     Ok(IS_CONSTANT_FN
         .invoke(&InvocationArgs {
             inputs: &[array.into()],
@@ -82,6 +84,7 @@ impl ComputeFnVTable for IsConstant {
         kernels: &[ArcRef<dyn Kernel>],
     ) -> VortexResult<Output> {
         let IsConstantArgs { array, options } = IsConstantArgs::try_from(args)?;
+        let array = array.to_array();
 
         // We try and rely on some easy-to-get stats
         if let Some(Precision::Exact(value)) = array.statistics().get_as::<bool>(Stat::IsConstant) {
@@ -89,7 +92,7 @@ impl ComputeFnVTable for IsConstant {
             return Ok(scalar.into());
         }
 
-        let value = is_constant_impl(array, options, kernels)?;
+        let value = is_constant_impl(&array, options, kernels)?;
 
         if options.cost == Cost::Canonicalize {
             // When we run linear canonicalize, there we must always return an exact answer.
@@ -126,7 +129,7 @@ impl ComputeFnVTable for IsConstant {
 }
 
 fn is_constant_impl(
-    array: &dyn Array,
+    array: &ArrayRef,
     options: &IsConstantOpts,
     kernels: &[ArcRef<dyn Kernel>],
 ) -> VortexResult<Option<bool>> {
@@ -190,8 +193,8 @@ fn is_constant_impl(
     );
 
     if options.cost == Cost::Canonicalize && !array.is_canonical() {
-        let array = array.to_canonical()?;
-        let is_constant = is_constant_opts(array.as_ref(), options)?;
+        let array = array.to_canonical()?.into_array();
+        let is_constant = is_constant_opts(&array, options)?;
         return Ok(is_constant);
     }
 
@@ -324,23 +327,24 @@ mod tests {
             .unwrap();
         assert!(is_constant(&arr).unwrap().unwrap_or_default());
 
-        let arr = PrimitiveArray::from_option_iter([Some(0), Some(0)]);
-        assert!(is_constant(arr.as_ref()).unwrap().unwrap_or_default());
+        let arr = PrimitiveArray::from_option_iter([Some(0), Some(0)]).into_array();
+        assert!(is_constant(&arr).unwrap().unwrap_or_default());
     }
 
     #[test]
     fn is_constant_min_max_with_nan() {
-        let arr = PrimitiveArray::from_iter([0.0, 0.0, f32::NAN]);
+        let arr = PrimitiveArray::from_iter([0.0, 0.0, f32::NAN]).into_array();
         arr.statistics()
             .compute_all(&[Stat::Min, Stat::Max])
             .unwrap();
-        assert!(!is_constant(arr.as_ref()).unwrap().unwrap_or_default());
+        assert!(!is_constant(&arr).unwrap().unwrap_or_default());
 
         let arr =
-            PrimitiveArray::from_option_iter([Some(f32::NEG_INFINITY), Some(f32::NEG_INFINITY)]);
+            PrimitiveArray::from_option_iter([Some(f32::NEG_INFINITY), Some(f32::NEG_INFINITY)])
+                .into_array();
         arr.statistics()
             .compute_all(&[Stat::Min, Stat::Max])
             .unwrap();
-        assert!(is_constant(arr.as_ref()).unwrap().unwrap_or_default());
+        assert!(is_constant(&arr).unwrap().unwrap_or_default());
     }
 }

--- a/vortex-array/src/compute/is_sorted.rs
+++ b/vortex-array/src/compute/is_sorted.rs
@@ -11,6 +11,8 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
 use crate::Array;
+use crate::ArrayRef;
+use crate::IntoArray as _;
 use crate::arrays::ConstantVTable;
 use crate::arrays::NullVTable;
 use crate::compute::ComputeFn;
@@ -39,15 +41,15 @@ pub(crate) fn warm_up_vtable() -> usize {
     IS_SORTED_FN.kernels().len()
 }
 
-pub fn is_sorted(array: &dyn Array) -> VortexResult<Option<bool>> {
+pub fn is_sorted(array: &ArrayRef) -> VortexResult<Option<bool>> {
     is_sorted_opts(array, false)
 }
 
-pub fn is_strict_sorted(array: &dyn Array) -> VortexResult<Option<bool>> {
+pub fn is_strict_sorted(array: &ArrayRef) -> VortexResult<Option<bool>> {
     is_sorted_opts(array, true)
 }
 
-pub fn is_sorted_opts(array: &dyn Array, strict: bool) -> VortexResult<Option<bool>> {
+pub fn is_sorted_opts(array: &ArrayRef, strict: bool) -> VortexResult<Option<bool>> {
     Ok(IS_SORTED_FN
         .invoke(&InvocationArgs {
             inputs: &[array.into()],
@@ -66,6 +68,7 @@ impl ComputeFnVTable for IsSorted {
         kernels: &[ArcRef<dyn Kernel>],
     ) -> VortexResult<Output> {
         let IsSortedArgs { array, strict } = IsSortedArgs::try_from(args)?;
+        let array = array.to_array();
 
         // We currently don't support sorting struct arrays.
         if array.dtype().is_struct() {
@@ -81,7 +84,7 @@ impl ComputeFnVTable for IsSorted {
                 return Ok(scalar.into());
             }
 
-            let is_strict_sorted = is_sorted_impl(array, kernels, true)?;
+            let is_strict_sorted = is_sorted_impl(&array, kernels, true)?;
             let array_stats = array.statistics();
 
             if is_strict_sorted.is_some() {
@@ -101,7 +104,7 @@ impl ComputeFnVTable for IsSorted {
                 return Ok(scalar.into());
             }
 
-            let is_sorted = is_sorted_impl(array, kernels, false)?;
+            let is_sorted = is_sorted_impl(&array, kernels, false)?;
             let array_stats = array.statistics();
 
             if is_sorted.is_some() {
@@ -244,7 +247,7 @@ where
 }
 
 fn is_sorted_impl(
-    array: &dyn Array,
+    array: &ArrayRef,
     kernels: &[ArcRef<dyn Kernel>],
     strict: bool,
 ) -> VortexResult<Option<bool>> {
@@ -292,12 +295,12 @@ fn is_sorted_impl(
         );
 
         // Recurse to canonical implementation
-        let array = array.to_canonical()?;
+        let array = array.to_canonical()?.into_array();
 
         return if strict {
-            is_strict_sorted(array.as_ref())
+            is_strict_sorted(&array)
         } else {
-            is_sorted(array.as_ref())
+            is_sorted(&array)
         };
     }
 
@@ -319,92 +322,58 @@ mod tests {
     use crate::validity::Validity;
     #[test]
     fn test_is_sorted() {
-        assert!(
-            is_sorted(PrimitiveArray::new(buffer!(0, 1, 2, 3), Validity::AllValid).as_ref())
-                .unwrap()
-                .unwrap()
-        );
-        assert!(
-            is_sorted(
-                PrimitiveArray::new(
-                    buffer!(0, 1, 2, 3),
-                    Validity::Array(BoolArray::from_iter([false, true, true, true]).into_array())
-                )
-                .as_ref()
-            )
-            .unwrap()
-            .unwrap()
-        );
-        assert!(
-            !is_sorted(
-                PrimitiveArray::new(
-                    buffer!(0, 1, 2, 3),
-                    Validity::Array(BoolArray::from_iter([true, false, true, true]).into_array())
-                )
-                .as_ref()
-            )
-            .unwrap()
-            .unwrap()
-        );
+        let arr = PrimitiveArray::new(buffer!(0, 1, 2, 3), Validity::AllValid).into_array();
+        assert!(is_sorted(&arr).unwrap().unwrap());
 
-        assert!(
-            !is_sorted(PrimitiveArray::new(buffer!(0, 1, 3, 2), Validity::AllValid).as_ref())
-                .unwrap()
-                .unwrap()
-        );
-        assert!(
-            !is_sorted(
-                PrimitiveArray::new(
-                    buffer!(0, 1, 3, 2),
-                    Validity::Array(BoolArray::from_iter([false, true, true, true]).into_array()),
-                )
-                .as_ref()
-            )
-            .unwrap()
-            .unwrap()
-        );
+        let arr = PrimitiveArray::new(
+            buffer!(0, 1, 2, 3),
+            Validity::Array(BoolArray::from_iter([false, true, true, true]).into_array()),
+        )
+        .into_array();
+        assert!(is_sorted(&arr).unwrap().unwrap());
+
+        let arr = PrimitiveArray::new(
+            buffer!(0, 1, 2, 3),
+            Validity::Array(BoolArray::from_iter([true, false, true, true]).into_array()),
+        )
+        .into_array();
+        assert!(!is_sorted(&arr).unwrap().unwrap());
+
+        let arr = PrimitiveArray::new(buffer!(0, 1, 3, 2), Validity::AllValid).into_array();
+        assert!(!is_sorted(&arr).unwrap().unwrap());
+
+        let arr = PrimitiveArray::new(
+            buffer!(0, 1, 3, 2),
+            Validity::Array(BoolArray::from_iter([false, true, true, true]).into_array()),
+        )
+        .into_array();
+        assert!(!is_sorted(&arr).unwrap().unwrap());
     }
 
     #[test]
     fn test_is_strict_sorted() {
-        assert!(
-            is_strict_sorted(PrimitiveArray::new(buffer!(0, 1, 2, 3), Validity::AllValid).as_ref())
-                .unwrap()
-                .unwrap()
-        );
-        assert!(
-            is_strict_sorted(
-                PrimitiveArray::new(
-                    buffer!(0, 1, 2, 3),
-                    Validity::Array(BoolArray::from_iter([false, true, true, true]).into_array())
-                )
-                .as_ref()
-            )
-            .unwrap()
-            .unwrap()
-        );
-        assert!(
-            !is_strict_sorted(
-                PrimitiveArray::new(
-                    buffer!(0, 1, 2, 3),
-                    Validity::Array(BoolArray::from_iter([true, false, true, true]).into_array()),
-                )
-                .as_ref()
-            )
-            .unwrap()
-            .unwrap()
-        );
+        let arr = PrimitiveArray::new(buffer!(0, 1, 2, 3), Validity::AllValid).into_array();
+        assert!(is_strict_sorted(&arr).unwrap().unwrap());
 
-        assert!(
-            !is_strict_sorted(
-                PrimitiveArray::new(
-                    buffer!(0, 1, 3, 2),
-                    Validity::Array(BoolArray::from_iter([false, true, true, true]).into_array()),
-                )
-                .as_ref()
-            )
-            .unwrap()
-            .unwrap()
-        );
+        let arr = PrimitiveArray::new(
+            buffer!(0, 1, 2, 3),
+            Validity::Array(BoolArray::from_iter([false, true, true, true]).into_array()),
+        )
+        .into_array();
+        assert!(is_strict_sorted(&arr).unwrap().unwrap());
+
+        let arr = PrimitiveArray::new(
+            buffer!(0, 1, 2, 3),
+            Validity::Array(BoolArray::from_iter([true, false, true, true]).into_array()),
+        )
+        .into_array();
+        assert!(!is_strict_sorted(&arr).unwrap().unwrap());
+
+        let arr = PrimitiveArray::new(
+            buffer!(0, 1, 3, 2),
+            Validity::Array(BoolArray::from_iter([false, true, true, true]).into_array()),
+        )
+        .into_array();
+        assert!(!is_strict_sorted(&arr).unwrap().unwrap());
     }
 }

--- a/vortex-array/src/compute/list_contains.rs
+++ b/vortex-array/src/compute/list_contains.rs
@@ -12,6 +12,6 @@ use crate::builtins::ArrayBuiltins;
 ///
 /// **Deprecated**: Use `array.list_contains(value)` via [`crate::builtins::ArrayBuiltins`] instead.
 #[deprecated(note = "Use `array.list_contains(value)` via `ArrayBuiltins` instead")]
-pub fn list_contains(array: &dyn Array, value: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn list_contains(array: &ArrayRef, value: &ArrayRef) -> VortexResult<ArrayRef> {
     array.to_array().list_contains(value.to_array())
 }

--- a/vortex-array/src/compute/mask.rs
+++ b/vortex-array/src/compute/mask.rs
@@ -21,7 +21,7 @@ use crate::scalar::Scalar;
 /// expression that defers the actual masking operation until execution time. The mask is inverted
 /// (true=mask-out becomes true=keep) and passed as a boolean child to the expression.
 #[deprecated(note = "use array.mask(mask_array) via ArrayBuiltins instead")]
-pub fn mask(array: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef> {
+pub fn mask(array: &ArrayRef, mask: &Mask) -> VortexResult<ArrayRef> {
     let mask = mask.not();
     match mask {
         Mask::AllTrue(_) => array.to_array().cast(array.dtype().as_nullable()),

--- a/vortex-array/src/compute/min_max.rs
+++ b/vortex-array/src/compute/min_max.rs
@@ -9,6 +9,8 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
 use crate::Array;
+use crate::ArrayRef;
+use crate::IntoArray as _;
 use crate::arrays::ConstantVTable;
 use crate::compute::ComputeFn;
 use crate::compute::ComputeFnVTable;
@@ -45,7 +47,7 @@ pub(crate) fn warm_up_vtable() -> usize {
 /// The return value dtype is the non-nullable version of the array dtype.
 ///
 /// This will update the stats set of this array (as a side effect).
-pub fn min_max(array: &dyn Array) -> VortexResult<Option<MinMaxResult>> {
+pub fn min_max(array: &ArrayRef) -> VortexResult<Option<MinMaxResult>> {
     let scalar = MIN_MAX_FN
         .invoke(&InvocationArgs {
             inputs: &[array.into()],
@@ -88,10 +90,11 @@ impl ComputeFnVTable for MinMax {
         kernels: &[ArcRef<dyn Kernel>],
     ) -> VortexResult<Output> {
         let UnaryArgs { array, .. } = UnaryArgs::<()>::try_from(args)?;
+        let array = array.to_array();
 
         let return_dtype = self.return_dtype(args)?;
 
-        match min_max_impl(array, kernels)? {
+        match min_max_impl(&array, kernels)? {
             None => Ok(Scalar::null(return_dtype).into()),
             Some(MinMaxResult { min, max }) => {
                 assert!(
@@ -147,7 +150,7 @@ impl ComputeFnVTable for MinMax {
 }
 
 fn min_max_impl(
-    array: &dyn Array,
+    array: &ArrayRef,
     kernels: &[ArcRef<dyn Kernel>],
 ) -> VortexResult<Option<MinMaxResult>> {
     if array.is_empty() || array.valid_count()? == 0 {
@@ -186,8 +189,8 @@ fn min_max_impl(
     }
 
     if !array.is_canonical() {
-        let array = array.to_canonical()?;
-        return min_max(array.as_ref());
+        let array = array.to_canonical()?.into_array();
+        return min_max(&array);
     }
 
     vortex_bail!(NotImplemented: "min_max", array.encoding_id());
@@ -237,6 +240,7 @@ mod tests {
     use vortex_buffer::BitBuffer;
     use vortex_buffer::buffer;
 
+    use crate::IntoArray as _;
     use crate::arrays::BoolArray;
     use crate::arrays::NullArray;
     use crate::arrays::PrimitiveArray;
@@ -246,9 +250,9 @@ mod tests {
 
     #[test]
     fn test_prim_max() {
-        let p = PrimitiveArray::new(buffer![1, 2, 3], Validity::NonNullable);
+        let p = PrimitiveArray::new(buffer![1, 2, 3], Validity::NonNullable).into_array();
         assert_eq!(
-            min_max(p.as_ref()).unwrap(),
+            min_max(&p).unwrap(),
             Some(MinMaxResult {
                 min: 1.into(),
                 max: 3.into()
@@ -261,9 +265,10 @@ mod tests {
         let p = BoolArray::new(
             BitBuffer::from([true, true, true].as_slice()),
             Validity::NonNullable,
-        );
+        )
+        .into_array();
         assert_eq!(
-            min_max(p.as_ref()).unwrap(),
+            min_max(&p).unwrap(),
             Some(MinMaxResult {
                 min: true.into(),
                 max: true.into()
@@ -273,9 +278,10 @@ mod tests {
         let p = BoolArray::new(
             BitBuffer::from([false, false, false].as_slice()),
             Validity::NonNullable,
-        );
+        )
+        .into_array();
         assert_eq!(
-            min_max(p.as_ref()).unwrap(),
+            min_max(&p).unwrap(),
             Some(MinMaxResult {
                 min: false.into(),
                 max: false.into()
@@ -285,9 +291,10 @@ mod tests {
         let p = BoolArray::new(
             BitBuffer::from([false, true, false].as_slice()),
             Validity::NonNullable,
-        );
+        )
+        .into_array();
         assert_eq!(
-            min_max(p.as_ref()).unwrap(),
+            min_max(&p).unwrap(),
             Some(MinMaxResult {
                 min: false.into(),
                 max: true.into()
@@ -297,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_null() {
-        let p = NullArray::new(1);
-        assert_eq!(min_max(p.as_ref()).unwrap(), None);
+        let p = NullArray::new(1).into_array();
+        assert_eq!(min_max(&p).unwrap(), None);
     }
 }

--- a/vortex-array/src/compute/mod.rs
+++ b/vortex-array/src/compute/mod.rs
@@ -296,6 +296,12 @@ impl<'a> From<&'a dyn Array> for Input<'a> {
     }
 }
 
+impl<'a> From<&'a ArrayRef> for Input<'a> {
+    fn from(value: &'a ArrayRef) -> Self {
+        Input::Array(value.as_ref())
+    }
+}
+
 impl<'a> From<&'a Scalar> for Input<'a> {
     fn from(value: &'a Scalar) -> Self {
         Input::Scalar(value)

--- a/vortex-array/src/compute/nan_count.rs
+++ b/vortex-array/src/compute/nan_count.rs
@@ -10,6 +10,8 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
 use crate::Array;
+use crate::ArrayRef;
+use crate::IntoArray as _;
 use crate::compute::ComputeFn;
 use crate::compute::ComputeFnVTable;
 use crate::compute::InvocationArgs;
@@ -37,7 +39,7 @@ pub(crate) fn warm_up_vtable() -> usize {
 }
 
 /// Computes the number of NaN values in the array.
-pub fn nan_count(array: &dyn Array) -> VortexResult<usize> {
+pub fn nan_count(array: &ArrayRef) -> VortexResult<usize> {
     Ok(NAN_COUNT_FN
         .invoke(&InvocationArgs {
             inputs: &[array.into()],
@@ -58,8 +60,9 @@ impl ComputeFnVTable for NaNCount {
         kernels: &[ArcRef<dyn Kernel>],
     ) -> VortexResult<Output> {
         let UnaryArgs { array, .. } = UnaryArgs::<()>::try_from(args)?;
+        let array = array.to_array();
 
-        let nan_count = nan_count_impl(array, kernels)?;
+        let nan_count = nan_count_impl(&array, kernels)?;
 
         // Update the stats set with the computed NaN count
         array.statistics().set(
@@ -114,7 +117,7 @@ impl<V: VTable + NaNCountKernel> Kernel for NaNCountKernelAdapter<V> {
     }
 }
 
-fn nan_count_impl(array: &dyn Array, kernels: &[ArcRef<dyn Kernel>]) -> VortexResult<usize> {
+fn nan_count_impl(array: &ArrayRef, kernels: &[ArcRef<dyn Kernel>]) -> VortexResult<usize> {
     if array.is_empty() || array.valid_count()? == 0 {
         return Ok(0);
     }
@@ -144,8 +147,8 @@ fn nan_count_impl(array: &dyn Array, kernels: &[ArcRef<dyn Kernel>]) -> VortexRe
     }
 
     if !array.is_canonical() {
-        let canonical = array.to_canonical()?;
-        return nan_count(canonical.as_ref());
+        let canonical = array.to_canonical()?.into_array();
+        return nan_count(&canonical);
     }
 
     vortex_bail!(

--- a/vortex-array/src/compute/numeric.rs
+++ b/vortex-array/src/compute/numeric.rs
@@ -22,59 +22,59 @@ use crate::scalar_fn::fns::operators::Operator;
 ///
 /// The result is null at any index that either input is null.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn add(lhs: &dyn Array, rhs: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn add(lhs: &ArrayRef, rhs: &ArrayRef) -> VortexResult<ArrayRef> {
     lhs.to_array().binary(rhs.to_array(), Operator::Add)
 }
 
 /// Point-wise add a scalar value to this array on the right-hand-side.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn add_scalar(lhs: &dyn Array, rhs: Scalar) -> VortexResult<ArrayRef> {
+pub fn add_scalar(lhs: &ArrayRef, rhs: Scalar) -> VortexResult<ArrayRef> {
     lhs.to_array()
         .binary(ConstantArray::new(rhs, lhs.len()).to_array(), Operator::Add)
 }
 
 /// Point-wise subtract two numeric arrays.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn sub(lhs: &dyn Array, rhs: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn sub(lhs: &ArrayRef, rhs: &ArrayRef) -> VortexResult<ArrayRef> {
     lhs.to_array().binary(rhs.to_array(), Operator::Sub)
 }
 
 /// Point-wise subtract a scalar value from this array on the right-hand-side.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn sub_scalar(lhs: &dyn Array, rhs: Scalar) -> VortexResult<ArrayRef> {
+pub fn sub_scalar(lhs: &ArrayRef, rhs: Scalar) -> VortexResult<ArrayRef> {
     lhs.to_array()
         .binary(ConstantArray::new(rhs, lhs.len()).to_array(), Operator::Sub)
 }
 
 /// Point-wise multiply two numeric arrays.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn mul(lhs: &dyn Array, rhs: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn mul(lhs: &ArrayRef, rhs: &ArrayRef) -> VortexResult<ArrayRef> {
     lhs.to_array().binary(rhs.to_array(), Operator::Mul)
 }
 
 /// Point-wise multiply a scalar value into this array on the right-hand-side.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn mul_scalar(lhs: &dyn Array, rhs: Scalar) -> VortexResult<ArrayRef> {
+pub fn mul_scalar(lhs: &ArrayRef, rhs: Scalar) -> VortexResult<ArrayRef> {
     lhs.to_array()
         .binary(ConstantArray::new(rhs, lhs.len()).to_array(), Operator::Mul)
 }
 
 /// Point-wise divide two numeric arrays.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn div(lhs: &dyn Array, rhs: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn div(lhs: &ArrayRef, rhs: &ArrayRef) -> VortexResult<ArrayRef> {
     lhs.to_array().binary(rhs.to_array(), Operator::Div)
 }
 
 /// Point-wise divide a scalar value into this array on the right-hand-side.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn div_scalar(lhs: &dyn Array, rhs: Scalar) -> VortexResult<ArrayRef> {
+pub fn div_scalar(lhs: &ArrayRef, rhs: Scalar) -> VortexResult<ArrayRef> {
     lhs.to_array()
         .binary(ConstantArray::new(rhs, lhs.len()).to_array(), Operator::Div)
 }
 
 /// Point-wise numeric operation between two arrays of the same type and length.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn numeric(lhs: &dyn Array, rhs: &dyn Array, op: NumericOperator) -> VortexResult<ArrayRef> {
+pub fn numeric(lhs: &ArrayRef, rhs: &ArrayRef, op: NumericOperator) -> VortexResult<ArrayRef> {
     arrow_numeric(lhs, rhs, op)
 }
 
@@ -86,8 +86,8 @@ impl Options for NumericOperator {
 
 /// Implementation of numeric operations using the Arrow crate.
 pub(crate) fn arrow_numeric(
-    lhs: &dyn Array,
-    rhs: &dyn Array,
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
     operator: NumericOperator,
 ) -> VortexResult<ArrayRef> {
     let nullable = lhs.dtype().is_nullable() || rhs.dtype().is_nullable();
@@ -133,7 +133,7 @@ mod test {
     #[test]
     fn test_scalar_subtract_nullable() {
         let values = PrimitiveArray::from_option_iter([Some(1u16), Some(2), None, Some(3)]);
-        let result = sub_scalar(values.as_ref(), Some(1u16).into()).unwrap();
+        let result = sub_scalar(&values.to_array(), Some(1u16).into()).unwrap();
         assert_arrays_eq!(
             result,
             PrimitiveArray::from_option_iter([Some(0u16), Some(1), None, Some(2)])

--- a/vortex-array/src/compute/sum.rs
+++ b/vortex-array/src/compute/sum.rs
@@ -14,6 +14,8 @@ use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 
 use crate::Array;
+use crate::ArrayRef;
+use crate::IntoArray as _;
 use crate::compute::ComputeFn;
 use crate::compute::ComputeFnVTable;
 use crate::compute::InvocationArgs;
@@ -45,10 +47,7 @@ pub(crate) fn warm_up_vtable() -> usize {
 /// If the sum is not supported for the array's dtype, an error will be raised.
 /// If the array is all-invalid, the sum will be the accumulator.
 /// The accumulator must have a dtype compatible with the sum result dtype.
-pub(crate) fn sum_with_accumulator(
-    array: &dyn Array,
-    accumulator: &Scalar,
-) -> VortexResult<Scalar> {
+pub(crate) fn sum_with_accumulator(array: &ArrayRef, accumulator: &Scalar) -> VortexResult<Scalar> {
     SUM_FN
         .invoke(&InvocationArgs {
             inputs: &[array.into(), accumulator.into()],
@@ -62,7 +61,7 @@ pub(crate) fn sum_with_accumulator(
 /// If the sum overflows, a null scalar will be returned.
 /// If the sum is not supported for the array's dtype, an error will be raised.
 /// If the array is all-invalid, the sum will be zero.
-pub fn sum(array: &dyn Array) -> VortexResult<Scalar> {
+pub fn sum(array: &ArrayRef) -> VortexResult<Scalar> {
     let sum_dtype = Stat::Sum
         .dtype(array.dtype())
         .ok_or_else(|| vortex_err!("Sum not supported for dtype: {}", array.dtype()))?;
@@ -102,6 +101,7 @@ impl ComputeFnVTable for Sum {
         kernels: &[ArcRef<dyn Kernel>],
     ) -> VortexResult<Output> {
         let SumArgs { array, accumulator } = args.try_into()?;
+        let array = array.to_array();
 
         // Compute the expected dtype of the sum.
         let sum_dtype = self.return_dtype(args)?;
@@ -143,7 +143,7 @@ impl ComputeFnVTable for Sum {
             }
         }
 
-        let sum_scalar = sum_impl(array, accumulator, kernels)?;
+        let sum_scalar = sum_impl(&array, accumulator, kernels)?;
 
         // Update the statistics with the computed sum. Stored statistic shouldn't include the accumulator.
         match sum_dtype {
@@ -233,7 +233,7 @@ impl<V: VTable + SumKernel> Kernel for SumKernelAdapter<V> {
 /// If the sum is not supported for the array's dtype, an error will be raised.
 /// If the array is all-invalid, the sum will be the accumulator.
 pub fn sum_impl(
-    array: &dyn Array,
+    array: &ArrayRef,
     accumulator: &Scalar,
     kernels: &[ArcRef<dyn Kernel>],
 ) -> VortexResult<Scalar> {
@@ -261,7 +261,8 @@ pub fn sum_impl(
             array.encoding_id()
         );
     }
-    sum_with_accumulator(array.to_canonical()?.as_ref(), accumulator)
+    let canonical = array.to_canonical()?.into_array();
+    sum_with_accumulator(&canonical, accumulator)
 }
 
 #[cfg(test)]
@@ -282,36 +283,36 @@ mod test {
 
     #[test]
     fn sum_all_invalid() {
-        let array = PrimitiveArray::from_option_iter::<i32, _>([None, None, None]);
-        let result = sum(array.as_ref()).unwrap();
+        let array = PrimitiveArray::from_option_iter::<i32, _>([None, None, None]).into_array();
+        let result = sum(&array).unwrap();
         assert_eq!(result, Scalar::primitive(0i64, Nullability::Nullable));
     }
 
     #[test]
     fn sum_all_invalid_float() {
-        let array = PrimitiveArray::from_option_iter::<f32, _>([None, None, None]);
-        let result = sum(array.as_ref()).unwrap();
+        let array = PrimitiveArray::from_option_iter::<f32, _>([None, None, None]).into_array();
+        let result = sum(&array).unwrap();
         assert_eq!(result, Scalar::primitive(0f64, Nullability::Nullable));
     }
 
     #[test]
     fn sum_constant() {
         let array = buffer![1, 1, 1, 1].into_array();
-        let result = sum(array.as_ref()).unwrap();
+        let result = sum(&array).unwrap();
         assert_eq!(result.as_primitive().as_::<i32>(), Some(4));
     }
 
     #[test]
     fn sum_constant_float() {
         let array = buffer![1., 1., 1., 1.].into_array();
-        let result = sum(array.as_ref()).unwrap();
+        let result = sum(&array).unwrap();
         assert_eq!(result.as_primitive().as_::<f32>(), Some(4.));
     }
 
     #[test]
     fn sum_boolean() {
-        let array = BoolArray::from_iter([true, false, false, true]);
-        let result = sum(array.as_ref()).unwrap();
+        let array = BoolArray::from_iter([true, false, false, true]).into_array();
+        let result = sum(&array).unwrap();
         assert_eq!(result.as_primitive().as_::<i32>(), Some(2));
     }
 
@@ -325,14 +326,11 @@ mod test {
             DType::Primitive(PType::I32, Nullability::NonNullable),
         )
         .vortex_expect("operation should succeed in test");
+        let array = array.into_array();
         // compute sum with accumulator to populate stats
-        sum_with_accumulator(
-            array.as_ref(),
-            &Scalar::primitive(2i64, Nullability::Nullable),
-        )
-        .unwrap();
+        sum_with_accumulator(&array, &Scalar::primitive(2i64, Nullability::Nullable)).unwrap();
 
-        let sum_without_acc = sum(array.as_ref()).unwrap();
+        let sum_without_acc = sum(&array).unwrap();
         assert_eq!(
             sum_without_acc,
             Scalar::primitive(9i64, Nullability::Nullable)

--- a/vortex-array/src/compute/zip.rs
+++ b/vortex-array/src/compute/zip.rs
@@ -18,7 +18,7 @@ use crate::builtins::ArrayBuiltins;
 /// SQL semantics (DuckDB, Trino) where a null condition falls through to the ELSE branch,
 /// rather than Arrow's `if_else` which propagates null conditions to the output.
 #[deprecated(note = "use if_true.zip(if_false, mask) via ArrayBuiltins instead")]
-pub fn zip(if_true: &dyn Array, if_false: &dyn Array, mask: &Mask) -> VortexResult<ArrayRef> {
+pub fn zip(if_true: &ArrayRef, if_false: &ArrayRef, mask: &Mask) -> VortexResult<ArrayRef> {
     if_true
         .to_array()
         .zip(if_false.to_array(), mask.clone().into_array())

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -185,9 +185,7 @@ impl Patches {
             );
 
             debug_assert!(
-                is_sorted(indices.as_ref())
-                    .unwrap_or(Some(false))
-                    .unwrap_or(false),
+                is_sorted(&indices).unwrap_or(Some(false)).unwrap_or(false),
                 "Patch indices must be sorted"
             );
         }
@@ -398,10 +396,7 @@ impl Patches {
     /// # Returns
     /// [`SearchResult::Found`] with the position if needle exists, or [`SearchResult::NotFound`]
     /// with the insertion point if not found.
-    fn search_index_binary_search(
-        indices: &dyn Array,
-        needle: usize,
-    ) -> VortexResult<SearchResult> {
+    fn search_index_binary_search(indices: &ArrayRef, needle: usize) -> VortexResult<SearchResult> {
         if indices.is_canonical() {
             let primitive = indices.to_primitive();
             match_each_integer_ptype!(primitive.ptype(), |T| {
@@ -698,7 +693,7 @@ impl Patches {
     /// Take the indices from the patches
     ///
     /// Any nulls in take_indices are added to the resulting patches.
-    pub fn take_with_nulls(&self, take_indices: &dyn Array) -> VortexResult<Option<Self>> {
+    pub fn take_with_nulls(&self, take_indices: &ArrayRef) -> VortexResult<Option<Self>> {
         if take_indices.is_empty() {
             return Ok(None);
         }
@@ -714,7 +709,7 @@ impl Patches {
     /// Take the indices from the patches.
     ///
     /// Any nulls in take_indices are ignored.
-    pub fn take(&self, take_indices: &dyn Array) -> VortexResult<Option<Self>> {
+    pub fn take(&self, take_indices: &ArrayRef) -> VortexResult<Option<Self>> {
         if take_indices.is_empty() {
             return Ok(None);
         }
@@ -1051,7 +1046,7 @@ where
 fn filter_patches_with_mask<T: IntegerPType>(
     patch_indices: &[T],
     offset: usize,
-    patch_values: &dyn Array,
+    patch_values: &ArrayRef,
     mask_indices: &[usize],
 ) -> VortexResult<Option<Patches>> {
     let true_count = mask_indices.len();

--- a/vortex-array/src/scalar_fn/fns/between/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/between/kernel.rs
@@ -7,7 +7,6 @@ use vortex_error::VortexResult;
 use super::Between;
 use super::BetweenOptions;
 use super::precondition;
-use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::arrays::ExactScalarFn;
@@ -23,8 +22,8 @@ use crate::vtable::VTable;
 pub trait BetweenReduce: VTable {
     fn between(
         array: &Self::Array,
-        lower: &dyn Array,
-        upper: &dyn Array,
+        lower: &ArrayRef,
+        upper: &ArrayRef,
         options: &BetweenOptions,
     ) -> VortexResult<Option<ArrayRef>>;
 }
@@ -35,8 +34,8 @@ pub trait BetweenReduce: VTable {
 pub trait BetweenKernel: VTable {
     fn between(
         array: &Self::Array,
-        lower: &dyn Array,
-        upper: &dyn Array,
+        lower: &ArrayRef,
+        upper: &ArrayRef,
         options: &BetweenOptions,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>>;
@@ -66,9 +65,10 @@ where
             .as_opt::<ScalarFnVTable>()
             .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
         let children = scalar_fn_array.children();
-        let lower = children[1].as_ref();
-        let upper = children[2].as_ref();
-        if let Some(result) = precondition(&**array, lower, upper)? {
+        let lower = &children[1];
+        let upper = &children[2];
+        let arr = array.to_array();
+        if let Some(result) = precondition(&arr, lower, upper)? {
             return Ok(Some(result));
         }
         <V as BetweenReduce>::between(array, lower, upper, parent.options)
@@ -100,9 +100,10 @@ where
             .as_opt::<ScalarFnVTable>()
             .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
         let children = scalar_fn_array.children();
-        let lower = children[1].as_ref();
-        let upper = children[2].as_ref();
-        if let Some(result) = precondition(&**array, lower, upper)? {
+        let lower = &children[1];
+        let upper = &children[2];
+        let arr = array.to_array();
+        if let Some(result) = precondition(&arr, lower, upper)? {
             return Ok(Some(result));
         }
         <V as BetweenKernel>::between(array, lower, upper, parent.options, ctx)

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -103,9 +103,9 @@ impl StrictComparison {
 /// (empty array, null bounds), or `None` if between should proceed with the
 /// encoding-specific implementation.
 pub(super) fn precondition(
-    arr: &dyn Array,
-    lower: &dyn Array,
-    upper: &dyn Array,
+    arr: &ArrayRef,
+    lower: &ArrayRef,
+    upper: &ArrayRef,
 ) -> VortexResult<Option<ArrayRef>> {
     let return_dtype =
         Bool(arr.dtype().nullability() | lower.dtype().nullability() | upper.dtype().nullability());
@@ -140,9 +140,9 @@ pub(super) fn precondition(
 ///
 /// Falls back to compare + boolean and if no kernel handles the input.
 fn between_canonical(
-    arr: &dyn Array,
-    lower: &dyn Array,
-    upper: &dyn Array,
+    arr: &ArrayRef,
+    lower: &ArrayRef,
+    upper: &ArrayRef,
     options: &BetweenOptions,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
@@ -312,7 +312,7 @@ impl ScalarFnVTable for Between {
             );
         }
 
-        between_canonical(arr.as_ref(), lower.as_ref(), upper.as_ref(), options, ctx)
+        between_canonical(&arr, &lower, &upper, options, ctx)
     }
 
     fn stat_falsification(
@@ -408,9 +408,9 @@ mod tests {
         let upper = buffer![2, 1, 1, 0, 0].into_array();
 
         let matches = between_canonical(
-            array.as_ref(),
-            lower.as_ref(),
-            upper.as_ref(),
+            &array,
+            &lower,
+            &upper,
             &BetweenOptions {
                 lower_strict,
                 upper_strict,
@@ -433,12 +433,13 @@ mod tests {
         let upper = ConstantArray::new(
             Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable)),
             5,
-        );
+        )
+        .into_array();
 
         let matches = between_canonical(
-            array.as_ref(),
-            lower.as_ref(),
-            upper.as_ref(),
+            &array,
+            &lower,
+            &upper,
             &BetweenOptions {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::NonStrict,
@@ -452,11 +453,11 @@ mod tests {
         assert!(indices.is_empty());
 
         // upper is a fixed constant
-        let upper = ConstantArray::new(Scalar::from(2), 5);
+        let upper = ConstantArray::new(Scalar::from(2), 5).into_array();
         let matches = between_canonical(
-            array.as_ref(),
-            lower.as_ref(),
-            upper.as_ref(),
+            &array,
+            &lower,
+            &upper,
             &BetweenOptions {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::NonStrict,
@@ -469,12 +470,12 @@ mod tests {
         assert_eq!(indices, vec![0, 1, 3]);
 
         // lower is also a constant
-        let lower = ConstantArray::new(Scalar::from(0), 5);
+        let lower = ConstantArray::new(Scalar::from(0), 5).into_array();
 
         let matches = between_canonical(
-            array.as_ref(),
-            lower.as_ref(),
-            upper.as_ref(),
+            &array,
+            &lower,
+            &upper,
             &BetweenOptions {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::NonStrict,
@@ -491,7 +492,7 @@ mod tests {
     fn test_between_decimal() {
         let values = buffer![100i128, 200i128, 300i128, 400i128];
         let decimal_type = DecimalDType::new(3, 2);
-        let array = DecimalArray::new(values, decimal_type, Validity::NonNullable);
+        let array = DecimalArray::new(values, decimal_type, Validity::NonNullable).into_array();
 
         let lower = ConstantArray::new(
             Scalar::decimal(
@@ -500,7 +501,8 @@ mod tests {
                 Nullability::NonNullable,
             ),
             array.len(),
-        );
+        )
+        .into_array();
         let upper = ConstantArray::new(
             Scalar::decimal(
                 DecimalValue::I128(400i128),
@@ -508,13 +510,14 @@ mod tests {
                 Nullability::NonNullable,
             ),
             array.len(),
-        );
+        )
+        .into_array();
 
         // Strict lower bound, non-strict upper bound
         let between_strict = between_canonical(
-            array.as_ref(),
-            lower.as_ref(),
-            upper.as_ref(),
+            &array,
+            &lower,
+            &upper,
             &BetweenOptions {
                 lower_strict: StrictComparison::Strict,
                 upper_strict: StrictComparison::NonStrict,
@@ -529,9 +532,9 @@ mod tests {
 
         // Non-strict lower bound, strict upper bound
         let between_strict = between_canonical(
-            array.as_ref(),
-            lower.as_ref(),
-            upper.as_ref(),
+            &array,
+            &lower,
+            &upper,
             &BetweenOptions {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::Strict,

--- a/vortex-array/src/scalar_fn/fns/binary/boolean.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/boolean.rs
@@ -19,13 +19,13 @@ use crate::scalar_fn::fns::operators::Operator;
 
 /// Point-wise Kleene logical _and_ between two Boolean arrays.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn and_kleene(lhs: &dyn Array, rhs: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn and_kleene(lhs: &ArrayRef, rhs: &ArrayRef) -> VortexResult<ArrayRef> {
     lhs.to_array().binary(rhs.to_array(), Operator::And)
 }
 
 /// Point-wise Kleene logical _or_ between two Boolean arrays.
 #[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn or_kleene(lhs: &dyn Array, rhs: &dyn Array) -> VortexResult<ArrayRef> {
+pub fn or_kleene(lhs: &ArrayRef, rhs: &ArrayRef) -> VortexResult<ArrayRef> {
     lhs.to_array().binary(rhs.to_array(), Operator::Or)
 }
 
@@ -34,8 +34,8 @@ pub fn or_kleene(lhs: &dyn Array, rhs: &dyn Array) -> VortexResult<ArrayRef> {
 /// This is the entry point for boolean operations from the binary expression.
 /// Handles constant-constant directly, otherwise falls back to Arrow.
 pub(crate) fn execute_boolean(
-    lhs: &dyn Array,
-    rhs: &dyn Array,
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
     op: Operator,
 ) -> VortexResult<ArrayRef> {
     if let Some(result) = constant_boolean(lhs, rhs, op)? {
@@ -62,8 +62,8 @@ fn arrow_execute_boolean(lhs: ArrayRef, rhs: ArrayRef, op: Operator) -> VortexRe
 
 /// Constant-folds a boolean operation between two constant arrays.
 fn constant_boolean(
-    lhs: &dyn Array,
-    rhs: &dyn Array,
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
     op: Operator,
 ) -> VortexResult<Option<ArrayRef>> {
     let (Some(lhs), Some(rhs)) = (

--- a/vortex-array/src/scalar_fn/fns/binary/compare.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare.rs
@@ -5,7 +5,6 @@ use arrow_array::BooleanArray;
 use arrow_ord::cmp;
 use vortex_error::VortexResult;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
@@ -35,7 +34,7 @@ use crate::vtable::VTable;
 pub trait CompareKernel: VTable {
     fn compare(
         lhs: &Self::Array,
-        rhs: &dyn Array,
+        rhs: &ArrayRef,
         operator: CompareOperator,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>>;
@@ -98,7 +97,7 @@ where
             ));
         }
 
-        V::compare(array, other.as_ref(), cmp_op, ctx)
+        V::compare(array, other, cmp_op, ctx)
     }
 }
 
@@ -107,8 +106,8 @@ where
 /// This is the entry point for compare operations from the binary expression.
 /// Handles empty, constant-null, and constant-constant directly, otherwise falls back to Arrow.
 pub(crate) fn execute_compare(
-    lhs: &dyn Array,
-    rhs: &dyn Array,
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
     op: CompareOperator,
 ) -> VortexResult<ArrayRef> {
     let nullable = lhs.dtype().is_nullable() || rhs.dtype().is_nullable();
@@ -139,8 +138,8 @@ pub(crate) fn execute_compare(
 
 /// Fall back to Arrow for comparison.
 fn arrow_compare_arrays(
-    left: &dyn Array,
-    right: &dyn Array,
+    left: &ArrayRef,
+    right: &ArrayRef,
     operator: CompareOperator,
 ) -> VortexResult<ArrayRef> {
     assert_eq!(left.len(), right.len());

--- a/vortex-array/src/scalar_fn/fns/binary/numeric.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
@@ -16,8 +15,8 @@ use crate::scalar::NumericOperator;
 /// This is the entry point for numeric operations from the binary expression.
 /// Handles constant-constant directly, otherwise falls back to Arrow.
 pub(crate) fn execute_numeric(
-    lhs: &dyn Array,
-    rhs: &dyn Array,
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
     op: NumericOperator,
 ) -> VortexResult<ArrayRef> {
     if let Some(result) = constant_numeric(lhs, rhs, op)? {
@@ -27,8 +26,8 @@ pub(crate) fn execute_numeric(
 }
 
 fn constant_numeric(
-    lhs: &dyn Array,
-    rhs: &dyn Array,
+    lhs: &ArrayRef,
+    rhs: &ArrayRef,
     op: NumericOperator,
 ) -> VortexResult<Option<ArrayRef>> {
     let (Some(lhs), Some(rhs)) = (

--- a/vortex-array/src/scalar_fn/fns/fill_null/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/kernel.rs
@@ -4,7 +4,6 @@
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
@@ -55,7 +54,7 @@ pub trait FillNullKernel: VTable {
 /// Returns `Some(result)` if the precondition short-circuits the fill_null operation,
 /// or `None` if fill_null should proceed with the encoding-specific implementation.
 pub(super) fn precondition(
-    array: &dyn Array,
+    array: &ArrayRef,
     fill_value: &Scalar,
 ) -> VortexResult<Option<ArrayRef>> {
     // If the array has no nulls, fill_null is a no-op (just cast for nullability).
@@ -113,7 +112,8 @@ where
         let fill_value = scalar_fn_array.children()[1]
             .as_constant()
             .vortex_expect("fill_null fill_value must be constant");
-        if let Some(result) = precondition(&**array, &fill_value)? {
+        let arr = array.to_array();
+        if let Some(result) = precondition(&arr, &fill_value)? {
             return Ok(Some(result));
         }
         <V as FillNullReduce>::fill_null(array, &fill_value)
@@ -147,7 +147,8 @@ where
         let fill_value = scalar_fn_array.children()[1]
             .as_constant()
             .vortex_expect("fill_null fill_value must be constant");
-        if let Some(result) = precondition(&**array, &fill_value)? {
+        let arr = array.to_array();
+        if let Some(result) = precondition(&arr, &fill_value)? {
             return Ok(Some(result));
         }
         <V as FillNullKernel>::fill_null(array, &fill_value, ctx)

--- a/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
@@ -157,7 +157,8 @@ fn fill_null_canonical(
     fill_value: &Scalar,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    if let Some(result) = precondition(canonical.as_ref(), fill_value)? {
+    let arr = canonical.as_ref().to_array();
+    if let Some(result) = precondition(&arr, fill_value)? {
         // The result of precondition may return another ScalarFn, in which case we should
         // apply it immediately.
         // TODO(aduffy): Remove this once we have better driver check. We're also implicitly

--- a/vortex-array/src/scalar_fn/fns/like/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/like/kernel.rs
@@ -4,7 +4,6 @@
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::arrays::ExactScalarFn;
@@ -27,7 +26,7 @@ use crate::vtable::VTable;
 pub trait LikeReduce: VTable {
     fn like(
         array: &Self::Array,
-        pattern: &dyn Array,
+        pattern: &ArrayRef,
         options: LikeOptions,
     ) -> VortexResult<Option<ArrayRef>>;
 }
@@ -42,7 +41,7 @@ pub trait LikeReduce: VTable {
 pub trait LikeKernel: VTable {
     fn like(
         array: &Self::Array,
-        pattern: &dyn Array,
+        pattern: &ArrayRef,
         options: LikeOptions,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>>;
@@ -71,7 +70,7 @@ where
             .as_opt::<ScalarFnVTable>()
             .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
         let children = scalar_fn_array.children();
-        let pattern = &*children[1];
+        let pattern = &children[1];
         let options = *parent.options;
         <V as LikeReduce>::like(array, pattern, options)
     }
@@ -101,7 +100,7 @@ where
             .as_opt::<ScalarFnVTable>()
             .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
         let children = scalar_fn_array.children();
-        let pattern = &*children[1];
+        let pattern = &children[1];
         let options = *parent.options;
         <V as LikeKernel>::like(array, pattern, options, ctx)
     }

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -204,8 +204,8 @@ impl ScalarFnVTable for Like {
 
 /// Implementation of LIKE using the Arrow crate.
 pub(crate) fn arrow_like(
-    array: &dyn Array,
-    pattern: &dyn Array,
+    array: &ArrayRef,
+    pattern: &ArrayRef,
     options: LikeOptions,
 ) -> VortexResult<ArrayRef> {
     let nullable = array.dtype().is_nullable() | pattern.dtype().is_nullable();

--- a/vortex-array/src/scalar_fn/fns/list_contains/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/kernel.rs
@@ -4,7 +4,6 @@
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::arrays::ExactScalarFn;
@@ -19,14 +18,14 @@ use crate::vtable::VTable;
 ///
 /// This trait dispatches on the **element** (needle) child at index 1 of the `ListContains`
 /// expression. `Self::Array` is the concrete element encoding, while the list (haystack) is
-/// passed as an opaque `&dyn Array`.
+/// passed as an opaque `&ArrayRef`.
 ///
 /// A future `ListContainsListReduce` could dispatch on the list side (child 0) for encodings
 /// with specialized list representations.
 ///
 /// Return `None` if the operation cannot be resolved from metadata alone.
 pub trait ListContainsElementReduce: VTable {
-    fn list_contains(list: &dyn Array, element: &Self::Array) -> VortexResult<Option<ArrayRef>>;
+    fn list_contains(list: &ArrayRef, element: &Self::Array) -> VortexResult<Option<ArrayRef>>;
 }
 
 /// Check list-contains, potentially reading buffers.
@@ -36,7 +35,7 @@ pub trait ListContainsElementReduce: VTable {
 /// the provided [`ExecutionCtx`].
 pub trait ListContainsElementKernel: VTable {
     fn list_contains(
-        list: &dyn Array,
+        list: &ArrayRef,
         element: &Self::Array,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>>;
@@ -66,7 +65,7 @@ where
             .as_opt::<ScalarFnVTable>()
             .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
         let list = &scalar_fn_array.children()[0];
-        <V as ListContainsElementReduce>::list_contains(list.as_ref(), array)
+        <V as ListContainsElementReduce>::list_contains(list, array)
     }
 }
 
@@ -95,6 +94,6 @@ where
             .as_opt::<ScalarFnVTable>()
             .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
         let list = &scalar_fn_array.children()[0];
-        <V as ListContainsElementKernel>::list_contains(list.as_ref(), array, ctx)
+        <V as ListContainsElementKernel>::list_contains(list, array, ctx)
     }
 }

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -136,7 +136,7 @@ impl ScalarFnVTable for ListContains {
             return Ok(ConstantArray::new(result, args.row_count()).into_array());
         }
 
-        compute_list_contains(list_array.as_ref(), value_array.as_ref())
+        compute_list_contains(&list_array, &value_array)
     }
 
     fn stat_falsification(
@@ -203,7 +203,7 @@ fn compute_contains_scalar(list: &Scalar, needle: &Scalar) -> VortexResult<Scala
     Ok(Scalar::bool(contains, nullability))
 }
 
-fn compute_list_contains(array: &dyn Array, value: &dyn Array) -> VortexResult<ArrayRef> {
+fn compute_list_contains(array: &ArrayRef, value: &ArrayRef) -> VortexResult<ArrayRef> {
     let DType::List(elem_dtype, _) = array.dtype() else {
         vortex_bail!("Array must be of List type");
     };
@@ -237,7 +237,7 @@ fn compute_list_contains(array: &dyn Array, value: &dyn Array) -> VortexResult<A
 /// There is a constant list scalar (haystack) being compared to an array of needles.
 fn constant_list_scalar_contains(
     list_scalar: &ListScalar,
-    values: &dyn Array,
+    values: &ArrayRef,
     nullability: Nullability,
 ) -> VortexResult<ArrayRef> {
     let elements = list_scalar.elements().vortex_expect("non null");
@@ -268,7 +268,7 @@ fn constant_list_scalar_contains(
 
 /// Returns a [`BoolArray`] where each bit represents if a list contains the scalar.
 fn list_contains_scalar(
-    array: &dyn Array,
+    array: &ArrayRef,
     value: &Scalar,
     nullability: Nullability,
 ) -> VortexResult<ArrayRef> {

--- a/vortex-array/src/scalar_fn/fns/merge.rs
+++ b/vortex-array/src/scalar_fn/fns/merge.rs
@@ -289,6 +289,7 @@ mod tests {
     use vortex_error::vortex_bail;
 
     use crate::Array;
+    use crate::ArrayRef;
     use crate::IntoArray;
     use crate::ToCanonical;
     use crate::arrays::PrimitiveArray;
@@ -308,7 +309,7 @@ mod tests {
     use crate::scalar_fn::fns::merge::DuplicateHandling;
     use crate::scalar_fn::fns::pack::Pack;
 
-    fn primitive_field(array: &dyn Array, field_path: &[&str]) -> VortexResult<PrimitiveArray> {
+    fn primitive_field(array: &ArrayRef, field_path: &[&str]) -> VortexResult<PrimitiveArray> {
         let mut field_path = field_path.iter();
 
         let Some(field) = field_path.next() else {

--- a/vortex-array/src/scalar_fn/fns/pack.rs
+++ b/vortex-array/src/scalar_fn/fns/pack.rs
@@ -188,7 +188,7 @@ mod tests {
         .into_array()
     }
 
-    fn primitive_field(array: &dyn Array, field_path: &[&str]) -> VortexResult<PrimitiveArray> {
+    fn primitive_field(array: &ArrayRef, field_path: &[&str]) -> VortexResult<PrimitiveArray> {
         let mut field_path = field_path.iter();
 
         let Some(field) = field_path.next() else {
@@ -234,15 +234,15 @@ mod tests {
         assert_eq!(actual_array.validity(), &Validity::NonNullable);
 
         assert_arrays_eq!(
-            primitive_field(actual_array.as_ref(), &["one"]).unwrap(),
+            primitive_field(&actual_array.to_array(), &["one"]).unwrap(),
             PrimitiveArray::from_iter([0i32, 1, 2])
         );
         assert_arrays_eq!(
-            primitive_field(actual_array.as_ref(), &["two"]).unwrap(),
+            primitive_field(&actual_array.to_array(), &["two"]).unwrap(),
             PrimitiveArray::from_iter([4i32, 5, 6])
         );
         assert_arrays_eq!(
-            primitive_field(actual_array.as_ref(), &["three"]).unwrap(),
+            primitive_field(&actual_array.to_array(), &["three"]).unwrap(),
             PrimitiveArray::from_iter([0i32, 1, 2])
         );
     }
@@ -272,19 +272,19 @@ mod tests {
         assert_eq!(actual_array.names(), ["one", "two", "three"]);
 
         assert_arrays_eq!(
-            primitive_field(actual_array.as_ref(), &["one"]).unwrap(),
+            primitive_field(&actual_array.to_array(), &["one"]).unwrap(),
             PrimitiveArray::from_iter([0i32, 1, 2])
         );
         assert_arrays_eq!(
-            primitive_field(actual_array.as_ref(), &["two", "two_one"]).unwrap(),
+            primitive_field(&actual_array.to_array(), &["two", "two_one"]).unwrap(),
             PrimitiveArray::from_iter([4i32, 5, 6])
         );
         assert_arrays_eq!(
-            primitive_field(actual_array.as_ref(), &["two", "two_two"]).unwrap(),
+            primitive_field(&actual_array.to_array(), &["two", "two_two"]).unwrap(),
             PrimitiveArray::from_iter([4i32, 5, 6])
         );
         assert_arrays_eq!(
-            primitive_field(actual_array.as_ref(), &["three"]).unwrap(),
+            primitive_field(&actual_array.to_array(), &["three"]).unwrap(),
             PrimitiveArray::from_iter([0i32, 1, 2])
         );
     }

--- a/vortex-array/src/scalar_fn/fns/zip/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/kernel.rs
@@ -5,7 +5,6 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
-use crate::Array;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::arrays::ExactScalarFn;
@@ -25,11 +24,8 @@ use crate::vtable::VTable;
 /// Dispatch is on child 0 (if_true). The `if_false` and `mask` are extracted from
 /// the parent `ScalarFnArray`.
 pub trait ZipReduce: VTable {
-    fn zip(
-        array: &Self::Array,
-        if_false: &dyn Array,
-        mask: &Mask,
-    ) -> VortexResult<Option<ArrayRef>>;
+    fn zip(array: &Self::Array, if_false: &ArrayRef, mask: &Mask)
+    -> VortexResult<Option<ArrayRef>>;
 }
 
 /// Zip two arrays using a mask, potentially reading buffers.
@@ -42,7 +38,7 @@ pub trait ZipReduce: VTable {
 pub trait ZipKernel: VTable {
     fn zip(
         array: &Self::Array,
-        if_false: &dyn Array,
+        if_false: &ArrayRef,
         mask: &Mask,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>>;
@@ -71,8 +67,8 @@ where
             .as_opt::<ScalarFnVTable>()
             .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
         let children = scalar_fn_array.children();
-        let if_false = &*children[1];
-        let mask_array = &*children[2];
+        let if_false = &children[1];
+        let mask_array = &children[2];
         let mask = mask_array.try_to_mask_fill_null_false()?;
         <V as ZipReduce>::zip(array, if_false, &mask)
     }
@@ -102,8 +98,8 @@ where
             .as_opt::<ScalarFnVTable>()
             .vortex_expect("ExactScalarFn matcher confirmed ScalarFnArray");
         let children = scalar_fn_array.children();
-        let if_false = &*children[1];
-        let mask_array = &*children[2];
+        let if_false = &children[1];
+        let mask_array = &children[2];
         let mask = mask_array.try_to_mask_fill_null_false()?;
         <V as ZipKernel>::zip(array, if_false, &mask, ctx)
     }

--- a/vortex-array/src/scalar_fn/fns/zip/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/mod.rs
@@ -174,8 +174,8 @@ impl ScalarFnVTable for Zip {
 }
 
 pub(crate) fn zip_impl(
-    if_true: &dyn Array,
-    if_false: &dyn Array,
+    if_true: &ArrayRef,
+    if_false: &ArrayRef,
     mask: &Mask,
 ) -> VortexResult<ArrayRef> {
     assert_eq!(
@@ -197,8 +197,8 @@ pub(crate) fn zip_impl(
 }
 
 fn zip_impl_with_builder(
-    if_true: &dyn Array,
-    if_false: &dyn Array,
+    if_true: &ArrayRef,
+    if_false: &ArrayRef,
     mask: &Mask,
     mut builder: Box<dyn ArrayBuilder>,
 ) -> VortexResult<ArrayRef> {

--- a/vortex-array/src/stats/array.rs
+++ b/vortex-array/src/stats/array.rs
@@ -147,16 +147,17 @@ impl StatsSetRef<'_> {
             return Ok(Some(s));
         }
 
+        let array_ref = self.dyn_array_ref.to_array();
         Ok(match stat {
-            Stat::Min => min_max(self.dyn_array_ref)?.map(|MinMaxResult { min, max: _ }| min),
-            Stat::Max => min_max(self.dyn_array_ref)?.map(|MinMaxResult { min: _, max }| max),
+            Stat::Min => min_max(&array_ref)?.map(|MinMaxResult { min, max: _ }| min),
+            Stat::Max => min_max(&array_ref)?.map(|MinMaxResult { min: _, max }| max),
             Stat::Sum => {
                 Stat::Sum
                     .dtype(self.dyn_array_ref.dtype())
                     .is_some()
                     .then(|| {
                         // Sum is supported for this dtype.
-                        sum(self.dyn_array_ref)
+                        sum(&array_ref)
                     })
                     .transpose()?
             }
@@ -165,16 +166,16 @@ impl StatsSetRef<'_> {
                 if self.dyn_array_ref.is_empty() {
                     None
                 } else {
-                    is_constant(self.dyn_array_ref)?.map(|v| v.into())
+                    is_constant(&array_ref)?.map(|v| v.into())
                 }
             }
-            Stat::IsSorted => is_sorted(self.dyn_array_ref)?.map(|v| v.into()),
-            Stat::IsStrictSorted => is_strict_sorted(self.dyn_array_ref)?.map(|v| v.into()),
+            Stat::IsSorted => is_sorted(&array_ref)?.map(|v| v.into()),
+            Stat::IsStrictSorted => is_strict_sorted(&array_ref)?.map(|v| v.into()),
             Stat::UncompressedSizeInBytes => {
                 let mut builder =
                     builder_with_capacity(self.dyn_array_ref.dtype(), self.dyn_array_ref.len());
                 unsafe {
-                    builder.extend_from_array_unchecked(self.dyn_array_ref);
+                    builder.extend_from_array_unchecked(&array_ref);
                 }
                 let nbytes = builder.finish().nbytes();
                 self.set(stat, Precision::exact(nbytes));
@@ -186,7 +187,7 @@ impl StatsSetRef<'_> {
                     .is_some()
                     .then(|| {
                         // NaNCount is supported for this dtype.
-                        nan_count(self.dyn_array_ref)
+                        nan_count(&array_ref)
                     })
                     .transpose()?
                     .map(|s| s.into())

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -167,7 +167,7 @@ impl Validity {
         }
     }
 
-    pub fn take(&self, indices: &dyn Array) -> VortexResult<Self> {
+    pub fn take(&self, indices: &ArrayRef) -> VortexResult<Self> {
         match self {
             Self::NonNullable => match indices.validity_mask()?.bit_buffer() {
                 AllOr::All => {
@@ -280,7 +280,7 @@ impl Validity {
         self,
         len: usize,
         indices_offset: usize,
-        indices: &dyn Array,
+        indices: &ArrayRef,
         patches: &Validity,
     ) -> VortexResult<Self> {
         match (&self, patches) {
@@ -374,7 +374,7 @@ impl Validity {
 
     /// Create Validity by copying the given array's validity.
     #[inline]
-    pub fn copy_from_array(array: &dyn Array) -> VortexResult<Self> {
+    pub fn copy_from_array(array: &ArrayRef) -> VortexResult<Self> {
         Ok(Validity::from_mask(
             array.validity_mask()?,
             array.dtype().nullability(),

--- a/vortex-array/src/variants.rs
+++ b/vortex-array/src/variants.rs
@@ -89,7 +89,7 @@ pub struct BoolTyped<'a>(&'a dyn Array);
 
 impl BoolTyped<'_> {
     pub fn true_count(&self) -> VortexResult<usize> {
-        let true_count = sum(self.0)?;
+        let true_count = sum(&self.0.to_array())?;
         Ok(true_count
             .as_primitive()
             .as_::<usize>()

--- a/vortex-array/src/vtable/dyn_.rs
+++ b/vortex-array/src/vtable/dyn_.rs
@@ -45,7 +45,7 @@ pub trait DynVTable: 'static + private::Sealed + Send + Sync + Debug {
         children: &dyn ArrayChildren,
         session: &VortexSession,
     ) -> VortexResult<ArrayRef>;
-    fn with_children(&self, array: &dyn Array, children: Vec<ArrayRef>) -> VortexResult<ArrayRef>;
+    fn with_children(&self, array: &ArrayRef, children: Vec<ArrayRef>) -> VortexResult<ArrayRef>;
 
     /// See [`VTable::reduce`]
     fn reduce(&self, array: &ArrayRef) -> VortexResult<Option<ArrayRef>>;
@@ -93,7 +93,7 @@ impl<V: VTable> DynVTable for ArrayVTableAdapter<V> {
         Ok(array.to_array())
     }
 
-    fn with_children(&self, array: &dyn Array, children: Vec<ArrayRef>) -> VortexResult<ArrayRef> {
+    fn with_children(&self, array: &ArrayRef, children: Vec<ArrayRef>) -> VortexResult<ArrayRef> {
         let mut array = array.as_::<V>().clone();
         V::with_children(&mut array, children)?;
         Ok(array.to_array())

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -131,8 +131,8 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
         builder: &mut dyn ArrayBuilder,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
-        let canonical = array.to_array().execute::<Canonical>(ctx)?;
-        builder.extend_from_array(canonical.as_ref());
+        let canonical = array.to_array().execute::<Canonical>(ctx)?.into_array();
+        builder.extend_from_array(&canonical);
         Ok(())
     }
 

--- a/vortex-btrblocks/benches/compress.rs
+++ b/vortex-btrblocks/benches/compress.rs
@@ -46,7 +46,7 @@ mod benchmarks {
             .with_inputs(|| &array)
             .input_counter(|array| ItemsCount::new(array.len()))
             .input_counter(|array| BytesCount::of_many::<i32>(array.len()))
-            .bench_refs(|array| compressor.compress(array.as_ref()).unwrap());
+            .bench_refs(|array| compressor.compress(&array.to_array()).unwrap());
     }
 }
 

--- a/vortex-btrblocks/benches/compress_listview.rs
+++ b/vortex-btrblocks/benches/compress_listview.rs
@@ -181,7 +181,7 @@ mod benchmarks {
             .with_inputs(|| &array)
             .input_counter(|_| ItemsCount::new(NUM_ROWS))
             .input_counter(move |_| BytesCount::new(nbytes as usize))
-            .bench_refs(|array| compressor.compress(array.as_ref()).unwrap());
+            .bench_refs(|array| compressor.compress(array).unwrap());
     }
 }
 

--- a/vortex-btrblocks/benches/dict_encode.rs
+++ b/vortex-btrblocks/benches/dict_encode.rs
@@ -34,7 +34,7 @@ fn encode_generic(bencher: Bencher) {
     let array = make_array().into_array();
     bencher
         .with_inputs(|| &array)
-        .bench_refs(|array| dict_encode(array.as_ref()).unwrap());
+        .bench_refs(|array| dict_encode(array).unwrap());
 }
 
 #[cfg(not(codspeed))]

--- a/vortex-btrblocks/public-api.lock
+++ b/vortex-btrblocks/public-api.lock
@@ -196,7 +196,7 @@ pub vortex_btrblocks::BtrBlocksCompressor::string_schemes: alloc::vec::Vec<&'sta
 
 impl vortex_btrblocks::BtrBlocksCompressor
 
-pub fn vortex_btrblocks::BtrBlocksCompressor::compress(&self, array: &dyn vortex_array::array::Array) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_btrblocks::BtrBlocksCompressor::compress(&self, array: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
 
 impl core::clone::Clone for vortex_btrblocks::BtrBlocksCompressor
 

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -111,7 +111,7 @@ impl BtrBlocksCompressor {
     /// Compresses an array using BtrBlocks-inspired compression.
     ///
     /// First canonicalizes and compacts the array, then applies optimal compression schemes.
-    pub fn compress(&self, array: &dyn Array) -> VortexResult<ArrayRef> {
+    pub fn compress(&self, array: &ArrayRef) -> VortexResult<ArrayRef> {
         // Canonicalize the array
         let canonical = array.to_canonical()?;
 
@@ -275,7 +275,7 @@ impl CanonicalCompressor for BtrBlocksCompressor {
                     && let TemporalMetadata::Timestamp(..) = temporal_array.temporal_metadata()
                 {
                     if is_constant_opts(
-                        temporal_array.as_ref(),
+                        &ext_array.to_array(),
                         &IsConstantOpts {
                             cost: Cost::Canonicalize,
                         },
@@ -355,7 +355,8 @@ mod tests {
         #[case] input: ListViewArray,
         #[case] expect_list: bool,
     ) -> VortexResult<()> {
-        let result = BtrBlocksCompressor::default().compress(input.as_ref())?;
+        let array_ref = input.clone().into_array();
+        let result = BtrBlocksCompressor::default().compress(&array_ref)?;
         if expect_list {
             assert!(result.as_opt::<ListVTable>().is_some());
         } else {

--- a/vortex-btrblocks/src/compressor/float/mod.rs
+++ b/vortex-btrblocks/src/compressor/float/mod.rs
@@ -501,7 +501,7 @@ impl Scheme for NullDominated {
         assert!(ctx.allowed_cascading > 0);
 
         // We pass None as we only run this pathway for NULL-dominated float arrays
-        let sparse_encoded = SparseArray::encode(stats.src.as_ref(), None)?;
+        let sparse_encoded = SparseArray::encode(&stats.src.to_array(), None)?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {
             // Compress the values

--- a/vortex-btrblocks/src/compressor/float/stats.rs
+++ b/vortex-btrblocks/src/compressor/float/stats.rs
@@ -92,7 +92,7 @@ impl CompressorStats for FloatStats {
     }
 
     fn sample_opts(&self, sample_size: u32, sample_count: u32, opts: GenerateStatsOptions) -> Self {
-        let sampled = sample(self.src.as_ref(), sample_size, sample_count).to_primitive();
+        let sampled = sample(&self.src.to_array(), sample_size, sample_count).to_primitive();
 
         Self::generate_opts(&sampled, opts)
     }

--- a/vortex-btrblocks/src/compressor/integer/mod.rs
+++ b/vortex-btrblocks/src/compressor/integer/mod.rs
@@ -601,7 +601,7 @@ impl Scheme for SparseScheme {
         }
 
         let sparse_encoded = SparseArray::encode(
-            stats.src.as_ref(),
+            &stats.src.to_array(),
             Some(Scalar::primitive_value(
                 top_pvalue,
                 top_pvalue.ptype(),
@@ -1063,7 +1063,7 @@ mod tests {
             .into_array();
 
         let btr = BtrBlocksCompressor::default();
-        drop(btr.compress(prim.as_ref())?);
+        drop(btr.compress(&prim)?);
 
         Ok(())
     }

--- a/vortex-btrblocks/src/compressor/integer/stats.rs
+++ b/vortex-btrblocks/src/compressor/integer/stats.rs
@@ -186,7 +186,7 @@ impl CompressorStats for IntegerStats {
     }
 
     fn sample_opts(&self, sample_size: u32, sample_count: u32, opts: GenerateStatsOptions) -> Self {
-        let sampled = sample(self.src.as_ref(), sample_size, sample_count).to_primitive();
+        let sampled = sample(&self.src.to_array(), sample_size, sample_count).to_primitive();
 
         Self::generate_opts(&sampled, opts)
     }

--- a/vortex-btrblocks/src/compressor/string.rs
+++ b/vortex-btrblocks/src/compressor/string.rs
@@ -111,7 +111,7 @@ impl CompressorStats for StringStats {
     }
 
     fn sample_opts(&self, sample_size: u32, sample_count: u32, opts: GenerateStatsOptions) -> Self {
-        let sampled = sample(self.src.as_ref(), sample_size, sample_count).to_varbinview();
+        let sampled = sample(&self.src.to_array(), sample_size, sample_count).to_varbinview();
 
         Self::generate_opts(&sampled, opts)
     }
@@ -412,7 +412,8 @@ impl Scheme for ConstantScheme {
             return Ok(0.0);
         }
 
-        if stats.estimated_distinct_count > 1 || !is_constant(stats.src.as_ref())?.unwrap_or(false)
+        if stats.estimated_distinct_count > 1
+            || !is_constant(&stats.src.to_array())?.unwrap_or(false)
         {
             return Ok(0.0);
         }
@@ -494,7 +495,7 @@ impl Scheme for NullDominated {
         assert!(ctx.allowed_cascading > 0);
 
         // We pass None as we only run this pathway for NULL-dominated string arrays
-        let sparse_encoded = SparseArray::encode(stats.src.as_ref(), None)?;
+        let sparse_encoded = SparseArray::encode(&stats.src.to_array(), None)?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {
             // Compress the indices only (not the values for strings)
@@ -566,6 +567,7 @@ impl Scheme for ZstdBuffersScheme {
 
 #[cfg(test)]
 mod tests {
+    use vortex_array::IntoArray;
     use vortex_array::arrays::VarBinViewArray;
     use vortex_array::builders::ArrayBuilder;
     use vortex_array::builders::VarBinViewBuilder;
@@ -587,7 +589,8 @@ mod tests {
         }
         let strings = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
 
-        let compressed = BtrBlocksCompressor::default().compress(strings.as_ref())?;
+        let array_ref = strings.into_array();
+        let compressed = BtrBlocksCompressor::default().compress(&array_ref)?;
         assert_eq!(compressed.len(), 2048);
 
         let display = compressed
@@ -608,7 +611,8 @@ mod tests {
 
         let strings = strings.finish_into_varbinview();
 
-        let compressed = BtrBlocksCompressor::default().compress(strings.as_ref())?;
+        let array_ref = strings.into_array();
+        let compressed = BtrBlocksCompressor::default().compress(&array_ref)?;
         assert_eq!(compressed.len(), 100);
 
         let display = compressed
@@ -624,6 +628,7 @@ mod tests {
 /// Tests to verify that each string compression scheme produces the expected encoding.
 #[cfg(test)]
 mod scheme_selection_tests {
+    use vortex_array::IntoArray;
     use vortex_array::arrays::ConstantVTable;
     use vortex_array::arrays::DictVTable;
     use vortex_array::arrays::VarBinViewArray;
@@ -638,7 +643,8 @@ mod scheme_selection_tests {
     fn test_constant_compressed() -> VortexResult<()> {
         let strings: Vec<Option<&str>> = vec![Some("constant_value"); 100];
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
-        let compressed = BtrBlocksCompressor::default().compress(array.as_ref())?;
+        let array_ref = array.into_array();
+        let compressed = BtrBlocksCompressor::default().compress(&array_ref)?;
         assert!(compressed.is::<ConstantVTable>());
         Ok(())
     }
@@ -651,7 +657,8 @@ mod scheme_selection_tests {
             strings.push(Some(distinct_values[i % 3]));
         }
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
-        let compressed = BtrBlocksCompressor::default().compress(array.as_ref())?;
+        let array_ref = array.into_array();
+        let compressed = BtrBlocksCompressor::default().compress(&array_ref)?;
         assert!(compressed.is::<DictVTable>());
         Ok(())
     }
@@ -665,7 +672,8 @@ mod scheme_selection_tests {
             )));
         }
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
-        let compressed = BtrBlocksCompressor::default().compress(array.as_ref())?;
+        let array_ref = array.into_array();
+        let compressed = BtrBlocksCompressor::default().compress(&array_ref)?;
         assert!(compressed.is::<FSSTVTable>());
         Ok(())
     }

--- a/vortex-btrblocks/src/sample.rs
+++ b/vortex-btrblocks/src/sample.rs
@@ -13,7 +13,7 @@ use vortex_error::VortexExpect;
 use crate::stats::SAMPLE_COUNT;
 use crate::stats::SAMPLE_SIZE;
 
-pub(crate) fn sample(input: &dyn Array, sample_size: u32, sample_count: u32) -> ArrayRef {
+pub(crate) fn sample(input: &ArrayRef, sample_size: u32, sample_count: u32) -> ArrayRef {
     if input.len() <= (sample_size as usize) * (sample_count as usize) {
         return input.to_array();
     }

--- a/vortex-cuda/benches/bitpacked_cuda.rs
+++ b/vortex-cuda/benches/bitpacked_cuda.rs
@@ -51,7 +51,7 @@ where
         .collect();
 
     let primitive_array = PrimitiveArray::new(Buffer::from(values), NonNullable);
-    BitPackedArray::encode(primitive_array.as_ref(), bit_width)
+    BitPackedArray::encode(&primitive_array.to_array(), bit_width)
         .vortex_expect("failed to create BitPacked array")
 }
 

--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -176,7 +176,7 @@ fn bench_for_bitpacked(c: &mut Criterion) {
             .map(|i| (i as u64 % (max_val + 1)) as u32)
             .collect();
         let prim = PrimitiveArray::new(Buffer::from(residuals), NonNullable);
-        let bp = BitPackedArray::encode(prim.as_ref(), bit_width).vortex_expect("bitpack");
+        let bp = BitPackedArray::encode(&prim.to_array(), bit_width).vortex_expect("bitpack");
         let for_arr =
             FoRArray::try_new(bp.into_array(), Scalar::from(reference)).vortex_expect("for");
         let array = for_arr.to_array();
@@ -220,7 +220,7 @@ fn bench_dict_bp_codes(c: &mut Criterion) {
 
         let codes: Vec<u32> = (0..*len).map(|i| (i % dict_size) as u32).collect();
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPackedArray::encode(codes_prim.as_ref(), dict_bit_width)
+        let codes_bp = BitPackedArray::encode(&codes_prim.to_array(), dict_bit_width)
             .vortex_expect("bitpack codes");
         let values_prim = PrimitiveArray::new(Buffer::from(dict_values.clone()), NonNullable);
         let dict = DictArray::new(codes_bp.into_array(), values_prim.into_array());
@@ -309,7 +309,7 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
     let dict_residuals: Vec<u32> = (0..dict_size as u32).collect();
     let dict_prim = PrimitiveArray::new(Buffer::from(dict_residuals), NonNullable);
     let dict_bp =
-        BitPackedArray::encode(dict_prim.as_ref(), dict_bit_width).vortex_expect("bitpack dict");
+        BitPackedArray::encode(&dict_prim.to_array(), dict_bit_width).vortex_expect("bitpack dict");
     let dict_for = FoRArray::try_new(dict_bp.into_array(), Scalar::from(dict_reference))
         .vortex_expect("for dict");
 
@@ -318,7 +318,7 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
 
         let codes: Vec<u32> = (0..*len).map(|i| (i % dict_size) as u32).collect();
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPackedArray::encode(codes_prim.as_ref(), codes_bit_width)
+        let codes_bp = BitPackedArray::encode(&codes_prim.to_array(), codes_bit_width)
             .vortex_expect("bitpack codes");
 
         let dict = DictArray::new(codes_bp.into_array(), dict_for.to_array());

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -55,8 +55,7 @@ where
         PrimitiveArray::new(Buffer::from(data), Validity::NonNullable).into_array();
 
     if bp && T::PTYPE != PType::U8 {
-        let child =
-            BitPackedArray::encode(primitive_array.as_ref(), 8).vortex_expect("failed to bitpack");
+        let child = BitPackedArray::encode(&primitive_array, 8).vortex_expect("failed to bitpack");
         FoRArray::try_new(child.into_array(), reference.into())
             .vortex_expect("failed to create FoR array")
     } else {

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -232,7 +232,7 @@ mod tests {
             .map(|i| ((i as u64) % (max_val + 1)) as u32)
             .collect();
         let primitive = PrimitiveArray::new(Buffer::from(values), NonNullable);
-        BitPackedArray::encode(primitive.as_ref(), bit_width)
+        BitPackedArray::encode(&primitive.to_array(), bit_width)
             .vortex_expect("failed to create BitPacked array")
     }
 
@@ -504,12 +504,12 @@ mod tests {
 
         // BitPack+FoR the dict values
         let dict_prim = PrimitiveArray::new(Buffer::from(dict_residuals), NonNullable);
-        let dict_bp = BitPackedArray::encode(dict_prim.as_ref(), 6)?;
+        let dict_bp = BitPackedArray::encode(&dict_prim.to_array(), 6)?;
         let dict_for = FoRArray::try_new(dict_bp.into_array(), Scalar::from(dict_reference))?;
 
         // BitPack the codes
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPackedArray::encode(codes_prim.as_ref(), 6)?;
+        let codes_bp = BitPackedArray::encode(&codes_prim.to_array(), 6)?;
 
         let dict = DictArray::try_new(codes_bp.into_array(), dict_for.into_array())?;
 
@@ -569,7 +569,7 @@ mod tests {
             .collect();
 
         let prim = PrimitiveArray::new(Buffer::from(raw), NonNullable);
-        let bp = BitPackedArray::encode(prim.as_ref(), bit_width)?;
+        let bp = BitPackedArray::encode(&prim.to_array(), bit_width)?;
         let zz = ZigZagArray::try_new(bp.into_array())?;
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
@@ -649,7 +649,7 @@ mod tests {
         // BitPack codes, then wrap in FoR (reference=0 so values unchanged)
         let bit_width: u8 = 3;
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPackedArray::encode(codes_prim.as_ref(), bit_width)?;
+        let codes_bp = BitPackedArray::encode(&codes_prim.to_array(), bit_width)?;
         let codes_for = FoRArray::try_new(codes_bp.into_array(), Scalar::from(0u32))?;
 
         let values_prim = PrimitiveArray::new(Buffer::from(dict_values), NonNullable);
@@ -674,7 +674,7 @@ mod tests {
 
         let bit_width: u8 = 2;
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPackedArray::encode(codes_prim.as_ref(), bit_width)?;
+        let codes_bp = BitPackedArray::encode(&codes_prim.to_array(), bit_width)?;
         let values_prim = PrimitiveArray::new(Buffer::from(dict_values), NonNullable);
 
         let dict = DictArray::try_new(codes_bp.into_array(), values_prim.into_array())?;

--- a/vortex-cuda/src/kernel/arrays/dict.rs
+++ b/vortex-cuda/src/kernel/arrays/dict.rs
@@ -99,7 +99,7 @@ async fn execute_dict_prim_typed<V: DeviceRepr + NativePType, I: DeviceRepr + Na
         validity: values_validity,
         ..
     } = values.into_parts();
-    let output_validity = values_validity.take(codes.as_ref())?;
+    let output_validity = values_validity.take(&codes.to_array())?;
     let PrimitiveArrayParts {
         buffer: codes_buffer,
         ..
@@ -184,7 +184,7 @@ async fn execute_dict_decimal_typed<
         validity: values_validity,
         ..
     } = values.into_parts();
-    let output_validity = values_validity.take(codes.as_ref())?;
+    let output_validity = values_validity.take(&codes.to_array())?;
 
     let PrimitiveArrayParts {
         buffer: codes_buffer,
@@ -252,7 +252,7 @@ async fn execute_dict_varbinview(
         validity: values_validity,
         ..
     } = values_vbv.into_parts();
-    let output_validity = values_validity.take(codes_prim.as_ref())?;
+    let output_validity = values_validity.take(&codes_prim.to_array())?;
 
     let PrimitiveArrayParts {
         buffer: codes_buffer,

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -180,7 +180,7 @@ mod tests {
         let array = PrimitiveArray::new((0u16..=513).collect::<Buffer<_>>(), NonNullable);
 
         // Last two items should be patched
-        let bp_with_patches = BitPackedArray::encode(array.as_ref(), 9)?;
+        let bp_with_patches = BitPackedArray::encode(&array.to_array(), 9)?;
         assert!(bp_with_patches.patches().is_some());
 
         let cpu_result = bp_with_patches.to_canonical()?.into_array();
@@ -221,7 +221,7 @@ mod tests {
             NonNullable,
         );
 
-        let bitpacked_array = BitPackedArray::encode(primitive_array.as_ref(), bit_width)
+        let bitpacked_array = BitPackedArray::encode(&primitive_array.to_array(), bit_width)
             .vortex_expect("operation should succeed in test");
         let cpu_result = bitpacked_array.to_canonical()?;
 
@@ -269,7 +269,7 @@ mod tests {
             NonNullable,
         );
 
-        let bitpacked_array = BitPackedArray::encode(primitive_array.as_ref(), bit_width)
+        let bitpacked_array = BitPackedArray::encode(&primitive_array.to_array(), bit_width)
             .vortex_expect("operation should succeed in test");
         let cpu_result = bitpacked_array.to_canonical()?;
 
@@ -333,7 +333,7 @@ mod tests {
             NonNullable,
         );
 
-        let bitpacked_array = BitPackedArray::encode(primitive_array.as_ref(), bit_width)
+        let bitpacked_array = BitPackedArray::encode(&primitive_array.to_array(), bit_width)
             .vortex_expect("operation should succeed in test");
         let cpu_result = bitpacked_array.to_canonical()?;
 
@@ -429,7 +429,7 @@ mod tests {
             NonNullable,
         );
 
-        let bitpacked_array = BitPackedArray::encode(primitive_array.as_ref(), bit_width)
+        let bitpacked_array = BitPackedArray::encode(&primitive_array.to_array(), bit_width)
             .vortex_expect("operation should succeed in test");
         let cpu_result = bitpacked_array.to_canonical()?;
         let gpu_result = block_on(async {
@@ -462,7 +462,7 @@ mod tests {
             NonNullable,
         );
 
-        let bitpacked_array = BitPackedArray::encode(primitive_array.as_ref(), bit_width)
+        let bitpacked_array = BitPackedArray::encode(&primitive_array.to_array(), bit_width)
             .vortex_expect("operation should succeed in test");
         let slice_ref = bitpacked_array.clone().into_array().slice(67..3969)?;
         let mut exec_ctx = ExecutionCtx::new(VortexSession::empty().with::<ArraySession>());

--- a/vortex-cuda/src/kernel/encodings/date_time_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/date_time_parts.rs
@@ -66,7 +66,7 @@ impl CudaExecute for DateTimePartsExecutor {
 
         let time_unit = options.unit;
         let time_zone = options.tz.clone();
-        let validity = Validity::copy_from_array(array.as_ref())?;
+        let validity = Validity::copy_from_array(&array.to_array())?;
 
         if output_len == 0 {
             return Ok(Canonical::empty(array.dtype()));

--- a/vortex-cuda/src/layout.rs
+++ b/vortex-cuda/src/layout.rs
@@ -506,7 +506,7 @@ impl LayoutStrategy for CudaFlatLayoutStrategy {
         };
 
         // Scan for constant array buffers before serialization (while data is still on host).
-        let host_buffers = extract_constant_buffers(&*chunk);
+        let host_buffers = extract_constant_buffers(&chunk);
 
         let buffers = chunk.serialize(
             &ctx,
@@ -546,7 +546,7 @@ impl LayoutStrategy for CudaFlatLayoutStrategy {
 /// Walk the array tree depth-first and extract buffer data for all `ConstantArray` nodes.
 ///
 /// The buffer ordering matches `Array::serialize()` because both use depth-first traversal.
-fn extract_constant_buffers(chunk: &dyn Array) -> Vec<InlinedBuffer> {
+fn extract_constant_buffers(chunk: &ArrayRef) -> Vec<InlinedBuffer> {
     let mut result = Vec::new();
     let mut buffer_idx = 0u32;
     for array in chunk.depth_first_traversal() {

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1198,7 +1198,7 @@ async fn write_nullable_top_level_struct() {
 }
 
 async fn round_trip(
-    array: &dyn Array,
+    array: &ArrayRef,
     f: impl Fn(ScanBuilder<ArrayRef>) -> VortexResult<ScanBuilder<ArrayRef>>,
 ) -> VortexResult<ArrayRef> {
     let mut writer = vec![];
@@ -1257,7 +1257,7 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
 async fn scan_empty_fields() -> VortexResult<()> {
     let array = (0..10000).collect::<PrimitiveArray>();
 
-    let result = round_trip(array.as_ref(), |scan| {
+    let result = round_trip(&array.to_array(), |scan| {
         Ok(scan.with_projection(Pack.new_expr(
             PackOptions {
                 names: Default::default(),

--- a/vortex-ipc/src/messages/decoder.rs
+++ b/vortex-ipc/src/messages/decoder.rs
@@ -168,6 +168,7 @@ impl MessageDecoder {
 mod test {
     use bytes::BytesMut;
     use vortex_array::Array;
+    use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
     use vortex_array::arrays::ConstantArray;
     use vortex_buffer::buffer;
@@ -178,7 +179,7 @@ mod test {
     use crate::messages::MessageEncoder;
     use crate::test::SESSION;
 
-    fn write_and_read(expected: &dyn Array) {
+    fn write_and_read(expected: &ArrayRef) {
         let mut ipc_bytes = BytesMut::new();
         let mut encoder = MessageEncoder::default();
         for buf in encoder.encode(EncoderMessage::Array(expected)).unwrap() {
@@ -213,6 +214,6 @@ mod test {
         // Constant arrays have a single buffer
         let array = ConstantArray::new(10i32, 20);
         assert_eq!(array.nbuffers(), 1, "Array should have a single buffer");
-        write_and_read(array.as_ref());
+        write_and_read(&array.to_array());
     }
 }

--- a/vortex-layout/public-api.lock
+++ b/vortex-layout/public-api.lock
@@ -186,19 +186,19 @@ pub fn vortex_layout::layouts::compressed::CompressingStrategy::write_stream<'li
 
 pub trait vortex_layout::layouts::compressed::CompressorPlugin: core::marker::Send + core::marker::Sync + 'static
 
-pub fn vortex_layout::layouts::compressed::CompressorPlugin::compress_chunk(&self, chunk: &dyn vortex_array::array::Array) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_layout::layouts::compressed::CompressorPlugin::compress_chunk(&self, chunk: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
 
 impl vortex_layout::layouts::compressed::CompressorPlugin for alloc::sync::Arc<dyn vortex_layout::layouts::compressed::CompressorPlugin>
 
-pub fn alloc::sync::Arc<dyn vortex_layout::layouts::compressed::CompressorPlugin>::compress_chunk(&self, chunk: &dyn vortex_array::array::Array) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn alloc::sync::Arc<dyn vortex_layout::layouts::compressed::CompressorPlugin>::compress_chunk(&self, chunk: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
 
 impl vortex_layout::layouts::compressed::CompressorPlugin for vortex_btrblocks::canonical_compressor::BtrBlocksCompressor
 
-pub fn vortex_btrblocks::canonical_compressor::BtrBlocksCompressor::compress_chunk(&self, chunk: &dyn vortex_array::array::Array) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_btrblocks::canonical_compressor::BtrBlocksCompressor::compress_chunk(&self, chunk: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
 
-impl<F> vortex_layout::layouts::compressed::CompressorPlugin for F where F: core::ops::function::Fn(&dyn vortex_array::array::Array) -> vortex_error::VortexResult<vortex_array::array::ArrayRef> + core::marker::Send + core::marker::Sync + 'static
+impl<F> vortex_layout::layouts::compressed::CompressorPlugin for F where F: core::ops::function::Fn(&vortex_array::array::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::ArrayRef> + core::marker::Send + core::marker::Sync + 'static
 
-pub fn F::compress_chunk(&self, chunk: &dyn vortex_array::array::Array) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn F::compress_chunk(&self, chunk: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
 
 pub mod vortex_layout::layouts::dict
 
@@ -816,9 +816,9 @@ pub fn vortex_layout::layouts::zoned::zone_map::StatsAccumulator::as_stats_table
 
 pub fn vortex_layout::layouts::zoned::zone_map::StatsAccumulator::new(dtype: &vortex_array::dtype::DType, stats: &[vortex_array::expr::stats::Stat], max_variable_length_statistics_size: usize) -> Self
 
-pub fn vortex_layout::layouts::zoned::zone_map::StatsAccumulator::push_chunk(&mut self, array: &dyn vortex_array::array::Array) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::zoned::zone_map::StatsAccumulator::push_chunk(&mut self, array: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<()>
 
-pub fn vortex_layout::layouts::zoned::zone_map::StatsAccumulator::push_chunk_without_compute(&mut self, array: &dyn vortex_array::array::Array) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::zoned::zone_map::StatsAccumulator::push_chunk_without_compute(&mut self, array: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<()>
 
 pub struct vortex_layout::layouts::zoned::zone_map::ZoneMap
 

--- a/vortex-layout/src/layouts/compressed.rs
+++ b/vortex-layout/src/layouts/compressed.rs
@@ -27,26 +27,26 @@ use crate::sequence::SequentialStreamExt;
 ///
 /// API consumers are free to implement this trait to provide new plugin compressors.
 pub trait CompressorPlugin: Send + Sync + 'static {
-    fn compress_chunk(&self, chunk: &dyn Array) -> VortexResult<ArrayRef>;
+    fn compress_chunk(&self, chunk: &ArrayRef) -> VortexResult<ArrayRef>;
 }
 
 impl CompressorPlugin for Arc<dyn CompressorPlugin> {
-    fn compress_chunk(&self, chunk: &dyn Array) -> VortexResult<ArrayRef> {
+    fn compress_chunk(&self, chunk: &ArrayRef) -> VortexResult<ArrayRef> {
         self.as_ref().compress_chunk(chunk)
     }
 }
 
 impl<F> CompressorPlugin for F
 where
-    F: Fn(&dyn Array) -> VortexResult<ArrayRef> + Send + Sync + 'static,
+    F: Fn(&ArrayRef) -> VortexResult<ArrayRef> + Send + Sync + 'static,
 {
-    fn compress_chunk(&self, chunk: &dyn Array) -> VortexResult<ArrayRef> {
+    fn compress_chunk(&self, chunk: &ArrayRef) -> VortexResult<ArrayRef> {
         self(chunk)
     }
 }
 
 impl CompressorPlugin for BtrBlocksCompressor {
-    fn compress_chunk(&self, chunk: &dyn Array) -> VortexResult<ArrayRef> {
+    fn compress_chunk(&self, chunk: &ArrayRef) -> VortexResult<ArrayRef> {
         self.compress(chunk)
     }
 }

--- a/vortex-layout/src/layouts/dict/writer.rs
+++ b/vortex-layout/src/layouts/dict/writer.rs
@@ -541,14 +541,14 @@ enum EncodingState {
     Done((ArrayRef, ArrayRef, ArrayRef)),
 }
 
-fn start_encoding(constraints: &DictConstraints, chunk: &dyn Array) -> VortexResult<EncodingState> {
+fn start_encoding(constraints: &DictConstraints, chunk: &ArrayRef) -> VortexResult<EncodingState> {
     let encoder = dict_encoder(chunk, constraints);
     encode_chunk(encoder, chunk)
 }
 
 fn encode_chunk(
     mut encoder: Box<dyn DictEncoder>,
-    chunk: &dyn Array,
+    chunk: &ArrayRef,
 ) -> VortexResult<EncodingState> {
     let encoded = encoder.encode(chunk);
     match remainder(chunk, encoded.len())? {
@@ -557,7 +557,7 @@ fn encode_chunk(
     }
 }
 
-fn remainder(array: &dyn Array, encoded_len: usize) -> VortexResult<Option<ArrayRef>> {
+fn remainder(array: &ArrayRef, encoded_len: usize) -> VortexResult<Option<ArrayRef>> {
     if encoded_len < array.len() {
         Ok(Some(array.slice(encoded_len..array.len())?))
     } else {

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -194,7 +194,7 @@ impl StatsAccumulator {
         }
     }
 
-    pub fn push_chunk_without_compute(&mut self, array: &dyn Array) -> VortexResult<()> {
+    pub fn push_chunk_without_compute(&mut self, array: &ArrayRef) -> VortexResult<()> {
         for builder in self.builders.iter_mut() {
             if let Some(Precision::Exact(v)) = array.statistics().get(builder.stat()) {
                 builder.append_scalar(v.cast(&v.dtype().as_nullable())?)?;
@@ -206,7 +206,7 @@ impl StatsAccumulator {
         Ok(())
     }
 
-    pub fn push_chunk(&mut self, array: &dyn Array) -> VortexResult<()> {
+    pub fn push_chunk(&mut self, array: &ArrayRef) -> VortexResult<()> {
         for builder in self.builders.iter_mut() {
             if let Some(v) = array.statistics().compute_stat(builder.stat())? {
                 builder.append_scalar(v.cast(&v.dtype().as_nullable())?)?;

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -523,8 +523,8 @@ impl PyArray {
     /// ```
     fn filter(slf: Bound<Self>, mask: PyArrayRef) -> PyVortexResult<PyArrayRef> {
         let slf = PyArrayRef::extract(slf.as_any().as_borrowed())?.into_inner();
-        let mask = (&*mask as &dyn Array).to_bool().to_mask_fill_null_false();
-        let inner = vortex::compute::filter(&*slf, &mask)?;
+        let mask = (&*mask as &ArrayRef).to_bool().to_mask_fill_null_false();
+        let inner = vortex::compute::filter(&slf, &mask)?;
         Ok(PyArrayRef::from(inner))
     }
 

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -135,7 +135,7 @@ mod setup {
         let codes_prim = PrimitiveArray::from_iter(codes);
 
         // Compress codes with BitPacked (6 bits should be enough for ~50 unique values)
-        let codes_bp = BitPackedArray::encode(codes_prim.as_ref(), 6)
+        let codes_bp = BitPackedArray::encode(&codes_prim.to_array(), 6)
             .unwrap()
             .into_array();
 
@@ -180,7 +180,7 @@ mod setup {
 
         // Compress the values with BitPacked
         let values_prim = runend.values().to_primitive();
-        let compressed_values = BitPackedArray::encode(values_prim.as_ref(), 8)
+        let compressed_values = BitPackedArray::encode(&values_prim.to_array(), 8)
             .unwrap()
             .into_array();
 
@@ -244,7 +244,7 @@ mod setup {
         // Compress the VarBin offsets with BitPacked
         let codes = fsst.codes();
         let offsets_prim = codes.offsets().to_primitive();
-        let offsets_bp = BitPackedArray::encode(offsets_prim.as_ref(), 20).unwrap();
+        let offsets_bp = BitPackedArray::encode(&offsets_prim.to_array(), 20).unwrap();
 
         // Rebuild VarBin with compressed offsets
         let compressed_codes = VarBinArray::try_new(

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -180,13 +180,13 @@ fn bench_dict_compress_u32(bencher: Bencher) {
 
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| &uint_array)
-        .bench_refs(|a| dict_encode(a.as_ref()).unwrap());
+        .bench_refs(|a| dict_encode(&a.to_array()).unwrap());
 }
 
 #[divan::bench(name = "dict_decompress_u32")]
 fn bench_dict_decompress_u32(bencher: Bencher) {
     let (uint_array, ..) = setup_primitive_arrays();
-    let compressed = dict_encode(uint_array.as_ref()).unwrap();
+    let compressed = dict_encode(&uint_array.to_array()).unwrap();
 
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| &compressed)
@@ -303,13 +303,13 @@ fn bench_dict_compress_string(bencher: Bencher) {
 
     with_byte_counter(bencher, nbytes)
         .with_inputs(|| &varbinview_arr)
-        .bench_refs(|a| dict_encode(a.as_ref()).unwrap());
+        .bench_refs(|a| dict_encode(&a.to_array()).unwrap());
 }
 
 #[divan::bench(name = "dict_decompress_string")]
 fn bench_dict_decompress_string(bencher: Bencher) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-    let dict = dict_encode(varbinview_arr.as_ref()).unwrap();
+    let dict = dict_encode(&varbinview_arr.to_array()).unwrap();
     let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
     with_byte_counter(bencher, nbytes)

--- a/vortex/examples/compression_showcase.rs
+++ b/vortex/examples/compression_showcase.rs
@@ -9,6 +9,7 @@
 //! Run with: cargo run --example compression_showcase
 
 use vortex::array::Array;
+use vortex::array::ArrayRef;
 use vortex::array::IntoArray;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
@@ -57,13 +58,13 @@ fn compress_sequential_data() -> Result<(), Box<dyn std::error::Error>> {
     // Create sequential data (e.g., timestamps, IDs)
     let sequential: PrimitiveArray = (1000..11000).map(|i| i as u64).collect();
 
-    let uncompressed_size = estimate_size(sequential.as_ref());
+    let uncompressed_size = estimate_size(&sequential.to_array());
     println!("  Original sequential data (10,000 values):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     // Compress using default strategy
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(sequential.as_ref())?;
+    let compressed = compressor.compress(&sequential.to_array())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -86,12 +87,12 @@ fn compress_repetitive_data() -> Result<(), Box<dyn std::error::Error>> {
     }
     let array: PrimitiveArray = repetitive.into_iter().collect();
 
-    let uncompressed_size = estimate_size(array.as_ref());
+    let uncompressed_size = estimate_size(&array.to_array());
     println!("  Repetitive data (100 values, each repeated 100 times):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(array.as_ref())?;
+    let compressed = compressor.compress(&array.to_array())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -118,12 +119,12 @@ fn compress_string_data() -> Result<(), Box<dyn std::error::Error>> {
 
     let array = VarBinArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
 
-    let uncompressed_size = estimate_size(array.as_ref());
+    let uncompressed_size = estimate_size(&array.to_array());
     println!("  Categorical string data (10,000 strings, 4 categories):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(array.as_ref())?;
+    let compressed = compressor.compress(&array.to_array())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -146,7 +147,7 @@ fn compress_float_data() -> Result<(), Box<dyn std::error::Error>> {
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(array.as_ref())?;
+    let compressed = compressor.compress(&array.to_array())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -167,12 +168,12 @@ fn compress_sparse_data() -> Result<(), Box<dyn std::error::Error>> {
     }
     let array: PrimitiveArray = sparse.into_iter().collect();
 
-    let uncompressed_size = estimate_size(array.as_ref());
+    let uncompressed_size = estimate_size(&array.to_array());
     println!("  Sparse data (10,000 values, 99% zeros):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(array.as_ref())?;
+    let compressed = compressor.compress(&array.to_array())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -217,12 +218,12 @@ fn compress_structured_data() -> Result<(), Box<dyn std::error::Error>> {
         Validity::NonNullable,
     )?;
 
-    let uncompressed_size = estimate_size(struct_array.as_ref());
+    let uncompressed_size = estimate_size(&struct_array.to_array());
     println!("  Structured data (5,000 records, 3 columns):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(struct_array.as_ref())?;
+    let compressed = compressor.compress(&struct_array.to_array())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -237,6 +238,6 @@ fn compress_structured_data() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Estimate the size of an array in bytes (approximation)
 #[allow(clippy::cast_possible_truncation)]
-fn estimate_size(array: &dyn Array) -> usize {
+fn estimate_size(array: &ArrayRef) -> usize {
     array.nbytes() as usize
 }

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -245,7 +245,7 @@ mod test {
         let array = PrimitiveArray::new(buffer![42u64; 100_000], Validity::NonNullable);
 
         // You can compress an array in-memory with the BtrBlocks compressor
-        let compressed = BtrBlocksCompressor::default().compress(array.as_ref())?;
+        let compressed = BtrBlocksCompressor::default().compress(&array.to_array())?;
         println!(
             "BtrBlocks size: {} / {}",
             compressed.nbytes(),


### PR DESCRIPTION
As part of #6544, we are making Vortex Arrays structs rather than a dyn trait. In preparation, this PR removes &dyn Array from APIs in favor of accepting &ArrayRef.