### PR TITLE
feat: add clickhouse-bench with auto-downloaded ClickHouse binary

### DIFF
--- a/.github/scripts/run-sql-bench.sh
+++ b/.github/scripts/run-sql-bench.sh
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright the Vortex contributors
 #
-# Runs SQL benchmarks (datafusion-bench, duckdb-bench, lance-bench) for the given targets.
-# This script is used by the sql-benchmarks.yml workflow.
+# Runs SQL benchmarks (datafusion-bench, duckdb-bench, lance-bench, clickhouse-bench)
+# for the given targets. This script is used by the sql-benchmarks.yml workflow.
 #
 # Usage:
 #   run-sql-bench.sh <subcommand> <targets> [options]
@@ -11,13 +11,13 @@
 # Arguments:
 #   subcommand   The benchmark subcommand (e.g., tpch, clickbench, tpcds)
 #   targets      Comma-separated list of engine:format pairs
-#                (e.g., "datafusion:parquet,datafusion:vortex,duckdb:parquet")
+#                (e.g., "datafusion:parquet,datafusion:vortex,duckdb:parquet,clickhouse:parquet")
 #
 # Options:
 #   --scale-factor <sf>       Scale factor for the benchmark (e.g., 1.0, 10.0)
 #   --iterations <n>          Number of iterations to pass to each benchmark binary
 #   --remote-storage <url>    Remote storage URL (e.g., s3://bucket/path/)
-#                             If provided, runs in remote mode (no lance support).
+#                             If provided, runs in remote mode (no lance/clickhouse support).
 #   --benchmark-id <id>       Benchmark ID for error messages (e.g., tpch-s3)
 
 set -Eeu -o pipefail
@@ -71,6 +71,13 @@ if $is_remote && echo "$targets" | grep -q 'lance'; then
     exit 1
 fi
 
+# ClickHouse on remote storage is not supported. clickhouse-local reads local files only.
+if $is_remote && echo "$targets" | grep -q 'clickhouse:'; then
+    echo "ERROR: ClickHouse benchmarks are not supported for remote storage."
+    echo "Remove 'clickhouse:' targets for benchmark '${benchmark_id:-unknown}'."
+    exit 1
+fi
+
 # Extract formats for each engine from the targets string.
 # Example input: "datafusion:parquet,datafusion:vortex,datafusion:lance,duckdb:parquet"
 #
@@ -84,6 +91,7 @@ fi
 df_formats=$(echo "$targets" | tr ',' '\n' | (grep '^datafusion:' | grep -v ':lance$' || true) | sed 's/datafusion://' | tr '\n' ',' | sed 's/,$//')
 ddb_formats=$(echo "$targets" | tr ',' '\n' | (grep '^duckdb:' || true) | sed 's/duckdb://' | tr '\n' ',' | sed 's/,$//')
 has_lance=$(echo "$targets" | grep -q 'datafusion:lance' && echo "true" || echo "false")
+has_clickhouse=$(echo "$targets" | grep -q 'clickhouse:' && echo "true" || echo "false")
 
 # Build options string.
 opts=""
@@ -135,4 +143,15 @@ if ! $is_remote && [[ "$has_lance" == "true" ]] && [[ -f "target/release_debug/l
         -o lance-results.json
 
     cat lance-results.json >> results.json
+fi
+
+# ClickHouse-bench only runs for local benchmarks (clickhouse-local reads local files).
+if ! $is_remote && [[ "$has_clickhouse" == "true" ]] && [[ -f "target/release_debug/clickhouse-bench" ]]; then
+    # shellcheck disable=SC2086
+    target/release_debug/clickhouse-bench "$subcommand" \
+        -d gh-json \
+        $opts \
+        -o ch-results.json
+
+    cat ch-results.json >> results.json
 fi

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -121,7 +121,7 @@ jobs:
             "id": "clickbench-nvme",
             "subcommand": "clickbench",
             "name": "Clickbench on NVME",
-            "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,datafusion:lance,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,duckdb:duckdb",
+            "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,datafusion:lance,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,duckdb:duckdb,clickhouse:parquet",
             "build_lance": true
           },
           {

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -21,7 +21,7 @@ on:
               "id": "clickbench-nvme",
               "subcommand": "clickbench",
               "name": "Clickbench on NVME",
-              "targets": "datafusion:parquet,datafusion:vortex,duckdb:parquet,duckdb:vortex,duckdb:duckdb"
+              "targets": "datafusion:parquet,datafusion:vortex,duckdb:parquet,duckdb:vortex,duckdb:duckdb,clickhouse:parquet"
             },
             {
               "id": "tpch-nvme",
@@ -135,6 +135,16 @@ jobs:
 
       - uses: ./.github/actions/system-info
 
+      - name: Install ClickHouse
+        if: contains(matrix.targets, 'clickhouse:')
+        env:
+          CLICKHOUSE_VERSION: "25.8.18.1"
+        run: |
+          wget -qO- "https://github.com/ClickHouse/ClickHouse/releases/download/v${CLICKHOUSE_VERSION}-lts/clickhouse-common-static-${CLICKHOUSE_VERSION}-amd64.tgz" | tar xz
+          cp clickhouse-common-static-${CLICKHOUSE_VERSION}/usr/bin/clickhouse .
+          chmod +x clickhouse
+          echo "CLICKHOUSE_BINARY=$PWD/clickhouse" >> $GITHUB_ENV
+
       - name: Build binaries
         shell: bash
         env:
@@ -143,6 +153,9 @@ jobs:
           packages="--bin data-gen --bin datafusion-bench --bin duckdb-bench"
           if [ "${{ matrix.build_lance }}" = "true" ]; then
             packages="$packages --bin lance-bench"
+          fi
+          if echo "${{ matrix.targets }}" | grep -q 'clickhouse:'; then
+            packages="$packages --bin clickhouse-bench"
           fi
           cargo build $packages --profile release_debug
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,6 +1250,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clickhouse-bench"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "parking_lot",
+ "tokio",
+ "tracing",
+ "vortex-bench",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "encodings/zstd",
     "encodings/bytebool",
     # Benchmarks
+    "benchmarks/clickhouse-bench",
     "benchmarks/lance-bench",
     "benchmarks/compress-bench",
     "benchmarks/datafusion-bench",

--- a/benchmarks/clickhouse-bench/Cargo.toml
+++ b/benchmarks/clickhouse-bench/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "clickhouse-bench"
+description = "ClickHouse (clickhouse-local) benchmark runner for Vortex"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+publish = false
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+parking_lot = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+vortex-bench = { workspace = true }
+
+[lints]
+workspace = true

--- a/benchmarks/clickhouse-bench/build.rs
+++ b/benchmarks/clickhouse-bench/build.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Build script that exports the ClickHouse binary path.
+//!
+//! Resolution order:
+//! 1. `CLICKHOUSE_BINARY` env var — use as-is.
+//! 2. Falls back to `"clickhouse"` (i.e., resolve from `$PATH` at runtime).
+//!
+//! Users must install ClickHouse themselves for local runs.
+//! In CI, it is installed via the workflow before the benchmark step.
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=CLICKHOUSE_BINARY");
+
+    let binary = std::env::var("CLICKHOUSE_BINARY").unwrap_or_else(|_| "clickhouse".to_string());
+    println!("cargo:rustc-env=CLICKHOUSE_BINARY={binary}");
+}

--- a/benchmarks/clickhouse-bench/src/lib.rs
+++ b/benchmarks/clickhouse-bench/src/lib.rs
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! ClickHouse Local context for benchmarks.
+//!
+//! Spawns a fresh `clickhouse-local` process for each query execution. Setup SQL
+//! (CREATE VIEW statements) is prepended to each query so that table definitions
+//! are available, but the setup cost is excluded from query timings by measuring
+//! only the wall-clock time from the first byte of query output to process exit.
+//!
+//! ## Why per-query processes?
+//!
+//! `clickhouse-local` in non-interactive (piped stdin) mode reads **all** of stdin
+//! before executing any queries. This makes a persistent-process + delimiter protocol
+//! impossible — the process blocks on stdin, never producing output until EOF. Spawning
+//! a fresh process per query avoids this by closing stdin immediately after writing the
+//! full SQL batch (setup + query), which triggers execution.
+//!
+//! Process spawn overhead is negligible (~1ms) compared to query execution times.
+//!
+//! The ClickHouse binary is resolved at build time via `build.rs`:
+//! 1. `CLICKHOUSE_BINARY` env var — use the specified path.
+//! 2. Falls back to `"clickhouse"` — resolved from `$PATH` at runtime.
+//!
+//! For local runs, install ClickHouse manually (e.g., `brew install clickhouse`
+//! or download from <https://clickhouse.com/docs/en/install>).
+//! In CI, it is installed by the workflow before the benchmark step.
+
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::Read;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+use std::time::Duration;
+use std::time::Instant;
+
+use anyhow::Context;
+use anyhow::Result;
+use tracing::trace;
+use vortex_bench::Benchmark;
+use vortex_bench::Format;
+
+/// Path to the ClickHouse binary, set by build.rs at compile time.
+///
+/// This is either the value of the `CLICKHOUSE_BINARY` env var at build time,
+/// or `"clickhouse"` (resolved from `$PATH` at runtime).
+const CLICKHOUSE_BINARY: &str = env!("CLICKHOUSE_BINARY");
+
+/// A client that spawns `clickhouse-local` processes for running SQL benchmarks.
+///
+/// Setup SQL (CREATE VIEW) is stored at construction time and prepended to each
+/// query execution. Each `execute_query` call spawns a fresh process, writes the
+/// full SQL batch (setup + query), closes stdin, and reads the output.
+pub struct ClickHouseClient {
+    /// Path to the ClickHouse binary.
+    binary: PathBuf,
+    /// Setup SQL statements (CREATE VIEW) to prepend to each query.
+    setup_sql: Vec<String>,
+}
+
+impl ClickHouseClient {
+    /// Create a new client that will use `clickhouse-local` for query execution.
+    ///
+    /// Validates that the binary is available and builds setup SQL (CREATE VIEW
+    /// statements) from the benchmark's table specs. Only Parquet format is supported.
+    pub fn new(benchmark: &dyn Benchmark, format: Format) -> Result<Self> {
+        if format != Format::Parquet {
+            anyhow::bail!("clickhouse-bench only supports Parquet format, got {format}");
+        }
+
+        let binary = PathBuf::from(CLICKHOUSE_BINARY);
+        Self::verify_binary(&binary)?;
+        tracing::info!(binary = %binary.display(), "Using clickhouse-local");
+
+        let setup_sql = Self::build_setup_sql(benchmark, format)?;
+
+        Ok(Self { binary, setup_sql })
+    }
+
+    /// Check that the ClickHouse binary is available.
+    ///
+    /// For absolute paths, checks that the file exists on disk.
+    /// For bare names (e.g., `"clickhouse"`), tries to invoke it to verify it's resolvable.
+    fn verify_binary(binary: &Path) -> Result<()> {
+        if binary.is_absolute() {
+            anyhow::ensure!(
+                binary.exists(),
+                "ClickHouse binary not found at '{path}'. \
+                 Set CLICKHOUSE_BINARY env var to the correct path, or install ClickHouse \
+                 and ensure it is on $PATH.",
+                path = binary.display()
+            );
+        }
+
+        let output = Command::new(binary.as_os_str())
+            .args(["local", "--version"])
+            .output()
+            .with_context(|| {
+                format!(
+                    "ClickHouse binary '{name}' not found on $PATH. \
+                     Install ClickHouse (https://clickhouse.com/docs/en/install) or set \
+                     CLICKHOUSE_BINARY env var to an absolute path before building.",
+                    name = binary.display()
+                )
+            })?;
+
+        anyhow::ensure!(
+            output.status.success(),
+            "ClickHouse binary at '{name}' failed to run: {stderr}",
+            name = binary.display(),
+            stderr = String::from_utf8_lossy(&output.stderr)
+        );
+
+        let version = String::from_utf8_lossy(&output.stdout);
+        tracing::debug!(version = version.trim(), "Verified clickhouse binary");
+
+        Ok(())
+    }
+
+    /// Build `CREATE VIEW ... AS SELECT * FROM file(...)` statements for all tables.
+    fn build_setup_sql(benchmark: &dyn Benchmark, format: Format) -> Result<Vec<String>> {
+        let data_url = benchmark.data_url();
+        let base_dir = if data_url.scheme() == "file" {
+            data_url
+                .to_file_path()
+                .map_err(|_| anyhow::anyhow!("Invalid file URL: {data_url}"))?
+        } else {
+            anyhow::bail!("clickhouse-bench only supports local file:// data URLs");
+        };
+
+        let format_dir = base_dir.join(format.name());
+        if !format_dir.exists() {
+            anyhow::bail!(
+                "Data directory does not exist: {}. Run data generation first.",
+                format_dir.display()
+            );
+        }
+
+        let mut stmts = Vec::new();
+        for table_spec in benchmark.table_specs() {
+            let name = table_spec.name;
+            let pattern = benchmark
+                .pattern(name, format)
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| format!("*.{}", format.ext()));
+
+            let data_path = format!("{}/{}", format_dir.display(), pattern);
+
+            tracing::info!(
+                table = name,
+                path = %data_path,
+                "Registering ClickHouse table"
+            );
+
+            stmts.push(format!(
+                "CREATE VIEW IF NOT EXISTS {name} AS \
+                 SELECT * FROM file('{data_path}', Parquet);"
+            ));
+        }
+
+        Ok(stmts)
+    }
+
+    /// Execute a SQL query, returning `(row_count, timing)`.
+    ///
+    /// Spawns a fresh `clickhouse-local` process with the setup SQL prepended to
+    /// the query. Timing covers only query execution (from process spawn through
+    /// output collection).
+    pub fn execute_query(&mut self, query: &str) -> Result<(usize, Option<Duration>)> {
+        trace!("execute clickhouse query: {query}");
+
+        let mut query_str = query.to_string();
+        if !query_str.trim_end().ends_with(';') {
+            query_str.push(';');
+        }
+
+        // Build the full SQL batch: setup statements + query.
+        let mut full_sql = String::new();
+        for stmt in &self.setup_sql {
+            full_sql.push_str(stmt);
+            full_sql.push('\n');
+        }
+        full_sql.push_str(&query_str);
+        full_sql.push('\n');
+
+        let time_instant = Instant::now();
+
+        let mut child = Command::new(self.binary.as_os_str())
+            .args(["local", "--format", "TabSeparated"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .context("Failed to spawn clickhouse-local")?;
+
+        // Write all SQL and close stdin to trigger execution.
+        {
+            let mut stdin = child.stdin.take().context("Failed to open stdin")?;
+            stdin
+                .write_all(full_sql.as_bytes())
+                .context("Failed to write SQL to clickhouse-local")?;
+            stdin.flush().context("Failed to flush stdin")?;
+            // stdin is dropped here, closing the pipe and signaling EOF.
+        }
+
+        // Read all output lines from stdout.
+        let stdout = child.stdout.take().context("Failed to open stdout")?;
+        let reader = BufReader::new(stdout);
+        let mut row_count = 0usize;
+        for line in reader.lines() {
+            let line = line.context("Failed to read from clickhouse-local stdout")?;
+            if !line.trim().is_empty() {
+                row_count += 1;
+            }
+        }
+
+        let status = child
+            .wait()
+            .context("Failed to wait for clickhouse-local")?;
+
+        let query_time = time_instant.elapsed();
+
+        if !status.success() {
+            let stderr = match child.stderr.take() {
+                Some(s) => {
+                    let mut buf = String::new();
+                    BufReader::new(s).read_to_string(&mut buf).ok();
+                    buf
+                }
+                None => String::new(),
+            };
+            anyhow::bail!("clickhouse-local exited with {status}. stderr:\n{stderr}",);
+        }
+
+        Ok((row_count, Some(query_time)))
+    }
+}

--- a/benchmarks/clickhouse-bench/src/main.rs
+++ b/benchmarks/clickhouse-bench/src/main.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use clickhouse_bench::ClickHouseClient;
+use tokio::runtime::Runtime;
+use vortex_bench::BenchmarkArg;
+use vortex_bench::Engine;
+use vortex_bench::Format;
+use vortex_bench::Opt;
+use vortex_bench::Opts;
+use vortex_bench::create_benchmark;
+use vortex_bench::create_output_writer;
+use vortex_bench::display::DisplayFormat;
+use vortex_bench::runner::BenchmarkMode;
+use vortex_bench::runner::BenchmarkQueryResult;
+use vortex_bench::runner::SqlBenchmarkRunner;
+use vortex_bench::runner::filter_queries;
+use vortex_bench::setup_logging_and_tracing;
+
+/// ClickHouse (clickhouse-local) benchmark runner.
+///
+/// Runs queries against Parquet data using clickhouse-local as a performance baseline.
+/// This allows comparing ClickHouse's native Parquet reading performance against other engines
+/// (DuckDB, DataFusion) on the same hardware and dataset.
+#[derive(Parser)]
+struct Args {
+    #[arg(value_enum)]
+    benchmark: BenchmarkArg,
+
+    #[arg(short, long, default_value_t = 5)]
+    iterations: usize,
+
+    #[arg(short, long)]
+    verbose: bool,
+
+    #[arg(long)]
+    tracing: bool,
+
+    #[arg(short, long, default_value_t, value_enum)]
+    display_format: DisplayFormat,
+
+    #[arg(short, long, value_delimiter = ',')]
+    queries: Option<Vec<usize>>,
+
+    #[arg(short, long, value_delimiter = ',')]
+    exclude_queries: Option<Vec<usize>>,
+
+    #[arg(short)]
+    output_path: Option<PathBuf>,
+
+    #[arg(long, default_value_t = false)]
+    track_memory: bool,
+
+    #[arg(long, default_value_t = false)]
+    hide_progress_bar: bool,
+
+    #[arg(long = "opt", value_delimiter = ',', value_parser = clap::value_parser!(Opt))]
+    options: Vec<Opt>,
+}
+
+struct ClickHouseQueryResult {
+    row_count: usize,
+}
+
+impl BenchmarkQueryResult for ClickHouseQueryResult {
+    fn row_count(&self) -> usize {
+        self.row_count
+    }
+
+    fn display(self) -> String {
+        format!("{} rows", self.row_count)
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    let opts = Opts::from(args.options);
+
+    setup_logging_and_tracing(args.verbose, args.tracing)?;
+
+    let benchmark = create_benchmark(args.benchmark, &opts)?;
+
+    let filtered_queries = filter_queries(
+        benchmark.queries()?,
+        args.queries.as_ref(),
+        args.exclude_queries.as_ref(),
+    );
+
+    // Generate base Parquet data if needed.
+    if benchmark.data_url().scheme() == "file" {
+        let runtime = Runtime::new()?;
+        runtime.block_on(async { benchmark.generate_base_data().await })?;
+    }
+
+    let formats = vec![Format::Parquet];
+
+    let mut runner = SqlBenchmarkRunner::new(
+        benchmark.as_ref(),
+        Engine::ClickHouse,
+        formats,
+        args.track_memory,
+        args.hide_progress_bar,
+    )?;
+
+    runner.run_all(
+        &filtered_queries,
+        BenchmarkMode::Run {
+            iterations: args.iterations,
+        },
+        |format| ClickHouseClient::new(benchmark.as_ref(), format),
+        |ctx, _query_idx, _format, query| {
+            let (row_count, duration) = ctx.execute_query(query)?;
+            Ok((duration, ClickHouseQueryResult { row_count }))
+        },
+    )?;
+
+    let benchmark_id = format!("clickhouse-{}", benchmark.dataset_name());
+    let writer = create_output_writer(&args.display_format, args.output_path, &benchmark_id)?;
+    runner.export_to(&args.display_format, writer)?;
+
+    Ok(())
+}

--- a/vortex-bench/src/clickbench/benchmark.rs
+++ b/vortex-bench/src/clickbench/benchmark.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use reqwest::Client;
 use url::Url;
-use vortex::error::VortexExpect;
 
 use crate::Benchmark;
 use crate::BenchmarkDataset;
@@ -37,14 +35,21 @@ impl ClickBenchBenchmark {
         })
     }
 
+    /// Returns the path to the queries file.
+    fn queries_file_path(&self) -> PathBuf {
+        if let Some(file) = &self.queries_file {
+            return file.into();
+        }
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        manifest_dir.join("clickbench_queries.sql")
+    }
+
     fn create_data_url(remote_data_dir: &Option<String>, flavor: Flavor) -> Result<Url> {
         match remote_data_dir {
             None => {
                 let basepath = format!("clickbench_{flavor}").to_data_path();
-                Ok(Url::parse(&format!(
-                    "file:{}/",
-                    basepath.to_str().vortex_expect("path should be utf8")
-                ))?)
+                Url::from_directory_path(basepath)
+                    .map_err(|_| anyhow::anyhow!("Failed to convert ClickBench data path to URL"))
             }
             Some(remote_data_dir) => {
                 if !remote_data_dir.ends_with("/") {
@@ -69,10 +74,7 @@ impl ClickBenchBenchmark {
 #[async_trait::async_trait]
 impl Benchmark for ClickBenchBenchmark {
     fn queries(&self) -> Result<Vec<(usize, String)>> {
-        let queries_filepath = match &self.queries_file {
-            Some(file) => file.into(),
-            None => Path::new(env!("CARGO_MANIFEST_DIR")).join("clickbench_queries.sql"),
-        };
+        let queries_filepath = self.queries_file_path();
 
         Ok(fs::read_to_string(queries_filepath)?
             .split(';')

--- a/vortex-bench/src/lib.rs
+++ b/vortex-bench/src/lib.rs
@@ -206,6 +206,9 @@ pub enum Engine {
     #[clap(name = "duckdb")]
     #[serde(rename = "duckdb")]
     DuckDB,
+    #[clap(name = "clickhouse")]
+    #[serde(rename = "clickhouse")]
+    ClickHouse,
 }
 
 impl Display for Engine {
@@ -213,6 +216,7 @@ impl Display for Engine {
         match self {
             Engine::DataFusion => write!(f, "datafusion"),
             Engine::DuckDB => write!(f, "duckdb"),
+            Engine::ClickHouse => write!(f, "clickhouse"),
             Engine::Vortex => write!(f, "vortex"),
             Engine::Arrow => write!(f, "arrow"),
         }

--- a/vortex-duckdb/cpp/replacement_scan.cpp
+++ b/vortex-duckdb/cpp/replacement_scan.cpp
@@ -34,7 +34,7 @@ VortexScanReplacement(duckdb::ClientContext &context,
         table_function->alias = fs.ExtractBaseName(table_name);
     }
 
-    return table_function;
+    return duckdb::unique_ptr<duckdb::TableRef>(table_function.release());
 }
 
 } // namespace vortex


### PR DESCRIPTION
Introduce a new clickhouse-bench benchmark crate that runs ClickBench queries against Parquet data via clickhouse-local, providing a baseline for comparing Vortex performance against ClickHouse.

Key design decisions:
- build.rs auto-downloads the full ClickHouse binary (with Parquet support) into target/clickhouse-local/, similar to how vortex-duckdb downloads the DuckDB library. This eliminates manual install steps and avoids issues with slim/homebrew builds lacking Parquet support.
- The binary path is baked in via CLICKHOUSE_BINARY env at compile time; CLICKHOUSE_LOCAL env var allows runtime override.
- ClickHouse-dialect SQL queries are maintained in a separate clickbench_clickhouse_queries.sql file (43 queries).
- CI workflows updated to include clickhouse:parquet target in ClickBench benchmarks and conditionally build clickhouse-bench.

#6425
