### PR TITLE
fix[vortex-array]: fix panic caused by take on listview during compression

### DIFF
--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -8,7 +8,9 @@ use vortex_error::VortexResult;
 
 use crate::DynArray;
 use crate::IntoArray;
+use crate::LEGACY_SESSION;
 use crate::ToCanonical;
+use crate::VortexSessionExecute;
 use crate::arrays::ConstantArray;
 use crate::arrays::ListViewArray;
 use crate::builders::builder_with_capacity;
@@ -19,7 +21,6 @@ use crate::dtype::Nullability;
 use crate::match_each_integer_ptype;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::operators::Operator;
-use crate::vtable::ValidityHelper;
 
 /// Modes for rebuilding a [`ListViewArray`].
 pub enum ListViewRebuildMode {
@@ -179,11 +180,16 @@ impl ListViewArray {
         let offsets = new_offsets.into_array();
         let sizes = new_sizes.into_array();
 
+        let validity = self
+            .validity
+            .clone()
+            .execute(&mut LEGACY_SESSION.create_execution_ctx())?;
+
         // SAFETY: same invariants as `rebuild_list_by_list` — offsets are sequential and
         // non-overlapping, all (offset, size) pairs reference valid elements, and the validity
         // array is preserved from the original.
         Ok(unsafe {
-            ListViewArray::new_unchecked(elements, offsets, sizes, self.validity.clone())
+            ListViewArray::new_unchecked(elements, offsets, sizes, validity)
                 .with_zero_copy_to_list(true)
         })
     }
@@ -265,8 +271,12 @@ impl ListViewArray {
         // - The validity array is preserved from the original array unchanged
         // - The array satisfies the zero-copy-to-list property by having sorted offsets, no gaps,
         //   and no overlaps.
+        let validity = self
+            .validity
+            .clone()
+            .execute(&mut LEGACY_SESSION.create_execution_ctx())?;
         Ok(unsafe {
-            ListViewArray::new_unchecked(elements, offsets, sizes, self.validity.clone())
+            ListViewArray::new_unchecked(elements, offsets, sizes, validity)
                 .with_zero_copy_to_list(true)
         })
     }
@@ -340,6 +350,10 @@ impl ListViewArray {
 
         let sliced_elements = self.elements().slice(start..end)?;
 
+        let validity = self
+            .validity
+            .clone()
+            .execute(&mut LEGACY_SESSION.create_execution_ctx())?;
         // SAFETY: The only thing we changed was the elements (which we verify through mins and
         // maxes that all adjusted offsets + sizes are within the correct bounds), so the parameters
         // are valid. And if the original array was zero-copyable to list, trimming elements doesn't
@@ -349,7 +363,7 @@ impl ListViewArray {
                 sliced_elements,
                 adjusted_offsets,
                 self.sizes().clone(),
-                self.validity().clone(),
+                validity,
             )
             .with_zero_copy_to_list(self.is_zero_copy_to_list())
         })

--- a/vortex-file/tests/test_write_table.rs
+++ b/vortex-file/tests/test_write_table.rs
@@ -10,6 +10,9 @@ use futures::StreamExt;
 use futures::pin_mut;
 use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
+use vortex_array::arrays::BoolArray;
+use vortex_array::arrays::DictArray;
+use vortex_array::arrays::ListViewArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::StructArray;
 use vortex_array::dtype::FieldNames;
@@ -110,4 +113,53 @@ async fn test_file_roundtrip() {
         assert!(b.is_canonical());
         assert!(raw.nbytes() > compressed.nbytes());
     }
+}
+
+/// Regression test: writing a Dict<ListView> where the list has
+/// Validity::Array(BoolArray) and the dict codes are nullable used to fail
+/// with "Array vortex.fill_null does not support serialization".
+#[tokio::test]
+async fn test_dict_listview_validity_roundtrip() {
+    let elements = PrimitiveArray::from_iter(vec![1i32, 2, 3, 4, 5]).into_array();
+    let offsets = PrimitiveArray::from_iter(vec![0u32, 2, 4]).into_array();
+    let sizes = PrimitiveArray::from_iter(vec![2u32, 2, 1]).into_array();
+    let list_validity = Validity::Array(BoolArray::from_iter([true, false, true]).into_array());
+    let listview = ListViewArray::new(elements, offsets, sizes, list_validity).into_array();
+
+    let codes = PrimitiveArray::new(
+        vortex_buffer::buffer![0u32, 0, 1, 0, 2],
+        Validity::from_iter(vec![true, false, true, true, true]),
+    )
+    .into_array();
+
+    let dict = DictArray::new(codes, listview).into_array();
+
+    let data = StructArray::from_fields(&[("col", dict)])
+        .expect("from_fields")
+        .into_array();
+
+    let mut bytes = Vec::new();
+    SESSION
+        .write_options()
+        .write(&mut bytes, data.to_array_stream())
+        .await
+        .expect("write should not fail with fill_null serialization error");
+
+    let bytes = ByteBuffer::from(bytes);
+    let vxf = SESSION.open_options().open_buffer(bytes).expect("open");
+
+    let stream = vxf
+        .scan()
+        .expect("scan")
+        .into_stream()
+        .expect("into_stream");
+    pin_mut!(stream);
+
+    let chunk = stream
+        .next()
+        .await
+        .unwrap()
+        .expect("read back should succeed");
+    vortex_array::assert_arrays_eq!(data, chunk);
+    assert!(stream.next().await.is_none(), "expected a single chunk");
 }


### PR DESCRIPTION
If a ListView is a child of a Dictionary which is canonicalized during compression, Take is executed on the ListView and subsequently its validity slice. This could result in a lazy FillNull array wrapping the validity which was never executed, causing a panic on serialization "Array vortex.fill_null does not support serialization". This PR executes the validity on rebuild, similar to how offsets/sizes are already executed implicitly via to_primitive.

<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

<!--
If this PR is related to a tracked effort, please link to the relevant issue
here (e.g., `Closes: #123`). Otherwise, feel free to ignore / delete this.

In this section, please:

1. Explain the rationale for this change.
2. Summarize the changes included in this PR.

A general rule of thumb is that larger PRs should have larger summaries. If
there are a lot of changes, please help us review the code by explaining what
was changed and why.

If there is an issue or discussion attached, there is no need to duplicate all
the details, but clarity is always preferred over brevity.
-->

Fixes a panic writing complex nested types -> dict<struct<list>>

<!--
## API Changes

Uncomment this section if there are any user-facing changes.

Consider whether the change affects users in one of the following ways:

1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the engine integrations.
3. Should some documentation be updated to reflect this change?

If a public API is changed in a breaking manner, make sure to add the
appropriate label. You can run `./scripts/public-api.sh` locally to see if there
are any public API changes (and this also runs in our CI).
-->

## Testing

<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
3. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
A high-level regression test was added