### PR TITLE
Upgrade to DataFusion 53

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6370,28 +6370,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
 dependencies = [
  "async-trait",
- "base64",
  "bytes",
  "chrono",
- "form_urlencoded",
  "futures",
  "http",
- "http-body-util",
- "httparse",
  "humantime",
- "hyper",
  "itertools 0.14.0",
- "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml",
- "rand 0.9.2",
- "reqwest 0.12.28",
- "ring",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7283,9 +7269,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-object_store"
-version = "0.10.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a900d022739373b3ea71fc77bbd237e094b478f71e4b5460c4371c9dedf7457"
+checksum = "a8b80a3a9af26abe307d2c01c13da487166c5c8ac5ac301a4d8e3c270e58ab50"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7294,7 +7280,7 @@ dependencies = [
  "http",
  "humantime",
  "itertools 0.14.0",
- "object_store 0.12.5",
+ "object_store 0.13.1",
  "percent-encoding",
  "pyo3",
  "pyo3-async-runtimes",
@@ -8109,15 +8095,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,19 +255,37 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
  "arrow-csv",
- "arrow-data",
- "arrow-ipc",
+ "arrow-data 57.3.0",
+ "arrow-ipc 57.3.0",
  "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-ord 57.3.0",
+ "arrow-row 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "arrow-string 57.3.0",
+]
+
+[[package]]
+name = "arrow"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602268ce9f569f282cedb9a9f6bac569b680af47b9b077d515900c03c5d190da"
+dependencies = [
+ "arrow-arith 58.0.0",
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-cast 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-ord 58.0.0",
+ "arrow-row 58.0.0",
+ "arrow-schema 58.0.0",
+ "arrow-select 58.0.0",
+ "arrow-string 58.0.0",
 ]
 
 [[package]]
@@ -276,10 +294,24 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd53c6bf277dea91f136ae8e3a5d7041b44b5e489e244e637d00ae302051f56f"
+dependencies = [
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-schema 58.0.0",
  "chrono",
  "num-traits",
 ]
@@ -291,11 +323,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
  "ahash 0.8.12",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "chrono-tz",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e53796e07a6525edaf7dc28b540d477a934aff14af97967ad1d5550878969b9e"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-schema 58.0.0",
+ "chrono",
  "half",
  "hashbrown 0.16.1",
  "num-complex",
@@ -316,17 +366,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-buffer"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c1a85bb2e94ee10b76531d8bc3ce9b7b4c0d508cabfb17d477f63f2617bd20"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
 name = "arrow-cast"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "atoi",
+ "base64",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89fb245db6b0e234ed8e15b644edb8664673fefe630575e94e62cd9d489a8a26"
+dependencies = [
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-ord 58.0.0",
+ "arrow-schema 58.0.0",
+ "arrow-select 58.0.0",
  "atoi",
  "base64",
  "chrono",
@@ -343,9 +427,9 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
 dependencies = [
- "arrow-array",
- "arrow-cast",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "csv",
  "csv-core",
@@ -358,8 +442,21 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d210bc4244c715fa3ed9e6e22864673cccb73d5da28c2723fb2e527329b33"
+dependencies = [
+ "arrow-buffer 58.0.0",
+ "arrow-schema 58.0.0",
  "half",
  "num-integer",
  "num-traits",
@@ -371,14 +468,28 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "flatbuffers",
  "lz4_flex 0.12.1",
  "zstd",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7968c2e5210c41f4909b2ef76f6e05e172b99021c2def5edf3cc48fdd39d1d6c"
+dependencies = [
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-schema 58.0.0",
+ "arrow-select 58.0.0",
+ "flatbuffers",
 ]
 
 [[package]]
@@ -387,11 +498,11 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "half",
  "indexmap",
@@ -411,11 +522,24 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "211136cb253577ee1a6665f741a13136d4e563f64f5093ffd6fb837af90b9495"
+dependencies = [
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-schema 58.0.0",
+ "arrow-select 58.0.0",
 ]
 
 [[package]]
@@ -424,10 +548,23 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "half",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e0f20145f9f5ea3fe383e2ba7a7487bf19be36aa9dbf5dd6a1f92f657179663"
+dependencies = [
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-schema 58.0.0",
  "half",
 ]
 
@@ -443,16 +580,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-schema"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "arrow-select"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-select"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "750a7d1dda177735f5e82a314485b6915c7cccdbb278262ac44090f4aba4a325"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-schema 58.0.0",
  "num-traits",
 ]
 
@@ -462,11 +622,28 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eab1208bc4fe55d768cdc9b9f3d9df5a794cdb3ee2586bf89f9b30dc31ad8c"
+dependencies = [
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-schema 58.0.0",
+ "arrow-select 58.0.0",
  "memchr",
  "num-traits",
  "regex",
@@ -761,7 +938,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1411,8 +1588,8 @@ name = "compress-bench"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 58.0.0",
+ "arrow-schema 58.0.0",
  "async-trait",
  "bytes",
  "clap",
@@ -1420,7 +1597,7 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "lance-bench",
- "parquet",
+ "parquet 58.0.0",
  "regex",
  "tokio",
  "tracing",
@@ -1868,8 +2045,8 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba7cb113e9c0bedf9e9765926031e132fa05a1b09ba6e93a6d1a4d7044457b8"
 dependencies = [
- "arrow",
- "arrow-schema",
+ "arrow 57.3.0",
+ "arrow-schema 57.3.0",
  "async-trait",
  "bytes",
  "chrono",
@@ -1900,7 +2077,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "parking_lot",
  "rand 0.9.2",
  "regex",
@@ -1918,8 +2095,8 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c18ba387f9c05ac1f3be32a73f8f3cc6c1cfc43e5d4b7a8e5b0d3a5eb48dc7"
 dependencies = [
- "arrow",
- "arrow-schema",
+ "arrow 57.3.0",
+ "arrow-schema 57.3.0",
  "async-trait",
  "bytes",
  "bzip2",
@@ -1955,9 +2132,9 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "parking_lot",
- "parquet",
+ "parquet 57.3.0",
  "rand 0.9.2",
  "regex",
  "sqlparser",
@@ -1980,7 +2157,7 @@ dependencies = [
  "datafusion-physical-plan 52.4.0",
  "futures",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.13.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -2000,7 +2177,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66a3a799f914a59b1ea343906a0486f17061f39509af74e874a866428951130d"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "dashmap",
  "datafusion-common 51.0.0",
@@ -2014,7 +2191,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "parking_lot",
  "tokio",
 ]
@@ -2025,7 +2202,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c75a4ce672b27fb8423810efb92a3600027717a1664d06a2c307eeeabcec694"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "dashmap",
  "datafusion-common 52.4.0",
@@ -2039,7 +2216,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "parking_lot",
  "tokio",
 ]
@@ -2050,7 +2227,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db1b113c80d7a0febcd901476a57aef378e717c54517a163ed51417d87621b0"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "datafusion-catalog 51.0.0",
  "datafusion-common 51.0.0",
@@ -2064,7 +2241,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "tokio",
 ]
 
@@ -2074,7 +2251,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8b9a3795ffb46bf4957a34c67d89a67558b311ae455c8d4295ff2115eeea50"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "datafusion-catalog 52.4.0",
  "datafusion-common 52.4.0",
@@ -2088,7 +2265,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.5",
 ]
 
 [[package]]
@@ -2098,15 +2275,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c10f7659e96127d25e8366be7c8be4109595d6a2c3eac70421f380a7006a1b0"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
- "arrow-ipc",
+ "arrow 57.3.0",
+ "arrow-ipc 57.3.0",
  "chrono",
  "half",
  "hashbrown 0.14.5",
  "indexmap",
  "libc",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "paste",
  "sqlparser",
  "tokio",
@@ -2121,16 +2298,16 @@ checksum = "205dc1e20441973f470e6b7ef87626a3b9187970e5106058fef1b713047f770c"
 dependencies = [
  "ahash 0.8.12",
  "apache-avro",
- "arrow",
- "arrow-ipc",
+ "arrow 57.3.0",
+ "arrow-ipc 57.3.0",
  "chrono",
  "half",
  "hashbrown 0.16.1",
  "indexmap",
  "libc",
  "log",
- "object_store",
- "parquet",
+ "object_store 0.12.5",
+ "parquet 57.3.0",
  "paste",
  "recursive",
  "sqlparser",
@@ -2166,7 +2343,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde13794244bc7581cd82f6fff217068ed79cdc344cafe4ab2c3a1c3510b38d6"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bytes",
  "chrono",
@@ -2183,7 +2360,7 @@ dependencies = [
  "glob",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "rand 0.9.2",
  "tokio",
  "url",
@@ -2195,7 +2372,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc614d6e709450e29b7b032a42c1bdb705f166a6b2edef7bed7c7897eb905499"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-compression",
  "async-trait",
  "bytes",
@@ -2216,7 +2393,7 @@ dependencies = [
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "rand 0.9.2",
  "tokio",
  "tokio-util",
@@ -2230,8 +2407,8 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804fa9b4ecf3157982021770617200ef7c1b2979d57bec9044748314775a9aea"
 dependencies = [
- "arrow",
- "arrow-ipc",
+ "arrow 57.3.0",
+ "arrow-ipc 57.3.0",
  "async-trait",
  "bytes",
  "datafusion-common 51.0.0",
@@ -2244,7 +2421,7 @@ dependencies = [
  "datafusion-session 51.0.0",
  "futures",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.12.5",
  "tokio",
 ]
 
@@ -2254,8 +2431,8 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e497d5fc48dac7ce86f6b4fb09a3a494385774af301ff20ec91aebfae9b05b4"
 dependencies = [
- "arrow",
- "arrow-ipc",
+ "arrow 57.3.0",
+ "arrow-ipc 57.3.0",
  "async-trait",
  "bytes",
  "datafusion-common 52.4.0",
@@ -2268,7 +2445,7 @@ dependencies = [
  "datafusion-session 52.4.0",
  "futures",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.12.5",
  "tokio",
 ]
 
@@ -2279,7 +2456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "474d9b26f185b57f549a0f7ce9183428dd0042014a2e0d093f5430fdc9dae289"
 dependencies = [
  "apache-avro",
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bytes",
  "datafusion-common 52.4.0",
@@ -2289,7 +2466,7 @@ dependencies = [
  "datafusion-session 52.4.0",
  "futures",
  "num-traits",
- "object_store",
+ "object_store 0.12.5",
 ]
 
 [[package]]
@@ -2298,7 +2475,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a1641a40b259bab38131c5e6f48fac0717bedb7dc93690e604142a849e0568"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bytes",
  "datafusion-common 51.0.0",
@@ -2310,7 +2487,7 @@ dependencies = [
  "datafusion-physical-plan 51.0.0",
  "datafusion-session 51.0.0",
  "futures",
- "object_store",
+ "object_store 0.12.5",
  "regex",
  "tokio",
 ]
@@ -2321,7 +2498,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dfc250cad940d0327ca2e9109dc98830892d17a3d6b2ca11d68570e872cf379"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bytes",
  "datafusion-common 52.4.0",
@@ -2333,7 +2510,7 @@ dependencies = [
  "datafusion-physical-plan 52.4.0",
  "datafusion-session 52.4.0",
  "futures",
- "object_store",
+ "object_store 0.12.5",
  "regex",
  "tokio",
 ]
@@ -2344,7 +2521,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adeacdb00c1d37271176f8fb6a1d8ce096baba16ea7a4b2671840c5c9c64fe85"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bytes",
  "datafusion-common 51.0.0",
@@ -2356,7 +2533,7 @@ dependencies = [
  "datafusion-physical-plan 51.0.0",
  "datafusion-session 51.0.0",
  "futures",
- "object_store",
+ "object_store 0.12.5",
  "tokio",
 ]
 
@@ -2366,7 +2543,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c91e9677ed62833b0e8129dec0d1a8f3c9bb7590bd6dd714a43e4c3b663e4aa0"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bytes",
  "datafusion-common 52.4.0",
@@ -2378,7 +2555,7 @@ dependencies = [
  "datafusion-physical-plan 52.4.0",
  "datafusion-session 52.4.0",
  "futures",
- "object_store",
+ "object_store 0.12.5",
  "tokio",
 ]
 
@@ -2388,7 +2565,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23798383465e0c569bd442d1453b50691261f8ad6511d840c48457b3bf51ae21"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bytes",
  "datafusion-common 52.4.0",
@@ -2406,9 +2583,9 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "parking_lot",
- "parquet",
+ "parquet 57.3.0",
  "tokio",
 ]
 
@@ -2430,14 +2607,14 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63695643190679037bc946ad46a263b62016931547bf119859c511f7ff2f5178"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "dashmap",
  "datafusion-common 51.0.0",
  "datafusion-expr 51.0.0",
  "futures",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "parking_lot",
  "rand 0.9.2",
  "tempfile",
@@ -2450,7 +2627,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48a6cc03e34899a54546b229235f7b192634c8e832f78a267f0989b18216c56d"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "chrono",
  "dashmap",
@@ -2458,7 +2635,7 @@ dependencies = [
  "datafusion-expr 52.4.0",
  "futures",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "parking_lot",
  "rand 0.9.2",
  "tempfile",
@@ -2471,7 +2648,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a4787cbf5feb1ab351f789063398f67654a6df75c4d37d7f637dc96f951a91"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "chrono",
  "datafusion-common 51.0.0",
@@ -2493,7 +2670,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3315d87eca7a7df58e52a1fb43b4c4171b545fd30ffc3102945c162a9f6ddb"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "chrono",
  "datafusion-common 52.4.0",
@@ -2516,7 +2693,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce2fb1b8c15c9ac45b0863c30b268c69dc9ee7a1ee13ecf5d067738338173dc"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "datafusion-common 51.0.0",
  "indexmap",
  "itertools 0.14.0",
@@ -2529,8 +2706,8 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c6d83feae0753799f933a2c47dfd15980c6947960cb95ed60f5c1f885548b3"
 dependencies = [
- "arrow",
- "datafusion-common 52.4.0",
+ "arrow 57.3.0",
+ "datafusion-common 52.2.0",
  "indexmap",
  "itertools 0.14.0",
  "paste",
@@ -2542,8 +2719,8 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 57.3.0",
+ "arrow-buffer 57.3.0",
  "base64",
  "blake2",
  "blake3",
@@ -2572,8 +2749,8 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b82962015cc3db4d7662459c9f7fcda0591b5edacb8af1cf3bc3031f274800"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 57.3.0",
+ "arrow-buffer 57.3.0",
  "base64",
  "blake2",
  "blake3",
@@ -2604,7 +2781,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c25210520a9dcf9c2b2cbbce31ebd4131ef5af7fc60ee92b266dc7d159cb305"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
+ "arrow 57.3.0",
  "datafusion-common 51.0.0",
  "datafusion-doc 51.0.0",
  "datafusion-execution 51.0.0",
@@ -2625,15 +2802,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e42c227d9e55a6c8041785d4a8a117e4de531033d480aae10984247ac62e27e"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
- "datafusion-common 52.4.0",
- "datafusion-doc 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-functions-aggregate-common 52.4.0",
- "datafusion-macros 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
+ "arrow 57.3.0",
+ "datafusion-common 52.2.0",
+ "datafusion-doc 52.2.0",
+ "datafusion-execution 52.2.0",
+ "datafusion-expr 52.2.0",
+ "datafusion-functions-aggregate-common 52.2.0",
+ "datafusion-macros 52.2.0",
+ "datafusion-physical-expr 52.2.0",
+ "datafusion-physical-expr-common 52.2.0",
  "half",
  "log",
  "paste",
@@ -2646,7 +2823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f4a66f3b87300bb70f4124b55434d2ae3fe80455f3574701d0348da040b55d"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
+ "arrow 57.3.0",
  "datafusion-common 51.0.0",
  "datafusion-expr-common 51.0.0",
  "datafusion-physical-expr-common 51.0.0",
@@ -2659,10 +2836,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cead3cfed825b0b688700f4338d281cd7857e4907775a5b9554c083edd5f3f95"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
- "datafusion-common 52.4.0",
- "datafusion-expr-common 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
+ "arrow 57.3.0",
+ "datafusion-common 52.2.0",
+ "datafusion-expr-common 52.2.0",
+ "datafusion-physical-expr-common 52.2.0",
 ]
 
 [[package]]
@@ -2671,8 +2848,8 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae5c06eed03918dc7fe7a9f082a284050f0e9ecf95d72f57712d1496da03b8c4"
 dependencies = [
- "arrow",
- "arrow-ord",
+ "arrow 57.3.0",
+ "arrow-ord 57.3.0",
  "datafusion-common 51.0.0",
  "datafusion-doc 51.0.0",
  "datafusion-execution 51.0.0",
@@ -2694,18 +2871,18 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62ea99612970aebab8cf864d02eb3d296bbab7f4881e1023d282b57fe431b201"
 dependencies = [
- "arrow",
- "arrow-ord",
- "datafusion-common 52.4.0",
- "datafusion-doc 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-expr-common 52.4.0",
- "datafusion-functions 52.4.0",
- "datafusion-functions-aggregate 52.4.0",
- "datafusion-functions-aggregate-common 52.4.0",
- "datafusion-macros 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
+ "arrow 57.3.0",
+ "arrow-ord 57.3.0",
+ "datafusion-common 52.2.0",
+ "datafusion-doc 52.2.0",
+ "datafusion-execution 52.2.0",
+ "datafusion-expr 52.2.0",
+ "datafusion-expr-common 52.2.0",
+ "datafusion-functions 52.2.0",
+ "datafusion-functions-aggregate 52.2.0",
+ "datafusion-functions-aggregate-common 52.2.0",
+ "datafusion-macros 52.2.0",
+ "datafusion-physical-expr-common 52.2.0",
  "itertools 0.14.0",
  "log",
  "paste",
@@ -2717,7 +2894,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4fed1d71738fbe22e2712d71396db04c25de4111f1ec252b8f4c6d3b25d7f5"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "datafusion-catalog 51.0.0",
  "datafusion-common 51.0.0",
@@ -2733,7 +2910,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83dbf3ab8b9af6f209b068825a7adbd3b88bf276f2a1ec14ba09567b97f5674"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "datafusion-catalog 52.4.0",
  "datafusion-common 52.4.0",
@@ -2749,7 +2926,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d92206aa5ae21892f1552b4d61758a862a70956e6fd7a95cb85db1de74bc6d1"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "datafusion-common 51.0.0",
  "datafusion-doc 51.0.0",
  "datafusion-expr 51.0.0",
@@ -2767,14 +2944,14 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "732edabe07496e2fc5a1e57a284d7a36edcea445a2821119770a0dea624b472c"
 dependencies = [
- "arrow",
- "datafusion-common 52.4.0",
- "datafusion-doc 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-functions-window-common 52.4.0",
- "datafusion-macros 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
+ "arrow 57.3.0",
+ "datafusion-common 52.2.0",
+ "datafusion-doc 52.2.0",
+ "datafusion-expr 52.2.0",
+ "datafusion-functions-window-common 52.2.0",
+ "datafusion-macros 52.2.0",
+ "datafusion-physical-expr 52.2.0",
+ "datafusion-physical-expr-common 52.2.0",
  "log",
  "paste",
 ]
@@ -2827,7 +3004,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f35f9ec5d08b87fd1893a30c2929f2559c2f9806ca072d8fefca5009dc0f06a"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "chrono",
  "datafusion-common 51.0.0",
  "datafusion-expr 51.0.0",
@@ -2846,7 +3023,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99f32edb8ba12f08138f86c09b80fae3d4a320551262fa06b91d8a8cb3065a5b"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "chrono",
  "datafusion-common 52.4.0",
  "datafusion-expr 52.4.0",
@@ -2867,7 +3044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30cc8012e9eedcb48bbe112c6eff4ae5ed19cf3003cb0f505662e88b7014c5d"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
+ "arrow 57.3.0",
  "datafusion-common 51.0.0",
  "datafusion-expr 51.0.0",
  "datafusion-expr-common 51.0.0",
@@ -2889,12 +3066,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "987c5e29e96186589301b42e25aa7d11bbe319a73eb02ef8d755edc55b5b89fc"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
- "datafusion-common 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-expr-common 52.4.0",
- "datafusion-functions-aggregate-common 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
+ "arrow 57.3.0",
+ "datafusion-common 52.2.0",
+ "datafusion-expr 52.2.0",
+ "datafusion-expr-common 52.2.0",
+ "datafusion-functions-aggregate-common 52.2.0",
+ "datafusion-physical-expr-common 52.2.0",
  "half",
  "hashbrown 0.16.1",
  "indexmap",
@@ -2912,7 +3089,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f9ff2dbd476221b1f67337699eff432781c4e6e1713d2aefdaa517dfbf79768"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "datafusion-common 51.0.0",
  "datafusion-expr 51.0.0",
  "datafusion-functions 51.0.0",
@@ -2927,12 +3104,12 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de89d0afa08b6686697bd8a6bac4ba2cd44c7003356e1bce6114d5a93f94b5c"
 dependencies = [
- "arrow",
- "datafusion-common 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-functions 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
+ "arrow 57.3.0",
+ "datafusion-common 52.2.0",
+ "datafusion-expr 52.2.0",
+ "datafusion-functions 52.2.0",
+ "datafusion-physical-expr 52.2.0",
+ "datafusion-physical-expr-common 52.2.0",
  "itertools 0.14.0",
 ]
 
@@ -2943,7 +3120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90da43e1ec550b172f34c87ec68161986ced70fd05c8d2a2add66eef9c276f03"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
+ "arrow 57.3.0",
  "datafusion-common 51.0.0",
  "datafusion-expr-common 51.0.0",
  "hashbrown 0.14.5",
@@ -2957,7 +3134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602d1970c0fe87f1c3a36665d131fbfe1c4379d35f8fc5ec43a362229ad2954d"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
+ "arrow 57.3.0",
  "chrono",
  "datafusion-common 52.4.0",
  "datafusion-expr-common 52.4.0",
@@ -2973,7 +3150,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9804f799acd7daef3be7aaffe77c0033768ed8fdbf5fb82fc4c5f2e6bc14e6"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "datafusion-common 51.0.0",
  "datafusion-execution 51.0.0",
  "datafusion-expr 51.0.0",
@@ -2991,15 +3168,15 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b24d704b6385ebe27c756a12e5ba15684576d3b47aeca79cc9fb09480236dc32"
 dependencies = [
- "arrow",
- "datafusion-common 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-expr-common 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
- "datafusion-physical-plan 52.4.0",
- "datafusion-pruning 52.4.0",
+ "arrow 57.3.0",
+ "datafusion-common 52.2.0",
+ "datafusion-execution 52.2.0",
+ "datafusion-expr 52.2.0",
+ "datafusion-expr-common 52.2.0",
+ "datafusion-physical-expr 52.2.0",
+ "datafusion-physical-expr-common 52.2.0",
+ "datafusion-physical-plan 52.2.0",
+ "datafusion-pruning 52.2.0",
  "itertools 0.14.0",
  "recursive",
 ]
@@ -3011,9 +3188,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acf0ad6b6924c6b1aa7d213b181e012e2d3ec0a64ff5b10ee6282ab0f8532ac"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
- "arrow-ord",
- "arrow-schema",
+ "arrow 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-schema 57.3.0",
  "async-trait",
  "chrono",
  "datafusion-common 51.0.0",
@@ -3042,9 +3219,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c21d94141ea5043e98793f170798e9c1887095813b8291c5260599341e383a38"
 dependencies = [
  "ahash 0.8.12",
- "arrow",
- "arrow-ord",
- "arrow-schema",
+ "arrow 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-schema 57.3.0",
  "async-trait",
  "datafusion-common 52.4.0",
  "datafusion-common-runtime 52.4.0",
@@ -3072,7 +3249,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2c2498a1f134a9e11a9f5ed202a2a7d7e9774bd9249295593053ea3be999db"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "datafusion-common 51.0.0",
  "datafusion-datasource 51.0.0",
  "datafusion-expr-common 51.0.0",
@@ -3089,13 +3266,13 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a68cce43d18c0dfac95cacd74e70565f7e2fb12b9ed41e2d312f0fa837626b1"
 dependencies = [
- "arrow",
- "datafusion-common 52.4.0",
- "datafusion-datasource 52.4.0",
- "datafusion-expr-common 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
- "datafusion-physical-plan 52.4.0",
+ "arrow 57.3.0",
+ "datafusion-common 52.2.0",
+ "datafusion-datasource 52.2.0",
+ "datafusion-expr-common 52.2.0",
+ "datafusion-physical-expr 52.2.0",
+ "datafusion-physical-expr-common 52.2.0",
+ "datafusion-physical-plan 52.2.0",
  "itertools 0.14.0",
  "log",
 ]
@@ -3134,7 +3311,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e53604bca77d4544426a425e2a50d7b911bbe35d3c8193de24093b445f23856"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "bigdecimal",
  "chrono",
  "crc32fast",
@@ -3157,7 +3334,7 @@ version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc195fe60634b2c6ccfd131b487de46dc30eccae8a3c35a13f136e7f440414f"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "bigdecimal",
  "chrono",
  "datafusion-common 51.0.0",
@@ -3174,7 +3351,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f1891e5b106d1d73c7fe403bd8a265d19c3977edc17f60808daf26c2fe65ffb"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "bigdecimal",
  "chrono",
  "datafusion-common 52.4.0",
@@ -3192,7 +3369,7 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3929b7067193345bc345a5ea5f231cccde36fe58fb055d8caef7247ad7566fd5"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bigdecimal",
  "clap",
@@ -3204,7 +3381,7 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "sqllogictest",
  "sqlparser",
  "tempfile",
@@ -3224,7 +3401,7 @@ dependencies = [
  "datafusion 52.4.0",
  "half",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.12.5",
  "pbjson-types",
  "prost 0.14.3",
  "substrait",
@@ -3254,9 +3431,9 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.12"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+checksum = "807800ff3288b621186fe0a8f3392c4652068257302709c24efd918c3dffcdc2"
 
 [[package]]
 name = "deranged"
@@ -3728,7 +3905,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f9e5c0b1c67a38cb92b41535d44623483beb9511592ae23a3bf42ddec758690"
 dependencies = [
- "arrow-array",
+ "arrow-array 57.3.0",
  "rand 0.9.2",
 ]
 
@@ -3943,9 +4120,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1cc4106ac0a0a512c398961ce95d8150475c84a84e17c4511c3643fa120a17"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
  "geo-traits",
  "geoarrow-schema",
  "num-traits",
@@ -3959,8 +4136,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa84300361ce57fb875bcaa6e32b95b0aff5c6b1af692b936bdd58ff343f4394"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
  "geo",
  "geo-traits",
  "geoarrow-array",
@@ -3973,7 +4150,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e97be4e9f523f92bd6a0e0458323f4b783d073d011664decd8dbf05651704f34"
 dependencies = [
- "arrow-schema",
+ "arrow-schema 57.3.0",
  "geo-traits",
  "serde",
  "serde_json",
@@ -3986,9 +4163,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773cfa1fb0d7f7661b76b3fde00f3ffd8e0ff7b3635096f0ff6294fe5ca62a2b"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-schema",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-schema 57.3.0",
  "datafusion 51.0.0",
  "geo",
  "geo-traits",
@@ -4062,7 +4239,6 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -4357,7 +4533,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4429,7 +4605,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4906,15 +5082,15 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b7f07b905df393a5554eba19055c620f9ea25a3e40a013bda4bd8dc4ca66f01"
 dependencies = [
- "arrow",
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-ipc",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
+ "arrow 57.3.0",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-ipc 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-row 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "async-recursion",
  "async-trait",
  "async_cell",
@@ -4946,7 +5122,7 @@ dependencies = [
  "lance-table",
  "log",
  "moka",
- "object_store",
+ "object_store 0.12.5",
  "permutation",
  "pin-project",
  "prost 0.14.3",
@@ -4971,13 +5147,13 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "100e076cb81c8f0c24cd2881c706fc53e037c7d6e81eb320e929e265d157effb"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "bytes",
  "getrandom 0.2.17",
  "half",
@@ -4991,13 +5167,13 @@ name = "lance-bench"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-cast",
+ "arrow-cast 57.3.0",
  "async-trait",
  "clap",
  "futures",
  "lance",
  "lance-encoding",
- "parquet",
+ "parquet 57.3.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -5021,9 +5197,9 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fa01d1cf490ccfd3b8eaeee2781415d0419e6be8366040e57e43677abf2644e"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
  "async-trait",
  "byteorder",
  "bytes",
@@ -5039,7 +5215,7 @@ dependencies = [
  "mock_instant",
  "moka",
  "num_cpus",
- "object_store",
+ "object_store 0.12.5",
  "pin-project",
  "prost 0.14.3",
  "rand 0.9.2",
@@ -5060,12 +5236,12 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef89a39e3284eef76f79e63f23de8881a0583ad6feb20ed39f47eadd847a2b88"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "async-trait",
  "chrono",
  "datafusion 51.0.0",
@@ -5092,10 +5268,10 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2a60eef5c47e65d91e2ffa8e7e1629c52e7190c8b88a371a1a60601dc49371"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-cast",
- "arrow-schema",
+ "arrow 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-schema 57.3.0",
  "chrono",
  "futures",
  "half",
@@ -5112,13 +5288,13 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95ce4a6631308aa681b2671af8f2a845ff781f8d4e755a2a7ccd012379467094"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "bytemuck",
  "byteorder",
  "bytes",
@@ -5151,12 +5327,12 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d4d82357cbfaa1a18494226c15b1cb3c8ed0b6c84b91146323c82047ede419"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "async-recursion",
  "async-trait",
  "byteorder",
@@ -5170,7 +5346,7 @@ dependencies = [
  "lance-io",
  "log",
  "num-traits",
- "object_store",
+ "object_store 0.12.5",
  "prost 0.14.3",
  "prost-build",
  "prost-types",
@@ -5201,12 +5377,12 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20e9c5aa7024a63af9ae89ee8c0f23c8421b7896742e5cd4a271a60f9956cb80"
 dependencies = [
- "arrow",
- "arrow-arith",
- "arrow-array",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow 57.3.0",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "async-channel",
  "async-recursion",
  "async-trait",
@@ -5243,7 +5419,7 @@ dependencies = [
  "log",
  "ndarray",
  "num-traits",
- "object_store",
+ "object_store 0.12.5",
  "prost 0.14.3",
  "prost-build",
  "prost-types",
@@ -5270,14 +5446,14 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d2af0b17fb374a8181bcf1a10bce5703ae3ee4373c1587ce4bba23e15e45c8"
 dependencies = [
- "arrow",
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow 57.3.0",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "async-recursion",
  "async-trait",
  "byteorder",
@@ -5289,7 +5465,7 @@ dependencies = [
  "lance-core",
  "lance-namespace",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "path_abs",
  "pin-project",
  "prost 0.14.3",
@@ -5308,9 +5484,9 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5125aa62696e75a7475807564b4921f252d8815be606b84bc00e6def0f5c24bb"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
  "cc",
  "deepsize",
  "half",
@@ -5326,7 +5502,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70545c2676ce954dfd801da5c6a631a70bba967826cd3a8f31b47d1f04bbfed3"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bytes",
  "lance-core",
@@ -5353,11 +5529,11 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06ad37bd90045de8ef533df170c6098e6ff6ecb427aade47d7db8e2c86f2678"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ipc",
- "arrow-schema",
+ "arrow 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-ipc 57.3.0",
+ "arrow-schema 57.3.0",
  "async-trait",
  "byteorder",
  "bytes",
@@ -5369,7 +5545,7 @@ dependencies = [
  "lance-file",
  "lance-io",
  "log",
- "object_store",
+ "object_store 0.12.5",
  "prost 0.14.3",
  "prost-build",
  "prost-types",
@@ -6226,6 +6402,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "http-body-util",
+ "httparse",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.9.2",
+ "reqwest",
+ "ring",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6450,13 +6664,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ipc 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "futures",
+ "half",
+ "hashbrown 0.16.1",
+ "lz4_flex 0.12.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "object_store 0.12.5",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "tokio",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "parquet"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f491d0ef1b510194426ee67ddc18a9b747ef3c42050c19322a2cd2e1666c29b"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-ipc 58.0.0",
+ "arrow-schema 58.0.0",
+ "arrow-select 58.0.0",
  "base64",
  "brotli",
  "bytes",
@@ -6469,7 +6719,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "object_store",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -6846,7 +7095,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -6878,7 +7127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7045,7 +7294,7 @@ dependencies = [
  "http",
  "humantime",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.12.5",
  "percent-encoding",
  "pyo3",
  "pyo3-async-runtimes",
@@ -7084,7 +7333,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7122,7 +7371,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8432,6 +8681,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
  "windows-sys 0.61.2",
 ]
 
@@ -9184,7 +9443,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -9260,21 +9519,21 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.1+spec-1.1.0"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.5+spec-1.1.0"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
@@ -9379,16 +9638,14 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "tpchgen"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d651db770ccf53b89dd769ed47899c0c089452e3b725c3c48fbc6a2be579638"
+source = "git+https://github.com/AdamGS/tpchgen-rs.git?branch=adamg%2Fbump-arrow-match-df#803355855df0ed62fc30ee2c125fe46fe1dbab47"
 
 [[package]]
 name = "tpchgen-arrow"
 version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180f3759dffbf26d47021d2a84245a00f20945384bcf22e63c32652b04916e5a"
+source = "git+https://github.com/AdamGS/tpchgen-rs.git?branch=adamg%2Fbump-arrow-match-df#803355855df0ed62fc30ee2c125fe46fe1dbab47"
 dependencies = [
- "arrow",
+ "arrow 58.0.0",
  "tpchgen",
 ]
 
@@ -9710,12 +9967,12 @@ name = "vortex"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array",
+ "arrow-array 58.0.0",
  "codspeed-divan-compat",
  "fastlanes",
  "mimalloc",
- "parquet",
- "rand 0.10.0",
+ "parquet 58.0.0",
+ "rand 0.9.2",
  "serde_json",
  "tokio",
  "tracing",
@@ -9776,15 +10033,15 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "arcref",
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 58.0.0",
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-cast 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-ord 58.0.0",
+ "arrow-schema 58.0.0",
+ "arrow-select 58.0.0",
+ "arrow-string 58.0.0",
  "async-lock",
  "bytes",
  "cfg-if",
@@ -9838,9 +10095,9 @@ name = "vortex-bench"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.0.0",
+ "arrow-schema 58.0.0",
+ "arrow-select 58.0.0",
  "async-trait",
  "bytes",
  "bzip2",
@@ -9855,8 +10112,8 @@ dependencies = [
  "noodles-bgzf",
  "noodles-vcf",
  "parking_lot",
- "parquet",
- "rand 0.10.0",
+ "parquet 58.0.0",
+ "rand 0.9.2",
  "regex",
  "reqwest 0.12.28",
  "serde",
@@ -9914,7 +10171,7 @@ dependencies = [
 name = "vortex-buffer"
 version = "0.1.0"
 dependencies = [
- "arrow-buffer",
+ "arrow-buffer 58.0.0",
  "bitvec",
  "bytes",
  "codspeed-divan-compat",
@@ -9989,7 +10246,7 @@ dependencies = [
  "fastlanes",
  "futures",
  "kanal",
- "object_store",
+ "object_store 0.13.1",
  "parking_lot",
  "prost 0.14.3",
  "rstest",
@@ -10017,8 +10274,8 @@ name = "vortex-cxx"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 58.0.0",
+ "arrow-schema 58.0.0",
  "async-fs",
  "cxx",
  "futures",
@@ -10032,7 +10289,7 @@ name = "vortex-datafusion"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-schema",
+ "arrow-schema 58.0.0",
  "async-trait",
  "datafusion 52.4.0",
  "datafusion-catalog 52.4.0",
@@ -10050,7 +10307,7 @@ dependencies = [
  "futures",
  "insta",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.13.1",
  "rstest",
  "tempfile",
  "tokio",
@@ -10106,7 +10363,8 @@ dependencies = [
  "jiff",
  "kanal",
  "num-traits",
- "object_store",
+ "object_store 0.13.1",
+ "once_cell",
  "parking_lot",
  "paste",
  "reqwest 0.12.28",
@@ -10126,10 +10384,10 @@ dependencies = [
 name = "vortex-error"
 version = "0.1.0"
 dependencies = [
- "arrow-schema",
+ "arrow-schema 58.0.0",
  "flatbuffers",
  "jiff",
- "object_store",
+ "object_store 0.13.1",
  "prost 0.14.3",
  "serial_test",
  "temp-env",
@@ -10167,7 +10425,7 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "mimalloc",
- "object_store",
+ "object_store 0.13.1",
  "paste",
  "prost 0.14.3",
  "tempfile",
@@ -10189,8 +10447,8 @@ dependencies = [
  "itertools 0.14.0",
  "kanal",
  "moka",
- "object_store",
- "oneshot 0.2.1",
+ "object_store 0.13.1",
+ "oneshot",
  "parking_lot",
  "pin-project-lite",
  "tokio",
@@ -10289,8 +10547,8 @@ dependencies = [
  "handle",
  "itertools 0.14.0",
  "kanal",
- "object_store",
- "oneshot 0.2.1",
+ "object_store 0.13.1",
+ "oneshot",
  "parking_lot",
  "pin-project-lite",
  "rstest",
@@ -10327,12 +10585,12 @@ dependencies = [
 name = "vortex-jni"
 version = "0.1.0"
 dependencies = [
- "arrow-array",
- "arrow-ipc",
- "arrow-schema",
+ "arrow-array 58.0.0",
+ "arrow-ipc 58.0.0",
+ "arrow-schema 58.0.0",
  "futures",
  "jni",
- "object_store",
+ "object_store 0.13.1",
  "parking_lot",
  "prost 0.14.3",
  "thiserror 2.0.18",
@@ -10388,8 +10646,7 @@ dependencies = [
 name = "vortex-mask"
 version = "0.1.0"
 dependencies = [
- "arrow-buffer",
- "codspeed-divan-compat",
+ "arrow-buffer 58.0.0",
  "itertools 0.14.0",
  "rstest",
  "serde",
@@ -10444,14 +10701,13 @@ dependencies = [
 name = "vortex-python"
 version = "0.1.0"
 dependencies = [
- "arrow-array",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-schema 58.0.0",
  "bytes",
  "itertools 0.14.0",
  "log",
- "mimalloc",
- "object_store",
+ "object_store 0.13.1",
  "parking_lot",
  "pyo3",
  "pyo3-bytes",
@@ -10468,8 +10724,8 @@ name = "vortex-runend"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 58.0.0",
+ "arrow-schema 58.0.0",
  "codspeed-divan-compat",
  "itertools 0.14.0",
  "num-traits",
@@ -10487,6 +10743,8 @@ dependencies = [
 name = "vortex-scan"
 version = "0.1.0"
 dependencies = [
+ "arrow-array 58.0.0",
+ "arrow-schema 58.0.0",
  "async-trait",
  "futures",
  "roaring 0.11.3",
@@ -10576,8 +10834,8 @@ dependencies = [
 name = "vortex-test-e2e-cuda"
 version = "0.1.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 58.0.0",
+ "arrow-schema 58.0.0",
  "futures",
  "vortex",
  "vortex-cuda",
@@ -10588,8 +10846,8 @@ name = "vortex-tui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 58.0.0",
+ "arrow-schema 58.0.0",
  "clap",
  "console_error_panic_hook",
  "crossterm",
@@ -10602,7 +10860,7 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "js-sys",
- "parquet",
+ "parquet 58.0.0",
  "ratatui",
  "ratzilla",
  "serde",
@@ -10901,7 +11159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -10912,7 +11170,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -10929,13 +11187,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-future"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -10973,8 +11244,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -11251,12 +11522,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-
-[[package]]
-name = "winnow"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
@@ -11463,18 +11728,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11628,3 +11893,73 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "datafusion"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-catalog"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-common"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-common-runtime"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-datasource"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-execution"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-expr"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-functions"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-physical-expr"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-physical-expr-adapter"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-physical-expr-common"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-physical-plan"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-pruning"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+
+[[patch.unused]]
+name = "datafusion-sqllogictest"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
  "arrow-schema 58.0.0",
  "arrow-select 58.0.0",
  "flatbuffers",
- "lz4_flex 0.12.0",
+ "lz4_flex 0.12.1",
  "zstd",
 ]
 
@@ -2139,7 +2139,8 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16"
 dependencies = [
  "arrow 58.0.0",
  "arrow-schema 58.0.0",
@@ -2245,7 +2246,8 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137"
 dependencies = [
  "arrow 58.0.0",
  "async-trait",
@@ -2293,7 +2295,8 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6"
 dependencies = [
  "arrow 58.0.0",
  "async-trait",
@@ -2337,7 +2340,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d7663f3af955292f8004e74bcaf8f7ea3d66cc38438749615bb84815b61a293"
 dependencies = [
  "ahash 0.8.12",
  "apache-avro",
@@ -2373,7 +2377,8 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f590205c7e32fe1fea48dd53ffb406e56ae0e7a062213a3ac848db8771641bd"
 dependencies = [
  "futures",
  "log",
@@ -2412,7 +2417,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79"
 dependencies = [
  "arrow 58.0.0",
  "async-compression",
@@ -2470,7 +2476,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15"
 dependencies = [
  "arrow 58.0.0",
  "arrow-ipc 58.0.0",
@@ -2493,7 +2500,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-avro"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49dda81c79b6ba57b1853a9158abc66eb85a3aa1cede0c517dabec6d8a4ed3aa"
 dependencies = [
  "apache-avro",
  "arrow 58.0.0",
@@ -2535,7 +2543,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c"
 dependencies = [
  "arrow 58.0.0",
  "async-trait",
@@ -2579,7 +2588,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8"
 dependencies = [
  "arrow 58.0.0",
  "async-trait",
@@ -2602,7 +2612,8 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946"
 dependencies = [
  "arrow 58.0.0",
  "async-trait",
@@ -2637,7 +2648,8 @@ checksum = "2b99e13947667b36ad713549237362afb054b2d8f8cc447751e23ec61202db07"
 [[package]]
 name = "datafusion-doc"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a"
 
 [[package]]
 name = "datafusion-execution"
@@ -2662,7 +2674,8 @@ dependencies = [
 [[package]]
 name = "datafusion-execution"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df"
 dependencies = [
  "arrow 58.0.0",
  "arrow-buffer 58.0.0",
@@ -2706,7 +2719,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf"
 dependencies = [
  "arrow 58.0.0",
  "async-trait",
@@ -2741,7 +2755,8 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9"
 dependencies = [
  "arrow 58.0.0",
  "datafusion-common 53.0.0",
@@ -2783,7 +2798,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e"
 dependencies = [
  "arrow 58.0.0",
  "arrow-buffer 58.0.0",
@@ -2835,7 +2851,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.0.0",
@@ -2869,7 +2886,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.0.0",
@@ -2904,7 +2922,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790"
 dependencies = [
  "arrow 58.0.0",
  "arrow-ord 58.0.0",
@@ -2944,7 +2963,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6"
 dependencies = [
  "arrow 58.0.0",
  "async-trait",
@@ -2977,7 +2997,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1"
 dependencies = [
  "arrow 58.0.0",
  "datafusion-common 53.0.0",
@@ -3004,7 +3025,8 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9"
 dependencies = [
  "datafusion-common 53.0.0",
  "datafusion-physical-expr-common 53.0.0",
@@ -3024,7 +3046,8 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578"
 dependencies = [
  "datafusion-doc 53.0.0",
  "quote",
@@ -3053,7 +3076,8 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46"
 dependencies = [
  "arrow 58.0.0",
  "chrono",
@@ -3094,7 +3118,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.0.0",
@@ -3132,7 +3157,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64"
 dependencies = [
  "arrow 58.0.0",
  "datafusion-common 53.0.0",
@@ -3160,7 +3186,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eacbcc4cfd502558184ed58fa3c72e775ec65bf077eef5fd2b3453db676f893c"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.0.0",
@@ -3194,7 +3221,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941"
 dependencies = [
  "arrow 58.0.0",
  "datafusion-common 53.0.0",
@@ -3243,7 +3271,8 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d"
 dependencies = [
  "ahash 0.8.12",
  "arrow 58.0.0",
@@ -3291,7 +3320,8 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6"
 dependencies = [
  "arrow 58.0.0",
  "datafusion-common 53.0.0",
@@ -3321,7 +3351,8 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba"
 dependencies = [
  "async-trait",
  "datafusion-common 53.0.0",
@@ -3334,7 +3365,8 @@ dependencies = [
 [[package]]
 name = "datafusion-spark"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923a8b871962a9d860f036f743a20af50ff04729f1da2468ed220dab4f61c97d"
 dependencies = [
  "arrow 58.0.0",
  "bigdecimal",
@@ -3377,7 +3409,8 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81"
 dependencies = [
  "arrow 58.0.0",
  "bigdecimal",
@@ -3395,7 +3428,8 @@ dependencies = [
 [[package]]
 name = "datafusion-sqllogictest"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a43746bd59e7f2655be4c5553ede4a1ceb1cd34005932fa9e2bd0641c714c46e"
 dependencies = [
  "arrow 58.0.0",
  "async-trait",
@@ -3420,7 +3454,8 @@ dependencies = [
 [[package]]
 name = "datafusion-substrait"
 version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e5656a7e63d51dd3e5af3dbd347ea83bbe993a77c66b854b74961570d16490"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -4266,6 +4301,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -4560,7 +4596,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4632,7 +4668,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6437,7 +6473,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.28",
  "ring",
  "rustls-pki-types",
  "serde",
@@ -6691,7 +6727,7 @@ dependencies = [
  "flate2",
  "half",
  "hashbrown 0.16.1",
- "lz4_flex 0.12.0",
+ "lz4_flex 0.12.1",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -6899,7 +6935,7 @@ checksum = "044b1fa4f259f4df9ad5078e587b208f5d288a25407575fcddb9face30c7c692"
 dependencies = [
  "rand 0.9.2",
  "socket2",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7294,9 +7330,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-object_store"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b80a3a9af26abe307d2c01c13da487166c5c8ac5ac301a4d8e3c270e58ab50"
+checksum = "b3056dc8a77db5d44d32e7f740db0b01e5b65a43d181487a6917576959c6eb9a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7344,7 +7380,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7382,7 +7418,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8683,16 +8719,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
  "windows-sys 0.61.2",
 ]
 
@@ -9466,7 +9492,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -9559,7 +9585,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -9662,12 +9688,12 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "tpchgen"
 version = "2.0.2"
-source = "git+https://github.com/AdamGS/tpchgen-rs.git?branch=adamg%2Fbump-arrow-match-df#803355855df0ed62fc30ee2c125fe46fe1dbab47"
+source = "git+https://github.com/clflushopt/tpchgen-rs.git?rev=438e9c2dbc25b2fff82c0efc08b3f13b5707874f#438e9c2dbc25b2fff82c0efc08b3f13b5707874f"
 
 [[package]]
 name = "tpchgen-arrow"
 version = "2.0.2"
-source = "git+https://github.com/AdamGS/tpchgen-rs.git?branch=adamg%2Fbump-arrow-match-df#803355855df0ed62fc30ee2c125fe46fe1dbab47"
+source = "git+https://github.com/clflushopt/tpchgen-rs.git?rev=438e9c2dbc25b2fff82c0efc08b3f13b5707874f#438e9c2dbc25b2fff82c0efc08b3f13b5707874f"
 dependencies = [
  "arrow 58.0.0",
  "tpchgen",
@@ -9996,7 +10022,7 @@ dependencies = [
  "fastlanes",
  "mimalloc",
  "parquet 58.0.0",
- "rand 0.9.2",
+ "rand 0.10.0",
  "serde_json",
  "tokio",
  "tracing",
@@ -10137,7 +10163,7 @@ dependencies = [
  "noodles-vcf",
  "parking_lot",
  "parquet 58.0.0",
- "rand 0.9.2",
+ "rand 0.10.0",
  "regex",
  "reqwest 0.12.28",
  "serde",
@@ -10225,12 +10251,12 @@ dependencies = [
 name = "vortex-compat"
 version = "0.1.0"
 dependencies = [
- "arrow-array",
- "arrow-select",
+ "arrow-array 58.0.0",
+ "arrow-select 58.0.0",
  "bytes",
  "clap",
  "futures",
- "parquet",
+ "parquet 58.0.0",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -10388,7 +10414,6 @@ dependencies = [
  "kanal",
  "num-traits",
  "object_store 0.13.1",
- "once_cell",
  "parking_lot",
  "paste",
  "reqwest 0.12.28",
@@ -10472,7 +10497,7 @@ dependencies = [
  "kanal",
  "moka",
  "object_store 0.13.1",
- "oneshot",
+ "oneshot 0.2.1",
  "parking_lot",
  "pin-project-lite",
  "tokio",
@@ -10572,7 +10597,7 @@ dependencies = [
  "itertools 0.14.0",
  "kanal",
  "object_store 0.13.1",
- "oneshot",
+ "oneshot 0.2.1",
  "parking_lot",
  "pin-project-lite",
  "rstest",
@@ -10630,8 +10655,8 @@ name = "vortex-layout"
 version = "0.1.0"
 dependencies = [
  "arcref",
- "arrow-array",
- "arrow-schema",
+ "arrow-array 58.0.0",
+ "arrow-schema 58.0.0",
  "async-stream",
  "async-trait",
  "bit-vec",
@@ -10671,6 +10696,7 @@ name = "vortex-mask"
 version = "0.1.0"
 dependencies = [
  "arrow-buffer 58.0.0",
+ "codspeed-divan-compat",
  "itertools 0.14.0",
  "rstest",
  "serde",
@@ -10731,6 +10757,7 @@ dependencies = [
  "bytes",
  "itertools 0.14.0",
  "log",
+ "mimalloc",
  "object_store 0.13.1",
  "parking_lot",
  "pyo3",
@@ -10767,8 +10794,6 @@ dependencies = [
 name = "vortex-scan"
 version = "0.1.0"
 dependencies = [
- "arrow-array 58.0.0",
- "arrow-schema 58.0.0",
  "async-trait",
  "futures",
  "roaring 0.11.3",
@@ -11183,7 +11208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -11194,7 +11219,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -11211,26 +11236,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -11268,8 +11280,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -11549,6 +11561,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,10 +259,10 @@ dependencies = [
  "arrow-array 57.3.0",
  "arrow-buffer 57.3.0",
  "arrow-cast 57.3.0",
- "arrow-csv",
+ "arrow-csv 57.3.0",
  "arrow-data 57.3.0",
  "arrow-ipc 57.3.0",
- "arrow-json",
+ "arrow-json 57.3.0",
  "arrow-ord 57.3.0",
  "arrow-row 57.3.0",
  "arrow-schema 57.3.0",
@@ -280,7 +280,10 @@ dependencies = [
  "arrow-array 58.0.0",
  "arrow-buffer 58.0.0",
  "arrow-cast 58.0.0",
+ "arrow-csv 58.0.0",
  "arrow-data 58.0.0",
+ "arrow-ipc 58.0.0",
+ "arrow-json 58.0.0",
  "arrow-ord 58.0.0",
  "arrow-row 58.0.0",
  "arrow-schema 58.0.0",
@@ -346,6 +349,7 @@ dependencies = [
  "arrow-data 58.0.0",
  "arrow-schema 58.0.0",
  "chrono",
+ "chrono-tz",
  "half",
  "hashbrown 0.16.1",
  "num-complex",
@@ -437,6 +441,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-csv"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d374882fb465a194462527c0c15a93aa19a554cf690a6b77a26b2a02539937a7"
+dependencies = [
+ "arrow-array 58.0.0",
+ "arrow-cast 58.0.0",
+ "arrow-schema 58.0.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
 name = "arrow-data"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +509,8 @@ dependencies = [
  "arrow-schema 58.0.0",
  "arrow-select 58.0.0",
  "flatbuffers",
+ "lz4_flex 0.12.0",
+ "zstd",
 ]
 
 [[package]]
@@ -503,6 +524,30 @@ dependencies = [
  "arrow-cast 57.3.0",
  "arrow-data 57.3.0",
  "arrow-schema 57.3.0",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-json"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92111dba5bf900f443488e01f00d8c4ddc2f47f5c50039d18120287b580baa22"
+dependencies = [
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-cast 58.0.0",
+ "arrow-data 58.0.0",
+ "arrow-schema 58.0.0",
  "chrono",
  "half",
  "indexmap",
@@ -586,6 +631,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b47e0ca91cc438d2c7879fe95e0bca5329fff28649e30a88c6f760b1faeddcb"
 dependencies = [
  "bitflags",
+ "serde_core",
+ "serde_json",
 ]
 
 [[package]]
@@ -2082,7 +2129,7 @@ dependencies = [
  "rand 0.9.2",
  "regex",
  "rstest",
- "sqlparser",
+ "sqlparser 0.59.0",
  "tempfile",
  "tokio",
  "url",
@@ -2091,53 +2138,52 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c18ba387f9c05ac1f3be32a73f8f3cc6c1cfc43e5d4b7a8e5b0d3a5eb48dc7"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow 58.0.0",
+ "arrow-schema 58.0.0",
  "async-trait",
  "bytes",
  "bzip2",
  "chrono",
- "datafusion-catalog 52.4.0",
- "datafusion-catalog-listing 52.4.0",
- "datafusion-common 52.4.0",
- "datafusion-common-runtime 52.4.0",
- "datafusion-datasource 52.4.0",
- "datafusion-datasource-arrow 52.4.0",
+ "datafusion-catalog 53.0.0",
+ "datafusion-catalog-listing 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-datasource-arrow 53.0.0",
  "datafusion-datasource-avro",
- "datafusion-datasource-csv 52.4.0",
- "datafusion-datasource-json 52.4.0",
+ "datafusion-datasource-csv 53.0.0",
+ "datafusion-datasource-json 53.0.0",
  "datafusion-datasource-parquet",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-expr-common 52.4.0",
- "datafusion-functions 52.4.0",
- "datafusion-functions-aggregate 52.4.0",
- "datafusion-functions-nested 52.4.0",
- "datafusion-functions-table 52.4.0",
- "datafusion-functions-window 52.4.0",
- "datafusion-optimizer 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-expr-adapter 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
- "datafusion-physical-optimizer 52.4.0",
- "datafusion-physical-plan 52.4.0",
- "datafusion-session 52.4.0",
- "datafusion-sql 52.4.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-functions-aggregate 53.0.0",
+ "datafusion-functions-nested 53.0.0",
+ "datafusion-functions-table 53.0.0",
+ "datafusion-functions-window 53.0.0",
+ "datafusion-optimizer 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-optimizer 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
+ "datafusion-sql 53.0.0",
  "flate2",
  "futures",
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store 0.12.5",
+ "object_store 0.13.1",
  "parking_lot",
- "parquet 57.3.0",
+ "parquet 58.0.0",
  "rand 0.9.2",
  "regex",
- "sqlparser",
+ "sqlparser 0.61.0",
  "tempfile",
  "tokio",
  "url",
@@ -2152,9 +2198,9 @@ dependencies = [
  "anyhow",
  "clap",
  "custom-labels",
- "datafusion 52.4.0",
- "datafusion-common 52.4.0",
- "datafusion-physical-plan 52.4.0",
+ "datafusion 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "futures",
  "itertools 0.14.0",
  "object_store 0.13.1",
@@ -2198,25 +2244,24 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c75a4ce672b27fb8423810efb92a3600027717a1664d06a2c307eeeabcec694"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "async-trait",
  "dashmap",
- "datafusion-common 52.4.0",
- "datafusion-common-runtime 52.4.0",
- "datafusion-datasource 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-plan 52.4.0",
- "datafusion-session 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store 0.12.5",
+ "object_store 0.13.1",
  "parking_lot",
  "tokio",
 ]
@@ -2247,25 +2292,24 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8b9a3795ffb46bf4957a34c67d89a67558b311ae455c8d4295ff2115eeea50"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "async-trait",
- "datafusion-catalog 52.4.0",
- "datafusion-common 52.4.0",
- "datafusion-datasource 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-expr-adapter 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
- "datafusion-physical-plan 52.4.0",
+ "datafusion-catalog 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store 0.12.5",
+ "object_store 0.13.1",
 ]
 
 [[package]]
@@ -2285,32 +2329,32 @@ dependencies = [
  "log",
  "object_store 0.12.5",
  "paste",
- "sqlparser",
+ "sqlparser 0.59.0",
  "tokio",
  "web-time",
 ]
 
 [[package]]
 name = "datafusion-common"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205dc1e20441973f470e6b7ef87626a3b9187970e5106058fef1b713047f770c"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
  "ahash 0.8.12",
  "apache-avro",
- "arrow 57.3.0",
- "arrow-ipc 57.3.0",
+ "arrow 58.0.0",
+ "arrow-ipc 58.0.0",
  "chrono",
  "half",
  "hashbrown 0.16.1",
  "indexmap",
+ "itertools 0.14.0",
  "libc",
  "log",
- "object_store 0.12.5",
- "parquet 57.3.0",
+ "object_store 0.13.1",
+ "parquet 58.0.0",
  "paste",
  "recursive",
- "sqlparser",
+ "sqlparser 0.61.0",
  "tokio",
  "web-time",
 ]
@@ -2328,9 +2372,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf5880c02ff6f5f11fb5bc19211789fb32fd3c53d79b7d6cb2b12e401312ba0"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
  "futures",
  "log",
@@ -2368,32 +2411,31 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc614d6e709450e29b7b032a42c1bdb705f166a6b2edef7bed7c7897eb905499"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "async-compression",
  "async-trait",
  "bytes",
  "bzip2",
  "chrono",
- "datafusion-common 52.4.0",
- "datafusion-common-runtime 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-expr-adapter 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
- "datafusion-physical-plan 52.4.0",
- "datafusion-session 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "flate2",
  "futures",
  "glob",
  "itertools 0.14.0",
  "liblzma",
  "log",
- "object_store 0.12.5",
+ "object_store 0.13.1",
  "rand 0.9.2",
  "tokio",
  "tokio-util",
@@ -2427,46 +2469,44 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-arrow"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e497d5fc48dac7ce86f6b4fb09a3a494385774af301ff20ec91aebfae9b05b4"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
- "arrow-ipc 57.3.0",
+ "arrow 58.0.0",
+ "arrow-ipc 58.0.0",
  "async-trait",
  "bytes",
- "datafusion-common 52.4.0",
- "datafusion-common-runtime 52.4.0",
- "datafusion-datasource 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
- "datafusion-physical-plan 52.4.0",
- "datafusion-session 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
  "itertools 0.14.0",
- "object_store 0.12.5",
+ "object_store 0.13.1",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-datasource-avro"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474d9b26f185b57f549a0f7ce9183428dd0042014a2e0d093f5430fdc9dae289"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
  "apache-avro",
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "async-trait",
  "bytes",
- "datafusion-common 52.4.0",
- "datafusion-datasource 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
- "datafusion-physical-plan 52.4.0",
- "datafusion-session 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
  "num-traits",
- "object_store 0.12.5",
+ "object_store 0.13.1",
 ]
 
 [[package]]
@@ -2494,23 +2534,22 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-csv"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dfc250cad940d0327ca2e9109dc98830892d17a3d6b2ca11d68570e872cf379"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "async-trait",
  "bytes",
- "datafusion-common 52.4.0",
- "datafusion-common-runtime 52.4.0",
- "datafusion-datasource 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
- "datafusion-physical-plan 52.4.0",
- "datafusion-session 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
- "object_store 0.12.5",
+ "object_store 0.13.1",
  "regex",
  "tokio",
 ]
@@ -2539,53 +2578,53 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91e9677ed62833b0e8129dec0d1a8f3c9bb7590bd6dd714a43e4c3b663e4aa0"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "async-trait",
  "bytes",
- "datafusion-common 52.4.0",
- "datafusion-common-runtime 52.4.0",
- "datafusion-datasource 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
- "datafusion-physical-plan 52.4.0",
- "datafusion-session 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
- "object_store 0.12.5",
+ "object_store 0.13.1",
+ "serde_json",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "datafusion-datasource-parquet"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23798383465e0c569bd442d1453b50691261f8ad6511d840c48457b3bf51ae21"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "async-trait",
  "bytes",
- "datafusion-common 52.4.0",
- "datafusion-common-runtime 52.4.0",
- "datafusion-datasource 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-functions-aggregate-common 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-expr-adapter 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
- "datafusion-physical-plan 52.4.0",
- "datafusion-pruning 52.4.0",
- "datafusion-session 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-pruning 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store 0.12.5",
+ "object_store 0.13.1",
  "parking_lot",
- "parquet 57.3.0",
+ "parquet 58.0.0",
  "tokio",
 ]
 
@@ -2597,9 +2636,8 @@ checksum = "2b99e13947667b36ad713549237362afb054b2d8f8cc447751e23ec61202db07"
 
 [[package]]
 name = "datafusion-doc"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e13e5fe3447baa0584b61ee8644086e007e1ef6e58f4be48bc8a72417854729"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 
 [[package]]
 name = "datafusion-execution"
@@ -2623,19 +2661,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48a6cc03e34899a54546b229235f7b192634c8e832f78a267f0989b18216c56d"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
+ "arrow-buffer 58.0.0",
  "async-trait",
  "chrono",
  "dashmap",
- "datafusion-common 52.4.0",
- "datafusion-expr 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "futures",
  "log",
- "object_store 0.12.5",
+ "object_store 0.13.1",
  "parking_lot",
  "rand 0.9.2",
  "tempfile",
@@ -2661,30 +2700,29 @@ dependencies = [
  "itertools 0.14.0",
  "paste",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.59.0",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3315d87eca7a7df58e52a1fb43b4c4171b545fd30ffc3102945c162a9f6ddb"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "async-trait",
  "chrono",
- "datafusion-common 52.4.0",
- "datafusion-doc 52.4.0",
- "datafusion-expr-common 52.4.0",
- "datafusion-functions-aggregate-common 52.4.0",
- "datafusion-functions-window-common 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-functions-window-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "indexmap",
  "itertools 0.14.0",
  "paste",
  "recursive",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.61.0",
 ]
 
 [[package]]
@@ -2702,12 +2740,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c6d83feae0753799f933a2c47dfd15980c6947960cb95ed60f5c1f885548b3"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
- "datafusion-common 52.2.0",
+ "arrow 58.0.0",
+ "datafusion-common 53.0.0",
  "indexmap",
  "itertools 0.14.0",
  "paste",
@@ -2745,27 +2782,27 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b82962015cc3db4d7662459c9f7fcda0591b5edacb8af1cf3bc3031f274800"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
- "arrow-buffer 57.3.0",
+ "arrow 58.0.0",
+ "arrow-buffer 58.0.0",
  "base64",
  "blake2",
  "blake3",
  "chrono",
  "chrono-tz",
- "datafusion-common 52.4.0",
- "datafusion-doc 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-expr-common 52.4.0",
- "datafusion-macros 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-macros 53.0.0",
  "hex",
  "itertools 0.14.0",
  "log",
  "md-5",
+ "memchr",
  "num-traits",
  "rand 0.9.2",
  "regex",
@@ -2797,22 +2834,22 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e42c227d9e55a6c8041785d4a8a117e4de531033d480aae10984247ac62e27e"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
  "ahash 0.8.12",
- "arrow 57.3.0",
- "datafusion-common 52.2.0",
- "datafusion-doc 52.2.0",
- "datafusion-execution 52.2.0",
- "datafusion-expr 52.2.0",
- "datafusion-functions-aggregate-common 52.2.0",
- "datafusion-macros 52.2.0",
- "datafusion-physical-expr 52.2.0",
- "datafusion-physical-expr-common 52.2.0",
+ "arrow 58.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-macros 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "half",
  "log",
+ "num-traits",
  "paste",
 ]
 
@@ -2831,15 +2868,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cead3cfed825b0b688700f4338d281cd7857e4907775a5b9554c083edd5f3f95"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
  "ahash 0.8.12",
- "arrow 57.3.0",
- "datafusion-common 52.2.0",
- "datafusion-expr-common 52.2.0",
- "datafusion-physical-expr-common 52.2.0",
+ "arrow 58.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
 ]
 
 [[package]]
@@ -2867,23 +2903,24 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ea99612970aebab8cf864d02eb3d296bbab7f4881e1023d282b57fe431b201"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
- "arrow-ord 57.3.0",
- "datafusion-common 52.2.0",
- "datafusion-doc 52.2.0",
- "datafusion-execution 52.2.0",
- "datafusion-expr 52.2.0",
- "datafusion-expr-common 52.2.0",
- "datafusion-functions 52.2.0",
- "datafusion-functions-aggregate 52.2.0",
- "datafusion-functions-aggregate-common 52.2.0",
- "datafusion-macros 52.2.0",
- "datafusion-physical-expr-common 52.2.0",
+ "arrow 58.0.0",
+ "arrow-ord 58.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-functions-aggregate 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-macros 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "hashbrown 0.16.1",
  "itertools 0.14.0",
+ "itoa",
  "log",
  "paste",
 ]
@@ -2906,16 +2943,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83dbf3ab8b9af6f209b068825a7adbd3b88bf276f2a1ec14ba09567b97f5674"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "async-trait",
- "datafusion-catalog 52.4.0",
- "datafusion-common 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-physical-plan 52.4.0",
+ "datafusion-catalog 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "parking_lot",
  "paste",
 ]
@@ -2940,18 +2976,17 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732edabe07496e2fc5a1e57a284d7a36edcea445a2821119770a0dea624b472c"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
- "datafusion-common 52.2.0",
- "datafusion-doc 52.2.0",
- "datafusion-expr 52.2.0",
- "datafusion-functions-window-common 52.2.0",
- "datafusion-macros 52.2.0",
- "datafusion-physical-expr 52.2.0",
- "datafusion-physical-expr-common 52.2.0",
+ "arrow 58.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-window-common 53.0.0",
+ "datafusion-macros 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "log",
  "paste",
 ]
@@ -2968,12 +3003,11 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c6e30e09700799bd52adce8c377ab03dda96e73a623e4803a31ad94fe7ce14"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "datafusion-common 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
 ]
 
 [[package]]
@@ -2989,11 +3023,10 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402f2a8ed70fb99a18f71580a1fe338604222a3d32ddeac6e72c5b34feea2d4d"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "datafusion-doc 52.4.0",
+ "datafusion-doc 53.0.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -3019,16 +3052,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f32edb8ba12f08138f86c09b80fae3d4a320551262fa06b91d8a8cb3065a5b"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "chrono",
- "datafusion-common 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-expr-common 52.4.0",
- "datafusion-physical-expr 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
  "indexmap",
  "itertools 0.14.0",
  "log",
@@ -3061,17 +3093,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987c5e29e96186589301b42e25aa7d11bbe319a73eb02ef8d755edc55b5b89fc"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
  "ahash 0.8.12",
- "arrow 57.3.0",
- "datafusion-common 52.2.0",
- "datafusion-expr 52.2.0",
- "datafusion-expr-common 52.2.0",
- "datafusion-functions-aggregate-common 52.2.0",
- "datafusion-physical-expr-common 52.2.0",
+ "arrow 58.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "half",
  "hashbrown 0.16.1",
  "indexmap",
@@ -3100,16 +3131,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-adapter"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de89d0afa08b6686697bd8a6bac4ba2cd44c7003356e1bce6114d5a93f94b5c"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
- "datafusion-common 52.2.0",
- "datafusion-expr 52.2.0",
- "datafusion-functions 52.2.0",
- "datafusion-physical-expr 52.2.0",
- "datafusion-physical-expr-common 52.2.0",
+ "arrow 58.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "itertools 0.14.0",
 ]
 
@@ -3129,15 +3159,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602d1970c0fe87f1c3a36665d131fbfe1c4379d35f8fc5ec43a362229ad2954d"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
  "ahash 0.8.12",
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "chrono",
- "datafusion-common 52.4.0",
- "datafusion-expr-common 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr-common 53.0.0",
  "hashbrown 0.16.1",
  "indexmap",
  "itertools 0.14.0",
@@ -3164,19 +3193,18 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b24d704b6385ebe27c756a12e5ba15684576d3b47aeca79cc9fb09480236dc32"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
- "datafusion-common 52.2.0",
- "datafusion-execution 52.2.0",
- "datafusion-expr 52.2.0",
- "datafusion-expr-common 52.2.0",
- "datafusion-physical-expr 52.2.0",
- "datafusion-physical-expr-common 52.2.0",
- "datafusion-physical-plan 52.2.0",
- "datafusion-pruning 52.2.0",
+ "arrow 58.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-pruning 53.0.0",
  "itertools 0.14.0",
  "recursive",
 ]
@@ -3214,30 +3242,30 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c21d94141ea5043e98793f170798e9c1887095813b8291c5260599341e383a38"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
  "ahash 0.8.12",
- "arrow 57.3.0",
- "arrow-ord 57.3.0",
- "arrow-schema 57.3.0",
+ "arrow 58.0.0",
+ "arrow-ord 58.0.0",
+ "arrow-schema 58.0.0",
  "async-trait",
- "datafusion-common 52.4.0",
- "datafusion-common-runtime 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-functions 52.4.0",
- "datafusion-functions-aggregate-common 52.4.0",
- "datafusion-functions-window-common 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-functions-window-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "futures",
  "half",
  "hashbrown 0.16.1",
  "indexmap",
  "itertools 0.14.0",
  "log",
+ "num-traits",
  "parking_lot",
  "pin-project-lite",
  "tokio",
@@ -3262,17 +3290,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-pruning"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68cce43d18c0dfac95cacd74e70565f7e2fb12b9ed41e2d312f0fa837626b1"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
- "datafusion-common 52.2.0",
- "datafusion-datasource 52.2.0",
- "datafusion-expr-common 52.2.0",
- "datafusion-physical-expr 52.2.0",
- "datafusion-physical-expr-common 52.2.0",
- "datafusion-physical-plan 52.2.0",
+ "arrow 58.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "itertools 0.14.0",
  "log",
 ]
@@ -3293,38 +3320,40 @@ dependencies = [
 
 [[package]]
 name = "datafusion-session"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4e1c40a0b1896aed4a4504145c2eb7fa9b9da13c2d04b40a4767a09f076199"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
  "async-trait",
- "datafusion-common 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-physical-plan 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "parking_lot",
 ]
 
 [[package]]
 name = "datafusion-spark"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e53604bca77d4544426a425e2a50d7b911bbe35d3c8193de24093b445f23856"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "bigdecimal",
  "chrono",
  "crc32fast",
- "datafusion-catalog 52.4.0",
- "datafusion-common 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-functions 52.4.0",
- "datafusion-functions-nested 52.4.0",
+ "datafusion 53.0.0",
+ "datafusion-catalog 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-functions-aggregate 53.0.0",
+ "datafusion-functions-nested 53.0.0",
  "log",
  "percent-encoding",
  "rand 0.9.2",
+ "serde_json",
  "sha1",
+ "sha2",
  "url",
 ]
 
@@ -3342,38 +3371,37 @@ dependencies = [
  "indexmap",
  "log",
  "regex",
- "sqlparser",
+ "sqlparser 0.59.0",
 ]
 
 [[package]]
 name = "datafusion-sql"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1891e5b106d1d73c7fe403bd8a265d19c3977edc17f60808daf26c2fe65ffb"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "bigdecimal",
  "chrono",
- "datafusion-common 52.4.0",
- "datafusion-expr 52.4.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-nested 53.0.0",
  "indexmap",
  "log",
  "recursive",
  "regex",
- "sqlparser",
+ "sqlparser 0.61.0",
 ]
 
 [[package]]
 name = "datafusion-sqllogictest"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3929b7067193345bc345a5ea5f231cccde36fe58fb055d8caef7247ad7566fd5"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
- "arrow 57.3.0",
+ "arrow 58.0.0",
  "async-trait",
  "bigdecimal",
  "clap",
- "datafusion 52.4.0",
+ "datafusion 53.0.0",
  "datafusion-spark",
  "datafusion-substrait",
  "futures",
@@ -3381,9 +3409,9 @@ dependencies = [
  "indicatif",
  "itertools 0.14.0",
  "log",
- "object_store 0.12.5",
+ "object_store 0.13.1",
  "sqllogictest",
- "sqlparser",
+ "sqlparser 0.61.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3391,17 +3419,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-substrait"
-version = "52.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2379388ecab67079eeb1185c953fb9c5ed4b283fa3cb81417538378a30545957"
+version = "53.0.0"
+source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
 dependencies = [
  "async-recursion",
  "async-trait",
  "chrono",
- "datafusion 52.4.0",
+ "datafusion 53.0.0",
  "half",
  "itertools 0.14.0",
- "object_store 0.12.5",
+ "object_store 0.13.1",
  "pbjson-types",
  "prost 0.14.3",
  "substrait",
@@ -6662,20 +6689,17 @@ dependencies = [
  "bytes",
  "chrono",
  "flate2",
- "futures",
  "half",
  "hashbrown 0.16.1",
  "lz4_flex 0.12.0",
  "num-bigint",
  "num-integer",
  "num-traits",
- "object_store 0.12.5",
  "paste",
  "seq-macro",
  "simdutf8",
  "snap",
  "thrift",
- "tokio",
  "twox-hash",
  "zstd",
 ]
@@ -6705,6 +6729,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "object_store 0.13.1",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -8685,9 +8710,9 @@ dependencies = [
 
 [[package]]
 name = "sqllogictest"
-version = "0.28.4"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566426f72a13e393aa34ca3d542c5b0eb86da4c0db137ee9b5cfccc6179e52d"
+checksum = "d03b2262a244037b0b510edbd25a8e6c9fb8d73ee0237fc6cc95a54c16f94a82"
 dependencies = [
  "async-trait",
  "educe",
@@ -8715,8 +8740,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
 dependencies = [
  "log",
+ "sqlparser_derive 0.3.0",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+dependencies = [
+ "log",
  "recursive",
- "sqlparser_derive",
+ "sqlparser_derive 0.5.0",
 ]
 
 [[package]]
@@ -8724,6 +8759,17 @@ name = "sqlparser_derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9455,6 +9501,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -10268,19 +10315,19 @@ dependencies = [
  "anyhow",
  "arrow-schema 58.0.0",
  "async-trait",
- "datafusion 52.4.0",
- "datafusion-catalog 52.4.0",
- "datafusion-common 52.4.0",
- "datafusion-common-runtime 52.4.0",
- "datafusion-datasource 52.4.0",
- "datafusion-execution 52.4.0",
- "datafusion-expr 52.4.0",
- "datafusion-functions 52.4.0",
- "datafusion-physical-expr 52.4.0",
- "datafusion-physical-expr-adapter 52.4.0",
- "datafusion-physical-expr-common 52.4.0",
- "datafusion-physical-plan 52.4.0",
- "datafusion-pruning 52.4.0",
+ "datafusion 53.0.0",
+ "datafusion-catalog 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-pruning 53.0.0",
  "futures",
  "insta",
  "itertools 0.14.0",
@@ -10783,7 +10830,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "clap",
- "datafusion 52.4.0",
+ "datafusion 53.0.0",
  "datafusion-sqllogictest",
  "futures",
  "indicatif",
@@ -10828,7 +10875,7 @@ dependencies = [
  "clap",
  "console_error_panic_hook",
  "crossterm",
- "datafusion 52.4.0",
+ "datafusion 53.0.0",
  "env_logger",
  "flatbuffers",
  "futures",
@@ -11870,73 +11917,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "datafusion"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-catalog"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-common"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-common-runtime"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-datasource"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-execution"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-expr"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-functions"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-physical-expr"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-physical-expr-adapter"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-physical-expr-common"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-physical-plan"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-pruning"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"
-
-[[patch.unused]]
-name = "datafusion-sqllogictest"
-version = "53.0.0"
-source = "git+https://github.com/apache/datafusion?branch=branch-53#7698fdc5a46062205877d9d251c313902afef3f2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,20 +125,20 @@ cudarc = { version = "0.18.2", features = [
 custom-labels = "0.4.4"
 daachorse = "1.0.0"
 dashmap = "6.1.0"
-datafusion = { version = "52", default-features = false, features = ["sql"] }
-datafusion-catalog = { version = "52" }
-datafusion-common = { version = "52" }
-datafusion-common-runtime = { version = "52" }
-datafusion-datasource = { version = "52", default-features = false }
-datafusion-execution = { version = "52" }
-datafusion-expr = { version = "52" }
-datafusion-functions = { version = "52" }
-datafusion-physical-expr = { version = "52" }
-datafusion-physical-expr-adapter = { version = "52" }
-datafusion-physical-expr-common = { version = "52" }
-datafusion-physical-plan = { version = "52" }
-datafusion-pruning = { version = "52" }
-datafusion-sqllogictest = { version = "52" }
+datafusion = { version = "53", default-features = false, features = ["sql"] }
+datafusion-catalog = { version = "53" }
+datafusion-common = { version = "53" }
+datafusion-common-runtime = { version = "53" }
+datafusion-datasource = { version = "53", default-features = false }
+datafusion-execution = { version = "53" }
+datafusion-expr = { version = "53" }
+datafusion-functions = { version = "53" }
+datafusion-physical-expr = { version = "53" }
+datafusion-physical-expr-adapter = { version = "53" }
+datafusion-physical-expr-common = { version = "53" }
+datafusion-physical-plan = { version = "53" }
+datafusion-pruning = { version = "53" }
+datafusion-sqllogictest = { version = "53" }
 dirs = "6.0.0"
 divan = { package = "codspeed-divan-compat", version = "4.0.4" }
 enum-iterator = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,8 +196,8 @@ public-api = "0.51"
 pyo3 = { version = "0.28.0" }
 pyo3-bytes = "0.6"
 pyo3-log = "0.13.0"
-pyo3-object_store = "0.10.0"
-quote = "1.0.41"
+pyo3-object_store = "0.9.0"
+quote = "1.0.44"
 rand = "0.10.0"
 rand_distr = "0.6"
 ratatui = { version = "0.30", default-features = false }
@@ -224,7 +224,7 @@ sketches-ddsketch = "0.4.0"
 smol = "2.0.2"
 static_assertions = "1.1"
 strum = "0.28"
-syn = { version = "2.0.113", features = ["full"] }
+syn = { version = "2.0.117", features = ["full"] }
 sysinfo = "0.38.0"
 tabled = { version = "0.20.0", default-features = false }
 taffy = "0.9.0"
@@ -238,13 +238,14 @@ thiserror = "2.0.3"
 tokio = { version = "1.48" }
 tokio-stream = "0.1.17"
 tokio-util = "0.7.17"
-tpchgen = { version = "2.0.2" }
-tpchgen-arrow = { version = "2.0.2" }
+# Pull these into non-public crates to support DF 58
+tpchgen = { version = "2.0.2", git = "https://github.com/clflushopt/tpchgen-rs.git", rev = "438e9c2dbc25b2fff82c0efc08b3f13b5707874f" }
+tpchgen-arrow = { version = "2.0.2", git = "https://github.com/clflushopt/tpchgen-rs.git", rev = "438e9c2dbc25b2fff82c0efc08b3f13b5707874f" }
 tracing = { version = "0.1.41", default-features = false }
 tracing-perfetto = "0.1.5"
 tracing-subscriber = "0.3"
 url = "2.5.7"
-uuid = { version = "1.19", features = ["js"] }
+uuid = { version = "1.21", features = ["js"] }
 wasm-bindgen-futures = "0.4.54"
 xshell = "0.2.6"
 zigzag = "0.1.0"
@@ -375,21 +376,3 @@ lto = false
 [profile.bench_assert]
 debug-assertions = true
 inherits = "bench"
-
-[patch.crates-io]
-datafusion = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-catalog = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-common = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-common-runtime = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-datasource = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-execution = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-expr = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-functions = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-physical-expr = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-physical-expr-adapter = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-physical-expr-common = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-physical-plan = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-pruning = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-datafusion-sqllogictest = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
-tpchgen = { git = "https://github.com/AdamGS/tpchgen-rs.git", branch = "adamg/bump-arrow-match-df" }
-tpchgen-arrow = { git = "https://github.com/AdamGS/tpchgen-rs.git", branch = "adamg/bump-arrow-match-df" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,16 +88,16 @@ arbitrary = "1.3.2"
 arc-swap = "1.8"
 arcref = "0.2.0"
 arrayref = "0.3.7"
-arrow-arith = "57.1"
-arrow-array = "57.1"
-arrow-buffer = "57.1"
-arrow-cast = "57.1"
-arrow-data = "57.1"
-arrow-ipc = "57.1"
-arrow-ord = "57.1"
-arrow-schema = "57.1"
-arrow-select = "57.1"
-arrow-string = "57.1"
+arrow-arith = "58"
+arrow-array = "58"
+arrow-buffer = "58"
+arrow-cast = "58"
+arrow-data = "58"
+arrow-ipc = "58"
+arrow-ord = "58"
+arrow-schema = "58"
+arrow-select = "58"
+arrow-string = "58"
 async-fs = "2.2.0"
 async-lock = "3.4"
 async-stream = "0.3.6"
@@ -176,14 +176,14 @@ noodles-bgzf = "0.46.0"
 noodles-vcf = { version = "0.86.0", features = ["async"] }
 num-traits = "0.2.19"
 num_enum = { version = "0.7.3", default-features = false }
-object_store = { version = "0.12.4", default-features = false }
+object_store = { version = "0.13.1", default-features = false }
 once_cell = "1.21"
 oneshot = { version = "0.2.0", features = ["async"] }
 opentelemetry = "0.31.0"
 opentelemetry-otlp = "0.31.0"
 opentelemetry_sdk = "0.31.0"
 parking_lot = { version = "0.12.3", features = ["nightly"] }
-parquet = "57.1"
+parquet = "58"
 paste = "1.0.15"
 pco = "1.0.1"
 pin-project-lite = "0.2.15"
@@ -375,3 +375,21 @@ lto = false
 [profile.bench_assert]
 debug-assertions = true
 inherits = "bench"
+
+[patch.crates-io]
+datafusion = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-catalog = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-common = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-common-runtime = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-datasource = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-execution = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-expr = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-functions = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-physical-expr = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-physical-expr-adapter = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-physical-expr-common = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-physical-plan = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-pruning = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+datafusion-sqllogictest = { git = "https://github.com/apache/datafusion", branch = "branch-53" }
+tpchgen = { git = "https://github.com/AdamGS/tpchgen-rs.git", branch = "adamg/bump-arrow-match-df" }
+tpchgen-arrow = { git = "https://github.com/AdamGS/tpchgen-rs.git", branch = "adamg/bump-arrow-match-df" }

--- a/vortex-bench/src/random_access/take.rs
+++ b/vortex-bench/src/random_access/take.rs
@@ -14,6 +14,7 @@ use itertools::Itertools;
 use parquet::arrow::ParquetRecordBatchStreamBuilder;
 use parquet::arrow::arrow_reader::ArrowReaderMetadata;
 use parquet::arrow::arrow_reader::ArrowReaderOptions;
+use parquet::file::metadata::PageIndexPolicy;
 use stream::StreamExt;
 use tokio::fs::File;
 use vortex::array::Canonical;
@@ -100,7 +101,7 @@ impl ParquetRandomAccessor {
     /// Open a Parquet file, parse the footer, and return a ready-to-use accessor.
     pub async fn open(path: PathBuf, name: impl Into<String>) -> anyhow::Result<Self> {
         let mut file = File::open(&path).await?;
-        let options = ArrowReaderOptions::new().with_page_index(true);
+        let options = ArrowReaderOptions::new().with_page_index_policy(PageIndexPolicy::Required);
         let arrow_metadata = ArrowReaderMetadata::load_async(&mut file, options).await?;
 
         let row_group_offsets = once(0)

--- a/vortex-cuda/src/pooled_read_at.rs
+++ b/vortex-cuda/src/pooled_read_at.rs
@@ -13,6 +13,7 @@ use object_store::GetOptions;
 use object_store::GetRange;
 use object_store::GetResultPayload;
 use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use object_store::path::Path as ObjectPath;
 use vortex::array::buffer::BufferHandle;
 use vortex::buffer::Alignment;

--- a/vortex-datafusion/src/convert/exprs.rs
+++ b/vortex-datafusion/src/convert/exprs.rs
@@ -395,7 +395,8 @@ fn try_operator_from_df(value: &DFOperator) -> DFResult<Operator> {
         | DFOperator::AtQuestion
         | DFOperator::Question
         | DFOperator::QuestionAnd
-        | DFOperator::QuestionPipe => {
+        | DFOperator::QuestionPipe
+        | DFOperator::Colon => {
             tracing::debug!(operator = %value, "Can't pushdown binary_operator operator");
             Err(exec_datafusion_err!(
                 "Unsupported datafusion operator {value}"

--- a/vortex-datafusion/src/persistent/format.rs
+++ b/vortex-datafusion/src/persistent/format.rs
@@ -32,6 +32,7 @@ use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::file_sink_config::FileSinkConfig;
 use datafusion_datasource::sink::DataSinkExec;
 use datafusion_datasource::source::DataSourceExec;
+use datafusion_execution::cache::cache_manager::CachedFileMetadataEntry;
 use datafusion_expr::dml::InsertOp;
 use datafusion_physical_expr::LexRequirement;
 use datafusion_physical_plan::ExecutionPlan;
@@ -251,16 +252,19 @@ impl FileFormat for VortexFormat {
                 let cache = file_metadata_cache.clone();
 
                 SpawnedTask::spawn(async move {
-                    // Check if we have cached metadata for this file
-                    if let Some(cached) = cache.get(&object)
-                        && let Some(cached_vortex) =
-                            cached.as_any().downcast_ref::<CachedVortexMetadata>()
+                    // Check if we have entry metadata for this file
+                    if let Some(entry) = cache.get(&object.location)
+                        && entry.is_valid_for(&object)
+                        && let Some(cached_vortex) = entry
+                            .file_metadata
+                            .as_any()
+                            .downcast_ref::<CachedVortexMetadata>()
                     {
                         let inferred_schema = cached_vortex.footer().dtype().to_arrow_schema()?;
                         return VortexResult::Ok((object.location, inferred_schema));
                     }
 
-                    // Not cached or invalid - open the file
+                    // Not entry or invalid - open the file
                     let reader = Arc::new(ObjectStoreReadAt::new(
                         store,
                         object.location.clone(),
@@ -276,7 +280,8 @@ impl FileFormat for VortexFormat {
 
                     // Cache the metadata
                     let cached_metadata = Arc::new(CachedVortexMetadata::new(&vxf));
-                    cache.put(&object, cached_metadata);
+                    let entry = CachedFileMetadataEntry::new(object.clone(), cached_metadata);
+                    cache.put(&object.location, entry);
 
                     let inferred_schema = vxf.dtype().to_arrow_schema()?;
                     VortexResult::Ok((object.location, inferred_schema))
@@ -310,24 +315,28 @@ impl FileFormat for VortexFormat {
         let file_metadata_cache = state.runtime_env().cache_manager.get_file_metadata_cache();
 
         SpawnedTask::spawn(async move {
-            // Try to get cached metadata first
-            let cached_metadata = file_metadata_cache.get(&object).and_then(|cached| {
-                cached
-                    .as_any()
-                    .downcast_ref::<CachedVortexMetadata>()
-                    .map(|m| {
-                        (
-                            m.footer().dtype().clone(),
-                            m.footer().statistics().cloned(),
-                            m.footer().row_count(),
-                        )
-                    })
-            });
+            // Try to get entry metadata first
+            let cached_metadata = file_metadata_cache
+                .get(&object.location)
+                .filter(|entry| entry.is_valid_for(&object))
+                .and_then(|entry| {
+                    entry
+                        .file_metadata
+                        .as_any()
+                        .downcast_ref::<CachedVortexMetadata>()
+                        .map(|m| {
+                            (
+                                m.footer().dtype().clone(),
+                                m.footer().statistics().cloned(),
+                                m.footer().row_count(),
+                            )
+                        })
+                });
 
             let (dtype, file_stats, row_count) = match cached_metadata {
                 Some(metadata) => metadata,
                 None => {
-                    // Not cached - open the file
+                    // Not entry - open the file
                     let reader = Arc::new(ObjectStoreReadAt::new(
                         store,
                         object.location.clone(),
@@ -348,8 +357,9 @@ impl FileFormat for VortexFormat {
                         })?;
 
                     // Cache the metadata
-                    let cached = Arc::new(CachedVortexMetadata::new(&vxf));
-                    file_metadata_cache.put(&object, cached);
+                    let file_metadata = Arc::new(CachedVortexMetadata::new(&vxf));
+                    let entry = CachedFileMetadataEntry::new(object.clone(), file_metadata);
+                    file_metadata_cache.put(&object.location, entry);
 
                     (
                         vxf.dtype().clone(),

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -185,8 +185,10 @@ impl FileOpener for VortexOpener {
                 .with_labels(labels);
 
             if let Some(file_metadata_cache) = file_metadata_cache
-                && let Some(file_metadata) = file_metadata_cache.get(&file.object_meta)
-                && let Some(vortex_metadata) = file_metadata
+                && let Some(entry) = file_metadata_cache.get(&file.path())
+                && entry.is_valid_for(&file.object_meta)
+                && let Some(vortex_metadata) = entry
+                    .file_metadata
                     .as_any()
                     .downcast_ref::<CachedVortexMetadata>()
             {
@@ -210,7 +212,7 @@ impl FileOpener for VortexOpener {
             let expr_adapter = expr_adapter_factory.create(
                 Arc::clone(&unified_file_schema),
                 Arc::clone(&this_file_schema),
-            );
+            )?;
 
             let simplifier = PhysicalExprSimplifier::new(&this_file_schema);
 

--- a/vortex-datafusion/src/persistent/opener.rs
+++ b/vortex-datafusion/src/persistent/opener.rs
@@ -185,7 +185,7 @@ impl FileOpener for VortexOpener {
                 .with_labels(labels);
 
             if let Some(file_metadata_cache) = file_metadata_cache
-                && let Some(entry) = file_metadata_cache.get(&file.path())
+                && let Some(entry) = file_metadata_cache.get(file.path())
                 && entry.is_valid_for(&file.object_meta)
                 && let Some(vortex_metadata) = entry
                     .file_metadata

--- a/vortex-io/src/object_store/read_at.rs
+++ b/vortex-io/src/object_store/read_at.rs
@@ -11,6 +11,7 @@ use object_store::GetOptions;
 use object_store::GetRange;
 use object_store::GetResultPayload;
 use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use object_store::path::Path as ObjectPath;
 use vortex_array::buffer::BufferHandle;
 use vortex_buffer::Alignment;

--- a/vortex-io/src/object_store/write.rs
+++ b/vortex-io/src/object_store/write.rs
@@ -9,6 +9,7 @@ use futures::TryStreamExt;
 use futures::stream::FuturesUnordered;
 use object_store::MultipartUpload;
 use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use object_store::PutPayload;
 use object_store::PutResult;
 use object_store::path::Path;

--- a/vortex-jni/src/file.rs
+++ b/vortex-jni/src/file.rs
@@ -15,6 +15,7 @@ use jni::objects::ReleaseMode;
 use jni::sys::jlong;
 use jni::sys::jobject;
 use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use object_store::path::Path;
 use prost::Message;
 use url::Url;

--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -52,7 +52,7 @@ parking_lot = { workspace = true }
 pyo3 = { workspace = true, features = ["abi3", "abi3-py311"] }
 pyo3-bytes = { workspace = true }
 pyo3-log = { workspace = true }
-pyo3-object_store = { version = "0.8" }
+pyo3-object_store = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 url = { workspace = true }
 vortex = { workspace = true, features = ["object_store", "tokio"] }

--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -52,7 +52,7 @@ parking_lot = { workspace = true }
 pyo3 = { workspace = true, features = ["abi3", "abi3-py311"] }
 pyo3-bytes = { workspace = true }
 pyo3-log = { workspace = true }
-pyo3-object_store = { workspace = true }
+pyo3-object_store = { version = "0.8" }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 url = { workspace = true }
 vortex = { workspace = true, features = ["object_store", "tokio"] }

--- a/vortex-sqllogictest/Cargo.toml
+++ b/vortex-sqllogictest/Cargo.toml
@@ -23,7 +23,7 @@ datafusion-sqllogictest = { workspace = true }
 futures.workspace = true
 indicatif.workspace = true
 rstest = { workspace = true }
-sqllogictest = "0.28"
+sqllogictest = "0.29.1"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 vortex = { workspace = true, features = ["tokio"] }


### PR DESCRIPTION
Just a routine upgrade to DataFusion 53.

- Tracking issue for the release: https://github.com/apache/datafusion/issues/19692

This PR includes a perf regression that is fixed by https://github.com/vortex-data/vortex/pull/7176, keeping them as separate PRs so it doesn't get lost in all the noise here.

~Things left here~ All done!
- [x] Either wait for https://github.com/clflushopt/tpchgen-rs/pull/246 to merge and release, or change how we generate data in benchmarks (either by removing the dependency on `tpchgen-arrow` or using the CLI).
- [x] Go through the 53 release changelog and see if there's anything new we should take advantage of or adjust.
- [x] Finish the `object_store` upgrade