### PR TITLE
perf: ensure that `into_array` is used for owned specific arrays

### DIFF
--- a/encodings/alp/public-api.lock
+++ b/encodings/alp/public-api.lock
@@ -20,6 +20,10 @@ pub fn vortex_alp::ALPArray::ptype(&self) -> vortex_array::dtype::ptype::PType
 
 pub fn vortex_alp::ALPArray::try_new(encoded: vortex_array::array::ArrayRef, exponents: vortex_alp::Exponents, patches: core::option::Option<vortex_array::patches::Patches>) -> vortex_error::VortexResult<Self>
 
+impl vortex_alp::ALPArray
+
+pub fn vortex_alp::ALPArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_alp::ALPArray
 
 pub fn vortex_alp::ALPArray::clone(&self) -> vortex_alp::ALPArray
@@ -85,6 +89,10 @@ pub fn vortex_alp::ALPRDArray::right_bit_width(&self) -> u8
 pub fn vortex_alp::ALPRDArray::right_parts(&self) -> &vortex_array::array::ArrayRef
 
 pub fn vortex_alp::ALPRDArray::try_new(dtype: vortex_array::dtype::DType, left_parts: vortex_array::array::ArrayRef, left_parts_dictionary: vortex_buffer::buffer::Buffer<u16>, right_parts: vortex_array::array::ArrayRef, right_bit_width: u8, left_parts_patches: core::option::Option<vortex_array::patches::Patches>) -> vortex_error::VortexResult<Self>
+
+impl vortex_alp::ALPRDArray
+
+pub fn vortex_alp::ALPRDArray::to_array(&self) -> vortex_array::array::ArrayRef
 
 impl core::clone::Clone for vortex_alp::ALPRDArray
 

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -526,7 +526,11 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.into_array().execute::<Canonical>(&mut ctx).unwrap()
+            encoded
+                .clone()
+                .into_array()
+                .execute::<Canonical>(&mut ctx)
+                .unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected =
@@ -551,7 +555,11 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.into_array().execute::<Canonical>(&mut ctx).unwrap()
+            encoded
+                .clone()
+                .into_array()
+                .execute::<Canonical>(&mut ctx)
+                .unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected =
@@ -582,7 +590,11 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.into_array().execute::<Canonical>(&mut ctx).unwrap()
+            encoded
+                .clone()
+                .into_array()
+                .execute::<Canonical>(&mut ctx)
+                .unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected =
@@ -611,7 +623,11 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.into_array().execute::<Canonical>(&mut ctx).unwrap()
+            encoded
+                .clone()
+                .into_array()
+                .execute::<Canonical>(&mut ctx)
+                .unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected =
@@ -643,7 +659,11 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.into_array().execute::<Canonical>(&mut ctx).unwrap()
+            encoded
+                .clone()
+                .into_array()
+                .execute::<Canonical>(&mut ctx)
+                .unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected =

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -526,7 +526,7 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
+            encoded.into_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected =
@@ -551,7 +551,7 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
+            encoded.into_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected =
@@ -582,7 +582,7 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
+            encoded.into_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected =
@@ -611,7 +611,7 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
+            encoded.into_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected =
@@ -643,7 +643,7 @@ mod tests {
 
         let result_canonical = {
             let mut ctx = SESSION.create_execution_ctx();
-            encoded.to_array().execute::<Canonical>(&mut ctx).unwrap()
+            encoded.into_array().execute::<Canonical>(&mut ctx).unwrap()
         };
         // Compare against the traditional array-based decompress path
         let expected =

--- a/encodings/alp/src/alp/compute/cast.rs
+++ b/encodings/alp/src/alp/compute/cast.rs
@@ -89,7 +89,7 @@ mod tests {
         );
 
         let nullable_dtype = DType::Primitive(PType::F32, Nullability::Nullable);
-        let casted = alp.to_array().cast(nullable_dtype.clone())?;
+        let casted = alp.into_array().cast(nullable_dtype.clone())?;
 
         let expected = values.cast(nullable_dtype)?;
 
@@ -104,7 +104,7 @@ mod tests {
         let alp = alp_encode(&values.to_primitive(), None)?;
 
         let casted = alp
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::F64, Nullability::NonNullable))?;
         assert_eq!(
             casted.dtype(),
@@ -126,7 +126,7 @@ mod tests {
         let alp = alp_encode(&values.to_primitive(), None)?;
 
         let casted = alp
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I32, Nullability::NonNullable))?;
         assert_eq!(
             casted.dtype(),
@@ -147,7 +147,7 @@ mod tests {
     #[case(buffer![0.0f32, -1.5, 2.5, -3.5, 4.5].into_array())]
     fn test_cast_alp_conformance(#[case] array: vortex_array::ArrayRef) -> VortexResult<()> {
         let alp = alp_encode(&array.to_primitive(), None).vortex_expect("cannot fail");
-        test_cast_conformance(&alp.to_array());
+        test_cast_conformance(&alp.into_array());
 
         Ok(())
     }

--- a/encodings/alp/src/alp/compute/filter.rs
+++ b/encodings/alp/src/alp/compute/filter.rs
@@ -31,7 +31,7 @@ impl FilterKernel for ALPVTable {
                     patches,
                     array.dtype().clone(),
                 )
-                .to_array(),
+                .into_array(),
             ))
         }
     }
@@ -60,6 +60,6 @@ mod test {
     ].into_array())]
     fn test_filter_alp_conformance(#[case] array: ArrayRef) {
         let alp = alp_encode(&array.to_primitive(), None).unwrap();
-        test_filter_conformance(&alp.to_array());
+        test_filter_conformance(&alp.into_array());
     }
 }

--- a/encodings/alp/src/alp/compute/filter.rs
+++ b/encodings/alp/src/alp/compute/filter.rs
@@ -3,6 +3,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::arrays::FilterKernel;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;

--- a/encodings/alp/src/alp/compute/mask.rs
+++ b/encodings/alp/src/alp/compute/mask.rs
@@ -3,6 +3,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::scalar_fn::fns::mask::MaskKernel;
 use vortex_array::scalar_fn::fns::mask::MaskReduce;

--- a/encodings/alp/src/alp/compute/mask.rs
+++ b/encodings/alp/src/alp/compute/mask.rs
@@ -20,7 +20,7 @@ impl MaskReduce for ALPVTable {
         }
         let masked_encoded = array.encoded().clone().mask(mask.clone())?;
         Ok(Some(
-            ALPArray::new(masked_encoded, array.exponents(), None).to_array(),
+            ALPArray::new(masked_encoded, array.exponents(), None).into_array(),
         ))
     }
 }
@@ -39,7 +39,7 @@ impl MaskKernel for ALPVTable {
             .transpose()?
             .flatten();
         Ok(Some(
-            ALPArray::new(masked_encoded, array.exponents(), masked_patches).to_array(),
+            ALPArray::new(masked_encoded, array.exponents(), masked_patches).into_array(),
         ))
     }
 }
@@ -66,7 +66,7 @@ mod test {
     ].into_array())]
     fn test_mask_alp_conformance(#[case] array: vortex_array::ArrayRef) {
         let alp = alp_encode(&array.to_primitive(), None).unwrap();
-        test_mask_conformance(&alp.to_array());
+        test_mask_conformance(&alp.into_array());
     }
 
     #[test]
@@ -79,6 +79,6 @@ mod test {
         let array = PrimitiveArray::from_iter(values);
         let alp = alp_encode(&array, None).unwrap();
         assert!(alp.patches().is_some(), "expected patches");
-        test_mask_conformance(&alp.to_array());
+        test_mask_conformance(&alp.into_array());
     }
 }

--- a/encodings/alp/src/alp/compute/mod.rs
+++ b/encodings/alp/src/alp/compute/mod.rs
@@ -36,7 +36,7 @@ mod tests {
     #[case::repeating_pattern(alp_encode(&PrimitiveArray::from_iter([1.1f32, 2.2, 3.3, 1.1, 2.2, 3.3, 1.1, 2.2, 3.3]), None).unwrap())]
     #[case::close_values(alp_encode(&PrimitiveArray::from_iter([100.001f64, 100.002, 100.003, 100.004, 100.005]), None).unwrap())]
     fn test_alp_consistency(#[case] array: ALPArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 
     #[rstest]

--- a/encodings/alp/src/alp/compute/take.rs
+++ b/encodings/alp/src/alp/compute/take.rs
@@ -55,6 +55,6 @@ mod test {
     #[case(buffer![42.42f64].into_array())]
     fn test_take_alp_conformance(#[case] array: vortex_array::ArrayRef) {
         let alp = alp_encode(&array.to_primitive(), None).unwrap();
-        test_take_conformance(&alp.to_array());
+        test_take_conformance(&alp.into_array());
     }
 }

--- a/encodings/alp/src/alp_rd/compute/cast.rs
+++ b/encodings/alp/src/alp_rd/compute/cast.rs
@@ -66,7 +66,7 @@ mod tests {
         let alprd = encoder.encode(&arr);
 
         let casted = alprd
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::F64, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -91,13 +91,13 @@ mod tests {
 
         // Cast to NonNullable should fail since we have nulls
         let result = alprd
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::F64, Nullability::NonNullable));
         assert!(result.is_err());
 
         // Cast to same type with Nullable should succeed
         let casted = alprd
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::F64, Nullability::Nullable))
             .unwrap();
         assert_eq!(
@@ -138,6 +138,6 @@ mod tests {
         encoder.encode(&arr)
     })]
     fn test_cast_alprd_conformance(#[case] alprd: crate::alp_rd::ALPRDArray) {
-        test_cast_conformance(&alprd.to_array());
+        test_cast_conformance(&alprd.into_array());
     }
 }

--- a/encodings/alp/src/alp_rd/compute/cast.rs
+++ b/encodings/alp/src/alp_rd/compute/cast.rs
@@ -48,6 +48,7 @@ impl CastReduce for ALPRDVTable {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::ToCanonical;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::builtins::ArrayBuiltins;
@@ -91,6 +92,7 @@ mod tests {
 
         // Cast to NonNullable should fail since we have nulls
         let result = alprd
+            .clone()
             .into_array()
             .cast(DType::Primitive(PType::F64, Nullability::NonNullable));
         assert!(result.is_err());

--- a/encodings/alp/src/alp_rd/compute/mod.rs
+++ b/encodings/alp/src/alp_rd/compute/mod.rs
@@ -66,7 +66,7 @@ mod tests {
         encoder.encode(&arr)
     })]
     fn test_alp_rd_consistency(#[case] array: ALPRDArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 
     #[rstest]

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -57,6 +57,7 @@ impl TakeExecute for ALPRDVTable {
 #[cfg(test)]
 mod test {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::ToCanonical;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -109,7 +109,7 @@ mod test {
         );
 
         let taken = encoded
-            .take(PrimitiveArray::from_option_iter([Some(0), Some(2), None]).to_array())
+            .take(PrimitiveArray::from_option_iter([Some(0), Some(2), None]).into_array())
             .unwrap()
             .to_primitive();
 
@@ -126,7 +126,7 @@ mod test {
         test_take_conformance(
             &RDEncoder::new(&[a, b])
                 .encode(&PrimitiveArray::from_iter([a, b, outlier, b, outlier]))
-                .to_array(),
+                .into_array(),
         );
     }
 
@@ -143,7 +143,7 @@ mod test {
                     Some(a),
                     None,
                 ]))
-                .to_array(),
+                .into_array(),
         );
     }
 }

--- a/encodings/bytebool/public-api.lock
+++ b/encodings/bytebool/public-api.lock
@@ -12,6 +12,10 @@ pub fn vortex_bytebool::ByteBoolArray::from_vec<V: core::convert::Into<vortex_ar
 
 pub fn vortex_bytebool::ByteBoolArray::new(buffer: vortex_array::buffer::BufferHandle, validity: vortex_array::validity::Validity) -> Self
 
+impl vortex_bytebool::ByteBoolArray
+
+pub fn vortex_bytebool::ByteBoolArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_bytebool::ByteBoolArray
 
 pub fn vortex_bytebool::ByteBoolArray::clone(&self) -> vortex_bytebool::ByteBoolArray

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -66,7 +66,7 @@ impl TakeExecute for ByteBoolVTable {
         let bools = array.as_slice();
 
         // This handles combining validity from both source array and nullable indices
-        let validity = array.validity().take(&indices.into_array())?;
+        let validity = array.validity().take(&indices.clone().into_array())?;
 
         let taken_bools = match_each_integer_ptype!(indices.ptype(), |I| {
             indices
@@ -117,7 +117,10 @@ mod tests {
         let lhs = ByteBoolArray::from(vec![true; 5]);
         let rhs = ByteBoolArray::from(vec![true; 5]);
 
-        let arr = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
+        let arr = lhs
+            .into_array()
+            .binary(rhs.into_array(), Operator::Eq)
+            .unwrap();
 
         let expected = ByteBoolArray::from(vec![true; 5]);
         assert_arrays_eq!(arr, expected.into_array());
@@ -128,7 +131,10 @@ mod tests {
         let lhs = ByteBoolArray::from(vec![false; 5]);
         let rhs = ByteBoolArray::from(vec![true; 5]);
 
-        let arr = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
+        let arr = lhs
+            .into_array()
+            .binary(rhs.into_array(), Operator::Eq)
+            .unwrap();
 
         let expected = ByteBoolArray::from(vec![false; 5]);
         assert_arrays_eq!(arr, expected.into_array());
@@ -139,7 +145,10 @@ mod tests {
         let lhs = ByteBoolArray::from(vec![true; 5]);
         let rhs = ByteBoolArray::from(vec![Some(true), Some(true), Some(true), Some(false), None]);
 
-        let arr = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
+        let arr = lhs
+            .into_array()
+            .binary(rhs.into_array(), Operator::Eq)
+            .unwrap();
 
         let expected =
             ByteBoolArray::from(vec![Some(true), Some(true), Some(true), Some(false), None]);
@@ -152,7 +161,8 @@ mod tests {
             &ByteBoolArray::from(vec![true, false, true, true, false]).into_array(),
         );
         test_mask_conformance(
-            &ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None]).into_array(),
+            &ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None])
+                .into_array(),
         );
     }
 
@@ -162,7 +172,8 @@ mod tests {
             &ByteBoolArray::from(vec![true, false, true, true, false]).into_array(),
         );
         test_filter_conformance(
-            &ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None]).into_array(),
+            &ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None])
+                .into_array(),
         );
     }
 

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -66,7 +66,7 @@ impl TakeExecute for ByteBoolVTable {
         let bools = array.as_slice();
 
         // This handles combining validity from both source array and nullable indices
-        let validity = array.validity().take(&indices.to_array())?;
+        let validity = array.validity().take(&indices.into_array())?;
 
         let taken_bools = match_each_integer_ptype!(indices.ptype(), |I| {
             indices
@@ -109,7 +109,7 @@ mod tests {
         let sliced_arr = vortex_arr.slice(1..4).unwrap();
 
         let expected = ByteBoolArray::from(vec![Some(true), None, Some(false)]);
-        assert_arrays_eq!(sliced_arr, expected.to_array());
+        assert_arrays_eq!(sliced_arr, expected.into_array());
     }
 
     #[test]
@@ -117,10 +117,10 @@ mod tests {
         let lhs = ByteBoolArray::from(vec![true; 5]);
         let rhs = ByteBoolArray::from(vec![true; 5]);
 
-        let arr = lhs.to_array().binary(rhs.to_array(), Operator::Eq).unwrap();
+        let arr = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
 
         let expected = ByteBoolArray::from(vec![true; 5]);
-        assert_arrays_eq!(arr, expected.to_array());
+        assert_arrays_eq!(arr, expected.into_array());
     }
 
     #[test]
@@ -128,10 +128,10 @@ mod tests {
         let lhs = ByteBoolArray::from(vec![false; 5]);
         let rhs = ByteBoolArray::from(vec![true; 5]);
 
-        let arr = lhs.to_array().binary(rhs.to_array(), Operator::Eq).unwrap();
+        let arr = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
 
         let expected = ByteBoolArray::from(vec![false; 5]);
-        assert_arrays_eq!(arr, expected.to_array());
+        assert_arrays_eq!(arr, expected.into_array());
     }
 
     #[test]
@@ -139,30 +139,30 @@ mod tests {
         let lhs = ByteBoolArray::from(vec![true; 5]);
         let rhs = ByteBoolArray::from(vec![Some(true), Some(true), Some(true), Some(false), None]);
 
-        let arr = lhs.to_array().binary(rhs.to_array(), Operator::Eq).unwrap();
+        let arr = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
 
         let expected =
             ByteBoolArray::from(vec![Some(true), Some(true), Some(true), Some(false), None]);
-        assert_arrays_eq!(arr, expected.to_array());
+        assert_arrays_eq!(arr, expected.into_array());
     }
 
     #[test]
     fn test_mask_byte_bool() {
         test_mask_conformance(
-            &ByteBoolArray::from(vec![true, false, true, true, false]).to_array(),
+            &ByteBoolArray::from(vec![true, false, true, true, false]).into_array(),
         );
         test_mask_conformance(
-            &ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None]).to_array(),
+            &ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None]).into_array(),
         );
     }
 
     #[test]
     fn test_filter_byte_bool() {
         test_filter_conformance(
-            &ByteBoolArray::from(vec![true, false, true, true, false]).to_array(),
+            &ByteBoolArray::from(vec![true, false, true, true, false]).into_array(),
         );
         test_filter_conformance(
-            &ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None]).to_array(),
+            &ByteBoolArray::from(vec![Some(true), Some(true), None, Some(false), None]).into_array(),
         );
     }
 
@@ -172,14 +172,14 @@ mod tests {
     #[case(ByteBoolArray::from(vec![true, false]))]
     #[case(ByteBoolArray::from(vec![true]))]
     fn test_take_byte_bool_conformance(#[case] array: ByteBoolArray) {
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 
     #[test]
     fn test_cast_bytebool_to_nullable() {
         let array = ByteBoolArray::from(vec![true, false, true, false]);
         let casted = array
-            .to_array()
+            .into_array()
             .cast(DType::Bool(Nullability::Nullable))
             .unwrap();
         assert_eq!(casted.dtype(), &DType::Bool(Nullability::Nullable));
@@ -193,7 +193,7 @@ mod tests {
     #[case(ByteBoolArray::from(vec![true]))]
     #[case(ByteBoolArray::from(vec![Some(true), None]))]
     fn test_cast_bytebool_conformance(#[case] array: ByteBoolArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 
     #[rstest]
@@ -206,6 +206,6 @@ mod tests {
     #[case::single_null(ByteBoolArray::from(vec![None]))]
     #[case::mixed_with_nulls(ByteBoolArray::from(vec![Some(true), None, Some(false), None, Some(true)]))]
     fn test_bytebool_consistency(#[case] array: ByteBoolArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/encodings/datetime-parts/public-api.lock
+++ b/encodings/datetime-parts/public-api.lock
@@ -14,6 +14,10 @@ pub fn vortex_datetime_parts::DateTimePartsArray::subseconds(&self) -> &vortex_a
 
 pub fn vortex_datetime_parts::DateTimePartsArray::try_new(dtype: vortex_array::dtype::DType, days: vortex_array::array::ArrayRef, seconds: vortex_array::array::ArrayRef, subseconds: vortex_array::array::ArrayRef) -> vortex_error::VortexResult<Self>
 
+impl vortex_datetime_parts::DateTimePartsArray
+
+pub fn vortex_datetime_parts::DateTimePartsArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_datetime_parts::DateTimePartsArray
 
 pub fn vortex_datetime_parts::DateTimePartsArray::clone(&self) -> vortex_datetime_parts::DateTimePartsArray

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -97,7 +97,7 @@ pub fn decode_to_temporal(
     Ok(TemporalArray::new_timestamp(
         PrimitiveArray::new(
             values.freeze(),
-            Validity::copy_from_array(&array.to_array())?,
+            Validity::copy_from_array(&array.into_array())?,
         )
         .into_array(),
         options.unit,

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -97,7 +97,7 @@ pub fn decode_to_temporal(
     Ok(TemporalArray::new_timestamp(
         PrimitiveArray::new(
             values.freeze(),
-            Validity::copy_from_array(&array.into_array())?,
+            Validity::copy_from_array(&array.clone().into_array())?,
         )
         .into_array(),
         options.unit,

--- a/encodings/datetime-parts/src/compress.rs
+++ b/encodings/datetime-parts/src/compress.rs
@@ -32,7 +32,7 @@ pub fn split_temporal(array: TemporalArray) -> VortexResult<TemporalParts> {
 
     // After this operation, timestamps will be a PrimitiveArray<i64>
     let timestamps = temporal_values
-        .to_array()
+        .into_array()
         .cast(DType::Primitive(
             PType::I64,
             temporal_values.dtype().nullability(),

--- a/encodings/datetime-parts/src/compress.rs
+++ b/encodings/datetime-parts/src/compress.rs
@@ -32,6 +32,7 @@ pub fn split_temporal(array: TemporalArray) -> VortexResult<TemporalParts> {
 
     // After this operation, timestamps will be a PrimitiveArray<i64>
     let timestamps = temporal_values
+        .clone()
         .into_array()
         .cast(DType::Primitive(
             PType::I64,

--- a/encodings/datetime-parts/src/compute/cast.rs
+++ b/encodings/datetime-parts/src/compute/cast.rs
@@ -134,6 +134,6 @@ mod tests {
     )).unwrap())]
     fn test_cast_datetime_parts_conformance(#[case] array: DateTimePartsArray) {
         use vortex_array::compute::conformance::cast::test_cast_conformance;
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -227,11 +227,18 @@ mod test {
     fn compare_date_time_parts_eq(#[case] lhs_validity: Validity, #[case] rhs_validity: Validity) {
         let lhs = dtp_array_from_timestamp(86400i64, lhs_validity); // January 2, 1970, 00:00:00 UTC
         let rhs = dtp_array_from_timestamp(86400i64, rhs_validity.clone()); // January 2, 1970, 00:00:00 UTC
-        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
+        let comparison = lhs
+            .clone()
+            .into_array()
+            .binary(rhs.into_array(), Operator::Eq)
+            .unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
 
         let rhs = dtp_array_from_timestamp(0i64, rhs_validity); // January 1, 1970, 00:00:00 UTC
-        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
+        let comparison = lhs
+            .into_array()
+            .binary(rhs.into_array(), Operator::Eq)
+            .unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 0);
     }
 
@@ -244,6 +251,7 @@ mod test {
         let lhs = dtp_array_from_timestamp(86400i64, lhs_validity); // January 2, 1970, 00:00:00 UTC
         let rhs = dtp_array_from_timestamp(86401i64, rhs_validity.clone()); // January 2, 1970, 00:00:01 UTC
         let comparison = lhs
+            .clone()
             .into_array()
             .binary(rhs.into_array(), Operator::NotEq)
             .unwrap();
@@ -266,7 +274,10 @@ mod test {
         let lhs = dtp_array_from_timestamp(0i64, lhs_validity); // January 1, 1970, 01:00:00 UTC
         let rhs = dtp_array_from_timestamp(86400i64, rhs_validity); // January 2, 1970, 00:00:00 UTC
 
-        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Lt).unwrap();
+        let comparison = lhs
+            .into_array()
+            .binary(rhs.into_array(), Operator::Lt)
+            .unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
     }
 
@@ -279,7 +290,10 @@ mod test {
         let lhs = dtp_array_from_timestamp(86400i64, lhs_validity); // January 2, 1970, 02:00:00 UTC
         let rhs = dtp_array_from_timestamp(0i64, rhs_validity); // January 1, 1970, 01:00:00 UTC
 
-        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Gt).unwrap();
+        let comparison = lhs
+            .into_array()
+            .binary(rhs.into_array(), Operator::Gt)
+            .unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
     }
 
@@ -309,16 +323,25 @@ mod test {
         // Timestamp with a value larger than i32::MAX.
         let rhs = dtp_array_from_timestamp(i64::MAX, rhs_validity);
 
-        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
+        let comparison = lhs
+            .clone()
+            .into_array()
+            .binary(rhs.clone().into_array(), Operator::Eq)
+            .unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 0);
 
         let comparison = lhs
+            .clone()
             .into_array()
-            .binary(rhs.into_array(), Operator::NotEq)
+            .binary(rhs.clone().into_array(), Operator::NotEq)
             .unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
 
-        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Lt).unwrap();
+        let comparison = lhs
+            .clone()
+            .into_array()
+            .binary(rhs.clone().into_array(), Operator::Lt)
+            .unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
 
         let comparison = lhs

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -227,11 +227,11 @@ mod test {
     fn compare_date_time_parts_eq(#[case] lhs_validity: Validity, #[case] rhs_validity: Validity) {
         let lhs = dtp_array_from_timestamp(86400i64, lhs_validity); // January 2, 1970, 00:00:00 UTC
         let rhs = dtp_array_from_timestamp(86400i64, rhs_validity.clone()); // January 2, 1970, 00:00:00 UTC
-        let comparison = lhs.to_array().binary(rhs.to_array(), Operator::Eq).unwrap();
+        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
 
         let rhs = dtp_array_from_timestamp(0i64, rhs_validity); // January 1, 1970, 00:00:00 UTC
-        let comparison = lhs.to_array().binary(rhs.to_array(), Operator::Eq).unwrap();
+        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 0);
     }
 
@@ -244,15 +244,15 @@ mod test {
         let lhs = dtp_array_from_timestamp(86400i64, lhs_validity); // January 2, 1970, 00:00:00 UTC
         let rhs = dtp_array_from_timestamp(86401i64, rhs_validity.clone()); // January 2, 1970, 00:00:01 UTC
         let comparison = lhs
-            .to_array()
-            .binary(rhs.to_array(), Operator::NotEq)
+            .into_array()
+            .binary(rhs.into_array(), Operator::NotEq)
             .unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
 
         let rhs = dtp_array_from_timestamp(86400i64, rhs_validity); // January 2, 1970, 00:00:00 UTC
         let comparison = lhs
-            .to_array()
-            .binary(rhs.to_array(), Operator::NotEq)
+            .into_array()
+            .binary(rhs.into_array(), Operator::NotEq)
             .unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 0);
     }
@@ -266,7 +266,7 @@ mod test {
         let lhs = dtp_array_from_timestamp(0i64, lhs_validity); // January 1, 1970, 01:00:00 UTC
         let rhs = dtp_array_from_timestamp(86400i64, rhs_validity); // January 2, 1970, 00:00:00 UTC
 
-        let comparison = lhs.to_array().binary(rhs.to_array(), Operator::Lt).unwrap();
+        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Lt).unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
     }
 
@@ -279,7 +279,7 @@ mod test {
         let lhs = dtp_array_from_timestamp(86400i64, lhs_validity); // January 2, 1970, 02:00:00 UTC
         let rhs = dtp_array_from_timestamp(0i64, rhs_validity); // January 1, 1970, 01:00:00 UTC
 
-        let comparison = lhs.to_array().binary(rhs.to_array(), Operator::Gt).unwrap();
+        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Gt).unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
     }
 
@@ -309,21 +309,21 @@ mod test {
         // Timestamp with a value larger than i32::MAX.
         let rhs = dtp_array_from_timestamp(i64::MAX, rhs_validity);
 
-        let comparison = lhs.to_array().binary(rhs.to_array(), Operator::Eq).unwrap();
+        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 0);
 
         let comparison = lhs
-            .to_array()
-            .binary(rhs.to_array(), Operator::NotEq)
+            .into_array()
+            .binary(rhs.into_array(), Operator::NotEq)
             .unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
 
-        let comparison = lhs.to_array().binary(rhs.to_array(), Operator::Lt).unwrap();
+        let comparison = lhs.into_array().binary(rhs.into_array(), Operator::Lt).unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
 
         let comparison = lhs
-            .to_array()
-            .binary(rhs.to_array(), Operator::Lte)
+            .into_array()
+            .binary(rhs.into_array(), Operator::Lte)
             .unwrap();
         assert_eq!(comparison.as_bool_typed().true_count().unwrap(), 1);
 

--- a/encodings/datetime-parts/src/compute/filter.rs
+++ b/encodings/datetime-parts/src/compute/filter.rs
@@ -51,7 +51,7 @@ mod test {
             TemporalArray::new_timestamp(timestamps, TimeUnit::Milliseconds, Some("UTC".into()));
 
         let array = DateTimePartsArray::try_from(temporal).unwrap();
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
 
         // Test with nullable values
         let timestamps = PrimitiveArray::from_option_iter([
@@ -67,6 +67,6 @@ mod test {
             TemporalArray::new_timestamp(timestamps, TimeUnit::Milliseconds, Some("UTC".into()));
 
         let array = DateTimePartsArray::try_from(temporal).unwrap();
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 }

--- a/encodings/datetime-parts/src/compute/mod.rs
+++ b/encodings/datetime-parts/src/compute/mod.rs
@@ -71,6 +71,6 @@ mod tests {
     )).unwrap())]
 
     fn test_datetime_parts_consistency(#[case] array: DateTimePartsArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/encodings/datetime-parts/src/compute/take.rs
+++ b/encodings/datetime-parts/src/compute/take.rs
@@ -22,9 +22,9 @@ fn take_datetime_parts(array: &DateTimePartsArray, indices: &ArrayRef) -> Vortex
     // we go ahead and canonicalize here to avoid worst-case canonicalizing 3 separate times
     let indices = indices.to_primitive();
 
-    let taken_days = array.days().take(indices.into_array())?;
-    let taken_seconds = array.seconds().take(indices.into_array())?;
-    let taken_subseconds = array.subseconds().take(indices.into_array())?;
+    let taken_days = array.days().take(indices.clone().into_array())?;
+    let taken_seconds = array.seconds().take(indices.clone().into_array())?;
+    let taken_subseconds = array.subseconds().take(indices.clone().into_array())?;
 
     // Update the dtype if the nullability changed due to nullable indices
     let dtype = if taken_days.dtype().is_nullable() != array.dtype().is_nullable() {

--- a/encodings/datetime-parts/src/compute/take.rs
+++ b/encodings/datetime-parts/src/compute/take.rs
@@ -22,9 +22,9 @@ fn take_datetime_parts(array: &DateTimePartsArray, indices: &ArrayRef) -> Vortex
     // we go ahead and canonicalize here to avoid worst-case canonicalizing 3 separate times
     let indices = indices.to_primitive();
 
-    let taken_days = array.days().take(indices.to_array())?;
-    let taken_seconds = array.seconds().take(indices.to_array())?;
-    let taken_subseconds = array.subseconds().take(indices.to_array())?;
+    let taken_days = array.days().take(indices.into_array())?;
+    let taken_seconds = array.seconds().take(indices.into_array())?;
+    let taken_subseconds = array.subseconds().take(indices.into_array())?;
 
     // Update the dtype if the nullability changed due to nullable indices
     let dtype = if taken_days.dtype().is_nullable() != array.dtype().is_nullable() {
@@ -136,6 +136,6 @@ mod tests {
         Some("UTC".into())
     )).unwrap())]
     fn test_take_datetime_parts_conformance(#[case] array: DateTimePartsArray) {
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 }

--- a/encodings/decimal-byte-parts/public-api.lock
+++ b/encodings/decimal-byte-parts/public-api.lock
@@ -10,6 +10,10 @@ pub fn vortex_decimal_byte_parts::DecimalBytePartsArray::into_parts(self) -> vor
 
 pub fn vortex_decimal_byte_parts::DecimalBytePartsArray::try_new(msp: vortex_array::array::ArrayRef, decimal_dtype: vortex_array::dtype::decimal::DecimalDType) -> vortex_error::VortexResult<Self>
 
+impl vortex_decimal_byte_parts::DecimalBytePartsArray
+
+pub fn vortex_decimal_byte_parts::DecimalBytePartsArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_decimal_byte_parts::DecimalBytePartsArray
 
 pub fn vortex_decimal_byte_parts::DecimalBytePartsArray::clone(&self) -> vortex_decimal_byte_parts::DecimalBytePartsArray

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/cast.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/cast.rs
@@ -65,7 +65,7 @@ mod tests {
 
         // Cast to nullable decimal
         let casted = array
-            .to_array()
+            .into_array()
             .cast(DType::Decimal(decimal_dtype, Nullability::Nullable))
             .unwrap();
         assert_eq!(
@@ -89,7 +89,7 @@ mod tests {
 
         // Cast to non-nullable should fail due to nulls - force evaluation via to_canonical
         let result = array
-            .to_array()
+            .into_array()
             .cast(DType::Decimal(decimal_dtype, Nullability::NonNullable))
             .and_then(|a| a.to_canonical().map(|c| c.into_array()));
         assert!(result.is_err());
@@ -118,6 +118,6 @@ mod tests {
         DecimalDType::new(10, 2),
     ).unwrap())]
     fn test_cast_decimal_byte_parts_conformance(#[case] array: DecimalBytePartsArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
@@ -6,6 +6,7 @@ use num_traits::NumCast;
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::IntegerPType;
@@ -230,11 +231,11 @@ mod tests {
             lhs.len(),
         );
 
-        let res = lhs.binary(rhs.into_array(), Operator::Eq).unwrap();
+        let res = lhs.binary(rhs.clone().into_array(), Operator::Eq).unwrap();
         let expected = BoolArray::from_iter([Some(false), Some(false), Some(false)]).into_array();
         assert_arrays_eq!(res, expected);
 
-        let res = lhs.binary(rhs.into_array(), Operator::Gt).unwrap();
+        let res = lhs.binary(rhs.clone().into_array(), Operator::Gt).unwrap();
         let expected = BoolArray::from_iter([Some(true), Some(true), Some(true)]).into_array();
         assert_arrays_eq!(res, expected);
 
@@ -248,11 +249,11 @@ mod tests {
             lhs.len(),
         );
 
-        let res = lhs.binary(rhs.into_array(), Operator::Eq).unwrap();
+        let res = lhs.binary(rhs.clone().into_array(), Operator::Eq).unwrap();
         let expected = BoolArray::from_iter([Some(false), Some(false), Some(false)]).into_array();
         assert_arrays_eq!(res, expected);
 
-        let res = lhs.binary(rhs.into_array(), Operator::Gt).unwrap();
+        let res = lhs.binary(rhs.clone().into_array(), Operator::Gt).unwrap();
         let expected = BoolArray::from_iter([Some(false), Some(false), Some(false)]).into_array();
         assert_arrays_eq!(res, expected);
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
@@ -51,7 +51,7 @@ impl CompareKernel for DecimalBytePartsVTable {
                 let encoded_scalar = Scalar::try_new(scalar_type, Some(value))?;
                 let encoded_const = ConstantArray::new(encoded_scalar, rhs.len());
                 lhs.msp
-                    .binary(encoded_const.to_array(), Operator::from(operator))
+                    .binary(encoded_const.into_array(), Operator::from(operator))
                     .map(Some)
             }
 
@@ -67,7 +67,7 @@ impl CompareKernel for DecimalBytePartsVTable {
                             unconvertible_value(sign, operator, nullability),
                             lhs.len(),
                         )
-                        .to_array(),
+                        .into_array(),
                     ))
                 } else {
                     Ok(None)
@@ -164,17 +164,17 @@ mod tests {
         let decimal_dtype = DecimalDType::new(8, 2);
         let dtype = DType::Decimal(decimal_dtype, Nullability::Nullable);
         let lhs = DecimalBytePartsArray::try_new(
-            PrimitiveArray::new(buffer![100i32, 200i32, 400i32], Validity::AllValid).to_array(),
+            PrimitiveArray::new(buffer![100i32, 200i32, 400i32], Validity::AllValid).into_array(),
             decimal_dtype,
         )
         .unwrap()
-        .to_array();
+        .into_array();
         let rhs = ConstantArray::new(
             Scalar::try_new(dtype, Some(DecimalValue::I64(400).into())).unwrap(),
             lhs.len(),
         );
 
-        let res = lhs.binary(rhs.to_array(), Operator::Eq).unwrap();
+        let res = lhs.binary(rhs.into_array(), Operator::Eq).unwrap();
 
         let expected = BoolArray::from_iter([Some(false), Some(false), Some(true)]).into_array();
         assert_arrays_eq!(res, expected);
@@ -202,7 +202,7 @@ mod tests {
         )
         .into_array();
 
-        let res = lhs.to_array().binary(rhs, Operator::Lte)?;
+        let res = lhs.into_array().binary(rhs, Operator::Lte)?;
         let expected =
             BoolArray::from_iter([None, Some(true), Some(true), Some(true)]).into_array();
         assert_arrays_eq!(res, expected);
@@ -215,11 +215,11 @@ mod tests {
         let decimal_dtype = DecimalDType::new(40, 2);
         let dtype = DType::Decimal(decimal_dtype, Nullability::Nullable);
         let lhs = DecimalBytePartsArray::try_new(
-            PrimitiveArray::new(buffer![100i32, 200i32, 400i32], Validity::AllValid).to_array(),
+            PrimitiveArray::new(buffer![100i32, 200i32, 400i32], Validity::AllValid).into_array(),
             decimal_dtype,
         )
         .unwrap()
-        .to_array();
+        .into_array();
         // This cannot be converted to a i32.
         let rhs = ConstantArray::new(
             Scalar::try_new(
@@ -230,15 +230,15 @@ mod tests {
             lhs.len(),
         );
 
-        let res = lhs.binary(rhs.to_array(), Operator::Eq).unwrap();
+        let res = lhs.binary(rhs.into_array(), Operator::Eq).unwrap();
         let expected = BoolArray::from_iter([Some(false), Some(false), Some(false)]).into_array();
         assert_arrays_eq!(res, expected);
 
-        let res = lhs.binary(rhs.to_array(), Operator::Gt).unwrap();
+        let res = lhs.binary(rhs.into_array(), Operator::Gt).unwrap();
         let expected = BoolArray::from_iter([Some(true), Some(true), Some(true)]).into_array();
         assert_arrays_eq!(res, expected);
 
-        let res = lhs.binary(rhs.to_array(), Operator::Lt).unwrap();
+        let res = lhs.binary(rhs.into_array(), Operator::Lt).unwrap();
         let expected = BoolArray::from_iter([Some(false), Some(false), Some(false)]).into_array();
         assert_arrays_eq!(res, expected);
 
@@ -248,15 +248,15 @@ mod tests {
             lhs.len(),
         );
 
-        let res = lhs.binary(rhs.to_array(), Operator::Eq).unwrap();
+        let res = lhs.binary(rhs.into_array(), Operator::Eq).unwrap();
         let expected = BoolArray::from_iter([Some(false), Some(false), Some(false)]).into_array();
         assert_arrays_eq!(res, expected);
 
-        let res = lhs.binary(rhs.to_array(), Operator::Gt).unwrap();
+        let res = lhs.binary(rhs.into_array(), Operator::Gt).unwrap();
         let expected = BoolArray::from_iter([Some(false), Some(false), Some(false)]).into_array();
         assert_arrays_eq!(res, expected);
 
-        let res = lhs.binary(rhs.to_array(), Operator::Lt).unwrap();
+        let res = lhs.binary(rhs.into_array(), Operator::Lt).unwrap();
         let expected = BoolArray::from_iter([Some(true), Some(true), Some(true)]).into_array();
         assert_arrays_eq!(res, expected);
     }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
 use vortex_array::arrays::FilterReduce;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
@@ -12,7 +12,7 @@ use crate::DecimalBytePartsVTable;
 impl FilterReduce for DecimalBytePartsVTable {
     fn filter(array: &DecimalBytePartsArray, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
         DecimalBytePartsArray::try_new(array.msp.filter(mask.clone())?, *array.decimal_dtype())
-            .map(|d| Some(d.to_array()))
+            .map(|d| Some(d.into_array()))
     }
 }
 
@@ -33,7 +33,7 @@ mod test {
 
         let decimal_dtype = DecimalDType::new(8, 2);
         let array = DecimalBytePartsArray::try_new(msp, decimal_dtype).unwrap();
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
 
         // Test with nullable values
         let msp = PrimitiveArray::from_option_iter([Some(10i64), None, Some(30), Some(40), None])
@@ -41,6 +41,6 @@ mod test {
 
         let decimal_dtype = DecimalDType::new(18, 4);
         let array = DecimalBytePartsArray::try_new(msp, decimal_dtype).unwrap();
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/mod.rs
@@ -68,6 +68,6 @@ mod tests {
     ).unwrap())]
 
     fn test_decimal_byte_parts_consistency(#[case] array: DecimalBytePartsArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/take.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/take.rs
@@ -4,6 +4,7 @@
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::arrays::TakeExecute;
 use vortex_error::VortexResult;
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/take.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/take.rs
@@ -17,6 +17,6 @@ impl TakeExecute for DecimalBytePartsVTable {
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         DecimalBytePartsArray::try_new(array.msp.take(indices.to_array())?, *array.decimal_dtype())
-            .map(|a| Some(a.to_array()))
+            .map(|a| Some(a.into_array()))
     }
 }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -346,13 +346,13 @@ mod tests {
         let array = DecimalBytePartsArray::try_new(
             PrimitiveArray::new(
                 buffer![100i32, 200i32, 400i32],
-                Validity::Array(BoolArray::from_iter(vec![false, true, true]).to_array()),
+                Validity::Array(BoolArray::from_iter(vec![false, true, true]).into_array()),
             )
-            .to_array(),
+            .into_array(),
             decimal_dtype,
         )
         .unwrap()
-        .to_array();
+        .into_array();
 
         assert_eq!(Scalar::null(dtype.clone()), array.scalar_at(0).unwrap());
         assert_eq!(

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -326,6 +326,7 @@ impl ValidityChild<DecimalBytePartsVTable> for DecimalBytePartsVTable {
 #[cfg(test)]
 mod tests {
     use vortex_array::DynArray;
+    use vortex_array::IntoArray;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::dtype::DType;

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -37,7 +37,7 @@ fn take_10_stratified(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -76,7 +76,7 @@ fn take_10k_random(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -94,7 +94,7 @@ fn take_10k_contiguous(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -112,7 +112,7 @@ fn take_200k_dispersed(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -130,7 +130,7 @@ fn take_200k_first_chunk_only(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -175,7 +175,7 @@ fn patched_take_10_stratified(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -221,7 +221,7 @@ fn patched_take_10k_random(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -239,7 +239,7 @@ fn patched_take_10k_contiguous_not_patches(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -265,7 +265,7 @@ fn patched_take_10k_contiguous_patches(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -283,7 +283,7 @@ fn patched_take_200k_dispersed(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -301,7 +301,7 @@ fn patched_take_200k_first_chunk_only(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -326,7 +326,7 @@ fn patched_take_10k_adversarial(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.to_array())
+                .take(indices.into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -37,7 +37,7 @@ fn take_10_stratified(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -76,7 +76,7 @@ fn take_10k_random(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -94,7 +94,7 @@ fn take_10k_contiguous(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -112,7 +112,7 @@ fn take_200k_dispersed(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -130,7 +130,7 @@ fn take_200k_first_chunk_only(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -175,7 +175,7 @@ fn patched_take_10_stratified(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -221,7 +221,7 @@ fn patched_take_10k_random(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -239,7 +239,7 @@ fn patched_take_10k_contiguous_not_patches(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -265,7 +265,7 @@ fn patched_take_10k_contiguous_patches(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -283,7 +283,7 @@ fn patched_take_200k_dispersed(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -301,7 +301,7 @@ fn patched_take_200k_first_chunk_only(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()
@@ -326,7 +326,7 @@ fn patched_take_10k_adversarial(bencher: Bencher) {
         .with_inputs(|| (&packed, &indices, LEGACY_SESSION.create_execution_ctx()))
         .bench_refs(|(packed, indices, execution_ctx)| {
             packed
-                .take(indices.into_array())
+                .take(indices.clone().into_array())
                 .unwrap()
                 .execute::<RecursiveCanonical>(execution_ctx)
                 .unwrap()

--- a/encodings/fastlanes/benches/compute_between.rs
+++ b/encodings/fastlanes/benches/compute_between.rs
@@ -99,14 +99,14 @@ mod primitive {
             .with_inputs(|| (&arr, LEGACY_SESSION.create_execution_ctx()))
             .bench_refs(|(arr, ctx)| {
                 let gte = arr
-                    .to_array()
+                    .into_array()
                     .binary(
                         ConstantArray::new(min, arr.len()).into_array(),
                         Operator::Gte,
                     )
                     .vortex_expect("");
                 let lt = arr
-                    .to_array()
+                    .into_array()
                     .binary(
                         ConstantArray::new(max, arr.len()).into_array(),
                         Operator::Lt,
@@ -135,7 +135,7 @@ mod primitive {
         bencher
             .with_inputs(|| (&arr, LEGACY_SESSION.create_execution_ctx()))
             .bench_refs(|(arr, ctx)| {
-                arr.to_array()
+                arr.into_array()
                     .between(
                         ConstantArray::new(min, arr.len()).into_array(),
                         ConstantArray::new(max, arr.len()).into_array(),

--- a/encodings/fastlanes/benches/compute_between.rs
+++ b/encodings/fastlanes/benches/compute_between.rs
@@ -99,6 +99,7 @@ mod primitive {
             .with_inputs(|| (&arr, LEGACY_SESSION.create_execution_ctx()))
             .bench_refs(|(arr, ctx)| {
                 let gte = arr
+                    .clone()
                     .into_array()
                     .binary(
                         ConstantArray::new(min, arr.len()).into_array(),
@@ -106,6 +107,7 @@ mod primitive {
                     )
                     .vortex_expect("");
                 let lt = arr
+                    .clone()
                     .into_array()
                     .binary(
                         ConstantArray::new(max, arr.len()).into_array(),
@@ -135,7 +137,8 @@ mod primitive {
         bencher
             .with_inputs(|| (&arr, LEGACY_SESSION.create_execution_ctx()))
             .bench_refs(|(arr, ctx)| {
-                arr.into_array()
+                arr.clone()
+                    .into_array()
                     .between(
                         ConstantArray::new(min, arr.len()).into_array(),
                         ConstantArray::new(max, arr.len()).into_array(),

--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -134,6 +134,10 @@ pub fn vortex_fastlanes::BitPackedArray::try_new(packed: vortex_array::buffer::B
 
 pub fn vortex_fastlanes::BitPackedArray::unpacked_chunks<T: vortex_fastlanes::unpack_iter::BitPacked>(&self) -> vortex_fastlanes::unpack_iter::BitUnpackedChunks<T>
 
+impl vortex_fastlanes::BitPackedArray
+
+pub fn vortex_fastlanes::BitPackedArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_fastlanes::BitPackedArray
 
 pub fn vortex_fastlanes::BitPackedArray::clone(&self) -> vortex_fastlanes::BitPackedArray
@@ -288,6 +292,10 @@ pub fn vortex_fastlanes::DeltaArray::try_from_vec<T: vortex_array::dtype::ptype:
 
 pub fn vortex_fastlanes::DeltaArray::try_new(bases: vortex_array::array::ArrayRef, deltas: vortex_array::array::ArrayRef, offset: usize, logical_len: usize) -> vortex_error::VortexResult<Self>
 
+impl vortex_fastlanes::DeltaArray
+
+pub fn vortex_fastlanes::DeltaArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_fastlanes::DeltaArray
 
 pub fn vortex_fastlanes::DeltaArray::clone(&self) -> vortex_fastlanes::DeltaArray
@@ -403,6 +411,10 @@ pub fn vortex_fastlanes::FoRArray::ptype(&self) -> vortex_array::dtype::ptype::P
 pub fn vortex_fastlanes::FoRArray::reference_scalar(&self) -> &vortex_array::scalar::Scalar
 
 pub fn vortex_fastlanes::FoRArray::try_new(encoded: vortex_array::array::ArrayRef, reference: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<Self>
+
+impl vortex_fastlanes::FoRArray
+
+pub fn vortex_fastlanes::FoRArray::to_array(&self) -> vortex_array::array::ArrayRef
 
 impl core::clone::Clone for vortex_fastlanes::FoRArray
 
@@ -553,6 +565,10 @@ pub fn vortex_fastlanes::RLEArray::values_idx_offsets(&self) -> &vortex_array::a
 impl vortex_fastlanes::RLEArray
 
 pub fn vortex_fastlanes::RLEArray::encode(array: &vortex_array::arrays::primitive::array::PrimitiveArray) -> vortex_error::VortexResult<Self>
+
+impl vortex_fastlanes::RLEArray
+
+pub fn vortex_fastlanes::RLEArray::to_array(&self) -> vortex_array::array::ArrayRef
 
 impl core::clone::Clone for vortex_fastlanes::RLEArray
 

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -461,7 +461,7 @@ mod test {
             Validity::from_iter(valid_values),
         );
         assert!(values.ptype().is_unsigned_int());
-        let compressed = BitPackedArray::encode(&values.to_array(), 4).unwrap();
+        let compressed = BitPackedArray::encode(&values.into_array(), 4).unwrap();
         assert!(compressed.patches().is_none());
         assert_eq!(
             (0..(1 << 4)).collect::<Vec<_>>(),
@@ -480,7 +480,7 @@ mod test {
         let array = PrimitiveArray::new(values, Validity::AllValid);
         assert!(array.ptype().is_signed_int());
 
-        let err = BitPackedArray::encode(&array.to_array(), 1024u32.ilog2() as u8).unwrap_err();
+        let err = BitPackedArray::encode(&array.into_array(), 1024u32.ilog2() as u8).unwrap_err();
         assert!(matches!(err, VortexError::InvalidArgument(_, _)));
     }
 

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -262,7 +262,7 @@ mod tests {
 
     fn compression_roundtrip(n: usize) {
         let values = PrimitiveArray::from_iter((0..n).map(|i| (i % 2047) as u16));
-        let compressed = BitPackedArray::encode(&values.into_array(), 11).unwrap();
+        let compressed = BitPackedArray::encode(&values.clone().into_array(), 11).unwrap();
         assert_arrays_eq!(compressed, values);
 
         values

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -262,7 +262,7 @@ mod tests {
 
     fn compression_roundtrip(n: usize) {
         let values = PrimitiveArray::from_iter((0..n).map(|i| (i % 2047) as u16));
-        let compressed = BitPackedArray::encode(&values.to_array(), 11).unwrap();
+        let compressed = BitPackedArray::encode(&values.into_array(), 11).unwrap();
         assert_arrays_eq!(compressed, values);
 
         values

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -319,7 +319,7 @@ mod test {
             Some(u64::MAX),
         ];
         let uncompressed = PrimitiveArray::from_option_iter(values);
-        let packed = BitPackedArray::encode(&uncompressed.to_array(), 1).unwrap();
+        let packed = BitPackedArray::encode(&uncompressed.into_array(), 1).unwrap();
         let expected = PrimitiveArray::from_option_iter(values);
         assert_arrays_eq!(packed.to_primitive(), expected);
     }
@@ -328,9 +328,9 @@ mod test {
     fn test_encode_too_wide() {
         let values = [Some(1u8), None, Some(1), None, Some(1), None];
         let uncompressed = PrimitiveArray::from_option_iter(values);
-        let _packed = BitPackedArray::encode(&uncompressed.to_array(), 8)
+        let _packed = BitPackedArray::encode(&uncompressed.into_array(), 8)
             .expect_err("Cannot pack value into the same width");
-        let _packed = BitPackedArray::encode(&uncompressed.to_array(), 9)
+        let _packed = BitPackedArray::encode(&uncompressed.into_array(), 9)
             .expect_err("Cannot pack value into larger width");
     }
 

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -328,7 +328,7 @@ mod test {
     fn test_encode_too_wide() {
         let values = [Some(1u8), None, Some(1), None, Some(1), None];
         let uncompressed = PrimitiveArray::from_option_iter(values);
-        let _packed = BitPackedArray::encode(&uncompressed.into_array(), 8)
+        let _packed = BitPackedArray::encode(&uncompressed.clone().into_array(), 8)
             .expect_err("Cannot pack value into the same width");
         let _packed = BitPackedArray::encode(&uncompressed.into_array(), 9)
             .expect_err("Cannot pack value into larger width");

--- a/encodings/fastlanes/src/bitpacking/compute/cast.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/cast.rs
@@ -71,7 +71,7 @@ mod tests {
             BitPackedArray::encode(&buffer![10u8, 20, 30, 40, 50, 60].into_array(), 6).unwrap();
 
         let casted = packed
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U32, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -88,10 +88,10 @@ mod tests {
     #[test]
     fn test_cast_bitpacked_nullable() {
         let values = PrimitiveArray::from_option_iter([Some(5u16), None, Some(10), Some(15), None]);
-        let packed = BitPackedArray::encode(&values.to_array(), 4).unwrap();
+        let packed = BitPackedArray::encode(&values.into_array(), 4).unwrap();
 
         let casted = packed
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U32, Nullability::Nullable))
             .unwrap();
         assert_eq!(
@@ -104,8 +104,8 @@ mod tests {
     #[case(BitPackedArray::encode(&buffer![0u8, 10, 20, 30, 40, 50, 60, 63].into_array(), 6).unwrap())]
     #[case(BitPackedArray::encode(&buffer![0u16, 100, 200, 300, 400, 500].into_array(), 9).unwrap())]
     #[case(BitPackedArray::encode(&buffer![0u32, 1000, 2000, 3000, 4000].into_array(), 12).unwrap())]
-    #[case(BitPackedArray::encode(&PrimitiveArray::from_option_iter([Some(1u32), None, Some(7), Some(15), None]).to_array(), 4).unwrap())]
+    #[case(BitPackedArray::encode(&PrimitiveArray::from_option_iter([Some(1u32), None, Some(7), Some(15), None]).into_array(), 4).unwrap())]
     fn test_cast_bitpacked_conformance(#[case] array: BitPackedArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -178,7 +178,7 @@ mod test {
     fn take_indices() {
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 6).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.into_array(), 6).unwrap();
 
         let mask = Mask::from_indices(bitpacked.len(), vec![0, 125, 2047, 2049, 2151, 2790]);
 
@@ -193,7 +193,7 @@ mod test {
     fn take_sliced_indices() {
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 6).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.into_array(), 6).unwrap();
         let sliced = bitpacked.slice(128..2050).unwrap();
 
         let mask = Mask::from_indices(sliced.len(), vec![1919, 1921]);
@@ -205,7 +205,7 @@ mod test {
     #[test]
     fn filter_bitpacked() {
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 6).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.into_array(), 6).unwrap();
         let filtered = bitpacked
             .filter(Mask::from_indices(4096, (0..1024).collect()))
             .unwrap();
@@ -219,7 +219,7 @@ mod test {
     fn filter_bitpacked_signed() {
         let values: Buffer<i64> = (0..500).collect();
         let unpacked = PrimitiveArray::new(values.clone(), Validity::NonNullable);
-        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 9).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.into_array(), 9).unwrap();
         let filtered = bitpacked
             .filter(Mask::from_indices(values.len(), (0..250).collect()))
             .unwrap()
@@ -236,17 +236,17 @@ mod test {
         // Test with u8 values
         let unpacked = buffer![1u8, 2, 3, 4, 5].into_array();
         let bitpacked = BitPackedArray::encode(&unpacked, 3).unwrap();
-        test_filter_conformance(&bitpacked.to_array());
+        test_filter_conformance(&bitpacked.into_array());
 
         // Test with u32 values
         let unpacked = buffer![100u32, 200, 300, 400, 500].into_array();
         let bitpacked = BitPackedArray::encode(&unpacked, 9).unwrap();
-        test_filter_conformance(&bitpacked.to_array());
+        test_filter_conformance(&bitpacked.into_array());
 
         // Test with nullable values
         let unpacked = PrimitiveArray::from_option_iter([Some(1u16), None, Some(3), Some(4), None]);
-        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 3).unwrap();
-        test_filter_conformance(&bitpacked.to_array());
+        let bitpacked = BitPackedArray::encode(&unpacked.into_array(), 3).unwrap();
+        test_filter_conformance(&bitpacked.into_array());
     }
 
     /// Regression test for signed integers with patches.
@@ -260,7 +260,7 @@ mod test {
         // Values 0-127 fit in 7 bits, but 1000 and 2000 do not.
         let values: Vec<i32> = vec![0, 10, 1000, 20, 30, 2000, 40, 50, 60, 70];
         let unpacked = PrimitiveArray::from_iter(values.clone());
-        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 7).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.into_array(), 7).unwrap();
         assert!(
             bitpacked.patches().is_some(),
             "Expected patches for values exceeding bit width"
@@ -292,7 +292,7 @@ mod test {
             })
             .collect();
         let unpacked = PrimitiveArray::from_iter(values.clone());
-        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 7).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.into_array(), 7).unwrap();
         assert!(
             bitpacked.patches().is_some(),
             "Expected patches for values exceeding bit width"

--- a/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
@@ -178,6 +178,6 @@ mod tests {
     #[test]
     fn is_constant_with_patches() {
         let array = BitPackedArray::encode(&buffer![4; 1025].into_array(), 2).unwrap();
-        assert!(is_constant(&array.to_array()).unwrap().unwrap());
+        assert!(is_constant(&array.into_array()).unwrap().unwrap());
     }
 }

--- a/encodings/fastlanes/src/bitpacking/compute/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/mod.rs
@@ -82,7 +82,7 @@ mod tests {
     #[case::alternating_bits(bitpack_encode(&PrimitiveArray::from_iter([0u16, 255, 0, 255, 0, 255]), 8, None).unwrap())]
 
     fn test_bitpacked_consistency(#[case] array: BitPackedArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 
     #[rstest]

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -135,7 +135,7 @@ fn take_primitive<T: NativePType + BitPacking, I: IntegerPType>(
         unpatched_taken = unpatched_taken.reinterpret_cast(array.ptype());
     }
     if let Some(patches) = array.patches()
-        && let Some(patches) = patches.take(&indices.into_array(), ctx)?
+        && let Some(patches) = patches.take(&indices.clone().into_array(), ctx)?
     {
         let cast_patches = patches.cast_values(unpatched_taken.dtype())?;
         return unpatched_taken.patch(&cast_patches, ctx);
@@ -217,7 +217,7 @@ mod test {
         let range = Uniform::new(0, values.len()).unwrap();
         let random_indices =
             PrimitiveArray::from_iter(rng.sample_iter(range).take(10_000).map(|i| i as u32));
-        let taken = packed.take(random_indices.into_array()).unwrap();
+        let taken = packed.take(random_indices.clone().into_array()).unwrap();
 
         // sanity check
         random_indices
@@ -258,7 +258,9 @@ mod test {
             BitPackedArray::encode(&buffer![1i32, 2i32, 3i32, 4i32].into_array(), 1).unwrap();
 
         let taken_primitive = start
-            .take(PrimitiveArray::from_option_iter([Some(0u64), Some(1), None, Some(3)]).into_array())
+            .take(
+                PrimitiveArray::from_option_iter([Some(0u64), Some(1), None, Some(3)]).into_array(),
+            )
             .unwrap();
         assert_arrays_eq!(
             taken_primitive,

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -135,7 +135,7 @@ fn take_primitive<T: NativePType + BitPacking, I: IntegerPType>(
         unpatched_taken = unpatched_taken.reinterpret_cast(array.ptype());
     }
     if let Some(patches) = array.patches()
-        && let Some(patches) = patches.take(&indices.to_array(), ctx)?
+        && let Some(patches) = patches.take(&indices.into_array(), ctx)?
     {
         let cast_patches = patches.cast_values(unpatched_taken.dtype())?;
         return unpatched_taken.patch(&cast_patches, ctx);
@@ -171,7 +171,7 @@ mod test {
 
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 6).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.into_array(), 6).unwrap();
 
         let primitive_result = bitpacked.take(indices.to_array()).unwrap();
         assert_arrays_eq!(
@@ -197,7 +197,7 @@ mod test {
 
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedArray::encode(&unpacked.to_array(), 6).unwrap();
+        let bitpacked = BitPackedArray::encode(&unpacked.into_array(), 6).unwrap();
         let sliced = bitpacked.slice(128..2050).unwrap();
 
         let primitive_result = sliced.take(indices.to_array()).unwrap();
@@ -210,14 +210,14 @@ mod test {
         let num_patches: usize = 128;
         let values = (0..u16::MAX as u32 + num_patches as u32).collect::<Buffer<_>>();
         let uncompressed = PrimitiveArray::new(values.clone(), Validity::NonNullable);
-        let packed = BitPackedArray::encode(&uncompressed.to_array(), 16).unwrap();
+        let packed = BitPackedArray::encode(&uncompressed.into_array(), 16).unwrap();
         assert!(packed.patches().is_some());
 
         let rng = rng();
         let range = Uniform::new(0, values.len()).unwrap();
         let random_indices =
             PrimitiveArray::from_iter(rng.sample_iter(range).take(10_000).map(|i| i as u32));
-        let taken = packed.take(random_indices.to_array()).unwrap();
+        let taken = packed.take(random_indices.into_array()).unwrap();
 
         // sanity check
         random_indices
@@ -258,7 +258,7 @@ mod test {
             BitPackedArray::encode(&buffer![1i32, 2i32, 3i32, 4i32].into_array(), 1).unwrap();
 
         let taken_primitive = start
-            .take(PrimitiveArray::from_option_iter([Some(0u64), Some(1), None, Some(3)]).to_array())
+            .take(PrimitiveArray::from_option_iter([Some(0u64), Some(1), None, Some(3)]).into_array())
             .unwrap();
         assert_arrays_eq!(
             taken_primitive,
@@ -268,17 +268,17 @@ mod test {
     }
 
     #[rstest]
-    #[case(BitPackedArray::encode(&PrimitiveArray::from_iter((0..100).map(|i| (i % 63) as u8)).to_array(), 6).unwrap())]
-    #[case(BitPackedArray::encode(&PrimitiveArray::from_iter((0..256).map(|i| i as u32)).to_array(), 8).unwrap())]
+    #[case(BitPackedArray::encode(&PrimitiveArray::from_iter((0..100).map(|i| (i % 63) as u8)).into_array(), 6).unwrap())]
+    #[case(BitPackedArray::encode(&PrimitiveArray::from_iter((0..256).map(|i| i as u32)).into_array(), 8).unwrap())]
     #[case(BitPackedArray::encode(&buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array(), 3).unwrap())]
     #[case(BitPackedArray::encode(
-        &PrimitiveArray::from_option_iter([Some(10u16), None, Some(20), Some(30), None]).to_array(),
+        &PrimitiveArray::from_option_iter([Some(10u16), None, Some(20), Some(30), None]).into_array(),
         5
     ).unwrap())]
     #[case(BitPackedArray::encode(&buffer![42u32].into_array(), 6).unwrap())]
-    #[case(BitPackedArray::encode(&PrimitiveArray::from_iter((0..1024).map(|i| i as u32)).to_array(), 8).unwrap())]
+    #[case(BitPackedArray::encode(&PrimitiveArray::from_iter((0..1024).map(|i| i as u32)).into_array(), 8).unwrap())]
     fn test_take_bitpacked_conformance(#[case] bitpacked: BitPackedArray) {
         use vortex_array::compute::conformance::take::test_take_conformance;
-        test_take_conformance(&bitpacked.to_array());
+        test_take_conformance(&bitpacked.into_array());
     }
 }

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -72,7 +72,7 @@ mod test {
     #[test]
     pub fn slice_block() {
         let arr = BitPackedArray::encode(
-            &PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).to_array(),
+            &PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).into_array(),
             6,
         )
         .unwrap();
@@ -86,7 +86,7 @@ mod test {
     #[test]
     pub fn slice_within_block() {
         let arr = BitPackedArray::encode(
-            &PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).to_array(),
+            &PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).into_array(),
             6,
         )
         .unwrap();
@@ -100,7 +100,7 @@ mod test {
     #[test]
     fn slice_within_block_u8s() {
         let packed = BitPackedArray::encode(
-            &PrimitiveArray::from_iter((0..10_000).map(|i| (i % 63) as u8)).to_array(),
+            &PrimitiveArray::from_iter((0..10_000).map(|i| (i % 63) as u8)).into_array(),
             7,
         )
         .unwrap();
@@ -113,7 +113,7 @@ mod test {
     #[test]
     fn slice_block_boundary_u8s() {
         let packed = BitPackedArray::encode(
-            &PrimitiveArray::from_iter((0..10_000).map(|i| (i % 63) as u8)).to_array(),
+            &PrimitiveArray::from_iter((0..10_000).map(|i| (i % 63) as u8)).into_array(),
             7,
         )
         .unwrap();
@@ -126,7 +126,7 @@ mod test {
     #[test]
     fn double_slice_within_block() {
         let arr = BitPackedArray::encode(
-            &PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).to_array(),
+            &PrimitiveArray::from_iter((0u32..2048).map(|v| v % 64)).into_array(),
             6,
         )
         .unwrap();
@@ -162,7 +162,7 @@ mod test {
         // Check that our take implementation respects the offsets applied after slicing.
 
         let array = BitPackedArray::encode(
-            &PrimitiveArray::from_iter((63u32..).take(3072)).to_array(),
+            &PrimitiveArray::from_iter((63u32..).take(3072)).into_array(),
             6,
         )
         .unwrap();
@@ -197,7 +197,7 @@ mod test {
                         8,
                         0,
                         buffer![1u32].into_array(),
-                        PrimitiveArray::new(buffer![999u32], Validity::AllValid).to_array(),
+                        PrimitiveArray::new(buffer![999u32], Validity::AllValid).into_array(),
                         None,
                     )
                     .unwrap(),

--- a/encodings/fastlanes/src/delta/compute/cast.rs
+++ b/encodings/fastlanes/src/delta/compute/cast.rs
@@ -46,6 +46,7 @@ impl CastReduce for DeltaVTable {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::builtins::ArrayBuiltins;

--- a/encodings/fastlanes/src/delta/compute/cast.rs
+++ b/encodings/fastlanes/src/delta/compute/cast.rs
@@ -63,7 +63,7 @@ mod tests {
         let array = DeltaArray::try_from_primitive_array(&primitive).unwrap();
 
         let casted = array
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U32, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -86,7 +86,7 @@ mod tests {
         let array = DeltaArray::try_from_primitive_array(&values).unwrap();
 
         let casted = array
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U32, Nullability::Nullable))
             .unwrap();
         assert_eq!(
@@ -122,6 +122,6 @@ mod tests {
     )]
     fn test_cast_delta_conformance(#[case] primitive: PrimitiveArray) {
         let delta_array = DeltaArray::try_from_primitive_array(&primitive).unwrap();
-        test_cast_conformance(&delta_array.to_array());
+        test_cast_conformance(&delta_array.into_array());
     }
 }

--- a/encodings/fastlanes/src/delta/vtable/operations.rs
+++ b/encodings/fastlanes/src/delta/vtable/operations.rs
@@ -228,7 +228,7 @@ mod tests {
     // Single element
     #[case::delta_single(DeltaArray::try_from_vec(vec![42u32]).unwrap())]
     fn test_delta_consistency(#[case] array: DeltaArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 
     #[rstest]

--- a/encodings/fastlanes/src/for/array/for_compress.rs
+++ b/encodings/fastlanes/src/for/array/for_compress.rs
@@ -130,7 +130,7 @@ mod test {
         // Create a range offset by a million.
         let expect = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7 + 10));
         let array = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7));
-        let bp = BitPackedArray::encode(&array.to_array(), 3).unwrap();
+        let bp = BitPackedArray::encode(&array.into_array(), 3).unwrap();
         let compressed = FoRArray::try_new(bp.into_array(), 10u32.into()).unwrap();
         assert_arrays_eq!(compressed, expect);
     }
@@ -140,7 +140,7 @@ mod test {
         // Create a range offset by a million.
         let expect = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7 + 10));
         let array = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7));
-        let bp = BitPackedArray::encode(&array.to_array(), 2).unwrap();
+        let bp = BitPackedArray::encode(&array.into_array(), 2).unwrap();
         let compressed = FoRArray::try_new(bp.clone().into_array(), 10u32.into()).unwrap();
         let decompressed =
             fused_decompress::<u32>(&compressed, &bp, &mut SESSION.create_execution_ctx())?;

--- a/encodings/fastlanes/src/for/compute/cast.rs
+++ b/encodings/fastlanes/src/for/compute/cast.rs
@@ -53,7 +53,7 @@ mod tests {
         .unwrap();
 
         let casted = for_array
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I64, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -74,7 +74,7 @@ mod tests {
         let for_array = FoRArray::try_new(values.into_array(), Scalar::from(50i32)).unwrap();
 
         let casted = for_array
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I64, Nullability::Nullable))
             .unwrap();
         assert_eq!(
@@ -101,6 +101,6 @@ mod tests {
         Scalar::from(-100i32)
     ).unwrap())]
     fn test_cast_for_conformance(#[case] array: FoRArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/encodings/fastlanes/src/for/compute/is_sorted.rs
+++ b/encodings/fastlanes/src/for/compute/is_sorted.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
 use vortex_array::compute::IsSortedKernel;
 use vortex_array::compute::IsSortedKernelAdapter;

--- a/encodings/fastlanes/src/for/compute/is_sorted.rs
+++ b/encodings/fastlanes/src/for/compute/is_sorted.rs
@@ -76,7 +76,7 @@ impl IsSortedKernel for FoRVTable {
         is_sorted(
             &encoded
                 .reinterpret_cast(encoded.ptype().to_unsigned())
-                .to_array(),
+                .into_array(),
         )
     }
 
@@ -85,7 +85,7 @@ impl IsSortedKernel for FoRVTable {
         is_strict_sorted(
             &encoded
                 .reinterpret_cast(encoded.ptype().to_unsigned())
-                .to_array(),
+                .into_array(),
         )
     }
 }

--- a/encodings/fastlanes/src/for/compute/mod.rs
+++ b/encodings/fastlanes/src/for/compute/mod.rs
@@ -61,20 +61,20 @@ mod test {
         let values = buffer![100i32, 101, 102, 103, 104].into_array();
         let reference = Scalar::from(100i32);
         let for_array = FoRArray::try_new(values, reference).unwrap();
-        test_filter_conformance(&for_array.to_array());
+        test_filter_conformance(&for_array.into_array());
 
         // Test with u64 values
         let values = buffer![1000u64, 1001, 1002, 1003, 1004].into_array();
         let reference = Scalar::from(1000u64);
         let for_array = FoRArray::try_new(values, reference).unwrap();
-        test_filter_conformance(&for_array.to_array());
+        test_filter_conformance(&for_array.into_array());
 
         // Test with nullable values
         let values =
             PrimitiveArray::from_option_iter([Some(50i16), None, Some(52), Some(53), None]);
         let reference = Scalar::from(50i16);
         let for_array = FoRArray::try_new(values.into_array(), reference).unwrap();
-        test_filter_conformance(&for_array.to_array());
+        test_filter_conformance(&for_array.into_array());
     }
 
     #[rstest]
@@ -88,7 +88,7 @@ mod test {
     #[case(FoRArray::try_new(buffer![42i64].into_array(), Scalar::from(40i64)).unwrap())]
     fn test_take_for_conformance(#[case] for_array: FoRArray) {
         use vortex_array::compute::conformance::take::test_take_conformance;
-        test_take_conformance(&for_array.to_array());
+        test_take_conformance(&for_array.into_array());
     }
 }
 
@@ -157,7 +157,7 @@ mod tests {
     ).unwrap())]
 
     fn test_for_consistency(#[case] array: FoRArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 
     #[rstest]

--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -485,6 +485,7 @@ mod tests {
 
         let ctx = ArrayContext::empty();
         let serialized = sliced
+            .clone()
             .into_array()
             .serialize(&ctx, &SerializeOptions::default())
             .unwrap();

--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -443,7 +443,7 @@ mod tests {
 
         let ctx = ArrayContext::empty();
         let serialized = rle_array
-            .to_array()
+            .into_array()
             .serialize(&ctx, &SerializeOptions::default())
             .unwrap();
 
@@ -485,7 +485,7 @@ mod tests {
 
         let ctx = ArrayContext::empty();
         let serialized = sliced
-            .to_array()
+            .into_array()
             .serialize(&ctx, &SerializeOptions::default())
             .unwrap();
 

--- a/encodings/fastlanes/src/rle/array/rle_decompress.rs
+++ b/encodings/fastlanes/src/rle/array/rle_decompress.rs
@@ -102,6 +102,6 @@ where
         buffer
             .freeze()
             .slice(offset_within_chunk..(offset_within_chunk + array.len())),
-        Validity::copy_from_array(&array.to_array())?,
+        Validity::copy_from_array(&array.into_array())?,
     ))
 }

--- a/encodings/fastlanes/src/rle/array/rle_decompress.rs
+++ b/encodings/fastlanes/src/rle/array/rle_decompress.rs
@@ -7,6 +7,7 @@ use fastlanes::RLE;
 use num_traits::AsPrimitive;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::NativePType;
 use vortex_array::match_each_native_ptype;
@@ -102,6 +103,6 @@ where
         buffer
             .freeze()
             .slice(offset_within_chunk..(offset_within_chunk + array.len())),
-        Validity::copy_from_array(&array.into_array())?,
+        Validity::copy_from_array(&array.clone().into_array())?,
     ))
 }

--- a/encodings/fastlanes/src/rle/compute/cast.rs
+++ b/encodings/fastlanes/src/rle/compute/cast.rs
@@ -66,7 +66,7 @@ mod tests {
         let rle = RLEArray::encode(&primitive).unwrap();
 
         let casted = rle
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U16, Nullability::NonNullable))
             .unwrap();
         assert_arrays_eq!(casted, PrimitiveArray::from_iter([10u16, 20, 30, 40, 50]));
@@ -80,7 +80,7 @@ mod tests {
             Validity::from_iter([true, false, true, true, false]),
         );
         let rle = RLEArray::encode(&primitive).unwrap();
-        rle.to_array()
+        rle.into_array()
             .cast(DType::Primitive(PType::U8, Nullability::NonNullable))
             .and_then(|a| a.to_canonical().map(|c| c.into_array()))
             .unwrap();
@@ -137,6 +137,6 @@ mod tests {
     )]
     fn test_cast_rle_conformance(#[case] primitive: PrimitiveArray) {
         let rle_array = RLEArray::encode(&primitive).unwrap();
-        test_cast_conformance(&rle_array.to_array());
+        test_cast_conformance(&rle_array.into_array());
     }
 }

--- a/encodings/fastlanes/src/rle/vtable/operations.rs
+++ b/encodings/fastlanes/src/rle/vtable/operations.rs
@@ -207,7 +207,7 @@ mod tests {
             Some(30),
             Some(10),
         ]);
-        assert_arrays_eq!(sliced.to_array(), expected.to_array());
+        assert_arrays_eq!(sliced.into_array(), expected.into_array());
     }
 
     #[test]
@@ -242,7 +242,7 @@ mod tests {
         let sliced = array.slice(1..4).unwrap(); // [null, 20, 20]
 
         let expected = PrimitiveArray::from_option_iter([Option::<u32>::None, Some(20), Some(20)]);
-        assert_arrays_eq!(sliced.to_array(), expected.to_array());
+        assert_arrays_eq!(sliced.into_array(), expected.into_array());
     }
 
     #[test]
@@ -251,7 +251,7 @@ mod tests {
         let sliced = array.slice(1..4).unwrap().to_array().to_primitive(); // [null, 20, 20]
 
         let expected = PrimitiveArray::from_option_iter([Option::<u32>::None, Some(20), Some(20)]);
-        assert_arrays_eq!(sliced.to_array(), expected.to_array());
+        assert_arrays_eq!(sliced.into_array(), expected.into_array());
     }
 
     #[test]

--- a/encodings/fsst/benches/fsst_compress.rs
+++ b/encodings/fsst/benches/fsst_compress.rs
@@ -98,8 +98,9 @@ fn pushdown_compare(bencher: Bencher, (string_count, avg_len, unique_chars): (us
         })
         .bench_refs(|(fsst_array, constant, ctx)| {
             fsst_array
+                .clone()
                 .into_array()
-                .binary(constant.into_array(), Operator::Eq)
+                .binary(constant.clone().into_array(), Operator::Eq)
                 .unwrap()
                 .execute::<RecursiveCanonical>(ctx)
                 .unwrap();
@@ -130,7 +131,7 @@ fn canonicalize_compare(
                 .unwrap()
                 .as_ref()
                 .to_array()
-                .binary(constant.into_array(), Operator::Eq)
+                .binary(constant.clone().into_array(), Operator::Eq)
                 .unwrap()
                 .execute::<RecursiveCanonical>(ctx)
                 .unwrap();

--- a/encodings/fsst/benches/fsst_compress.rs
+++ b/encodings/fsst/benches/fsst_compress.rs
@@ -98,8 +98,8 @@ fn pushdown_compare(bencher: Bencher, (string_count, avg_len, unique_chars): (us
         })
         .bench_refs(|(fsst_array, constant, ctx)| {
             fsst_array
-                .to_array()
-                .binary(constant.to_array(), Operator::Eq)
+                .into_array()
+                .binary(constant.into_array(), Operator::Eq)
                 .unwrap()
                 .execute::<RecursiveCanonical>(ctx)
                 .unwrap();
@@ -130,7 +130,7 @@ fn canonicalize_compare(
                 .unwrap()
                 .as_ref()
                 .to_array()
-                .binary(constant.to_array(), Operator::Eq)
+                .binary(constant.into_array(), Operator::Eq)
                 .unwrap()
                 .execute::<RecursiveCanonical>(ctx)
                 .unwrap();

--- a/encodings/fsst/public-api.lock
+++ b/encodings/fsst/public-api.lock
@@ -22,6 +22,10 @@ pub fn vortex_fsst::FSSTArray::uncompressed_lengths(&self) -> &vortex_array::arr
 
 pub fn vortex_fsst::FSSTArray::uncompressed_lengths_dtype(&self) -> &vortex_array::dtype::DType
 
+impl vortex_fsst::FSSTArray
+
+pub fn vortex_fsst::FSSTArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_fsst::FSSTArray
 
 pub fn vortex_fsst::FSSTArray::clone(&self) -> vortex_fsst::FSSTArray

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -193,7 +193,7 @@ impl VTable for FSSTVTable {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let Some(builder) = builder.as_any_mut().downcast_mut::<VarBinViewBuilder>() else {
-            builder.extend_from_array(&array.to_array().execute::<Canonical>(ctx)?.into_array());
+            builder.extend_from_array(&array.into_array().execute::<Canonical>(ctx)?.into_array());
             return Ok(());
         };
 
@@ -451,7 +451,7 @@ impl FSSTArray {
             Compressor::rebuild_from(symbols2.as_slice(), symbol_lengths2.as_slice())
         })
             as Box<dyn Fn() -> Compressor + Send>));
-        let codes_array = codes.to_array();
+        let codes_array = codes.into_array();
 
         Self {
             dtype,

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -193,7 +193,13 @@ impl VTable for FSSTVTable {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let Some(builder) = builder.as_any_mut().downcast_mut::<VarBinViewBuilder>() else {
-            builder.extend_from_array(&array.into_array().execute::<Canonical>(ctx)?.into_array());
+            builder.extend_from_array(
+                &array
+                    .clone()
+                    .into_array()
+                    .execute::<Canonical>(ctx)?
+                    .into_array(),
+            );
             return Ok(());
         };
 
@@ -451,7 +457,7 @@ impl FSSTArray {
             Compressor::rebuild_from(symbols2.as_slice(), symbol_lengths2.as_slice())
         })
             as Box<dyn Fn() -> Compressor + Send>));
-        let codes_array = codes.into_array();
+        let codes_array = codes.clone().into_array();
 
         Self {
             dtype,

--- a/encodings/fsst/src/compute/cast.rs
+++ b/encodings/fsst/src/compute/cast.rs
@@ -20,6 +20,7 @@ impl CastReduce for FSSTVTable {
             // Cast codes array to handle nullability
             let new_codes = array
                 .codes()
+                .clone()
                 .into_array()
                 .cast(array.codes().dtype().with_nullability(dtype.nullability()))?;
 
@@ -42,6 +43,7 @@ impl CastReduce for FSSTVTable {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::arrays::VarBinArray;
     use vortex_array::builtins::ArrayBuiltins;
     use vortex_array::compute::conformance::cast::test_cast_conformance;

--- a/encodings/fsst/src/compute/cast.rs
+++ b/encodings/fsst/src/compute/cast.rs
@@ -20,7 +20,7 @@ impl CastReduce for FSSTVTable {
             // Cast codes array to handle nullability
             let new_codes = array
                 .codes()
-                .to_array()
+                .into_array()
                 .cast(array.codes().dtype().with_nullability(dtype.nullability()))?;
 
             Ok(Some(
@@ -63,7 +63,7 @@ mod tests {
 
         // Cast to nullable
         let casted = fsst
-            .to_array()
+            .into_array()
             .cast(DType::Utf8(Nullability::Nullable))
             .unwrap();
         assert_eq!(casted.dtype(), &DType::Utf8(Nullability::Nullable));
@@ -85,6 +85,6 @@ mod tests {
     fn test_cast_fsst_conformance(#[case] array: VarBinArray) {
         let compressor = fsst_train_compressor(&array);
         let fsst = fsst_compress(&array, &compressor);
-        test_cast_conformance(&fsst.to_array());
+        test_cast_conformance(&fsst.into_array());
     }
 }

--- a/encodings/fsst/src/compute/compare.rs
+++ b/encodings/fsst/src/compute/compare.rs
@@ -78,7 +78,7 @@ fn compare_fsst_constant(
         return Ok(Some(
             BoolArray::new(
                 buffer,
-                Validity::copy_from_array(&left.into_array())?
+                Validity::copy_from_array(&left.clone().into_array())?
                     .union_nullability(right.dtype().nullability()),
             )
             .into_array(),
@@ -116,6 +116,7 @@ fn compare_fsst_constant(
 
     let rhs = ConstantArray::new(encoded_scalar, left.len());
     left.codes()
+        .clone()
         .into_array()
         .binary(rhs.into_array(), Operator::from(operator))
         .map(Some)
@@ -124,6 +125,7 @@ fn compare_fsst_constant(
 #[cfg(test)]
 mod tests {
     use vortex_array::DynArray;
+    use vortex_array::IntoArray;
     use vortex_array::ToCanonical;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::ConstantArray;
@@ -158,8 +160,9 @@ mod tests {
 
         // Ensure fastpath for Eq exists, and returns correct answer
         let equals = lhs
+            .clone()
             .into_array()
-            .binary(rhs.into_array(), Operator::Eq)
+            .binary(rhs.clone().into_array(), Operator::Eq)
             .unwrap()
             .to_bool();
 
@@ -172,6 +175,7 @@ mod tests {
 
         // Ensure fastpath for Eq exists, and returns correct answer
         let not_equals = lhs
+            .clone()
             .into_array()
             .binary(rhs.into_array(), Operator::NotEq)
             .unwrap()
@@ -187,8 +191,9 @@ mod tests {
         let null_rhs =
             ConstantArray::new(Scalar::null(DType::Utf8(Nullability::Nullable)), lhs.len());
         let equals_null = lhs
+            .clone()
             .into_array()
-            .binary(null_rhs.into_array(), Operator::Eq)
+            .binary(null_rhs.clone().into_array(), Operator::Eq)
             .unwrap();
         assert_arrays_eq!(
             &equals_null,

--- a/encodings/fsst/src/compute/compare.rs
+++ b/encodings/fsst/src/compute/compare.rs
@@ -78,7 +78,7 @@ fn compare_fsst_constant(
         return Ok(Some(
             BoolArray::new(
                 buffer,
-                Validity::copy_from_array(&left.to_array())?
+                Validity::copy_from_array(&left.into_array())?
                     .union_nullability(right.dtype().nullability()),
             )
             .into_array(),
@@ -116,7 +116,7 @@ fn compare_fsst_constant(
 
     let rhs = ConstantArray::new(encoded_scalar, left.len());
     left.codes()
-        .to_array()
+        .into_array()
         .binary(rhs.into_array(), Operator::from(operator))
         .map(Some)
 }
@@ -158,8 +158,8 @@ mod tests {
 
         // Ensure fastpath for Eq exists, and returns correct answer
         let equals = lhs
-            .to_array()
-            .binary(rhs.to_array(), Operator::Eq)
+            .into_array()
+            .binary(rhs.into_array(), Operator::Eq)
             .unwrap()
             .to_bool();
 
@@ -172,8 +172,8 @@ mod tests {
 
         // Ensure fastpath for Eq exists, and returns correct answer
         let not_equals = lhs
-            .to_array()
-            .binary(rhs.to_array(), Operator::NotEq)
+            .into_array()
+            .binary(rhs.into_array(), Operator::NotEq)
             .unwrap()
             .to_bool();
 
@@ -187,8 +187,8 @@ mod tests {
         let null_rhs =
             ConstantArray::new(Scalar::null(DType::Utf8(Nullability::Nullable)), lhs.len());
         let equals_null = lhs
-            .to_array()
-            .binary(null_rhs.to_array(), Operator::Eq)
+            .into_array()
+            .binary(null_rhs.into_array(), Operator::Eq)
             .unwrap();
         assert_arrays_eq!(
             &equals_null,
@@ -196,8 +196,8 @@ mod tests {
         );
 
         let noteq_null = lhs
-            .to_array()
-            .binary(null_rhs.to_array(), Operator::NotEq)
+            .into_array()
+            .binary(null_rhs.into_array(), Operator::NotEq)
             .unwrap();
         assert_arrays_eq!(
             &noteq_null,

--- a/encodings/fsst/src/compute/filter.rs
+++ b/encodings/fsst/src/compute/filter.rs
@@ -62,7 +62,7 @@ mod test {
 
         let compressor = fsst_train_compressor(&varbin);
         let array = fsst_compress(&varbin, &compressor);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
 
         // Test with longer strings that benefit from compression
         let mut builder = VarBinBuilder::<i32>::with_capacity(5);
@@ -75,7 +75,7 @@ mod test {
 
         let compressor = fsst_train_compressor(&varbin);
         let array = fsst_compress(&varbin, &compressor);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
 
         // Test with nullable strings
         let mut builder = VarBinBuilder::<i32>::with_capacity(5);
@@ -88,6 +88,6 @@ mod test {
 
         let compressor = fsst_train_compressor(&varbin);
         let array = fsst_compress(&varbin, &compressor);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 }

--- a/encodings/fsst/src/compute/filter.rs
+++ b/encodings/fsst/src/compute/filter.rs
@@ -41,6 +41,7 @@ impl FilterKernel for FSSTVTable {
 
 #[cfg(test)]
 mod test {
+    use vortex_array::IntoArray;
     use vortex_array::arrays::builder::VarBinBuilder;
     use vortex_array::compute::conformance::filter::test_filter_conformance;
     use vortex_array::dtype::DType;

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -54,6 +54,7 @@ impl TakeExecute for FSSTVTable {
 mod tests {
     use rstest::rstest;
     use vortex_array::DynArray;
+    use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::VarBinArray;
     use vortex_array::compute::conformance::consistency::test_array_consistency;

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -74,14 +74,14 @@ mod tests {
         let idx1: PrimitiveArray = (0..1).collect();
 
         assert_eq!(
-            fsst.take(idx1.to_array()).unwrap().dtype(),
+            fsst.take(idx1.into_array()).unwrap().dtype(),
             &DType::Utf8(Nullability::NonNullable)
         );
 
         let idx2: PrimitiveArray = PrimitiveArray::from_option_iter(vec![Some(0)]);
 
         assert_eq!(
-            fsst.take(idx2.to_array()).unwrap().dtype(),
+            fsst.take(idx2.into_array()).unwrap().dtype(),
             &DType::Utf8(Nullability::Nullable)
         );
     }
@@ -102,7 +102,7 @@ mod tests {
     fn test_take_fsst_conformance(#[case] varbin: VarBinArray) {
         let compressor = fsst_train_compressor(&varbin);
         let array = fsst_compress(&varbin, &compressor);
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 
     #[rstest]
@@ -172,6 +172,6 @@ mod tests {
     })]
 
     fn test_fsst_consistency(#[case] array: FSSTArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/encodings/pco/public-api.lock
+++ b/encodings/pco/public-api.lock
@@ -12,6 +12,10 @@ pub fn vortex_pco::PcoArray::from_primitive(parray: &vortex_array::arrays::primi
 
 pub fn vortex_pco::PcoArray::new(chunk_metas: alloc::vec::Vec<vortex_buffer::ByteBuffer>, pages: alloc::vec::Vec<vortex_buffer::ByteBuffer>, dtype: vortex_array::dtype::DType, metadata: vortex_pco::PcoMetadata, len: usize, validity: vortex_array::validity::Validity) -> Self
 
+impl vortex_pco::PcoArray
+
+pub fn vortex_pco::PcoArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_pco::PcoArray
 
 pub fn vortex_pco::PcoArray::clone(&self) -> vortex_pco::PcoArray

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -293,7 +293,7 @@ pub(crate) fn number_type_from_dtype(dtype: &DType) -> NumberType {
 
 fn collect_valid(parray: &PrimitiveArray) -> VortexResult<PrimitiveArray> {
     let mask = parray.validity_mask()?;
-    Ok(parray.to_array().filter(mask)?.to_primitive())
+    Ok(parray.into_array().filter(mask)?.to_primitive())
 }
 
 pub(crate) fn vortex_err_from_pco(err: PcoError) -> VortexError {

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -293,7 +293,7 @@ pub(crate) fn number_type_from_dtype(dtype: &DType) -> NumberType {
 
 fn collect_valid(parray: &PrimitiveArray) -> VortexResult<PrimitiveArray> {
     let mask = parray.validity_mask()?;
-    Ok(parray.into_array().filter(mask)?.to_primitive())
+    Ok(parray.clone().into_array().filter(mask)?.to_primitive())
 }
 
 pub(crate) fn vortex_err_from_pco(err: PcoError) -> VortexError {

--- a/encodings/pco/src/compute/cast.rs
+++ b/encodings/pco/src/compute/cast.rs
@@ -69,7 +69,7 @@ mod tests {
         let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
 
         let casted = pco
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::F64, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -90,7 +90,7 @@ mod tests {
         let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
 
         let casted = pco
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U32, Nullability::Nullable))
             .unwrap();
         assert_arrays_eq!(
@@ -163,6 +163,6 @@ mod tests {
     ))]
     fn test_cast_pco_conformance(#[case] values: PrimitiveArray) {
         let pco = PcoArray::from_primitive(&values, 0, 128).unwrap();
-        test_cast_conformance(&pco.to_array());
+        test_cast_conformance(&pco.into_array());
     }
 }

--- a/encodings/pco/src/compute/cast.rs
+++ b/encodings/pco/src/compute/cast.rs
@@ -51,6 +51,7 @@ impl CastReduce for PcoVTable {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::builtins::ArrayBuiltins;

--- a/encodings/pco/src/compute/mod.rs
+++ b/encodings/pco/src/compute/mod.rs
@@ -61,6 +61,6 @@ mod tests {
     #[case::single(pco_single())]
     #[case::large(pco_large())]
     fn test_pco_consistency(#[case] array: PcoArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/encodings/pco/src/compute/mod.rs
+++ b/encodings/pco/src/compute/mod.rs
@@ -6,6 +6,7 @@ mod cast;
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
 

--- a/encodings/pco/src/test.rs
+++ b/encodings/pco/src/test.rs
@@ -89,7 +89,7 @@ fn test_validity_and_multiple_chunks_and_pages() {
     validity[101] = false;
     let array = PrimitiveArray::new(
         Buffer::from(data),
-        Validity::Array(BoolArray::from_iter(validity).to_array()),
+        Validity::Array(BoolArray::from_iter(validity).into_array()),
     );
     let compression_level = 3;
     let values_per_chunk = 33;
@@ -119,7 +119,7 @@ fn test_validity_and_multiple_chunks_and_pages() {
     let primitive = slice.to_primitive();
     assert_eq!(
         primitive.validity(),
-        &Validity::Array(BoolArray::from_iter(vec![true, false, true]).to_array())
+        &Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array())
     );
 }
 
@@ -129,7 +129,7 @@ fn test_validity_vtable() {
     let mask_bools = vec![false, true, true, false, true];
     let array = PrimitiveArray::new(
         Buffer::from(data),
-        Validity::Array(BoolArray::from_iter(mask_bools.clone()).to_array()),
+        Validity::Array(BoolArray::from_iter(mask_bools.clone()).into_array()),
     );
     let compressed = PcoArray::from_primitive(&array, 3, 0).unwrap();
     assert_eq!(
@@ -145,7 +145,7 @@ fn test_validity_vtable() {
 #[test]
 fn test_serde() -> VortexResult<()> {
     let data: PrimitiveArray = (0i32..1_000_000).collect();
-    let pco = PcoArray::from_primitive(&data, 3, 100)?.to_array();
+    let pco = PcoArray::from_primitive(&data, 3, 100)?.into_array();
 
     let context = ArrayContext::empty();
 

--- a/encodings/runend/benches/run_end_compress.rs
+++ b/encodings/runend/benches/run_end_compress.rs
@@ -73,7 +73,7 @@ fn decompress<T: IntegerPType>(bencher: Bencher, (length, run_step): (usize, usi
         .into_array();
 
     let run_end_array = RunEndArray::new(ends, values);
-    let array = run_end_array.to_array();
+    let array = run_end_array.into_array();
 
     bencher
         .with_inputs(|| &array)
@@ -95,7 +95,7 @@ fn take_indices(bencher: Bencher, (length, run_step): (usize, usize)) {
     let (ends, values) = runend_encode(&values);
     let runend_array = RunEndArray::try_new(ends.into_array(), values)
         .unwrap()
-        .to_array();
+        .into_array();
 
     bencher
         .with_inputs(|| {

--- a/encodings/runend/public-api.lock
+++ b/encodings/runend/public-api.lock
@@ -36,6 +36,10 @@ pub fn vortex_runend::RunEndArray::try_new_offset_length(ends: vortex_array::arr
 
 pub fn vortex_runend::RunEndArray::values(&self) -> &vortex_array::array::ArrayRef
 
+impl vortex_runend::RunEndArray
+
+pub fn vortex_runend::RunEndArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_runend::RunEndArray
 
 pub fn vortex_runend::RunEndArray::clone(&self) -> vortex_runend::RunEndArray

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -550,6 +550,6 @@ mod tests {
         // 2, 3, 4 => 2
         // 5, 6, 7, 8, 9 => 3
         let expected = buffer![1, 1, 2, 2, 2, 3, 3, 3, 3, 3].into_array();
-        assert_arrays_eq!(arr.to_array(), expected);
+        assert_arrays_eq!(arr.into_array(), expected);
     }
 }

--- a/encodings/runend/src/arrow.rs
+++ b/encodings/runend/src/arrow.rs
@@ -38,7 +38,7 @@ where
                 .as_primitive_typed()
                 .search_sorted(&PValue::from(offset), SearchSortedSide::Right)?
                 .to_ends_index(ends.len());
-            let slice_end = find_slice_end_index(&ends.into_array(), offset + len)?;
+            let slice_end = find_slice_end_index(&ends.clone().into_array(), offset + len)?;
 
             (
                 ends.slice(slice_begin..slice_end)?,

--- a/encodings/runend/src/arrow.rs
+++ b/encodings/runend/src/arrow.rs
@@ -38,7 +38,7 @@ where
                 .as_primitive_typed()
                 .search_sorted(&PValue::from(offset), SearchSortedSide::Right)?
                 .to_ends_index(ends.len());
-            let slice_end = find_slice_end_index(&ends.to_array(), offset + len)?;
+            let slice_end = find_slice_end_index(&ends.into_array(), offset + len)?;
 
             (
                 ends.slice(slice_begin..slice_end)?,

--- a/encodings/runend/src/compute/cast.rs
+++ b/encodings/runend/src/compute/cast.rs
@@ -155,6 +155,6 @@ mod tests {
         BoolArray::from_iter(vec![true, false, true, false, true]).into_array()
     ).unwrap())]
     fn test_cast_runend_conformance(#[case] array: RunEndArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/encodings/runend/src/compute/compare.rs
+++ b/encodings/runend/src/compute/compare.rs
@@ -67,7 +67,7 @@ mod test {
     fn compare_run_end() {
         let arr = ree_array();
         let res = arr
-            .to_array()
+            .into_array()
             .binary(ConstantArray::new(5, 12).into_array(), Operator::Eq)
             .unwrap();
         let expected = BoolArray::from_iter([

--- a/encodings/runend/src/compute/mod.rs
+++ b/encodings/runend/src/compute/mod.rs
@@ -45,6 +45,6 @@ mod tests {
     ).unwrap())]
 
     fn test_runend_consistency(#[case] array: RunEndArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/encodings/runend/src/compute/take.rs
+++ b/encodings/runend/src/compute/take.rs
@@ -6,6 +6,7 @@ use num_traits::NumCast;
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::TakeExecute;

--- a/encodings/runend/src/compute/take.rs
+++ b/encodings/runend/src/compute/take.rs
@@ -84,7 +84,7 @@ pub fn take_indices_unchecked<T: AsPrimitive<usize>>(
         PrimitiveArray::new(buffer, validity.clone())
     });
 
-    array.values().take(physical_indices.to_array())
+    array.values().take(physical_indices.into_array())
 }
 
 #[cfg(test)]
@@ -143,11 +143,11 @@ mod test {
     #[test]
     fn ree_take_nullable() {
         let taken = ree_array()
-            .take(PrimitiveArray::from_option_iter([Some(1), None]).to_array())
+            .take(PrimitiveArray::from_option_iter([Some(1), None]).into_array())
             .unwrap();
 
         let expected = PrimitiveArray::from_option_iter([Some(1i32), None]);
-        assert_arrays_eq!(taken, expected.to_array());
+        assert_arrays_eq!(taken, expected.into_array());
     }
 
     #[rstest]
@@ -182,7 +182,7 @@ mod test {
         RunEndArray::encode(PrimitiveArray::from_iter(values).into_array()).unwrap()
     })]
     fn test_take_runend_conformance(#[case] array: RunEndArray) {
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 
     #[rstest]

--- a/encodings/sequence/public-api.lock
+++ b/encodings/sequence/public-api.lock
@@ -18,6 +18,10 @@ pub fn vortex_sequence::SequenceArray::try_new(base: vortex_array::scalar::typed
 
 pub fn vortex_sequence::SequenceArray::try_new_typed<T: vortex_array::dtype::ptype::NativePType + core::convert::Into<vortex_array::scalar::typed_view::primitive::pvalue::PValue>>(base: T, multiplier: T, nullability: vortex_array::dtype::nullability::Nullability, length: usize) -> vortex_error::VortexResult<Self>
 
+impl vortex_sequence::SequenceArray
+
+pub fn vortex_sequence::SequenceArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_sequence::SequenceArray
 
 pub fn vortex_sequence::SequenceArray::clone(&self) -> vortex_sequence::SequenceArray

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -4,6 +4,7 @@
 use num_traits::CheckedAdd;
 use num_traits::CheckedSub;
 use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -49,7 +49,7 @@ fn encode_primitive_array<P: NativePType + Into<PValue> + CheckedAdd + CheckedSu
     if slice.len() == 1 {
         // The multiplier here can be any value, zero is chosen
         return SequenceArray::try_new_typed(slice[0], P::zero(), nullability, 1)
-            .map(|a| Some(a.to_array()));
+            .map(|a| Some(a.into_array()));
     }
     let base = slice[0];
     let Some(multiplier) = slice[1].checked_sub(&base) else {
@@ -70,7 +70,7 @@ fn encode_primitive_array<P: NativePType + Into<PValue> + CheckedAdd + CheckedSu
         .all(|w| Some(w[1]) == w[0].checked_add(&multiplier))
         .then_some(
             SequenceArray::try_new_typed(base, multiplier, nullability, slice.len())
-                .map(|a| a.to_array()),
+                .map(|a| a.into_array()),
         )
         .transpose()
 }

--- a/encodings/sequence/src/compute/cast.rs
+++ b/encodings/sequence/src/compute/cast.rs
@@ -89,6 +89,7 @@ impl CastReduce for SequenceVTable {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::ToCanonical;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;

--- a/encodings/sequence/src/compute/cast.rs
+++ b/encodings/sequence/src/compute/cast.rs
@@ -107,7 +107,7 @@ mod tests {
 
         // Cast to nullable
         let casted = sequence
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U32, Nullability::Nullable))
             .unwrap();
         assert_eq!(
@@ -122,7 +122,7 @@ mod tests {
             SequenceArray::try_new_typed(100u32, 10u32, Nullability::NonNullable, 4).unwrap();
 
         let casted = sequence
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I64, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -142,7 +142,7 @@ mod tests {
             SequenceArray::try_new_typed(5i16, 3i16, Nullability::NonNullable, 3).unwrap();
 
         let casted = sequence
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I32, Nullability::Nullable))
             .unwrap();
         assert_eq!(
@@ -165,7 +165,7 @@ mod tests {
 
         // Cast to float should delegate to canonical (SequenceArray doesn't support float)
         let casted = sequence
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::F32, Nullability::NonNullable))
             .unwrap();
         // Should still succeed by decoding to canonical first
@@ -198,6 +198,6 @@ mod tests {
         5,
     ).unwrap())]
     fn test_cast_sequence_conformance(#[case] sequence: SequenceArray) {
-        test_cast_conformance(&sequence.to_array());
+        test_cast_conformance(&sequence.into_array());
     }
 }

--- a/encodings/sequence/src/compute/compare.rs
+++ b/encodings/sequence/src/compute/compare.rs
@@ -4,6 +4,7 @@
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::dtype::NativePType;
@@ -135,6 +136,7 @@ fn find_intersection<P: NativePType>(
 
 #[cfg(test)]
 mod tests {
+    use vortex_array::IntoArray;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::ConstantArray;
     use vortex_array::assert_arrays_eq;
@@ -149,7 +151,10 @@ mod tests {
     fn test_compare_match() {
         let lhs = SequenceArray::try_new_typed(2i64, 1, NonNullable, 4).unwrap();
         let rhs = ConstantArray::new(4i64, lhs.len());
-        let result = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
+        let result = lhs
+            .into_array()
+            .binary(rhs.into_array(), Operator::Eq)
+            .unwrap();
         let expected = BoolArray::from_iter([false, false, true, false]);
         assert_arrays_eq!(result, expected);
     }
@@ -158,7 +163,10 @@ mod tests {
     fn test_compare_match_scale() {
         let lhs = SequenceArray::try_new_typed(2i64, 3, Nullable, 4).unwrap();
         let rhs = ConstantArray::new(8i64, lhs.len());
-        let result = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
+        let result = lhs
+            .into_array()
+            .binary(rhs.into_array(), Operator::Eq)
+            .unwrap();
         let expected = BoolArray::from_iter([Some(false), Some(false), Some(true), Some(false)]);
         assert_arrays_eq!(result, expected);
     }
@@ -167,7 +175,10 @@ mod tests {
     fn test_compare_no_match() {
         let lhs = SequenceArray::try_new_typed(2i64, 1, NonNullable, 4).unwrap();
         let rhs = ConstantArray::new(1i64, lhs.len());
-        let result = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
+        let result = lhs
+            .into_array()
+            .binary(rhs.into_array(), Operator::Eq)
+            .unwrap();
         let expected = BoolArray::from_iter([false, false, false, false]);
         assert_arrays_eq!(result, expected);
     }

--- a/encodings/sequence/src/compute/compare.rs
+++ b/encodings/sequence/src/compute/compare.rs
@@ -57,10 +57,10 @@ impl CompareKernel for SequenceVTable {
 
         if let Ok(set_idx) = set_idx {
             let buffer = BitBuffer::from_iter((0..lhs.len()).map(|idx| idx == set_idx));
-            Ok(Some(BoolArray::new(buffer, validity).to_array()))
+            Ok(Some(BoolArray::new(buffer, validity).into_array()))
         } else {
             Ok(Some(
-                ConstantArray::new(Scalar::bool(false, nullability), lhs.len()).to_array(),
+                ConstantArray::new(Scalar::bool(false, nullability), lhs.len()).into_array(),
             ))
         }
     }
@@ -149,7 +149,7 @@ mod tests {
     fn test_compare_match() {
         let lhs = SequenceArray::try_new_typed(2i64, 1, NonNullable, 4).unwrap();
         let rhs = ConstantArray::new(4i64, lhs.len());
-        let result = lhs.to_array().binary(rhs.to_array(), Operator::Eq).unwrap();
+        let result = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
         let expected = BoolArray::from_iter([false, false, true, false]);
         assert_arrays_eq!(result, expected);
     }
@@ -158,7 +158,7 @@ mod tests {
     fn test_compare_match_scale() {
         let lhs = SequenceArray::try_new_typed(2i64, 3, Nullable, 4).unwrap();
         let rhs = ConstantArray::new(8i64, lhs.len());
-        let result = lhs.to_array().binary(rhs.to_array(), Operator::Eq).unwrap();
+        let result = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
         let expected = BoolArray::from_iter([Some(false), Some(false), Some(true), Some(false)]);
         assert_arrays_eq!(result, expected);
     }
@@ -167,7 +167,7 @@ mod tests {
     fn test_compare_no_match() {
         let lhs = SequenceArray::try_new_typed(2i64, 1, NonNullable, 4).unwrap();
         let rhs = ConstantArray::new(1i64, lhs.len());
-        let result = lhs.to_array().binary(rhs.to_array(), Operator::Eq).unwrap();
+        let result = lhs.into_array().binary(rhs.into_array(), Operator::Eq).unwrap();
         let expected = BoolArray::from_iter([false, false, false, false]);
         assert_arrays_eq!(result, expected);
     }

--- a/encodings/sequence/src/compute/filter.rs
+++ b/encodings/sequence/src/compute/filter.rs
@@ -47,6 +47,7 @@ fn filter_impl<T: NativePType>(mul: T, base: T, mask: &Mask, validity: Validity)
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::compute::conformance::filter::LARGE_SIZE;
     use vortex_array::compute::conformance::filter::MEDIUM_SIZE;
     use vortex_array::compute::conformance::filter::test_filter_conformance;

--- a/encodings/sequence/src/compute/filter.rs
+++ b/encodings/sequence/src/compute/filter.rs
@@ -68,6 +68,6 @@ mod tests {
     #[case(SequenceArray::try_new_typed(0u32, 5, Nullability::NonNullable, MEDIUM_SIZE).unwrap())]
     #[case(SequenceArray::try_new_typed(0u64, 1, Nullability::NonNullable, LARGE_SIZE).unwrap())]
     fn test_filter_sequence_conformance(#[case] array: SequenceArray) {
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 }

--- a/encodings/sequence/src/compute/list_contains.rs
+++ b/encodings/sequence/src/compute/list_contains.rs
@@ -40,7 +40,7 @@ impl ListContainsElementReduce for SequenceVTable {
         let nullability = list.dtype().nullability() | element.dtype().nullability();
 
         Ok(Some(
-            BoolArray::from_indices(element.len(), set_indices, nullability.into()).to_array(),
+            BoolArray::from_indices(element.len(), set_indices, nullability.into()).into_array(),
         ))
     }
 }

--- a/encodings/sequence/src/compute/list_contains.rs
+++ b/encodings/sequence/src/compute/list_contains.rs
@@ -3,6 +3,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
+use vortex_array::IntoArray;
 use vortex_array::arrays::BoolArray;
 use vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduce;
 use vortex_error::VortexExpect;

--- a/encodings/sequence/src/compute/mod.rs
+++ b/encodings/sequence/src/compute/mod.rs
@@ -82,6 +82,6 @@ mod tests {
     ).unwrap())] // Results in [1000, 1100, 1200, ..., 150900]
 
     fn test_sequence_consistency(#[case] array: SequenceArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/encodings/sequence/src/compute/mod.rs
+++ b/encodings/sequence/src/compute/mod.rs
@@ -13,6 +13,7 @@ mod take;
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
     use vortex_array::dtype::Nullability;
 

--- a/encodings/sequence/src/compute/slice.rs
+++ b/encodings/sequence/src/compute/slice.rs
@@ -23,7 +23,7 @@ impl SliceReduce for SequenceVTable {
                     range.len(),
                 )
             }
-            .to_array(),
+            .into_array(),
         ))
     }
 }

--- a/encodings/sequence/src/compute/slice.rs
+++ b/encodings/sequence/src/compute/slice.rs
@@ -4,6 +4,7 @@
 use std::ops::Range;
 
 use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
 use vortex_array::arrays::SliceReduce;
 use vortex_error::VortexResult;
 

--- a/encodings/sequence/src/compute/take.rs
+++ b/encodings/sequence/src/compute/take.rs
@@ -105,6 +105,7 @@ impl TakeExecute for SequenceVTable {
 mod test {
     use rstest::rstest;
     use vortex_array::Canonical;
+    use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute;
     use vortex_array::dtype::Nullability;

--- a/encodings/sequence/src/compute/take.rs
+++ b/encodings/sequence/src/compute/take.rs
@@ -162,7 +162,7 @@ mod test {
     ).unwrap())]
     fn test_take_conformance(#[case] sequence: SequenceArray) {
         use vortex_array::compute::conformance::take::test_take_conformance;
-        test_take_conformance(&sequence.to_array());
+        test_take_conformance(&sequence.into_array());
     }
 
     #[test]
@@ -171,7 +171,7 @@ mod test {
         let array = SequenceArray::try_new_typed(0i32, 1i32, Nullability::NonNullable, 10).unwrap();
         let indices = vortex_array::arrays::PrimitiveArray::from_iter([0i32, 20]);
         let _array = array
-            .take(indices.to_array())
+            .take(indices.into_array())
             .unwrap()
             .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
             .unwrap();

--- a/encodings/sparse/public-api.lock
+++ b/encodings/sparse/public-api.lock
@@ -36,6 +36,10 @@ pub fn vortex_sparse::SparseArray::try_new(indices: vortex_array::array::ArrayRe
 
 pub fn vortex_sparse::SparseArray::try_new_from_patches(patches: vortex_array::patches::Patches, fill_value: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<Self>
 
+impl vortex_sparse::SparseArray
+
+pub fn vortex_sparse::SparseArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_sparse::SparseArray
 
 pub fn vortex_sparse::SparseArray::clone(&self) -> vortex_sparse::SparseArray

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -646,7 +646,7 @@ mod test {
             struct_fields.clone(),
             4,
             Validity::Array(
-                BoolArray::from_indices(4, vec![0, 1, 2], Validity::NonNullable).to_array(),
+                BoolArray::from_indices(4, vec![0, 1, 2], Validity::NonNullable).into_array(),
             ),
         )
         .unwrap()
@@ -690,7 +690,7 @@ mod test {
             Validity::from_mask(Mask::from_excluded_indices(10, vec![8]), Nullable),
         )
         .unwrap()
-        .to_array();
+        .into_array();
 
         let actual = sparse_struct.to_struct();
         assert_arrays_eq!(actual, expected);
@@ -716,7 +716,7 @@ mod test {
             struct_fields.clone(),
             4,
             Validity::Array(
-                BoolArray::from_indices(4, vec![0, 1, 2], Validity::NonNullable).to_array(),
+                BoolArray::from_indices(4, vec![0, 1, 2], Validity::NonNullable).into_array(),
             ),
         )
         .unwrap()
@@ -757,7 +757,7 @@ mod test {
             Validity::from_mask(Mask::from_indices(10, vec![0, 1, 7]), Nullable),
         )
         .unwrap()
-        .to_array();
+        .into_array();
 
         let actual = sparse_struct.to_struct();
         assert_arrays_eq!(actual, expected);
@@ -772,7 +772,7 @@ mod test {
             decimal_dtype,
             Validity::from_iter([true, true, true, false]),
         )
-        .to_array();
+        .into_array();
         let len = 10;
         let fill_scalar = Scalar::decimal(DecimalValue::I32(123), decimal_dtype, Nullable);
         let sparse_struct = SparseArray::try_new(indices, patch_values, len, fill_scalar).unwrap();
@@ -783,13 +783,13 @@ mod test {
             // NB: patch indices: [0, 1, 7, 8]; patch validity: [Valid, Valid, Valid, Invalid]; ergo 0, 1, 7 are valid.
             Validity::from_mask(Mask::from_excluded_indices(10, vec![8]), Nullable),
         )
-        .to_array()
+        .into_array()
         .into_arrow_preferred()
         .unwrap();
 
         let actual = sparse_struct
             .to_decimal()
-            .to_array()
+            .into_array()
             .into_arrow_preferred()
             .unwrap();
 

--- a/encodings/sparse/src/compute/cast.rs
+++ b/encodings/sparse/src/compute/cast.rs
@@ -54,7 +54,7 @@ mod tests {
         .unwrap();
 
         let casted = sparse
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I64, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -77,7 +77,7 @@ mod tests {
         .unwrap();
 
         let casted = sparse
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I64, Nullability::Nullable))
             .unwrap();
         assert_eq!(
@@ -112,6 +112,6 @@ mod tests {
         Scalar::from(0u8)
     ).unwrap())]
     fn test_cast_sparse_conformance(#[case] array: SparseArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/encodings/sparse/src/compute/filter.rs
+++ b/encodings/sparse/src/compute/filter.rs
@@ -130,7 +130,7 @@ mod tests {
                 null_fill_value,
             )
             .unwrap()
-            .to_array(),
+            .into_array(),
         );
 
         let ten_fill_value = Scalar::from(10i32);
@@ -142,7 +142,7 @@ mod tests {
                 ten_fill_value,
             )
             .unwrap()
-            .to_array(),
+            .into_array(),
         )
     }
 }

--- a/encodings/sparse/src/compute/mod.rs
+++ b/encodings/sparse/src/compute/mod.rs
@@ -107,7 +107,7 @@ mod test {
                 null_fill_value,
             )
             .unwrap()
-            .to_array(),
+            .into_array(),
         );
 
         let ten_fill_value = Scalar::from(10i32);
@@ -119,7 +119,7 @@ mod test {
                 ten_fill_value,
             )
             .unwrap()
-            .to_array(),
+            .into_array(),
         )
     }
 }
@@ -202,7 +202,7 @@ mod tests {
     })]
 
     fn test_sparse_consistency(#[case] array: SparseArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 
     #[rstest]

--- a/encodings/sparse/src/compute/take.rs
+++ b/encodings/sparse/src/compute/take.rs
@@ -92,7 +92,7 @@ mod test {
         let sparse = sparse.slice(30..40).unwrap();
         let taken = sparse.take(buffer![6, 7, 8].into_array()).unwrap();
         let expected = PrimitiveArray::from_option_iter([Option::<f64>::None, Some(0.47), None]);
-        assert_arrays_eq!(taken, expected.to_array());
+        assert_arrays_eq!(taken, expected.into_array());
     }
 
     #[test]
@@ -106,7 +106,7 @@ mod test {
             Some(1.23),
             Some(3.5),
         ]);
-        assert_arrays_eq!(taken, expected.to_array());
+        assert_arrays_eq!(taken, expected.into_array());
     }
 
     #[test]
@@ -124,7 +124,7 @@ mod test {
         let taken = sparse.take(buffer![69, 37].into_array()).unwrap();
         // Index 69 is not in sparse array (fill value is null), index 37 has value 0.47
         let expected = PrimitiveArray::from_option_iter([Option::<f64>::None, Some(0.47f64)]);
-        assert_arrays_eq!(taken, expected.to_array());
+        assert_arrays_eq!(taken, expected.into_array());
     }
 
     #[test]
@@ -140,12 +140,12 @@ mod test {
         let taken = arr
             .take(
                 PrimitiveArray::from_option_iter([Some(2u32), Some(1u32), Option::<u32>::None])
-                    .to_array(),
+                    .into_array(),
             )
             .unwrap();
 
         let expected = PrimitiveArray::from_option_iter([Some(1), Some(10), Option::<i32>::None]);
-        assert_arrays_eq!(taken, expected.to_array());
+        assert_arrays_eq!(taken, expected.into_array());
     }
 
     #[test]
@@ -161,12 +161,12 @@ mod test {
         let taken = arr
             .take(
                 PrimitiveArray::from_option_iter([Some(2u32), Some(1u32), Option::<u32>::None])
-                    .to_array(),
+                    .into_array(),
             )
             .unwrap();
 
         let expected = PrimitiveArray::from_option_iter([Some(1), Some(10), Option::<i32>::None]);
-        assert_arrays_eq!(taken, expected.to_array());
+        assert_arrays_eq!(taken, expected.into_array());
     }
 
     #[rstest]
@@ -199,6 +199,6 @@ mod test {
     ).unwrap())]
     fn test_take_sparse_conformance(#[case] sparse: SparseArray) {
         use vortex_array::compute::conformance::take::test_take_conformance;
-        test_take_conformance(&sparse.to_array());
+        test_take_conformance(&sparse.into_array());
     }
 }

--- a/encodings/zigzag/public-api.lock
+++ b/encodings/zigzag/public-api.lock
@@ -12,6 +12,10 @@ pub fn vortex_zigzag::ZigZagArray::ptype(&self) -> vortex_array::dtype::ptype::P
 
 pub fn vortex_zigzag::ZigZagArray::try_new(encoded: vortex_array::array::ArrayRef) -> vortex_error::VortexResult<Self>
 
+impl vortex_zigzag::ZigZagArray
+
+pub fn vortex_zigzag::ZigZagArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_zigzag::ZigZagArray
 
 pub fn vortex_zigzag::ZigZagArray::clone(&self) -> vortex_zigzag::ZigZagArray

--- a/encodings/zigzag/src/compress.rs
+++ b/encodings/zigzag/src/compress.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::IntoArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::PType;

--- a/encodings/zigzag/src/compress.rs
+++ b/encodings/zigzag/src/compress.rs
@@ -26,7 +26,7 @@ pub fn zigzag_encode(parray: PrimitiveArray) -> VortexResult<ZigZagArray> {
             parray.ptype()
         ),
     };
-    ZigZagArray::try_new(encoded.to_array())
+    ZigZagArray::try_new(encoded.into_array())
 }
 
 fn zigzag_encode_primitive<T: ExternalZigZag + NativePType>(

--- a/encodings/zigzag/src/compute/cast.rs
+++ b/encodings/zigzag/src/compute/cast.rs
@@ -45,7 +45,7 @@ mod tests {
         let zigzag = zigzag_encode(values).unwrap();
 
         let casted = zigzag
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I64, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -71,7 +71,7 @@ mod tests {
         let zigzag = zigzag_encode(values).unwrap();
 
         let casted = zigzag
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I16, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -90,7 +90,7 @@ mod tests {
         let zigzag16 = zigzag_encode(values16).unwrap();
 
         let casted64 = zigzag16
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I64, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -112,7 +112,7 @@ mod tests {
         let zigzag = zigzag_encode(values).unwrap();
 
         let casted = zigzag
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I64, Nullability::Nullable))
             .unwrap();
         assert_eq!(
@@ -127,6 +127,6 @@ mod tests {
     #[case(zigzag_encode(PrimitiveArray::from_option_iter([Some(-5i16), None, Some(0), Some(5), None])).unwrap())]
     #[case(zigzag_encode(PrimitiveArray::from_iter([i32::MIN, -1, 0, 1, i32::MAX])).unwrap())]
     fn test_cast_zigzag_conformance(#[case] array: ZigZagArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/encodings/zigzag/src/compute/cast.rs
+++ b/encodings/zigzag/src/compute/cast.rs
@@ -28,6 +28,7 @@ impl CastReduce for ZigZagVTable {
 mod tests {
     use rstest::rstest;
     use vortex_array::DynArray;
+    use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::builtins::ArrayBuiltins;

--- a/encodings/zigzag/src/compute/mod.rs
+++ b/encodings/zigzag/src/compute/mod.rs
@@ -140,20 +140,20 @@ mod tests {
             buffer![-189i32, -160, 1, 42, -73],
             Validity::AllValid,
         ))?;
-        test_filter_conformance(&zigzag.to_array());
+        test_filter_conformance(&zigzag.into_array());
 
         // Test with i64 values
         let zigzag = zigzag_encode(PrimitiveArray::new(
             buffer![1000i64, -2000, 3000, -4000, 5000],
             Validity::AllValid,
         ))?;
-        test_filter_conformance(&zigzag.to_array());
+        test_filter_conformance(&zigzag.into_array());
 
         // Test with nullable values
         let array =
             PrimitiveArray::from_option_iter([Some(-10i16), None, Some(20), Some(-30), None]);
         let zigzag = zigzag_encode(array)?;
-        test_filter_conformance(&zigzag.to_array());
+        test_filter_conformance(&zigzag.into_array());
         Ok(())
     }
 
@@ -166,14 +166,14 @@ mod tests {
             buffer![-100i32, 200, -300, 400, -500],
             Validity::AllValid,
         ))?;
-        test_mask_conformance(&zigzag.to_array());
+        test_mask_conformance(&zigzag.into_array());
 
         // Test with i8 values
         let zigzag = zigzag_encode(PrimitiveArray::new(
             buffer![-127i8, 0, 127, -1, 1],
             Validity::AllValid,
         ))?;
-        test_mask_conformance(&zigzag.to_array());
+        test_mask_conformance(&zigzag.into_array());
         Ok(())
     }
 
@@ -187,7 +187,7 @@ mod tests {
         use vortex_array::compute::conformance::take::test_take_conformance;
 
         let zigzag = zigzag_encode(array.to_primitive())?;
-        test_take_conformance(&zigzag.to_array());
+        test_take_conformance(&zigzag.into_array());
         Ok(())
     }
 
@@ -214,7 +214,7 @@ mod tests {
     #[case::zigzag_large_i64(zigzag_encode(PrimitiveArray::from_iter((-1000..1000).map(|i| i as i64 * 100))).unwrap()
     )]
     fn test_zigzag_consistency(#[case] array: ZigZagArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 
     #[rstest]

--- a/encodings/zstd/public-api.lock
+++ b/encodings/zstd/public-api.lock
@@ -22,6 +22,10 @@ pub fn vortex_zstd::ZstdArray::into_parts(self) -> vortex_zstd::ZstdArrayParts
 
 pub fn vortex_zstd::ZstdArray::new(dictionary: core::option::Option<vortex_buffer::ByteBuffer>, frames: alloc::vec::Vec<vortex_buffer::ByteBuffer>, dtype: vortex_array::dtype::DType, metadata: vortex_zstd::ZstdMetadata, n_rows: usize, validity: vortex_array::validity::Validity) -> Self
 
+impl vortex_zstd::ZstdArray
+
+pub fn vortex_zstd::ZstdArray::to_array(&self) -> vortex_array::array::ArrayRef
+
 impl core::clone::Clone for vortex_zstd::ZstdArray
 
 pub fn vortex_zstd::ZstdArray::clone(&self) -> vortex_zstd::ZstdArray

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -341,7 +341,7 @@ fn choose_max_dict_size(uncompressed_size: usize) -> usize {
 
 fn collect_valid_primitive(parray: &PrimitiveArray) -> VortexResult<PrimitiveArray> {
     let mask = parray.validity_mask()?;
-    Ok(parray.to_array().filter(mask)?.to_primitive())
+    Ok(parray.into_array().filter(mask)?.to_primitive())
 }
 
 fn collect_valid_vbv(vbv: &VarBinViewArray) -> VortexResult<(ByteBuffer, Vec<usize>)> {

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -341,7 +341,7 @@ fn choose_max_dict_size(uncompressed_size: usize) -> usize {
 
 fn collect_valid_primitive(parray: &PrimitiveArray) -> VortexResult<PrimitiveArray> {
     let mask = parray.validity_mask()?;
-    Ok(parray.into_array().filter(mask)?.to_primitive())
+    Ok(parray.clone().into_array().filter(mask)?.to_primitive())
 }
 
 fn collect_valid_vbv(vbv: &VarBinViewArray) -> VortexResult<(ByteBuffer, Vec<usize>)> {

--- a/encodings/zstd/src/compute/cast.rs
+++ b/encodings/zstd/src/compute/cast.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
@@ -25,7 +26,9 @@ impl CastReduce for ZstdVTable {
             // Same type case. This should be handled in the layer above but for
             // completeness of the match arms we also handle it here.
             (Nullability::Nullable, Nullability::Nullable)
-            | (Nullability::NonNullable, Nullability::NonNullable) => Ok(Some(array.into_array())),
+            | (Nullability::NonNullable, Nullability::NonNullable) => {
+                Ok(Some(array.clone().into_array()))
+            }
             (Nullability::NonNullable, Nullability::Nullable) => {
                 // nonnull => null, trivial cast by altering the validity
                 Ok(Some(
@@ -73,6 +76,7 @@ impl CastReduce for ZstdVTable {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::ToCanonical;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;

--- a/encodings/zstd/src/compute/cast.rs
+++ b/encodings/zstd/src/compute/cast.rs
@@ -25,7 +25,7 @@ impl CastReduce for ZstdVTable {
             // Same type case. This should be handled in the layer above but for
             // completeness of the match arms we also handle it here.
             (Nullability::Nullable, Nullability::Nullable)
-            | (Nullability::NonNullable, Nullability::NonNullable) => Ok(Some(array.to_array())),
+            | (Nullability::NonNullable, Nullability::NonNullable) => Ok(Some(array.into_array())),
             (Nullability::NonNullable, Nullability::Nullable) => {
                 // nonnull => null, trivial cast by altering the validity
                 Ok(Some(
@@ -92,7 +92,7 @@ mod tests {
         let zstd = ZstdArray::from_primitive(&values, 0, 0).unwrap();
 
         let casted = zstd
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I64, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -110,7 +110,7 @@ mod tests {
         let zstd = ZstdArray::from_primitive(&values, 0, 0).unwrap();
 
         let casted = zstd
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U32, Nullability::Nullable))
             .unwrap();
         assert_eq!(
@@ -182,6 +182,6 @@ mod tests {
     ))]
     fn test_cast_zstd_conformance(#[case] values: PrimitiveArray) {
         let zstd = ZstdArray::from_primitive(&values, 0, 0).unwrap();
-        test_cast_conformance(&zstd.to_array());
+        test_cast_conformance(&zstd.into_array());
     }
 }

--- a/encodings/zstd/src/compute/mod.rs
+++ b/encodings/zstd/src/compute/mod.rs
@@ -6,6 +6,7 @@ mod cast;
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::IntoArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
     use vortex_buffer::buffer;

--- a/encodings/zstd/src/compute/mod.rs
+++ b/encodings/zstd/src/compute/mod.rs
@@ -72,6 +72,6 @@ mod tests {
     #[case::all_same(zstd_all_same())]
     #[case::negative(zstd_negative())]
     fn test_zstd_consistency(#[case] array: ZstdArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/encodings/zstd/src/test.rs
+++ b/encodings/zstd/src/test.rs
@@ -64,7 +64,7 @@ fn test_zstd_with_validity_and_multi_frame() {
     validity[177] = true;
     let array = PrimitiveArray::new(
         Buffer::from(data),
-        Validity::Array(BoolArray::from_iter(validity).to_array()),
+        Validity::Array(BoolArray::from_iter(validity).into_array()),
     );
 
     let compressed = ZstdArray::from_primitive(&array, 0, 30).unwrap();
@@ -89,7 +89,7 @@ fn test_zstd_with_validity_and_multi_frame() {
     );
     assert_eq!(
         primitive.validity(),
-        &Validity::Array(BoolArray::from_iter(vec![false, true, false]).to_array())
+        &Validity::Array(BoolArray::from_iter(vec![false, true, false]).into_array())
     );
 }
 
@@ -120,7 +120,7 @@ fn test_validity_vtable() {
     let mask_bools = vec![false, true, true, false, true];
     let array = PrimitiveArray::new(
         (0..5).collect::<Buffer<_>>(),
-        Validity::Array(BoolArray::from_iter(mask_bools.clone()).to_array()),
+        Validity::Array(BoolArray::from_iter(mask_bools.clone()).into_array()),
     );
     let compressed = ZstdArray::from_primitive(&array, 3, 0).unwrap();
     assert_eq!(

--- a/encodings/zstd/src/test.rs
+++ b/encodings/zstd/src/test.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 #![allow(clippy::cast_possible_truncation)]
 
+use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::PrimitiveArray;

--- a/fuzz/src/array/cast.rs
+++ b/fuzz/src/array/cast.rs
@@ -3,6 +3,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
+use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::DType;

--- a/fuzz/src/array/cast.rs
+++ b/fuzz/src/array/cast.rs
@@ -42,7 +42,7 @@ pub fn cast_canonical_array(array: &ArrayRef, target: &DType) -> VortexResult<Op
                             .collect::<Buffer<Out>>(),
                         Validity::from_mask(array.validity_mask()?, target.nullability()),
                     )
-                    .to_array()
+                    .into_array()
                 })
             }
         )))
@@ -68,7 +68,7 @@ pub fn cast_canonical_array(array: &ArrayRef, target: &DType) -> VortexResult<Op
                         .collect::<Buffer<f64>>(),
                     Validity::from_mask(array.validity_mask()?, target.nullability()),
                 )
-                .to_array(),
+                .into_array(),
             )),
             (PType::F64, PType::F32) =>
             {
@@ -83,7 +83,7 @@ pub fn cast_canonical_array(array: &ArrayRef, target: &DType) -> VortexResult<Op
                             .collect::<Buffer<f32>>(),
                         Validity::from_mask(array.validity_mask()?, target.nullability()),
                     )
-                    .to_array(),
+                    .into_array(),
                 ))
             }
             _ => Ok(None),

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -111,7 +111,7 @@ pub fn slice_canonical_array(
                         validity,
                     )
                 })
-                .to_array(),
+                .into_array(),
             )
         }
         d @ (DType::Null | DType::Extension(_)) => {

--- a/vortex-array/benches/dict_compare.rs
+++ b/vortex-array/benches/dict_compare.rs
@@ -49,15 +49,15 @@ const LENGTH_AND_UNIQUE_VALUES: &[(usize, usize)] = &[
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let primitive_arr = gen_primitive_for_dict::<i32>(len, uniqueness);
-    let dict = dict_encode(&primitive_arr.to_array()).unwrap();
+    let dict = dict_encode(&primitive_arr.into_array()).unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
     let session = VortexSession::empty();
 
     bencher
         .with_inputs(|| (&dict, session.create_execution_ctx()))
         .bench_refs(|(dict, ctx)| {
-            dict.to_array()
-                .binary(ConstantArray::new(value, len).to_array(), Operator::Eq)
+            dict.into_array()
+                .binary(ConstantArray::new(value, len).into_array(), Operator::Eq)
                 .unwrap()
                 .execute::<Canonical>(ctx)
                 .unwrap()
@@ -67,7 +67,7 @@ fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, u
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(len, uniqueness));
-    let dict = dict_encode(&varbin_arr.to_array()).unwrap();
+    let dict = dict_encode(&varbin_arr.into_array()).unwrap();
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
     let session = VortexSession::empty();
@@ -75,8 +75,8 @@ fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usiz
     bencher
         .with_inputs(|| (&dict, session.create_execution_ctx()))
         .bench_refs(|(dict, ctx)| {
-            dict.to_array()
-                .binary(ConstantArray::new(value, len).to_array(), Operator::Eq)
+            dict.into_array()
+                .binary(ConstantArray::new(value, len).into_array(), Operator::Eq)
                 .unwrap()
                 .execute::<RecursiveCanonical>(ctx)
                 .unwrap()
@@ -86,7 +86,7 @@ fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usiz
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_varbinview(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(len, uniqueness));
-    let dict = dict_encode(&varbinview_arr.to_array()).unwrap();
+    let dict = dict_encode(&varbinview_arr.into_array()).unwrap();
     let bytes = varbinview_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
     let session = VortexSession::empty();
@@ -94,8 +94,8 @@ fn bench_compare_varbinview(bencher: divan::Bencher, (len, uniqueness): (usize, 
     bencher
         .with_inputs(|| (&dict, session.create_execution_ctx()))
         .bench_refs(|(dict, ctx)| {
-            dict.to_array()
-                .binary(ConstantArray::new(value, len).to_array(), Operator::Eq)
+            dict.into_array()
+                .binary(ConstantArray::new(value, len).into_array(), Operator::Eq)
                 .unwrap()
                 .execute::<RecursiveCanonical>(ctx)
                 .unwrap()
@@ -120,7 +120,7 @@ fn bench_compare_sliced_dict_primitive(
     (codes_len, values_len): (usize, usize),
 ) {
     let primitive_arr = gen_primitive_for_dict::<i32>(codes_len.max(values_len), values_len);
-    let dict = dict_encode(&primitive_arr.to_array()).unwrap();
+    let dict = dict_encode(&primitive_arr.into_array()).unwrap();
     let dict = dict.slice(0..codes_len).unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
     let session = VortexSession::empty();
@@ -141,7 +141,7 @@ fn bench_compare_sliced_dict_varbinview(
     (codes_len, values_len): (usize, usize),
 ) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(codes_len.max(values_len), values_len));
-    let dict = dict_encode(&varbin_arr.to_array()).unwrap();
+    let dict = dict_encode(&varbin_arr.into_array()).unwrap();
     let dict = dict.slice(0..codes_len).unwrap();
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();

--- a/vortex-array/benches/dict_compare.rs
+++ b/vortex-array/benches/dict_compare.rs
@@ -6,6 +6,7 @@
 use std::str::from_utf8;
 
 use vortex_array::Canonical;
+use vortex_array::IntoArray;
 use vortex_array::RecursiveCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
@@ -49,14 +50,15 @@ const LENGTH_AND_UNIQUE_VALUES: &[(usize, usize)] = &[
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let primitive_arr = gen_primitive_for_dict::<i32>(len, uniqueness);
-    let dict = dict_encode(&primitive_arr.into_array()).unwrap();
+    let dict = dict_encode(&primitive_arr.clone().into_array()).unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
     let session = VortexSession::empty();
 
     bencher
         .with_inputs(|| (&dict, session.create_execution_ctx()))
         .bench_refs(|(dict, ctx)| {
-            dict.into_array()
+            dict.clone()
+                .into_array()
                 .binary(ConstantArray::new(value, len).into_array(), Operator::Eq)
                 .unwrap()
                 .execute::<Canonical>(ctx)
@@ -67,7 +69,7 @@ fn bench_compare_primitive(bencher: divan::Bencher, (len, uniqueness): (usize, u
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(len, uniqueness));
-    let dict = dict_encode(&varbin_arr.into_array()).unwrap();
+    let dict = dict_encode(&varbin_arr.clone().into_array()).unwrap();
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
     let session = VortexSession::empty();
@@ -75,7 +77,8 @@ fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usiz
     bencher
         .with_inputs(|| (&dict, session.create_execution_ctx()))
         .bench_refs(|(dict, ctx)| {
-            dict.into_array()
+            dict.clone()
+                .into_array()
                 .binary(ConstantArray::new(value, len).into_array(), Operator::Eq)
                 .unwrap()
                 .execute::<RecursiveCanonical>(ctx)
@@ -86,7 +89,7 @@ fn bench_compare_varbin(bencher: divan::Bencher, (len, uniqueness): (usize, usiz
 #[divan::bench(args = LENGTH_AND_UNIQUE_VALUES)]
 fn bench_compare_varbinview(bencher: divan::Bencher, (len, uniqueness): (usize, usize)) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(len, uniqueness));
-    let dict = dict_encode(&varbinview_arr.into_array()).unwrap();
+    let dict = dict_encode(&varbinview_arr.clone().into_array()).unwrap();
     let bytes = varbinview_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();
     let session = VortexSession::empty();
@@ -94,7 +97,8 @@ fn bench_compare_varbinview(bencher: divan::Bencher, (len, uniqueness): (usize, 
     bencher
         .with_inputs(|| (&dict, session.create_execution_ctx()))
         .bench_refs(|(dict, ctx)| {
-            dict.into_array()
+            dict.clone()
+                .into_array()
                 .binary(ConstantArray::new(value, len).into_array(), Operator::Eq)
                 .unwrap()
                 .execute::<RecursiveCanonical>(ctx)
@@ -120,7 +124,7 @@ fn bench_compare_sliced_dict_primitive(
     (codes_len, values_len): (usize, usize),
 ) {
     let primitive_arr = gen_primitive_for_dict::<i32>(codes_len.max(values_len), values_len);
-    let dict = dict_encode(&primitive_arr.into_array()).unwrap();
+    let dict = dict_encode(&primitive_arr.clone().into_array()).unwrap();
     let dict = dict.slice(0..codes_len).unwrap();
     let value = primitive_arr.as_slice::<i32>()[0];
     let session = VortexSession::empty();
@@ -141,7 +145,7 @@ fn bench_compare_sliced_dict_varbinview(
     (codes_len, values_len): (usize, usize),
 ) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(codes_len.max(values_len), values_len));
-    let dict = dict_encode(&varbin_arr.into_array()).unwrap();
+    let dict = dict_encode(&varbin_arr.clone().into_array()).unwrap();
     let dict = dict.slice(0..codes_len).unwrap();
     let bytes = varbin_arr.with_iterator(|i| i.next().unwrap().unwrap().to_vec());
     let value = from_utf8(bytes.as_slice()).unwrap();

--- a/vortex-array/benches/dict_compress.rs
+++ b/vortex-array/benches/dict_compress.rs
@@ -6,6 +6,7 @@
 use divan::Bencher;
 use rand::distr::Distribution;
 use rand::distr::StandardUniform;
+use vortex_array::IntoArray;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::dict_test::gen_primitive_for_dict;
@@ -43,7 +44,7 @@ where
 
     bencher
         .with_inputs(|| &primitive_arr)
-        .bench_refs(|arr| dict_encode(&arr.into_array()));
+        .bench_refs(|arr| dict_encode(&arr.clone().into_array()));
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -52,7 +53,7 @@ fn encode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
 
     bencher
         .with_inputs(|| &varbin_arr)
-        .bench_refs(|arr| dict_encode(&arr.into_array()));
+        .bench_refs(|arr| dict_encode(&arr.clone().into_array()));
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -61,7 +62,7 @@ fn encode_varbinview(bencher: Bencher, (len, unique_values): (usize, usize)) {
 
     bencher
         .with_inputs(|| &varbinview_arr)
-        .bench_refs(|arr| dict_encode(&arr.into_array()));
+        .bench_refs(|arr| dict_encode(&arr.clone().into_array()));
 }
 
 #[divan::bench(types = [u8, f32, i64], args = BENCH_ARGS)]

--- a/vortex-array/benches/dict_compress.rs
+++ b/vortex-array/benches/dict_compress.rs
@@ -43,7 +43,7 @@ where
 
     bencher
         .with_inputs(|| &primitive_arr)
-        .bench_refs(|arr| dict_encode(&arr.to_array()));
+        .bench_refs(|arr| dict_encode(&arr.into_array()));
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -52,7 +52,7 @@ fn encode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
 
     bencher
         .with_inputs(|| &varbin_arr)
-        .bench_refs(|arr| dict_encode(&arr.to_array()));
+        .bench_refs(|arr| dict_encode(&arr.into_array()));
 }
 
 #[divan::bench(args = BENCH_ARGS)]
@@ -61,7 +61,7 @@ fn encode_varbinview(bencher: Bencher, (len, unique_values): (usize, usize)) {
 
     bencher
         .with_inputs(|| &varbinview_arr)
-        .bench_refs(|arr| dict_encode(&arr.to_array()));
+        .bench_refs(|arr| dict_encode(&arr.into_array()));
 }
 
 #[divan::bench(types = [u8, f32, i64], args = BENCH_ARGS)]
@@ -71,7 +71,7 @@ where
     StandardUniform: Distribution<T>,
 {
     let primitive_arr = gen_primitive_for_dict::<T>(len, unique_values);
-    let dict = dict_encode(&primitive_arr.to_array()).unwrap();
+    let dict = dict_encode(&primitive_arr.into_array()).unwrap();
 
     bencher
         .with_inputs(|| &dict)
@@ -81,7 +81,7 @@ where
 #[divan::bench(args = BENCH_ARGS)]
 fn decode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let varbin_arr = VarBinArray::from(gen_varbin_words(len, unique_values));
-    let dict = dict_encode(&varbin_arr.to_array()).unwrap();
+    let dict = dict_encode(&varbin_arr.into_array()).unwrap();
 
     bencher
         .with_inputs(|| &dict)
@@ -91,7 +91,7 @@ fn decode_varbin(bencher: Bencher, (len, unique_values): (usize, usize)) {
 #[divan::bench(args = BENCH_ARGS)]
 fn decode_varbinview(bencher: Bencher, (len, unique_values): (usize, usize)) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(len, unique_values));
-    let dict = dict_encode(&varbinview_arr.to_array()).unwrap();
+    let dict = dict_encode(&varbinview_arr.into_array()).unwrap();
 
     bencher
         .with_inputs(|| &dict)

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -356,6 +356,10 @@ impl vortex_array::arrays::BoolArray
 
 pub fn vortex_array::arrays::BoolArray::patch(self, patches: &vortex_array::patches::Patches, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
+impl vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::BoolArray
 
 pub fn vortex_array::arrays::BoolArray::clone(&self) -> vortex_array::arrays::BoolArray
@@ -570,6 +574,10 @@ pub fn vortex_array::arrays::ChunkedArray::try_new(chunks: alloc::vec::Vec<vorte
 
 pub fn vortex_array::arrays::ChunkedArray::validate(chunks: &[vortex_array::ArrayRef], dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
 
+impl vortex_array::arrays::ChunkedArray
+
+pub fn vortex_array::arrays::ChunkedArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::ChunkedArray
 
 pub fn vortex_array::arrays::ChunkedArray::clone(&self) -> vortex_array::arrays::ChunkedArray
@@ -727,6 +735,10 @@ pub fn vortex_array::arrays::ConstantArray::into_parts(self) -> vortex_array::sc
 pub fn vortex_array::arrays::ConstantArray::new<S>(scalar: S, len: usize) -> Self where S: core::convert::Into<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::arrays::ConstantArray::scalar(&self) -> &vortex_array::scalar::Scalar
+
+impl vortex_array::arrays::ConstantArray
+
+pub fn vortex_array::arrays::ConstantArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl core::clone::Clone for vortex_array::arrays::ConstantArray
 
@@ -903,6 +915,10 @@ pub fn vortex_array::arrays::DecimalArray::try_new<T: vortex_array::dtype::Nativ
 pub fn vortex_array::arrays::DecimalArray::try_new_handle(values: vortex_array::buffer::BufferHandle, values_type: vortex_array::dtype::DecimalType, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_array::arrays::DecimalArray::values_type(&self) -> vortex_array::dtype::DecimalType
+
+impl vortex_array::arrays::DecimalArray
+
+pub fn vortex_array::arrays::DecimalArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl core::clone::Clone for vortex_array::arrays::DecimalArray
 
@@ -1103,6 +1119,10 @@ pub fn vortex_array::arrays::DictArray::try_new(codes: vortex_array::ArrayRef, v
 pub fn vortex_array::arrays::DictArray::validate_all_values_referenced(&self) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::DictArray::values(&self) -> &vortex_array::ArrayRef
+
+impl vortex_array::arrays::DictArray
+
+pub fn vortex_array::arrays::DictArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl core::clone::Clone for vortex_array::arrays::DictArray
 
@@ -1320,6 +1340,10 @@ pub fn vortex_array::arrays::ExtensionArray::new(ext_dtype: vortex_array::dtype:
 
 pub fn vortex_array::arrays::ExtensionArray::storage(&self) -> &vortex_array::ArrayRef
 
+impl vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::ExtensionArray
 
 pub fn vortex_array::arrays::ExtensionArray::clone(&self) -> vortex_array::arrays::ExtensionArray
@@ -1492,6 +1516,10 @@ pub fn vortex_array::arrays::FilterArray::new(array: vortex_array::ArrayRef, mas
 
 pub fn vortex_array::arrays::FilterArray::try_new(array: vortex_array::ArrayRef, mask: vortex_mask::Mask) -> vortex_error::VortexResult<Self>
 
+impl vortex_array::arrays::FilterArray
+
+pub fn vortex_array::arrays::FilterArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::FilterArray
 
 pub fn vortex_array::arrays::FilterArray::clone(&self) -> vortex_array::arrays::FilterArray
@@ -1647,6 +1675,10 @@ pub unsafe fn vortex_array::arrays::FixedSizeListArray::new_unchecked(elements: 
 pub fn vortex_array::arrays::FixedSizeListArray::try_new(elements: vortex_array::ArrayRef, list_size: u32, validity: vortex_array::validity::Validity, len: usize) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_array::arrays::FixedSizeListArray::validate(elements: &vortex_array::ArrayRef, len: usize, list_size: u32, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+
+impl vortex_array::arrays::FixedSizeListArray
+
+pub fn vortex_array::arrays::FixedSizeListArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl core::clone::Clone for vortex_array::arrays::FixedSizeListArray
 
@@ -1836,6 +1868,10 @@ pub fn vortex_array::arrays::ListArray::try_new(elements: vortex_array::ArrayRef
 
 pub fn vortex_array::arrays::ListArray::validate(elements: &vortex_array::ArrayRef, offsets: &vortex_array::ArrayRef, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
+impl vortex_array::arrays::ListArray
+
+pub fn vortex_array::arrays::ListArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::ListArray
 
 pub fn vortex_array::arrays::ListArray::clone(&self) -> vortex_array::arrays::ListArray
@@ -2014,6 +2050,10 @@ impl vortex_array::arrays::ListViewArray
 
 pub fn vortex_array::arrays::ListViewArray::rebuild(&self, mode: vortex_array::arrays::ListViewRebuildMode) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
 
+impl vortex_array::arrays::ListViewArray
+
+pub fn vortex_array::arrays::ListViewArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::ListViewArray
 
 pub fn vortex_array::arrays::ListViewArray::clone(&self) -> vortex_array::arrays::ListViewArray
@@ -2165,6 +2205,10 @@ impl vortex_array::arrays::MaskedArray
 pub fn vortex_array::arrays::MaskedArray::child(&self) -> &vortex_array::ArrayRef
 
 pub fn vortex_array::arrays::MaskedArray::try_new(child: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::arrays::MaskedArray
+
+pub fn vortex_array::arrays::MaskedArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl core::clone::Clone for vortex_array::arrays::MaskedArray
 
@@ -2351,6 +2395,10 @@ pub struct vortex_array::arrays::NullArray
 impl vortex_array::arrays::NullArray
 
 pub fn vortex_array::arrays::NullArray::new(len: usize) -> Self
+
+impl vortex_array::arrays::NullArray
+
+pub fn vortex_array::arrays::NullArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl core::clone::Clone for vortex_array::arrays::NullArray
 
@@ -2541,6 +2589,10 @@ pub fn vortex_array::arrays::PrimitiveArray::into_parts(self) -> vortex_array::a
 impl vortex_array::arrays::PrimitiveArray
 
 pub fn vortex_array::arrays::PrimitiveArray::patch(self, patches: &vortex_array::patches::Patches, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl vortex_array::arrays::PrimitiveArray
 
@@ -2772,6 +2824,10 @@ pub fn vortex_array::arrays::ScalarFnArray::scalar_fn(&self) -> &vortex_array::s
 
 pub fn vortex_array::arrays::ScalarFnArray::try_new(bound: vortex_array::scalar_fn::ScalarFnRef, children: alloc::vec::Vec<vortex_array::ArrayRef>, len: usize) -> vortex_error::VortexResult<Self>
 
+impl vortex_array::arrays::ScalarFnArray
+
+pub fn vortex_array::arrays::ScalarFnArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::ScalarFnArray
 
 pub fn vortex_array::arrays::ScalarFnArray::clone(&self) -> vortex_array::arrays::ScalarFnArray
@@ -2908,6 +2964,10 @@ pub async fn vortex_array::arrays::SharedArray::get_or_compute_async<F, Fut>(&se
 
 pub fn vortex_array::arrays::SharedArray::new(source: vortex_array::ArrayRef) -> Self
 
+impl vortex_array::arrays::SharedArray
+
+pub fn vortex_array::arrays::SharedArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::SharedArray
 
 pub fn vortex_array::arrays::SharedArray::clone(&self) -> vortex_array::arrays::SharedArray
@@ -3019,6 +3079,10 @@ pub fn vortex_array::arrays::SliceArray::new(child: vortex_array::ArrayRef, rang
 pub fn vortex_array::arrays::SliceArray::slice_range(&self) -> &core::ops::range::Range<usize>
 
 pub fn vortex_array::arrays::SliceArray::try_new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::arrays::SliceArray
+
+pub fn vortex_array::arrays::SliceArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl core::clone::Clone for vortex_array::arrays::SliceArray
 
@@ -3211,6 +3275,10 @@ pub fn vortex_array::arrays::StructArray::with_column(&self, name: impl core::co
 impl vortex_array::arrays::StructArray
 
 pub fn vortex_array::arrays::StructArray::into_record_batch_with_schema(self, schema: impl core::convert::AsRef<arrow_schema::schema::Schema>) -> vortex_error::VortexResult<arrow_array::record_batch::RecordBatch>
+
+impl vortex_array::arrays::StructArray
+
+pub fn vortex_array::arrays::StructArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl core::clone::Clone for vortex_array::arrays::StructArray
 
@@ -3480,6 +3548,10 @@ pub fn vortex_array::arrays::VarBinArray::try_new_from_handle(offsets: vortex_ar
 
 pub fn vortex_array::arrays::VarBinArray::validate(offsets: &vortex_array::ArrayRef, bytes: &vortex_array::buffer::BufferHandle, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
+impl vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::VarBinArray
 
 pub fn vortex_array::arrays::VarBinArray::clone(&self) -> vortex_array::arrays::VarBinArray
@@ -3723,6 +3795,10 @@ impl vortex_array::arrays::VarBinViewArray
 pub fn vortex_array::arrays::VarBinViewArray::compact_buffers(&self) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
 
 pub fn vortex_array::arrays::VarBinViewArray::compact_with_threshold(&self, buffer_utilization_threshold: f64) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
+
+impl vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl core::clone::Clone for vortex_array::arrays::VarBinViewArray
 

--- a/vortex-array/src/arrays/bool/compute/cast.rs
+++ b/vortex-array/src/arrays/bool/compute/cast.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 
+use crate::IntoArray;
 use crate::array::ArrayRef;
 use crate::arrays::BoolArray;
 use crate::arrays::BoolVTable;
@@ -22,7 +23,7 @@ impl CastReduce for BoolVTable {
             .clone()
             .cast_nullability(new_nullability, array.len())?;
         Ok(Some(
-            BoolArray::new(array.to_bit_buffer(), new_validity).to_array(),
+            BoolArray::new(array.to_bit_buffer(), new_validity).into_array(),
         ))
     }
 }
@@ -41,7 +42,7 @@ mod tests {
     fn try_cast_bool_success() {
         let bool = BoolArray::from_iter(vec![Some(true), Some(false), Some(true)]);
 
-        let res = bool.to_array().cast(DType::Bool(Nullability::NonNullable));
+        let res = bool.into_array().cast(DType::Bool(Nullability::NonNullable));
         assert!(res.is_ok());
         assert_eq!(res.unwrap().dtype(), &DType::Bool(Nullability::NonNullable));
     }
@@ -50,7 +51,7 @@ mod tests {
     #[should_panic]
     fn try_cast_bool_fail() {
         let bool = BoolArray::from_iter(vec![Some(true), Some(false), None]);
-        bool.to_array()
+        bool.into_array()
             .cast(DType::Bool(Nullability::NonNullable))
             .unwrap();
     }
@@ -61,6 +62,6 @@ mod tests {
     #[case(BoolArray::from_iter(vec![true]))]
     #[case(BoolArray::from_iter(vec![false, false]))]
     fn test_cast_bool_conformance(#[case] array: BoolArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/bool/compute/cast.rs
+++ b/vortex-array/src/arrays/bool/compute/cast.rs
@@ -32,6 +32,7 @@ impl CastReduce for BoolVTable {
 mod tests {
     use rstest::rstest;
 
+    use crate::IntoArray;
     use crate::arrays::BoolArray;
     use crate::builtins::ArrayBuiltins;
     use crate::compute::conformance::cast::test_cast_conformance;
@@ -42,7 +43,9 @@ mod tests {
     fn try_cast_bool_success() {
         let bool = BoolArray::from_iter(vec![Some(true), Some(false), Some(true)]);
 
-        let res = bool.into_array().cast(DType::Bool(Nullability::NonNullable));
+        let res = bool
+            .into_array()
+            .cast(DType::Bool(Nullability::NonNullable));
         assert!(res.is_ok());
         assert_eq!(res.unwrap().dtype(), &DType::Bool(Nullability::NonNullable));
     }

--- a/vortex-array/src/arrays/bool/compute/fill_null.rs
+++ b/vortex-array/src/arrays/bool/compute/fill_null.rs
@@ -63,7 +63,7 @@ mod tests {
             Validity::from_iter([true, false, true, false]),
         );
         let non_null_array = bool_array
-            .to_array()
+            .into_array()
             .fill_null(Scalar::from(fill_value))
             .unwrap()
             .to_bool();

--- a/vortex-array/src/arrays/bool/compute/fill_null.rs
+++ b/vortex-array/src/arrays/bool/compute/fill_null.rs
@@ -46,6 +46,7 @@ mod tests {
     use vortex_buffer::BitBuffer;
     use vortex_buffer::bitbuffer;
 
+    use crate::IntoArray;
     use crate::arrays::BoolArray;
     use crate::builtins::ArrayBuiltins;
     use crate::canonical::ToCanonical;

--- a/vortex-array/src/arrays/bool/compute/filter.rs
+++ b/vortex-array/src/arrays/bool/compute/filter.rs
@@ -79,6 +79,7 @@ mod test {
     use itertools::Itertools;
     use vortex_mask::Mask;
 
+    use crate::IntoArray;
     use crate::arrays::BoolArray;
     use crate::arrays::bool::compute::filter::filter_indices;
     use crate::arrays::bool::compute::filter::filter_slices;

--- a/vortex-array/src/arrays/bool/compute/filter.rs
+++ b/vortex-array/src/arrays/bool/compute/filter.rs
@@ -120,6 +120,6 @@ mod test {
     #[case(BoolArray::from_iter((0..100).map(|i| i % 2 == 0)))]
     #[case(BoolArray::from_iter((0..1024).map(|i| i % 3 != 0)))]
     fn test_filter_bool_conformance(#[case] array: BoolArray) {
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/bool/compute/is_constant.rs
+++ b/vortex-array/src/arrays/bool/compute/is_constant.rs
@@ -41,6 +41,6 @@ mod tests {
     }, false)]
     fn test_is_constant(#[case] input: Vec<bool>, #[case] expected: bool) {
         let array = BoolArray::from_iter(input);
-        assert_eq!(is_constant(&array.to_array()).unwrap(), Some(expected));
+        assert_eq!(is_constant(&array.into_array()).unwrap(), Some(expected));
     }
 }

--- a/vortex-array/src/arrays/bool/compute/is_constant.rs
+++ b/vortex-array/src/arrays/bool/compute/is_constant.rs
@@ -29,6 +29,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::IntoArray;
     use crate::compute::is_constant;
 
     #[rstest]

--- a/vortex-array/src/arrays/bool/compute/mask.rs
+++ b/vortex-array/src/arrays/bool/compute/mask.rs
@@ -30,6 +30,7 @@ impl MaskReduce for BoolVTable {
 mod test {
     use rstest::rstest;
 
+    use crate::IntoArray;
     use crate::arrays::BoolArray;
     use crate::compute::conformance::mask::test_mask_conformance;
 

--- a/vortex-array/src/arrays/bool/compute/mask.rs
+++ b/vortex-array/src/arrays/bool/compute/mask.rs
@@ -40,6 +40,6 @@ mod test {
     #[case(BoolArray::from_iter([false, false]))]
     #[case(BoolArray::from_iter((0..100).map(|i| i % 2 == 0)))]
     fn test_mask_bool_conformance(#[case] array: BoolArray) {
-        test_mask_conformance(&array.to_array());
+        test_mask_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/bool/compute/min_max.rs
+++ b/vortex-array/src/arrays/bool/compute/min_max.rs
@@ -78,6 +78,7 @@ register_kernel!(MinMaxKernelAdapter(BoolVTable).lift());
 mod tests {
     use Nullability::NonNullable;
 
+    use crate::IntoArray;
     use crate::arrays::BoolArray;
     use crate::compute::MinMaxResult;
     use crate::compute::min_max;
@@ -96,7 +97,8 @@ mod tests {
         );
 
         assert_eq!(
-            min_max(&BoolArray::from_iter(vec![None, Some(true), Some(true)]).into_array()).unwrap(),
+            min_max(&BoolArray::from_iter(vec![None, Some(true), Some(true)]).into_array())
+                .unwrap(),
             Some(MinMaxResult {
                 min: Scalar::bool(true, NonNullable),
                 max: Scalar::bool(true, NonNullable),

--- a/vortex-array/src/arrays/bool/compute/min_max.rs
+++ b/vortex-array/src/arrays/bool/compute/min_max.rs
@@ -87,7 +87,7 @@ mod tests {
     #[test]
     fn test_min_max_nulls() {
         assert_eq!(
-            min_max(&BoolArray::from_iter(vec![Some(true), Some(true), None, None]).to_array())
+            min_max(&BoolArray::from_iter(vec![Some(true), Some(true), None, None]).into_array())
                 .unwrap(),
             Some(MinMaxResult {
                 min: Scalar::bool(true, NonNullable),
@@ -96,7 +96,7 @@ mod tests {
         );
 
         assert_eq!(
-            min_max(&BoolArray::from_iter(vec![None, Some(true), Some(true)]).to_array()).unwrap(),
+            min_max(&BoolArray::from_iter(vec![None, Some(true), Some(true)]).into_array()).unwrap(),
             Some(MinMaxResult {
                 min: Scalar::bool(true, NonNullable),
                 max: Scalar::bool(true, NonNullable),
@@ -104,7 +104,7 @@ mod tests {
         );
 
         assert_eq!(
-            min_max(&BoolArray::from_iter(vec![None, Some(true), Some(true), None]).to_array())
+            min_max(&BoolArray::from_iter(vec![None, Some(true), Some(true), None]).into_array())
                 .unwrap(),
             Some(MinMaxResult {
                 min: Scalar::bool(true, NonNullable),
@@ -113,7 +113,7 @@ mod tests {
         );
 
         assert_eq!(
-            min_max(&BoolArray::from_iter(vec![Some(false), Some(false), None, None]).to_array())
+            min_max(&BoolArray::from_iter(vec![Some(false), Some(false), None, None]).into_array())
                 .unwrap(),
             Some(MinMaxResult {
                 min: Scalar::bool(false, NonNullable),

--- a/vortex-array/src/arrays/bool/compute/mod.rs
+++ b/vortex-array/src/arrays/bool/compute/mod.rs
@@ -17,6 +17,7 @@ mod take;
 mod tests {
     use rstest::rstest;
 
+    use crate::IntoArray;
     use crate::arrays::BoolArray;
     use crate::compute::conformance::consistency::test_array_consistency;
 

--- a/vortex-array/src/arrays/bool/compute/mod.rs
+++ b/vortex-array/src/arrays/bool/compute/mod.rs
@@ -42,6 +42,6 @@ mod tests {
         None, None, Some(true), None, None, None, Some(false), None, None
     ]))]
     fn test_bool_consistency(#[case] array: BoolArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/bool/compute/take.rs
+++ b/vortex-array/src/arrays/bool/compute/take.rs
@@ -46,7 +46,7 @@ impl TakeExecute for BoolVTable {
         });
 
         Ok(Some(
-            BoolArray::new(buffer, array.validity().take(indices)?).to_array(),
+            BoolArray::new(buffer, array.validity().take(indices)?).into_array(),
         ))
     }
 }
@@ -112,7 +112,7 @@ mod test {
         );
 
         let all_invalid_indices = PrimitiveArray::from_option_iter([None::<i32>, None, None]);
-        let b = reference.take(all_invalid_indices.to_array()).unwrap();
+        let b = reference.take(all_invalid_indices.into_array()).unwrap();
         assert_arrays_eq!(b, BoolArray::from_iter([None, None, None]));
     }
 
@@ -121,9 +121,9 @@ mod test {
         let values = BoolArray::from_iter(vec![Some(false), Some(true), None, None, Some(false)]);
         let indices = PrimitiveArray::new(
             buffer![0, 3, 100],
-            Validity::Array(BoolArray::from_iter([true, true, false]).to_array()),
+            Validity::Array(BoolArray::from_iter([true, true, false]).into_array()),
         );
-        let actual = values.take(indices.to_array()).unwrap();
+        let actual = values.take(indices.into_array()).unwrap();
 
         // position 3 is null, the third index is null
         assert_arrays_eq!(actual, BoolArray::from_iter([Some(false), None, None]));
@@ -134,9 +134,9 @@ mod test {
         let values = BoolArray::from_iter(vec![false, true, false, true, false]);
         let indices = PrimitiveArray::new(
             buffer![0, 3, 100],
-            Validity::Array(BoolArray::from_iter([true, true, false]).to_array()),
+            Validity::Array(BoolArray::from_iter([true, true, false]).into_array()),
         );
-        let actual = values.take(indices.to_array()).unwrap();
+        let actual = values.take(indices.into_array()).unwrap();
         // the third index is null
         assert_arrays_eq!(
             actual,
@@ -149,9 +149,9 @@ mod test {
         let values = BoolArray::from_iter(vec![Some(false), Some(true), None, None, Some(false)]);
         let indices = PrimitiveArray::new(
             buffer![0, 3, 100],
-            Validity::Array(BoolArray::from_iter([false, false, false]).to_array()),
+            Validity::Array(BoolArray::from_iter([false, false, false]).into_array()),
         );
-        let actual = values.take(indices.to_array()).unwrap();
+        let actual = values.take(indices.into_array()).unwrap();
         assert_arrays_eq!(actual, BoolArray::from_iter([None, None, None]));
     }
 
@@ -160,9 +160,9 @@ mod test {
         let values = BoolArray::from_iter(vec![false, true, false, true, false]);
         let indices = PrimitiveArray::new(
             buffer![0, 3, 100],
-            Validity::Array(BoolArray::from_iter([false, false, false]).to_array()),
+            Validity::Array(BoolArray::from_iter([false, false, false]).into_array()),
         );
-        let actual = values.take(indices.to_array()).unwrap();
+        let actual = values.take(indices.into_array()).unwrap();
         assert_arrays_eq!(actual, BoolArray::from_iter([None, None, None]));
     }
 
@@ -172,6 +172,6 @@ mod test {
     #[case(BoolArray::from_iter([true, false]))]
     #[case(BoolArray::from_iter([true]))]
     fn test_take_bool_conformance(#[case] array: BoolArray) {
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/bool/patch.rs
+++ b/vortex-array/src/arrays/bool/patch.rs
@@ -21,7 +21,7 @@ impl BoolArray {
         let patched_validity = self.validity().clone().patch(
             len,
             offset,
-            &indices.to_array(),
+            patches.indices(),
             values.validity(),
             ctx,
         )?;

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -12,6 +12,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::DeserializeMetadata;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
 use crate::arrays::BoolArray;
@@ -184,7 +185,7 @@ impl VTable for BoolVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.to_array())
+        Ok(array.clone().into_array())
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/chunked/compute/fill_null.rs
+++ b/vortex-array/src/arrays/chunked/compute/fill_null.rs
@@ -44,14 +44,14 @@ mod tests {
     fn fill_null_chunks() {
         let chunked = ChunkedArray::try_new(
             vec![
-                BoolArray::new(BitBuffer::new_set(5), Validity::AllInvalid).to_array(),
-                BoolArray::new(BitBuffer::new_set(5), Validity::AllValid).to_array(),
+                BoolArray::new(BitBuffer::new_set(5), Validity::AllInvalid).into_array(),
+                BoolArray::new(BitBuffer::new_set(5), Validity::AllValid).into_array(),
             ],
             DType::Bool(Nullability::Nullable),
         )
         .unwrap();
 
-        let filled = chunked.to_array().fill_null(Scalar::from(false)).unwrap();
+        let filled = chunked.into_array().fill_null(Scalar::from(false)).unwrap();
         assert_eq!(*filled.dtype(), DType::Bool(Nullability::NonNullable));
     }
 }

--- a/vortex-array/src/arrays/chunked/compute/fill_null.rs
+++ b/vortex-array/src/arrays/chunked/compute/fill_null.rs
@@ -31,6 +31,7 @@ impl FillNullReduce for ChunkedVTable {
 mod tests {
     use vortex_buffer::BitBuffer;
 
+    use crate::IntoArray;
     use crate::array::DynArray;
     use crate::arrays::BoolArray;
     use crate::arrays::ChunkedArray;

--- a/vortex-array/src/arrays/chunked/compute/filter.rs
+++ b/vortex-array/src/arrays/chunked/compute/filter.rs
@@ -163,7 +163,7 @@ fn filter_indices(
                 let chunk = array.chunk(current_chunk_id);
                 let indices =
                     PrimitiveArray::new(chunk_indices.clone().freeze(), Validity::NonNullable);
-                result.push(chunk.take(indices.to_array())?);
+                result.push(chunk.take(indices.into_array())?);
             }
 
             // Advance the chunk forward, reset the chunk indices buffer.
@@ -177,7 +177,7 @@ fn filter_indices(
     if !chunk_indices.is_empty() {
         let chunk = array.chunk(current_chunk_id);
         let indices = PrimitiveArray::new(chunk_indices.clone().freeze(), Validity::NonNullable);
-        let filtered_chunk = chunk.take(indices.to_array())?;
+        let filtered_chunk = chunk.take(indices.into_array())?;
         result.push(filtered_chunk);
     }
 
@@ -253,17 +253,17 @@ mod test {
         vec![
             buffer![0u64, 1].into_array(),
             buffer![2_u64].into_array(),
-            PrimitiveArray::empty::<u64>(Nullability::NonNullable).to_array(),
+            PrimitiveArray::empty::<u64>(Nullability::NonNullable).into_array(),
             buffer![3_u64, 4].into_array(),
         ],
         DType::Primitive(PType::U64, Nullability::NonNullable),
     ).unwrap())]
     #[case(ChunkedArray::try_new(
         vec![
-            PrimitiveArray::from_option_iter([Some(0u64), None]).to_array(),
-            PrimitiveArray::from_option_iter([Some(2u64)]).to_array(),
-            PrimitiveArray::empty::<u64>(Nullability::Nullable).to_array(),
-            PrimitiveArray::from_option_iter([None, Some(4u64)]).to_array(),
+            PrimitiveArray::from_option_iter([Some(0u64), None]).into_array(),
+            PrimitiveArray::from_option_iter([Some(2u64)]).into_array(),
+            PrimitiveArray::empty::<u64>(Nullability::Nullable).into_array(),
+            PrimitiveArray::from_option_iter([None, Some(4u64)]).into_array(),
         ],
         DType::Primitive(PType::U64, Nullability::Nullable),
     ).unwrap())]
@@ -278,6 +278,6 @@ mod test {
         DType::Primitive(PType::I64, Nullability::NonNullable),
     ).unwrap())]
     fn test_filter_chunked_conformance(#[case] chunked: ChunkedArray) {
-        test_filter_conformance(&chunked.to_array());
+        test_filter_conformance(&chunked.into_array());
     }
 }

--- a/vortex-array/src/arrays/chunked/compute/mask.rs
+++ b/vortex-array/src/arrays/chunked/compute/mask.rs
@@ -56,15 +56,15 @@ mod test {
         vec![
             buffer![0u64, 1].into_array(),
             buffer![2_u64].into_array(),
-            PrimitiveArray::empty::<u64>(Nullability::NonNullable).to_array(),
+            PrimitiveArray::empty::<u64>(Nullability::NonNullable).into_array(),
             buffer![3_u64, 4].into_array(),
         ],
         DType::Primitive(PType::U64, Nullability::NonNullable),
     ).unwrap())]
     #[case(ChunkedArray::try_new(
         vec![
-            PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]).to_array(),
-            PrimitiveArray::from_option_iter([Some(4i32), Some(5)]).to_array(),
+            PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]).into_array(),
+            PrimitiveArray::from_option_iter([Some(4i32), Some(5)]).into_array(),
         ],
         DType::Primitive(PType::I32, Nullability::Nullable),
     ).unwrap())]
@@ -79,6 +79,6 @@ mod test {
         DType::Primitive(PType::F32, Nullability::NonNullable),
     ).unwrap())]
     fn test_mask_chunked_conformance(#[case] chunked: ChunkedArray) {
-        test_mask_conformance(&chunked.to_array());
+        test_mask_conformance(&chunked.into_array());
     }
 }

--- a/vortex-array/src/arrays/chunked/compute/mod.rs
+++ b/vortex-array/src/arrays/chunked/compute/mod.rs
@@ -82,7 +82,7 @@ mod tests {
     ).unwrap())]
 
     fn test_chunked_consistency(#[case] array: ChunkedArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 
     #[rstest]

--- a/vortex-array/src/arrays/chunked/compute/sum.rs
+++ b/vortex-array/src/arrays/chunked/compute/sum.rs
@@ -65,7 +65,7 @@ mod tests {
         .unwrap();
 
         // Compute sum
-        let result = sum(&chunked.to_array()).unwrap();
+        let result = sum(&chunked.into_array()).unwrap();
 
         // Expected sum: 1.5 + 3.2 + 4.8 + 2.1 + 5.7 + 1.0 + 2.5 = 20.8
         assert_eq!(result.as_primitive().as_::<f64>(), Some(20.8));
@@ -81,7 +81,7 @@ mod tests {
         let chunked =
             ChunkedArray::try_new(vec![chunk1.into_array(), chunk2.into_array()], dtype).unwrap();
         // Compute sum - should return null for all nulls
-        let result = sum(&chunked.to_array()).unwrap();
+        let result = sum(&chunked.into_array()).unwrap();
         assert_eq!(result, Scalar::primitive(0f64, Nullability::Nullable));
     }
 
@@ -104,7 +104,7 @@ mod tests {
         .unwrap();
 
         // Compute sum: 10.5 + 20.3 + 5.2 = 36.0
-        let result = sum(&chunked.to_array()).unwrap();
+        let result = sum(&chunked.into_array()).unwrap();
         assert_eq!(result.as_primitive().as_::<f64>(), Some(36.0));
     }
 
@@ -117,7 +117,7 @@ mod tests {
         let chunked =
             ChunkedArray::try_new(vec![chunk1.into_array(), chunk2.into_array()], dtype).unwrap();
 
-        let result = sum(&chunked.to_array()).unwrap();
+        let result = sum(&chunked.into_array()).unwrap();
         assert_eq!(result.as_primitive().as_::<u64>(), Some(1));
     }
 
@@ -149,7 +149,7 @@ mod tests {
         .unwrap();
 
         // Compute sum: 5*100 + 3*200 + 2*300 = 500 + 600 + 600 = 1700 (represents 17.00)
-        let result = sum(&chunked.to_array()).unwrap();
+        let result = sum(&chunked.into_array()).unwrap();
         let decimal_result = result.as_decimal();
         assert_eq!(
             decimal_result.decimal_value(),
@@ -186,7 +186,7 @@ mod tests {
         .unwrap();
 
         // Compute sum: 3*100 + 2*200 = 300 + 400 = 700 (nulls ignored)
-        let result = sum(&chunked.to_array()).unwrap();
+        let result = sum(&chunked.into_array()).unwrap();
         let decimal_result = result.as_decimal();
         assert_eq!(
             decimal_result.decimal_value(),
@@ -222,7 +222,7 @@ mod tests {
 
         // Compute sum: 500 + 600 = 1100
         // Result should have precision 13 (3+10), scale 0
-        let result = sum(&chunked.to_array()).unwrap();
+        let result = sum(&chunked.into_array()).unwrap();
         let decimal_result = result.as_decimal();
         assert_eq!(
             decimal_result.decimal_value(),

--- a/vortex-array/src/arrays/chunked/compute/take.rs
+++ b/vortex-array/src/arrays/chunked/compute/take.rs
@@ -151,7 +151,7 @@ mod test {
         assert_eq!(arr.len(), 9);
         let indices = PrimitiveArray::new(buffer![0u64, 0, 6, 4], Validity::NonNullable);
 
-        let result = arr.take(indices.to_array()).unwrap();
+        let result = arr.take(indices.into_array()).unwrap();
         assert_arrays_eq!(
             result,
             PrimitiveArray::from_option_iter([1i32, 1, 1, 2].map(Some))
@@ -170,7 +170,7 @@ mod test {
             Validity::Array(bitbuffer![1 0 0 1].into_array()),
         );
 
-        let result = arr.take(indices.to_array()).unwrap();
+        let result = arr.take(indices.into_array()).unwrap();
         assert_arrays_eq!(
             result,
             PrimitiveArray::from_option_iter([Some(1i32), None, None, Some(2)])
@@ -183,17 +183,17 @@ mod test {
             StructArray::try_new(FieldNames::default(), vec![], 100, Validity::NonNullable)
                 .unwrap();
 
-        let arr = ChunkedArray::from_iter(vec![struct_array.to_array(), struct_array.to_array()]);
+        let arr = ChunkedArray::from_iter(vec![struct_array.into_array(), struct_array.into_array()]);
 
         let result = arr
-            .take(PrimitiveArray::from_option_iter(vec![Some(0), None, Some(101)]).to_array())
+            .take(PrimitiveArray::from_option_iter(vec![Some(0), None, Some(101)]).into_array())
             .unwrap();
 
         let expect = StructArray::try_new(
             FieldNames::default(),
             vec![],
             3,
-            Validity::Array(BoolArray::from_iter(vec![true, false, true]).to_array()),
+            Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array()),
         )
         .unwrap();
         assert_arrays_eq!(result, expect);
@@ -208,7 +208,7 @@ mod test {
         assert_eq!(arr.len(), 9);
 
         let indices = PrimitiveArray::empty::<u64>(Nullability::NonNullable);
-        let result = arr.take(indices.to_array()).unwrap();
+        let result = arr.take(indices.into_array()).unwrap();
 
         assert!(result.is_empty());
         assert_eq!(result.dtype(), arr.dtype());
@@ -269,7 +269,7 @@ mod test {
             vortex_buffer::Buffer::from(indices.clone()),
             Validity::NonNullable,
         );
-        let result = arr.take(indices_arr.to_array())?;
+        let result = arr.take(indices_arr.into_array())?;
 
         // Verify every element.
         let result = result.to_primitive();
@@ -298,7 +298,7 @@ mod test {
         // Indices with nulls scattered across chunk boundaries.
         let indices =
             PrimitiveArray::from_option_iter([Some(5u64), None, Some(0), Some(3), None, Some(2)]);
-        let result = arr.take(indices.to_array())?;
+        let result = arr.take(indices.into_array())?;
 
         assert_arrays_eq!(
             result,
@@ -325,14 +325,14 @@ mod test {
                 .clone(),
         )
         .unwrap();
-        test_take_conformance(&arr.to_array());
+        test_take_conformance(&arr.into_array());
 
         // Test with nullable chunked array
         let a = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]);
         let b = PrimitiveArray::from_option_iter([Some(4i32), Some(5)]);
         let dtype = a.dtype().clone();
         let arr = ChunkedArray::try_new(vec![a.into_array(), b.into_array()], dtype).unwrap();
-        test_take_conformance(&arr.to_array());
+        test_take_conformance(&arr.into_array());
 
         // Test with multiple identical chunks
         let chunk = buffer![10i32, 20, 30, 40, 50].into_array();
@@ -341,6 +341,6 @@ mod test {
             chunk.dtype().clone(),
         )
         .unwrap();
-        test_take_conformance(&arr.to_array());
+        test_take_conformance(&arr.into_array());
     }
 }

--- a/vortex-array/src/arrays/chunked/compute/take.rs
+++ b/vortex-array/src/arrays/chunked/compute/take.rs
@@ -183,7 +183,10 @@ mod test {
             StructArray::try_new(FieldNames::default(), vec![], 100, Validity::NonNullable)
                 .unwrap();
 
-        let arr = ChunkedArray::from_iter(vec![struct_array.into_array(), struct_array.into_array()]);
+        let arr = ChunkedArray::from_iter(vec![
+            struct_array.clone().into_array(),
+            struct_array.into_array(),
+        ]);
 
         let result = arr
             .take(PrimitiveArray::from_option_iter(vec![Some(0), None, Some(101)]).into_array())

--- a/vortex-array/src/arrays/chunked/compute/zip.rs
+++ b/vortex-array/src/arrays/chunked/compute/zip.rs
@@ -5,6 +5,7 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::ChunkedArray;
 use crate::arrays::ChunkedVTable;
 use crate::builtins::ArrayBuiltins;
@@ -65,7 +66,7 @@ impl ZipKernel for ChunkedVTable {
 
         // SAFETY: chunks originate from zipping slices of inputs that share dtype/nullability.
         let chunked = unsafe { ChunkedArray::new_unchecked(out_chunks, dtype) };
-        Ok(Some(chunked.to_array()))
+        Ok(Some(chunked.into_array()))
     }
 }
 
@@ -112,7 +113,7 @@ mod tests {
 
         let zipped = &mask
             .into_array()
-            .zip(if_true.to_array(), if_false.to_array())
+            .zip(if_true.into_array(), if_false.into_array())
             .unwrap();
         // One step of execution will push down the zip.
         let zipped = zipped

--- a/vortex-array/src/arrays/chunked/tests.rs
+++ b/vortex-array/src/arrays/chunked/tests.rs
@@ -147,7 +147,7 @@ pub fn pack_nested_structs() {
     let dtype = struct_array.dtype().clone();
     let chunked = ChunkedArray::try_new(
         vec![
-            ChunkedArray::try_new(vec![struct_array.into_array()], dtype.clone())
+            ChunkedArray::try_new(vec![struct_array.clone().into_array()], dtype.clone())
                 .unwrap()
                 .into_array(),
         ],

--- a/vortex-array/src/arrays/chunked/tests.rs
+++ b/vortex-array/src/arrays/chunked/tests.rs
@@ -147,7 +147,7 @@ pub fn pack_nested_structs() {
     let dtype = struct_array.dtype().clone();
     let chunked = ChunkedArray::try_new(
         vec![
-            ChunkedArray::try_new(vec![struct_array.to_array()], dtype.clone())
+            ChunkedArray::try_new(vec![struct_array.into_array()], dtype.clone())
                 .unwrap()
                 .into_array(),
         ],

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -38,7 +38,7 @@ pub(super) fn _canonicalize(
         DType::Struct(struct_dtype, _) => {
             let struct_array = pack_struct_chunks(
                 array.chunks(),
-                Validity::copy_from_array(&array.to_array())?,
+                Validity::copy_from_array(&array.clone().into_array())?,
                 struct_dtype,
                 ctx,
             )?;
@@ -46,7 +46,7 @@ pub(super) fn _canonicalize(
         }
         DType::List(elem_dtype, _) => Canonical::List(swizzle_list_chunks(
             array.chunks(),
-            Validity::copy_from_array(&array.to_array())?,
+            Validity::copy_from_array(&array.clone().into_array())?,
             elem_dtype,
             ctx,
         )?),
@@ -219,7 +219,7 @@ mod tests {
         let dtype = struct_array.dtype().clone();
         let chunked = ChunkedArray::try_new(
             vec![
-                ChunkedArray::try_new(vec![struct_array.to_array()], dtype.clone())
+                ChunkedArray::try_new(vec![struct_array.into_array()], dtype.clone())
                     .unwrap()
                     .into_array(),
             ],

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -219,7 +219,7 @@ mod tests {
         let dtype = struct_array.dtype().clone();
         let chunked = ChunkedArray::try_new(
             vec![
-                ChunkedArray::try_new(vec![struct_array.into_array()], dtype.clone())
+                ChunkedArray::try_new(vec![struct_array.clone().into_array()], dtype.clone())
                     .unwrap()
                     .into_array(),
             ],

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -112,7 +112,7 @@ impl VTable for ChunkedVTable {
 
     fn child(array: &ChunkedArray, idx: usize) -> ArrayRef {
         match idx {
-            0 => array.chunk_offsets.to_array(),
+            0 => array.chunk_offsets.clone().into_array(),
             n => array.chunks()[n - 1].clone(),
         }
     }

--- a/vortex-array/src/arrays/constant/compute/min_max.rs
+++ b/vortex-array/src/arrays/constant/compute/min_max.rs
@@ -28,6 +28,7 @@ register_kernel!(MinMaxKernelAdapter(ConstantVTable).lift());
 
 #[cfg(test)]
 mod test {
+    use crate::IntoArray;
     use crate::arrays::ConstantArray;
     use crate::compute::min_max;
     use crate::dtype::Nullability;

--- a/vortex-array/src/arrays/constant/compute/min_max.rs
+++ b/vortex-array/src/arrays/constant/compute/min_max.rs
@@ -37,7 +37,7 @@ mod test {
     #[test]
     fn test_min_max_nan() {
         let scalar = Scalar::primitive(f16::NAN, Nullability::NonNullable);
-        let array = ConstantArray::new(scalar, 2).to_array();
+        let array = ConstantArray::new(scalar, 2).into_array();
         let result = min_max(&array).unwrap();
         assert_eq!(result, None);
     }

--- a/vortex-array/src/arrays/constant/compute/mod.rs
+++ b/vortex-array/src/arrays/constant/compute/mod.rs
@@ -61,6 +61,6 @@ mod test {
     #[case::constant_single(ConstantArray::new(Scalar::from(99u64), 1))]
     #[case::constant_large(ConstantArray::new(Scalar::from("hello"), 1000))]
     fn test_constant_consistency(#[case] array: ConstantArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/constant/compute/sum.rs
+++ b/vortex-array/src/arrays/constant/compute/sum.rs
@@ -292,7 +292,7 @@ mod tests {
     fn test_sum_float_non_multiply() {
         let acc = -2048669276050936500000000000f64;
         let array = ConstantArray::new(6.1811675e16f64, 25);
-        let sum = sum_with_accumulator(&array.to_array(), &Scalar::primitive(acc, Nullable))
+        let sum = sum_with_accumulator(&array.into_array(), &Scalar::primitive(acc, Nullable))
             .vortex_expect("operation should succeed in test");
         assert_eq!(
             f64::try_from(&sum).vortex_expect("operation should succeed in test"),

--- a/vortex-array/src/arrays/constant/compute/take.rs
+++ b/vortex-array/src/arrays/constant/compute/take.rs
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn take_nullable_indices() {
-        let array = ConstantArray::new(42, 10).to_array();
+        let array = ConstantArray::new(42, 10).into_array();
         let taken = array
             .take(
                 PrimitiveArray::new(
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn take_all_valid_indices() {
-        let array = ConstantArray::new(42, 10).to_array();
+        let array = ConstantArray::new(42, 10).into_array();
         let taken = array
             .take(PrimitiveArray::new(buffer![0, 5, 7], Validity::AllValid).into_array())
             .unwrap();
@@ -128,6 +128,6 @@ mod tests {
     #[case(ConstantArray::new(Scalar::null_native::<i64>(), 5))]
     #[case(ConstantArray::new(true, 1))]
     fn test_take_constant_conformance(#[case] array: ConstantArray) {
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/decimal/array.rs
+++ b/vortex-array/src/arrays/decimal/array.rs
@@ -12,6 +12,7 @@ use vortex_error::vortex_ensure;
 use vortex_error::vortex_panic;
 
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
 use crate::buffer::BufferHandle;
 use crate::dtype::BigCast;
@@ -378,7 +379,7 @@ impl DecimalArray {
         let patched_validity = self.validity().clone().patch(
             self.len(),
             offset,
-            &patch_indices.to_array(),
+            &patch_indices.clone().into_array(),
             patch_values.validity(),
             ctx,
         )?;

--- a/vortex-array/src/arrays/decimal/compute/cast.rs
+++ b/vortex-array/src/arrays/decimal/compute/cast.rs
@@ -9,6 +9,7 @@ use vortex_error::vortex_panic;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::DecimalArray;
 use crate::arrays::DecimalVTable;
 use crate::dtype::DType;
@@ -55,7 +56,7 @@ impl CastKernel for DecimalVTable {
 
         // If the dtype is exactly the same, return self
         if array.dtype() == dtype {
-            return Ok(Some(array.to_array()));
+            return Ok(Some(array.clone().into_array()));
         }
 
         // Cast the validity to the new nullability
@@ -81,7 +82,7 @@ impl CastKernel for DecimalVTable {
                     *to_decimal_dtype,
                     new_validity,
                 )
-                .to_array(),
+                .into_array(),
             ))
         }
     }
@@ -169,7 +170,7 @@ mod tests {
         // Cast to nullable
         let nullable_dtype = DType::Decimal(decimal_dtype, Nullability::Nullable);
         let casted = array
-            .to_array()
+            .into_array()
             .cast(nullable_dtype.clone())
             .unwrap()
             .to_decimal();
@@ -189,7 +190,7 @@ mod tests {
         // Cast to non-nullable
         let non_nullable_dtype = DType::Decimal(decimal_dtype, Nullability::NonNullable);
         let casted = array
-            .to_array()
+            .into_array()
             .cast(non_nullable_dtype.clone())
             .unwrap()
             .to_decimal();
@@ -209,7 +210,7 @@ mod tests {
         // Attempt to cast to non-nullable should fail
         let non_nullable_dtype = DType::Decimal(decimal_dtype, Nullability::NonNullable);
         array
-            .to_array()
+            .into_array()
             .cast(non_nullable_dtype)
             .and_then(|a| a.to_canonical().map(|c| c.into_array()))
             .unwrap();
@@ -226,7 +227,7 @@ mod tests {
         // Try to cast to different scale - not supported
         let different_dtype = DType::Decimal(DecimalDType::new(15, 3), Nullability::NonNullable);
         let result = array
-            .to_array()
+            .into_array()
             .cast(different_dtype)
             .and_then(|a| a.to_canonical().map(|c| c.into_array()));
 
@@ -250,7 +251,7 @@ mod tests {
         // Try to downcast precision - not supported
         let smaller_dtype = DType::Decimal(DecimalDType::new(10, 2), Nullability::NonNullable);
         let result = array
-            .to_array()
+            .into_array()
             .cast(smaller_dtype)
             .and_then(|a| a.to_canonical().map(|c| c.into_array()));
 
@@ -273,7 +274,7 @@ mod tests {
 
         // Cast to higher precision with same scale - should succeed
         let wider_dtype = DType::Decimal(DecimalDType::new(38, 2), Nullability::NonNullable);
-        let casted = array.to_array().cast(wider_dtype).unwrap().to_decimal();
+        let casted = array.into_array().cast(wider_dtype).unwrap().to_decimal();
 
         assert_eq!(casted.precision(), 38);
         assert_eq!(casted.scale(), 2);
@@ -292,7 +293,7 @@ mod tests {
 
         // Try to cast to non-decimal type - should fail since no kernel can handle it
         let result = array
-            .to_array()
+            .into_array()
             .cast(DType::Utf8(Nullability::NonNullable))
             .and_then(|a| a.to_canonical().map(|c| c.into_array()));
 
@@ -311,7 +312,7 @@ mod tests {
     #[case(DecimalArray::from_option_iter([Some(100i32), None, Some(300)], DecimalDType::new(10, 2)))]
     #[case(DecimalArray::new(buffer![42i32], DecimalDType::new(5, 1), Validity::NonNullable))]
     fn test_cast_decimal_conformance(#[case] array: DecimalArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 
     #[test]

--- a/vortex-array/src/arrays/decimal/compute/fill_null.rs
+++ b/vortex-array/src/arrays/decimal/compute/fill_null.rs
@@ -109,7 +109,7 @@ mod tests {
             decimal_dtype,
         );
         let p = arr
-            .to_array()
+            .into_array()
             .fill_null(Scalar::decimal(
                 DecimalValue::I128(4200i128),
                 DecimalDType::new(19, 2),
@@ -138,7 +138,7 @@ mod tests {
         );
 
         let p = arr
-            .to_array()
+            .into_array()
             .fill_null(Scalar::decimal(
                 DecimalValue::I128(25500i128),
                 DecimalDType::new(19, 2),
@@ -159,7 +159,7 @@ mod tests {
         let arr = DecimalArray::from_option_iter([None, Some(10i8), None], decimal_dtype);
         // i8 max is 127, so 200 doesn't fit — the array should be widened to i16.
         let result = arr
-            .to_array()
+            .into_array()
             .fill_null(Scalar::decimal(
                 DecimalValue::I128(200i128),
                 DecimalDType::new(3, 0),
@@ -183,7 +183,7 @@ mod tests {
             Validity::NonNullable,
         );
         let p = arr
-            .to_array()
+            .into_array()
             .fill_null(Scalar::decimal(
                 DecimalValue::I128(25500i128),
                 DecimalDType::new(19, 2),

--- a/vortex-array/src/arrays/decimal/compute/fill_null.rs
+++ b/vortex-array/src/arrays/decimal/compute/fill_null.rs
@@ -91,6 +91,7 @@ fn fill_buffer<T: NativeDecimalType>(
 mod tests {
     use vortex_buffer::buffer;
 
+    use crate::IntoArray;
     use crate::arrays::decimal::DecimalArray;
     use crate::assert_arrays_eq;
     use crate::builtins::ArrayBuiltins;

--- a/vortex-array/src/arrays/decimal/compute/is_constant.rs
+++ b/vortex-array/src/arrays/decimal/compute/is_constant.rs
@@ -44,7 +44,7 @@ mod tests {
             Validity::NonNullable,
         );
 
-        assert!(!is_constant(&array.to_array()).unwrap().unwrap());
+        assert!(!is_constant(&array.into_array()).unwrap().unwrap());
 
         let array = DecimalArray::new(
             buffer![100i128, 100i128, 100i128],
@@ -52,6 +52,6 @@ mod tests {
             Validity::NonNullable,
         );
 
-        assert!(is_constant(&array.to_array()).unwrap().unwrap());
+        assert!(is_constant(&array.into_array()).unwrap().unwrap());
     }
 }

--- a/vortex-array/src/arrays/decimal/compute/is_constant.rs
+++ b/vortex-array/src/arrays/decimal/compute/is_constant.rs
@@ -31,6 +31,7 @@ register_kernel!(IsConstantKernelAdapter(DecimalVTable).lift());
 mod tests {
     use vortex_buffer::buffer;
 
+    use crate::IntoArray;
     use crate::arrays::DecimalArray;
     use crate::compute::is_constant;
     use crate::dtype::DecimalDType;

--- a/vortex-array/src/arrays/decimal/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/decimal/compute/is_sorted.rs
@@ -91,8 +91,8 @@ mod tests {
         let sorted_array = DecimalArray::new(sorted, dtype, Validity::NonNullable);
         let unsorted_array = DecimalArray::new(unsorted, dtype, Validity::NonNullable);
 
-        assert!(is_sorted(&sorted_array.to_array()).unwrap().unwrap());
-        assert!(!is_sorted(&unsorted_array.to_array()).unwrap().unwrap());
+        assert!(is_sorted(&sorted_array.into_array()).unwrap().unwrap());
+        assert!(!is_sorted(&unsorted_array.into_array()).unwrap().unwrap());
     }
 
     #[test]
@@ -114,10 +114,10 @@ mod tests {
         let sorted_array = DecimalArray::new(sorted, dtype, Validity::NonNullable);
 
         assert!(
-            is_strict_sorted(&strict_sorted_array.to_array())
+            is_strict_sorted(&strict_sorted_array.into_array())
                 .unwrap()
                 .unwrap()
         );
-        assert!(!is_strict_sorted(&sorted_array.to_array()).unwrap().unwrap());
+        assert!(!is_strict_sorted(&sorted_array.into_array()).unwrap().unwrap());
     }
 }

--- a/vortex-array/src/arrays/decimal/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/decimal/compute/is_sorted.rs
@@ -71,6 +71,7 @@ mod tests {
     use arrow_cast::parse::parse_decimal;
     use vortex_buffer::buffer;
 
+    use crate::IntoArray;
     use crate::arrays::DecimalArray;
     use crate::compute::is_sorted;
     use crate::compute::is_strict_sorted;
@@ -118,6 +119,10 @@ mod tests {
                 .unwrap()
                 .unwrap()
         );
-        assert!(!is_strict_sorted(&sorted_array.into_array()).unwrap().unwrap());
+        assert!(
+            !is_strict_sorted(&sorted_array.into_array())
+                .unwrap()
+                .unwrap()
+        );
     }
 }

--- a/vortex-array/src/arrays/decimal/compute/min_max.rs
+++ b/vortex-array/src/arrays/decimal/compute/min_max.rs
@@ -91,7 +91,7 @@ mod tests {
             Validity::from_iter([true, false, true]),
         );
 
-        let min_max = min_max(&decimal.to_array()).unwrap();
+        let min_max = min_max(&decimal.into_array()).unwrap();
 
         let non_nullable_dtype = decimal.dtype().as_nonnullable();
         let expected = MinMaxResult {

--- a/vortex-array/src/arrays/decimal/compute/min_max.rs
+++ b/vortex-array/src/arrays/decimal/compute/min_max.rs
@@ -74,6 +74,7 @@ where
 mod tests {
     use vortex_buffer::buffer;
 
+    use crate::IntoArray;
     use crate::arrays::DecimalArray;
     use crate::compute::MinMaxResult;
     use crate::compute::min_max;
@@ -91,7 +92,7 @@ mod tests {
             Validity::from_iter([true, false, true]),
         );
 
-        let min_max = min_max(&decimal.into_array()).unwrap();
+        let min_max = min_max(&decimal.clone().into_array()).unwrap();
 
         let non_nullable_dtype = decimal.dtype().as_nonnullable();
         let expected = MinMaxResult {

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -17,6 +17,7 @@ mod tests {
     use rstest::rstest;
     use vortex_buffer::buffer;
 
+    use crate::IntoArray;
     use crate::arrays::DecimalArray;
     use crate::compute::conformance::consistency::test_array_consistency;
     use crate::dtype::DecimalDType;

--- a/vortex-array/src/arrays/decimal/compute/mod.rs
+++ b/vortex-array/src/arrays/decimal/compute/mod.rs
@@ -56,6 +56,6 @@ mod tests {
         Validity::NonNullable,
     ))]
     fn test_decimal_consistency(#[case] array: DecimalArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/decimal/compute/sum.rs
+++ b/vortex-array/src/arrays/decimal/compute/sum.rs
@@ -150,7 +150,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
 
         let expected = Scalar::try_new(
             DType::Decimal(DecimalDType::new(14, 2), Nullability::NonNullable),
@@ -169,7 +169,7 @@ mod tests {
             Validity::from_iter([true, false, true, true]),
         );
 
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
 
         let expected = Scalar::try_new(
             DType::Decimal(DecimalDType::new(14, 2), Nullability::Nullable),
@@ -188,7 +188,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
 
         let expected = Scalar::try_new(
             DType::Decimal(DecimalDType::new(14, 2), Nullability::NonNullable),
@@ -209,7 +209,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
 
         // Should use i64 for accumulation since precision increases
         let expected_sum = near_max as i64 + 500 + 400;
@@ -232,7 +232,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
 
         let expected_sum = (large_val as i128) * 4 + 1;
         let expected = Scalar::try_new(
@@ -257,7 +257,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
 
         // Should use i256 for accumulation
         let expected_sum =
@@ -282,7 +282,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
 
         let expected_sum = (large_pos as i128) + (large_neg as i128) + (large_pos as i128) + 1000;
         let expected = Scalar::try_new(
@@ -302,7 +302,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
 
         // Scale should be preserved, precision increased by 10
         let expected = Scalar::try_new(
@@ -319,7 +319,7 @@ mod tests {
         let decimal =
             DecimalArray::new(buffer![42i32], DecimalDType::new(3, 1), Validity::AllValid);
 
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
 
         let expected = Scalar::try_new(
             DType::Decimal(DecimalDType::new(13, 1), Nullability::NonNullable),
@@ -338,7 +338,7 @@ mod tests {
             Validity::from_iter([false, false, true, false]),
         );
 
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
 
         let expected = Scalar::try_new(
             DType::Decimal(DecimalDType::new(14, 2), Nullability::Nullable),
@@ -362,7 +362,7 @@ mod tests {
             Validity::AllValid,
         );
 
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
 
         // Should use i256 for accumulation since 9 * (i128::MAX / 10) fits in i128 but we increase precision
         let expected_sum = i256::from_i128(large_i128).wrapping_pow(1) * i256::from_i128(9);
@@ -389,7 +389,7 @@ mod tests {
         let decimal = DecimalArray::new(buffer![val, val], decimal_dtype, Validity::AllValid);
 
         // Sum = 12 * 10^75 = 1.2 * 10^76, which exceeds precision 76 but fits in `i256`.
-        let result = sum(&decimal.to_array()).unwrap();
+        let result = sum(&decimal.into_array()).unwrap();
         assert_eq!(
             result,
             Scalar::null(DType::Decimal(decimal_dtype, Nullability::Nullable))
@@ -406,7 +406,7 @@ mod tests {
         );
 
         assert_eq!(
-            sum(&decimal.to_array()).vortex_expect("operation should succeed in test"),
+            sum(&decimal.into_array()).vortex_expect("operation should succeed in test"),
             Scalar::null(DType::Decimal(decimal_dtype, Nullability::Nullable))
         );
     }

--- a/vortex-array/src/arrays/decimal/compute/sum.rs
+++ b/vortex-array/src/arrays/decimal/compute/sum.rs
@@ -131,6 +131,7 @@ mod tests {
     use vortex_buffer::buffer;
     use vortex_error::VortexExpect;
 
+    use crate::IntoArray;
     use crate::arrays::DecimalArray;
     use crate::compute::sum;
     use crate::dtype::DType;

--- a/vortex-array/src/arrays/decimal/compute/take.rs
+++ b/vortex-array/src/arrays/decimal/compute/take.rs
@@ -5,6 +5,7 @@ use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::IntoArray;
 use crate::arrays::DecimalArray;
 use crate::arrays::DecimalVTable;
 use crate::arrays::PrimitiveArray;
@@ -23,7 +24,7 @@ impl TakeExecute for DecimalVTable {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let indices = indices.to_array().execute::<PrimitiveArray>(ctx)?;
-        let validity = array.validity().take(&indices.to_array())?;
+        let validity = array.validity().take(&indices.clone().into_array())?;
 
         // TODO(joe): if the true count of take indices validity is low, only take array values with
         // valid indices.
@@ -37,7 +38,7 @@ impl TakeExecute for DecimalVTable {
             })
         });
 
-        Ok(Some(decimal.to_array()))
+        Ok(Some(decimal.into_array()))
     }
 }
 
@@ -127,6 +128,6 @@ mod tests {
         )
     })]
     fn test_take_decimal_conformance(#[case] array: DecimalArray) {
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -13,6 +13,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::DeserializeMetadata;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
 use crate::arrays::DecimalArray;
@@ -206,7 +207,7 @@ impl VTable for DecimalVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.to_array())
+        Ok(array.clone().into_array())
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/decimal/vtable/operations.rs
+++ b/vortex-array/src/arrays/decimal/vtable/operations.rs
@@ -42,7 +42,7 @@ mod tests {
             DecimalDType::new(3, 2),
             Validity::NonNullable,
         )
-        .to_array();
+        .into_array();
 
         let sliced = array.slice(1..3).unwrap();
         assert_eq!(sliced.len(), 2);
@@ -58,7 +58,7 @@ mod tests {
             DecimalDType::new(3, 2),
             Validity::from_iter([false, true, false, true]),
         )
-        .to_array();
+        .into_array();
 
         let sliced = array.slice(1..3).unwrap();
         assert_eq!(sliced.len(), 2);

--- a/vortex-array/src/arrays/decimal/vtable/operations.rs
+++ b/vortex-array/src/arrays/decimal/vtable/operations.rs
@@ -27,6 +27,7 @@ mod tests {
     use vortex_buffer::buffer;
 
     use crate::DynArray;
+    use crate::IntoArray;
     use crate::arrays::DecimalArray;
     use crate::arrays::DecimalVTable;
     use crate::dtype::DecimalDType;

--- a/vortex-array/src/arrays/dict/compute/cast.rs
+++ b/vortex-array/src/arrays/dict/compute/cast.rs
@@ -68,7 +68,7 @@ mod tests {
         let dict = dict_encode(&values).unwrap();
 
         let casted = dict
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I64, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -84,10 +84,10 @@ mod tests {
     fn test_cast_dict_nullable() {
         let values =
             PrimitiveArray::from_option_iter([Some(10i32), None, Some(20), Some(10), None]);
-        let dict = dict_encode(&values.to_array()).unwrap();
+        let dict = dict_encode(&values.into_array()).unwrap();
 
         let casted = dict
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I64, Nullability::Nullable))
             .unwrap();
         assert_eq!(
@@ -111,7 +111,7 @@ mod tests {
 
         // Cast to NonNullable (should be identity since already NonNullable)
         let non_nullable = dict
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I32, Nullability::NonNullable))
             .unwrap();
         assert_eq!(
@@ -209,7 +209,7 @@ mod tests {
 
         // Casting to NonNullable should succeed since all logical values are non-null.
         let result = dict
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::F64, Nullability::NonNullable));
         assert!(
             result.is_ok(),

--- a/vortex-array/src/arrays/dict/compute/cast.rs
+++ b/vortex-array/src/arrays/dict/compute/cast.rs
@@ -111,6 +111,7 @@ mod tests {
 
         // Cast to NonNullable (should be identity since already NonNullable)
         let non_nullable = dict
+            .clone()
             .into_array()
             .cast(DType::Primitive(PType::I32, Nullability::NonNullable))
             .unwrap();

--- a/vortex-array/src/arrays/dict/compute/compare.rs
+++ b/vortex-array/src/arrays/dict/compute/compare.rs
@@ -31,7 +31,7 @@ impl CompareKernel for DictVTable {
         // If the RHS is constant, then we just need to compare against our encoded values.
         if let Some(rhs) = rhs.as_constant() {
             let compare_result = lhs.values().to_array().binary(
-                ConstantArray::new(rhs, lhs.values().len()).to_array(),
+                ConstantArray::new(rhs, lhs.values().len()).into_array(),
                 Operator::from(operator),
             )?;
 

--- a/vortex-array/src/arrays/dict/compute/fill_null.rs
+++ b/vortex-array/src/arrays/dict/compute/fill_null.rs
@@ -31,7 +31,7 @@ impl FillNullKernel for DictVTable {
             .values()
             .to_array()
             .binary(
-                ConstantArray::new(fill_value.clone(), array.values().len()).to_array(),
+                ConstantArray::new(fill_value.clone(), array.values().len()).into_array(),
                 Operator::Eq,
             )?
             .execute::<BoolArray>(ctx)?;
@@ -43,7 +43,7 @@ impl FillNullKernel for DictVTable {
             // No fill values found, so we must canonicalize and fill_null.
             return Ok(Some(
                 array
-                    .to_array()
+                    .clone().into_array()
                     .execute::<Canonical>(ctx)?
                     .into_array()
                     .fill_null(fill_value.clone())?,
@@ -112,7 +112,7 @@ mod tests {
         .vortex_expect("operation should succeed in test");
 
         let filled = dict
-            .to_array()
+            .into_array()
             .fill_null(Scalar::primitive(20, Nullability::NonNullable))
             .vortex_expect("operation should succeed in test");
         let filled_primitive = filled.to_primitive();

--- a/vortex-array/src/arrays/dict/compute/fill_null.rs
+++ b/vortex-array/src/arrays/dict/compute/fill_null.rs
@@ -43,7 +43,8 @@ impl FillNullKernel for DictVTable {
             // No fill values found, so we must canonicalize and fill_null.
             return Ok(Some(
                 array
-                    .clone().into_array()
+                    .clone()
+                    .into_array()
                     .execute::<Canonical>(ctx)?
                     .into_array()
                     .fill_null(fill_value.clone())?,

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -104,18 +104,18 @@ mod tests {
     )]
     #[case::nullable_values(
         dict_encode(
-            &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).to_array()
+            &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).into_array()
         ).unwrap(),
         (1, 2)
     )]
     fn test_min_max(#[case] dict: DictArray, #[case] expected: (i32, i32)) {
-        assert_min_max(&dict.to_array(), Some(expected));
+        assert_min_max(&dict.into_array(), Some(expected));
     }
 
     #[test]
     fn test_sliced_dict() {
         let reference = PrimitiveArray::from_iter([1, 5, 10, 50, 100]);
-        let dict = dict_encode(&reference.to_array()).unwrap();
+        let dict = dict_encode(&reference.into_array()).unwrap();
         let sliced = dict.slice(1..3).unwrap();
         assert_min_max(&sliced, Some((5, 10)));
     }
@@ -134,6 +134,6 @@ mod tests {
         ).unwrap()
     )]
     fn test_min_max_none(#[case] dict: DictArray) {
-        assert_min_max(&dict.to_array(), None);
+        assert_min_max(&dict.into_array(), None);
     }
 }

--- a/vortex-array/src/arrays/dict/compute/mod.rs
+++ b/vortex-array/src/arrays/dict/compute/mod.rs
@@ -88,7 +88,7 @@ mod test {
             .collect();
 
         let dict =
-            dict_encode(&PrimitiveArray::from_option_iter(values.clone()).to_array()).unwrap();
+            dict_encode(&PrimitiveArray::from_option_iter(values.clone()).into_array()).unwrap();
         let actual = dict.to_primitive();
 
         let expected = PrimitiveArray::from_option_iter(values);
@@ -101,7 +101,7 @@ mod test {
         let unique_values: Vec<i32> = (0..32).collect();
         let expected = PrimitiveArray::from_iter((0..1000).map(|i| unique_values[i % 32]));
 
-        let dict = dict_encode(&expected.to_array()).unwrap();
+        let dict = dict_encode(&expected.into_array()).unwrap();
         let actual = dict.to_primitive();
 
         assert_arrays_eq!(actual, expected);
@@ -112,7 +112,7 @@ mod test {
         let unique_values: Vec<i32> = (0..100).collect();
         let expected = PrimitiveArray::from_iter((0..1000).map(|i| unique_values[i % 100]));
 
-        let dict = dict_encode(&expected.to_array()).unwrap();
+        let dict = dict_encode(&expected.into_array()).unwrap();
         let actual = dict.to_primitive();
 
         assert_arrays_eq!(actual, expected);
@@ -125,7 +125,7 @@ mod test {
             DType::Utf8(Nullability::Nullable),
         );
         assert_eq!(reference.len(), 6);
-        let dict = dict_encode(&reference.to_array()).unwrap();
+        let dict = dict_encode(&reference.into_array()).unwrap();
         let flattened_dict = dict.to_varbinview();
         assert_eq!(
             flattened_dict.with_iterator(|iter| iter
@@ -146,7 +146,7 @@ mod test {
             Some(1),
             Some(5),
         ]);
-        let dict = dict_encode(&reference.to_array()).unwrap();
+        let dict = dict_encode(&reference.into_array()).unwrap();
         dict.slice(1..4).unwrap()
     }
 
@@ -155,24 +155,24 @@ mod test {
         use crate::arrays::BoolArray;
         let sliced = sliced_dict_array();
         let compared = sliced
-            .binary(ConstantArray::new(42, 3).to_array(), Operator::Eq)
+            .binary(ConstantArray::new(42, 3).into_array(), Operator::Eq)
             .unwrap();
 
         let expected = BoolArray::from_iter([Some(false), None, Some(true)]);
-        assert_arrays_eq!(compared, expected.to_array());
+        assert_arrays_eq!(compared, expected.into_array());
     }
 
     #[test]
     fn test_mask_dict_array() {
         let array = dict_encode(&buffer![2, 0, 2, 0, 10].into_array()).unwrap();
-        test_mask_conformance(&array.to_array());
+        test_mask_conformance(&array.into_array());
 
         let array = dict_encode(
             &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
-                .to_array(),
+                .into_array(),
         )
         .unwrap();
-        test_mask_conformance(&array.to_array());
+        test_mask_conformance(&array.into_array());
 
         let array = dict_encode(
             &VarBinArray::from_iter(
@@ -188,20 +188,20 @@ mod test {
             .into_array(),
         )
         .unwrap();
-        test_mask_conformance(&array.to_array());
+        test_mask_conformance(&array.into_array());
     }
 
     #[test]
     fn test_filter_dict_array() {
         let array = dict_encode(&buffer![2, 0, 2, 0, 10].into_array()).unwrap();
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
 
         let array = dict_encode(
             &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
-                .to_array(),
+                .into_array(),
         )
         .unwrap();
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
 
         let array = dict_encode(
             &VarBinArray::from_iter(
@@ -217,7 +217,7 @@ mod test {
             .into_array(),
         )
         .unwrap();
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[test]
@@ -226,7 +226,7 @@ mod test {
 
         assert_eq!(
             array
-                .take(PrimitiveArray::from_option_iter([Option::<i32>::None]).to_array())
+                .take(PrimitiveArray::from_option_iter([Option::<i32>::None]).into_array())
                 .unwrap()
                 .dtype(),
             &DType::Primitive(I32, Nullability::Nullable)
@@ -236,14 +236,14 @@ mod test {
     #[test]
     fn test_take_dict_conformance() {
         let array = dict_encode(&buffer![2, 0, 2, 0, 10].into_array()).unwrap();
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
 
         let array = dict_encode(
             &PrimitiveArray::from_option_iter([Some(2), None, Some(2), Some(0), Some(10)])
-                .to_array(),
+                .into_array(),
         )
         .unwrap();
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
 
         let array = dict_encode(
             &VarBinArray::from_iter(
@@ -259,7 +259,7 @@ mod test {
             .into_array(),
         )
         .unwrap();
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 }
 
@@ -285,7 +285,7 @@ mod tests {
         PrimitiveArray::from_option_iter([Some(10), Some(20), None]).into_array(),
     ).unwrap())]
     #[case::dict_nullable_values(dict_encode(
-        &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).to_array()
+        &PrimitiveArray::from_option_iter([Some(1i32), None, Some(2), Some(1), None]).into_array()
     ).unwrap())]
     #[case::dict_u64(dict_encode(&buffer![100u64, 200, 100, 300, 200].into_array()).unwrap())]
     // String arrays
@@ -306,6 +306,6 @@ mod tests {
     #[case::dict_all_same(dict_encode(&buffer![5i32, 5, 5, 5, 5].into_array()).unwrap())]
     #[case::dict_large(dict_encode(&PrimitiveArray::from_iter((0..1000).map(|i| i % 10)).into_array()).unwrap())]
     fn test_dict_consistency(#[case] array: DictArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/dict/compute/mod.rs
+++ b/vortex-array/src/arrays/dict/compute/mod.rs
@@ -101,7 +101,7 @@ mod test {
         let unique_values: Vec<i32> = (0..32).collect();
         let expected = PrimitiveArray::from_iter((0..1000).map(|i| unique_values[i % 32]));
 
-        let dict = dict_encode(&expected.into_array()).unwrap();
+        let dict = dict_encode(&expected.clone().into_array()).unwrap();
         let actual = dict.to_primitive();
 
         assert_arrays_eq!(actual, expected);
@@ -112,7 +112,7 @@ mod test {
         let unique_values: Vec<i32> = (0..100).collect();
         let expected = PrimitiveArray::from_iter((0..1000).map(|i| unique_values[i % 100]));
 
-        let dict = dict_encode(&expected.into_array()).unwrap();
+        let dict = dict_encode(&expected.clone().into_array()).unwrap();
         let actual = dict.to_primitive();
 
         assert_arrays_eq!(actual, expected);
@@ -125,7 +125,7 @@ mod test {
             DType::Utf8(Nullability::Nullable),
         );
         assert_eq!(reference.len(), 6);
-        let dict = dict_encode(&reference.into_array()).unwrap();
+        let dict = dict_encode(&reference.clone().into_array()).unwrap();
         let flattened_dict = dict.to_varbinview();
         assert_eq!(
             flattened_dict.with_iterator(|iter| iter

--- a/vortex-array/src/arrays/dict/compute/slice.rs
+++ b/vortex-array/src/arrays/dict/compute/slice.rs
@@ -32,7 +32,7 @@ impl SliceReduce for DictVTable {
             } else {
                 Ok(Some(
                     ConstantArray::new(Scalar::null(array.dtype().clone()), sliced_code.len())
-                        .to_array(),
+                        .into_array(),
                 ))
             };
         }

--- a/vortex-array/src/arrays/dict/execute.rs
+++ b/vortex-array/src/arrays/dict/execute.rs
@@ -8,6 +8,7 @@ use vortex_error::VortexResult;
 
 use crate::Canonical;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::BoolArray;
 use crate::arrays::BoolVTable;
 use crate::arrays::DecimalArray;
@@ -64,7 +65,7 @@ fn take_bool(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<BoolArray> {
     Ok(
-        <BoolVTable as TakeExecute>::take(array, &codes.to_array(), ctx)?
+        <BoolVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)?
             .vortex_expect("take bool should not return None")
             .as_::<BoolVTable>()
             .clone(),
@@ -76,7 +77,7 @@ fn take_primitive(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> PrimitiveArray {
-    <PrimitiveVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
+    <PrimitiveVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
         .vortex_expect("take primitive array")
         .vortex_expect("take primitive should not return None")
         .as_::<PrimitiveVTable>()
@@ -88,7 +89,7 @@ fn take_decimal(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> DecimalArray {
-    <DecimalVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
+    <DecimalVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
         .vortex_expect("take decimal array")
         .vortex_expect("take decimal should not return None")
         .as_::<DecimalVTable>()
@@ -100,7 +101,7 @@ fn take_varbinview(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> VarBinViewArray {
-    <VarBinViewVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
+    <VarBinViewVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
         .vortex_expect("take varbinview array")
         .vortex_expect("take varbinview should not return None")
         .as_::<VarBinViewVTable>()
@@ -108,7 +109,7 @@ fn take_varbinview(
 }
 
 fn take_listview(array: &ListViewArray, codes: &PrimitiveArray) -> ListViewArray {
-    <ListViewVTable as TakeReduce>::take(array, &codes.to_array())
+    <ListViewVTable as TakeReduce>::take(array, &codes.clone().into_array())
         .vortex_expect("take listview array")
         .vortex_expect("take listview should not return None")
         .as_::<ListViewVTable>()
@@ -120,7 +121,7 @@ fn take_fixed_size_list(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> FixedSizeListArray {
-    <FixedSizeListVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
+    <FixedSizeListVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
         .vortex_expect("take fixed size list array")
         .vortex_expect("take fixed size list should not return None")
         .as_::<FixedSizeListVTable>()
@@ -128,7 +129,7 @@ fn take_fixed_size_list(
 }
 
 fn take_struct(array: &StructArray, codes: &PrimitiveArray) -> StructArray {
-    <StructVTable as TakeReduce>::take(array, &codes.to_array())
+    <StructVTable as TakeReduce>::take(array, &codes.clone().into_array())
         .vortex_expect("take struct array")
         .vortex_expect("take struct should not return None")
         .as_::<StructVTable>()
@@ -140,7 +141,7 @@ fn take_extension(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> ExtensionArray {
-    <ExtensionVTable as TakeExecute>::take(array, &codes.to_array(), ctx)
+    <ExtensionVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
         .vortex_expect("take extension storage")
         .vortex_expect("take extension should not return None")
         .as_::<ExtensionVTable>()

--- a/vortex-array/src/arrays/dict/tests.rs
+++ b/vortex-array/src/arrays/dict/tests.rs
@@ -16,7 +16,7 @@ use crate::validity::Validity;
 #[test]
 fn test_scalar_at_null_code() {
     let dict = DictArray::try_new(
-        PrimitiveArray::from_option_iter(vec![None, Some(0u32), None]).to_array(),
+        PrimitiveArray::from_option_iter(vec![None, Some(0u32), None]).into_array(),
         buffer![1i32].into_array(),
     )
     .unwrap();

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -57,6 +57,7 @@ mod tests {
         let arr = ExtensionArray::new(ext_dtype.clone(), storage);
 
         let output = arr
+            .clone()
             .into_array()
             .cast(DType::Extension(ext_dtype.clone()))
             .unwrap();
@@ -75,7 +76,7 @@ mod tests {
 
         let new_dtype = DType::Extension(ext_dtype).with_nullability(Nullability::Nullable);
 
-        let output = arr.into_array().cast(new_dtype.clone()).unwrap();
+        let output = arr.clone().into_array().cast(new_dtype.clone()).unwrap();
         assert_eq!(arr.len(), output.len());
         assert!(arr.dtype().eq_ignore_nullability(output.dtype()));
         assert_eq!(output.dtype(), &new_dtype);

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -57,7 +57,7 @@ mod tests {
         let arr = ExtensionArray::new(ext_dtype.clone(), storage);
 
         let output = arr
-            .to_array()
+            .into_array()
             .cast(DType::Extension(ext_dtype.clone()))
             .unwrap();
         assert_eq!(arr.len(), output.len());
@@ -75,7 +75,7 @@ mod tests {
 
         let new_dtype = DType::Extension(ext_dtype).with_nullability(Nullability::Nullable);
 
-        let output = arr.to_array().cast(new_dtype.clone()).unwrap();
+        let output = arr.into_array().cast(new_dtype.clone()).unwrap();
         assert_eq!(arr.len(), output.len());
         assert!(arr.dtype().eq_ignore_nullability(output.dtype()));
         assert_eq!(output.dtype(), &new_dtype);
@@ -92,7 +92,7 @@ mod tests {
         let arr = ExtensionArray::new(original_dtype, storage);
 
         assert!(
-            arr.to_array()
+            arr.into_array()
                 .cast(DType::Extension(target_dtype))
                 .and_then(|a| a.to_canonical().map(|c| c.into_array()))
                 .is_err()
@@ -105,7 +105,7 @@ mod tests {
     #[case(create_timestamp_array(TimeUnit::Nanoseconds, false))]
     #[case(create_timestamp_array(TimeUnit::Seconds, true))]
     fn test_cast_extension_conformance(#[case] array: ExtensionArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 
     fn create_timestamp_array(time_unit: TimeUnit, nullable: bool) -> ExtensionArray {

--- a/vortex-array/src/arrays/extension/compute/compare.rs
+++ b/vortex-array/src/arrays/extension/compute/compare.rs
@@ -6,6 +6,7 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::ExtensionArray;
 use crate::arrays::ExtensionVTable;
@@ -28,7 +29,7 @@ impl CompareKernel for ExtensionVTable {
                 .storage()
                 .to_array()
                 .binary(
-                    ConstantArray::new(storage_scalar, lhs.len()).to_array(),
+                    ConstantArray::new(storage_scalar, lhs.len()).into_array(),
                     Operator::from(operator),
                 )
                 .map(Some);

--- a/vortex-array/src/arrays/extension/compute/mod.rs
+++ b/vortex-array/src/arrays/extension/compute/mod.rs
@@ -35,14 +35,14 @@ mod test {
         // Create storage array
         let storage = buffer![1i32, 2, 3, 4, 5].into_array();
         let array = ExtensionArray::new(ext_dtype.clone(), storage);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
 
         // Test with nullable extension type
         let ext_dtype_nullable = ext_dtype.with_nullability(Nullability::Nullable);
         let storage = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), Some(4), None])
             .into_array();
         let array = ExtensionArray::new(ext_dtype_nullable, storage);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[rstest]
@@ -81,7 +81,7 @@ mod test {
         ExtensionArray::new(ext_dtype_large, storage)
     })]
     fn test_take_extension_array_conformance(#[case] array: ExtensionArray) {
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 }
 
@@ -118,6 +118,6 @@ mod tests {
         ExtensionArray::new(ext_dtype, storage)
     })]
     fn test_extension_consistency(#[case] array: ExtensionArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -18,6 +18,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::Precision;
 use crate::arrays::extension::ExtensionArray;
 use crate::arrays::extension::compute::rules::PARENT_RULES;
@@ -149,7 +150,7 @@ impl VTable for ExtensionVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.to_array())
+        Ok(array.clone().into_array())
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/filter/execute/bool.rs
+++ b/vortex-array/src/arrays/filter/execute/bool.rs
@@ -26,6 +26,7 @@ mod test {
     use rstest::rstest;
     use vortex_mask::Mask;
 
+    use crate::IntoArray;
     use crate::arrays::BoolArray;
     use crate::canonical::ToCanonical;
     use crate::compute::conformance::filter::test_filter_conformance;

--- a/vortex-array/src/arrays/filter/execute/bool.rs
+++ b/vortex-array/src/arrays/filter/execute/bool.rs
@@ -52,6 +52,6 @@ mod test {
     #[case(BoolArray::from_iter((0..100).map(|i| i % 2 == 0)))]
     #[case(BoolArray::from_iter((0..1024).map(|i| i % 3 != 0)))]
     fn test_filter_bool_conformance(#[case] array: BoolArray) {
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/filter/execute/decimal.rs
+++ b/vortex-array/src/arrays/filter/execute/decimal.rs
@@ -43,7 +43,7 @@ mod test {
             Some(99999),
         ];
         let array = DecimalArray::from_option_iter(values, decimal_dtype);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[test]
@@ -51,6 +51,6 @@ mod test {
         let decimal_dtype = DecimalDType::new(38, 4);
         let values = vec![Some(12345i128), None, Some(-12345), Some(0), None];
         let array = DecimalArray::from_option_iter(values, decimal_dtype);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/filter/execute/decimal.rs
+++ b/vortex-array/src/arrays/filter/execute/decimal.rs
@@ -28,6 +28,7 @@ pub fn filter_decimal(array: &DecimalArray, mask: &Arc<MaskValues>) -> DecimalAr
 
 #[cfg(test)]
 mod test {
+    use crate::IntoArray;
     use crate::arrays::DecimalArray;
     use crate::compute::conformance::filter::test_filter_conformance;
     use crate::dtype::DecimalDType;

--- a/vortex-array/src/arrays/filter/execute/fixed_size_list.rs
+++ b/vortex-array/src/arrays/filter/execute/fixed_size_list.rs
@@ -130,7 +130,7 @@ mod test {
     fn test_filter_fixed_size_list_conformance() {
         let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6, 7, 8, 9]);
         let array = FixedSizeListArray::new(elements.into_array(), 3, Validity::NonNullable, 3);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[test]
@@ -139,7 +139,7 @@ mod test {
             PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), Some(4), Some(5), None]);
         let validity = Validity::from_iter([true, false, true]);
         let array = FixedSizeListArray::new(elements.into_array(), 2, validity, 3);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[test]

--- a/vortex-array/src/arrays/filter/execute/listview.rs
+++ b/vortex-array/src/arrays/filter/execute/listview.rs
@@ -96,7 +96,7 @@ mod test {
         let sizes = buffer![2u32, 2, 2].into_array();
         let array =
             ListViewArray::new(elements.into_array(), offsets, sizes, Validity::NonNullable);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[test]
@@ -107,7 +107,7 @@ mod test {
         let sizes = buffer![2u32, 2, 2].into_array();
         let validity = Validity::from_iter([true, false, true]);
         let array = ListViewArray::new(elements.into_array(), offsets, sizes, validity);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[test]
@@ -120,7 +120,7 @@ mod test {
             ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
                 .with_zero_copy_to_list(true)
         };
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[test]
@@ -131,7 +131,7 @@ mod test {
         let offsets = buffer![5u32, 2, 8, 0, 1].into_array();
         let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
         let array = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[test]
@@ -141,7 +141,7 @@ mod test {
         let offsets = buffer![0u32, 100, 200, 300, 400, 500, 600, 700, 800, 900].into_array();
         let sizes = buffer![50u32, 50, 50, 50, 50, 50, 50, 50, 50, 50].into_array();
         let array = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[test]
@@ -183,7 +183,7 @@ mod test {
         let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
 
         let listview =
-            ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
+            ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
 
         // Filter to keep only 2 lists.
         let mask = Mask::from_iter([true, false, false, true, false]);
@@ -215,7 +215,7 @@ mod test {
         let sizes = buffer![3u32, 3, 2, 2, 2].into_array();
 
         let listview =
-            ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
+            ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
 
         // Filter to keep lists with gaps and overlaps.
         let mask = Mask::from_iter([false, true, true, true, false]);
@@ -259,7 +259,7 @@ mod test {
             varying_sizes,
             Validity::NonNullable,
         )
-        .to_array();
+        .into_array();
 
         let mask1 = Mask::from_iter([true, false, true, false]);
         let result1 = const_offset_list.filter(mask1).unwrap();
@@ -282,7 +282,7 @@ mod test {
             both_constant_sizes,
             Validity::NonNullable,
         )
-        .to_array();
+        .into_array();
 
         let mask2 = Mask::from_iter([true, false, true]);
         let result2 = both_const_list.filter(mask2).unwrap();
@@ -307,7 +307,7 @@ mod test {
         let sizes = buffer![5u32, 2, 5, 3, 4].into_array();
 
         let listview =
-            ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
+            ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
 
         // Filter to keep only 2 lists, demonstrating we keep all 10000 elements.
         let mask = Mask::from_iter([false, true, false, false, true]);

--- a/vortex-array/src/arrays/filter/execute/listview.rs
+++ b/vortex-array/src/arrays/filter/execute/listview.rs
@@ -182,8 +182,8 @@ mod test {
         let offsets = buffer![5u32, 2, 8, 0, 1].into_array();
         let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
 
-        let listview =
-            ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
+        let listview = ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable)
+            .into_array();
 
         // Filter to keep only 2 lists.
         let mask = Mask::from_iter([true, false, false, true, false]);
@@ -214,8 +214,8 @@ mod test {
         let offsets = buffer![0u32, 6, 10, 1, 7].into_array();
         let sizes = buffer![3u32, 3, 2, 2, 2].into_array();
 
-        let listview =
-            ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
+        let listview = ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable)
+            .into_array();
 
         // Filter to keep lists with gaps and overlaps.
         let mask = Mask::from_iter([false, true, true, true, false]);
@@ -306,8 +306,8 @@ mod test {
         let offsets = buffer![0u32, 4999, 9995, 2500, 7500].into_array();
         let sizes = buffer![5u32, 2, 5, 3, 4].into_array();
 
-        let listview =
-            ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
+        let listview = ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable)
+            .into_array();
 
         // Filter to keep only 2 lists, demonstrating we keep all 10000 elements.
         let mask = Mask::from_iter([false, true, false, false, true]);

--- a/vortex-array/src/arrays/filter/execute/primitive.rs
+++ b/vortex-array/src/arrays/filter/execute/primitive.rs
@@ -33,6 +33,7 @@ mod test {
     use rstest::rstest;
     use vortex_mask::Mask;
 
+    use crate::IntoArray;
     use crate::arrays::primitive::PrimitiveArray;
     use crate::canonical::ToCanonical;
     use crate::compute::conformance::filter::LARGE_SIZE;

--- a/vortex-array/src/arrays/filter/execute/primitive.rs
+++ b/vortex-array/src/arrays/filter/execute/primitive.rs
@@ -73,6 +73,6 @@ mod test {
     #[case(PrimitiveArray::from_iter([0.1f32, 0.2, 0.3, 0.4, 0.5]))]
     #[case(PrimitiveArray::from_option_iter([Some(1.1f64), None, Some(2.2), Some(3.3), None]))]
     fn test_filter_primitive_conformance(#[case] array: PrimitiveArray) {
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/filter/execute/struct_.rs
+++ b/vortex-array/src/arrays/filter/execute/struct_.rs
@@ -64,7 +64,7 @@ mod test {
         ];
         let array =
             StructArray::try_new(["a", "b"].into(), fields, 5, Validity::NonNullable).unwrap();
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[test]
@@ -77,7 +77,7 @@ mod test {
         ];
         let array =
             StructArray::try_new(["a", "b"].into(), fields, 5, Validity::NonNullable).unwrap();
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[test]
@@ -140,7 +140,7 @@ mod test {
         test_filter_conformance(
             &StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
                 .unwrap()
-                .to_array(),
+                .into_array(),
         );
     }
 
@@ -174,7 +174,7 @@ mod test {
                 Validity::NonNullable,
             )
             .unwrap()
-            .to_array(),
+            .into_array(),
         );
     }
 }

--- a/vortex-array/src/arrays/filter/execute/varbinview.rs
+++ b/vortex-array/src/arrays/filter/execute/varbinview.rs
@@ -40,6 +40,7 @@ fn arrow_filter_fn(array: &ArrayRef, mask: &Mask) -> vortex_error::VortexResult<
 
 #[cfg(test)]
 mod test {
+    use crate::IntoArray;
     use crate::arrays::VarBinViewArray;
     use crate::compute::conformance::filter::test_filter_conformance;
 

--- a/vortex-array/src/arrays/filter/execute/varbinview.rs
+++ b/vortex-array/src/arrays/filter/execute/varbinview.rs
@@ -10,6 +10,7 @@ use vortex_mask::MaskValues;
 
 use crate::ArrayRef;
 use crate::DynArray;
+use crate::IntoArray;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::VarBinViewVTable;
 use crate::arrays::filter::execute::values_to_mask;
@@ -18,7 +19,7 @@ use crate::arrow::IntoArrowArray;
 
 pub fn filter_varbinview(array: &VarBinViewArray, mask: &Arc<MaskValues>) -> VarBinViewArray {
     // Delegate to the Arrow implementation of filter over `VarBinView`.
-    arrow_filter_fn(&array.to_array(), &values_to_mask(mask))
+    arrow_filter_fn(&array.clone().into_array(), &values_to_mask(mask))
         .vortex_expect("VarBinViewArray is Arrow-compatible and supports arrow_filter_fn")
         .as_::<VarBinViewVTable>()
         .clone()
@@ -45,7 +46,7 @@ mod test {
     #[test]
     fn test_filter_varbinview_conformance() {
         test_filter_conformance(
-            &VarBinViewArray::from_iter_str(["one", "two", "three", "four", "five"]).to_array(),
+            &VarBinViewArray::from_iter_str(["one", "two", "three", "four", "five"]).into_array(),
         );
 
         test_filter_conformance(
@@ -56,7 +57,7 @@ mod test {
                 Some("four"),
                 Some("five"),
             ])
-            .to_array(),
+            .into_array(),
         );
     }
 }

--- a/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
@@ -4,6 +4,7 @@
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::IntoArray;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::FixedSizeListVTable;
 use crate::builtins::ArrayBuiltins;
@@ -38,7 +39,7 @@ impl CastReduce for FixedSizeListVTable {
                     array.len(),
                 )
             }
-            .to_array(),
+            .into_array(),
         ))
     }
 }

--- a/vortex-array/src/arrays/fixed_size_list/compute/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/take.rs
@@ -115,7 +115,7 @@ fn take_non_nullable_fsl<I: IntegerPType>(
     debug_assert_eq!(elements_indices.len(), new_len * list_size);
 
     let elements_indices_array = PrimitiveArray::new(elements_indices, Validity::NonNullable);
-    let new_elements = array.elements().take(elements_indices_array.to_array())?;
+    let new_elements = array.elements().take(elements_indices_array.into_array())?;
     debug_assert_eq!(new_elements.len(), new_len * list_size);
 
     // Both inputs are non-nullable, so the result is non-nullable.
@@ -182,7 +182,7 @@ fn take_nullable_fsl<I: IntegerPType>(
     debug_assert_eq!(elements_indices.len(), new_len * list_size);
 
     let elements_indices_array = PrimitiveArray::new(elements_indices, Validity::NonNullable);
-    let new_elements = array.elements().take(elements_indices_array.to_array())?;
+    let new_elements = array.elements().take(elements_indices_array.into_array())?;
     debug_assert_eq!(new_elements.len(), new_len * list_size);
 
     // At least one input was nullable, so the result is nullable.

--- a/vortex-array/src/arrays/fixed_size_list/tests/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/take.rs
@@ -31,7 +31,7 @@ use crate::validity::Validity;
 #[case::single_element(create_single_element_fsl())]
 #[case::empty(create_empty_fsl())]
 fn test_take_fsl_conformance(#[case] fsl: FixedSizeListArray) {
-    test_take_conformance(&fsl.to_array());
+    test_take_conformance(&fsl.into_array());
 }
 
 // FSL-specific edge case tests that aren't covered by conformance.
@@ -85,11 +85,11 @@ fn test_take_degenerate_lists(
     let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
     let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, 5);
 
-    test_take_conformance(&fsl.to_array());
+    test_take_conformance(&fsl.into_array());
 
     // Also test the specific behavior.
     let indices_array = PrimitiveArray::from_option_iter(indices);
-    let result = fsl.take(indices_array.to_array()).unwrap();
+    let result = fsl.take(indices_array.into_array()).unwrap();
 
     assert_eq!(result.len(), expected_len);
     for (i, expected_null) in expected_nulls.iter().enumerate() {
@@ -118,7 +118,7 @@ fn test_take_fsl_with_null_indices_preserves_elements() {
 
     // Indices with nulls: [1, null, 0].
     let indices = PrimitiveArray::from_option_iter([Some(1u32), None, Some(0)]);
-    let result = fsl.take(indices.to_array()).unwrap();
+    let result = fsl.take(indices.into_array()).unwrap();
 
     // Expected: [[3,4], null, [1,2]]
     let expected = FixedSizeListArray::new(
@@ -184,7 +184,7 @@ fn test_take_nullable_arrays_fsl_specific(
 
     // Create indices (with possible nulls).
     let indices_array = PrimitiveArray::from_option_iter(indices.clone());
-    let result = fsl.take(indices_array.to_array()).unwrap();
+    let result = fsl.take(indices_array.into_array()).unwrap();
 
     assert_eq!(result.len(), indices.len());
     for (i, expected_null) in expected_nulls.iter().enumerate() {

--- a/vortex-array/src/arrays/fixed_size_list/tests/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/take.rs
@@ -85,7 +85,7 @@ fn test_take_degenerate_lists(
     let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
     let fsl = FixedSizeListArray::new(elements.into_array(), 0, validity, 5);
 
-    test_take_conformance(&fsl.into_array());
+    test_take_conformance(&fsl.clone().into_array());
 
     // Also test the specific behavior.
     let indices_array = PrimitiveArray::from_option_iter(indices);

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -13,6 +13,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::Precision;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::fixed_size_list::compute::rules::PARENT_RULES;
@@ -218,6 +219,6 @@ impl VTable for FixedSizeListVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.to_array())
+        Ok(array.clone().into_array())
     }
 }

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -66,7 +66,11 @@ mod tests {
             Nullability::Nullable,
         );
 
-        let result = list.into_array().cast(target_dtype.clone()).unwrap();
+        let result = list
+            .clone()
+            .into_array()
+            .cast(target_dtype.clone())
+            .unwrap();
         assert_eq!(result.dtype(), &target_dtype);
         assert_eq!(result.len(), list.len());
     }

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -4,6 +4,7 @@
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::IntoArray;
 use crate::arrays::ListArray;
 use crate::arrays::ListVTable;
 use crate::builtins::ArrayBuiltins;
@@ -25,7 +26,7 @@ impl CastReduce for ListVTable {
         let new_elements = array.elements().cast((**target_element_type).clone())?;
 
         ListArray::try_new(new_elements, array.offsets().clone(), validity)
-            .map(|a| Some(a.to_array()))
+            .map(|a| Some(a.into_array()))
     }
 }
 
@@ -65,7 +66,7 @@ mod tests {
             Nullability::Nullable,
         );
 
-        let result = list.to_array().cast(target_dtype.clone()).unwrap();
+        let result = list.into_array().cast(target_dtype.clone()).unwrap();
         assert_eq!(result.dtype(), &target_dtype);
         assert_eq!(result.len(), list.len());
     }
@@ -83,7 +84,7 @@ mod tests {
         // can't cast list to u64
 
         let result = list
-            .to_array()
+            .into_array()
             .cast(target_dtype)
             .and_then(|a| a.to_canonical().map(|c| c.into_array()));
         assert!(result.is_err());
@@ -97,7 +98,7 @@ mod tests {
         let list = ListArray::try_new(
             buffer![0i32, 2, 3, 4].into_array().to_array(),
             buffer![0, 2, 3].into_array().to_array(),
-            Validity::Array(BoolArray::from_iter(vec![false, true]).to_array()),
+            Validity::Array(BoolArray::from_iter(vec![false, true]).into_array()),
         )
         .unwrap();
 
@@ -107,7 +108,7 @@ mod tests {
         );
 
         let result = list
-            .to_array()
+            .into_array()
             .cast(target_dtype)
             .and_then(|a| a.to_canonical().map(|c| c.into_array()));
         assert!(result.is_err());
@@ -115,7 +116,7 @@ mod tests {
         // Nulls in list element array — the inner cast error is deferred until
         // the elements are executed.
         let list = ListArray::try_new(
-            PrimitiveArray::from_option_iter([Some(0i32), Some(2), None, None]).to_array(),
+            PrimitiveArray::from_option_iter([Some(0i32), Some(2), None, None]).into_array(),
             buffer![0, 2, 3].into_array().to_array(),
             Validity::NonNullable,
         )
@@ -126,7 +127,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = list.to_array().cast(target_dtype).and_then(|a| {
+        let result = list.into_array().cast(target_dtype).and_then(|a| {
             a.execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
                 .map(|c| c.0.into_array())
         });
@@ -140,7 +141,7 @@ mod tests {
     #[case(create_nested_list())]
     #[case(create_empty_lists())]
     fn test_cast_list_conformance(#[case] array: ListArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 
     fn create_simple_list() -> ListArray {

--- a/vortex-array/src/arrays/list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/list/compute/is_constant.rs
@@ -109,7 +109,7 @@ mod tests {
                 .unwrap()
         );
         assert!(
-            is_constant(&struct_of_lists.to_array())
+            is_constant(&struct_of_lists.into_array())
                 .unwrap()
                 .unwrap_or_default()
         );

--- a/vortex-array/src/arrays/list/compute/mod.rs
+++ b/vortex-array/src/arrays/list/compute/mod.rs
@@ -36,7 +36,7 @@ mod tests {
         let array =
             ListArray::try_new(elements.into_array(), offsets.into_array(), validity).unwrap();
 
-        test_mask_conformance(&array.to_array());
+        test_mask_conformance(&array.into_array());
     }
 
     #[test]
@@ -47,7 +47,7 @@ mod tests {
         let array =
             ListArray::try_new(elements.into_array(), offsets.into_array(), validity).unwrap();
 
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 
     #[rstest]
@@ -79,6 +79,6 @@ mod tests {
         Validity::NonNullable,
     ).unwrap())]
     fn test_list_consistency(#[case] array: ListArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -6,6 +6,7 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::DynArray;
+use crate::IntoArray;
 use crate::arrays::ListArray;
 use crate::arrays::ListVTable;
 use crate::arrays::PrimitiveArray;
@@ -105,9 +106,9 @@ fn _take<I: IntegerPType, O: IntegerPType, OutputOffsetType: IntegerPType>(
     Ok(ListArray::try_new(
         new_elements,
         new_offsets,
-        array.validity().clone().take(&indices_array.to_array())?,
+        array.validity().clone().take(&indices_array.clone().into_array())?,
     )?
-    .to_array())
+    .into_array())
 }
 
 fn _take_nullable<I: IntegerPType, O: IntegerPType, OutputOffsetType: IntegerPType>(
@@ -174,9 +175,9 @@ fn _take_nullable<I: IntegerPType, O: IntegerPType, OutputOffsetType: IntegerPTy
     Ok(ListArray::try_new(
         new_elements,
         new_offsets,
-        array.validity().clone().take(&indices_array.to_array())?,
+        array.validity().clone().take(&indices_array.clone().into_array())?,
     )?
-    .to_array())
+    .into_array())
 }
 
 #[cfg(test)]
@@ -204,13 +205,13 @@ mod test {
         let list = ListArray::try_new(
             buffer![0i32, 5, 3, 4].into_array(),
             buffer![0, 2, 3, 4, 4].into_array(),
-            Validity::Array(BoolArray::from_iter(vec![true, true, false, true]).to_array()),
+            Validity::Array(BoolArray::from_iter(vec![true, true, false, true]).into_array()),
         )
         .unwrap()
-        .to_array();
+        .into_array();
 
         let idx =
-            PrimitiveArray::from_option_iter(vec![Some(0), None, Some(1), Some(3)]).to_array();
+            PrimitiveArray::from_option_iter(vec![Some(0), None, Some(1), Some(3)]).into_array();
 
         let result = list.take(idx.to_array()).unwrap();
 
@@ -265,9 +266,9 @@ mod test {
             Validity::NonNullable,
         )
         .unwrap()
-        .to_array();
+        .into_array();
 
-        let idx = PrimitiveArray::from_option_iter(vec![Some(0), Some(1), None]).to_array();
+        let idx = PrimitiveArray::from_option_iter(vec![Some(0), Some(1), None]).into_array();
         // since idx is nullable, the final list will also be nullable
 
         let result = list.take(idx.to_array()).unwrap();
@@ -288,7 +289,7 @@ mod test {
             Validity::NonNullable,
         )
         .unwrap()
-        .to_array();
+        .into_array();
 
         let idx = buffer![1, 0, 2].into_array();
 
@@ -343,9 +344,9 @@ mod test {
             Validity::NonNullable,
         )
         .unwrap()
-        .to_array();
+        .into_array();
 
-        let idx = PrimitiveArray::empty::<i32>(Nullability::Nullable).to_array();
+        let idx = PrimitiveArray::empty::<i32>(Nullability::Nullable).into_array();
 
         let result = list.take(idx.to_array()).unwrap();
         assert_eq!(
@@ -367,7 +368,7 @@ mod test {
     #[case(ListArray::try_new(
         buffer![10i32, 20, 30, 40, 50].into_array(),
         buffer![0, 2, 3, 4, 5].into_array(),
-        Validity::Array(BoolArray::from_iter(vec![true, false, true, true]).to_array()),
+        Validity::Array(BoolArray::from_iter(vec![true, false, true, true]).into_array()),
     ).unwrap())]
     #[case(ListArray::try_new(
         buffer![1i32, 2, 3].into_array(),
@@ -387,17 +388,17 @@ mod test {
         }
         ListArray::try_new(
             elements,
-            PrimitiveArray::from_iter(offsets).to_array(),
+            PrimitiveArray::from_iter(offsets).into_array(),
             Validity::NonNullable,
         ).unwrap()
     })]
     #[case(ListArray::try_new(
-        PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), Some(4), None]).to_array(),
+        PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), Some(4), None]).into_array(),
         buffer![0, 2, 3, 5].into_array(),
         Validity::NonNullable,
     ).unwrap())]
     fn test_take_list_conformance(#[case] list: ListArray) {
-        test_take_conformance(&list.to_array());
+        test_take_conformance(&list.into_array());
     }
 
     #[test]
@@ -406,7 +407,7 @@ mod test {
         let offsets = buffer![0u8, 200].into_array();
         let list = ListArray::try_new(elements, offsets, Validity::NonNullable)
             .unwrap()
-            .to_array();
+            .into_array();
 
         // Take the same large list twice - would overflow u8 but works with u64.
         let idx = buffer![0u8, 0].into_array();
@@ -424,13 +425,13 @@ mod test {
     fn test_u64_offset_accumulation_nullable() {
         let elements = buffer![0i32; 150].into_array();
         let offsets = buffer![0u8, 150, 150].into_array();
-        let validity = BoolArray::from_iter(vec![true, false]).to_array();
+        let validity = BoolArray::from_iter(vec![true, false]).into_array();
         let list = ListArray::try_new(elements, offsets, Validity::Array(validity))
             .unwrap()
-            .to_array();
+            .into_array();
 
         // Take the same large list twice - would overflow u8 but works with u64.
-        let idx = PrimitiveArray::from_option_iter(vec![Some(0u8), None, Some(0u8)]).to_array();
+        let idx = PrimitiveArray::from_option_iter(vec![Some(0u8), None, Some(0u8)]).into_array();
         let result = list.take(idx.to_array()).unwrap();
 
         assert_eq!(result.len(), 3);
@@ -452,10 +453,10 @@ mod test {
         let list = ListArray::try_new(
             buffer![1i32, 2, 3, 4].into_array(),
             buffer![0, 2, 4].into_array(),
-            Validity::Array(BoolArray::from_iter(vec![true, true]).to_array()),
+            Validity::Array(BoolArray::from_iter(vec![true, true]).into_array()),
         )
         .unwrap()
-        .to_array();
+        .into_array();
 
         // Take more indices than source length (4 vs 2) with non-nullable indices.
         let idx = buffer![0u32, 1, 0, 1].into_array();

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -106,7 +106,10 @@ fn _take<I: IntegerPType, O: IntegerPType, OutputOffsetType: IntegerPType>(
     Ok(ListArray::try_new(
         new_elements,
         new_offsets,
-        array.validity().clone().take(&indices_array.clone().into_array())?,
+        array
+            .validity()
+            .clone()
+            .take(&indices_array.clone().into_array())?,
     )?
     .into_array())
 }
@@ -175,7 +178,10 @@ fn _take_nullable<I: IntegerPType, O: IntegerPType, OutputOffsetType: IntegerPTy
     Ok(ListArray::try_new(
         new_elements,
         new_offsets,
-        array.validity().clone().take(&indices_array.clone().into_array())?,
+        array
+            .validity()
+            .clone()
+            .take(&indices_array.clone().into_array())?,
     )?
     .into_array())
 }

--- a/vortex-array/src/arrays/listview/tests/filter.rs
+++ b/vortex-array/src/arrays/listview/tests/filter.rs
@@ -28,7 +28,7 @@ use crate::validity::Validity;
 #[case::overlapping(create_overlapping_listview())]
 #[case::large(create_large_listview())]
 fn test_filter_listview_conformance(#[case] listview: ListViewArray) {
-    test_filter_conformance(&listview.to_array());
+    test_filter_conformance(&listview.into_array());
 }
 
 #[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `filter`"]
@@ -43,7 +43,7 @@ fn test_filter_preserves_unreferenced_elements() {
     let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
 
     let listview =
-        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
 
     // Filter to keep only 2 lists.
     let mask = Mask::from_iter([true, false, false, true, false]);
@@ -75,7 +75,7 @@ fn test_filter_with_gaps() {
     let sizes = buffer![3u32, 3, 2, 2, 2].into_array();
 
     let listview =
-        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
 
     // Filter to keep lists with gaps and overlaps.
     let mask = Mask::from_iter([false, true, true, true, false]);
@@ -119,7 +119,7 @@ fn test_filter_constant_arrays() {
         varying_sizes,
         Validity::NonNullable,
     )
-    .to_array();
+    .into_array();
 
     let mask1 = Mask::from_iter([true, false, true, false]);
     let result1 = const_offset_list.filter(mask1).unwrap();
@@ -142,7 +142,7 @@ fn test_filter_constant_arrays() {
         both_constant_sizes,
         Validity::NonNullable,
     )
-    .to_array();
+    .into_array();
 
     let mask2 = Mask::from_iter([true, false, true]);
     let result2 = both_const_list.filter(mask2).unwrap();
@@ -167,7 +167,7 @@ fn test_filter_extreme_offsets() {
     let sizes = buffer![5u32, 2, 5, 3, 4].into_array();
 
     let listview =
-        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
 
     // Filter to keep only 2 lists, demonstrating we keep all 10000 elements.
     let mask = Mask::from_iter([false, true, false, false, true]);

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -39,7 +39,7 @@ fn test_slice_comprehensive() {
     let offsets = buffer![0i32, 3, 5, 7].into_array();
     let sizes = buffer![3i32, 2, 3, 2].into_array();
 
-    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).into_array();
 
     // Test basic slice [1..3] - middle portion.
     let sliced = listview.slice(1..3).unwrap();
@@ -80,7 +80,7 @@ fn test_slice_out_of_order() {
     let offsets = buffer![6i32, 0, 3, 8, 2].into_array(); // Out of order.
     let sizes = buffer![2i32, 3, 3, 1, 1].into_array();
 
-    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).into_array();
 
     // Slice [1..4] should maintain the out-of-order offsets.
     let sliced = listview.slice(1..4).unwrap();
@@ -224,7 +224,7 @@ fn test_cast_numeric_types(#[case] from_ptype: PType, #[case] to_ptype: PType) {
         ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
             .with_zero_copy_to_list(true)
     }
-    .to_array();
+    .into_array();
 
     let target_dtype = DType::List(
         Arc::new(DType::Primitive(to_ptype, Nullability::NonNullable)),
@@ -260,7 +260,7 @@ fn test_cast_with_nulls() {
         ListViewArray::new_unchecked(elements, offsets, sizes, validity)
             .with_zero_copy_to_list(true)
     }
-    .to_array();
+    .into_array();
 
     let target_dtype = DType::List(
         Arc::new(DType::Primitive(PType::I64, Nullability::NonNullable)),
@@ -297,7 +297,7 @@ fn test_cast_special_patterns(#[case] expected_sizes: Vec<usize>, #[case] list_c
         )
     };
 
-    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).into_array();
 
     let target_dtype = if is_empty_case {
         DType::List(
@@ -336,7 +336,7 @@ fn test_cast_large_dataset() {
         ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
             .with_zero_copy_to_list(true)
     }
-    .to_array();
+    .into_array();
 
     let target_dtype = DType::List(
         Arc::new(DType::Primitive(PType::U32, Nullability::NonNullable)),
@@ -406,7 +406,7 @@ fn test_is_constant_basic(
         sizes.into_array(),
         validity,
     )
-    .to_array();
+    .into_array();
 
     assert_eq!(is_constant(&listview).unwrap(), Some(expected));
 }
@@ -474,7 +474,7 @@ fn test_constant_repeated_same_lists() {
     let offsets = buffer![0i32, 0, 0, 0].into_array(); // All point to same start.
     let sizes = buffer![3i32, 3, 3, 3].into_array(); // All same size.
 
-    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).into_array();
 
     // All lists are [10, 20, 30] so should be constant.
     assert_eq!(is_constant(&listview).unwrap(), Some(true));
@@ -490,7 +490,7 @@ fn test_constant_repeated_same_lists() {
 #[case::nullable(create_nullable_listview())]
 #[case::large(create_large_listview())]
 fn test_mask_listview_conformance(#[case] listview: ListViewArray) {
-    test_mask_conformance(&listview.to_array());
+    test_mask_conformance(&listview.into_array());
 }
 
 #[test]
@@ -505,7 +505,7 @@ fn test_mask_preserves_structure() {
         ListViewArray::new_unchecked(elements, offsets, sizes, Validity::NonNullable)
             .with_zero_copy_to_list(true)
     }
-    .to_array();
+    .into_array();
 
     // Mask sets elements to null where true.
     let selection = Mask::from_iter([true, false, true, true]);
@@ -544,7 +544,7 @@ fn test_mask_with_existing_nulls() {
         ListViewArray::new_unchecked(elements, offsets, sizes, validity)
             .with_zero_copy_to_list(true)
     }
-    .to_array();
+    .into_array();
 
     // Mask additional elements.
     let selection = Mask::from_iter([false, true, true]);
@@ -565,7 +565,7 @@ fn test_mask_with_gaps() {
     let offsets = buffer![0u32, 4, 8].into_array();
     let sizes = buffer![2u32, 2, 2].into_array();
 
-    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).to_array();
+    let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable).into_array();
 
     let selection = Mask::from_iter([true, false, false]);
     let result = listview.clone().mask((!&selection).into_array()).unwrap();
@@ -597,7 +597,7 @@ fn test_mask_constant_arrays() {
         constant_sizes,
         Validity::NonNullable,
     )
-    .to_array();
+    .into_array();
 
     let selection = Mask::from_iter([false, true, false]);
     let result = const_list.clone().mask((!&selection).into_array()).unwrap();

--- a/vortex-array/src/arrays/listview/tests/take.rs
+++ b/vortex-array/src/arrays/listview/tests/take.rs
@@ -27,7 +27,7 @@ use crate::validity::Validity;
 #[case::overlapping(create_overlapping_listview())]
 #[case::large(create_large_listview())]
 fn test_take_listview_conformance(#[case] listview: ListViewArray) {
-    test_take_conformance(&listview.to_array());
+    test_take_conformance(&listview.into_array());
 }
 
 // ListView-specific tests that aren't covered by conformance.
@@ -42,7 +42,7 @@ fn test_take_preserves_unreferenced_elements() {
     let sizes = buffer![3u32, 2, 2, 2, 4].into_array();
 
     let listview =
-        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
 
     // Take only 2 lists.
     let indices = buffer![1u32, 3].into_array();
@@ -72,7 +72,7 @@ fn test_take_with_gaps() {
     let sizes = buffer![3u32, 3, 2, 2, 2].into_array();
 
     let listview =
-        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
 
     let indices = buffer![1u32, 3, 4, 2].into_array();
     let result = listview.take(indices.to_array()).unwrap();
@@ -107,7 +107,7 @@ fn test_take_constant_arrays() {
         varying_sizes,
         Validity::NonNullable,
     )
-    .to_array();
+    .into_array();
 
     let indices = buffer![3u32, 0, 2].into_array();
     let result = const_offset_list.take(indices.to_array()).unwrap();
@@ -131,7 +131,7 @@ fn test_take_constant_arrays() {
         both_constant_sizes,
         Validity::NonNullable,
     )
-    .to_array();
+    .into_array();
 
     let indices2 = buffer![2u32, 0].into_array();
     let result2 = both_const_list.take(indices2.to_array()).unwrap();
@@ -156,7 +156,7 @@ fn test_take_extreme_offsets() {
     let sizes = buffer![5u32, 2, 5, 3, 4].into_array();
 
     let listview =
-        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).to_array();
+        ListViewArray::new(elements.clone(), offsets, sizes, Validity::NonNullable).into_array();
 
     // Take only 2 lists, demonstrating we keep all 10000 elements.
     let indices = buffer![1u32, 4].into_array();

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -13,6 +13,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::DeserializeMetadata;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::Precision;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
@@ -238,7 +239,7 @@ impl VTable for ListViewVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.to_array())
+        Ok(array.clone().into_array())
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/masked/compute/filter.rs
+++ b/vortex-array/src/arrays/masked/compute/filter.rs
@@ -57,6 +57,6 @@ mod tests {
         ).unwrap()
     )]
     fn test_filter_masked_conformance(#[case] array: MaskedArray) {
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/masked/compute/mask.rs
+++ b/vortex-array/src/arrays/masked/compute/mask.rs
@@ -60,6 +60,6 @@ mod tests {
         ).unwrap()
     )]
     fn test_mask_masked_conformance(#[case] array: MaskedArray) {
-        test_mask_conformance(&array.to_array());
+        test_mask_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/masked/compute/take.rs
+++ b/vortex-array/src/arrays/masked/compute/take.rs
@@ -64,6 +64,6 @@ mod tests {
         ).unwrap()
     )]
     fn test_take_masked_conformance(#[case] array: MaskedArray) {
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -256,6 +256,7 @@ mod tests {
 
         let ctx = ArrayContext::empty();
         let serialized = array
+            .clone()
             .into_array()
             .serialize(&ctx, &SerializeOptions::default())
             .unwrap();

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -256,7 +256,7 @@ mod tests {
 
         let ctx = ArrayContext::empty();
         let serialized = array
-            .to_array()
+            .into_array()
             .serialize(&ctx, &SerializeOptions::default())
             .unwrap();
 

--- a/vortex-array/src/arrays/null/compute/cast.rs
+++ b/vortex-array/src/arrays/null/compute/cast.rs
@@ -31,6 +31,7 @@ impl CastReduce for NullVTable {
 mod tests {
     use rstest::rstest;
 
+    use crate::IntoArray;
     use crate::arrays::NullArray;
     use crate::builtins::ArrayBuiltins;
     use crate::compute::conformance::cast::test_cast_conformance;

--- a/vortex-array/src/arrays/null/compute/cast.rs
+++ b/vortex-array/src/arrays/null/compute/cast.rs
@@ -19,7 +19,7 @@ impl CastReduce for NullVTable {
             vortex_bail!("Cannot cast Null to {}", dtype);
         }
         if dtype == &DType::Null {
-            return Ok(Some(array.to_array()));
+            return Ok(Some(array.clone().into_array()));
         }
 
         let scalar = Scalar::null(dtype.clone());
@@ -41,7 +41,7 @@ mod tests {
     #[test]
     fn test_cast_null_to_null() {
         let null_array = NullArray::new(5);
-        let result = null_array.to_array().cast(DType::Null).unwrap();
+        let result = null_array.into_array().cast(DType::Null).unwrap();
         assert_eq!(result.len(), 5);
         assert_eq!(result.dtype(), &DType::Null);
     }
@@ -50,7 +50,7 @@ mod tests {
     fn test_cast_null_to_nullable_succeeds() {
         let null_array = NullArray::new(5);
         let result = null_array
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I32, Nullability::Nullable))
             .unwrap();
 
@@ -71,7 +71,7 @@ mod tests {
     fn test_cast_null_to_non_nullable_fails() {
         let null_array = NullArray::new(5);
         let result = null_array
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::I32, Nullability::NonNullable));
         assert!(result.is_err());
     }
@@ -82,6 +82,6 @@ mod tests {
     #[case(NullArray::new(100))]
     #[case(NullArray::new(0))]
     fn test_cast_null_conformance(#[case] array: NullArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/null/compute/mask.rs
+++ b/vortex-array/src/arrays/null/compute/mask.rs
@@ -4,6 +4,7 @@
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::IntoArray;
 use crate::arrays::NullArray;
 use crate::arrays::NullVTable;
 use crate::scalar_fn::fns::mask::MaskReduce;
@@ -11,6 +12,6 @@ use crate::scalar_fn::fns::mask::MaskReduce;
 impl MaskReduce for NullVTable {
     fn mask(array: &NullArray, _mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         // Null array is already all nulls, masking has no effect.
-        Ok(Some(array.to_array()))
+        Ok(Some(array.clone().into_array()))
     }
 }

--- a/vortex-array/src/arrays/null/compute/mod.rs
+++ b/vortex-array/src/arrays/null/compute/mod.rs
@@ -56,21 +56,21 @@ mod test {
 
     #[test]
     fn test_filter_null_array() {
-        test_filter_conformance(&NullArray::new(5).to_array());
-        test_filter_conformance(&NullArray::new(1).to_array());
-        test_filter_conformance(&NullArray::new(10).to_array());
+        test_filter_conformance(&NullArray::new(5).into_array());
+        test_filter_conformance(&NullArray::new(1).into_array());
+        test_filter_conformance(&NullArray::new(10).into_array());
     }
 
     #[test]
     fn test_mask_null_array() {
-        test_mask_conformance(&NullArray::new(5).to_array());
+        test_mask_conformance(&NullArray::new(5).into_array());
     }
 
     #[test]
     fn test_take_null_array_conformance() {
-        test_take_conformance(&NullArray::new(5).to_array());
-        test_take_conformance(&NullArray::new(1).to_array());
-        test_take_conformance(&NullArray::new(10).to_array());
+        test_take_conformance(&NullArray::new(5).into_array());
+        test_take_conformance(&NullArray::new(1).into_array());
+        test_take_conformance(&NullArray::new(10).into_array());
     }
 
     #[rstest]
@@ -82,6 +82,6 @@ mod test {
     #[case::null_array_large(NullArray::new(1000))]
     #[case::null_array_empty(NullArray::new(0))]
     fn test_null_consistency(#[case] array: NullArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -11,6 +11,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::Precision;
 use crate::arrays::null::compute::rules::PARENT_RULES;
 use crate::buffer::BufferHandle;
@@ -131,7 +132,7 @@ impl VTable for NullVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.to_array())
+        Ok(array.clone().into_array())
     }
 }
 

--- a/vortex-array/src/arrays/primitive/array/cast.rs
+++ b/vortex-array/src/arrays/primitive/array/cast.rs
@@ -6,6 +6,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 
+use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::PrimitiveArray;
 use crate::builtins::ArrayBuiltins;
@@ -66,7 +67,7 @@ impl PrimitiveArray {
             return Ok(self.clone());
         }
 
-        let Some(min_max) = min_max(&self.to_array())? else {
+        let Some(min_max) = min_max(&self.clone().into_array())? else {
             return Ok(PrimitiveArray::new(
                 Buffer::<u8>::zeroed(self.len()),
                 self.validity.clone(),
@@ -94,21 +95,24 @@ impl PrimitiveArray {
             // Signed
             if min >= i8::MIN as i64 && max <= i8::MAX as i64 {
                 return Ok(self
-                    .to_array()
+                    .clone()
+                    .into_array()
                     .cast(DType::Primitive(PType::I8, self.dtype().nullability()))?
                     .to_primitive());
             }
 
             if min >= i16::MIN as i64 && max <= i16::MAX as i64 {
                 return Ok(self
-                    .to_array()
+                    .clone()
+                    .into_array()
                     .cast(DType::Primitive(PType::I16, self.dtype().nullability()))?
                     .to_primitive());
             }
 
             if min >= i32::MIN as i64 && max <= i32::MAX as i64 {
                 return Ok(self
-                    .to_array()
+                    .clone()
+                    .into_array()
                     .cast(DType::Primitive(PType::I32, self.dtype().nullability()))?
                     .to_primitive());
             }
@@ -116,21 +120,24 @@ impl PrimitiveArray {
             // Unsigned
             if max <= u8::MAX as i64 {
                 return Ok(self
-                    .to_array()
+                    .clone()
+                    .into_array()
                     .cast(DType::Primitive(PType::U8, self.dtype().nullability()))?
                     .to_primitive());
             }
 
             if max <= u16::MAX as i64 {
                 return Ok(self
-                    .to_array()
+                    .clone()
+                    .into_array()
                     .cast(DType::Primitive(PType::U16, self.dtype().nullability()))?
                     .to_primitive());
             }
 
             if max <= u32::MAX as i64 {
                 return Ok(self
-                    .to_array()
+                    .clone()
+                    .into_array()
                     .cast(DType::Primitive(PType::U32, self.dtype().nullability()))?
                     .to_primitive());
             }

--- a/vortex-array/src/arrays/primitive/array/patch.rs
+++ b/vortex-array/src/arrays/primitive/array/patch.rs
@@ -6,6 +6,7 @@ use std::ops::Range;
 use vortex_error::VortexResult;
 
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
 use crate::dtype::IntegerPType;
 use crate::dtype::NativePType;
@@ -25,7 +26,7 @@ impl PrimitiveArray {
         let patched_validity = self.validity().clone().patch(
             self.len(),
             patches.offset(),
-            &patch_indices.to_array(),
+            &patch_indices.clone().into_array(),
             patch_values.validity(),
             ctx,
         )?;

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -126,7 +126,7 @@ mod test {
 
         // to nullable
         let p = p
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U8, Nullability::Nullable))
             .unwrap()
             .to_primitive();
@@ -138,7 +138,7 @@ mod test {
 
         // back to non-nullable
         let p = p
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U8, Nullability::NonNullable))
             .unwrap()
             .to_primitive();
@@ -147,7 +147,7 @@ mod test {
 
         // to nullable u32
         let p = p
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U32, Nullability::Nullable))
             .unwrap()
             .to_primitive();
@@ -159,7 +159,7 @@ mod test {
 
         // to non-nullable u8
         let p = p
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U8, Nullability::NonNullable))
             .unwrap()
             .to_primitive();
@@ -189,7 +189,7 @@ mod test {
     fn cast_array_with_nulls_to_nonnullable() {
         let arr = PrimitiveArray::from_option_iter([Some(-1i32), None, Some(10)]);
         let err = arr
-            .to_array()
+            .into_array()
             .cast(PType::I32.into())
             .and_then(|a| a.to_canonical().map(|c| c.into_array()))
             .unwrap_err();
@@ -208,7 +208,7 @@ mod test {
             Validity::from_iter([false, true, true]),
         );
         let p = arr
-            .to_array()
+            .into_array()
             .cast(DType::Primitive(PType::U32, Nullability::Nullable))
             .unwrap()
             .to_primitive();

--- a/vortex-array/src/arrays/primitive/compute/fill_null.rs
+++ b/vortex-array/src/arrays/primitive/compute/fill_null.rs
@@ -67,7 +67,7 @@ mod test {
     fn fill_null_leading_none() {
         let arr = PrimitiveArray::from_option_iter([None, Some(8u8), None, Some(10), None]);
         let p = arr
-            .to_array()
+            .into_array()
             .fill_null(Scalar::from(42u8))
             .unwrap()
             .to_primitive();
@@ -80,7 +80,7 @@ mod test {
         let arr = PrimitiveArray::from_option_iter([Option::<u8>::None, None, None, None, None]);
 
         let p = arr
-            .to_array()
+            .into_array()
             .fill_null(Scalar::from(255u8))
             .unwrap()
             .to_primitive();
@@ -95,7 +95,7 @@ mod test {
             Validity::Array(BoolArray::from_iter([true, true, true, true, true]).into_array()),
         );
         let p = arr
-            .to_array()
+            .into_array()
             .fill_null(Scalar::from(255u8))
             .unwrap()
             .to_primitive();

--- a/vortex-array/src/arrays/primitive/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/primitive/compute/is_sorted.rs
@@ -95,6 +95,7 @@ mod tests {
     use vortex_error::VortexExpect;
 
     use super::*;
+    use crate::IntoArray;
     use crate::compute::is_sorted;
     use crate::compute::is_strict_sorted;
 

--- a/vortex-array/src/arrays/primitive/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/primitive/compute/is_sorted.rs
@@ -106,7 +106,7 @@ mod tests {
     #[case(PrimitiveArray::from_option_iter([None, Some(5_u8), None]), false)]
     fn test_primitive_is_sorted(#[case] array: PrimitiveArray, #[case] expected: bool) {
         assert_eq!(
-            is_sorted(&array.to_array()).vortex_expect("operation should succeed in test"),
+            is_sorted(&array.into_array()).vortex_expect("operation should succeed in test"),
             Some(expected)
         );
     }
@@ -119,7 +119,7 @@ mod tests {
     #[case(PrimitiveArray::from_option_iter([None, Some(5_u8), None]), false)]
     fn test_primitive_is_strict_sorted(#[case] array: PrimitiveArray, #[case] expected: bool) {
         assert_eq!(
-            is_strict_sorted(&array.to_array()).vortex_expect("operation should succeed in test"),
+            is_strict_sorted(&array.into_array()).vortex_expect("operation should succeed in test"),
             Some(expected)
         );
     }

--- a/vortex-array/src/arrays/primitive/compute/mask.rs
+++ b/vortex-array/src/arrays/primitive/compute/mask.rs
@@ -32,6 +32,7 @@ impl MaskReduce for PrimitiveVTable {
 mod test {
     use rstest::rstest;
 
+    use crate::IntoArray;
     use crate::arrays::PrimitiveArray;
     use crate::compute::conformance::mask::test_mask_conformance;
 

--- a/vortex-array/src/arrays/primitive/compute/mask.rs
+++ b/vortex-array/src/arrays/primitive/compute/mask.rs
@@ -44,6 +44,6 @@ mod test {
     #[case(PrimitiveArray::from_iter([0.1f32, 0.2, 0.3, 0.4, 0.5]))]
     #[case(PrimitiveArray::from_option_iter([Some(1.1f64), None, Some(2.2), Some(3.3), None]))]
     fn test_mask_primitive_conformance(#[case] array: PrimitiveArray) {
-        test_mask_conformance(&array.to_array());
+        test_mask_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/min_max.rs
+++ b/vortex-array/src/arrays/primitive/compute/min_max.rs
@@ -86,7 +86,7 @@ mod tests {
             buffer![f32::NAN, -f32::NAN, -1.0, 1.0],
             Validity::NonNullable,
         );
-        let min_max = min_max(&array.to_array()).unwrap().unwrap();
+        let min_max = min_max(&array.into_array()).unwrap().unwrap();
         assert_eq!(f32::try_from(&min_max.min).unwrap(), -1.0);
         assert_eq!(f32::try_from(&min_max.max).unwrap(), 1.0);
     }
@@ -97,7 +97,7 @@ mod tests {
             buffer![f32::INFINITY, f32::NEG_INFINITY, -1.0, 1.0],
             Validity::NonNullable,
         );
-        let min_max = min_max(&array.to_array()).unwrap().unwrap();
+        let min_max = min_max(&array.into_array()).unwrap().unwrap();
         assert_eq!(f32::try_from(&min_max.min).unwrap(), f32::NEG_INFINITY);
         assert_eq!(f32::try_from(&min_max.max).unwrap(), f32::INFINITY);
     }

--- a/vortex-array/src/arrays/primitive/compute/min_max.rs
+++ b/vortex-array/src/arrays/primitive/compute/min_max.rs
@@ -76,6 +76,7 @@ where
 mod tests {
     use vortex_buffer::buffer;
 
+    use crate::IntoArray;
     use crate::arrays::PrimitiveArray;
     use crate::compute::min_max;
     use crate::validity::Validity;

--- a/vortex-array/src/arrays/primitive/compute/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/mod.rs
@@ -42,7 +42,7 @@ mod tests {
     #[case::i16_negative(PrimitiveArray::from_iter([-100i16, -50, 0, 50, 100]))]
     #[case::f64_special(PrimitiveArray::from_iter([0.0f64, 1.0, -1.0, f64::INFINITY, f64::NEG_INFINITY]))]
     fn test_primitive_consistency(#[case] array: PrimitiveArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 
     #[rstest]

--- a/vortex-array/src/arrays/primitive/compute/nan_count.rs
+++ b/vortex-array/src/arrays/primitive/compute/nan_count.rs
@@ -58,6 +58,6 @@ mod tests {
             ],
             Validity::NonNullable,
         );
-        assert_eq!(nan_count(&p.to_array()).unwrap(), 2);
+        assert_eq!(nan_count(&p.into_array()).unwrap(), 2);
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/nan_count.rs
+++ b/vortex-array/src/arrays/primitive/compute/nan_count.rs
@@ -40,6 +40,7 @@ fn compute_nan_count_with_validity<T: NativePType>(values: &[T], validity: Mask)
 mod tests {
     use vortex_buffer::buffer;
 
+    use crate::IntoArray;
     use crate::arrays::PrimitiveArray;
     use crate::compute::nan_count;
     use crate::validity::Validity;

--- a/vortex-array/src/arrays/primitive/compute/take/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/mod.rs
@@ -168,7 +168,7 @@ mod test {
             buffer![0, 3, 4],
             Validity::Array(BoolArray::from_iter([true, true, false]).into_array()),
         );
-        let actual = values.take(indices.to_array()).unwrap();
+        let actual = values.take(indices.into_array()).unwrap();
         assert_eq!(
             actual.scalar_at(0).vortex_expect("no fail"),
             Scalar::from(Some(1))
@@ -197,6 +197,6 @@ mod test {
     ))]
     #[case(PrimitiveArray::from_option_iter([Some(1), None, Some(3), Some(4), None]))]
     fn test_take_primitive_conformance(#[case] array: PrimitiveArray) {
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/primitive/compute/take/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/mod.rs
@@ -100,7 +100,9 @@ impl TakeExecute for PrimitiveVTable {
                 .execute::<PrimitiveArray>(ctx)?
         };
 
-        let validity = array.validity().take(&unsigned_indices.clone().into_array())?;
+        let validity = array
+            .validity()
+            .take(&unsigned_indices.clone().into_array())?;
         // Delegate to the best kernel based on the target CPU
         PRIMITIVE_TAKE_KERNEL
             .take(array, &unsigned_indices, validity)

--- a/vortex-array/src/arrays/primitive/compute/take/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/mod.rs
@@ -100,7 +100,7 @@ impl TakeExecute for PrimitiveVTable {
                 .execute::<PrimitiveArray>(ctx)?
         };
 
-        let validity = array.validity().take(&unsigned_indices.to_array())?;
+        let validity = array.validity().take(&unsigned_indices.clone().into_array())?;
         // Delegate to the best kernel based on the target CPU
         PRIMITIVE_TAKE_KERNEL
             .take(array, &unsigned_indices, validity)

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -11,6 +11,7 @@ use vortex_error::vortex_panic;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
@@ -198,7 +199,7 @@ impl VTable for PrimitiveVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.to_array())
+        Ok(array.clone().into_array())
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -253,7 +253,7 @@ mod tests {
             DType::Primitive(PType::U64, Nullability::Nullable),
         )
         .vortex_expect("construction")
-        .to_array();
+        .into_array();
 
         let expr = is_null(root());
         array.apply(&expr).vortex_expect("expr evaluation");

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -207,7 +207,10 @@ mod tests {
 
         let target_dtype = struct_array.dtype().as_nullable();
 
-        let result = struct_array.into_array().cast(target_dtype.clone()).unwrap();
+        let result = struct_array
+            .into_array()
+            .cast(target_dtype.clone())
+            .unwrap();
         assert_eq!(result.dtype(), &target_dtype);
         assert_eq!(result.len(), 3);
         assert_eq!(result.to_struct().unmasked_fields().len(), 2);
@@ -233,7 +236,10 @@ mod tests {
         let struct_array =
             StructArray::try_new(names, vec![field1, field2], 3, Validity::NonNullable).unwrap();
 
-        let result = struct_array.into_array().cast(target_dtype.clone()).unwrap();
+        let result = struct_array
+            .into_array()
+            .cast(target_dtype.clone())
+            .unwrap();
         assert_eq!(result.dtype(), &target_dtype);
         assert_eq!(result.len(), 3);
         assert_eq!(result.to_struct().unmasked_fields().len(), 3);

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -115,7 +115,7 @@ mod tests {
     #[case(create_nested_struct())]
     #[case(create_simple_struct())]
     fn test_cast_struct_conformance(#[case] array: StructArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 
     fn create_test_struct(nullable: bool) -> StructArray {
@@ -179,12 +179,12 @@ mod tests {
     fn cast_nullable_all_invalid() {
         let empty_struct = StructArray::try_new(
             FieldNames::from(["a"]),
-            vec![PrimitiveArray::new::<i32>(buffer![], Validity::AllInvalid).to_array()],
+            vec![PrimitiveArray::new::<i32>(buffer![], Validity::AllInvalid).into_array()],
             0,
             Validity::AllInvalid,
         )
         .unwrap()
-        .to_array();
+        .into_array();
 
         let target_dtype = DType::struct_(
             [("a", DType::Primitive(PType::I32, Nullability::NonNullable))],
@@ -207,7 +207,7 @@ mod tests {
 
         let target_dtype = struct_array.dtype().as_nullable();
 
-        let result = struct_array.to_array().cast(target_dtype.clone()).unwrap();
+        let result = struct_array.into_array().cast(target_dtype.clone()).unwrap();
         assert_eq!(result.dtype(), &target_dtype);
         assert_eq!(result.len(), 3);
         assert_eq!(result.to_struct().unmasked_fields().len(), 2);
@@ -233,7 +233,7 @@ mod tests {
         let struct_array =
             StructArray::try_new(names, vec![field1, field2], 3, Validity::NonNullable).unwrap();
 
-        let result = struct_array.to_array().cast(target_dtype.clone()).unwrap();
+        let result = struct_array.into_array().cast(target_dtype.clone()).unwrap();
         assert_eq!(result.dtype(), &target_dtype);
         assert_eq!(result.len(), 3);
         assert_eq!(result.to_struct().unmasked_fields().len(), 3);

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -46,7 +46,7 @@ mod tests {
         let struct_arr =
             StructArray::try_new(FieldNames::empty(), vec![], 10, Validity::NonNullable).unwrap();
         let indices = PrimitiveArray::from_option_iter([Some(1), None]);
-        let taken = struct_arr.take(indices.to_array()).unwrap();
+        let taken = struct_arr.take(indices.into_array()).unwrap();
 
         assert_arrays_eq!(
             taken,
@@ -68,7 +68,7 @@ mod tests {
         .unwrap();
         let indices = PrimitiveArray::from_option_iter([Option::<u64>::None]);
         let taken = struct_arr
-            .take(indices.to_array())
+            .take(indices.into_array())
             .unwrap()
             .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
             .unwrap();
@@ -81,7 +81,7 @@ mod tests {
         let arr = PrimitiveArray::from_iter(Vec::<u64>::new());
         let indices = PrimitiveArray::from_option_iter([Option::<u64>::None]);
         let taken = arr
-            .take(indices.to_array())
+            .take(indices.into_array())
             .unwrap()
             .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
             .unwrap();
@@ -91,10 +91,10 @@ mod tests {
     #[test]
     fn take_field_struct() {
         let struct_arr =
-            StructArray::from_fields(&[("a", PrimitiveArray::from_iter(0..10).to_array())])
+            StructArray::from_fields(&[("a", PrimitiveArray::from_iter(0..10).into_array())])
                 .unwrap();
         let indices = PrimitiveArray::from_option_iter([Some(1), None]);
-        let taken = struct_arr.take(indices.to_array()).unwrap();
+        let taken = struct_arr.take(indices.into_array()).unwrap();
         assert_arrays_eq!(
             taken,
             StructArray::try_from_iter_with_validity(
@@ -110,7 +110,7 @@ mod tests {
         test_mask_conformance(
             &StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
                 .unwrap()
-                .to_array(),
+                .into_array(),
         );
     }
 
@@ -144,7 +144,7 @@ mod tests {
                 Validity::NonNullable,
             )
             .unwrap()
-            .to_array(),
+            .into_array(),
         );
     }
 
@@ -179,7 +179,7 @@ mod tests {
             vec![
                 StructArray::try_new(
                     ["left", "right"].into(),
-                    vec![xs.to_array(), xs.to_array()],
+                    vec![xs.into_array(), xs.into_array()],
                     5,
                     Validity::AllValid,
                 )
@@ -253,7 +253,7 @@ mod tests {
     fn test_empty_struct_is_constant() {
         let array = StructArray::new_fieldless_with_len(2);
         let is_constant =
-            is_constant(&array.to_array()).vortex_expect("operation should succeed in test");
+            is_constant(&array.into_array()).vortex_expect("operation should succeed in test");
         assert_eq!(is_constant, Some(true));
     }
 
@@ -262,7 +262,7 @@ mod tests {
         test_take_conformance(
             &StructArray::try_new(FieldNames::empty(), vec![], 5, Validity::NonNullable)
                 .unwrap()
-                .to_array(),
+                .into_array(),
         );
     }
 
@@ -278,7 +278,7 @@ mod tests {
         test_take_conformance(
             &StructArray::try_new(["xs", "ys"].into(), vec![xs, ys], 5, Validity::NonNullable)
                 .unwrap()
-                .to_array(),
+                .into_array(),
         );
     }
 
@@ -299,7 +299,7 @@ mod tests {
                 Validity::NonNullable,
             )
             .unwrap()
-            .to_array(),
+            .into_array(),
         );
     }
 
@@ -327,7 +327,7 @@ mod tests {
                 Validity::NonNullable,
             )
             .unwrap()
-            .to_array(),
+            .into_array(),
         );
     }
 
@@ -339,7 +339,7 @@ mod tests {
         test_take_conformance(
             &StructArray::try_new(["xs", "ys"].into(), vec![xs, ys], 1, Validity::NonNullable)
                 .unwrap()
-                .to_array(),
+                .into_array(),
         );
     }
 
@@ -362,7 +362,7 @@ mod tests {
                 Validity::NonNullable,
             )
             .unwrap()
-            .to_array(),
+            .into_array(),
         );
     }
 
@@ -412,6 +412,6 @@ mod tests {
         StructArray::try_new(["xs", "ys"].into(), vec![xs, ys], 100, Validity::NonNullable).unwrap()
     })]
     fn test_struct_consistency(#[case] array: StructArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -179,7 +179,7 @@ mod tests {
             vec![
                 StructArray::try_new(
                     ["left", "right"].into(),
-                    vec![xs.into_array(), xs.into_array()],
+                    vec![xs.clone().into_array(), xs.into_array()],
                     5,
                     Validity::AllValid,
                 )

--- a/vortex-array/src/arrays/struct_/compute/zip.rs
+++ b/vortex-array/src/arrays/struct_/compute/zip.rs
@@ -9,6 +9,7 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::StructArray;
 use crate::arrays::StructVTable;
 use crate::builtins::ArrayBuiltins;
@@ -59,7 +60,7 @@ impl ZipKernel for StructVTable {
 
         Ok(Some(
             StructArray::try_new(if_true.names().clone(), fields, if_true.len(), validity)?
-                .to_array(),
+                .into_array(),
         ))
     }
 }

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -15,6 +15,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::struct_::StructArray;
 use crate::arrays::struct_::compute::rules::PARENT_RULES;
 use crate::buffer::BufferHandle;
@@ -206,7 +207,7 @@ impl VTable for StructVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.to_array())
+        Ok(array.clone().into_array())
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/varbin/compute/cast.rs
+++ b/vortex-array/src/arrays/varbin/compute/cast.rs
@@ -39,6 +39,7 @@ impl CastReduce for VarBinVTable {
 mod tests {
     use rstest::rstest;
 
+    use crate::IntoArray;
     use crate::arrays::VarBinArray;
     use crate::builtins::ArrayBuiltins;
     use crate::compute::conformance::cast::test_cast_conformance;

--- a/vortex-array/src/arrays/varbin/compute/cast.rs
+++ b/vortex-array/src/arrays/varbin/compute/cast.rs
@@ -65,7 +65,7 @@ mod tests {
     fn try_cast_varbin_nullable(#[case] source: DType, #[case] target: DType) {
         let varbin = VarBinArray::from_iter(vec![Some("a"), Some("b"), Some("c")], source);
 
-        let res = varbin.to_array().cast(target.clone());
+        let res = varbin.into_array().cast(target.clone());
         assert_eq!(res.unwrap().dtype(), &target);
     }
 
@@ -77,7 +77,7 @@ mod tests {
     fn try_cast_varbin_fail(#[case] source: DType) {
         let non_nullable_source = source.as_nonnullable();
         let varbin = VarBinArray::from_iter(vec![Some("a"), Some("b"), None], source);
-        varbin.to_array().cast(non_nullable_source).unwrap();
+        varbin.into_array().cast(non_nullable_source).unwrap();
     }
 
     #[rstest]
@@ -87,6 +87,6 @@ mod tests {
     #[case(VarBinArray::from_iter(vec![Some(b"test".as_slice()), None], DType::Binary(Nullability::Nullable)))]
     #[case(VarBinArray::from_iter(vec![Some("single")], DType::Utf8(Nullability::NonNullable)))]
     fn test_cast_varbin_conformance(#[case] array: VarBinArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -120,7 +120,8 @@ impl CompareKernel for VarBinVTable {
             // Arrow doesn't support comparing VarBin to VarBinView arrays, so we convert ourselves
             // to VarBinView and re-invoke.
             return Ok(Some(
-                lhs.clone().into_array()
+                lhs.clone()
+                    .into_array()
                     .execute::<VarBinViewArray>(ctx)?
                     .into_array()
                     .binary(rhs.to_array(), Operator::from(operator))?,
@@ -146,6 +147,7 @@ mod test {
     use vortex_buffer::BitBuffer;
     use vortex_buffer::ByteBuffer;
 
+    use crate::IntoArray;
     use crate::ToCanonical;
     use crate::arrays::ConstantArray;
     use crate::arrays::VarBinArray;
@@ -215,6 +217,7 @@ mod test {
 #[cfg(test)]
 mod tests {
     use crate::DynArray;
+    use crate::IntoArray;
     use crate::arrays::ConstantArray;
     use crate::arrays::VarBinArray;
     use crate::builtins::ArrayBuiltins;

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -83,7 +83,7 @@ impl CompareKernel for VarBinVTable {
                 ));
             }
 
-            let lhs = Datum::try_new(&lhs.to_array())?;
+            let lhs = Datum::try_new(&lhs.clone().into_array())?;
 
             // Use StringViewArray/BinaryViewArray to match the Utf8View/BinaryView types
             // produced by Datum::try_new (which uses into_arrow_preferred())
@@ -120,9 +120,9 @@ impl CompareKernel for VarBinVTable {
             // Arrow doesn't support comparing VarBin to VarBinView arrays, so we convert ourselves
             // to VarBinView and re-invoke.
             return Ok(Some(
-                lhs.to_array()
+                lhs.clone().into_array()
                     .execute::<VarBinViewArray>(ctx)?
-                    .to_array()
+                    .into_array()
                     .binary(rhs.to_array(), Operator::from(operator))?,
             ));
         } else {
@@ -163,13 +163,13 @@ mod test {
             DType::Binary(Nullability::Nullable),
         );
         let result = array
-            .to_array()
+            .into_array()
             .binary(
                 ConstantArray::new(
                     Scalar::binary(ByteBuffer::copy_from(b"abc"), Nullability::Nullable),
                     3,
                 )
-                .to_array(),
+                .into_array(),
                 Operator::Eq,
             )
             .unwrap()
@@ -196,8 +196,8 @@ mod test {
             DType::Binary(Nullability::Nullable),
         );
         let result = array
-            .to_array()
-            .binary(vbv.to_array(), Operator::Eq)
+            .into_array()
+            .binary(vbv.into_array(), Operator::Eq)
             .unwrap()
             .to_bool();
 
@@ -230,8 +230,8 @@ mod tests {
         let const_ = ConstantArray::new(Scalar::utf8("", Nullability::Nullable), 1);
 
         assert_eq!(
-            arr.to_array()
-                .binary(const_.to_array(), Operator::Eq)
+            arr.into_array()
+                .binary(const_.into_array(), Operator::Eq)
                 .unwrap()
                 .dtype(),
             &DType::Bool(Nullability::Nullable)

--- a/vortex-array/src/arrays/varbin/compute/filter.rs
+++ b/vortex-array/src/arrays/varbin/compute/filter.rs
@@ -355,12 +355,12 @@ mod test {
             vec!["hello", "world", "filter", "good", "bye"],
             DType::Utf8(NonNullable),
         );
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
 
         let array = VarBinArray::from_iter(
             vec![Some("hello"), None, Some("filter"), Some("good"), None],
             DType::Utf8(Nullable),
         );
-        test_filter_conformance(&array.to_array());
+        test_filter_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/varbin/compute/mask.rs
+++ b/vortex-array/src/arrays/varbin/compute/mask.rs
@@ -30,6 +30,7 @@ impl MaskReduce for VarBinVTable {
 
 #[cfg(test)]
 mod test {
+    use crate::IntoArray;
     use crate::arrays::VarBinArray;
     use crate::compute::conformance::mask::test_mask_conformance;
     use crate::dtype::DType;

--- a/vortex-array/src/arrays/varbin/compute/mask.rs
+++ b/vortex-array/src/arrays/varbin/compute/mask.rs
@@ -41,12 +41,12 @@ mod test {
             vec!["hello", "world", "filter", "good", "bye"],
             DType::Utf8(Nullability::NonNullable),
         );
-        test_mask_conformance(&array.to_array());
+        test_mask_conformance(&array.into_array());
 
         let array = VarBinArray::from_iter(
             vec![Some("hello"), None, Some("filter"), Some("good"), None],
             DType::Utf8(Nullability::Nullable),
         );
-        test_mask_conformance(&array.to_array());
+        test_mask_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/varbin/compute/min_max.rs
+++ b/vortex-array/src/arrays/varbin/compute/min_max.rs
@@ -63,6 +63,7 @@ fn make_scalar(dtype: &DType, value: &[u8]) -> Scalar {
 mod tests {
     use vortex_buffer::BufferString;
 
+    use crate::IntoArray;
     use crate::arrays::VarBinArray;
     use crate::compute::MinMaxResult;
     use crate::compute::min_max;

--- a/vortex-array/src/arrays/varbin/compute/min_max.rs
+++ b/vortex-array/src/arrays/varbin/compute/min_max.rs
@@ -84,7 +84,7 @@ mod tests {
             ],
             Utf8(Nullable),
         );
-        let MinMaxResult { min, max } = min_max(&array.to_array()).unwrap().unwrap();
+        let MinMaxResult { min, max } = min_max(&array.into_array()).unwrap().unwrap();
 
         assert_eq!(
             min,

--- a/vortex-array/src/arrays/varbin/compute/mod.rs
+++ b/vortex-array/src/arrays/varbin/compute/mod.rs
@@ -18,6 +18,7 @@ mod take;
 mod tests {
     use rstest::rstest;
 
+    use crate::IntoArray;
     use crate::arrays::VarBinArray;
     use crate::compute::conformance::consistency::test_array_consistency;
     use crate::dtype::DType;

--- a/vortex-array/src/arrays/varbin/compute/mod.rs
+++ b/vortex-array/src/arrays/varbin/compute/mod.rs
@@ -63,6 +63,6 @@ mod tests {
         DType::Utf8(Nullability::NonNullable),
     ))]
     fn test_varbin_consistency(#[case] array: VarBinArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/varbin/compute/take.rs
+++ b/vortex-array/src/arrays/varbin/compute/take.rs
@@ -268,14 +268,14 @@ mod tests {
         let idx1: PrimitiveArray = (0..1).collect();
 
         assert_eq!(
-            arr.take(idx1.to_array()).unwrap().dtype(),
+            arr.take(idx1.into_array()).unwrap().dtype(),
             &DType::Utf8(Nullability::NonNullable)
         );
 
         let idx2: PrimitiveArray = PrimitiveArray::from_option_iter(vec![Some(0)]);
 
         assert_eq!(
-            arr.take(idx2.to_array()).unwrap().dtype(),
+            arr.take(idx2.into_array()).unwrap().dtype(),
             &DType::Utf8(Nullability::Nullable)
         );
     }
@@ -295,7 +295,7 @@ mod tests {
     ))]
     #[case(VarBinArray::from_iter(["single"].map(Some), DType::Utf8(Nullability::NonNullable)))]
     fn test_take_varbin_conformance(#[case] array: VarBinArray) {
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 
     #[test]

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -10,6 +10,7 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::IntoArray;
 use crate::arrays::Ref;
 use crate::arrays::VarBinViewArray;
 use crate::builders::ArrayBuilder;
@@ -130,7 +131,7 @@ impl VarBinViewArray {
             self.len(),
             buffer_utilization_threshold,
         );
-        builder.extend_from_array(&self.to_array());
+        builder.extend_from_array(&self.clone().into_array());
         Ok(builder.finish_into_varbinview())
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/cast.rs
+++ b/vortex-array/src/arrays/varbinview/compute/cast.rs
@@ -43,6 +43,7 @@ impl CastReduce for VarBinViewVTable {
 mod tests {
     use rstest::rstest;
 
+    use crate::IntoArray;
     use crate::arrays::VarBinViewArray;
     use crate::builtins::ArrayBuiltins;
     use crate::compute::conformance::cast::test_cast_conformance;

--- a/vortex-array/src/arrays/varbinview/compute/cast.rs
+++ b/vortex-array/src/arrays/varbinview/compute/cast.rs
@@ -69,7 +69,7 @@ mod tests {
     fn try_cast_varbin_nullable(#[case] source: DType, #[case] target: DType) {
         let varbin = VarBinViewArray::from_iter(vec![Some("a"), Some("b"), Some("c")], source);
 
-        let res = varbin.to_array().cast(target.clone());
+        let res = varbin.into_array().cast(target.clone());
         assert_eq!(res.unwrap().dtype(), &target);
     }
 
@@ -81,7 +81,7 @@ mod tests {
     fn try_cast_varbin_fail(#[case] source: DType) {
         let non_nullable_source = source.as_nonnullable();
         let varbin = VarBinViewArray::from_iter(vec![Some("a"), Some("b"), None], source);
-        varbin.to_array().cast(non_nullable_source).unwrap();
+        varbin.into_array().cast(non_nullable_source).unwrap();
     }
 
     #[rstest]
@@ -92,6 +92,6 @@ mod tests {
     #[case(VarBinViewArray::from_iter(vec![Some("single")], DType::Utf8(Nullability::NonNullable)))]
     #[case(VarBinViewArray::from_iter(vec![Some("very long string that exceeds the inline size to test view functionality with multiple buffers")], DType::Utf8(Nullability::NonNullable)))]
     fn test_cast_varbinview_conformance(#[case] array: VarBinViewArray) {
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/mask.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mask.rs
@@ -39,7 +39,7 @@ mod tests {
     #[test]
     fn take_mask_var_bin_view_array() {
         test_mask_conformance(
-            &VarBinViewArray::from_iter_str(["one", "two", "three", "four", "five"]).to_array(),
+            &VarBinViewArray::from_iter_str(["one", "two", "three", "four", "five"]).into_array(),
         );
 
         test_mask_conformance(
@@ -50,7 +50,7 @@ mod tests {
                 Some("four"),
                 Some("five"),
             ])
-            .to_array(),
+            .into_array(),
         );
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/mask.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mask.rs
@@ -33,6 +33,7 @@ impl MaskReduce for VarBinViewVTable {
 
 #[cfg(test)]
 mod tests {
+    use crate::IntoArray;
     use crate::arrays::VarBinViewArray;
     use crate::compute::conformance::mask::test_mask_conformance;
 

--- a/vortex-array/src/arrays/varbinview/compute/mod.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mod.rs
@@ -82,6 +82,6 @@ mod tests {
         None::<&str>, None, None, None
     ]))]
     fn test_varbinview_consistency(#[case] array: VarBinViewArray) {
-        test_array_consistency(&array.to_array());
+        test_array_consistency(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/take.rs
+++ b/vortex-array/src/arrays/varbinview/compute/take.rs
@@ -130,7 +130,7 @@ mod tests {
             Validity::from(BitBuffer::from(vec![true, false])),
         );
 
-        let taken = arr.take(indices.to_array()).unwrap();
+        let taken = arr.take(indices.into_array()).unwrap();
 
         assert!(taken.dtype().is_nullable());
         assert_eq!(
@@ -159,6 +159,6 @@ mod tests {
     ))]
     #[case(VarBinViewArray::from_iter(["single"].map(Some), DType::Utf8(NonNullable)))]
     fn test_take_varbinview_conformance(#[case] array: VarBinViewArray) {
-        test_take_conformance(&array.to_array());
+        test_take_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/arrays/varbinview/compute/zip.rs
+++ b/vortex-array/src/arrays/varbinview/compute/zip.rs
@@ -11,6 +11,7 @@ use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::BinaryView;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::VarBinViewVTable;
@@ -121,7 +122,7 @@ impl ZipKernel for VarBinViewVTable {
             )
         };
 
-        Ok(Some(array.to_array()))
+        Ok(Some(array.into_array()))
     }
 }
 
@@ -246,7 +247,7 @@ mod tests {
         let zipped = mask
             .clone()
             .into_array()
-            .zip(a.to_array(), b.to_array())
+            .zip(a.into_array(), b.into_array())
             .unwrap()
             .to_varbinview();
 

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -17,6 +17,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::Precision;
 use crate::arrays::BinaryView;
 use crate::arrays::varbinview::VarBinViewArray;
@@ -242,6 +243,6 @@ impl VTable for VarBinViewVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.to_array())
+        Ok(array.clone().into_array())
     }
 }

--- a/vortex-array/src/arrow/executor/struct_.rs
+++ b/vortex-array/src/arrow/executor/struct_.rs
@@ -42,7 +42,7 @@ pub(super) fn to_arrow_struct(
         Ok(array) => {
             // NOTE(ngates): this currently uses the old into_canonical code path, but we should
             //  just call directly into the swizzle-chunks function.
-            array.to_array().execute::<StructArray>(ctx)?.into_array()
+            array.into_array().execute::<StructArray>(ctx)?.into_array()
         }
         Err(array) => array,
     };

--- a/vortex-array/src/arrow/record_batch.rs
+++ b/vortex-array/src/arrow/record_batch.rs
@@ -46,7 +46,7 @@ impl StructArray {
     ) -> VortexResult<RecordBatch> {
         let data_type = DataType::Struct(schema.as_ref().fields.clone());
         let array_ref = self
-            .to_array()
+            .into_array()
             .execute_arrow(Some(&data_type), &mut LEGACY_SESSION.create_execution_ctx())?;
         Ok(RecordBatch::from(array_ref.as_struct()))
     }

--- a/vortex-array/src/builders/dict/bytes.rs
+++ b/vortex-array/src/builders/dict/bytes.rs
@@ -214,7 +214,7 @@ mod test {
     #[test]
     fn encode_varbin() {
         let arr = VarBinArray::from(vec!["hello", "world", "hello", "again", "world"]);
-        let dict = dict_encode(&arr.to_array()).unwrap();
+        let dict = dict_encode(&arr.into_array()).unwrap();
         assert_eq!(
             dict.codes().to_primitive().as_slice::<u8>(),
             &[0, 1, 0, 2, 1]
@@ -243,7 +243,7 @@ mod test {
         ]
         .into_iter()
         .collect();
-        let dict = dict_encode(&arr.to_array()).unwrap();
+        let dict = dict_encode(&arr.into_array()).unwrap();
         assert_eq!(
             dict.codes().to_primitive().as_slice::<u8>(),
             &[0, 1, 2, 0, 1, 3, 2, 1]
@@ -260,7 +260,7 @@ mod test {
     #[test]
     fn repeated_values() {
         let arr = VarBinArray::from(vec!["a", "a", "b", "b", "a", "b", "a", "b"]);
-        let dict = dict_encode(&arr.to_array()).unwrap();
+        let dict = dict_encode(&arr.into_array()).unwrap();
         dict.values().to_varbinview().with_iterator(|iter| {
             assert_eq!(
                 iter.flatten()

--- a/vortex-array/src/builders/dict/bytes.rs
+++ b/vortex-array/src/builders/dict/bytes.rs
@@ -206,6 +206,7 @@ impl<Code: UnsignedPType> DictEncoder for BytesDictBuilder<Code> {
 mod test {
     use std::str;
 
+    use crate::IntoArray;
     use crate::ToCanonical;
     use crate::accessor::ArrayAccessor;
     use crate::arrays::VarBinArray;

--- a/vortex-array/src/builders/dict/primitive.rs
+++ b/vortex-array/src/builders/dict/primitive.rs
@@ -188,7 +188,7 @@ mod test {
             Some(3),
             None,
         ]);
-        let dict = dict_encode(&arr.to_array()).unwrap();
+        let dict = dict_encode(&arr.into_array()).unwrap();
 
         let expected_codes = buffer![0u8, 0, 1, 2, 2, 1, 2, 1].into_array();
         assert_arrays_eq!(dict.codes(), expected_codes);

--- a/vortex-array/src/compute/conformance/cast.rs
+++ b/vortex-array/src/compute/conformance/cast.rs
@@ -354,19 +354,19 @@ mod tests {
     #[test]
     fn test_cast_conformance_nullable() {
         let array = PrimitiveArray::from_option_iter([Some(1u8), None, Some(255), Some(0), None]);
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 
     #[test]
     fn test_cast_conformance_bool() {
         let array = BoolArray::from_iter(vec![true, false, true, false]);
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 
     #[test]
     fn test_cast_conformance_null() {
         let array = NullArray::new(5);
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 
     #[test]
@@ -375,7 +375,7 @@ mod tests {
             vec![Some("hello"), None, Some("world")],
             DType::Utf8(Nullability::Nullable),
         );
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 
     #[test]
@@ -384,7 +384,7 @@ mod tests {
             vec![Some(b"data".as_slice()), None, Some(b"bytes".as_slice())],
             DType::Binary(Nullability::Nullable),
         );
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 
     #[test]
@@ -401,7 +401,7 @@ mod tests {
         let array =
             StructArray::try_new(names, vec![a, b], 3, crate::validity::Validity::NonNullable)
                 .unwrap();
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 
     #[test]
@@ -411,6 +411,6 @@ mod tests {
 
         let array =
             ListArray::try_new(data, offsets, crate::validity::Validity::NonNullable).unwrap();
-        test_cast_conformance(&array.to_array());
+        test_cast_conformance(&array.into_array());
     }
 }

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -721,10 +721,10 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
     if let (Ok(eq_result), Ok(neq_result)) = (
         array
             .to_array()
-            .binary(const_array.to_array(), Operator::Eq),
+            .binary(const_array.clone().into_array(), Operator::Eq),
         array
             .to_array()
-            .binary(const_array.to_array(), Operator::NotEq),
+            .binary(const_array.clone().into_array(), Operator::NotEq),
     ) {
         let inverted_eq = eq_result
             .not()
@@ -755,10 +755,10 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
     if let (Ok(gt_result), Ok(lte_result)) = (
         array
             .to_array()
-            .binary(const_array.to_array(), Operator::Gt),
+            .binary(const_array.clone().into_array(), Operator::Gt),
         array
             .to_array()
-            .binary(const_array.to_array(), Operator::Lte),
+            .binary(const_array.clone().into_array(), Operator::Lte),
     ) {
         let inverted_gt = gt_result
             .not()
@@ -783,10 +783,10 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
     if let (Ok(lt_result), Ok(gte_result)) = (
         array
             .to_array()
-            .binary(const_array.to_array(), Operator::Lt),
+            .binary(const_array.clone().into_array(), Operator::Lt),
         array
             .to_array()
-            .binary(const_array.to_array(), Operator::Gte),
+            .binary(const_array.clone().into_array(), Operator::Gte),
     ) {
         let inverted_lt = lt_result
             .not()
@@ -851,9 +851,10 @@ fn test_comparison_symmetry_consistency(array: &ArrayRef) {
     if let (Ok(arr_gt_scalar), Ok(scalar_lt_arr)) = (
         array
             .to_array()
-            .binary(const_array.to_array(), Operator::Gt),
+            .binary(const_array.clone().into_array(), Operator::Gt),
         const_array
-            .to_array()
+            .clone()
+            .into_array()
             .binary(array.to_array(), Operator::Lt),
     ) {
         assert_eq!(
@@ -881,9 +882,10 @@ fn test_comparison_symmetry_consistency(array: &ArrayRef) {
     if let (Ok(arr_eq_scalar), Ok(scalar_eq_arr)) = (
         array
             .to_array()
-            .binary(const_array.to_array(), Operator::Eq),
+            .binary(const_array.clone().into_array(), Operator::Eq),
         const_array
-            .to_array()
+            .clone()
+            .into_array()
             .binary(array.to_array(), Operator::Eq),
     ) {
         for i in 0..arr_eq_scalar.len() {
@@ -927,7 +929,7 @@ fn test_boolean_demorgan_consistency(array: &ArrayRef) {
         let mask_pattern: Vec<bool> = (0..array.len()).map(|i| i % 3 == 0).collect();
         BoolArray::from_iter(mask_pattern)
     };
-    let bool_mask = bool_mask.to_array();
+    let bool_mask = bool_mask.into_array();
 
     // Test first De Morgan's law: NOT(A AND B) = (NOT A) OR (NOT B)
     if let (Ok(a_and_b), Ok(not_a), Ok(not_b)) = (

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -786,7 +786,7 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
             .binary(const_array.clone().into_array(), Operator::Lt),
         array
             .to_array()
-            .binary(const_array.clone().into_array(), Operator::Gte),
+            .binary(const_array.into_array(), Operator::Gte),
     ) {
         let inverted_lt = lt_result
             .not()
@@ -884,7 +884,6 @@ fn test_comparison_symmetry_consistency(array: &ArrayRef) {
             .to_array()
             .binary(const_array.clone().into_array(), Operator::Eq),
         const_array
-            .clone()
             .into_array()
             .binary(array.to_array(), Operator::Eq),
     ) {

--- a/vortex-array/src/compute/conformance/take.rs
+++ b/vortex-array/src/compute/conformance/take.rs
@@ -56,7 +56,7 @@ fn test_take_all(array: &ArrayRef) {
     let len = array.len();
     let indices = PrimitiveArray::from_iter(0..len as u64);
     let result = array
-        .take(indices.to_array())
+        .take(indices.into_array())
         .vortex_expect("take should succeed in conformance test");
 
     assert_eq!(result.len(), len);
@@ -96,7 +96,7 @@ fn test_take_all(array: &ArrayRef) {
 fn test_take_none(array: &ArrayRef) {
     let indices: PrimitiveArray = PrimitiveArray::from_iter::<[u64; 0]>([]);
     let result = array
-        .take(indices.to_array())
+        .take(indices.into_array())
         .vortex_expect("take should succeed in conformance test");
 
     assert_eq!(result.len(), 0);
@@ -113,7 +113,7 @@ fn test_take_selective(array: &ArrayRef) {
     let indices_array = PrimitiveArray::from_iter(indices.clone());
 
     let result = array
-        .take(indices_array.to_array())
+        .take(indices_array.into_array())
         .vortex_expect("take should succeed in conformance test");
     assert_eq!(result.len(), expected_len);
 
@@ -134,7 +134,7 @@ fn test_take_first_and_last(array: &ArrayRef) {
     let len = array.len();
     let indices = PrimitiveArray::from_iter([0u64, (len - 1) as u64]);
     let result = array
-        .take(indices.to_array())
+        .take(indices.into_array())
         .vortex_expect("take should succeed in conformance test");
 
     assert_eq!(result.len(), 2);
@@ -171,7 +171,7 @@ fn test_take_with_nullable_indices(array: &ArrayRef) {
 
     let indices = PrimitiveArray::from_option_iter(indices_vec.clone());
     let result = array
-        .take(indices.to_array())
+        .take(indices.into_array())
         .vortex_expect("take should succeed in conformance test");
 
     assert_eq!(result.len(), indices_vec.len());
@@ -232,7 +232,7 @@ fn test_take_repeated_indices(array: &ArrayRef) {
 fn test_empty_indices(array: &ArrayRef) {
     let indices = PrimitiveArray::empty::<u64>(Nullability::NonNullable);
     let result = array
-        .take(indices.to_array())
+        .take(indices.into_array())
         .vortex_expect("take should succeed in conformance test");
 
     assert_eq!(result.len(), 0);
@@ -244,7 +244,7 @@ fn test_take_reverse(array: &ArrayRef) {
     // Take elements in reverse order
     let indices = PrimitiveArray::from_iter((0..len as u64).rev());
     let result = array
-        .take(indices.to_array())
+        .take(indices.into_array())
         .vortex_expect("take should succeed in conformance test");
 
     assert_eq!(result.len(), len);
@@ -268,7 +268,7 @@ fn test_take_single_middle(array: &ArrayRef) {
 
     let indices = PrimitiveArray::from_iter([middle_idx as u64]);
     let result = array
-        .take(indices.to_array())
+        .take(indices.into_array())
         .vortex_expect("take should succeed in conformance test");
 
     assert_eq!(result.len(), 1);
@@ -296,7 +296,7 @@ fn test_take_random_unsorted(array: &ArrayRef) {
 
     let indices_array = PrimitiveArray::from_iter(indices.clone());
     let result = array
-        .take(indices_array.to_array())
+        .take(indices_array.into_array())
         .vortex_expect("take should succeed in conformance test");
 
     assert_eq!(result.len(), indices.len());
@@ -322,7 +322,7 @@ fn test_take_contiguous_range(array: &ArrayRef) {
     // Take a contiguous range from the middle
     let indices = PrimitiveArray::from_iter(start as u64..end as u64);
     let result = array
-        .take(indices.to_array())
+        .take(indices.into_array())
         .vortex_expect("take should succeed in conformance test");
 
     assert_eq!(result.len(), end - start);
@@ -358,7 +358,7 @@ fn test_take_mixed_repeated(array: &ArrayRef) {
 
     let indices_array = PrimitiveArray::from_iter(indices.clone());
     let result = array
-        .take(indices_array.to_array())
+        .take(indices_array.into_array())
         .vortex_expect("take should succeed in conformance test");
 
     assert_eq!(result.len(), indices.len());
@@ -389,7 +389,7 @@ fn test_take_large_indices(array: &ArrayRef) {
 
     let indices_array = PrimitiveArray::from_iter(indices.clone());
     let result = array
-        .take(indices_array.to_array())
+        .take(indices_array.into_array())
         .vortex_expect("take should succeed in conformance test");
 
     assert_eq!(result.len(), num_indices);

--- a/vortex-array/src/scalar_fn/fns/between/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/between/kernel.rs
@@ -9,6 +9,7 @@ use super::BetweenOptions;
 use super::precondition;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::ExactScalarFn;
 use crate::arrays::ScalarFnArrayView;
 use crate::arrays::ScalarFnVTable;
@@ -67,7 +68,7 @@ where
         let children = scalar_fn_array.children();
         let lower = &children[1];
         let upper = &children[2];
-        let arr = array.to_array();
+        let arr = array.clone().into_array();
         if let Some(result) = precondition(&arr, lower, upper)? {
             return Ok(Some(result));
         }
@@ -102,7 +103,7 @@ where
         let children = scalar_fn_array.children();
         let lower = &children[1];
         let upper = &children[2];
-        let arr = array.to_array();
+        let arr = array.clone().into_array();
         if let Some(result) = precondition(&arr, lower, upper)? {
             return Ok(Some(result));
         }

--- a/vortex-array/src/scalar_fn/fns/binary/boolean.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/boolean.rs
@@ -8,6 +8,7 @@ use vortex_error::vortex_err;
 
 use crate::ArrayRef;
 use crate::DynArray;
+use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::ConstantVTable;
 use crate::arrow::FromArrowArray;
@@ -100,7 +101,7 @@ fn constant_boolean(
         .map(|b| Scalar::bool(b, nullable.into()))
         .unwrap_or_else(|| Scalar::null(DType::Bool(nullable.into())));
 
-    Ok(Some(ConstantArray::new(scalar, length).to_array()))
+    Ok(Some(ConstantArray::new(scalar, length).into_array()))
 }
 
 #[cfg(test)]

--- a/vortex-array/src/scalar_fn/fns/binary/compare.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare.rs
@@ -269,15 +269,15 @@ mod tests {
         );
 
         let matches = arr
-            .to_array()
-            .binary(arr.to_array(), Operator::Eq)
+            .into_array()
+            .binary(arr.into_array(), Operator::Eq)
             .unwrap()
             .to_bool();
         assert_eq!(to_int_indices(matches).unwrap(), [1u64, 2, 3, 4]);
 
         let matches = arr
-            .to_array()
-            .binary(arr.to_array(), Operator::NotEq)
+            .into_array()
+            .binary(arr.into_array(), Operator::NotEq)
             .unwrap()
             .to_bool();
         let empty: [u64; 0] = [];
@@ -289,29 +289,29 @@ mod tests {
         );
 
         let matches = arr
-            .to_array()
-            .binary(other.to_array(), Operator::Lte)
+            .into_array()
+            .binary(other.into_array(), Operator::Lte)
             .unwrap()
             .to_bool();
         assert_eq!(to_int_indices(matches).unwrap(), [2u64, 3, 4]);
 
         let matches = arr
-            .to_array()
-            .binary(other.to_array(), Operator::Lt)
+            .into_array()
+            .binary(other.into_array(), Operator::Lt)
             .unwrap()
             .to_bool();
         assert_eq!(to_int_indices(matches).unwrap(), [4u64]);
 
         let matches = other
-            .to_array()
-            .binary(arr.to_array(), Operator::Gte)
+            .into_array()
+            .binary(arr.into_array(), Operator::Gte)
             .unwrap()
             .to_bool();
         assert_eq!(to_int_indices(matches).unwrap(), [2u64, 3, 4]);
 
         let matches = other
-            .to_array()
-            .binary(arr.to_array(), Operator::Gt)
+            .into_array()
+            .binary(arr.into_array(), Operator::Gt)
             .unwrap()
             .to_bool();
         assert_eq!(to_int_indices(matches).unwrap(), [4u64]);
@@ -323,8 +323,8 @@ mod tests {
         let right = ConstantArray::new(Scalar::from(10u32), 10);
 
         let result = left
-            .to_array()
-            .binary(right.to_array(), Operator::Gt)
+            .into_array()
+            .binary(right.into_array(), Operator::Gt)
             .unwrap();
         assert_eq!(result.len(), 10);
         let scalar = result.scalar_at(0).unwrap();
@@ -364,22 +364,22 @@ mod tests {
         .unwrap();
 
         let result = list1
-            .to_array()
-            .binary(list2.to_array(), Operator::Eq)
+            .into_array()
+            .binary(list2.into_array(), Operator::Eq)
             .unwrap();
         let expected = BoolArray::from_iter([true, true, false]);
         assert_arrays_eq!(result, expected);
 
         let result = list1
-            .to_array()
-            .binary(list2.to_array(), Operator::NotEq)
+            .into_array()
+            .binary(list2.into_array(), Operator::NotEq)
             .unwrap();
         let expected = BoolArray::from_iter([false, false, true]);
         assert_arrays_eq!(result, expected);
 
         let result = list1
-            .to_array()
-            .binary(list2.to_array(), Operator::Lt)
+            .into_array()
+            .binary(list2.into_array(), Operator::Lt)
             .unwrap();
         let expected = BoolArray::from_iter([false, false, true]);
         assert_arrays_eq!(result, expected);
@@ -405,8 +405,8 @@ mod tests {
         let constant = ConstantArray::new(list_scalar, 3);
 
         let result = list
-            .to_array()
-            .binary(constant.to_array(), Operator::Eq)
+            .into_array()
+            .binary(constant.into_array(), Operator::Eq)
             .unwrap();
         let expected = BoolArray::from_iter([false, true, false]);
         assert_arrays_eq!(result, expected);
@@ -433,15 +433,15 @@ mod tests {
         .unwrap();
 
         let result = struct1
-            .to_array()
-            .binary(struct2.to_array(), Operator::Eq)
+            .into_array()
+            .binary(struct2.into_array(), Operator::Eq)
             .unwrap();
         let expected = BoolArray::from_iter([true, true, false]);
         assert_arrays_eq!(result, expected);
 
         let result = struct1
-            .to_array()
-            .binary(struct2.to_array(), Operator::Gt)
+            .into_array()
+            .binary(struct2.into_array(), Operator::Gt)
             .unwrap();
         let expected = BoolArray::from_iter([false, false, true]);
         assert_arrays_eq!(result, expected);
@@ -466,8 +466,8 @@ mod tests {
         .unwrap();
 
         let result = empty1
-            .to_array()
-            .binary(empty2.to_array(), Operator::Eq)
+            .into_array()
+            .binary(empty2.into_array(), Operator::Eq)
             .unwrap();
         let expected = BoolArray::from_iter([true, true, true, true, true]);
         assert_arrays_eq!(result, expected);
@@ -483,8 +483,8 @@ mod tests {
         );
 
         let result = list
-            .to_array()
-            .binary(list.to_array(), Operator::Eq)
+            .into_array()
+            .binary(list.into_array(), Operator::Eq)
             .unwrap();
         assert!(result.scalar_at(0).unwrap().is_valid());
         assert!(result.scalar_at(1).unwrap().is_valid());

--- a/vortex-array/src/scalar_fn/fns/binary/compare.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare.rs
@@ -269,15 +269,17 @@ mod tests {
         );
 
         let matches = arr
+            .clone()
             .into_array()
-            .binary(arr.into_array(), Operator::Eq)
+            .binary(arr.clone().into_array(), Operator::Eq)
             .unwrap()
             .to_bool();
         assert_eq!(to_int_indices(matches).unwrap(), [1u64, 2, 3, 4]);
 
         let matches = arr
+            .clone()
             .into_array()
-            .binary(arr.into_array(), Operator::NotEq)
+            .binary(arr.clone().into_array(), Operator::NotEq)
             .unwrap()
             .to_bool();
         let empty: [u64; 0] = [];
@@ -289,22 +291,25 @@ mod tests {
         );
 
         let matches = arr
+            .clone()
             .into_array()
-            .binary(other.into_array(), Operator::Lte)
+            .binary(other.clone().into_array(), Operator::Lte)
             .unwrap()
             .to_bool();
         assert_eq!(to_int_indices(matches).unwrap(), [2u64, 3, 4]);
 
         let matches = arr
+            .clone()
             .into_array()
-            .binary(other.into_array(), Operator::Lt)
+            .binary(other.clone().into_array(), Operator::Lt)
             .unwrap()
             .to_bool();
         assert_eq!(to_int_indices(matches).unwrap(), [4u64]);
 
         let matches = other
+            .clone()
             .into_array()
-            .binary(arr.into_array(), Operator::Gte)
+            .binary(arr.clone().into_array(), Operator::Gte)
             .unwrap()
             .to_bool();
         assert_eq!(to_int_indices(matches).unwrap(), [2u64, 3, 4]);
@@ -364,15 +369,17 @@ mod tests {
         .unwrap();
 
         let result = list1
+            .clone()
             .into_array()
-            .binary(list2.into_array(), Operator::Eq)
+            .binary(list2.clone().into_array(), Operator::Eq)
             .unwrap();
         let expected = BoolArray::from_iter([true, true, false]);
         assert_arrays_eq!(result, expected);
 
         let result = list1
+            .clone()
             .into_array()
-            .binary(list2.into_array(), Operator::NotEq)
+            .binary(list2.clone().into_array(), Operator::NotEq)
             .unwrap();
         let expected = BoolArray::from_iter([false, false, true]);
         assert_arrays_eq!(result, expected);
@@ -433,8 +440,9 @@ mod tests {
         .unwrap();
 
         let result = struct1
+            .clone()
             .into_array()
-            .binary(struct2.into_array(), Operator::Eq)
+            .binary(struct2.clone().into_array(), Operator::Eq)
             .unwrap();
         let expected = BoolArray::from_iter([true, true, false]);
         assert_arrays_eq!(result, expected);
@@ -483,6 +491,7 @@ mod tests {
         );
 
         let result = list
+            .clone()
             .into_array()
             .binary(list.into_array(), Operator::Eq)
             .unwrap();

--- a/vortex-array/src/scalar_fn/fns/cast/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/cast/kernel.rs
@@ -5,6 +5,7 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::IntoArray;
 use crate::arrays::ExactScalarFn;
 use crate::arrays::ScalarFnArrayView;
 use crate::dtype::DType;
@@ -57,7 +58,7 @@ where
     ) -> VortexResult<Option<ArrayRef>> {
         let dtype = parent.options;
         if array.dtype() == dtype {
-            return Ok(Some(array.to_array()));
+            return Ok(Some(array.clone().into_array()));
         }
         <V as CastReduce>::cast(array, dtype)
     }
@@ -82,7 +83,7 @@ where
     ) -> VortexResult<Option<ArrayRef>> {
         let dtype = parent.options;
         if array.dtype() == dtype {
-            return Ok(Some(array.to_array()));
+            return Ok(Some(array.clone().into_array()));
         }
         <V as CastKernel>::cast(array, dtype, ctx)
     }

--- a/vortex-array/src/scalar_fn/fns/get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/get_item.rs
@@ -246,7 +246,7 @@ mod tests {
     fn get_item_by_name() {
         let st = test_array();
         let get_item = get_item("a", root());
-        let item = st.to_array().apply(&get_item).unwrap();
+        let item = st.into_array().apply(&get_item).unwrap();
         assert_eq!(item.dtype(), &DType::from(PType::I32))
     }
 
@@ -254,7 +254,7 @@ mod tests {
     fn get_item_by_name_none() {
         let st = test_array();
         let get_item = get_item("c", root());
-        assert!(st.to_array().apply(&get_item).is_err());
+        assert!(st.into_array().apply(&get_item).is_err());
     }
 
     #[test]
@@ -267,7 +267,7 @@ mod tests {
             Validity::AllInvalid,
         )
         .unwrap()
-        .to_array();
+        .into_array();
 
         let get_item_expr = get_item("a", root());
         let item = st.apply(&get_item_expr).unwrap();
@@ -370,6 +370,6 @@ mod tests {
         )
         .unwrap();
 
-        st.to_array().apply(&get_item("data", root())).unwrap();
+        st.into_array().apply(&get_item("data", root())).unwrap();
     }
 }

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -278,7 +278,7 @@ mod tests {
         let not_expr = not(root());
         let bools = BoolArray::from_iter([false, true, false, false, true, true]);
         assert_arrays_eq!(
-            bools.to_array().apply(&not_expr).unwrap(),
+            bools.into_array().apply(&not_expr).unwrap(),
             BoolArray::from_iter([true, false, true, true, false, false])
         );
     }

--- a/vortex-array/src/scalar_fn/fns/like/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/like/mod.rs
@@ -257,6 +257,7 @@ impl<'a> LikeVariant<'a> {
 
 #[cfg(test)]
 mod tests {
+    use crate::IntoArray;
     use crate::arrays::BoolArray;
     use crate::assert_arrays_eq;
     use crate::dtype::DType;

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -292,8 +292,11 @@ fn list_contains_scalar(
     }
 
     let rhs = ConstantArray::new(value.clone(), elems.len());
-    let matching_elements =
-        Binary.try_new_array(elems.len(), Operator::Eq, &[elems.clone(), rhs.clone().into_array()])?;
+    let matching_elements = Binary.try_new_array(
+        elems.len(),
+        Operator::Eq,
+        &[elems.clone(), rhs.clone().into_array()],
+    )?;
     let matches = matching_elements.execute::<BoolArray>(ctx)?;
 
     // Fast path: no elements match.

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -267,7 +267,7 @@ fn constant_list_scalar_contains(
         .into_iter()
         .try_reduce_balanced(|acc, res| acc.binary(res, Operator::Or))?;
 
-    Ok(result.unwrap_or_else(|| ConstantArray::new(false_scalar, len).to_array()))
+    Ok(result.unwrap_or_else(|| ConstantArray::new(false_scalar, len).into_array()))
 }
 
 /// Returns a [`BoolArray`] where each bit represents if a list contains the scalar.
@@ -293,7 +293,7 @@ fn list_contains_scalar(
 
     let rhs = ConstantArray::new(value.clone(), elems.len());
     let matching_elements =
-        Binary.try_new_array(elems.len(), Operator::Eq, &[elems.clone(), rhs.to_array()])?;
+        Binary.try_new_array(elems.len(), Operator::Eq, &[elems.clone(), rhs.clone().into_array()])?;
     let matches = matching_elements.execute::<BoolArray>(ctx)?;
 
     // Fast path: no elements match.

--- a/vortex-array/src/scalar_fn/fns/not/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/not/mod.rs
@@ -121,6 +121,7 @@ impl ScalarFnVTable for Not {
 
 #[cfg(test)]
 mod tests {
+    use crate::IntoArray;
     use crate::ToCanonical;
     use crate::arrays::BoolArray;
     use crate::dtype::DType;

--- a/vortex-array/src/scalar_fn/fns/not/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/not/mod.rs
@@ -137,7 +137,7 @@ mod tests {
         let bools = BoolArray::from_iter([false, true, false, false, true, true]);
         assert_eq!(
             bools
-                .to_array()
+                .into_array()
                 .apply(&not_expr)
                 .unwrap()
                 .to_bool()

--- a/vortex-array/src/scalar_fn/fns/pack.rs
+++ b/vortex-array/src/scalar_fn/fns/pack.rs
@@ -234,15 +234,15 @@ mod tests {
         assert_eq!(actual_array.validity(), &Validity::NonNullable);
 
         assert_arrays_eq!(
-            primitive_field(&actual_array.to_array(), &["one"]).unwrap(),
+            primitive_field(&actual_array.into_array(), &["one"]).unwrap(),
             PrimitiveArray::from_iter([0i32, 1, 2])
         );
         assert_arrays_eq!(
-            primitive_field(&actual_array.to_array(), &["two"]).unwrap(),
+            primitive_field(&actual_array.into_array(), &["two"]).unwrap(),
             PrimitiveArray::from_iter([4i32, 5, 6])
         );
         assert_arrays_eq!(
-            primitive_field(&actual_array.to_array(), &["three"]).unwrap(),
+            primitive_field(&actual_array.into_array(), &["three"]).unwrap(),
             PrimitiveArray::from_iter([0i32, 1, 2])
         );
     }
@@ -272,19 +272,19 @@ mod tests {
         assert_eq!(actual_array.names(), ["one", "two", "three"]);
 
         assert_arrays_eq!(
-            primitive_field(&actual_array.to_array(), &["one"]).unwrap(),
+            primitive_field(&actual_array.into_array(), &["one"]).unwrap(),
             PrimitiveArray::from_iter([0i32, 1, 2])
         );
         assert_arrays_eq!(
-            primitive_field(&actual_array.to_array(), &["two", "two_one"]).unwrap(),
+            primitive_field(&actual_array.into_array(), &["two", "two_one"]).unwrap(),
             PrimitiveArray::from_iter([4i32, 5, 6])
         );
         assert_arrays_eq!(
-            primitive_field(&actual_array.to_array(), &["two", "two_two"]).unwrap(),
+            primitive_field(&actual_array.into_array(), &["two", "two_two"]).unwrap(),
             PrimitiveArray::from_iter([4i32, 5, 6])
         );
         assert_arrays_eq!(
-            primitive_field(&actual_array.to_array(), &["three"]).unwrap(),
+            primitive_field(&actual_array.into_array(), &["three"]).unwrap(),
             PrimitiveArray::from_iter([0i32, 1, 2])
         );
     }

--- a/vortex-array/src/scalar_fn/fns/pack.rs
+++ b/vortex-array/src/scalar_fn/fns/pack.rs
@@ -234,11 +234,11 @@ mod tests {
         assert_eq!(actual_array.validity(), &Validity::NonNullable);
 
         assert_arrays_eq!(
-            primitive_field(&actual_array.into_array(), &["one"]).unwrap(),
+            primitive_field(&actual_array.clone().into_array(), &["one"]).unwrap(),
             PrimitiveArray::from_iter([0i32, 1, 2])
         );
         assert_arrays_eq!(
-            primitive_field(&actual_array.into_array(), &["two"]).unwrap(),
+            primitive_field(&actual_array.clone().into_array(), &["two"]).unwrap(),
             PrimitiveArray::from_iter([4i32, 5, 6])
         );
         assert_arrays_eq!(
@@ -272,15 +272,15 @@ mod tests {
         assert_eq!(actual_array.names(), ["one", "two", "three"]);
 
         assert_arrays_eq!(
-            primitive_field(&actual_array.into_array(), &["one"]).unwrap(),
+            primitive_field(&actual_array.clone().into_array(), &["one"]).unwrap(),
             PrimitiveArray::from_iter([0i32, 1, 2])
         );
         assert_arrays_eq!(
-            primitive_field(&actual_array.into_array(), &["two", "two_one"]).unwrap(),
+            primitive_field(&actual_array.clone().into_array(), &["two", "two_one"]).unwrap(),
             PrimitiveArray::from_iter([4i32, 5, 6])
         );
         assert_arrays_eq!(
-            primitive_field(&actual_array.into_array(), &["two", "two_two"]).unwrap(),
+            primitive_field(&actual_array.clone().into_array(), &["two", "two_two"]).unwrap(),
             PrimitiveArray::from_iter([4i32, 5, 6])
         );
         assert_arrays_eq!(

--- a/vortex-array/src/scalar_fn/fns/select.rs
+++ b/vortex-array/src/scalar_fn/fns/select.rs
@@ -333,7 +333,7 @@ mod tests {
     pub fn include_columns() {
         let st = test_array();
         let select = select(vec![FieldName::from("a")], root());
-        let selected = st.to_array().apply(&select).unwrap().to_struct();
+        let selected = st.into_array().apply(&select).unwrap().to_struct();
         let selected_names = selected.names().clone();
         assert_eq!(selected_names.as_ref(), &["a"]);
     }
@@ -342,7 +342,7 @@ mod tests {
     pub fn exclude_columns() {
         let st = test_array();
         let select = select_exclude(vec![FieldName::from("a")], root());
-        let selected = st.to_array().apply(&select).unwrap().to_struct();
+        let selected = st.into_array().apply(&select).unwrap().to_struct();
         let selected_names = selected.names().clone();
         assert_eq!(selected_names.as_ref(), &["b"]);
     }

--- a/vortex-array/src/stream/ext.rs
+++ b/vortex-array/src/stream/ext.rs
@@ -7,6 +7,7 @@ use futures::TryStreamExt;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::IntoArray;
 use crate::arrays::ChunkedArray;
 use crate::stream::ArrayStream;
 use crate::stream::SendableArrayStream;
@@ -33,7 +34,7 @@ pub trait ArrayStreamExt: ArrayStream {
             if chunks.len() == 1 {
                 Ok(chunks.remove(0))
             } else {
-                Ok(ChunkedArray::try_new(chunks, dtype)?.to_array())
+                Ok(ChunkedArray::try_new(chunks, dtype)?.into_array())
             }
         }
     }

--- a/vortex-array/src/vtable/dyn_.rs
+++ b/vortex-array/src/vtable/dyn_.rs
@@ -16,6 +16,7 @@ use vortex_session::VortexSession;
 use crate::ArrayAdapter;
 use crate::ArrayRef;
 use crate::DynArray;
+use crate::IntoArray;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::executor::ExecutionCtx;
@@ -90,13 +91,13 @@ impl<V: VTable> DynVTable for ArrayVTableAdapter<V> {
         let array = V::build(dtype, len, &metadata, buffers, children)?;
         assert_eq!(array.len(), len, "Array length mismatch after building");
         assert_eq!(array.dtype(), dtype, "Array dtype mismatch after building");
-        Ok(array.to_array())
+        Ok(array.into_array())
     }
 
     fn with_children(&self, array: &ArrayRef, children: Vec<ArrayRef>) -> VortexResult<ArrayRef> {
         let mut array = array.as_::<V>().clone();
         V::with_children(&mut array, children)?;
-        Ok(array.to_array())
+        Ok(array.into_array())
     }
 
     fn reduce(&self, array: &ArrayRef) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -339,6 +339,14 @@ macro_rules! vtable {
                     value.into_array()
                 }
             }
+
+            impl [<$V Array>] {
+                #[deprecated(note = "use `.into_array()` (owned) or `.clone().into_array()` (ref) to make clones explicit")]
+                pub fn to_array(&self) -> $crate::ArrayRef {
+                    use $crate::IntoArray;
+                    self.clone().into_array()
+                }
+            }
         }
     };
 }

--- a/vortex-btrblocks/benches/compress.rs
+++ b/vortex-btrblocks/benches/compress.rs
@@ -46,7 +46,7 @@ mod benchmarks {
             .with_inputs(|| &array)
             .input_counter(|array| ItemsCount::new(array.len()))
             .input_counter(|array| BytesCount::of_many::<i32>(array.len()))
-            .bench_refs(|array| compressor.compress(&array.to_array()).unwrap());
+            .bench_refs(|array| compressor.compress(&array.into_array()).unwrap());
     }
 }
 

--- a/vortex-btrblocks/benches/compress.rs
+++ b/vortex-btrblocks/benches/compress.rs
@@ -46,7 +46,7 @@ mod benchmarks {
             .with_inputs(|| &array)
             .input_counter(|array| ItemsCount::new(array.len()))
             .input_counter(|array| BytesCount::of_many::<i32>(array.len()))
-            .bench_refs(|array| compressor.compress(&array.into_array()).unwrap());
+            .bench_refs(|array| compressor.compress(&array.clone().into_array()).unwrap());
     }
 }
 

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -271,11 +271,11 @@ impl CanonicalCompressor for BtrBlocksCompressor {
             }
             Canonical::Extension(ext_array) => {
                 // We compress Timestamp-level arrays with DateTimeParts compression
-                if let Ok(temporal_array) = TemporalArray::try_from(ext_array.into_array())
+                if let Ok(temporal_array) = TemporalArray::try_from(ext_array.clone().into_array())
                     && let TemporalMetadata::Timestamp(..) = temporal_array.temporal_metadata()
                 {
                     if is_constant_opts(
-                        &ext_array.into_array(),
+                        &ext_array.clone().into_array(),
                         &IsConstantOpts {
                             cost: Cost::Canonicalize,
                         },

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -271,11 +271,11 @@ impl CanonicalCompressor for BtrBlocksCompressor {
             }
             Canonical::Extension(ext_array) => {
                 // We compress Timestamp-level arrays with DateTimeParts compression
-                if let Ok(temporal_array) = TemporalArray::try_from(ext_array.to_array())
+                if let Ok(temporal_array) = TemporalArray::try_from(ext_array.into_array())
                     && let TemporalMetadata::Timestamp(..) = temporal_array.temporal_metadata()
                 {
                     if is_constant_opts(
-                        &ext_array.to_array(),
+                        &ext_array.into_array(),
                         &IsConstantOpts {
                             cost: Cost::Canonicalize,
                         },

--- a/vortex-btrblocks/src/compressor/decimal.rs
+++ b/vortex-btrblocks/src/compressor/decimal.rs
@@ -3,6 +3,7 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::IntoArray;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::narrowed_decimal;

--- a/vortex-btrblocks/src/compressor/decimal.rs
+++ b/vortex-btrblocks/src/compressor/decimal.rs
@@ -29,7 +29,7 @@ pub fn compress_decimal(
         DecimalType::I16 => PrimitiveArray::new(decimal.buffer::<i16>(), validity.clone()),
         DecimalType::I32 => PrimitiveArray::new(decimal.buffer::<i32>(), validity.clone()),
         DecimalType::I64 => PrimitiveArray::new(decimal.buffer::<i64>(), validity.clone()),
-        _ => return Ok(decimal.to_array()),
+        _ => return Ok(decimal.into_array()),
     };
 
     let compressed = compressor.compress_canonical(
@@ -38,5 +38,5 @@ pub fn compress_decimal(
         Excludes::none(),
     )?;
 
-    DecimalBytePartsArray::try_new(compressed, decimal.decimal_dtype()).map(|d| d.to_array())
+    DecimalBytePartsArray::try_new(compressed, decimal.decimal_dtype()).map(|d| d.into_array())
 }

--- a/vortex-btrblocks/src/compressor/float/mod.rs
+++ b/vortex-btrblocks/src/compressor/float/mod.rs
@@ -219,7 +219,7 @@ impl Scheme for UncompressedScheme {
         _ctx: CompressorContext,
         _excludes: &[FloatCode],
     ) -> VortexResult<ArrayRef> {
-        Ok(stats.source().to_array())
+        Ok(stats.source().into_array())
     }
 }
 
@@ -501,7 +501,7 @@ impl Scheme for NullDominated {
         assert!(ctx.allowed_cascading > 0);
 
         // We pass None as we only run this pathway for NULL-dominated float arrays
-        let sparse_encoded = SparseArray::encode(&stats.src.to_array(), None)?;
+        let sparse_encoded = SparseArray::encode(&stats.src.into_array(), None)?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {
             // Compress the values

--- a/vortex-btrblocks/src/compressor/float/mod.rs
+++ b/vortex-btrblocks/src/compressor/float/mod.rs
@@ -219,7 +219,7 @@ impl Scheme for UncompressedScheme {
         _ctx: CompressorContext,
         _excludes: &[FloatCode],
     ) -> VortexResult<ArrayRef> {
-        Ok(stats.source().into_array())
+        Ok(stats.source().clone().into_array())
     }
 }
 
@@ -501,7 +501,7 @@ impl Scheme for NullDominated {
         assert!(ctx.allowed_cascading > 0);
 
         // We pass None as we only run this pathway for NULL-dominated float arrays
-        let sparse_encoded = SparseArray::encode(&stats.src.into_array(), None)?;
+        let sparse_encoded = SparseArray::encode(&stats.src.clone().into_array(), None)?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {
             // Compress the values

--- a/vortex-btrblocks/src/compressor/float/stats.rs
+++ b/vortex-btrblocks/src/compressor/float/stats.rs
@@ -92,7 +92,7 @@ impl CompressorStats for FloatStats {
     }
 
     fn sample_opts(&self, sample_size: u32, sample_count: u32, opts: GenerateStatsOptions) -> Self {
-        let sampled = sample(&self.src.to_array(), sample_size, sample_count).to_primitive();
+        let sampled = sample(&self.src.into_array(), sample_size, sample_count).to_primitive();
 
         Self::generate_opts(&sampled, opts)
     }

--- a/vortex-btrblocks/src/compressor/float/stats.rs
+++ b/vortex-btrblocks/src/compressor/float/stats.rs
@@ -6,6 +6,7 @@ use std::hash::Hash;
 use itertools::Itertools;
 use num_traits::Float;
 use rustc_hash::FxBuildHasher;
+use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
 use vortex_array::arrays::NativeValue;
 use vortex_array::arrays::PrimitiveArray;
@@ -92,7 +93,8 @@ impl CompressorStats for FloatStats {
     }
 
     fn sample_opts(&self, sample_size: u32, sample_count: u32, opts: GenerateStatsOptions) -> Self {
-        let sampled = sample(&self.src.into_array(), sample_size, sample_count).to_primitive();
+        let sampled =
+            sample(&self.src.clone().into_array(), sample_size, sample_count).to_primitive();
 
         Self::generate_opts(&sampled, opts)
     }

--- a/vortex-btrblocks/src/compressor/integer/mod.rs
+++ b/vortex-btrblocks/src/compressor/integer/mod.rs
@@ -251,7 +251,7 @@ impl Scheme for UncompressedScheme {
         _ctx: CompressorContext,
         _excludes: &[IntCode],
     ) -> VortexResult<ArrayRef> {
-        Ok(stats.source().into_array())
+        Ok(stats.source().clone().into_array())
     }
 }
 
@@ -601,7 +601,7 @@ impl Scheme for SparseScheme {
         }
 
         let sparse_encoded = SparseArray::encode(
-            &stats.src.into_array(),
+            &stats.src.clone().into_array(),
             Some(Scalar::primitive_value(
                 top_pvalue,
                 top_pvalue.ptype(),

--- a/vortex-btrblocks/src/compressor/integer/mod.rs
+++ b/vortex-btrblocks/src/compressor/integer/mod.rs
@@ -251,7 +251,7 @@ impl Scheme for UncompressedScheme {
         _ctx: CompressorContext,
         _excludes: &[IntCode],
     ) -> VortexResult<ArrayRef> {
-        Ok(stats.source().to_array())
+        Ok(stats.source().into_array())
     }
 }
 
@@ -601,7 +601,7 @@ impl Scheme for SparseScheme {
         }
 
         let sparse_encoded = SparseArray::encode(
-            &stats.src.to_array(),
+            &stats.src.into_array(),
             Some(Scalar::primitive_value(
                 top_pvalue,
                 top_pvalue.ptype(),

--- a/vortex-btrblocks/src/compressor/integer/stats.rs
+++ b/vortex-btrblocks/src/compressor/integer/stats.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 
 use num_traits::PrimInt;
 use rustc_hash::FxBuildHasher;
+use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
 use vortex_array::arrays::NativeValue;
 use vortex_array::arrays::PrimitiveArray;
@@ -186,7 +187,8 @@ impl CompressorStats for IntegerStats {
     }
 
     fn sample_opts(&self, sample_size: u32, sample_count: u32, opts: GenerateStatsOptions) -> Self {
-        let sampled = sample(&self.src.into_array(), sample_size, sample_count).to_primitive();
+        let sampled =
+            sample(&self.src.clone().into_array(), sample_size, sample_count).to_primitive();
 
         Self::generate_opts(&sampled, opts)
     }

--- a/vortex-btrblocks/src/compressor/integer/stats.rs
+++ b/vortex-btrblocks/src/compressor/integer/stats.rs
@@ -186,7 +186,7 @@ impl CompressorStats for IntegerStats {
     }
 
     fn sample_opts(&self, sample_size: u32, sample_count: u32, opts: GenerateStatsOptions) -> Self {
-        let sampled = sample(&self.src.to_array(), sample_size, sample_count).to_primitive();
+        let sampled = sample(&self.src.into_array(), sample_size, sample_count).to_primitive();
 
         Self::generate_opts(&sampled, opts)
     }

--- a/vortex-btrblocks/src/compressor/string.rs
+++ b/vortex-btrblocks/src/compressor/string.rs
@@ -111,7 +111,8 @@ impl CompressorStats for StringStats {
     }
 
     fn sample_opts(&self, sample_size: u32, sample_count: u32, opts: GenerateStatsOptions) -> Self {
-        let sampled = sample(&self.src.into_array(), sample_size, sample_count).to_varbinview();
+        let sampled =
+            sample(&self.src.clone().into_array(), sample_size, sample_count).to_varbinview();
 
         Self::generate_opts(&sampled, opts)
     }
@@ -267,7 +268,7 @@ impl Scheme for UncompressedScheme {
         _ctx: CompressorContext,
         _excludes: &[StringCode],
     ) -> VortexResult<ArrayRef> {
-        Ok(stats.source().into_array())
+        Ok(stats.source().clone().into_array())
     }
 }
 
@@ -413,7 +414,7 @@ impl Scheme for ConstantScheme {
         }
 
         if stats.estimated_distinct_count > 1
-            || !is_constant(&stats.src.into_array())?.unwrap_or(false)
+            || !is_constant(&stats.src.clone().into_array())?.unwrap_or(false)
         {
             return Ok(0.0);
         }
@@ -495,7 +496,7 @@ impl Scheme for NullDominated {
         assert!(ctx.allowed_cascading > 0);
 
         // We pass None as we only run this pathway for NULL-dominated string arrays
-        let sparse_encoded = SparseArray::encode(&stats.src.into_array(), None)?;
+        let sparse_encoded = SparseArray::encode(&stats.src.clone().into_array(), None)?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {
             // Compress the indices only (not the values for strings)
@@ -561,7 +562,10 @@ impl Scheme for ZstdBuffersScheme {
         _ctx: CompressorContext,
         _excludes: &[StringCode],
     ) -> VortexResult<ArrayRef> {
-        Ok(vortex_zstd::ZstdBuffersArray::compress(&stats.source().into_array(), 3)?.into_array())
+        Ok(
+            vortex_zstd::ZstdBuffersArray::compress(&stats.source().clone().into_array(), 3)?
+                .into_array(),
+        )
     }
 }
 

--- a/vortex-btrblocks/src/compressor/string.rs
+++ b/vortex-btrblocks/src/compressor/string.rs
@@ -111,7 +111,7 @@ impl CompressorStats for StringStats {
     }
 
     fn sample_opts(&self, sample_size: u32, sample_count: u32, opts: GenerateStatsOptions) -> Self {
-        let sampled = sample(&self.src.to_array(), sample_size, sample_count).to_varbinview();
+        let sampled = sample(&self.src.into_array(), sample_size, sample_count).to_varbinview();
 
         Self::generate_opts(&sampled, opts)
     }
@@ -267,7 +267,7 @@ impl Scheme for UncompressedScheme {
         _ctx: CompressorContext,
         _excludes: &[StringCode],
     ) -> VortexResult<ArrayRef> {
-        Ok(stats.source().to_array())
+        Ok(stats.source().into_array())
     }
 }
 
@@ -413,7 +413,7 @@ impl Scheme for ConstantScheme {
         }
 
         if stats.estimated_distinct_count > 1
-            || !is_constant(&stats.src.to_array())?.unwrap_or(false)
+            || !is_constant(&stats.src.into_array())?.unwrap_or(false)
         {
             return Ok(0.0);
         }
@@ -495,7 +495,7 @@ impl Scheme for NullDominated {
         assert!(ctx.allowed_cascading > 0);
 
         // We pass None as we only run this pathway for NULL-dominated string arrays
-        let sparse_encoded = SparseArray::encode(&stats.src.to_array(), None)?;
+        let sparse_encoded = SparseArray::encode(&stats.src.into_array(), None)?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {
             // Compress the indices only (not the values for strings)
@@ -561,7 +561,7 @@ impl Scheme for ZstdBuffersScheme {
         _ctx: CompressorContext,
         _excludes: &[StringCode],
     ) -> VortexResult<ArrayRef> {
-        Ok(vortex_zstd::ZstdBuffersArray::compress(&stats.source().to_array(), 3)?.into_array())
+        Ok(vortex_zstd::ZstdBuffersArray::compress(&stats.source().into_array(), 3)?.into_array())
     }
 }
 

--- a/vortex-cuda/benches/bitpacked_cuda.rs
+++ b/vortex-cuda/benches/bitpacked_cuda.rs
@@ -127,7 +127,7 @@ where
                     .with_launch_strategy(Arc::new(timed));
 
                 for _ in 0..iters {
-                    block_on(array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                    block_on(array.clone().into_array().execute_cuda(&mut cuda_ctx)).unwrap();
                 }
 
                 Duration::from_nanos(timer.load(Ordering::Relaxed))
@@ -173,7 +173,7 @@ where
                         .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
-                        block_on(array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                        block_on(array.clone().into_array().execute_cuda(&mut cuda_ctx)).unwrap();
                     }
 
                     Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/benches/bitpacked_cuda.rs
+++ b/vortex-cuda/benches/bitpacked_cuda.rs
@@ -56,7 +56,7 @@ where
         .collect();
 
     let primitive_array = PrimitiveArray::new(Buffer::from(values), NonNullable);
-    BitPackedArray::encode(&primitive_array.to_array(), bit_width)
+    BitPackedArray::encode(&primitive_array.into_array(), bit_width)
         .vortex_expect("failed to create BitPacked array")
 }
 
@@ -127,7 +127,7 @@ where
                     .with_launch_strategy(Arc::new(timed));
 
                 for _ in 0..iters {
-                    block_on(array.to_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                    block_on(array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
                 }
 
                 Duration::from_nanos(timer.load(Ordering::Relaxed))
@@ -173,7 +173,7 @@ where
                         .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
-                        block_on(array.to_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                        block_on(array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
                     }
 
                     Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/benches/date_time_parts_cuda.rs
+++ b/vortex-cuda/benches/date_time_parts_cuda.rs
@@ -76,7 +76,7 @@ fn benchmark_datetimeparts(c: &mut Criterion) {
 
                     for _ in 0..iters {
                         // block on immediately here
-                        block_on(dtp_array.to_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                        block_on(dtp_array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
                     }
 
                     Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/benches/date_time_parts_cuda.rs
+++ b/vortex-cuda/benches/date_time_parts_cuda.rs
@@ -76,7 +76,8 @@ fn benchmark_datetimeparts(c: &mut Criterion) {
 
                     for _ in 0..iters {
                         // block on immediately here
-                        block_on(dtp_array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                        block_on(dtp_array.clone().into_array().execute_cuda(&mut cuda_ctx))
+                            .unwrap();
                     }
 
                     Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/benches/dict_cuda.rs
+++ b/vortex-cuda/benches/dict_cuda.rs
@@ -100,7 +100,7 @@ where
                         .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
-                        block_on(dict_array.to_array().execute_cuda(&mut cuda_ctx))
+                        block_on(dict_array.into_array().execute_cuda(&mut cuda_ctx))
                             .vortex_expect("execute");
                     }
 

--- a/vortex-cuda/benches/dict_cuda.rs
+++ b/vortex-cuda/benches/dict_cuda.rs
@@ -100,7 +100,7 @@ where
                         .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
-                        block_on(dict_array.into_array().execute_cuda(&mut cuda_ctx))
+                        block_on(dict_array.clone().into_array().execute_cuda(&mut cuda_ctx))
                             .vortex_expect("execute");
                     }
 

--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -176,10 +176,10 @@ fn bench_for_bitpacked(c: &mut Criterion) {
             .map(|i| (i as u64 % (max_val + 1)) as u32)
             .collect();
         let prim = PrimitiveArray::new(Buffer::from(residuals), NonNullable);
-        let bp = BitPackedArray::encode(&prim.to_array(), bit_width).vortex_expect("bitpack");
+        let bp = BitPackedArray::encode(&prim.into_array(), bit_width).vortex_expect("bitpack");
         let for_arr =
             FoRArray::try_new(bp.into_array(), Scalar::from(reference)).vortex_expect("for");
-        let array = for_arr.to_array();
+        let array = for_arr.into_array();
 
         group.bench_with_input(
             BenchmarkId::new("dynamic_dispatch_u32", len_str),
@@ -220,11 +220,11 @@ fn bench_dict_bp_codes(c: &mut Criterion) {
 
         let codes: Vec<u32> = (0..*len).map(|i| (i % dict_size) as u32).collect();
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPackedArray::encode(&codes_prim.to_array(), dict_bit_width)
+        let codes_bp = BitPackedArray::encode(&codes_prim.into_array(), dict_bit_width)
             .vortex_expect("bitpack codes");
         let values_prim = PrimitiveArray::new(Buffer::from(dict_values.clone()), NonNullable);
         let dict = DictArray::new(codes_bp.into_array(), values_prim.into_array());
-        let array = dict.to_array();
+        let array = dict.into_array();
 
         group.bench_with_input(
             BenchmarkId::new("dynamic_dispatch_u32", len_str),
@@ -268,7 +268,7 @@ fn bench_runend(c: &mut Criterion) {
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
         let re = RunEndArray::new(ends_arr, values_arr);
-        let array = re.to_array();
+        let array = re.into_array();
 
         group.bench_with_input(
             BenchmarkId::new("dynamic_dispatch_u32", len_str),
@@ -309,7 +309,7 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
     let dict_residuals: Vec<u32> = (0..dict_size as u32).collect();
     let dict_prim = PrimitiveArray::new(Buffer::from(dict_residuals), NonNullable);
     let dict_bp =
-        BitPackedArray::encode(&dict_prim.to_array(), dict_bit_width).vortex_expect("bitpack dict");
+        BitPackedArray::encode(&dict_prim.into_array(), dict_bit_width).vortex_expect("bitpack dict");
     let dict_for = FoRArray::try_new(dict_bp.into_array(), Scalar::from(dict_reference))
         .vortex_expect("for dict");
 
@@ -318,11 +318,11 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
 
         let codes: Vec<u32> = (0..*len).map(|i| (i % dict_size) as u32).collect();
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPackedArray::encode(&codes_prim.to_array(), codes_bit_width)
+        let codes_bp = BitPackedArray::encode(&codes_prim.into_array(), codes_bit_width)
             .vortex_expect("bitpack codes");
 
-        let dict = DictArray::new(codes_bp.into_array(), dict_for.to_array());
-        let array = dict.to_array();
+        let dict = DictArray::new(codes_bp.into_array(), dict_for.into_array());
+        let array = dict.into_array();
 
         group.bench_with_input(
             BenchmarkId::new("dynamic_dispatch_u32", len_str),
@@ -380,7 +380,7 @@ fn bench_alp_for_bitpacked(c: &mut Criterion) {
             exponents,
             None,
         );
-        let array = tree.to_array();
+        let array = tree.into_array();
 
         group.bench_with_input(
             BenchmarkId::new("dynamic_dispatch_f32", len_str),

--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -308,8 +308,8 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
     // Dict values: residuals 0..63 bitpacked, FoR adds 1_000_000
     let dict_residuals: Vec<u32> = (0..dict_size as u32).collect();
     let dict_prim = PrimitiveArray::new(Buffer::from(dict_residuals), NonNullable);
-    let dict_bp =
-        BitPackedArray::encode(&dict_prim.into_array(), dict_bit_width).vortex_expect("bitpack dict");
+    let dict_bp = BitPackedArray::encode(&dict_prim.into_array(), dict_bit_width)
+        .vortex_expect("bitpack dict");
     let dict_for = FoRArray::try_new(dict_bp.into_array(), Scalar::from(dict_reference))
         .vortex_expect("for dict");
 
@@ -321,7 +321,7 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
         let codes_bp = BitPackedArray::encode(&codes_prim.into_array(), codes_bit_width)
             .vortex_expect("bitpack codes");
 
-        let dict = DictArray::new(codes_bp.into_array(), dict_for.into_array());
+        let dict = DictArray::new(codes_bp.into_array(), dict_for.clone().into_array());
         let array = dict.into_array();
 
         group.bench_with_input(

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -91,7 +91,8 @@ where
                         .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
-                        block_on(for_array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                        block_on(for_array.clone().into_array().execute_cuda(&mut cuda_ctx))
+                            .unwrap();
                     }
 
                     Duration::from_nanos(timer.load(Ordering::Relaxed))
@@ -129,7 +130,8 @@ where
                         .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
-                        block_on(for_array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                        block_on(for_array.clone().into_array().execute_cuda(&mut cuda_ctx))
+                            .unwrap();
                     }
 
                     Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -91,7 +91,7 @@ where
                         .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
-                        block_on(for_array.to_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                        block_on(for_array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
                     }
 
                     Duration::from_nanos(timer.load(Ordering::Relaxed))
@@ -129,7 +129,7 @@ where
                         .with_launch_strategy(Arc::new(timed));
 
                     for _ in 0..iters {
-                        block_on(for_array.to_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                        block_on(for_array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
                     }
 
                     Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/benches/runend_cuda.rs
+++ b/vortex-cuda/benches/runend_cuda.rs
@@ -89,7 +89,7 @@ where
                                 .with_launch_strategy(Arc::new(timed));
 
                         for _ in 0..iters {
-                            block_on(runend_array.to_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                            block_on(runend_array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
                         }
 
                         Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/benches/runend_cuda.rs
+++ b/vortex-cuda/benches/runend_cuda.rs
@@ -89,7 +89,13 @@ where
                                 .with_launch_strategy(Arc::new(timed));
 
                         for _ in 0..iters {
-                            block_on(runend_array.into_array().execute_cuda(&mut cuda_ctx)).unwrap();
+                            block_on(
+                                runend_array
+                                    .clone()
+                                    .into_array()
+                                    .execute_cuda(&mut cuda_ctx),
+                            )
+                            .unwrap();
                         }
 
                         Duration::from_nanos(timer.load(Ordering::Relaxed))

--- a/vortex-cuda/src/kernel/arrays/dict.rs
+++ b/vortex-cuda/src/kernel/arrays/dict.rs
@@ -99,7 +99,7 @@ async fn execute_dict_prim_typed<V: DeviceRepr + NativePType, I: DeviceRepr + Na
         validity: values_validity,
         ..
     } = values.into_parts();
-    let output_validity = values_validity.take(&codes.to_array())?;
+    let output_validity = values_validity.take(&codes.into_array())?;
     let PrimitiveArrayParts {
         buffer: codes_buffer,
         ..
@@ -184,7 +184,7 @@ async fn execute_dict_decimal_typed<
         validity: values_validity,
         ..
     } = values.into_parts();
-    let output_validity = values_validity.take(&codes.to_array())?;
+    let output_validity = values_validity.take(&codes.into_array())?;
 
     let PrimitiveArrayParts {
         buffer: codes_buffer,
@@ -252,7 +252,7 @@ async fn execute_dict_varbinview(
         validity: values_validity,
         ..
     } = values_vbv.into_parts();
-    let output_validity = values_validity.take(&codes_prim.to_array())?;
+    let output_validity = values_validity.take(&codes_prim.into_array())?;
 
     let PrimitiveArrayParts {
         buffer: codes_buffer,

--- a/vortex-cuda/src/kernel/arrays/dict.rs
+++ b/vortex-cuda/src/kernel/arrays/dict.rs
@@ -9,6 +9,7 @@ use cudarc::driver::PushKernelArg;
 use tracing::instrument;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
+use vortex::array::IntoArray;
 use vortex::array::arrays::DecimalArray;
 use vortex::array::arrays::DecimalArrayParts;
 use vortex::array::arrays::DictArray;
@@ -99,7 +100,7 @@ async fn execute_dict_prim_typed<V: DeviceRepr + NativePType, I: DeviceRepr + Na
         validity: values_validity,
         ..
     } = values.into_parts();
-    let output_validity = values_validity.take(&codes.into_array())?;
+    let output_validity = values_validity.take(&codes.clone().into_array())?;
     let PrimitiveArrayParts {
         buffer: codes_buffer,
         ..
@@ -184,7 +185,7 @@ async fn execute_dict_decimal_typed<
         validity: values_validity,
         ..
     } = values.into_parts();
-    let output_validity = values_validity.take(&codes.into_array())?;
+    let output_validity = values_validity.take(&codes.clone().into_array())?;
 
     let PrimitiveArrayParts {
         buffer: codes_buffer,
@@ -252,7 +253,7 @@ async fn execute_dict_varbinview(
         validity: values_validity,
         ..
     } = values_vbv.into_parts();
-    let output_validity = values_validity.take(&codes_prim.into_array())?;
+    let output_validity = values_validity.take(&codes_prim.clone().into_array())?;
 
     let PrimitiveArrayParts {
         buffer: codes_buffer,

--- a/vortex-cuda/src/kernel/encodings/date_time_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/date_time_parts.rs
@@ -66,7 +66,7 @@ impl CudaExecute for DateTimePartsExecutor {
 
         let time_unit = options.unit;
         let time_zone = options.tz.clone();
-        let validity = Validity::copy_from_array(&array.to_array())?;
+        let validity = Validity::copy_from_array(&array.into_array())?;
 
         if output_len == 0 {
             return Ok(Canonical::empty(array.dtype()));

--- a/vortex-cuda/src/kernel/encodings/date_time_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/date_time_parts.rs
@@ -66,7 +66,7 @@ impl CudaExecute for DateTimePartsExecutor {
 
         let time_unit = options.unit;
         let time_zone = options.tz.clone();
-        let validity = Validity::copy_from_array(&array.into_array())?;
+        let validity = Validity::copy_from_array(&array.clone().into_array())?;
 
         if output_len == 0 {
             return Ok(Canonical::empty(array.dtype()));

--- a/vortex-duckdb/src/convert/vector.rs
+++ b/vortex-duckdb/src/convert/vector.rs
@@ -371,7 +371,7 @@ pub fn data_chunk_to_vortex(
         len.as_(),
         Validity::NonNullable,
     )
-    .map(|a| a.to_array())
+    .map(|a| a.into_array())
 }
 
 #[cfg(test)]

--- a/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
+++ b/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
@@ -310,9 +310,9 @@ fn test_vortex_multi_column() {
             vec![true, false, true, true, false].into(),
             Validity::NonNullable,
         )
-        .to_array();
-        let f2 = (0..5).collect::<PrimitiveArray>().to_array();
-        let f3 = (100..105).collect::<PrimitiveArray>().to_array();
+        .into_array();
+        let f2 = (0..5).collect::<PrimitiveArray>().into_array();
+        let f3 = (100..105).collect::<PrimitiveArray>().into_array();
         write_vortex_file([("f1", f1), ("f2", f2), ("f3", f3)].into_iter()).await
     });
 

--- a/vortex-duckdb/src/exporter/struct_.rs
+++ b/vortex-duckdb/src/exporter/struct_.rs
@@ -45,7 +45,7 @@ pub(crate) fn new_exporter(
         .map(|child| {
             if validity.to_bit_buffer().true_count() != validity.len() {
                 // TODO(joe): use new mask.
-                new_array_exporter(child.clone().mask(validity.to_array())?, cache, ctx)
+                new_array_exporter(child.clone().mask(validity.into_array())?, cache, ctx)
             } else {
                 new_array_exporter(child.clone().into_array(), cache, ctx)
             }

--- a/vortex-duckdb/src/exporter/struct_.rs
+++ b/vortex-duckdb/src/exporter/struct_.rs
@@ -45,7 +45,11 @@ pub(crate) fn new_exporter(
         .map(|child| {
             if validity.to_bit_buffer().true_count() != validity.len() {
                 // TODO(joe): use new mask.
-                new_array_exporter(child.clone().mask(validity.into_array())?, cache, ctx)
+                new_array_exporter(
+                    child.clone().mask(validity.clone().into_array())?,
+                    cache,
+                    ctx,
+                )
             } else {
                 new_array_exporter(child.clone().into_array(), cache, ctx)
             }

--- a/vortex-duckdb/src/exporter/temporal.rs
+++ b/vortex-duckdb/src/exporter/temporal.rs
@@ -87,7 +87,7 @@ mod tests {
     fn test_timestamp_us() {
         let arr = TemporalArray::new_timestamp(
             PrimitiveArray::from_iter((0..10).map(|i| 1_000_000 * i + 1750265188000001i64))
-                .to_array(),
+                .into_array(),
             TimeUnit::Microseconds,
             None,
         );
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn test_timestamp_time_us() {
         let arr = TemporalArray::new_time(
-            PrimitiveArray::from_iter((1i64..10).map(|i| 1_000_000 * i)).to_array(),
+            PrimitiveArray::from_iter((1i64..10).map(|i| 1_000_000 * i)).into_array(),
             TimeUnit::Microseconds,
         );
 

--- a/vortex-file/src/pruning.rs
+++ b/vortex-file/src/pruning.rs
@@ -30,7 +30,7 @@ pub fn extract_relevant_file_stats_as_struct_row(
 ) -> VortexResult<Option<ArrayRef>> {
     if access.is_empty() {
         return StructArray::try_new(FieldNames::default(), vec![], 1, Validity::NonNullable)
-            .map(|s| Some(s.to_array()));
+            .map(|s| Some(s.into_array()));
     }
 
     let mut columns: Vec<(FieldName, ArrayRef)> = Vec::with_capacity(access.len() * 2);
@@ -64,7 +64,7 @@ pub fn extract_relevant_file_stats_as_struct_row(
                 };
                 columns.push((
                     field_path_stat_field_name(field_path, *stat),
-                    ConstantArray::new(stat_value, 1).to_array(),
+                    ConstantArray::new(stat_value, 1).into_array(),
                 ));
             } else {
                 todo!("unsupported file prune stat {stat}")
@@ -72,6 +72,6 @@ pub fn extract_relevant_file_stats_as_struct_row(
         }
     }
     Ok(Some(
-        StructArray::from_fields(columns.as_slice())?.to_array(),
+        StructArray::from_fields(columns.as_slice())?.into_array(),
     ))
 }

--- a/vortex-file/src/pruning.rs
+++ b/vortex-file/src/pruning.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::StructArray;
 use vortex_array::dtype::Field;

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1257,7 +1257,7 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
 async fn scan_empty_fields() -> VortexResult<()> {
     let array = (0..10000).collect::<PrimitiveArray>();
 
-    let result = round_trip(&array.into_array(), |scan| {
+    let result = round_trip(&array.clone().into_array(), |scan| {
         Ok(scan.with_projection(Pack.new_expr(
             PackOptions {
                 names: Default::default(),

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1229,7 +1229,7 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
         Nullability::Nullable,
     );
 
-    let struct_ = ConstantArray::new(Scalar::null(nested_dtype.clone()), 3).to_array();
+    let struct_ = ConstantArray::new(Scalar::null(nested_dtype.clone()), 3).into_array();
 
     let array = StructArray::try_new(
         ["struct"].into(),
@@ -1257,7 +1257,7 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
 async fn scan_empty_fields() -> VortexResult<()> {
     let array = (0..10000).collect::<PrimitiveArray>();
 
-    let result = round_trip(&array.to_array(), |scan| {
+    let result = round_trip(&array.into_array(), |scan| {
         Ok(scan.with_projection(Pack.new_expr(
             PackOptions {
                 names: Default::default(),

--- a/vortex-ipc/src/messages/decoder.rs
+++ b/vortex-ipc/src/messages/decoder.rs
@@ -214,6 +214,6 @@ mod test {
         // Constant arrays have a single buffer
         let array = ConstantArray::new(10i32, 20);
         assert_eq!(array.nbuffers(), 1, "Array should have a single buffer");
-        write_and_read(&array.to_array());
+        write_and_read(&array.into_array());
     }
 }

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -292,7 +292,7 @@ impl LayoutReader for ChunkedReader {
     ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
         let dtype = expr.return_dtype(self.dtype())?;
         if row_range.is_empty() {
-            return Ok(async move { Ok(ChunkedArray::try_new(vec![], dtype)?.to_array()) }.boxed());
+            return Ok(async move { Ok(ChunkedArray::try_new(vec![], dtype)?.into_array()) }.boxed());
         }
 
         let mut chunk_evals = vec![];
@@ -317,7 +317,7 @@ impl LayoutReader for ChunkedReader {
             }
 
             // Combine the arrays.
-            Ok(ChunkedArray::try_new(chunks, dtype)?.to_array())
+            Ok(ChunkedArray::try_new(chunks, dtype)?.into_array())
         }
         .boxed())
     }

--- a/vortex-layout/src/layouts/chunked/reader.rs
+++ b/vortex-layout/src/layouts/chunked/reader.rs
@@ -11,6 +11,7 @@ use futures::future::BoxFuture;
 use futures::stream::FuturesOrdered;
 use itertools::Itertools;
 use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
 use vortex_array::MaskFuture;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::dtype::DType;
@@ -292,7 +293,9 @@ impl LayoutReader for ChunkedReader {
     ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
         let dtype = expr.return_dtype(self.dtype())?;
         if row_range.is_empty() {
-            return Ok(async move { Ok(ChunkedArray::try_new(vec![], dtype)?.into_array()) }.boxed());
+            return Ok(
+                async move { Ok(ChunkedArray::try_new(vec![], dtype)?.into_array()) }.boxed(),
+            );
         }
 
         let mut chunk_evals = vec![];

--- a/vortex-layout/src/layouts/collect.rs
+++ b/vortex-layout/src/layouts/collect.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use futures::pin_mut;
 use vortex_array::ArrayContext;
+use vortex_array::IntoArray;
 use vortex_array::arrays::ChunkedArray;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;

--- a/vortex-layout/src/layouts/collect.rs
+++ b/vortex-layout/src/layouts/collect.rs
@@ -60,7 +60,7 @@ impl LayoutStrategy for CollectStrategy {
                 chunks.push(chunk);
             }
 
-            let collected = ChunkedArray::try_new(chunks, _dtype)?.to_array();
+            let collected = ChunkedArray::try_new(chunks, _dtype)?.into_array();
             yield (latest_sequence_id.vortex_expect("must have visited at least one chunk"), collected);
         };
 

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -226,7 +226,7 @@ impl LayoutReader for DictReader {
                 DictArray::new_unchecked(codes, values)
                     .set_all_values_referenced(all_values_referenced)
             }
-            .to_array()
+            .into_array()
             .optimize()?;
 
             array.apply(&expr)
@@ -298,7 +298,7 @@ mod tests {
                 ],
                 DType::Utf8(Nullability::Nullable),
             )
-            .to_array();
+            .into_array();
             let array_to_write = array.clone();
             let ctx = ArrayContext::empty();
             let segments = Arc::new(TestSegments::default());
@@ -382,7 +382,7 @@ mod tests {
                 DictLayoutOptions::default(),
             );
 
-            let array = VarBinArray::from_iter(data, DType::Utf8(Nullability::Nullable)).to_array();
+            let array = VarBinArray::from_iter(data, DType::Utf8(Nullability::Nullable)).into_array();
             let ctx = ArrayContext::empty();
             let segments = Arc::new(TestSegments::default());
             let (ptr, eof) = SequenceId::root().split();
@@ -444,7 +444,7 @@ mod tests {
                 ],
                 DType::Utf8(Nullability::Nullable),
             )
-            .to_array();
+            .into_array();
             let array_to_write = array.clone();
             let ctx = ArrayContext::empty();
 

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -382,7 +382,8 @@ mod tests {
                 DictLayoutOptions::default(),
             );
 
-            let array = VarBinArray::from_iter(data, DType::Utf8(Nullability::Nullable)).into_array();
+            let array =
+                VarBinArray::from_iter(data, DType::Utf8(Nullability::Nullable)).into_array();
             let ctx = ArrayContext::empty();
             let segments = Arc::new(TestSegments::default());
             let (ptr, eof) = SequenceId::root().split();

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -250,7 +250,7 @@ mod test {
             let ctx = ArrayContext::empty();
             let segments = Arc::new(TestSegments::default());
             let (ptr, eof) = SequenceId::root().split();
-            let array = PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).to_array();
+            let array = PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).into_array();
             let layout = FlatLayoutStrategy::default()
                 .write_stream(
                     ctx,
@@ -288,7 +288,7 @@ mod test {
 
             let segments = Arc::new(TestSegments::default());
             let (ptr, eof) = SequenceId::root().split();
-            let array = PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).to_array();
+            let array = PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).into_array();
             let layout = FlatLayoutStrategy::default()
                 .write_stream(
                     ctx,
@@ -324,7 +324,7 @@ mod test {
             let ctx = ArrayContext::empty();
             let segments = Arc::new(TestSegments::default());
             let (ptr, eof) = SequenceId::root().split();
-            let array = PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).to_array();
+            let array = PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).into_array();
             let layout = FlatLayoutStrategy::default()
                 .write_stream(
                     ctx,

--- a/vortex-layout/src/layouts/flat/reader.rs
+++ b/vortex-layout/src/layouts/flat/reader.rs
@@ -250,7 +250,8 @@ mod test {
             let ctx = ArrayContext::empty();
             let segments = Arc::new(TestSegments::default());
             let (ptr, eof) = SequenceId::root().split();
-            let array = PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).into_array();
+            let array =
+                PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).into_array();
             let layout = FlatLayoutStrategy::default()
                 .write_stream(
                     ctx,
@@ -288,7 +289,8 @@ mod test {
 
             let segments = Arc::new(TestSegments::default());
             let (ptr, eof) = SequenceId::root().split();
-            let array = PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).into_array();
+            let array =
+                PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).into_array();
             let layout = FlatLayoutStrategy::default()
                 .write_stream(
                     ctx,
@@ -324,7 +326,8 @@ mod test {
             let ctx = ArrayContext::empty();
             let segments = Arc::new(TestSegments::default());
             let (ptr, eof) = SequenceId::root().split();
-            let array = PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).into_array();
+            let array =
+                PrimitiveArray::new(buffer![1, 2, 3, 4, 5], Validity::AllValid).into_array();
             let layout = FlatLayoutStrategy::default()
                 .write_stream(
                     ctx,

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -156,7 +156,7 @@ impl ZoneMap {
     pub fn prune(&self, predicate: &Expression, session: &VortexSession) -> VortexResult<Mask> {
         let mut ctx = session.create_execution_ctx();
         self.array
-            .to_array()
+            .into_array()
             .apply(predicate)?
             .execute::<Mask>(&mut ctx)
     }

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
+use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::StructArray;
 use vortex_array::compute::sum;
@@ -156,6 +157,7 @@ impl ZoneMap {
     pub fn prune(&self, predicate: &Expression, session: &VortexSession) -> VortexResult<Mask> {
         let mut ctx = session.create_execution_ctx();
         self.array
+            .clone()
             .into_array()
             .apply(predicate)?
             .execute::<Mask>(&mut ctx)

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -107,7 +107,7 @@ impl<'py> FromPyObject<'_, 'py> for PyArrayRef {
         }
 
         // Otherwise, if it's a subclass of `PyArray`, then we can extract the inner array.
-        PythonArray::extract(ob).map(|instance| Self(instance.to_array()))
+        PythonArray::extract(ob).map(|instance| Self(instance.into_array()))
     }
 }
 

--- a/vortex-python/src/arrays/range_to_sequence.rs
+++ b/vortex-python/src/arrays/range_to_sequence.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex::array::ArrayRef;
+use vortex::array::IntoArray;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::validity::Validity;
 use vortex::buffer::Buffer;

--- a/vortex-python/src/arrays/range_to_sequence.rs
+++ b/vortex-python/src/arrays/range_to_sequence.rs
@@ -29,7 +29,7 @@ pub fn sequence_array_from_range<T: NativePType + TryFrom<isize> + Into<PValue>>
             Nullability::NonNullable => Validity::NonNullable,
             Nullability::Nullable => Validity::AllValid,
         };
-        return Ok(PrimitiveArray::new::<T>(Buffer::empty(), validity).to_array());
+        return Ok(PrimitiveArray::new::<T>(Buffer::empty(), validity).into_array());
     };
     let Ok(start) = T::try_from(start) else {
         vortex_bail!(
@@ -42,7 +42,7 @@ pub fn sequence_array_from_range<T: NativePType + TryFrom<isize> + Into<PValue>>
         vortex_bail!("Step, {}, does not fit in requested dtype: {}", step, dtype);
     };
 
-    Ok(SequenceArray::try_new_typed::<T>(start, step, dtype.nullability(), len)?.to_array())
+    Ok(SequenceArray::try_new_typed::<T>(start, step, dtype.nullability(), len)?.into_array())
 }
 
 fn range_len(start: isize, stop: isize, step: isize) -> Option<usize> {

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -69,11 +69,13 @@ mod setup {
         let uint_array =
             PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
         let int_array = uint_array
+            .clone()
             .into_array()
             .cast(PType::I32.into())
             .unwrap()
             .to_primitive();
         let float_array = uint_array
+            .clone()
             .into_array()
             .cast(PType::F64.into())
             .unwrap()

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -69,12 +69,12 @@ mod setup {
         let uint_array =
             PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
         let int_array = uint_array
-            .to_array()
+            .into_array()
             .cast(PType::I32.into())
             .unwrap()
             .to_primitive();
         let float_array = uint_array
-            .to_array()
+            .into_array()
             .cast(PType::F64.into())
             .unwrap()
             .to_primitive();
@@ -135,7 +135,7 @@ mod setup {
         let codes_prim = PrimitiveArray::from_iter(codes);
 
         // Compress codes with BitPacked (6 bits should be enough for ~50 unique values)
-        let codes_bp = BitPackedArray::encode(&codes_prim.to_array(), 6)
+        let codes_bp = BitPackedArray::encode(&codes_prim.into_array(), 6)
             .unwrap()
             .into_array();
 
@@ -180,7 +180,7 @@ mod setup {
 
         // Compress the values with BitPacked
         let values_prim = runend.values().to_primitive();
-        let compressed_values = BitPackedArray::encode(&values_prim.to_array(), 8)
+        let compressed_values = BitPackedArray::encode(&values_prim.into_array(), 8)
             .unwrap()
             .into_array();
 
@@ -244,7 +244,7 @@ mod setup {
         // Compress the VarBin offsets with BitPacked
         let codes = fsst.codes();
         let offsets_prim = codes.offsets().to_primitive();
-        let offsets_bp = BitPackedArray::encode(&offsets_prim.to_array(), 20).unwrap();
+        let offsets_bp = BitPackedArray::encode(&offsets_prim.into_array(), 20).unwrap();
 
         // Rebuild VarBin with compressed offsets
         let compressed_codes = VarBinArray::try_new(

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -57,11 +57,13 @@ fn setup_primitive_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) 
     let uint_array =
         PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
     let int_array = uint_array
+        .clone()
         .into_array()
         .cast(PType::I32.into())
         .unwrap()
         .to_primitive();
     let float_array = uint_array
+        .clone()
         .into_array()
         .cast(PType::F64.into())
         .unwrap()
@@ -180,7 +182,7 @@ fn bench_dict_compress_u32(bencher: Bencher) {
 
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| &uint_array)
-        .bench_refs(|a| dict_encode(&a.into_array()).unwrap());
+        .bench_refs(|a| dict_encode(&a.clone().into_array()).unwrap());
 }
 
 #[divan::bench(name = "dict_decompress_u32")]
@@ -303,13 +305,13 @@ fn bench_dict_compress_string(bencher: Bencher) {
 
     with_byte_counter(bencher, nbytes)
         .with_inputs(|| &varbinview_arr)
-        .bench_refs(|a| dict_encode(&a.into_array()).unwrap());
+        .bench_refs(|a| dict_encode(&a.clone().into_array()).unwrap());
 }
 
 #[divan::bench(name = "dict_decompress_string")]
 fn bench_dict_decompress_string(bencher: Bencher) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-    let dict = dict_encode(&varbinview_arr.into_array()).unwrap();
+    let dict = dict_encode(&varbinview_arr.clone().into_array()).unwrap();
     let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
     with_byte_counter(bencher, nbytes)

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -57,12 +57,12 @@ fn setup_primitive_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) 
     let uint_array =
         PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
     let int_array = uint_array
-        .to_array()
+        .into_array()
         .cast(PType::I32.into())
         .unwrap()
         .to_primitive();
     let float_array = uint_array
-        .to_array()
+        .into_array()
         .cast(PType::F64.into())
         .unwrap()
         .to_primitive();
@@ -180,13 +180,13 @@ fn bench_dict_compress_u32(bencher: Bencher) {
 
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| &uint_array)
-        .bench_refs(|a| dict_encode(&a.to_array()).unwrap());
+        .bench_refs(|a| dict_encode(&a.into_array()).unwrap());
 }
 
 #[divan::bench(name = "dict_decompress_u32")]
 fn bench_dict_decompress_u32(bencher: Bencher) {
     let (uint_array, ..) = setup_primitive_arrays();
-    let compressed = dict_encode(&uint_array.to_array()).unwrap();
+    let compressed = dict_encode(&uint_array.into_array()).unwrap();
 
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| &compressed)
@@ -303,13 +303,13 @@ fn bench_dict_compress_string(bencher: Bencher) {
 
     with_byte_counter(bencher, nbytes)
         .with_inputs(|| &varbinview_arr)
-        .bench_refs(|a| dict_encode(&a.to_array()).unwrap());
+        .bench_refs(|a| dict_encode(&a.into_array()).unwrap());
 }
 
 #[divan::bench(name = "dict_decompress_string")]
 fn bench_dict_decompress_string(bencher: Bencher) {
     let varbinview_arr = VarBinViewArray::from_iter_str(gen_varbin_words(1_000_000, 0.00005));
-    let dict = dict_encode(&varbinview_arr.to_array()).unwrap();
+    let dict = dict_encode(&varbinview_arr.into_array()).unwrap();
     let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
     with_byte_counter(bencher, nbytes)

--- a/vortex/examples/compression_showcase.rs
+++ b/vortex/examples/compression_showcase.rs
@@ -58,13 +58,13 @@ fn compress_sequential_data() -> Result<(), Box<dyn std::error::Error>> {
     // Create sequential data (e.g., timestamps, IDs)
     let sequential: PrimitiveArray = (1000..11000).map(|i| i as u64).collect();
 
-    let uncompressed_size = estimate_size(&sequential.to_array());
+    let uncompressed_size = estimate_size(&sequential.into_array());
     println!("  Original sequential data (10,000 values):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     // Compress using default strategy
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(&sequential.to_array())?;
+    let compressed = compressor.compress(&sequential.into_array())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -87,12 +87,12 @@ fn compress_repetitive_data() -> Result<(), Box<dyn std::error::Error>> {
     }
     let array: PrimitiveArray = repetitive.into_iter().collect();
 
-    let uncompressed_size = estimate_size(&array.to_array());
+    let uncompressed_size = estimate_size(&array.into_array());
     println!("  Repetitive data (100 values, each repeated 100 times):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(&array.to_array())?;
+    let compressed = compressor.compress(&array.into_array())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -119,12 +119,12 @@ fn compress_string_data() -> Result<(), Box<dyn std::error::Error>> {
 
     let array = VarBinArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
 
-    let uncompressed_size = estimate_size(&array.to_array());
+    let uncompressed_size = estimate_size(&array.into_array());
     println!("  Categorical string data (10,000 strings, 4 categories):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(&array.to_array())?;
+    let compressed = compressor.compress(&array.into_array())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -168,12 +168,12 @@ fn compress_sparse_data() -> Result<(), Box<dyn std::error::Error>> {
     }
     let array: PrimitiveArray = sparse.into_iter().collect();
 
-    let uncompressed_size = estimate_size(&array.to_array());
+    let uncompressed_size = estimate_size(&array.into_array());
     println!("  Sparse data (10,000 values, 99% zeros):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(&array.to_array())?;
+    let compressed = compressor.compress(&array.into_array())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;
@@ -218,12 +218,12 @@ fn compress_structured_data() -> Result<(), Box<dyn std::error::Error>> {
         Validity::NonNullable,
     )?;
 
-    let uncompressed_size = estimate_size(&struct_array.to_array());
+    let uncompressed_size = estimate_size(&struct_array.into_array());
     println!("  Structured data (5,000 records, 3 columns):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
     let compressor = BtrBlocksCompressor::default();
-    let compressed = compressor.compress(&struct_array.to_array())?;
+    let compressed = compressor.compress(&struct_array.into_array())?;
 
     let compressed_size = compressed.nbytes();
     let ratio = uncompressed_size as f64 / compressed_size as f64;

--- a/vortex/examples/compression_showcase.rs
+++ b/vortex/examples/compression_showcase.rs
@@ -58,7 +58,7 @@ fn compress_sequential_data() -> Result<(), Box<dyn std::error::Error>> {
     // Create sequential data (e.g., timestamps, IDs)
     let sequential: PrimitiveArray = (1000..11000).map(|i| i as u64).collect();
 
-    let uncompressed_size = estimate_size(&sequential.into_array());
+    let uncompressed_size = estimate_size(&sequential.clone().into_array());
     println!("  Original sequential data (10,000 values):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
@@ -87,7 +87,7 @@ fn compress_repetitive_data() -> Result<(), Box<dyn std::error::Error>> {
     }
     let array: PrimitiveArray = repetitive.into_iter().collect();
 
-    let uncompressed_size = estimate_size(&array.into_array());
+    let uncompressed_size = estimate_size(&array.clone().into_array());
     println!("  Repetitive data (100 values, each repeated 100 times):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
@@ -119,7 +119,7 @@ fn compress_string_data() -> Result<(), Box<dyn std::error::Error>> {
 
     let array = VarBinArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
 
-    let uncompressed_size = estimate_size(&array.into_array());
+    let uncompressed_size = estimate_size(&array.clone().into_array());
     println!("  Categorical string data (10,000 strings, 4 categories):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
@@ -168,7 +168,7 @@ fn compress_sparse_data() -> Result<(), Box<dyn std::error::Error>> {
     }
     let array: PrimitiveArray = sparse.into_iter().collect();
 
-    let uncompressed_size = estimate_size(&array.into_array());
+    let uncompressed_size = estimate_size(&array.clone().into_array());
     println!("  Sparse data (10,000 values, 99% zeros):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 
@@ -218,7 +218,7 @@ fn compress_structured_data() -> Result<(), Box<dyn std::error::Error>> {
         Validity::NonNullable,
     )?;
 
-    let uncompressed_size = estimate_size(&struct_array.into_array());
+    let uncompressed_size = estimate_size(&struct_array.clone().into_array());
     println!("  Structured data (5,000 records, 3 columns):");
     println!("    Uncompressed size: ~{} bytes", uncompressed_size);
 

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -245,7 +245,7 @@ mod test {
         let array = PrimitiveArray::new(buffer![42u64; 100_000], Validity::NonNullable);
 
         // You can compress an array in-memory with the BtrBlocks compressor
-        let compressed = BtrBlocksCompressor::default().compress(&array.to_array())?;
+        let compressed = BtrBlocksCompressor::default().compress(&array.into_array())?;
         println!(
             "BtrBlocks size: {} / {}",
             compressed.nbytes(),

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -245,7 +245,7 @@ mod test {
         let array = PrimitiveArray::new(buffer![42u64; 100_000], Validity::NonNullable);
 
         // You can compress an array in-memory with the BtrBlocks compressor
-        let compressed = BtrBlocksCompressor::default().compress(&array.into_array())?;
+        let compressed = BtrBlocksCompressor::default().compress(&array.clone().into_array())?;
         println!(
             "BtrBlocks size: {} / {}",
             compressed.nbytes(),


### PR DESCRIPTION
The pattern `ConstantArray::new(..).to_array()` hides a clone, one should use `into_array`.

We cannot remove this form the DynArray since its required to create a ArrayRef.
This PR shadows the auto-deref  `to_array` on `DynArray` with a deprecated method in the vtable macro.