### PR TITLE
Make the constant metadata a `Scalar`

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -812,7 +812,7 @@ impl vortex_array::vtable::VTable for vortex_array::arrays::ConstantVTable
 
 pub type vortex_array::arrays::ConstantVTable::Array = vortex_array::arrays::ConstantArray
 
-pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::scalar::Scalar
 
 pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::arrays::ConstantVTable
 
@@ -828,13 +828,13 @@ pub fn vortex_array::arrays::ConstantVTable::buffer(array: &vortex_array::arrays
 
 pub fn vortex_array::arrays::ConstantVTable::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ConstantVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
+pub fn vortex_array::arrays::ConstantVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
 
 pub fn vortex_array::arrays::ConstantVTable::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
 
 pub fn vortex_array::arrays::ConstantVTable::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
 
@@ -846,7 +846,7 @@ pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_
 
 pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::metadata(_array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
 
@@ -16682,7 +16682,7 @@ impl vortex_array::vtable::VTable for vortex_array::arrays::ConstantVTable
 
 pub type vortex_array::arrays::ConstantVTable::Array = vortex_array::arrays::ConstantArray
 
-pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::scalar::Scalar
 
 pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::arrays::ConstantVTable
 
@@ -16698,13 +16698,13 @@ pub fn vortex_array::arrays::ConstantVTable::buffer(array: &vortex_array::arrays
 
 pub fn vortex_array::arrays::ConstantVTable::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ConstantVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
+pub fn vortex_array::arrays::ConstantVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
 
 pub fn vortex_array::arrays::ConstantVTable::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
 
 pub fn vortex_array::arrays::ConstantVTable::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
 
@@ -16716,7 +16716,7 @@ pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_
 
 pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::metadata(_array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
 

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -11,7 +11,6 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 
 use crate::ArrayRef;
-use crate::EmptyMetadata;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::Precision;
@@ -43,7 +42,7 @@ impl ConstantVTable {
 impl VTable for ConstantVTable {
     type Array = ConstantArray;
 
-    type Metadata = EmptyMetadata;
+    type Metadata = Scalar;
     type OperationsVTable = Self;
     type ValidityVTable = Self;
 
@@ -108,31 +107,23 @@ impl VTable for ConstantVTable {
         vortex_panic!("ConstantArray child_name index {idx} out of bounds")
     }
 
-    fn metadata(_array: &ConstantArray) -> VortexResult<Self::Metadata> {
-        Ok(EmptyMetadata)
+    fn metadata(array: &ConstantArray) -> VortexResult<Self::Metadata> {
+        Ok(array.scalar().clone())
     }
 
     fn serialize(_metadata: Self::Metadata) -> VortexResult<Option<Vec<u8>>> {
-        Ok(Some(Vec::new()))
+        // HACK: Because the scalar is stored in the buffers, we do not need to serialize the
+        // metadata at all.
+        Ok(Some(vec![]))
     }
 
     fn deserialize(
         _bytes: &[u8],
-        _dtype: &DType,
+        dtype: &DType,
         _len: usize,
-        _buffers: &[BufferHandle],
+        buffers: &[BufferHandle],
         _session: &VortexSession,
     ) -> VortexResult<Self::Metadata> {
-        Ok(EmptyMetadata)
-    }
-
-    fn build(
-        dtype: &DType,
-        len: usize,
-        _metadata: &Self::Metadata,
-        buffers: &[BufferHandle],
-        _children: &dyn ArrayChildren,
-    ) -> VortexResult<ConstantArray> {
         vortex_ensure!(
             buffers.len() == 1,
             "Expected 1 buffer, got {}",
@@ -145,7 +136,17 @@ impl VTable for ConstantVTable {
         let scalar_value = ScalarValue::from_proto_bytes(bytes, dtype)?;
         let scalar = Scalar::try_new(dtype.clone(), scalar_value)?;
 
-        Ok(ConstantArray::new(scalar, len))
+        Ok(scalar)
+    }
+
+    fn build(
+        _dtype: &DType,
+        len: usize,
+        metadata: &Self::Metadata,
+        _buffers: &[BufferHandle],
+        _children: &dyn ArrayChildren,
+    ) -> VortexResult<ConstantArray> {
+        Ok(ConstantArray::new(metadata.clone(), len))
     }
 
     fn with_children(_array: &mut Self::Array, children: Vec<ArrayRef>) -> VortexResult<()> {


### PR DESCRIPTION
## Summary

Tracking Issue: https://github.com/vortex-data/vortex/issues/6771

Changes the `Metadata` for `ConstantArray` to be a `Scalar`. Note that this is not a breaking change since the `Metadata` is purely an in-memory construct.

## Testing

All of the existing tests should be sufficient.