### PR TITLE
Fast path append_to_builder ConstantArray

### DIFF
--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -13,6 +13,7 @@ use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ChunkedArray;
+use vortex_array::arrays::ConstantArray;
 use vortex_array::builders::ArrayBuilder;
 use vortex_array::builders::VarBinViewBuilder;
 use vortex_array::builders::builder_with_capacity;
@@ -118,6 +119,27 @@ fn chunked_varbinview_opt_into_canonical(bencher: Bencher, (len, chunk_count): (
     bencher
         .with_inputs(|| &chunks)
         .bench_refs(|chunk| chunk.to_canonical())
+}
+
+#[divan::bench(args = BENCH_ARGS)]
+fn chunked_constant_i32_append_to_builder(bencher: Bencher, (len, chunk_count): (usize, usize)) {
+    let chunk = make_constant_i32_chunks(len, chunk_count);
+
+    bencher.with_inputs(|| &chunk).bench_refs(|chunk| {
+        let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
+        chunk
+            .append_to_builder(builder.as_mut(), &mut SESSION.create_execution_ctx())
+            .vortex_expect("append failed");
+        builder.finish()
+    })
+}
+
+fn make_constant_i32_chunks(len: usize, chunk_count: usize) -> ArrayRef {
+    // Each chunk is a ConstantArray of i32; dtype is I32/NonNullable via From<i32> for Scalar.
+    (0..chunk_count)
+        .map(|i| ConstantArray::new(i as i32, len).into_array())
+        .collect::<ChunkedArray>()
+        .into_array()
 }
 
 fn make_opt_bool_chunks(len: usize, chunk_count: usize) -> ArrayRef {

--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -137,7 +137,7 @@ fn chunked_constant_i32_append_to_builder(bencher: Bencher, (len, chunk_count): 
 fn make_constant_i32_chunks(len: usize, chunk_count: usize) -> ArrayRef {
     // Each chunk is a ConstantArray of i32; dtype is I32/NonNullable via From<i32> for Scalar.
     (0..chunk_count)
-        .map(|i| ConstantArray::new(i as i32, len).into_array())
+        .map(|_| ConstantArray::new(42i32, len).into_array())
         .collect::<ChunkedArray>()
         .into_array()
 }

--- a/vortex-array/benches/chunk_array_builder.rs
+++ b/vortex-array/benches/chunk_array_builder.rs
@@ -134,6 +134,40 @@ fn chunked_constant_i32_append_to_builder(bencher: Bencher, (len, chunk_count): 
     })
 }
 
+const CONSTANT_UTF8_BENCH_ARGS: &[(&str, usize, usize)] = &[
+    // value, length, chunk_count
+    ("hi", 1000, 10),            // inline (≤12 bytes)
+    ("hello world!!", 1000, 10), // non-inline (>12 bytes)
+];
+
+#[divan::bench(args = CONSTANT_UTF8_BENCH_ARGS)]
+fn chunked_constant_utf8_append_to_builder(
+    bencher: Bencher,
+    (value, len, chunk_count): (&str, usize, usize),
+) {
+    let chunk = make_constant_utf8_chunks(value, len, chunk_count);
+
+    bencher.with_inputs(|| &chunk).bench_refs(|chunk| {
+        let mut builder = builder_with_capacity(chunk.dtype(), len * chunk_count);
+        chunk
+            .append_to_builder(builder.as_mut(), &mut SESSION.create_execution_ctx())
+            .vortex_expect("append failed");
+        builder.finish()
+    })
+}
+
+fn make_constant_utf8_chunks(value: &str, len: usize, chunk_count: usize) -> ArrayRef {
+    use vortex_array::dtype::Nullability;
+    use vortex_array::scalar::Scalar;
+
+    (0..chunk_count)
+        .map(|_| {
+            ConstantArray::new(Scalar::utf8(value, Nullability::NonNullable), len).into_array()
+        })
+        .collect::<ChunkedArray>()
+        .into_array()
+}
+
 fn make_constant_i32_chunks(len: usize, chunk_count: usize) -> ArrayRef {
     // Each chunk is a ConstantArray of i32; dtype is I32/NonNullable via From<i32> for Scalar.
     (0..chunk_count)

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -818,7 +818,7 @@ pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::
 
 pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 
@@ -4933,6 +4933,8 @@ pub struct vortex_array::builders::PrimitiveBuilder<T>
 impl<T: vortex_array::dtype::NativePType> vortex_array::builders::PrimitiveBuilder<T>
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::append_value(&mut self, value: T)
+
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_value_n(&mut self, value: T, n: usize)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::extend_with_iterator(&mut self, iter: impl core::iter::traits::collect::IntoIterator<Item = T>, mask: vortex_mask::Mask)
 
@@ -16644,7 +16646,7 @@ pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::
 
 pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -818,7 +818,7 @@ pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::
 
 pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 
@@ -4588,6 +4588,8 @@ pub struct vortex_array::builders::DecimalBuilder
 
 impl vortex_array::builders::DecimalBuilder
 
+pub fn vortex_array::builders::DecimalBuilder::append_n_values<V: vortex_array::dtype::NativeDecimalType>(&mut self, value: V, n: usize)
+
 pub fn vortex_array::builders::DecimalBuilder::append_value<V: vortex_array::dtype::NativeDecimalType>(&mut self, value: V)
 
 pub fn vortex_array::builders::DecimalBuilder::decimal_dtype(&self) -> &vortex_array::dtype::DecimalDType
@@ -4932,9 +4934,9 @@ pub struct vortex_array::builders::PrimitiveBuilder<T>
 
 impl<T: vortex_array::dtype::NativePType> vortex_array::builders::PrimitiveBuilder<T>
 
-pub fn vortex_array::builders::PrimitiveBuilder<T>::append_value(&mut self, value: T)
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_n_values(&mut self, value: T, n: usize)
 
-pub fn vortex_array::builders::PrimitiveBuilder<T>::append_value_n(&mut self, value: T, n: usize)
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_value(&mut self, value: T)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::extend_with_iterator(&mut self, iter: impl core::iter::traits::collect::IntoIterator<Item = T>, mask: vortex_mask::Mask)
 
@@ -5069,6 +5071,8 @@ pub unsafe fn vortex_array::builders::UninitRange<'_, T>::slice_uninit_mut(&mut 
 pub struct vortex_array::builders::VarBinViewBuilder
 
 impl vortex_array::builders::VarBinViewBuilder
+
+pub fn vortex_array::builders::VarBinViewBuilder::append_n_values<S: core::convert::AsRef<[u8]>>(&mut self, value: S, n: usize)
 
 pub fn vortex_array::builders::VarBinViewBuilder::append_value<S: core::convert::AsRef<[u8]>>(&mut self, value: S)
 
@@ -16646,7 +16650,7 @@ pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::
 
 pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 
 use vortex_buffer::ByteBufferMut;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_panic;
@@ -18,7 +19,10 @@ use crate::arrays::ConstantArray;
 use crate::arrays::constant::compute::rules::PARENT_RULES;
 use crate::arrays::constant::vtable::canonical::constant_canonicalize;
 use crate::buffer::BufferHandle;
+use crate::builders::ArrayBuilder;
+use crate::builders::PrimitiveBuilder;
 use crate::dtype::DType;
+use crate::match_each_native_ptype;
 use crate::scalar::Scalar;
 use crate::scalar::ScalarValue;
 use crate::serde::ArrayChildren;
@@ -168,5 +172,38 @@ impl VTable for ConstantVTable {
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
         Ok(constant_canonicalize(array)?.into_array())
+    }
+
+    fn append_to_builder(
+        array: &ConstantArray,
+        builder: &mut dyn ArrayBuilder,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<()> {
+        match array.dtype() {
+            DType::Primitive(ptype, _) => {
+                match_each_native_ptype!(ptype, |P| {
+                    let pbuilder = builder
+                        .as_any_mut()
+                        .downcast_mut::<PrimitiveBuilder<P>>()
+                        .vortex_expect("Expected PrimitiveBuilder for primitive ConstantArray");
+                    if array.scalar().is_null() {
+                        // SAFETY: append_nulls_unchecked requires a nullable builder.
+                        // A null scalar implies a nullable dtype, so the builder created
+                        // for this array's dtype is necessarily nullable.
+                        unsafe { pbuilder.append_nulls_unchecked(array.len()) }
+                    } else {
+                        let value = P::try_from(array.scalar())
+                            .vortex_expect("Couldn't unwrap constant scalar to primitive");
+                        pbuilder.append_value_n(value, array.len());
+                    }
+                });
+                Ok(())
+            }
+            _ => {
+                let canonical = constant_canonicalize(array)?.into_array();
+                builder.extend_from_array(&canonical);
+                Ok(())
+            }
+        }
     }
 }

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -20,9 +20,16 @@ use crate::arrays::constant::compute::rules::PARENT_RULES;
 use crate::arrays::constant::vtable::canonical::constant_canonicalize;
 use crate::buffer::BufferHandle;
 use crate::builders::ArrayBuilder;
+use crate::builders::BoolBuilder;
+use crate::builders::DecimalBuilder;
+use crate::builders::NullBuilder;
 use crate::builders::PrimitiveBuilder;
+use crate::builders::VarBinViewBuilder;
+use crate::canonical::Canonical;
 use crate::dtype::DType;
+use crate::match_each_decimal_value;
 use crate::match_each_native_ptype;
+use crate::scalar::DecimalValue;
 use crate::scalar::Scalar;
 use crate::scalar::ScalarValue;
 use crate::serde::ArrayChildren;
@@ -177,33 +184,243 @@ impl VTable for ConstantVTable {
     fn append_to_builder(
         array: &ConstantArray,
         builder: &mut dyn ArrayBuilder,
-        _ctx: &mut ExecutionCtx,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
+        let n = array.len();
+        let scalar = array.scalar();
+
         match array.dtype() {
+            DType::Null => append_value_or_nulls::<NullBuilder>(builder, true, n, |_| {}),
+            DType::Bool(_) => {
+                append_value_or_nulls::<BoolBuilder>(builder, scalar.is_null(), n, |b| {
+                    b.append_values(
+                        scalar
+                            .as_bool()
+                            .value()
+                            .vortex_expect("non-null bool scalar must have a value"),
+                        n,
+                    );
+                })
+            }
             DType::Primitive(ptype, _) => {
                 match_each_native_ptype!(ptype, |P| {
-                    let pbuilder = builder
-                        .as_any_mut()
-                        .downcast_mut::<PrimitiveBuilder<P>>()
-                        .vortex_expect("Expected PrimitiveBuilder for primitive ConstantArray");
-                    if array.scalar().is_null() {
-                        // SAFETY: append_nulls_unchecked requires a nullable builder.
-                        // A null scalar implies a nullable dtype, so the builder created
-                        // for this array's dtype is necessarily nullable.
-                        unsafe { pbuilder.append_nulls_unchecked(array.len()) }
-                    } else {
-                        let value = P::try_from(array.scalar())
-                            .vortex_expect("Couldn't unwrap constant scalar to primitive");
-                        pbuilder.append_value_n(value, array.len());
-                    }
+                    append_value_or_nulls::<PrimitiveBuilder<P>>(
+                        builder,
+                        scalar.is_null(),
+                        n,
+                        |b| {
+                            let value = P::try_from(scalar)
+                                .vortex_expect("Couldn't unwrap constant scalar to primitive");
+                            b.append_n_values(value, n);
+                        },
+                    );
                 });
-                Ok(())
             }
+            DType::Decimal(..) => {
+                append_value_or_nulls::<DecimalBuilder>(builder, scalar.is_null(), n, |b| {
+                    let value = scalar
+                        .as_decimal()
+                        .decimal_value()
+                        .vortex_expect("non-null decimal scalar must have a value");
+                    match_each_decimal_value!(value, |v| { b.append_n_values(v, n) });
+                });
+            }
+            DType::Utf8(_) => {
+                append_value_or_nulls::<VarBinViewBuilder>(builder, scalar.is_null(), n, |b| {
+                    let typed = scalar.as_utf8();
+                    let value = typed
+                        .value()
+                        .vortex_expect("non-null utf8 scalar must have a value");
+                    b.append_n_values(value.as_bytes(), n);
+                });
+            }
+            DType::Binary(_) => {
+                append_value_or_nulls::<VarBinViewBuilder>(builder, scalar.is_null(), n, |b| {
+                    let typed = scalar.as_binary();
+                    let value = typed
+                        .value()
+                        .vortex_expect("non-null binary scalar must have a value");
+                    b.append_n_values(value, n);
+                });
+            }
+            // TODO: add fast paths for DType::Struct, DType::List, DType::FixedSizeList, DType::Extension.
             _ => {
-                let canonical = constant_canonicalize(array)?.into_array();
+                let canonical = array
+                    .clone()
+                    .into_array()
+                    .execute::<Canonical>(ctx)?
+                    .into_array();
                 builder.extend_from_array(&canonical);
-                Ok(())
             }
         }
+
+        Ok(())
+    }
+}
+
+/// Downcasts `builder` to `B`, then either appends `n` nulls or calls `fill` with the typed
+/// builder depending on `is_null`.
+///
+/// `is_null` must only be `true` when the builder is nullable.
+fn append_value_or_nulls<B: ArrayBuilder + 'static>(
+    builder: &mut dyn ArrayBuilder,
+    is_null: bool,
+    n: usize,
+    fill: impl FnOnce(&mut B),
+) {
+    let b = builder
+        .as_any_mut()
+        .downcast_mut::<B>()
+        .vortex_expect("builder dtype must match array dtype");
+    if is_null {
+        // SAFETY: is_null=true only when the scalar (and thus the builder) is nullable.
+        unsafe { b.append_nulls_unchecked(n) };
+    } else {
+        fill(b);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+    use vortex_session::VortexSession;
+
+    use crate::ExecutionCtx;
+    use crate::IntoArray;
+    use crate::arrays::ConstantArray;
+    use crate::arrays::constant::vtable::canonical::constant_canonicalize;
+    use crate::assert_arrays_eq;
+    use crate::builders::builder_with_capacity;
+    use crate::dtype::DType;
+    use crate::dtype::Nullability;
+    use crate::dtype::PType;
+    use crate::dtype::StructFields;
+    use crate::scalar::Scalar;
+
+    fn ctx() -> ExecutionCtx {
+        ExecutionCtx::new(VortexSession::empty())
+    }
+
+    /// Appends `array` into a fresh builder and asserts the result matches `constant_canonicalize`.
+    fn assert_append_matches_canonical(array: ConstantArray) -> vortex_error::VortexResult<()> {
+        let expected = constant_canonicalize(&array)?.into_array();
+        let mut builder = builder_with_capacity(array.dtype(), array.len());
+        array
+            .into_array()
+            .append_to_builder(builder.as_mut(), &mut ctx())?;
+        let result = builder.finish();
+        assert_arrays_eq!(&result, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn test_null_constant_append() -> vortex_error::VortexResult<()> {
+        assert_append_matches_canonical(ConstantArray::new(Scalar::null(DType::Null), 5))
+    }
+
+    #[rstest]
+    #[case::bool_true(true, 5)]
+    #[case::bool_false(false, 3)]
+    fn test_bool_constant_append(
+        #[case] value: bool,
+        #[case] n: usize,
+    ) -> vortex_error::VortexResult<()> {
+        assert_append_matches_canonical(ConstantArray::new(
+            Scalar::bool(value, Nullability::NonNullable),
+            n,
+        ))
+    }
+
+    #[test]
+    fn test_bool_null_constant_append() -> vortex_error::VortexResult<()> {
+        assert_append_matches_canonical(ConstantArray::new(
+            Scalar::null(DType::Bool(Nullability::Nullable)),
+            4,
+        ))
+    }
+
+    #[rstest]
+    #[case::i32(Scalar::primitive(42i32, Nullability::NonNullable), 5)]
+    #[case::u8(Scalar::primitive(7u8, Nullability::NonNullable), 3)]
+    #[case::f64(Scalar::primitive(1.5f64, Nullability::NonNullable), 4)]
+    #[case::i32_null(Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable)), 3)]
+    fn test_primitive_constant_append(
+        #[case] scalar: Scalar,
+        #[case] n: usize,
+    ) -> vortex_error::VortexResult<()> {
+        assert_append_matches_canonical(ConstantArray::new(scalar, n))
+    }
+
+    #[rstest]
+    #[case::utf8_inline("hi", 5)] // ≤12 bytes: inlined in BinaryView
+    #[case::utf8_noninline("hello world!!", 5)] // >12 bytes: requires buffer block
+    #[case::utf8_empty("", 3)]
+    #[case::utf8_n_zero("hello world!!", 0)] // n=0 with non-inline: must not write orphaned bytes
+    fn test_utf8_constant_append(
+        #[case] value: &str,
+        #[case] n: usize,
+    ) -> vortex_error::VortexResult<()> {
+        assert_append_matches_canonical(ConstantArray::new(
+            Scalar::utf8(value, Nullability::NonNullable),
+            n,
+        ))
+    }
+
+    #[test]
+    fn test_utf8_null_constant_append() -> vortex_error::VortexResult<()> {
+        assert_append_matches_canonical(ConstantArray::new(
+            Scalar::null(DType::Utf8(Nullability::Nullable)),
+            4,
+        ))
+    }
+
+    #[rstest]
+    #[case::binary_inline(vec![1u8, 2, 3], 5)] // ≤12 bytes: inlined
+    #[case::binary_noninline(vec![0u8; 13], 5)] // >12 bytes: buffer block
+    fn test_binary_constant_append(
+        #[case] value: Vec<u8>,
+        #[case] n: usize,
+    ) -> vortex_error::VortexResult<()> {
+        assert_append_matches_canonical(ConstantArray::new(
+            Scalar::binary(value, Nullability::NonNullable),
+            n,
+        ))
+    }
+
+    #[test]
+    fn test_binary_null_constant_append() -> vortex_error::VortexResult<()> {
+        assert_append_matches_canonical(ConstantArray::new(
+            Scalar::null(DType::Binary(Nullability::Nullable)),
+            4,
+        ))
+    }
+
+    #[test]
+    fn test_struct_constant_append() -> vortex_error::VortexResult<()> {
+        let fields = StructFields::new(
+            ["x", "y"].into(),
+            vec![
+                DType::Primitive(PType::I32, Nullability::NonNullable),
+                DType::Utf8(Nullability::NonNullable),
+            ],
+        );
+        let scalar = Scalar::struct_(
+            DType::Struct(fields, Nullability::NonNullable),
+            [
+                Scalar::primitive(42i32, Nullability::NonNullable),
+                Scalar::utf8("hi", Nullability::NonNullable),
+            ],
+        );
+        assert_append_matches_canonical(ConstantArray::new(scalar, 3))
+    }
+
+    #[test]
+    fn test_null_struct_constant_append() -> vortex_error::VortexResult<()> {
+        let fields = StructFields::new(
+            ["x"].into(),
+            vec![DType::Primitive(PType::I32, Nullability::Nullable)],
+        );
+        let dtype = DType::Struct(fields, Nullability::Nullable);
+        assert_append_matches_canonical(ConstantArray::new(Scalar::null(dtype), 4))
     }
 }

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -120,6 +120,12 @@ impl DecimalBuilder {
         self.nulls.append_non_null();
     }
 
+    /// Appends `n` copies of `value` as non-null entries, directly writing into the buffer.
+    pub fn append_n_values<V: NativeDecimalType>(&mut self, value: V, n: usize) {
+        self.values.push_n(value, n);
+        self.nulls.append_n_non_nulls(n);
+    }
+
     /// Finishes the builder directly into a [`DecimalArray`].
     pub fn finish_into_decimal(&mut self) -> DecimalArray {
         let validity = self.nulls.finish_with_nullability(self.dtype.nullability());

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -52,7 +52,7 @@ impl<T: NativePType> PrimitiveBuilder<T> {
     }
 
     /// Appends `n` copies of `value` as non-null entries, directly writing into the buffer.
-    pub fn append_value_n(&mut self, value: T, n: usize) {
+    pub fn append_n_values(&mut self, value: T, n: usize) {
         self.values.push_n(value, n);
         self.nulls.append_n_non_nulls(n);
     }

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -51,6 +51,12 @@ impl<T: NativePType> PrimitiveBuilder<T> {
         self.nulls.append_non_null();
     }
 
+    /// Appends `n` copies of `value` as non-null entries, directly writing into the buffer.
+    pub fn append_value_n(&mut self, value: T, n: usize) {
+        self.values.push_n(value, n);
+        self.nulls.append_n_non_nulls(n);
+    }
+
     /// Returns the raw primitive values in this builder as a slice.
     pub fn values(&self) -> &[T] {
         self.values.as_ref()

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -107,6 +107,22 @@ impl VarBinViewBuilder {
         self.nulls.append_non_null();
     }
 
+    /// Appends `n` copies of `value` as non-null entries.
+    pub fn append_n_values<S: AsRef<[u8]>>(&mut self, value: S, n: usize) {
+        if n == 0 {
+            return;
+        }
+        let bytes = value.as_ref();
+        let view = if bytes.len() <= BinaryView::MAX_INLINED_SIZE {
+            BinaryView::make_view(bytes, 0, 0)
+        } else {
+            let (buffer_idx, offset) = self.append_value_to_buffer(bytes);
+            BinaryView::make_view(bytes, buffer_idx, offset)
+        };
+        self.views_builder.push_n(view, n);
+        self.nulls.append_n_non_nulls(n);
+    }
+
     fn flush_in_progress(&mut self) {
         if self.in_progress.is_empty() {
             return;
@@ -126,7 +142,10 @@ impl VarBinViewBuilder {
 
     /// append a non inlined value to self.in_progress.
     fn append_value_to_buffer(&mut self, value: &[u8]) -> (u32, u32) {
-        assert!(value.len() > 12, "must inline small strings");
+        assert!(
+            value.len() > BinaryView::MAX_INLINED_SIZE,
+            "must inline small strings"
+        );
         let required_cap = self.in_progress.len() + value.len();
         if self.in_progress.capacity() < required_cap {
             self.flush_in_progress();


### PR DESCRIPTION
Adds a `ConstantVTable::append_to_builder` override that bypasses the default canonicalize-then-copy path for all common leaf dtypes (Null, Bool, Primitive, Decimal, Utf8, Binary).

The default path allocates a full canonical array of n copies and copies it into the builder. For a ConstantArray, this is pure waste. The fast paths instead write the scalar value once and fill n slots directly.

For the newly added micro bench
<img width="643" height="255" alt="Screenshot 2026-03-03 at 17 47 06" src="https://github.com/user-attachments/assets/28ce8654-69fb-4f34-bd0f-8cc7046ef0a8" />

