### PR TITLE
fix[layout]: canonical validity in compressor

### DIFF
--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -528,6 +528,7 @@ impl Executable for CanonicalValidity {
                 })))
             }
             Canonical::List(l) => {
+                let zctl = l.is_zero_copy_to_list();
                 let ListViewArrayParts {
                     elements,
                     offsets,
@@ -537,6 +538,7 @@ impl Executable for CanonicalValidity {
                 } = l.into_parts();
                 Ok(CanonicalValidity(Canonical::List(unsafe {
                     ListViewArray::new_unchecked(elements, offsets, sizes, validity.execute(ctx)?)
+                        .with_zero_copy_to_list(zctl)
                 })))
             }
             Canonical::FixedSizeList(fsl) => {

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -638,6 +638,7 @@ impl Executable for RecursiveCanonical {
                 })))
             }
             Canonical::List(l) => {
+                let zctl = l.is_zero_copy_to_list();
                 let ListViewArrayParts {
                     elements,
                     offsets,
@@ -652,6 +653,7 @@ impl Executable for RecursiveCanonical {
                         sizes.execute::<RecursiveCanonical>(ctx)?.0.into_array(),
                         validity.execute(ctx)?,
                     )
+                    .with_zero_copy_to_list(zctl)
                 })))
             }
             Canonical::FixedSizeList(fsl) => {

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -5,9 +5,12 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::CanonicalValidity;
 use vortex_array::DynArray;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
 use vortex_array::ToCanonical;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
@@ -113,7 +116,10 @@ impl BtrBlocksCompressor {
     /// First canonicalizes and compacts the array, then applies optimal compression schemes.
     pub fn compress(&self, array: &ArrayRef) -> VortexResult<ArrayRef> {
         // Canonicalize the array
-        let canonical = array.to_canonical()?;
+        let canonical = array
+            .clone()
+            .execute::<CanonicalValidity>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .0;
 
         // Compact it, removing any wasted space before we attempt to compress it
         let compact = canonical.compact()?;

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -116,6 +116,7 @@ impl BtrBlocksCompressor {
     /// First canonicalizes and compacts the array, then applies optimal compression schemes.
     pub fn compress(&self, array: &ArrayRef) -> VortexResult<ArrayRef> {
         // Canonicalize the array
+        // TODO(joe): take ctx and use it
         let canonical = array
             .clone()
             .execute::<CanonicalValidity>(&mut LEGACY_SESSION.create_execution_ctx())?

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -116,7 +116,7 @@ impl BtrBlocksCompressor {
     /// First canonicalizes and compacts the array, then applies optimal compression schemes.
     pub fn compress(&self, array: &ArrayRef) -> VortexResult<ArrayRef> {
         // Canonicalize the array
-        // TODO(joe): take ctx and use it
+        // TODO(joe): receive `ctx` and use it.
         let canonical = array
             .clone()
             .execute::<CanonicalValidity>(&mut LEGACY_SESSION.create_execution_ctx())?

--- a/vortex-file/tests/test_write_table.rs
+++ b/vortex-file/tests/test_write_table.rs
@@ -10,6 +10,9 @@ use futures::StreamExt;
 use futures::pin_mut;
 use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
+use vortex_array::arrays::BoolArray;
+use vortex_array::arrays::DictArray;
+use vortex_array::arrays::ListViewArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::StructArray;
 use vortex_array::dtype::FieldNames;
@@ -110,4 +113,53 @@ async fn test_file_roundtrip() {
         assert!(b.is_canonical());
         assert!(raw.nbytes() > compressed.nbytes());
     }
+}
+
+/// Regression test: writing a Dict<ListView> where the list has
+/// Validity::Array(BoolArray) and the dict codes are nullable used to fail
+/// with "Array vortex.fill_null does not support serialization".
+#[tokio::test]
+async fn test_dict_listview_validity_roundtrip() {
+    let elements = PrimitiveArray::from_iter(vec![1i32, 2, 3, 4, 5]).into_array();
+    let offsets = PrimitiveArray::from_iter(vec![0u32, 2, 4]).into_array();
+    let sizes = PrimitiveArray::from_iter(vec![2u32, 2, 1]).into_array();
+    let list_validity = Validity::Array(BoolArray::from_iter([true, false, true]).into_array());
+    let listview = ListViewArray::new(elements, offsets, sizes, list_validity).into_array();
+
+    let codes = PrimitiveArray::new(
+        vortex_buffer::buffer![0u32, 0, 1, 0, 2],
+        Validity::from_iter(vec![true, false, true, true, true]),
+    )
+    .into_array();
+
+    let dict = DictArray::new(codes, listview).into_array();
+
+    let data = StructArray::from_fields(&[("col", dict)])
+        .expect("from_fields")
+        .into_array();
+
+    let mut bytes = Vec::new();
+    SESSION
+        .write_options()
+        .write(&mut bytes, data.to_array_stream())
+        .await
+        .expect("write should not fail with fill_null serialization error");
+
+    let bytes = ByteBuffer::from(bytes);
+    let vxf = SESSION.open_options().open_buffer(bytes).expect("open");
+
+    let stream = vxf
+        .scan()
+        .expect("scan")
+        .into_stream()
+        .expect("into_stream");
+    pin_mut!(stream);
+
+    let chunk = stream
+        .next()
+        .await
+        .unwrap()
+        .expect("read back should succeed");
+    vortex_array::assert_arrays_eq!(data, chunk);
+    assert!(stream.next().await.is_none(), "expected a single chunk");
 }

--- a/vortex-python/src/io.rs
+++ b/vortex-python/src/io.rs
@@ -277,7 +277,7 @@ impl PyVortexWriteOptions {
     /// >>> vx.io.VortexWriteOptions.default().write(sprl, "chonky.vortex")
     /// >>> import os
     /// >>> os.path.getsize('chonky.vortex')
-    /// 216020
+    /// 215972
     /// ```
     ///
     /// Wow, Vortex manages to use about two bytes per integer! So advanced. So tiny.

--- a/vortex-test/e2e/src/lib.rs
+++ b/vortex-test/e2e/src/lib.rs
@@ -41,9 +41,9 @@ mod tests {
             .collect();
 
         #[cfg(feature = "unstable_encodings")]
-        const EXPECTED_SIZE: usize = 216052;
+        const EXPECTED_SIZE: usize = 216004;
         #[cfg(not(feature = "unstable_encodings"))]
-        const EXPECTED_SIZE: usize = 216020;
+        const EXPECTED_SIZE: usize = 215972;
 
         let sizes = futures::future::try_join_all(futures).await?;
         for (i, size) in sizes.iter().enumerate() {


### PR DESCRIPTION
Decompress validity in the compressor and pass around zctl in those functions