### PR TITLE
Configure benchmark boxes to try and reduce noise

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -57,6 +57,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup benchmark environment
+        run: sudo bash scripts/setup-benchmark.sh
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -54,6 +54,8 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v6
+      - name: Setup benchmark environment
+        run: sudo bash scripts/setup-benchmark.sh
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -726,6 +726,8 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v6
+      - name: Setup benchmark environment
+        run: sudo bash scripts/setup-benchmark.sh
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -118,6 +118,8 @@ jobs:
 
       - uses: actions/checkout@v6
         if: inputs.mode != 'pr'
+      - name: Setup benchmark environment
+        run: sudo bash scripts/setup-benchmark.sh
       - uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/setup-benchmark.sh
+++ b/scripts/setup-benchmark.sh
@@ -20,14 +20,11 @@ sudo sysctl kernel.randomize_va_space
 dmesg -n 1
 
 # Disable some unused services and features
-sudo systemctl stop apparmor snapd unattended-upgrades multipathd ModemManager
-sudo systemctl disable apparmor snapd unattended-upgrades multipathd ModemManager
+sudo systemctl stop apparmor ModemManager
+sudo systemctl disable apparmor ModemManager
 
 # mask prevents them from being started by other services
-sudo systemctl mask snapd unattended-upgrades multipathd ModemManager
+sudo systemctl mask ModemManager
 
 # For apparmor specifically, also teardown loaded profiles
 sudo aa-teardown
-
-# For auditd, also disable kernel audit
-sudo auditctl -e 0

--- a/scripts/setup-benchmark.sh
+++ b/scripts/setup-benchmark.sh
@@ -11,20 +11,20 @@ if [ "$EUID" -ne 0 ]; then
 fi
 
 # Really discourage swapping to disk
-sudo sysctl vm.swappiness=0
+sysctl vm.swappiness=0
 
 # Disable ASLR - https://docs.kernel.org/admin-guide/sysctl/kernel.html#randomize-va-space
-sudo sysctl kernel.randomize_va_space=0
+sysctl kernel.randomize_va_space=0
 
 # Reduce kernel logging to minimum
 dmesg -n 1
 
 # Disable some unused services and features
-sudo systemctl stop apparmor ModemManager
-sudo systemctl disable apparmor ModemManager
+systemctl stop apparmor ModemManager
+systemctl disable apparmor ModemManager
 
 # mask prevents them from being started by other services
-sudo systemctl mask ModemManager
+systemctl mask ModemManager
 
 # For apparmor specifically, also teardown loaded profiles
-sudo aa-teardown
+aa-teardown

--- a/scripts/setup-benchmark.sh
+++ b/scripts/setup-benchmark.sh
@@ -10,6 +10,11 @@ if [ "$EUID" -ne 0 ]; then
     exit 0
 fi
 
+# Turn off frequency scaling
+for gov in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+    echo performance > "$gov" 2>/dev/null || true
+done
+
 # Really discourage swapping to disk
 sysctl vm.swappiness=0
 

--- a/scripts/setup-benchmark.sh
+++ b/scripts/setup-benchmark.sh
@@ -14,7 +14,7 @@ fi
 sudo sysctl vm.swappiness=0
 
 # Disable ASLR - https://docs.kernel.org/admin-guide/sysctl/kernel.html#randomize-va-space
-sudo sysctl kernel.randomize_va_space
+sudo sysctl kernel.randomize_va_space=0
 
 # Reduce kernel logging to minimum
 dmesg -n 1

--- a/scripts/setup-benchmark.sh
+++ b/scripts/setup-benchmark.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+set -Eeu -o pipefail -x
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Environment setup script for benchmarks should run as root."
+    exit 0
+fi
+
+# Really discourage swapping to disk
+sudo sysctl vm.swappiness=0
+
+# Disable ASLR - https://docs.kernel.org/admin-guide/sysctl/kernel.html#randomize-va-space
+sudo sysctl kernel.randomize_va_space
+
+# Reduce kernel logging to minimum
+dmesg -n 1
+
+# Disable some unused services and features
+sudo systemctl stop apparmor snapd unattended-upgrades multipathd ModemManager
+sudo systemctl disable apparmor snapd unattended-upgrades multipathd ModemManager
+
+# mask prevents them from being started by other services
+sudo systemctl mask snapd unattended-upgrades multipathd ModemManager
+
+# For apparmor specifically, also teardown loaded profiles
+sudo aa-teardown
+
+# For auditd, also disable kernel audit
+sudo auditctl -e 0


### PR DESCRIPTION
This PR introduces a script to try and cleanup some noise from linux machines, disabling background services and trying to configuring memory behavior better.