### PR TITLE
Log which FS is used in DuckDB as debug

### DIFF
--- a/vortex-duckdb/src/filesystem.rs
+++ b/vortex-duckdb/src/filesystem.rs
@@ -53,7 +53,7 @@ pub(super) fn resolve_filesystem(
     let fs_config = fs_config.as_string();
 
     Ok(if fs_config.as_str() == "duckdb" {
-        tracing::info!(
+        tracing::debug!(
             "Using DuckDB's built-in filesystem for URL scheme '{}'",
             base_url.scheme()
         );
@@ -63,7 +63,7 @@ pub(super) fn resolve_filesystem(
             ctx.erase_lifetime()
         }))
     } else if fs_config.as_str() == "vortex" {
-        tracing::info!(
+        tracing::debug!(
             "Using Vortex's object store filesystem for URL scheme '{}'",
             base_url.scheme()
         );


### PR DESCRIPTION
This log is currently just noisy in benchmarks, I remember that's was the thing we agreed to do