### PR TITLE
Canonical::empty creates arrays directly instead of going through builders

### DIFF
--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -308,7 +308,7 @@ mod tests {
         let elements = buffer![0i32, 1, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
         let offsets = buffer![0u32, 3, 5, 7, 10].into_array();
         let list_array =
-            ListArray::try_new(elements.clone(), offsets.clone(), Validity::NonNullable).unwrap();
+            ListArray::try_new(elements.clone(), offsets.clone(), Validity::NonNullable)?;
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let list_view = list_view_from_list(list_array.clone(), &mut ctx)?;
@@ -354,8 +354,7 @@ mod tests {
         let empty_elements = PrimitiveArray::from_iter::<[i32; 0]>([]).into_array();
         let empty_offsets = buffer![0u32].into_array();
         let empty_list =
-            ListArray::try_new(empty_elements.clone(), empty_offsets, Validity::NonNullable)
-                .unwrap();
+            ListArray::try_new(empty_elements.clone(), empty_offsets, Validity::NonNullable)?;
 
         // This conversion will create an empty ListViewArray.
         // Note: list_view_from_list handles the empty case specially.
@@ -379,7 +378,7 @@ mod tests {
         let offsets = buffer![0u32, 2, 4, 5].into_array();
         let validity = Validity::Array(BoolArray::from_iter(vec![true, false, true]).into_array());
         let nullable_list =
-            ListArray::try_new(elements.clone(), offsets.clone(), validity.clone()).unwrap();
+            ListArray::try_new(elements.clone(), offsets.clone(), validity.clone())?;
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let nullable_list_view = list_view_from_list(nullable_list.clone(), &mut ctx)?;
@@ -438,8 +437,7 @@ mod tests {
         let elements = buffer![1i32, 2, 3, 4, 5].into_array();
         let i32_offsets = buffer![0i32, 2, 5].into_array();
         let list_i32 =
-            ListArray::try_new(elements.clone(), i32_offsets.clone(), Validity::NonNullable)
-                .unwrap();
+            ListArray::try_new(elements.clone(), i32_offsets.clone(), Validity::NonNullable)?;
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let list_view_i32 = list_view_from_list(list_i32.clone(), &mut ctx)?;
@@ -449,8 +447,7 @@ mod tests {
         // Test with i64 offsets.
         let i64_offsets = buffer![0i64, 2, 5].into_array();
         let list_i64 =
-            ListArray::try_new(elements.clone(), i64_offsets.clone(), Validity::NonNullable)
-                .unwrap();
+            ListArray::try_new(elements.clone(), i64_offsets.clone(), Validity::NonNullable)?;
 
         let list_view_i64 = list_view_from_list(list_i64.clone(), &mut ctx)?;
         assert_eq!(list_view_i64.offsets().dtype(), i64_offsets.dtype());
@@ -493,7 +490,7 @@ mod tests {
         let elements = buffer![100i32, 200, 300].into_array();
         let offsets = buffer![0u32, 1, 2, 3].into_array();
         let single_elem_list =
-            ListArray::try_new(elements.clone(), offsets, Validity::NonNullable).unwrap();
+            ListArray::try_new(elements.clone(), offsets, Validity::NonNullable)?;
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let list_view = list_view_from_list(single_elem_list.clone(), &mut ctx)?;
@@ -515,7 +512,7 @@ mod tests {
         let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
         let offsets = buffer![0u32, 2, 2, 3, 3, 6].into_array();
         let mixed_list =
-            ListArray::try_new(elements.clone(), offsets.clone(), Validity::NonNullable).unwrap();
+            ListArray::try_new(elements.clone(), offsets.clone(), Validity::NonNullable)?;
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let list_view = list_view_from_list(mixed_list.clone(), &mut ctx)?;
@@ -585,8 +582,7 @@ mod tests {
             vec![listview_field, primitive_field],
             4,
             Validity::NonNullable,
-        )
-        .unwrap();
+        )?;
 
         let result = recursive_list_from_list_view(struct_array.clone().into_array())?;
 
@@ -625,8 +621,7 @@ mod tests {
 
         let dtype = lv1.dtype().clone();
         let chunked_listviews =
-            crate::arrays::ChunkedArray::try_new(vec![lv1.into_array(), lv2.into_array()], dtype)
-                .unwrap();
+            crate::arrays::ChunkedArray::try_new(vec![lv1.into_array(), lv2.into_array()], dtype)?;
 
         let fixed_list =
             FixedSizeListArray::new(chunked_listviews.into_array(), 1, Validity::NonNullable, 2);
@@ -658,8 +653,7 @@ mod tests {
             vec![innermost_listview.into_array()],
             2,
             Validity::NonNullable,
-        )
-        .unwrap();
+        )?;
 
         let outer_offsets = buffer![0u32, 1].into_array();
         let outer_sizes = buffer![1u32, 1].into_array();
@@ -700,8 +694,7 @@ mod tests {
             vec![listview.into_array(), list.into_array()],
             4,
             Validity::NonNullable,
-        )
-        .unwrap();
+        )?;
 
         let result = recursive_list_from_list_view(struct_array.clone().into_array())?;
 

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -12,6 +12,7 @@ use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::DynArray;
 use crate::IntoArray;
 use crate::arrays::ListArray;
@@ -297,6 +298,10 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
 
     fn finish(&mut self) -> ArrayRef {
         self.finish_into_list().into_array()
+    }
+
+    fn finish_into_canonical(&mut self) -> Canonical {
+        Canonical::List(self.finish_into_list().to_listview())
     }
 }
 

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -30,7 +30,6 @@
 
 use std::any::Any;
 
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 use vortex_mask::Mask;
@@ -211,11 +210,7 @@ pub trait ArrayBuilder: Send {
     /// This method provides a default implementation that creates an [`ArrayRef`] via `finish` and
     /// then converts it to canonical form. Specific builders can override this with optimized
     /// implementations that avoid the intermediate [`ArrayRef`] creation.
-    fn finish_into_canonical(&mut self) -> Canonical {
-        self.finish()
-            .to_canonical()
-            .vortex_expect("finish_into_canonical failed")
-    }
+    fn finish_into_canonical(&mut self) -> Canonical;
 }
 
 /// Construct a new canonical builder for the given [`DType`].

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -208,6 +208,7 @@ impl Canonical {
                         .into_array(),
                     Validity::from(n),
                 )
+                .with_zero_copy_to_list(true)
             }),
             DType::FixedSizeList(elem_dtype, list_size, null) => Canonical::FixedSizeList(unsafe {
                 FixedSizeListArray::new_unchecked(

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -44,10 +44,14 @@ use crate::arrays::VarBinViewArray;
 use crate::arrays::VarBinViewArrayParts;
 use crate::arrays::VarBinViewVTable;
 use crate::arrays::constant_canonicalize;
-use crate::builders::builder_with_capacity;
 use crate::dtype::DType;
 use crate::dtype::NativePType;
+use crate::dtype::Nullability;
+use crate::dtype::PType;
+use crate::match_each_decimal_value_type;
+use crate::match_each_native_ptype;
 use crate::matcher::Matcher;
+use crate::validity::Validity;
 
 /// An enum capturing the default uncompressed encodings for each [Vortex type](DType).
 ///
@@ -140,10 +144,84 @@ macro_rules! match_each_canonical {
 }
 
 impl Canonical {
-    // TODO(connor): This can probably be specialized for each of the canonical arrays.
     /// Create an empty canonical array of the given dtype.
     pub fn empty(dtype: &DType) -> Canonical {
-        builder_with_capacity(dtype, 0).finish_into_canonical()
+        match dtype {
+            DType::Null => Canonical::Null(NullArray::new(0)),
+            DType::Bool(n) => Canonical::Bool(unsafe {
+                BoolArray::new_unchecked(BitBuffer::empty(), Validity::from(n))
+            }),
+            DType::Primitive(ptype, n) => {
+                match_each_native_ptype!(ptype, |P| {
+                    Canonical::Primitive(unsafe {
+                        PrimitiveArray::new_unchecked(Buffer::<P>::empty(), Validity::from(n))
+                    })
+                })
+            }
+            DType::Decimal(decimal_type, n) => {
+                match_each_decimal_value_type!(
+                    DecimalType::smallest_decimal_value_type(decimal_type),
+                    |D| {
+                        Canonical::Decimal(unsafe {
+                            DecimalArray::new_unchecked::<D>(
+                                Buffer::empty(),
+                                *decimal_type,
+                                Validity::from(n),
+                            )
+                        })
+                    }
+                )
+            }
+            DType::Utf8(n) => Canonical::VarBinView(unsafe {
+                VarBinViewArray::new_unchecked(
+                    Buffer::empty(),
+                    Arc::new([]),
+                    dtype.clone(),
+                    Validity::from(n),
+                )
+            }),
+            DType::Binary(n) => Canonical::VarBinView(unsafe {
+                VarBinViewArray::new_unchecked(
+                    Buffer::empty(),
+                    Arc::new([]),
+                    dtype.clone(),
+                    Validity::from(n),
+                )
+            }),
+            DType::Struct(struct_dtype, n) => Canonical::Struct(unsafe {
+                StructArray::new_unchecked(
+                    struct_dtype
+                        .fields()
+                        .map(|f| Canonical::empty(&f).into_array())
+                        .collect::<Arc<[_]>>(),
+                    struct_dtype.clone(),
+                    0,
+                    Validity::from(n),
+                )
+            }),
+            DType::List(dtype, n) => Canonical::List(unsafe {
+                ListViewArray::new_unchecked(
+                    Canonical::empty(dtype).into_array(),
+                    Canonical::empty(&DType::Primitive(PType::U8, Nullability::NonNullable))
+                        .into_array(),
+                    Canonical::empty(&DType::Primitive(PType::U8, Nullability::NonNullable))
+                        .into_array(),
+                    Validity::from(n),
+                )
+            }),
+            DType::FixedSizeList(elem_dtype, list_size, null) => Canonical::FixedSizeList(unsafe {
+                FixedSizeListArray::new_unchecked(
+                    Canonical::empty(elem_dtype).into_array(),
+                    *list_size,
+                    Validity::from(null),
+                    0,
+                )
+            }),
+            DType::Extension(ext_dtype) => Canonical::Extension(ExtensionArray::new(
+                ext_dtype.clone(),
+                Canonical::empty(ext_dtype.storage_dtype()).into_array(),
+            )),
+        }
     }
 
     pub fn len(&self) -> usize {


### PR DESCRIPTION
Gets rid of one more todo and avoids creating builders and array refs just to go back to canonical enum