### PR TITLE
fix[layout]: add required ALLOWED_ENCODINGS to `WriteStrategyBuilder`

### DIFF
--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -139,7 +139,7 @@ impl Default for WriteStrategyBuilder {
             compressor: None,
             row_block_size: 8192,
             field_writers: HashMap::new(),
-            allow_encodings: None,
+            allow_encodings: Some(ALLOWED_ENCODINGS.clone()),
             flat_strategy: None,
         }
     }


### PR DESCRIPTION
This is incorrectly set to none allowing all encodings