### PR TITLE
chore: Convert `SliceKernel` impls to `SliceReduce`

### DIFF
--- a/encodings/alp/public-api.lock
+++ b/encodings/alp/public-api.lock
@@ -156,9 +156,9 @@ impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_alp::ALPRDVTa
 
 pub fn vortex_alp::ALPRDVTable::filter(array: &vortex_alp::ALPRDArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceKernel for vortex_alp::ALPRDVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_alp::ALPRDVTable
 
-pub fn vortex_alp::ALPRDVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_alp::ALPRDVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_alp::ALPRDVTable
 
@@ -244,9 +244,9 @@ impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_alp::ALPVTabl
 
 pub fn vortex_alp::ALPVTable::filter(array: &vortex_alp::ALPArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceKernel for vortex_alp::ALPVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_alp::ALPVTable
 
-pub fn vortex_alp::ALPVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_alp::ALPVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::compute::nan_count::NaNCountKernel for vortex_alp::ALPVTable
 

--- a/encodings/alp/src/alp/compute/slice.rs
+++ b/encodings/alp/src/alp/compute/slice.rs
@@ -4,20 +4,15 @@
 use std::ops::Range;
 
 use vortex_array::ArrayRef;
-use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::arrays::SliceKernel;
+use vortex_array::arrays::SliceReduce;
 use vortex_error::VortexResult;
 
 use crate::ALPArray;
 use crate::ALPVTable;
 
-impl SliceKernel for ALPVTable {
-    fn slice(
-        array: &Self::Array,
-        range: Range<usize>,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<ArrayRef>> {
+impl SliceReduce for ALPVTable {
+    fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let sliced_alp = ALPArray::new(
             array.encoded().slice(range.clone())?,
             array.exponents(),

--- a/encodings/alp/src/alp/rules.rs
+++ b/encodings/alp/src/alp/rules.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::arrays::FilterExecuteAdaptor;
-use vortex_array::arrays::SliceExecuteAdaptor;
+use vortex_array::arrays::SliceReduceAdaptor;
 use vortex_array::arrays::TakeExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 use vortex_array::optimizer::rules::ParentRuleSet;
@@ -18,7 +18,6 @@ pub(super) const PARENT_KERNELS: ParentKernelSet<ALPVTable> = ParentKernelSet::n
     ParentKernelSet::lift(&CompareExecuteAdaptor(ALPVTable)),
     ParentKernelSet::lift(&FilterExecuteAdaptor(ALPVTable)),
     ParentKernelSet::lift(&MaskExecuteAdaptor(ALPVTable)),
-    ParentKernelSet::lift(&SliceExecuteAdaptor(ALPVTable)),
     ParentKernelSet::lift(&TakeExecuteAdaptor(ALPVTable)),
 ]);
 
@@ -26,4 +25,5 @@ pub(super) const RULES: ParentRuleSet<ALPVTable> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&BetweenReduceAdaptor(ALPVTable)),
     ParentRuleSet::lift(&CastReduceAdaptor(ALPVTable)),
     ParentRuleSet::lift(&MaskReduceAdaptor(ALPVTable)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(ALPVTable)),
 ]);

--- a/encodings/alp/src/alp_rd/kernel.rs
+++ b/encodings/alp/src/alp_rd/kernel.rs
@@ -2,14 +2,12 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::arrays::FilterExecuteAdaptor;
-use vortex_array::arrays::SliceExecuteAdaptor;
 use vortex_array::arrays::TakeExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 
 use crate::alp_rd::ALPRDVTable;
 
 pub(crate) static PARENT_KERNELS: ParentKernelSet<ALPRDVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&SliceExecuteAdaptor(ALPRDVTable)),
     ParentKernelSet::lift(&FilterExecuteAdaptor(ALPRDVTable)),
     ParentKernelSet::lift(&TakeExecuteAdaptor(ALPRDVTable)),
 ]);

--- a/encodings/alp/src/alp_rd/rules.rs
+++ b/encodings/alp/src/alp_rd/rules.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::arrays::SliceReduceAdaptor;
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 use vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor;
@@ -10,4 +11,5 @@ use crate::alp_rd::ALPRDVTable;
 pub(crate) static RULES: ParentRuleSet<ALPRDVTable> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&CastReduceAdaptor(ALPRDVTable)),
     ParentRuleSet::lift(&MaskReduceAdaptor(ALPRDVTable)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(ALPRDVTable)),
 ]);

--- a/encodings/alp/src/alp_rd/slice.rs
+++ b/encodings/alp/src/alp_rd/slice.rs
@@ -4,20 +4,15 @@
 use std::ops::Range;
 
 use vortex_array::ArrayRef;
-use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::arrays::SliceKernel;
+use vortex_array::arrays::SliceReduce;
 use vortex_error::VortexResult;
 
 use crate::alp_rd::ALPRDArray;
 use crate::alp_rd::ALPRDVTable;
 
-impl SliceKernel for ALPRDVTable {
-    fn slice(
-        array: &Self::Array,
-        range: Range<usize>,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<ArrayRef>> {
+impl SliceReduce for ALPRDVTable {
+    fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let left_parts_exceptions = array
             .left_parts_patches()
             .map(|patches| patches.slice(range.clone()))

--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -196,9 +196,9 @@ impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_fastlanes::Bi
 
 pub fn vortex_fastlanes::BitPackedVTable::filter(array: &vortex_fastlanes::BitPackedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceKernel for vortex_fastlanes::BitPackedVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_fastlanes::BitPackedVTable
 
-pub fn vortex_fastlanes::BitPackedVTable::slice(array: &vortex_fastlanes::BitPackedArray, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::BitPackedVTable::slice(array: &vortex_fastlanes::BitPackedArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::compute::is_constant::IsConstantKernel for vortex_fastlanes::BitPackedVTable
 
@@ -594,9 +594,9 @@ impl core::fmt::Debug for vortex_fastlanes::RLEVTable
 
 pub fn vortex_fastlanes::RLEVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::slice::SliceKernel for vortex_fastlanes::RLEVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_fastlanes::RLEVTable
 
-pub fn vortex_fastlanes::RLEVTable::slice(array: &vortex_fastlanes::RLEArray, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::RLEVTable::slice(array: &vortex_fastlanes::RLEArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::RLEVTable
 
@@ -631,8 +631,6 @@ pub fn vortex_fastlanes::RLEVTable::deserialize(bytes: &[u8], _dtype: &vortex_ar
 pub fn vortex_fastlanes::RLEVTable::dtype(array: &vortex_fastlanes::RLEArray) -> &vortex_array::dtype::DType
 
 pub fn vortex_fastlanes::RLEVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
-
-pub fn vortex_fastlanes::RLEVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 pub fn vortex_fastlanes::RLEVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
 

--- a/encodings/fastlanes/src/bitpacking/compute/slice.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/slice.rs
@@ -5,20 +5,15 @@ use std::cmp::max;
 use std::ops::Range;
 
 use vortex_array::ArrayRef;
-use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::arrays::SliceKernel;
+use vortex_array::arrays::SliceReduce;
 use vortex_error::VortexResult;
 
 use crate::BitPackedArray;
 use crate::BitPackedVTable;
 
-impl SliceKernel for BitPackedVTable {
-    fn slice(
-        array: &BitPackedArray,
-        range: Range<usize>,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<ArrayRef>> {
+impl SliceReduce for BitPackedVTable {
+    fn slice(array: &BitPackedArray, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let offset_start = range.start + array.offset() as usize;
         let offset_stop = range.end + array.offset() as usize;
         let offset = offset_start % 1024;
@@ -51,38 +46,23 @@ impl SliceKernel for BitPackedVTable {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::LazyLock;
-
     use vortex_array::Array;
     use vortex_array::IntoArray;
-    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::SliceArray;
-    use vortex_array::session::ArraySession;
-    use vortex_array::vtable::VTable;
+    use vortex_array::optimizer::ArrayOptimizer;
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use crate::BitPackedVTable;
     use crate::bitpack_compress::bitpack_encode;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
-
     #[test]
-    fn test_execute_parent_returns_bitpacked_slice() -> VortexResult<()> {
+    fn test_reduce_parent_returns_bitpacked_slice() -> VortexResult<()> {
         let values = vortex_array::arrays::PrimitiveArray::from_iter(0u32..2048);
         let bitpacked = bitpack_encode(&values, 11, None)?;
 
-        let slice_array = SliceArray::new(bitpacked.clone().into_array(), 500..1500);
+        let slice_array = SliceArray::new(bitpacked.into_array(), 500..1500);
 
-        let mut ctx = SESSION.create_execution_ctx();
-        let reduced = <BitPackedVTable as VTable>::execute_parent(
-            &bitpacked,
-            &slice_array.into_array(),
-            0,
-            &mut ctx,
-        )?
-        .expect("expected slice kernel to execute");
+        let reduced = slice_array.into_array().optimize()?;
 
         assert!(reduced.is::<BitPackedVTable>());
         let reduced_bp = reduced.as_::<BitPackedVTable>();

--- a/encodings/fastlanes/src/bitpacking/vtable/kernels.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/kernels.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::arrays::FilterExecuteAdaptor;
-use vortex_array::arrays::SliceExecuteAdaptor;
 use vortex_array::arrays::TakeExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 
@@ -10,6 +9,5 @@ use crate::BitPackedVTable;
 
 pub(crate) const PARENT_KERNELS: ParentKernelSet<BitPackedVTable> = ParentKernelSet::new(&[
     ParentKernelSet::lift(&FilterExecuteAdaptor(BitPackedVTable)),
-    ParentKernelSet::lift(&SliceExecuteAdaptor(BitPackedVTable)),
     ParentKernelSet::lift(&TakeExecuteAdaptor(BitPackedVTable)),
 ]);

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -26,11 +26,9 @@ impl OperationsVTable<BitPackedVTable> for BitPackedVTable {
 #[cfg(test)]
 mod test {
     use std::ops::Range;
-    use std::sync::LazyLock;
 
     use vortex_array::Array;
     use vortex_array::IntoArray;
-    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::SliceArray;
     use vortex_array::assert_arrays_eq;
@@ -39,11 +37,10 @@ mod test {
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
+    use vortex_array::optimizer::ArrayOptimizer;
     use vortex_array::patches::Patches;
     use vortex_array::scalar::Scalar;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
-    use vortex_array::vtable::VTable;
     use vortex_buffer::Alignment;
     use vortex_buffer::Buffer;
     use vortex_buffer::ByteBuffer;
@@ -52,20 +49,12 @@ mod test {
     use crate::BitPackedArray;
     use crate::BitPackedVTable;
 
-    static SESSION: LazyLock<vortex_session::VortexSession> =
-        LazyLock::new(|| vortex_session::VortexSession::empty().with::<ArraySession>());
-
-    fn slice_via_kernel(array: &BitPackedArray, range: Range<usize>) -> BitPackedArray {
+    fn slice_via_reduce(array: &BitPackedArray, range: Range<usize>) -> BitPackedArray {
         let slice_array = SliceArray::new(array.clone().into_array(), range);
-        let mut ctx = SESSION.create_execution_ctx();
-        let sliced = <BitPackedVTable as VTable>::execute_parent(
-            array,
-            &slice_array.into_array(),
-            0,
-            &mut ctx,
-        )
-        .expect("execute_parent failed")
-        .expect("expected slice kernel to execute");
+        let sliced = slice_array
+            .into_array()
+            .optimize()
+            .expect("optimize failed");
         sliced.as_::<BitPackedVTable>().clone()
     }
 
@@ -76,7 +65,7 @@ mod test {
             6,
         )
         .unwrap();
-        let sliced = slice_via_kernel(&arr, 1024..2048);
+        let sliced = slice_via_reduce(&arr, 1024..2048);
         assert_nth_scalar!(sliced, 0, 1024u32 % 64);
         assert_nth_scalar!(sliced, 1023, 2047u32 % 64);
         assert_eq!(sliced.offset(), 0);
@@ -90,7 +79,7 @@ mod test {
             6,
         )
         .unwrap();
-        let sliced = slice_via_kernel(&arr, 512..1434);
+        let sliced = slice_via_reduce(&arr, 512..1434);
         assert_nth_scalar!(sliced, 0, 512u32 % 64);
         assert_nth_scalar!(sliced, 921, 1433u32 % 64);
         assert_eq!(sliced.offset(), 512);
@@ -130,12 +119,12 @@ mod test {
             6,
         )
         .unwrap();
-        let sliced = slice_via_kernel(&arr, 512..1434);
+        let sliced = slice_via_reduce(&arr, 512..1434);
         assert_nth_scalar!(sliced, 0, 512u32 % 64);
         assert_nth_scalar!(sliced, 921, 1433u32 % 64);
         assert_eq!(sliced.offset(), 512);
         assert_eq!(sliced.len(), 922);
-        let doubly_sliced = slice_via_kernel(&sliced, 127..911);
+        let doubly_sliced = slice_via_reduce(&sliced, 127..911);
         assert_nth_scalar!(doubly_sliced, 0, (512u32 + 127) % 64);
         assert_nth_scalar!(doubly_sliced, 783, (512u32 + 910) % 64);
         assert_eq!(doubly_sliced.offset(), 639);
@@ -153,7 +142,7 @@ mod test {
         assert_eq!(patch_indices.len(), 1);
 
         // Slicing drops the empty patches array.
-        let sliced_bp = slice_via_kernel(&array, 0..64);
+        let sliced_bp = slice_via_reduce(&array, 0..64);
         assert!(sliced_bp.patches().is_none());
     }
 

--- a/encodings/fastlanes/src/bitpacking/vtable/rules.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/rules.rs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::arrays::SliceReduceAdaptor;
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 
 use crate::BitPackedVTable;
 
-pub(crate) const RULES: ParentRuleSet<BitPackedVTable> =
-    ParentRuleSet::new(&[ParentRuleSet::lift(&CastReduceAdaptor(BitPackedVTable))]);
+pub(crate) const RULES: ParentRuleSet<BitPackedVTable> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(BitPackedVTable)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(BitPackedVTable)),
+]);

--- a/encodings/fastlanes/src/rle/kernel.rs
+++ b/encodings/fastlanes/src/rle/kernel.rs
@@ -4,26 +4,16 @@
 use std::ops::Range;
 
 use vortex_array::ArrayRef;
-use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::arrays::SliceExecuteAdaptor;
-use vortex_array::arrays::SliceKernel;
-use vortex_array::kernel::ParentKernelSet;
+use vortex_array::arrays::SliceReduce;
 use vortex_error::VortexResult;
 
 use crate::FL_CHUNK_SIZE;
 use crate::RLEArray;
 use crate::RLEVTable;
 
-pub(crate) static PARENT_KERNELS: ParentKernelSet<RLEVTable> =
-    ParentKernelSet::new(&[ParentKernelSet::lift(&SliceExecuteAdaptor(RLEVTable))]);
-
-impl SliceKernel for RLEVTable {
-    fn slice(
-        array: &RLEArray,
-        range: Range<usize>,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<ArrayRef>> {
+impl SliceReduce for RLEVTable {
+    fn slice(array: &RLEArray, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let offset_in_chunk = array.offset();
         let chunk_start_idx = (offset_in_chunk + range.start) / FL_CHUNK_SIZE;
         let chunk_end_idx = (offset_in_chunk + range.end).div_ceil(FL_CHUNK_SIZE);

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -28,7 +28,6 @@ use vortex_session::VortexSession;
 
 use crate::RLEArray;
 use crate::rle::array::rle_decompress::rle_decompress;
-use crate::rle::kernel::PARENT_KERNELS;
 use crate::rle::vtable::rules::RULES;
 
 mod operations;
@@ -219,15 +218,6 @@ impl VTable for RLEVTable {
             metadata.offset as usize,
             len,
         )
-    }
-
-    fn execute_parent(
-        array: &Self::Array,
-        parent: &ArrayRef,
-        child_idx: usize,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<ArrayRef>> {
-        PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 
     fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {

--- a/encodings/fastlanes/src/rle/vtable/rules.rs
+++ b/encodings/fastlanes/src/rle/vtable/rules.rs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::arrays::SliceReduceAdaptor;
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 
 use crate::RLEVTable;
 
-pub(crate) const RULES: ParentRuleSet<RLEVTable> =
-    ParentRuleSet::new(&[ParentRuleSet::lift(&CastReduceAdaptor(RLEVTable))]);
+pub(crate) const RULES: ParentRuleSet<RLEVTable> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(RLEVTable)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(RLEVTable)),
+]);

--- a/encodings/sparse/public-api.lock
+++ b/encodings/sparse/public-api.lock
@@ -80,9 +80,9 @@ impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_sparse::Spars
 
 pub fn vortex_sparse::SparseVTable::filter(array: &vortex_sparse::SparseArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceKernel for vortex_sparse::SparseVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_sparse::SparseVTable
 
-pub fn vortex_sparse::SparseVTable::slice(array: &vortex_sparse::SparseArray, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_sparse::SparseVTable::slice(array: &vortex_sparse::SparseArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_sparse::SparseVTable
 

--- a/encodings/sparse/src/kernel.rs
+++ b/encodings/sparse/src/kernel.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::arrays::FilterExecuteAdaptor;
-use vortex_array::arrays::SliceExecuteAdaptor;
 use vortex_array::arrays::TakeExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 
@@ -10,6 +9,5 @@ use crate::SparseVTable;
 
 pub(crate) static PARENT_KERNELS: ParentKernelSet<SparseVTable> = ParentKernelSet::new(&[
     ParentKernelSet::lift(&FilterExecuteAdaptor(SparseVTable)),
-    ParentKernelSet::lift(&SliceExecuteAdaptor(SparseVTable)),
     ParentKernelSet::lift(&TakeExecuteAdaptor(SparseVTable)),
 ]);

--- a/encodings/sparse/src/rules.rs
+++ b/encodings/sparse/src/rules.rs
@@ -3,6 +3,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
+use vortex_array::arrays::SliceReduceAdaptor;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
@@ -16,6 +17,7 @@ use crate::SparseVTable;
 pub(crate) static RULES: ParentRuleSet<SparseVTable> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&CastReduceAdaptor(SparseVTable)),
     ParentRuleSet::lift(&NotReduceAdaptor(SparseVTable)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(SparseVTable)),
 ]);
 
 impl NotReduce for SparseVTable {

--- a/encodings/sparse/src/slice.rs
+++ b/encodings/sparse/src/slice.rs
@@ -4,21 +4,16 @@
 use std::ops::Range;
 
 use vortex_array::ArrayRef;
-use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::ConstantArray;
-use vortex_array::arrays::SliceKernel;
+use vortex_array::arrays::SliceReduce;
 use vortex_error::VortexResult;
 
 use crate::SparseArray;
 use crate::SparseVTable;
 
-impl SliceKernel for SparseVTable {
-    fn slice(
-        array: &SparseArray,
-        range: Range<usize>,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<ArrayRef>> {
+impl SliceReduce for SparseVTable {
+    fn slice(array: &SparseArray, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let Some(new_patches) = array.patches().slice(range.clone())? else {
             return Ok(Some(
                 ConstantArray::new(array.fill_scalar().clone(), range.len()).into_array(),

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -614,9 +614,9 @@ impl vortex_array::arrays::FilterKernel for vortex_array::arrays::ChunkedVTable
 
 pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::SliceKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ChunkedVTable
 
-pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ChunkedVTable
 
@@ -3952,10 +3952,6 @@ pub trait vortex_array::arrays::SliceKernel: vortex_array::vtable::VTable
 
 pub fn vortex_array::arrays::SliceKernel::slice(array: &Self::Array, range: core::ops::range::Range<usize>, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::SliceKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
 pub trait vortex_array::arrays::SliceReduce: vortex_array::vtable::VTable
 
 pub fn vortex_array::arrays::SliceReduce::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
@@ -3963,6 +3959,10 @@ pub fn vortex_array::arrays::SliceReduce::slice(array: &Self::Array, range: core
 impl vortex_array::arrays::SliceReduce for vortex_array::arrays::BoolVTable
 
 pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ConstantVTable
 

--- a/vortex-array/src/arrays/chunked/compute/kernel.rs
+++ b/vortex-array/src/arrays/chunked/compute/kernel.rs
@@ -3,7 +3,6 @@
 
 use crate::arrays::ChunkedVTable;
 use crate::arrays::FilterExecuteAdaptor;
-use crate::arrays::SliceExecuteAdaptor;
 use crate::arrays::TakeExecuteAdaptor;
 use crate::kernel::ParentKernelSet;
 use crate::scalar_fn::fns::mask::MaskExecuteAdaptor;
@@ -11,6 +10,5 @@ use crate::scalar_fn::fns::mask::MaskExecuteAdaptor;
 pub(crate) static PARENT_KERNELS: ParentKernelSet<ChunkedVTable> = ParentKernelSet::new(&[
     ParentKernelSet::lift(&FilterExecuteAdaptor(ChunkedVTable)),
     ParentKernelSet::lift(&MaskExecuteAdaptor(ChunkedVTable)),
-    ParentKernelSet::lift(&SliceExecuteAdaptor(ChunkedVTable)),
     ParentKernelSet::lift(&TakeExecuteAdaptor(ChunkedVTable)),
 ]);

--- a/vortex-array/src/arrays/chunked/compute/rules.rs
+++ b/vortex-array/src/arrays/chunked/compute/rules.rs
@@ -12,6 +12,7 @@ use crate::arrays::ChunkedVTable;
 use crate::arrays::ConstantArray;
 use crate::arrays::ConstantVTable;
 use crate::arrays::ScalarFnArray;
+use crate::arrays::SliceReduceAdaptor;
 use crate::optimizer::ArrayOptimizer;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
@@ -24,6 +25,7 @@ pub(crate) const PARENT_RULES: ParentRuleSet<ChunkedVTable> = ParentRuleSet::new
     ParentRuleSet::lift(&ChunkedUnaryScalarFnPushDownRule),
     ParentRuleSet::lift(&ChunkedConstantScalarFnPushDownRule),
     ParentRuleSet::lift(&FillNullReduceAdaptor(ChunkedVTable)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(ChunkedVTable)),
     ParentRuleSet::lift(&ZipReduceAdaptor(ChunkedVTable)),
 ]);
 

--- a/vortex-array/src/arrays/chunked/compute/slice.rs
+++ b/vortex-array/src/arrays/chunked/compute/slice.rs
@@ -7,18 +7,13 @@ use itertools::Itertools;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
-use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ChunkedArray;
 use crate::arrays::ChunkedVTable;
-use crate::arrays::SliceKernel;
+use crate::arrays::SliceReduce;
 
-impl SliceKernel for ChunkedVTable {
-    fn slice(
-        array: &Self::Array,
-        range: Range<usize>,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<ArrayRef>> {
+impl SliceReduce for ChunkedVTable {
+    fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         assert!(
             !array.is_empty() || (range.start > 0 && range.end > 0),
             "Empty chunked array can't be sliced from {} to {}",

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -157,13 +157,10 @@ where
 mod tests {
     use futures::executor::block_on;
     use rstest::rstest;
-    use vortex::array::ExecutionCtx;
     use vortex::array::IntoArray;
     use vortex::array::arrays::PrimitiveArray;
     use vortex::array::assert_arrays_eq;
-    use vortex::array::session::ArraySession;
     use vortex::array::validity::Validity::NonNullable;
-    use vortex::array::vtable::VTable;
     use vortex::buffer::Buffer;
     use vortex::error::VortexExpect;
     use vortex::session::VortexSession;
@@ -464,15 +461,7 @@ mod tests {
 
         let bitpacked_array = BitPackedArray::encode(&primitive_array.to_array(), bit_width)
             .vortex_expect("operation should succeed in test");
-        let slice_ref = bitpacked_array.clone().into_array().slice(67..3969)?;
-        let mut exec_ctx = ExecutionCtx::new(VortexSession::empty().with::<ArraySession>());
-        let sliced_array = <BitPackedVTable as VTable>::execute_parent(
-            &bitpacked_array,
-            &slice_ref,
-            0,
-            &mut exec_ctx,
-        )?
-        .expect("expected slice kernel to execute");
+        let sliced_array = bitpacked_array.into_array().slice(67..3969)?;
         let cpu_result = sliced_array.to_canonical()?;
         let gpu_result = block_on(async {
             BitPackedExecutor


### PR DESCRIPTION
Resolving `SliceArray` nodes at optimization time rather than execution time.

Changed for: `ALPVTable`, `ALPRDVTable`, `BitPackedVTable`, `RLEVTable`, `SparseVTable`, `ChunkedVTable`.