### PR TITLE
fix[util]: add balanced reduce iterator

### DIFF
--- a/vortex-array/src/expr/exprs.rs
+++ b/vortex-array/src/expr/exprs.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use vortex_error::VortexExpect;
+use vortex_utils::iter::ReduceBalanced;
 
 use crate::dtype::DType;
 use crate::dtype::FieldName;
@@ -286,8 +287,7 @@ pub fn or_collect<I>(iter: I) -> Option<Expression>
 where
     I: IntoIterator<Item = Expression>,
 {
-    let exprs: Vec<_> = iter.into_iter().collect();
-    balanced_reduce(exprs, or)
+    iter.into_iter().reduce_balanced(or)
 }
 
 /// Create a new [`Binary`] using the [`And`](Operator::And) operator.
@@ -322,42 +322,7 @@ pub fn and_collect<I>(iter: I) -> Option<Expression>
 where
     I: IntoIterator<Item = Expression>,
 {
-    let exprs: Vec<_> = iter.into_iter().collect();
-    balanced_reduce(exprs, and)
-}
-
-/// Helper function to reduce a list of expressions into a balanced binary tree.
-fn balanced_reduce<F>(mut exprs: Vec<Expression>, combine: F) -> Option<Expression>
-where
-    F: Fn(Expression, Expression) -> Expression + Copy,
-{
-    if exprs.is_empty() {
-        return None;
-    }
-    if exprs.len() == 1 {
-        return exprs.pop();
-    }
-
-    while exprs.len() > 1 {
-        let exprs_len = exprs.len();
-
-        for target_idx in 0..(exprs.len() / 2) {
-            let item_idx = target_idx * 2;
-            let new = combine(exprs[item_idx].clone(), exprs[item_idx + 1].clone());
-            exprs[target_idx] = new;
-        }
-
-        if !exprs.len().is_multiple_of(2) {
-            // We want the odd nodes to be inside the tree and not at root
-            let lhs = exprs[(exprs.len() / 2) - 1].clone();
-            let rhs = exprs[exprs.len() - 1].clone();
-            exprs[exprs_len / 2 - 1] = combine(lhs, rhs);
-        }
-
-        exprs.truncate(exprs_len / 2);
-    }
-
-    exprs.pop()
+    iter.into_iter().reduce_balanced(and)
 }
 
 /// Create a new [`Binary`] using the [`Add`](Operator::Add) operator.

--- a/vortex-array/src/expr/exprs.rs
+++ b/vortex-array/src/expr/exprs.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use vortex_error::VortexExpect;
-use vortex_utils::iter::ReduceBalanced;
+use vortex_utils::iter::ReduceBalancedIterExt;
 
 use crate::dtype::DType;
 use crate::dtype::FieldName;

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -15,7 +15,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_session::VortexSession;
-use vortex_utils::iter::ReduceBalanced;
+use vortex_utils::iter::ReduceBalancedIterExt;
 
 use crate::Array;
 use crate::ArrayRef;

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -15,6 +15,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 use vortex_session::VortexSession;
+use vortex_utils::iter::ReduceBalanced;
 
 use crate::Array;
 use crate::ArrayRef;
@@ -243,26 +244,26 @@ fn constant_list_scalar_contains(
     let elements = list_scalar.elements().vortex_expect("non null");
 
     let len = values.len();
-    let mut result: Option<ArrayRef> = None;
     let false_scalar = Scalar::bool(false, nullability);
 
-    for element in elements {
-        let res = Binary
-            .try_new_array(
-                len,
-                Operator::Eq,
-                [
-                    ConstantArray::new(element, len).into_array(),
-                    values.to_array(),
-                ],
-            )?
-            .fill_null(false_scalar.clone())?;
-        if let Some(acc) = result {
-            result = Some(acc.binary(res, Operator::Or)?)
-        } else {
-            result = Some(res);
-        }
-    }
+    let result = elements
+        .iter()
+        .map(|element| {
+            Binary
+                .try_new_array(
+                    len,
+                    Operator::Eq,
+                    [
+                        ConstantArray::new(element.clone(), len).into_array(),
+                        values.to_array(),
+                    ],
+                )?
+                .fill_null(false_scalar.clone())
+        })
+        .collect::<VortexResult<Vec<_>>>()?
+        .into_iter()
+        .try_reduce_balanced(|acc, res| acc.binary(res, Operator::Or))?;
+
     Ok(result.unwrap_or_else(|| ConstantArray::new(false_scalar, len).to_array()))
 }
 

--- a/vortex-utils/public-api.lock
+++ b/vortex-utils/public-api.lock
@@ -72,13 +72,13 @@ pub fn T::dyn_hash(&self, state: &mut dyn core::hash::Hasher)
 
 pub mod vortex_utils::iter
 
-pub trait vortex_utils::iter::ReduceBalanced: core::iter::traits::iterator::Iterator + core::marker::Sized
+pub trait vortex_utils::iter::ReduceBalancedIterExt: core::iter::traits::iterator::Iterator
 
-pub fn vortex_utils::iter::ReduceBalanced::reduce_balanced<F>(self, combine: F) -> core::option::Option<Self::Item> where Self::Item: core::clone::Clone, F: core::ops::function::Fn(Self::Item, Self::Item) -> Self::Item
+pub fn vortex_utils::iter::ReduceBalancedIterExt::reduce_balanced<F>(self, combine: F) -> core::option::Option<Self::Item> where Self::Item: core::clone::Clone, F: core::ops::function::Fn(Self::Item, Self::Item) -> Self::Item
 
-pub fn vortex_utils::iter::ReduceBalanced::try_reduce_balanced<F, E>(self, combine: F) -> core::result::Result<core::option::Option<Self::Item>, E> where Self::Item: core::clone::Clone, F: core::ops::function::Fn(Self::Item, Self::Item) -> core::result::Result<Self::Item, E>
+pub fn vortex_utils::iter::ReduceBalancedIterExt::try_reduce_balanced<F, E>(self, combine: F) -> core::result::Result<core::option::Option<Self::Item>, E> where Self::Item: core::clone::Clone, F: core::ops::function::Fn(Self::Item, Self::Item) -> core::result::Result<Self::Item, E>
 
-impl<I: core::iter::traits::iterator::Iterator + core::marker::Sized> vortex_utils::iter::ReduceBalanced for I
+impl<I: core::iter::traits::iterator::Iterator + core::marker::Sized> vortex_utils::iter::ReduceBalancedIterExt for I
 
 pub fn I::reduce_balanced<F>(self, combine: F) -> core::option::Option<Self::Item> where Self::Item: core::clone::Clone, F: core::ops::function::Fn(Self::Item, Self::Item) -> Self::Item
 

--- a/vortex-utils/public-api.lock
+++ b/vortex-utils/public-api.lock
@@ -69,3 +69,17 @@ pub fn vortex_utils::dyn_traits::DynHash::dyn_hash(&self, state: &mut dyn core::
 impl<T: core::hash::Hash + 'static> vortex_utils::dyn_traits::DynHash for T
 
 pub fn T::dyn_hash(&self, state: &mut dyn core::hash::Hasher)
+
+pub mod vortex_utils::iter
+
+pub trait vortex_utils::iter::ReduceBalanced: core::iter::traits::iterator::Iterator + core::marker::Sized
+
+pub fn vortex_utils::iter::ReduceBalanced::reduce_balanced<F>(self, combine: F) -> core::option::Option<Self::Item> where Self::Item: core::clone::Clone, F: core::ops::function::Fn(Self::Item, Self::Item) -> Self::Item
+
+pub fn vortex_utils::iter::ReduceBalanced::try_reduce_balanced<F, E>(self, combine: F) -> core::result::Result<core::option::Option<Self::Item>, E> where Self::Item: core::clone::Clone, F: core::ops::function::Fn(Self::Item, Self::Item) -> core::result::Result<Self::Item, E>
+
+impl<I: core::iter::traits::iterator::Iterator + core::marker::Sized> vortex_utils::iter::ReduceBalanced for I
+
+pub fn I::reduce_balanced<F>(self, combine: F) -> core::option::Option<Self::Item> where Self::Item: core::clone::Clone, F: core::ops::function::Fn(Self::Item, Self::Item) -> Self::Item
+
+pub fn I::try_reduce_balanced<F, E>(self, combine: F) -> core::result::Result<core::option::Option<Self::Item>, E> where Self::Item: core::clone::Clone, F: core::ops::function::Fn(Self::Item, Self::Item) -> core::result::Result<Self::Item, E>

--- a/vortex-utils/src/iter.rs
+++ b/vortex-utils/src/iter.rs
@@ -19,7 +19,7 @@
 /// |\
 /// a b
 /// ```
-pub trait ReduceBalanced: Iterator + Sized {
+pub trait ReduceBalancedIterExt: Iterator + Sized {
     /// Like [`Iterator::reduce`], but builds a balanced binary tree instead of a linear chain.
     ///
     /// `[a, b, c, d]` becomes `combine(combine(a, b), combine(c, d))`.
@@ -39,7 +39,7 @@ pub trait ReduceBalanced: Iterator + Sized {
         F: Fn(Self::Item, Self::Item) -> Result<Self::Item, E>;
 }
 
-impl<I: Iterator + Sized> ReduceBalanced for I {
+impl<I: Iterator + Sized> ReduceBalancedIterExt for I {
     fn reduce_balanced<F>(self, combine: F) -> Option<Self::Item>
     where
         Self::Item: Clone,
@@ -72,6 +72,7 @@ impl<I: Iterator + Sized> ReduceBalanced for I {
             items.truncate(len / 2);
         }
 
+        assert_eq!(items.len(), 1);
         items.pop()
     }
 
@@ -106,6 +107,7 @@ impl<I: Iterator + Sized> ReduceBalanced for I {
             items.truncate(len / 2);
         }
 
+        assert_eq!(items.len(), 1);
         Ok(items.pop())
     }
 }

--- a/vortex-utils/src/iter.rs
+++ b/vortex-utils/src/iter.rs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Iterator extension traits.
+
+/// An extension trait for iterators that provides balanced binary tree reduction.
+///
+/// Unlike [`Iterator::reduce`], which builds a left-leaning linear chain of depth N,
+/// `reduce_balanced` builds a balanced binary tree of depth log(N). This avoids deep
+/// nesting that can cause stack overflows on drop or suboptimal evaluation.
+///
+/// ```text
+/// reduce:          reduce_balanced:
+///     f                  f
+///    / \                / \
+///   f   d              f   f
+///  / \                / \ / \
+/// f   c              a  b c  d
+/// |\
+/// a b
+/// ```
+pub trait ReduceBalanced: Iterator + Sized {
+    /// Like [`Iterator::reduce`], but builds a balanced binary tree instead of a linear chain.
+    ///
+    /// `[a, b, c, d]` becomes `combine(combine(a, b), combine(c, d))`.
+    ///
+    /// Returns `None` if the iterator is empty.
+    fn reduce_balanced<F>(self, combine: F) -> Option<Self::Item>
+    where
+        Self::Item: Clone,
+        F: Fn(Self::Item, Self::Item) -> Self::Item;
+
+    /// Fallible version of [`reduce_balanced`](ReduceBalanced::reduce_balanced).
+    ///
+    /// Short-circuits on the first error.
+    fn try_reduce_balanced<F, E>(self, combine: F) -> Result<Option<Self::Item>, E>
+    where
+        Self::Item: Clone,
+        F: Fn(Self::Item, Self::Item) -> Result<Self::Item, E>;
+}
+
+impl<I: Iterator + Sized> ReduceBalanced for I {
+    fn reduce_balanced<F>(self, combine: F) -> Option<Self::Item>
+    where
+        Self::Item: Clone,
+        F: Fn(Self::Item, Self::Item) -> Self::Item,
+    {
+        let mut items: Vec<_> = self.collect();
+        if items.is_empty() {
+            return None;
+        }
+        if items.len() == 1 {
+            return items.pop();
+        }
+
+        while items.len() > 1 {
+            let len = items.len();
+
+            for target_idx in 0..(len / 2) {
+                let item_idx = target_idx * 2;
+                let new = combine(items[item_idx].clone(), items[item_idx + 1].clone());
+                items[target_idx] = new;
+            }
+
+            if !len.is_multiple_of(2) {
+                // Merge the odd element into the last paired element so it stays inside the tree.
+                let lhs = items[(len / 2) - 1].clone();
+                let rhs = items[len - 1].clone();
+                items[len / 2 - 1] = combine(lhs, rhs);
+            }
+
+            items.truncate(len / 2);
+        }
+
+        items.pop()
+    }
+
+    fn try_reduce_balanced<F, E>(self, combine: F) -> Result<Option<Self::Item>, E>
+    where
+        Self::Item: Clone,
+        F: Fn(Self::Item, Self::Item) -> Result<Self::Item, E>,
+    {
+        let mut items: Vec<_> = self.collect();
+        if items.is_empty() {
+            return Ok(None);
+        }
+        if items.len() == 1 {
+            return Ok(items.pop());
+        }
+
+        while items.len() > 1 {
+            let len = items.len();
+
+            for target_idx in 0..(len / 2) {
+                let item_idx = target_idx * 2;
+                let new = combine(items[item_idx].clone(), items[item_idx + 1].clone())?;
+                items[target_idx] = new;
+            }
+
+            if !len.is_multiple_of(2) {
+                let lhs = items[(len / 2) - 1].clone();
+                let rhs = items[len - 1].clone();
+                items[len / 2 - 1] = combine(lhs, rhs)?;
+            }
+
+            items.truncate(len / 2);
+        }
+
+        Ok(items.pop())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty() {
+        let result = std::iter::empty::<i32>().reduce_balanced(|a, b| a + b);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_single() {
+        let result = [42].into_iter().reduce_balanced(|a, b| a + b);
+        assert_eq!(result, Some(42));
+    }
+
+    #[test]
+    fn test_two() {
+        let result = [1, 2].into_iter().reduce_balanced(|a, b| a + b);
+        assert_eq!(result, Some(3));
+    }
+
+    #[test]
+    fn test_power_of_two() {
+        let result = [1, 2, 3, 4].into_iter().reduce_balanced(|a, b| a + b);
+        assert_eq!(result, Some(10));
+    }
+
+    #[test]
+    fn test_odd_count() {
+        let result = [1, 2, 3, 4, 5].into_iter().reduce_balanced(|a, b| a + b);
+        assert_eq!(result, Some(15));
+    }
+
+    #[test]
+    fn test_balanced_structure() {
+        // Use string concatenation to verify the tree shape.
+        // [a, b, c, d] should produce ((a+b)+(c+d)), not (((a+b)+c)+d).
+        let result = ["a", "b", "c", "d"]
+            .into_iter()
+            .map(String::from)
+            .reduce_balanced(|a, b| format!("({a}+{b})"));
+        assert_eq!(result, Some("((a+b)+(c+d))".to_string()));
+    }
+
+    #[test]
+    fn test_balanced_structure_odd() {
+        // [a, b, c] should produce ((a+b)+c) — odd element merges into last pair.
+        let result = ["a", "b", "c"]
+            .into_iter()
+            .map(String::from)
+            .reduce_balanced(|a, b| format!("({a}+{b})"));
+        assert_eq!(result, Some("((a+b)+c)".to_string()));
+    }
+
+    #[test]
+    fn test_balanced_structure_five() {
+        // [a, b, c, d, e] => ((a+b)+((c+d)+e))
+        let result = ["a", "b", "c", "d", "e"]
+            .into_iter()
+            .map(String::from)
+            .reduce_balanced(|a, b| format!("({a}+{b})"));
+        assert_eq!(result, Some("((a+b)+((c+d)+e))".to_string()));
+    }
+
+    #[test]
+    fn test_try_reduce_balanced_ok() {
+        let result: Result<_, &str> = [1, 2, 3, 4]
+            .into_iter()
+            .try_reduce_balanced(|a, b| Ok(a + b));
+        assert_eq!(result, Ok(Some(10)));
+    }
+
+    #[test]
+    fn test_try_reduce_balanced_err() {
+        let result: Result<Option<i32>, &str> =
+            [1, 2, 3, 4]
+                .into_iter()
+                .try_reduce_balanced(|a, b| if a + b > 4 { Err("too big") } else { Ok(a + b) });
+        assert_eq!(result, Err("too big"));
+    }
+
+    #[test]
+    fn test_try_reduce_balanced_empty() {
+        let result: Result<_, &str> =
+            std::iter::empty::<i32>().try_reduce_balanced(|a, b| Ok(a + b));
+        assert_eq!(result, Ok(None));
+    }
+
+    #[test]
+    fn test_try_reduce_balanced_single() {
+        let result: Result<_, &str> = [42].into_iter().try_reduce_balanced(|a, b| Ok(a + b));
+        assert_eq!(result, Ok(Some(42)));
+    }
+}

--- a/vortex-utils/src/iter.rs
+++ b/vortex-utils/src/iter.rs
@@ -185,10 +185,9 @@ mod tests {
 
     #[test]
     fn test_try_reduce_balanced_err() {
-        let result: Result<Option<i32>, &str> =
-            [1, 2, 3, 4]
-                .into_iter()
-                .try_reduce_balanced(|a, b| if a + b > 4 { Err("too big") } else { Ok(a + b) });
+        let result: Result<Option<i32>, &str> = [1, 2, 3, 4]
+            .into_iter()
+            .try_reduce_balanced(|a, b| if a + b > 4 { Err("too big") } else { Ok(a + b) });
         assert_eq!(result, Err("too big"));
     }
 

--- a/vortex-utils/src/iter.rs
+++ b/vortex-utils/src/iter.rs
@@ -30,7 +30,7 @@ pub trait ReduceBalancedIterExt: Iterator {
         Self::Item: Clone,
         F: Fn(Self::Item, Self::Item) -> Self::Item;
 
-    /// Fallible version of [`reduce_balanced`](ReduceBalanced::reduce_balanced).
+    /// Fallible version of [`reduce_balanced`](ReduceBalancedIterExt::reduce_balanced).
     ///
     /// Short-circuits on the first error.
     fn try_reduce_balanced<F, E>(self, combine: F) -> Result<Option<Self::Item>, E>

--- a/vortex-utils/src/iter.rs
+++ b/vortex-utils/src/iter.rs
@@ -19,7 +19,7 @@
 /// |\
 /// a b
 /// ```
-pub trait ReduceBalancedIterExt: Iterator + Sized {
+pub trait ReduceBalancedIterExt: Iterator {
     /// Like [`Iterator::reduce`], but builds a balanced binary tree instead of a linear chain.
     ///
     /// `[a, b, c, d]` becomes `combine(combine(a, b), combine(c, d))`.

--- a/vortex-utils/src/lib.rs
+++ b/vortex-utils/src/lib.rs
@@ -11,3 +11,4 @@ pub mod debug_with;
 pub mod dyn_traits;
 #[cfg(feature = "_test-harness")]
 pub mod env;
+pub mod iter;


### PR DESCRIPTION
We want expr/array tree to be wide not deep.

We use a balanced reduce added in this PR and use in list_contains and or/and collect from exprs