### PR TITLE
perf: faster sequence array decompress iter

### DIFF
--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::ops::Add;
+
 use num_traits::CheckedAdd;
 use num_traits::CheckedSub;
 use vortex_array::ArrayRef;
@@ -13,28 +15,64 @@ use vortex_array::match_each_native_ptype;
 use vortex_array::scalar::PValue;
 use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
+use vortex_buffer::trusted_len::TrustedLen;
 use vortex_error::VortexResult;
 
 use crate::SequenceArray;
 
+/// An iterator that yields `base, base + step, base + 2*step, ...` via repeated addition.
+struct SequenceIter<T> {
+    acc: T,
+    step: T,
+    remaining: usize,
+}
+
+impl<T: Copy + Add<Output = T>> Iterator for SequenceIter<T> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<T> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let val = self.acc;
+        self.remaining -= 1;
+        if self.remaining > 0 {
+            self.acc = self.acc + self.step;
+        }
+        Some(val)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+// SAFETY: `size_hint` returns an exact count and `next` yields exactly that many items.
+unsafe impl<T: Copy + Add<Output = T>> TrustedLen for SequenceIter<T> {}
+
 /// Decompresses a [`SequenceArray`] into a [`PrimitiveArray`].
+#[inline]
 pub fn sequence_decompress(array: &SequenceArray) -> VortexResult<ArrayRef> {
+    fn decompress_inner<P: NativePType>(
+        base: P,
+        multiplier: P,
+        len: usize,
+        nullability: Nullability,
+    ) -> PrimitiveArray {
+        let values = BufferMut::from_trusted_len_iter(SequenceIter {
+            acc: base,
+            step: multiplier,
+            remaining: len,
+        });
+        PrimitiveArray::new(values, Validity::from(nullability))
+    }
+
     let prim = match_each_native_ptype!(array.ptype(), |P| {
         let base = array.base().cast::<P>()?;
         let multiplier = array.multiplier().cast::<P>()?;
-        let len = array.len();
-        // Construction validates len-1 fits in P (via try_last), so we
-        // can use an accumulator without per-element overflow checks.
-        let mut values = BufferMut::<P>::with_capacity(len);
-        let spare = values.spare_capacity_mut();
-        let mut acc = base;
-        for v in &mut spare[..len] {
-            v.write(acc);
-            acc += multiplier;
-        }
-        // SAFETY: we initialized exactly `len` elements above.
-        unsafe { values.set_len(len) };
-        PrimitiveArray::new(values, Validity::from(array.dtype().nullability()))
+        decompress_inner(base, multiplier, array.len(), array.dtype().nullability())
     });
     Ok(prim.into_array())
 }
@@ -143,5 +181,14 @@ mod tests {
 
         let encoded = sequence_encode(&primitive_array).unwrap();
         assert!(encoded.is_none());
+    }
+
+    #[test]
+    fn test_encode_all_u8_values() {
+        let primitive_array = PrimitiveArray::from_iter(0u8..=255);
+        let encoded = sequence_encode(&primitive_array).unwrap();
+        assert!(encoded.is_some());
+        let decoded = encoded.unwrap().to_primitive();
+        assert_arrays_eq!(decoded, primitive_array);
     }
 }

--- a/vortex-buffer/public-api.lock
+++ b/vortex-buffer/public-api.lock
@@ -14,6 +14,138 @@ pub use vortex_buffer::UnalignedBitChunk
 
 pub use vortex_buffer::UnalignedBitChunkIterator
 
+pub mod vortex_buffer::trusted_len
+
+pub struct vortex_buffer::trusted_len::TrustedLenAdapter<I>
+
+impl<I: core::iter::traits::iterator::Iterator> core::iter::traits::iterator::Iterator for vortex_buffer::trusted_len::TrustedLenAdapter<I>
+
+pub type vortex_buffer::trusted_len::TrustedLenAdapter<I>::Item = <I as core::iter::traits::iterator::Iterator>::Item
+
+pub fn vortex_buffer::trusted_len::TrustedLenAdapter<I>::next(&mut self) -> core::option::Option<Self::Item>
+
+pub fn vortex_buffer::trusted_len::TrustedLenAdapter<I>::size_hint(&self) -> (usize, core::option::Option<usize>)
+
+impl<I: core::iter::traits::iterator::Iterator> vortex_buffer::trusted_len::TrustedLen for vortex_buffer::trusted_len::TrustedLenAdapter<I>
+
+pub unsafe trait vortex_buffer::trusted_len::TrustedLen: core::iter::traits::iterator::Iterator
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::Range<i16>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::Range<i32>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::Range<i64>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::Range<i8>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::Range<u16>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::Range<u32>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::Range<u64>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::Range<u8>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::Range<usize>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::RangeInclusive<i16>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::RangeInclusive<i32>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::RangeInclusive<i64>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::RangeInclusive<i8>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::RangeInclusive<u16>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::RangeInclusive<u32>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::RangeInclusive<u64>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::RangeInclusive<u8>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::step_by::StepBy<core::ops::range::RangeInclusive<usize>>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::Range<i16>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::Range<i32>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::Range<i64>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::Range<i8>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::Range<u16>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::Range<u32>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::Range<u64>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::Range<u8>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::Range<usize>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::RangeInclusive<i16>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::RangeInclusive<i32>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::RangeInclusive<i64>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::RangeInclusive<i8>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::RangeInclusive<u16>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::RangeInclusive<u32>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::RangeInclusive<u64>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::RangeInclusive<u8>
+
+impl vortex_buffer::trusted_len::TrustedLen for core::ops::range::RangeInclusive<usize>
+
+impl<'a, I, T: 'a, E: 'a> vortex_buffer::trusted_len::TrustedLen for itertools::process_results_impl::ProcessResults<'a, I, E> where I: vortex_buffer::trusted_len::TrustedLen<Item = core::result::Result<T, E>>
+
+impl<'a, I, T> vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::cloned::Cloned<I> where I: vortex_buffer::trusted_len::TrustedLen<Item = &'a T>, T: core::clone::Clone + 'a
+
+impl<'a, I, T> vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::copied::Copied<I> where I: vortex_buffer::trusted_len::TrustedLen<Item = &'a T>, T: core::marker::Copy + 'a
+
+impl<'a> vortex_buffer::trusted_len::TrustedLen for arrow_buffer::util::bit_chunk_iterator::BitChunkIterator<'a>
+
+impl<'a> vortex_buffer::trusted_len::TrustedLen for arrow_buffer::util::bit_chunk_iterator::UnalignedBitChunkIterator<'a>
+
+impl<'a> vortex_buffer::trusted_len::TrustedLen for arrow_buffer::util::bit_iterator::BitIterator<'a>
+
+impl<B, I, F> vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::map::Map<I, F> where I: vortex_buffer::trusted_len::TrustedLen, F: core::ops::function::FnMut(<I as core::iter::traits::iterator::Iterator>::Item) -> B
+
+impl<I, T> vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::enumerate::Enumerate<I> where I: vortex_buffer::trusted_len::TrustedLen<Item = T>
+
+impl<I: core::iter::traits::iterator::Iterator> vortex_buffer::trusted_len::TrustedLen for vortex_buffer::trusted_len::TrustedLenAdapter<I>
+
+impl<I> vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::skip::Skip<I> where I: vortex_buffer::trusted_len::TrustedLen
+
+impl<T, U> vortex_buffer::trusted_len::TrustedLen for core::iter::adapters::zip::Zip<T, U> where T: vortex_buffer::trusted_len::TrustedLen, U: vortex_buffer::trusted_len::TrustedLen
+
+impl<T, const N: usize> vortex_buffer::trusted_len::TrustedLen for core::array::iter::IntoIter<T, N>
+
+impl<T: core::clone::Clone> vortex_buffer::trusted_len::TrustedLen for core::iter::sources::repeat_n::RepeatN<T>
+
+impl<T: core::marker::Copy> vortex_buffer::trusted_len::TrustedLen for vortex_buffer::BufferIterator<T>
+
+impl<T> vortex_buffer::trusted_len::TrustedLen for alloc::vec::into_iter::IntoIter<T>
+
+impl<T> vortex_buffer::trusted_len::TrustedLen for core::slice::iter::Iter<'_, T>
+
+impl<T> vortex_buffer::trusted_len::TrustedLen for core::slice::iter::IterMut<'_, T>
+
+impl<T> vortex_buffer::trusted_len::TrustedLen for vortex_buffer::Iter<'_, T>
+
+pub trait vortex_buffer::trusted_len::TrustedLenExt: core::iter::traits::iterator::Iterator + core::marker::Sized
+
+pub unsafe fn vortex_buffer::trusted_len::TrustedLenExt::trusted_len(self) -> vortex_buffer::trusted_len::TrustedLenAdapter<Self>
+
+impl<I: core::iter::traits::iterator::Iterator> vortex_buffer::trusted_len::TrustedLenExt for I
+
+pub unsafe fn I::trusted_len(self) -> vortex_buffer::trusted_len::TrustedLenAdapter<Self>
+
 pub macro vortex_buffer::bitbuffer!
 
 pub macro vortex_buffer::bitbuffer_mut!
@@ -582,6 +714,8 @@ pub fn vortex_buffer::BufferIterator<T>::next(&mut self) -> core::option::Option
 
 pub fn vortex_buffer::BufferIterator<T>::size_hint(&self) -> (usize, core::option::Option<usize>)
 
+impl<T: core::marker::Copy> vortex_buffer::trusted_len::TrustedLen for vortex_buffer::BufferIterator<T>
+
 pub struct vortex_buffer::BufferMut<T>
 
 impl<T> vortex_buffer::BufferMut<T>
@@ -865,6 +999,8 @@ pub fn vortex_buffer::Iter<'a, T>::size_hint(&self) -> (usize, core::option::Opt
 impl<T> core::iter::traits::exact_size::ExactSizeIterator for vortex_buffer::Iter<'_, T>
 
 pub fn vortex_buffer::Iter<'_, T>::len(&self) -> usize
+
+impl<T> vortex_buffer::trusted_len::TrustedLen for vortex_buffer::Iter<'_, T>
 
 pub const vortex_buffer::ALIGNMENT_TO_HOST_COPY: vortex_buffer::Alignment
 

--- a/vortex-buffer/src/lib.rs
+++ b/vortex-buffer/src/lib.rs
@@ -70,7 +70,8 @@ mod memmap2;
 #[cfg(feature = "serde")]
 mod serde;
 mod string;
-mod trusted_len;
+/// Trusted-length iterator trait and adapters for safe pre-allocation.
+pub mod trusted_len;
 
 /// An immutable buffer of u8.
 pub type ByteBuffer = Buffer<u8>;

--- a/vortex-buffer/src/trusted_len.rs
+++ b/vortex-buffer/src/trusted_len.rs
@@ -65,6 +65,7 @@ impl<I: Iterator> Iterator for TrustedLenAdapter<I> {
 
 unsafe impl<I: Iterator> TrustedLen for TrustedLenAdapter<I> {}
 
+/// Extension trait for wrapping any iterator in a [`TrustedLenAdapter`].
 pub trait TrustedLenExt: Iterator + Sized {
     /// Wraps this iterator in a `TrustedLenAdapter`.
     ///


### PR DESCRIPTION
Fixes an overflow bug.
Uses an fixed sized iter instead of a ptr to decompress.