### PR TITLE
perf: faster sequence array decompress

### DIFF
--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -383,17 +383,7 @@ impl VTable for SequenceVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        let prim = match_each_native_ptype!(array.ptype(), |P| {
-            let base = array.base().cast::<P>()?;
-            let multiplier = array.multiplier().cast::<P>()?;
-            let values = BufferMut::from_iter(
-                (0..array.len())
-                    .map(|i| base + <P>::from_usize(i).vortex_expect("must fit") * multiplier),
-            );
-            PrimitiveArray::new(values, array.dtype.nullability().into())
-        });
-
-        Ok(prim.into_array())
+        crate::compress::sequence_decompress(array)
     }
 
     fn execute_parent(

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -7,11 +7,9 @@ use num_traits::cast::FromPrimitive;
 use vortex_array::ArrayRef;
 use vortex_array::DeserializeMetadata;
 use vortex_array::ExecutionCtx;
-use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
-use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
@@ -36,7 +34,6 @@ use vortex_array::vtable::ArrayId;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
-use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -45,6 +42,7 @@ use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 
+use crate::compress::sequence_decompress;
 use crate::kernel::PARENT_KERNELS;
 use crate::rules::RULES;
 
@@ -383,7 +381,7 @@ impl VTable for SequenceVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        crate::compress::sequence_decompress(array)
+        sequence_decompress(array)
     }
 
     fn execute_parent(

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -9,10 +9,35 @@ use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
 use vortex_array::match_each_integer_ptype;
+use vortex_array::match_each_native_ptype;
 use vortex_array::scalar::PValue;
+use vortex_array::validity::Validity;
+use vortex_buffer::BufferMut;
 use vortex_error::VortexResult;
 
 use crate::SequenceArray;
+
+/// Decompresses a [`SequenceArray`] into a [`PrimitiveArray`].
+pub fn sequence_decompress(array: &SequenceArray) -> VortexResult<ArrayRef> {
+    let prim = match_each_native_ptype!(array.ptype(), |P| {
+        let base = array.base().cast::<P>()?;
+        let multiplier = array.multiplier().cast::<P>()?;
+        let len = array.len();
+        // Construction validates len-1 fits in P (via try_last), so we
+        // can use an accumulator without per-element overflow checks.
+        let mut values = BufferMut::<P>::with_capacity(len);
+        let spare = values.spare_capacity_mut();
+        let mut acc = base;
+        for v in &mut spare[..len] {
+            v.write(acc);
+            acc += multiplier;
+        }
+        // SAFETY: we initialized exactly `len` elements above.
+        unsafe { values.set_len(len) };
+        PrimitiveArray::new(values, Validity::from(array.dtype().nullability()))
+    });
+    Ok(prim.into_array())
+}
 
 /// Encodes a primitive array into a sequence array, this is possible if:
 /// 1. The array is not empty, and contains no nulls

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -28,8 +28,11 @@ use vortex::encodings::fsst::fsst_compress;
 use vortex::encodings::fsst::fsst_train_compressor;
 use vortex::encodings::pco::PcoArray;
 use vortex::encodings::runend::RunEndArray;
+use vortex::encodings::sequence::sequence_encode;
 use vortex::encodings::zigzag::zigzag_encode;
 use vortex::encodings::zstd::ZstdArray;
+use vortex_array::dtype::Nullability;
+use vortex_sequence::SequenceArray;
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -208,6 +211,29 @@ fn bench_zigzag_compress_i32(bencher: Bencher) {
 fn bench_zigzag_decompress_i32(bencher: Bencher) {
     let (_, int_array, _) = setup_primitive_arrays();
     let compressed = zigzag_encode(int_array).unwrap();
+
+    with_byte_counter(bencher, NUM_VALUES * 4)
+        .with_inputs(|| &compressed)
+        .bench_refs(|a| a.to_canonical());
+}
+
+#[expect(clippy::cast_possible_truncation)]
+#[divan::bench(name = "sequence_compress_u32")]
+fn bench_sequence_compress_u32(bencher: Bencher) {
+    let seq_array = PrimitiveArray::from_iter(0..NUM_VALUES as u32);
+
+    with_byte_counter(bencher, NUM_VALUES * 4)
+        .with_inputs(|| seq_array.clone())
+        .bench_values(|a| sequence_encode(&a).unwrap().unwrap());
+}
+
+#[expect(clippy::cast_possible_truncation)]
+#[divan::bench(name = "sequence_decompress_u32")]
+fn bench_sequence_decompress_u32(bencher: Bencher) {
+    let compressed =
+        SequenceArray::try_new_typed(0, 1, Nullability::NonNullable, NUM_VALUES as usize)
+            .unwrap()
+            .into_array();
 
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| &compressed)


### PR DESCRIPTION
Also adds a seq compress/decompress bench

locally
```
  │        │ Median │ Throughput │                                                                                                                                                 
  ├────────┼────────┼────────────┤                                                                                                                                                 
  │ Before │ ~60 µs │ ~67 GB/s   │                                                                                                                                                 
  ├────────┼────────┼────────────┤                                                                                                                                                 
  │ After  │ ~40 µs │ ~99 GB/s   │
```