### PR TITLE
Remove reuse lint check

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -53,40 +53,7 @@ ROOT_DIR="$(git rev-parse --show-toplevel)"
 cd "$ROOT_DIR"
 
 # ============================================================================
-# CHECK 1: REUSE Compliance (License Headers)
-# ============================================================================
-# Ensure all files have proper license headers as required by REUSE specification.
-# This helps maintain clear licensing information throughout the codebase.
-
-print_header "📜 Checking REUSE compliance"
-
-if ! command -v reuse &> /dev/null; then
-    print_warning "⚠️  REUSE tool not found - skipping license check."
-    echo "   Install from: https://reuse.software/"
-else
-    # Run REUSE lint check.
-    REUSE_OUTPUT=$(reuse lint 2>&1)
-    REUSE_EXIT_CODE=$?
-
-    if [ $REUSE_EXIT_CODE -eq 0 ]; then
-        print_success "✅ REUSE compliant - all files have proper license headers"
-    else
-        print_error "❌ REUSE compliance check failed"
-        echo
-        # Show first 30 lines of errors.
-        echo "$REUSE_OUTPUT" | head -30
-        if [ $(echo "$REUSE_OUTPUT" | wc -l) -gt 30 ]; then
-            echo
-            echo "... (output truncated, run 'reuse lint' for full report)"
-        fi
-        echo
-        print_warning "⚠️  To skip checks: git commit --no-verify"
-        exit 1
-    fi
-fi
-
-# ============================================================================
-# CHECK 2: Code Formatting
+# CHECK: Code Formatting
 # ============================================================================
 # Verify that all Rust code and TOML files follow the project's formatting standards.
 # Consistent formatting improves readability and reduces merge conflicts.


### PR DESCRIPTION
## Summary

For some reason, `reuse lint` has slowly gotten slower and slower to run on my machine over the past few months. To the point where I can't be bothered to run it anymore pre commit.

## Testing

N/A
