### PR TITLE
feat: Iterative Execution

### DIFF
--- a/encodings/alp/public-api.lock
+++ b/encodings/alp/public-api.lock
@@ -204,7 +204,7 @@ pub fn vortex_alp::ALPRDVTable::deserialize(bytes: &[u8], _dtype: &vortex_array:
 
 pub fn vortex_alp::ALPRDVTable::dtype(array: &vortex_alp::ALPRDArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_alp::ALPRDVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_alp::ALPRDVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_alp::ALPRDVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
@@ -308,7 +308,7 @@ pub fn vortex_alp::ALPVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::d
 
 pub fn vortex_alp::ALPVTable::dtype(array: &vortex_alp::ALPArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_alp::ALPVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_alp::ALPVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_alp::ALPVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -10,6 +10,7 @@ use vortex_array::ArrayRef;
 use vortex_array::DeserializeMetadata;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
@@ -234,9 +235,11 @@ impl VTable for ALPVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
         // TODO(joe): take by value
-        Ok(execute_decompress(array.clone(), ctx)?.into_array())
+        Ok(ExecutionStep::Done(
+            execute_decompress(array.clone(), ctx)?.into_array(),
+        ))
     }
 
     fn reduce_parent(

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -11,6 +11,7 @@ use vortex_array::ArrayRef;
 use vortex_array::DeserializeMetadata;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
@@ -295,7 +296,7 @@ impl VTable for ALPRDVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
         let left_parts = array.left_parts().clone().execute::<PrimitiveArray>(ctx)?;
         let right_parts = array.right_parts().clone().execute::<PrimitiveArray>(ctx)?;
 
@@ -334,7 +335,7 @@ impl VTable for ALPRDVTable {
             )
         };
 
-        Ok(decoded_array.into_array())
+        Ok(ExecutionStep::Done(decoded_array.into_array()))
     }
 
     fn reduce_parent(

--- a/encodings/bytebool/public-api.lock
+++ b/encodings/bytebool/public-api.lock
@@ -108,7 +108,7 @@ pub fn vortex_bytebool::ByteBoolVTable::deserialize(_bytes: &[u8], _dtype: &vort
 
 pub fn vortex_bytebool::ByteBoolVTable::dtype(array: &vortex_bytebool::ByteBoolArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_bytebool::ByteBoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_bytebool::ByteBoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_bytebool::ByteBoolVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -9,6 +9,7 @@ use vortex_array::ArrayHash;
 use vortex_array::ArrayRef;
 use vortex_array::EmptyMetadata;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::arrays::BoolArray;
@@ -182,10 +183,12 @@ impl VTable for ByteBoolVTable {
         crate::rules::RULES.evaluate(array, parent, child_idx)
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
         let boolean_buffer = BitBuffer::from(array.as_slice());
         let validity = array.validity().clone();
-        Ok(BoolArray::new(boolean_buffer, validity).into_array())
+        Ok(ExecutionStep::Done(
+            BoolArray::new(boolean_buffer, validity).into_array(),
+        ))
     }
 
     fn execute_parent(

--- a/encodings/datetime-parts/public-api.lock
+++ b/encodings/datetime-parts/public-api.lock
@@ -182,7 +182,7 @@ pub fn vortex_datetime_parts::DateTimePartsVTable::deserialize(bytes: &[u8], _dt
 
 pub fn vortex_datetime_parts::DateTimePartsVTable::dtype(array: &vortex_datetime_parts::DateTimePartsArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_datetime_parts::DateTimePartsVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_datetime_parts::DateTimePartsVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_datetime_parts::DateTimePartsVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -10,6 +10,7 @@ use vortex_array::ArrayRef;
 use vortex_array::DeserializeMetadata;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
@@ -221,8 +222,10 @@ impl VTable for DateTimePartsVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(decode_to_temporal(array, ctx)?.into_array())
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(
+            decode_to_temporal(array, ctx)?.into_array(),
+        ))
     }
 
     fn reduce_parent(

--- a/encodings/decimal-byte-parts/public-api.lock
+++ b/encodings/decimal-byte-parts/public-api.lock
@@ -112,7 +112,7 @@ pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::deserialize(bytes: &[u
 
 pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::dtype(array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -13,6 +13,7 @@ use vortex_array::ArrayHash;
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
@@ -189,8 +190,8 @@ impl VTable for DecimalBytePartsVTable {
         PARENT_RULES.evaluate(array, parent, child_idx)
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        to_canonical_decimal(array, ctx)
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        to_canonical_decimal(array, ctx).map(ExecutionStep::Done)
     }
 
     fn execute_parent(

--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -242,7 +242,7 @@ pub fn vortex_fastlanes::BitPackedVTable::deserialize(bytes: &[u8], _dtype: &vor
 
 pub fn vortex_fastlanes::BitPackedVTable::dtype(array: &vortex_fastlanes::BitPackedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_fastlanes::BitPackedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_fastlanes::BitPackedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_fastlanes::BitPackedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
@@ -372,7 +372,7 @@ pub fn vortex_fastlanes::DeltaVTable::deserialize(bytes: &[u8], _dtype: &vortex_
 
 pub fn vortex_fastlanes::DeltaVTable::dtype(array: &vortex_fastlanes::DeltaArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_fastlanes::DeltaVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_fastlanes::DeltaVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_fastlanes::DeltaVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
 
@@ -510,7 +510,7 @@ pub fn vortex_fastlanes::FoRVTable::deserialize(bytes: &[u8], dtype: &vortex_arr
 
 pub fn vortex_fastlanes::FoRVTable::dtype(array: &vortex_fastlanes::FoRArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_fastlanes::FoRVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_fastlanes::FoRVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_fastlanes::FoRVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
@@ -646,7 +646,7 @@ pub fn vortex_fastlanes::RLEVTable::deserialize(bytes: &[u8], _dtype: &vortex_ar
 
 pub fn vortex_fastlanes::RLEVTable::dtype(array: &vortex_fastlanes::RLEArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_fastlanes::RLEVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_fastlanes::RLEVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_fastlanes::RLEVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -8,6 +8,7 @@ use vortex_array::ArrayHash;
 use vortex_array::ArrayRef;
 use vortex_array::DeserializeMetadata;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
@@ -353,8 +354,8 @@ impl VTable for BitPackedVTable {
         })
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(unpack_array(array, ctx)?.into_array())
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(unpack_array(array, ctx)?.into_array()))
     }
 
     fn execute_parent(

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -9,6 +9,7 @@ use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
@@ -189,8 +190,10 @@ impl VTable for DeltaVTable {
         DeltaArray::try_new(bases, deltas, metadata.0.offset as usize, len)
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(delta_decompress(array, ctx)?.into_array())
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(
+            delta_decompress(array, ctx)?.into_array(),
+        ))
     }
 }
 

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -8,6 +8,7 @@ use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::buffer::BufferHandle;
@@ -165,8 +166,8 @@ impl VTable for FoRVTable {
         PARENT_RULES.evaluate(array, parent, child_idx)
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(decompress(array, ctx)?.into_array())
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(decompress(array, ctx)?.into_array()))
     }
 
     fn execute_parent(

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -8,6 +8,7 @@ use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
@@ -230,8 +231,10 @@ impl VTable for RLEVTable {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(rle_decompress(array, ctx)?.into_array())
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(
+            rle_decompress(array, ctx)?.into_array(),
+        ))
     }
 }
 

--- a/encodings/fsst/public-api.lock
+++ b/encodings/fsst/public-api.lock
@@ -146,7 +146,7 @@ pub fn vortex_fsst::FSSTVTable::deserialize(bytes: &[u8], _dtype: &vortex_array:
 
 pub fn vortex_fsst::FSSTVTable::dtype(array: &vortex_fsst::FSSTArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_fsst::FSSTVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_fsst::FSSTVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_fsst::FSSTVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -17,6 +17,7 @@ use vortex_array::Canonical;
 use vortex_array::DeserializeMetadata;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
@@ -338,8 +339,8 @@ impl VTable for FSSTVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        canonicalize_fsst(array, ctx)
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        canonicalize_fsst(array, ctx).map(ExecutionStep::Done)
     }
 
     fn execute_parent(

--- a/encodings/pco/public-api.lock
+++ b/encodings/pco/public-api.lock
@@ -160,7 +160,7 @@ pub fn vortex_pco::PcoVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::d
 
 pub fn vortex_pco::PcoVTable::dtype(array: &vortex_pco::PcoArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_pco::PcoVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_pco::PcoVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_pco::PcoVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
 

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -20,6 +20,7 @@ use vortex_array::ArrayHash;
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
@@ -262,8 +263,8 @@ impl VTable for PcoVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.decompress()?.into_array())
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(array.decompress()?.into_array()))
     }
 
     fn reduce_parent(

--- a/encodings/runend/public-api.lock
+++ b/encodings/runend/public-api.lock
@@ -182,7 +182,7 @@ pub fn vortex_runend::RunEndVTable::deserialize(bytes: &[u8], _dtype: &vortex_ar
 
 pub fn vortex_runend::RunEndVTable::dtype(array: &vortex_runend::RunEndArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_runend::RunEndVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_runend::RunEndVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_runend::RunEndVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -10,6 +10,7 @@ use vortex_array::ArrayRef;
 use vortex_array::DeserializeMetadata;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
@@ -202,8 +203,8 @@ impl VTable for RunEndVTable {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        run_end_canonicalize(array, ctx)
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        run_end_canonicalize(array, ctx).map(ExecutionStep::Done)
     }
 }
 

--- a/encodings/sequence/public-api.lock
+++ b/encodings/sequence/public-api.lock
@@ -132,7 +132,7 @@ pub fn vortex_sequence::SequenceVTable::deserialize(bytes: &[u8], dtype: &vortex
 
 pub fn vortex_sequence::SequenceVTable::dtype(array: &vortex_sequence::SequenceArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_sequence::SequenceVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_sequence::SequenceVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_sequence::SequenceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -8,11 +8,9 @@ use vortex_array::ArrayRef;
 use vortex_array::DeserializeMetadata;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionStep;
-use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
-use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
@@ -37,7 +35,6 @@ use vortex_array::vtable::ArrayId;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
-use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -385,17 +382,7 @@ impl VTable for SequenceVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
-        let prim = match_each_native_ptype!(array.ptype(), |P| {
-            let base = array.base().cast::<P>()?;
-            let multiplier = array.multiplier().cast::<P>()?;
-            let values = BufferMut::from_iter(
-                (0..array.len())
-                    .map(|i| base + <P>::from_usize(i).vortex_expect("must fit") * multiplier),
-            );
-            PrimitiveArray::new(values, array.dtype.nullability().into())
-        });
-
-        Ok(ExecutionStep::Done(prim.into_array()))
+        sequence_decompress(array).map(ExecutionStep::Done)
     }
 
     fn execute_parent(

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -5,7 +5,6 @@ use std::hash::Hash;
 
 use num_traits::cast::FromPrimitive;
 use vortex_array::ArrayRef;
-use vortex_array::arrays::PrimitiveArray;
 use vortex_array::DeserializeMetadata;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionStep;
@@ -13,6 +12,7 @@ use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -5,8 +5,11 @@ use std::hash::Hash;
 
 use num_traits::cast::FromPrimitive;
 use vortex_array::ArrayRef;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::DeserializeMetadata;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
+use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
@@ -34,6 +37,7 @@ use vortex_array::vtable::ArrayId;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
+use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -380,8 +384,18 @@ impl VTable for SequenceVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        sequence_decompress(array)
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        let prim = match_each_native_ptype!(array.ptype(), |P| {
+            let base = array.base().cast::<P>()?;
+            let multiplier = array.multiplier().cast::<P>()?;
+            let values = BufferMut::from_iter(
+                (0..array.len())
+                    .map(|i| base + <P>::from_usize(i).vortex_expect("must fit") * multiplier),
+            );
+            PrimitiveArray::new(values, array.dtype.nullability().into())
+        });
+
+        Ok(ExecutionStep::Done(prim.into_array()))
     }
 
     fn execute_parent(

--- a/encodings/sparse/public-api.lock
+++ b/encodings/sparse/public-api.lock
@@ -130,7 +130,7 @@ pub fn vortex_sparse::SparseVTable::deserialize(bytes: &[u8], dtype: &vortex_arr
 
 pub fn vortex_sparse::SparseVTable::dtype(array: &vortex_sparse::SparseArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_sparse::SparseVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_sparse::SparseVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_sparse::SparseVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -11,6 +11,7 @@ use vortex_array::ArrayHash;
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ToCanonical;
@@ -255,8 +256,8 @@ impl VTable for SparseVTable {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        execute_sparse(array, ctx)
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        execute_sparse(array, ctx).map(ExecutionStep::Done)
     }
 }
 

--- a/encodings/zigzag/public-api.lock
+++ b/encodings/zigzag/public-api.lock
@@ -100,7 +100,7 @@ pub fn vortex_zigzag::ZigZagVTable::deserialize(_bytes: &[u8], _dtype: &vortex_a
 
 pub fn vortex_zigzag::ZigZagVTable::dtype(array: &vortex_zigzag::ZigZagArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_zigzag::ZigZagVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_zigzag::ZigZagVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_zigzag::ZigZagVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -9,6 +9,7 @@ use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::EmptyMetadata;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::buffer::BufferHandle;
@@ -148,8 +149,10 @@ impl VTable for ZigZagVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(zigzag_decode(array.encoded().clone().execute(ctx)?).into_array())
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(
+            zigzag_decode(array.encoded().clone().execute(ctx)?).into_array(),
+        ))
     }
 
     fn reduce_parent(

--- a/encodings/zstd/public-api.lock
+++ b/encodings/zstd/public-api.lock
@@ -200,7 +200,7 @@ pub fn vortex_zstd::ZstdVTable::deserialize(bytes: &[u8], _dtype: &vortex_array:
 
 pub fn vortex_zstd::ZstdVTable::dtype(array: &vortex_zstd::ZstdArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_zstd::ZstdVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::ArrayRef>
+pub fn vortex_zstd::ZstdVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
 pub fn vortex_zstd::ZstdVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
 

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -13,6 +13,7 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
@@ -271,8 +272,11 @@ impl VTable for ZstdVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        array.decompress()?.execute(ctx)
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        array
+            .decompress()?
+            .execute::<ArrayRef>(ctx)
+            .map(ExecutionStep::Done)
     }
 
     fn reduce_parent(

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -10,6 +10,7 @@ use vortex_array::ArrayEq;
 use vortex_array::ArrayHash;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionStep;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::buffer::BufferHandle;
@@ -466,10 +467,12 @@ impl VTable for ZstdBuffersVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
         let session = ctx.session();
         let inner_array = array.decompress_and_build_inner(session)?;
-        inner_array.execute::<ArrayRef>(ctx)
+        inner_array
+            .execute::<ArrayRef>(ctx)
+            .map(ExecutionStep::Done)
     }
 }
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -54,61 +54,47 @@ pub fn vortex_array::aggregate_fn::fns::sum::Sum::fmt(&self, f: &mut core::fmt::
 
 impl vortex_array::aggregate_fn::AggregateFnVTable for vortex_array::aggregate_fn::fns::sum::Sum
 
-pub type vortex_array::aggregate_fn::fns::sum::Sum::GroupState = vortex_array::aggregate_fn::fns::sum::SumGroupState
+pub type vortex_array::aggregate_fn::fns::sum::Sum::Options = vortex_array::aggregate_fn::EmptyOptions
 
-pub type vortex_array::aggregate_fn::fns::sum::Sum::Options = vortex_array::aggregate_fn::fns::sum::SumOptions
+pub type vortex_array::aggregate_fn::fns::sum::Sum::Partial = vortex_array::aggregate_fn::fns::sum::SumPartial
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::accumulate(&self, partial: &mut Self::Partial, batch: &vortex_array::Canonical, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::combine_partials(&self, partial: &mut Self::Partial, other: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize(&self, states: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::empty_partial(&self, _options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::Partial>
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize_scalar(&self, state: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize(&self, partials: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize_scalar(&self, partial: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::flush(&self, partial: &mut Self::Partial) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::id(&self) -> vortex_array::aggregate_fn::AggregateFnId
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::is_saturated(&self, partial: &Self::Partial) -> bool
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::partial_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::return_dtype(&self, _options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_accumulate(&self, state: &mut Self::GroupState, batch: &vortex_array::Canonical, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub struct vortex_array::aggregate_fn::fns::sum::SumPartial
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+pub mod vortex_array::aggregate_fn::kernels
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_flush(&self, state: &mut Self::GroupState) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub trait vortex_array::aggregate_fn::kernels::DynAggregateKernel: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_is_saturated(&self, state: &Self::GroupState) -> bool
+pub fn vortex_array::aggregate_fn::kernels::DynAggregateKernel::aggregate(&self, aggregate_fn: &vortex_array::aggregate_fn::AggregateFnRef, batch: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar::Scalar>>
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_merge(&self, state: &mut Self::GroupState, other: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+pub trait vortex_array::aggregate_fn::kernels::DynGroupedAggregateKernel: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_new(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::GroupState>
+pub fn vortex_array::aggregate_fn::kernels::DynGroupedAggregateKernel::grouped_aggregate(&self, aggregate_fn: &vortex_array::aggregate_fn::AggregateFnRef, groups: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub struct vortex_array::aggregate_fn::fns::sum::SumGroupState
-
-pub struct vortex_array::aggregate_fn::fns::sum::SumOptions
-
-impl core::clone::Clone for vortex_array::aggregate_fn::fns::sum::SumOptions
-
-pub fn vortex_array::aggregate_fn::fns::sum::SumOptions::clone(&self) -> vortex_array::aggregate_fn::fns::sum::SumOptions
-
-impl core::cmp::Eq for vortex_array::aggregate_fn::fns::sum::SumOptions
-
-impl core::cmp::PartialEq for vortex_array::aggregate_fn::fns::sum::SumOptions
-
-pub fn vortex_array::aggregate_fn::fns::sum::SumOptions::eq(&self, other: &vortex_array::aggregate_fn::fns::sum::SumOptions) -> bool
-
-impl core::fmt::Debug for vortex_array::aggregate_fn::fns::sum::SumOptions
-
-pub fn vortex_array::aggregate_fn::fns::sum::SumOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::fmt::Display for vortex_array::aggregate_fn::fns::sum::SumOptions
-
-pub fn vortex_array::aggregate_fn::fns::sum::SumOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::hash::Hash for vortex_array::aggregate_fn::fns::sum::SumOptions
-
-pub fn vortex_array::aggregate_fn::fns::sum::SumOptions::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-
-impl core::marker::StructuralPartialEq for vortex_array::aggregate_fn::fns::sum::SumOptions
+pub fn vortex_array::aggregate_fn::kernels::DynGroupedAggregateKernel::grouped_aggregate_fixed_size(&self, aggregate_fn: &vortex_array::aggregate_fn::AggregateFnRef, groups: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::aggregate_fn::session
 
@@ -118,11 +104,13 @@ impl vortex_array::aggregate_fn::session::AggregateFnSession
 
 pub fn vortex_array::aggregate_fn::session::AggregateFnSession::register<V: vortex_array::aggregate_fn::AggregateFnVTable>(&self, vtable: V)
 
+pub fn vortex_array::aggregate_fn::session::AggregateFnSession::register_aggregate_kernel(&self, array_id: vortex_array::vtable::ArrayId, agg_fn_id: core::option::Option<vortex_array::aggregate_fn::AggregateFnId>, kernel: &'static dyn vortex_array::aggregate_fn::kernels::DynAggregateKernel)
+
 pub fn vortex_array::aggregate_fn::session::AggregateFnSession::registry(&self) -> &vortex_array::aggregate_fn::session::AggregateFnRegistry
 
 impl core::default::Default for vortex_array::aggregate_fn::session::AggregateFnSession
 
-pub fn vortex_array::aggregate_fn::session::AggregateFnSession::default() -> vortex_array::aggregate_fn::session::AggregateFnSession
+pub fn vortex_array::aggregate_fn::session::AggregateFnSession::default() -> Self
 
 impl core::fmt::Debug for vortex_array::aggregate_fn::session::AggregateFnSession
 
@@ -294,63 +282,63 @@ pub fn V::id(&self) -> arcref::ArcRef<str>
 
 pub trait vortex_array::aggregate_fn::AggregateFnVTable: 'static + core::marker::Sized + core::clone::Clone + core::marker::Send + core::marker::Sync
 
-pub type vortex_array::aggregate_fn::AggregateFnVTable::GroupState: 'static + core::marker::Send
-
 pub type vortex_array::aggregate_fn::AggregateFnVTable::Options: 'static + core::marker::Send + core::marker::Sync + core::clone::Clone + core::fmt::Debug + core::fmt::Display + core::cmp::PartialEq + core::cmp::Eq + core::hash::Hash
 
+pub type vortex_array::aggregate_fn::AggregateFnVTable::Partial: 'static + core::marker::Send
+
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::accumulate(&self, state: &mut Self::Partial, batch: &vortex_array::Canonical, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::combine_partials(&self, partial: &mut Self::Partial, other: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
+
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::empty_partial(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::Partial>
 
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::finalize(&self, states: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::finalize_scalar(&self, state: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::flush(&self, partial: &mut Self::Partial) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::id(&self) -> vortex_array::aggregate_fn::AggregateFnId
+
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::is_saturated(&self, state: &Self::Partial) -> bool
+
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::partial_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::return_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_accumulate(&self, state: &mut Self::GroupState, batch: &vortex_array::Canonical, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
-
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_flush(&self, state: &mut Self::GroupState) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_is_saturated(&self, state: &Self::GroupState) -> bool
-
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_merge(&self, state: &mut Self::GroupState, partial: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_new(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::GroupState>
-
 impl vortex_array::aggregate_fn::AggregateFnVTable for vortex_array::aggregate_fn::fns::sum::Sum
 
-pub type vortex_array::aggregate_fn::fns::sum::Sum::GroupState = vortex_array::aggregate_fn::fns::sum::SumGroupState
+pub type vortex_array::aggregate_fn::fns::sum::Sum::Options = vortex_array::aggregate_fn::EmptyOptions
 
-pub type vortex_array::aggregate_fn::fns::sum::Sum::Options = vortex_array::aggregate_fn::fns::sum::SumOptions
+pub type vortex_array::aggregate_fn::fns::sum::Sum::Partial = vortex_array::aggregate_fn::fns::sum::SumPartial
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::accumulate(&self, partial: &mut Self::Partial, batch: &vortex_array::Canonical, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::combine_partials(&self, partial: &mut Self::Partial, other: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize(&self, states: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::empty_partial(&self, _options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::Partial>
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize_scalar(&self, state: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize(&self, partials: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize_scalar(&self, partial: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::flush(&self, partial: &mut Self::Partial) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::id(&self) -> vortex_array::aggregate_fn::AggregateFnId
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::is_saturated(&self, partial: &Self::Partial) -> bool
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::partial_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::return_dtype(&self, _options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_accumulate(&self, state: &mut Self::GroupState, batch: &vortex_array::Canonical, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_flush(&self, state: &mut Self::GroupState) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_is_saturated(&self, state: &Self::GroupState) -> bool
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_merge(&self, state: &mut Self::GroupState, other: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_new(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::GroupState>
 
 pub trait vortex_array::aggregate_fn::AggregateFnVTableExt: vortex_array::aggregate_fn::AggregateFnVTable
 
@@ -406,301 +394,9 @@ pub type vortex_array::aggregate_fn::GroupedAccumulatorRef = alloc::boxed::Box<d
 
 pub mod vortex_array::arrays
 
-pub mod vortex_array::arrays::build_views
+pub mod vortex_array::arrays::bool
 
-#[repr(C, align(16))] pub union vortex_array::arrays::build_views::BinaryView
-
-impl vortex_array::arrays::BinaryView
-
-pub const vortex_array::arrays::BinaryView::MAX_INLINED_SIZE: usize
-
-pub fn vortex_array::arrays::BinaryView::as_inlined(&self) -> &vortex_array::arrays::Inlined
-
-pub fn vortex_array::arrays::BinaryView::as_u128(&self) -> u128
-
-pub fn vortex_array::arrays::BinaryView::as_view(&self) -> &vortex_array::arrays::Ref
-
-pub fn vortex_array::arrays::BinaryView::as_view_mut(&mut self) -> &mut vortex_array::arrays::Ref
-
-pub fn vortex_array::arrays::BinaryView::empty_view() -> Self
-
-pub fn vortex_array::arrays::BinaryView::is_empty(&self) -> bool
-
-pub fn vortex_array::arrays::BinaryView::is_inlined(&self) -> bool
-
-pub fn vortex_array::arrays::BinaryView::len(&self) -> u32
-
-pub fn vortex_array::arrays::BinaryView::make_view(value: &[u8], block: u32, offset: u32) -> Self
-
-pub fn vortex_array::arrays::BinaryView::new_inlined(value: &[u8]) -> Self
-
-impl core::clone::Clone for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::clone(&self) -> vortex_array::arrays::BinaryView
-
-impl core::cmp::Eq for vortex_array::arrays::BinaryView
-
-impl core::cmp::PartialEq for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::eq(&self, other: &Self) -> bool
-
-impl core::convert::From<u128> for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::from(value: u128) -> Self
-
-impl core::convert::From<vortex_array::arrays::Ref> for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::from(value: vortex_array::arrays::Ref) -> Self
-
-impl core::default::Default for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::default() -> Self
-
-impl core::fmt::Debug for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::hash::Hash for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::marker::Copy for vortex_array::arrays::BinaryView
-
-pub const vortex_array::arrays::build_views::MAX_BUFFER_LEN: usize
-
-pub fn vortex_array::arrays::build_views::build_views<P: vortex_array::dtype::NativePType + num_traits::cast::AsPrimitive<usize>>(start_buf_index: u32, max_buffer_len: usize, bytes: vortex_buffer::ByteBufferMut, lens: &[P]) -> (alloc::vec::Vec<vortex_buffer::ByteBuffer>, vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>)
-
-pub fn vortex_array::arrays::build_views::offsets_to_lengths<P: vortex_array::dtype::NativePType>(offsets: &[P]) -> vortex_buffer::buffer::Buffer<P>
-
-pub mod vortex_array::arrays::builder
-
-pub struct vortex_array::arrays::builder::VarBinBuilder<O: vortex_array::dtype::IntegerPType>
-
-impl<O: vortex_array::dtype::IntegerPType> vortex_array::arrays::builder::VarBinBuilder<O>
-
-pub fn vortex_array::arrays::builder::VarBinBuilder<O>::append(&mut self, value: core::option::Option<&[u8]>)
-
-pub fn vortex_array::arrays::builder::VarBinBuilder<O>::append_n_nulls(&mut self, n: usize)
-
-pub fn vortex_array::arrays::builder::VarBinBuilder<O>::append_null(&mut self)
-
-pub fn vortex_array::arrays::builder::VarBinBuilder<O>::append_value(&mut self, value: impl core::convert::AsRef<[u8]>)
-
-pub fn vortex_array::arrays::builder::VarBinBuilder<O>::append_values(&mut self, values: &[u8], end_offsets: impl core::iter::traits::iterator::Iterator<Item = O>, num: usize) where O: 'static, usize: num_traits::cast::AsPrimitive<O>
-
-pub fn vortex_array::arrays::builder::VarBinBuilder<O>::finish(self, dtype: vortex_array::dtype::DType) -> vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::builder::VarBinBuilder<O>::new() -> Self
-
-pub fn vortex_array::arrays::builder::VarBinBuilder<O>::with_capacity(len: usize) -> Self
-
-impl<O: vortex_array::dtype::IntegerPType> core::default::Default for vortex_array::arrays::builder::VarBinBuilder<O>
-
-pub fn vortex_array::arrays::builder::VarBinBuilder<O>::default() -> Self
-
-pub mod vortex_array::arrays::vtable
-
-pub struct vortex_array::arrays::vtable::DictVTable
-
-impl vortex_array::arrays::DictVTable
-
-pub const vortex_array::arrays::DictVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::filter(array: &vortex_array::arrays::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::is_constant(&self, array: &vortex_array::arrays::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::is_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::min_max(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::cast(array: &vortex_array::arrays::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::fill_null(array: &vortex_array::arrays::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::mask(array: &vortex_array::arrays::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::scalar_at(array: &vortex_array::arrays::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::DictVTable
-
-pub type vortex_array::arrays::DictVTable::Array = vortex_array::arrays::DictArray
-
-pub type vortex_array::arrays::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::DictMetadata>
-
-pub type vortex_array::arrays::DictVTable::OperationsVTable = vortex_array::arrays::DictVTable
-
-pub type vortex_array::arrays::DictVTable::ValidityVTable = vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::DictVTable::array_eq(array: &vortex_array::arrays::DictArray, other: &vortex_array::arrays::DictArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DictArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::DictVTable::buffer(_array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::DictVTable::buffer_name(_array: &vortex_array::arrays::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
-
-pub fn vortex_array::arrays::DictVTable::child(array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::DictVTable::child_name(_array: &vortex_array::arrays::DictArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::DictVTable::dtype(array: &vortex_array::arrays::DictArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::DictVTable::len(array: &vortex_array::arrays::DictArray) -> usize
-
-pub fn vortex_array::arrays::DictVTable::metadata(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::DictVTable::nbuffers(_array: &vortex_array::arrays::DictArray) -> usize
-
-pub fn vortex_array::arrays::DictVTable::nchildren(_array: &vortex_array::arrays::DictArray) -> usize
-
-pub fn vortex_array::arrays::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::DictVTable::stats(array: &vortex_array::arrays::DictArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::validity(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub enum vortex_array::arrays::ListViewRebuildMode
-
-pub vortex_array::arrays::ListViewRebuildMode::MakeExact
-
-pub vortex_array::arrays::ListViewRebuildMode::MakeZeroCopyToList
-
-pub vortex_array::arrays::ListViewRebuildMode::OverlapCompression
-
-pub vortex_array::arrays::ListViewRebuildMode::TrimElements
-
-#[repr(C, align(16))] pub union vortex_array::arrays::BinaryView
-
-impl vortex_array::arrays::BinaryView
-
-pub const vortex_array::arrays::BinaryView::MAX_INLINED_SIZE: usize
-
-pub fn vortex_array::arrays::BinaryView::as_inlined(&self) -> &vortex_array::arrays::Inlined
-
-pub fn vortex_array::arrays::BinaryView::as_u128(&self) -> u128
-
-pub fn vortex_array::arrays::BinaryView::as_view(&self) -> &vortex_array::arrays::Ref
-
-pub fn vortex_array::arrays::BinaryView::as_view_mut(&mut self) -> &mut vortex_array::arrays::Ref
-
-pub fn vortex_array::arrays::BinaryView::empty_view() -> Self
-
-pub fn vortex_array::arrays::BinaryView::is_empty(&self) -> bool
-
-pub fn vortex_array::arrays::BinaryView::is_inlined(&self) -> bool
-
-pub fn vortex_array::arrays::BinaryView::len(&self) -> u32
-
-pub fn vortex_array::arrays::BinaryView::make_view(value: &[u8], block: u32, offset: u32) -> Self
-
-pub fn vortex_array::arrays::BinaryView::new_inlined(value: &[u8]) -> Self
-
-impl core::clone::Clone for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::clone(&self) -> vortex_array::arrays::BinaryView
-
-impl core::cmp::Eq for vortex_array::arrays::BinaryView
-
-impl core::cmp::PartialEq for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::eq(&self, other: &Self) -> bool
-
-impl core::convert::From<u128> for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::from(value: u128) -> Self
-
-impl core::convert::From<vortex_array::arrays::Ref> for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::from(value: vortex_array::arrays::Ref) -> Self
-
-impl core::default::Default for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::default() -> Self
-
-impl core::fmt::Debug for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::hash::Hash for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::marker::Copy for vortex_array::arrays::BinaryView
-
-pub struct vortex_array::arrays::AnyScalarFn
-
-impl core::fmt::Debug for vortex_array::arrays::AnyScalarFn
-
-pub fn vortex_array::arrays::AnyScalarFn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::matcher::Matcher for vortex_array::arrays::AnyScalarFn
-
-pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
-
-pub fn vortex_array::arrays::AnyScalarFn::matches(array: &dyn vortex_array::Array) -> bool
-
-pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
-
-pub struct vortex_array::arrays::BoolArray
+pub struct vortex_array::arrays::bool::BoolArray
 
 impl vortex_array::arrays::BoolArray
 
@@ -708,7 +404,7 @@ pub fn vortex_array::arrays::BoolArray::from_indices<I: core::iter::traits::coll
 
 pub fn vortex_array::arrays::BoolArray::into_bit_buffer(self) -> vortex_buffer::bit::buf::BitBuffer
 
-pub fn vortex_array::arrays::BoolArray::into_parts(self) -> vortex_array::arrays::BoolArrayParts
+pub fn vortex_array::arrays::BoolArray::into_parts(self) -> vortex_array::arrays::bool::BoolArrayParts
 
 pub fn vortex_array::arrays::BoolArray::maybe_to_mask(&self) -> vortex_error::VortexResult<core::option::Option<vortex_mask::Mask>>
 
@@ -734,13 +430,17 @@ impl vortex_array::arrays::BoolArray
 
 pub fn vortex_array::arrays::BoolArray::patch(self, patches: &vortex_array::patches::Patches, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
+impl vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::BoolArray
 
 pub fn vortex_array::arrays::BoolArray::clone(&self) -> vortex_array::arrays::BoolArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::BoolArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::BoolArray
 
-pub fn vortex_array::arrays::BoolArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::BoolArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::BoolArray> for vortex_array::ArrayRef
 
@@ -764,7 +464,7 @@ pub fn vortex_array::arrays::BoolArray::from_iter<I: core::iter::traits::collect
 
 impl core::ops::deref::Deref for vortex_array::arrays::BoolArray
 
-pub type vortex_array::arrays::BoolArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::BoolArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::BoolArray::deref(&self) -> &Self::Target
 
@@ -780,33 +480,33 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::BoolArray
 
 pub fn vortex_array::arrays::BoolArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::BoolArrayParts
+pub struct vortex_array::arrays::bool::BoolArrayParts
 
-pub vortex_array::arrays::BoolArrayParts::bits: vortex_array::buffer::BufferHandle
+pub vortex_array::arrays::bool::BoolArrayParts::bits: vortex_array::buffer::BufferHandle
 
-pub vortex_array::arrays::BoolArrayParts::len: usize
+pub vortex_array::arrays::bool::BoolArrayParts::len: usize
 
-pub vortex_array::arrays::BoolArrayParts::offset: usize
+pub vortex_array::arrays::bool::BoolArrayParts::offset: usize
 
-pub vortex_array::arrays::BoolArrayParts::validity: vortex_array::validity::Validity
+pub vortex_array::arrays::bool::BoolArrayParts::validity: vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::BoolMaskedValidityRule
+pub struct vortex_array::arrays::bool::BoolMaskedValidityRule
 
-impl core::default::Default for vortex_array::arrays::BoolMaskedValidityRule
+impl core::default::Default for vortex_array::arrays::bool::BoolMaskedValidityRule
 
-pub fn vortex_array::arrays::BoolMaskedValidityRule::default() -> vortex_array::arrays::BoolMaskedValidityRule
+pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::default() -> vortex_array::arrays::bool::BoolMaskedValidityRule
 
-impl core::fmt::Debug for vortex_array::arrays::BoolMaskedValidityRule
+impl core::fmt::Debug for vortex_array::arrays::bool::BoolMaskedValidityRule
 
-pub fn vortex_array::arrays::BoolMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
 
-pub type vortex_array::arrays::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub struct vortex_array::arrays::BoolVTable
+pub struct vortex_array::arrays::bool::BoolVTable
 
 impl vortex_array::arrays::BoolVTable
 
@@ -816,17 +516,17 @@ impl core::fmt::Debug for vortex_array::arrays::BoolVTable
 
 pub fn vortex_array::arrays::BoolVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::BoolVTable
 
 pub fn vortex_array::arrays::BoolVTable::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::BoolVTable
 
 pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::BoolVTable
 
@@ -846,11 +546,4183 @@ impl vortex_array::compute::SumKernel for vortex_array::arrays::BoolVTable
 
 pub fn vortex_array::arrays::BoolVTable::sum(&self, array: &vortex_array::arrays::BoolArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
 
-pub type vortex_array::arrays::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::cast(array: &vortex_array::arrays::BoolArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::fill_null(array: &vortex_array::arrays::BoolArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::mask(array: &vortex_array::arrays::BoolArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::BoolVTable
+
+pub type vortex_array::arrays::BoolVTable::Array = vortex_array::arrays::BoolArray
+
+pub type vortex_array::arrays::BoolVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::bool::vtable::BoolMetadata>
+
+pub type vortex_array::arrays::BoolVTable::OperationsVTable = vortex_array::arrays::BoolVTable
+
+pub type vortex_array::arrays::BoolVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::BoolVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::BoolVTable::array_eq(array: &vortex_array::arrays::BoolArray, other: &vortex_array::arrays::BoolArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::BoolVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::BoolArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::BoolVTable::buffer(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::BoolVTable::buffer_name(_array: &vortex_array::arrays::BoolArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::BoolVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::BoolArray>
+
+pub fn vortex_array::arrays::BoolVTable::child(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::BoolVTable::child_name(_array: &vortex_array::arrays::BoolArray, _idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::BoolVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::BoolVTable::dtype(array: &vortex_array::arrays::BoolArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::BoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::BoolVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::BoolVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::BoolVTable::len(array: &vortex_array::arrays::BoolArray) -> usize
+
+pub fn vortex_array::arrays::BoolVTable::metadata(array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::BoolVTable::nbuffers(_array: &vortex_array::arrays::BoolArray) -> usize
+
+pub fn vortex_array::arrays::BoolVTable::nchildren(array: &vortex_array::arrays::BoolArray) -> usize
+
+pub fn vortex_array::arrays::BoolVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::BoolVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::BoolVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::BoolVTable::stats(array: &vortex_array::arrays::BoolArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::BoolVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+pub mod vortex_array::arrays::chunked
+
+pub struct vortex_array::arrays::chunked::ChunkedArray
+
+impl vortex_array::arrays::ChunkedArray
+
+pub fn vortex_array::arrays::ChunkedArray::array_iterator(&self) -> impl vortex_array::iter::ArrayIterator + '_
+
+pub fn vortex_array::arrays::ChunkedArray::array_stream(&self) -> impl vortex_array::stream::ArrayStream + '_
+
+pub fn vortex_array::arrays::ChunkedArray::chunk(&self, idx: usize) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ChunkedArray::chunk_offsets(&self) -> vortex_buffer::buffer::Buffer<u64>
+
+pub fn vortex_array::arrays::ChunkedArray::chunks(&self) -> &[vortex_array::ArrayRef]
+
+pub fn vortex_array::arrays::ChunkedArray::nchunks(&self) -> usize
+
+pub unsafe fn vortex_array::arrays::ChunkedArray::new_unchecked(chunks: alloc::vec::Vec<vortex_array::ArrayRef>, dtype: vortex_array::dtype::DType) -> Self
+
+pub fn vortex_array::arrays::ChunkedArray::non_empty_chunks(&self) -> impl core::iter::traits::iterator::Iterator<Item = &vortex_array::ArrayRef> + '_
+
+pub fn vortex_array::arrays::ChunkedArray::rechunk(&self, target_bytesize: u64, target_rowsize: usize) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::ChunkedArray::try_new(chunks: alloc::vec::Vec<vortex_array::ArrayRef>, dtype: vortex_array::dtype::DType) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::ChunkedArray::validate(chunks: &[vortex_array::ArrayRef], dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
+
+impl vortex_array::arrays::ChunkedArray
+
+pub fn vortex_array::arrays::ChunkedArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::ChunkedArray
+
+pub fn vortex_array::arrays::ChunkedArray::clone(&self) -> vortex_array::arrays::ChunkedArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ChunkedArray
+
+pub fn vortex_array::arrays::ChunkedArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::ChunkedArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ChunkedArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::ChunkedArray
+
+pub fn vortex_array::arrays::ChunkedArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::iter::traits::collect::FromIterator<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::arrays::ChunkedArray
+
+pub fn vortex_array::arrays::ChunkedArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = vortex_array::ArrayRef>>(iter: T) -> Self
+
+impl core::ops::deref::Deref for vortex_array::arrays::ChunkedArray
+
+pub type vortex_array::arrays::ChunkedArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::ChunkedArray::deref(&self) -> &Self::Target
+
+impl vortex_array::IntoArray for vortex_array::arrays::ChunkedArray
+
+pub fn vortex_array::arrays::ChunkedArray::into_array(self) -> vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::chunked::ChunkedVTable
+
+impl vortex_array::arrays::ChunkedVTable
+
+pub const vortex_array::arrays::ChunkedVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::is_constant(&self, array: &vortex_array::arrays::ChunkedArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::is_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::ChunkedVTable::is_strict_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::min_max(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::sum(&self, array: &vortex_array::arrays::ChunkedArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::cast(array: &vortex_array::arrays::ChunkedArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::fill_null(array: &vortex_array::arrays::ChunkedArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::mask(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::ChunkedVTable
+
+pub type vortex_array::arrays::ChunkedVTable::Array = vortex_array::arrays::ChunkedArray
+
+pub type vortex_array::arrays::ChunkedVTable::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::ChunkedVTable::OperationsVTable = vortex_array::arrays::ChunkedVTable
+
+pub type vortex_array::arrays::ChunkedVTable::ValidityVTable = vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::append_to_builder(array: &vortex_array::arrays::ChunkedArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::ChunkedVTable::array_eq(array: &vortex_array::arrays::ChunkedArray, other: &vortex_array::arrays::ChunkedArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::ChunkedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ChunkedArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::ChunkedVTable::buffer(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::ChunkedVTable::buffer_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::ChunkedVTable::build(dtype: &vortex_array::dtype::DType, _len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ChunkedArray>
+
+pub fn vortex_array::arrays::ChunkedVTable::child(array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ChunkedVTable::child_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::ChunkedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ChunkedVTable::dtype(array: &vortex_array::arrays::ChunkedArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::ChunkedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::ChunkedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ChunkedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::ChunkedVTable::len(array: &vortex_array::arrays::ChunkedArray) -> usize
+
+pub fn vortex_array::arrays::ChunkedVTable::metadata(_array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ChunkedVTable::nbuffers(_array: &vortex_array::arrays::ChunkedArray) -> usize
+
+pub fn vortex_array::arrays::ChunkedVTable::nchildren(array: &vortex_array::arrays::ChunkedArray) -> usize
+
+pub fn vortex_array::arrays::ChunkedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ChunkedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ChunkedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::ChunkedVTable::stats(array: &vortex_array::arrays::ChunkedArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::ChunkedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::validity(array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub mod vortex_array::arrays::constant
+
+pub struct vortex_array::arrays::constant::ConstantArray
+
+impl vortex_array::arrays::ConstantArray
+
+pub fn vortex_array::arrays::ConstantArray::into_parts(self) -> vortex_array::scalar::Scalar
+
+pub fn vortex_array::arrays::ConstantArray::new<S>(scalar: S, len: usize) -> Self where S: core::convert::Into<vortex_array::scalar::Scalar>
+
+pub fn vortex_array::arrays::ConstantArray::scalar(&self) -> &vortex_array::scalar::Scalar
+
+impl vortex_array::arrays::ConstantArray
+
+pub fn vortex_array::arrays::ConstantArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::ConstantArray
+
+pub fn vortex_array::arrays::ConstantArray::clone(&self) -> vortex_array::arrays::ConstantArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ConstantArray
+
+pub fn vortex_array::arrays::ConstantArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::ConstantArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ConstantArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::ConstantArray
+
+pub fn vortex_array::arrays::ConstantArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::ConstantArray
+
+pub type vortex_array::arrays::ConstantArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::ConstantArray::deref(&self) -> &Self::Target
+
+impl vortex_array::IntoArray for vortex_array::arrays::ConstantArray
+
+pub fn vortex_array::arrays::ConstantArray::into_array(self) -> vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::constant::ConstantVTable
+
+impl vortex_array::arrays::ConstantVTable
+
+pub const vortex_array::arrays::ConstantVTable::ID: vortex_array::vtable::ArrayId
+
+impl vortex_array::arrays::ConstantVTable
+
+pub const vortex_array::arrays::ConstantVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
+
+impl core::fmt::Debug for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::min_max(&self, array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::sum(&self, array: &vortex_array::arrays::ConstantArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::between(array: &vortex_array::arrays::ConstantArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::cast(array: &vortex_array::arrays::ConstantArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::fill_null(array: &vortex_array::arrays::ConstantArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::not::NotReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::invert(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::ConstantVTable
+
+pub type vortex_array::arrays::ConstantVTable::Array = vortex_array::arrays::ConstantArray
+
+pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::scalar::Scalar
+
+pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::arrays::ConstantVTable
+
+pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::ConstantVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ConstantArray, state: &mut H, _precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::ConstantVTable::buffer(array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::ConstantVTable::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::ConstantVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
+
+pub fn vortex_array::arrays::ConstantVTable::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ConstantVTable::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::ConstantVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::ConstantVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
+
+pub fn vortex_array::arrays::ConstantVTable::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
+
+pub fn vortex_array::arrays::ConstantVTable::nchildren(_array: &vortex_array::arrays::ConstantArray) -> usize
+
+pub fn vortex_array::arrays::ConstantVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ConstantVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ConstantVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::ConstantVTable::stats(array: &vortex_array::arrays::ConstantArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::ConstantVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::validity(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub mod vortex_array::arrays::datetime
+
+pub struct vortex_array::arrays::datetime::TemporalArray
+
+impl vortex_array::arrays::datetime::TemporalArray
+
+pub fn vortex_array::arrays::datetime::TemporalArray::dtype(&self) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::datetime::TemporalArray::ext_dtype(&self) -> vortex_array::dtype::extension::ExtDTypeRef
+
+pub fn vortex_array::arrays::datetime::TemporalArray::temporal_metadata(&self) -> vortex_array::extension::datetime::TemporalMetadata<'_>
+
+pub fn vortex_array::arrays::datetime::TemporalArray::temporal_values(&self) -> &vortex_array::ArrayRef
+
+impl vortex_array::arrays::datetime::TemporalArray
+
+pub fn vortex_array::arrays::datetime::TemporalArray::new_date(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
+
+pub fn vortex_array::arrays::datetime::TemporalArray::new_time(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
+
+pub fn vortex_array::arrays::datetime::TemporalArray::new_timestamp(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit, time_zone: core::option::Option<alloc::sync::Arc<str>>) -> Self
+
+impl core::clone::Clone for vortex_array::arrays::datetime::TemporalArray
+
+pub fn vortex_array::arrays::datetime::TemporalArray::clone(&self) -> vortex_array::arrays::datetime::TemporalArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::datetime::TemporalArray
+
+pub fn vortex_array::arrays::datetime::TemporalArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<&vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::datetime::TemporalArray) -> Self
+
+impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
+
+impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
+
+impl core::convert::TryFrom<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::arrays::datetime::TemporalArray
+
+pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
+
+pub fn vortex_array::arrays::datetime::TemporalArray::try_from(value: vortex_array::ArrayRef) -> core::result::Result<Self, Self::Error>
+
+impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::datetime::TemporalArray
+
+pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
+
+pub fn vortex_array::arrays::datetime::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
+
+impl core::fmt::Debug for vortex_array::arrays::datetime::TemporalArray
+
+pub fn vortex_array::arrays::datetime::TemporalArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::IntoArray for vortex_array::arrays::datetime::TemporalArray
+
+pub fn vortex_array::arrays::datetime::TemporalArray::into_array(self) -> vortex_array::ArrayRef
+
+pub mod vortex_array::arrays::decimal
+
+pub struct vortex_array::arrays::decimal::DecimalArray
+
+impl vortex_array::arrays::DecimalArray
+
+pub fn vortex_array::arrays::DecimalArray::buffer<T: vortex_array::dtype::NativeDecimalType>(&self) -> vortex_buffer::buffer::Buffer<T>
+
+pub fn vortex_array::arrays::DecimalArray::buffer_handle(&self) -> &vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::DecimalArray::decimal_dtype(&self) -> vortex_array::dtype::DecimalDType
+
+pub fn vortex_array::arrays::DecimalArray::from_iter<T: vortex_array::dtype::NativeDecimalType, I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I, decimal_dtype: vortex_array::dtype::DecimalDType) -> Self
+
+pub fn vortex_array::arrays::DecimalArray::from_option_iter<T: vortex_array::dtype::NativeDecimalType, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I, decimal_dtype: vortex_array::dtype::DecimalDType) -> Self
+
+pub fn vortex_array::arrays::DecimalArray::into_parts(self) -> vortex_array::arrays::decimal::DecimalArrayParts
+
+pub fn vortex_array::arrays::DecimalArray::new<T: vortex_array::dtype::NativeDecimalType>(buffer: vortex_buffer::buffer::Buffer<T>, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::DecimalArray::new_handle(values: vortex_array::buffer::BufferHandle, values_type: vortex_array::dtype::DecimalType, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::DecimalArray::new_unchecked<T: vortex_array::dtype::NativeDecimalType>(buffer: vortex_buffer::buffer::Buffer<T>, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::DecimalArray::new_unchecked_from_byte_buffer(byte_buffer: vortex_buffer::ByteBuffer, values_type: vortex_array::dtype::DecimalType, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::DecimalArray::new_unchecked_handle(values: vortex_array::buffer::BufferHandle, values_type: vortex_array::dtype::DecimalType, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::DecimalArray::patch(self, patches: &vortex_array::patches::Patches, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::DecimalArray::precision(&self) -> u8
+
+pub fn vortex_array::arrays::DecimalArray::scale(&self) -> i8
+
+pub fn vortex_array::arrays::DecimalArray::try_new<T: vortex_array::dtype::NativeDecimalType>(buffer: vortex_buffer::buffer::Buffer<T>, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::DecimalArray::try_new_handle(values: vortex_array::buffer::BufferHandle, values_type: vortex_array::dtype::DecimalType, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::DecimalArray::values_type(&self) -> vortex_array::dtype::DecimalType
+
+impl vortex_array::arrays::DecimalArray
+
+pub fn vortex_array::arrays::DecimalArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::DecimalArray
+
+pub fn vortex_array::arrays::DecimalArray::clone(&self) -> vortex_array::arrays::DecimalArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::DecimalArray
+
+pub fn vortex_array::arrays::DecimalArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::DecimalArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::DecimalArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::DecimalArray
+
+pub fn vortex_array::arrays::DecimalArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::DecimalArray
+
+pub type vortex_array::arrays::DecimalArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::DecimalArray::deref(&self) -> &Self::Target
+
+impl vortex_array::Executable for vortex_array::arrays::DecimalArray
+
+pub fn vortex_array::arrays::DecimalArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::IntoArray for vortex_array::arrays::DecimalArray
+
+pub fn vortex_array::arrays::DecimalArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::DecimalArray
+
+pub fn vortex_array::arrays::DecimalArray::validity(&self) -> &vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::decimal::DecimalArrayParts
+
+pub vortex_array::arrays::decimal::DecimalArrayParts::decimal_dtype: vortex_array::dtype::DecimalDType
+
+pub vortex_array::arrays::decimal::DecimalArrayParts::validity: vortex_array::validity::Validity
+
+pub vortex_array::arrays::decimal::DecimalArrayParts::values: vortex_array::buffer::BufferHandle
+
+pub vortex_array::arrays::decimal::DecimalArrayParts::values_type: vortex_array::dtype::DecimalType
+
+pub struct vortex_array::arrays::decimal::DecimalMaskedValidityRule
+
+impl core::default::Default for vortex_array::arrays::decimal::DecimalMaskedValidityRule
+
+pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::default() -> vortex_array::arrays::decimal::DecimalMaskedValidityRule
+
+impl core::fmt::Debug for vortex_array::arrays::decimal::DecimalMaskedValidityRule
+
+pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
+
+pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub struct vortex_array::arrays::decimal::DecimalVTable
+
+impl vortex_array::arrays::DecimalVTable
+
+pub const vortex_array::arrays::DecimalVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::is_constant(&self, array: &vortex_array::arrays::DecimalArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::is_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::DecimalVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::min_max(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::sum(&self, array: &vortex_array::arrays::DecimalArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
+
+pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::between(arr: &vortex_array::arrays::DecimalArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::cast(array: &vortex_array::arrays::DecimalArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::fill_null(array: &vortex_array::arrays::DecimalArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::mask(array: &vortex_array::arrays::DecimalArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::DecimalVTable
+
+pub type vortex_array::arrays::DecimalVTable::Array = vortex_array::arrays::DecimalArray
+
+pub type vortex_array::arrays::DecimalVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::decimal::vtable::DecimalMetadata>
+
+pub type vortex_array::arrays::DecimalVTable::OperationsVTable = vortex_array::arrays::DecimalVTable
+
+pub type vortex_array::arrays::DecimalVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::DecimalVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::DecimalVTable::array_eq(array: &vortex_array::arrays::DecimalArray, other: &vortex_array::arrays::DecimalArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::DecimalVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DecimalArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::DecimalVTable::buffer(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::DecimalVTable::buffer_name(_array: &vortex_array::arrays::DecimalArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::DecimalVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DecimalArray>
+
+pub fn vortex_array::arrays::DecimalVTable::child(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::DecimalVTable::child_name(_array: &vortex_array::arrays::DecimalArray, _idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::DecimalVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::DecimalVTable::dtype(array: &vortex_array::arrays::DecimalArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::DecimalVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::DecimalVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::DecimalVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::DecimalVTable::len(array: &vortex_array::arrays::DecimalArray) -> usize
+
+pub fn vortex_array::arrays::DecimalVTable::metadata(array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::DecimalVTable::nbuffers(_array: &vortex_array::arrays::DecimalArray) -> usize
+
+pub fn vortex_array::arrays::DecimalVTable::nchildren(array: &vortex_array::arrays::DecimalArray) -> usize
+
+pub fn vortex_array::arrays::DecimalVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::DecimalVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::DecimalVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::DecimalVTable::stats(array: &vortex_array::arrays::DecimalArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::DecimalVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::decimal::narrowed_decimal(decimal_array: vortex_array::arrays::DecimalArray) -> vortex_array::arrays::DecimalArray
+
+pub mod vortex_array::arrays::dict
+
+pub mod vortex_array::arrays::dict::vtable
+
+pub struct vortex_array::arrays::dict::vtable::DictVTable
+
+impl vortex_array::arrays::dict::DictVTable
+
+pub const vortex_array::arrays::dict::DictVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
+
+pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
+
+pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
+
+pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
+
+pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+
+pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub struct vortex_array::arrays::dict::DictArray
+
+impl vortex_array::arrays::dict::DictArray
+
+pub fn vortex_array::arrays::dict::DictArray::codes(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::dict::DictArray::compute_referenced_values_mask(&self, referenced: bool) -> vortex_error::VortexResult<vortex_buffer::bit::buf::BitBuffer>
+
+pub fn vortex_array::arrays::dict::DictArray::has_all_values_referenced(&self) -> bool
+
+pub fn vortex_array::arrays::dict::DictArray::into_parts(self) -> vortex_array::arrays::dict::DictArrayParts
+
+pub fn vortex_array::arrays::dict::DictArray::new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
+
+pub unsafe fn vortex_array::arrays::dict::DictArray::new_unchecked(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
+
+pub unsafe fn vortex_array::arrays::dict::DictArray::set_all_values_referenced(self, all_values_referenced: bool) -> Self
+
+pub fn vortex_array::arrays::dict::DictArray::try_new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::dict::DictArray::validate_all_values_referenced(&self) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::dict::DictArray::values(&self) -> &vortex_array::ArrayRef
+
+impl vortex_array::arrays::dict::DictArray
+
+pub fn vortex_array::arrays::dict::DictArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::dict::DictArray
+
+pub fn vortex_array::arrays::dict::DictArray::clone(&self) -> vortex_array::arrays::dict::DictArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::dict::DictArray
+
+pub fn vortex_array::arrays::dict::DictArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::dict::DictArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::dict::DictArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::dict::DictArray
+
+pub fn vortex_array::arrays::dict::DictArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::dict::DictArray
+
+pub type vortex_array::arrays::dict::DictArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::dict::DictArray::deref(&self) -> &Self::Target
+
+impl vortex_array::IntoArray for vortex_array::arrays::dict::DictArray
+
+pub fn vortex_array::arrays::dict::DictArray::into_array(self) -> vortex_array::ArrayRef
+
+impl<K: arrow_array::types::ArrowDictionaryKeyType> vortex_array::arrow::FromArrowArray<&arrow_array::array::dictionary_array::DictionaryArray<K>> for vortex_array::arrays::dict::DictArray
+
+pub fn vortex_array::arrays::dict::DictArray::from_arrow(array: &arrow_array::array::dictionary_array::DictionaryArray<K>, nullable: bool) -> vortex_error::VortexResult<Self>
+
+pub struct vortex_array::arrays::dict::DictArrayParts
+
+pub vortex_array::arrays::dict::DictArrayParts::codes: vortex_array::ArrayRef
+
+pub vortex_array::arrays::dict::DictArrayParts::dtype: vortex_array::dtype::DType
+
+pub vortex_array::arrays::dict::DictArrayParts::values: vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::dict::DictMetadata
+
+impl vortex_array::arrays::dict::DictMetadata
+
+pub fn vortex_array::arrays::dict::DictMetadata::all_values_referenced(&self) -> bool
+
+pub fn vortex_array::arrays::dict::DictMetadata::codes_ptype(&self) -> vortex_array::dtype::PType
+
+pub fn vortex_array::arrays::dict::DictMetadata::is_nullable_codes(&self) -> bool
+
+pub fn vortex_array::arrays::dict::DictMetadata::set_codes_ptype(&mut self, value: vortex_array::dtype::PType)
+
+impl core::clone::Clone for vortex_array::arrays::dict::DictMetadata
+
+pub fn vortex_array::arrays::dict::DictMetadata::clone(&self) -> vortex_array::arrays::dict::DictMetadata
+
+impl core::default::Default for vortex_array::arrays::dict::DictMetadata
+
+pub fn vortex_array::arrays::dict::DictMetadata::default() -> Self
+
+impl core::fmt::Debug for vortex_array::arrays::dict::DictMetadata
+
+pub fn vortex_array::arrays::dict::DictMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl prost::message::Message for vortex_array::arrays::dict::DictMetadata
+
+pub fn vortex_array::arrays::dict::DictMetadata::clear(&mut self)
+
+pub fn vortex_array::arrays::dict::DictMetadata::encoded_len(&self) -> usize
+
+pub struct vortex_array::arrays::dict::DictVTable
+
+impl vortex_array::arrays::dict::DictVTable
+
+pub const vortex_array::arrays::dict::DictVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
+
+pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
+
+pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
+
+pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
+
+pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+
+pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub struct vortex_array::arrays::dict::TakeExecuteAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::dict::TakeExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::dict::TakeExecuteAdaptor<V>::default() -> vortex_array::arrays::dict::TakeExecuteAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::dict::TakeExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::dict::TakeExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::dict::TakeExecuteAdaptor<V> where V: vortex_array::arrays::dict::TakeExecute
+
+pub type vortex_array::arrays::dict::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub struct vortex_array::arrays::dict::TakeReduceAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::dict::TakeReduceAdaptor<V>
+
+pub fn vortex_array::arrays::dict::TakeReduceAdaptor<V>::default() -> vortex_array::arrays::dict::TakeReduceAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::dict::TakeReduceAdaptor<V>
+
+pub fn vortex_array::arrays::dict::TakeReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::dict::TakeReduceAdaptor<V> where V: vortex_array::arrays::dict::TakeReduce
+
+pub type vortex_array::arrays::dict::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::TakeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::dict::DictArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub trait vortex_array::arrays::dict::TakeExecute: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::dict::TakeExecute::take(array: &Self::Array, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub trait vortex_array::arrays::dict::TakeReduce: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::dict::TakeReduce::take(array: &Self::Array, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::take_canonical(values: vortex_array::Canonical, codes: &vortex_array::arrays::PrimitiveArray, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::Canonical>
+
+pub mod vortex_array::arrays::extension
+
+pub struct vortex_array::arrays::extension::ExtensionArray
+
+impl vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::ext_dtype(&self) -> &vortex_array::dtype::extension::ExtDTypeRef
+
+pub fn vortex_array::arrays::ExtensionArray::id(&self) -> vortex_array::dtype::extension::ExtId
+
+pub fn vortex_array::arrays::ExtensionArray::new(ext_dtype: vortex_array::dtype::extension::ExtDTypeRef, storage: vortex_array::ArrayRef) -> Self
+
+pub fn vortex_array::arrays::ExtensionArray::storage(&self) -> &vortex_array::ArrayRef
+
+impl vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::clone(&self) -> vortex_array::arrays::ExtensionArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<&vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::datetime::TemporalArray) -> Self
+
+impl core::convert::From<vortex_array::arrays::ExtensionArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ExtensionArray) -> vortex_array::ArrayRef
+
+impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
+
+impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::datetime::TemporalArray
+
+pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
+
+pub fn vortex_array::arrays::datetime::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
+
+impl core::fmt::Debug for vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::ExtensionArray
+
+pub type vortex_array::arrays::ExtensionArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::ExtensionArray::deref(&self) -> &Self::Target
+
+impl vortex_array::Executable for vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::IntoArray for vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::into_array(self) -> vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::extension::ExtensionVTable
+
+impl vortex_array::arrays::ExtensionVTable
+
+pub const vortex_array::arrays::ExtensionVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::is_constant(&self, array: &vortex_array::arrays::ExtensionArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::is_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::ExtensionVTable::is_strict_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::min_max(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::sum(&self, array: &vortex_array::arrays::ExtensionArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::cast(array: &vortex_array::arrays::ExtensionArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::mask(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::ExtensionVTable
+
+pub type vortex_array::arrays::ExtensionVTable::Array = vortex_array::arrays::ExtensionArray
+
+pub type vortex_array::arrays::ExtensionVTable::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::ExtensionVTable::OperationsVTable = vortex_array::arrays::ExtensionVTable
+
+pub type vortex_array::arrays::ExtensionVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromChild
+
+pub fn vortex_array::arrays::ExtensionVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::ExtensionVTable::array_eq(array: &vortex_array::arrays::ExtensionArray, other: &vortex_array::arrays::ExtensionArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::ExtensionVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ExtensionArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::ExtensionVTable::buffer(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::ExtensionVTable::buffer_name(_array: &vortex_array::arrays::ExtensionArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::ExtensionVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ExtensionArray>
+
+pub fn vortex_array::arrays::ExtensionVTable::child(array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ExtensionVTable::child_name(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::ExtensionVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ExtensionVTable::dtype(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::ExtensionVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::ExtensionVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ExtensionVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::ExtensionVTable::len(array: &vortex_array::arrays::ExtensionArray) -> usize
+
+pub fn vortex_array::arrays::ExtensionVTable::metadata(_array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ExtensionVTable::nbuffers(_array: &vortex_array::arrays::ExtensionArray) -> usize
+
+pub fn vortex_array::arrays::ExtensionVTable::nchildren(_array: &vortex_array::arrays::ExtensionArray) -> usize
+
+pub fn vortex_array::arrays::ExtensionVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ExtensionVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ExtensionVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::ExtensionVTable::stats(array: &vortex_array::arrays::ExtensionArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::ExtensionVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityChild<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::validity_child(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::ArrayRef
+
+pub mod vortex_array::arrays::filter
+
+pub struct vortex_array::arrays::filter::FilterArray
+
+impl vortex_array::arrays::FilterArray
+
+pub fn vortex_array::arrays::FilterArray::child(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::FilterArray::filter_mask(&self) -> &vortex_mask::Mask
+
+pub fn vortex_array::arrays::FilterArray::into_parts(self) -> vortex_array::arrays::filter::FilterArrayParts
+
+pub fn vortex_array::arrays::FilterArray::new(array: vortex_array::ArrayRef, mask: vortex_mask::Mask) -> Self
+
+pub fn vortex_array::arrays::FilterArray::try_new(array: vortex_array::ArrayRef, mask: vortex_mask::Mask) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::arrays::FilterArray
+
+pub fn vortex_array::arrays::FilterArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::FilterArray
+
+pub fn vortex_array::arrays::FilterArray::clone(&self) -> vortex_array::arrays::FilterArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::FilterArray
+
+pub fn vortex_array::arrays::FilterArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::FilterArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::FilterArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::FilterArray
+
+pub fn vortex_array::arrays::FilterArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::FilterArray
+
+pub type vortex_array::arrays::FilterArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::FilterArray::deref(&self) -> &Self::Target
+
+impl vortex_array::IntoArray for vortex_array::arrays::FilterArray
+
+pub fn vortex_array::arrays::FilterArray::into_array(self) -> vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::filter::FilterArrayParts
+
+pub vortex_array::arrays::filter::FilterArrayParts::child: vortex_array::ArrayRef
+
+pub vortex_array::arrays::filter::FilterArrayParts::mask: vortex_mask::Mask
+
+pub struct vortex_array::arrays::filter::FilterExecuteAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::filter::FilterExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::filter::FilterExecuteAdaptor<V>::default() -> vortex_array::arrays::filter::FilterExecuteAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::filter::FilterExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::filter::FilterExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::filter::FilterExecuteAdaptor<V> where V: vortex_array::arrays::filter::FilterKernel
+
+pub type vortex_array::arrays::filter::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+
+pub fn vortex_array::arrays::filter::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub struct vortex_array::arrays::filter::FilterReduceAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::filter::FilterReduceAdaptor<V>
+
+pub fn vortex_array::arrays::filter::FilterReduceAdaptor<V>::default() -> vortex_array::arrays::filter::FilterReduceAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::filter::FilterReduceAdaptor<V>
+
+pub fn vortex_array::arrays::filter::FilterReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::filter::FilterReduceAdaptor<V> where V: vortex_array::arrays::filter::FilterReduce
+
+pub type vortex_array::arrays::filter::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+
+pub fn vortex_array::arrays::filter::FilterReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::FilterArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub struct vortex_array::arrays::filter::FilterVTable
+
+impl vortex_array::arrays::FilterVTable
+
+pub const vortex_array::arrays::FilterVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::FilterVTable
+
+pub fn vortex_array::arrays::FilterVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
+
+pub fn vortex_array::arrays::FilterVTable::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::FilterVTable
+
+pub type vortex_array::arrays::FilterVTable::Array = vortex_array::arrays::FilterArray
+
+pub type vortex_array::arrays::FilterVTable::Metadata = vortex_array::arrays::filter::vtable::FilterMetadata
+
+pub type vortex_array::arrays::FilterVTable::OperationsVTable = vortex_array::arrays::FilterVTable
+
+pub type vortex_array::arrays::FilterVTable::ValidityVTable = vortex_array::arrays::FilterVTable
+
+pub fn vortex_array::arrays::FilterVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::FilterVTable::array_eq(array: &vortex_array::arrays::FilterArray, other: &vortex_array::arrays::FilterArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::FilterVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FilterArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::FilterVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::FilterVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::FilterVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::filter::vtable::FilterMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+
+pub fn vortex_array::arrays::FilterVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::FilterVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::FilterVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::FilterVTable::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::FilterVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::FilterVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FilterVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::FilterVTable::len(array: &vortex_array::arrays::FilterArray) -> usize
+
+pub fn vortex_array::arrays::FilterVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::FilterVTable::nbuffers(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::FilterVTable::nchildren(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::FilterVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FilterVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FilterVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::FilterVTable::stats(array: &vortex_array::arrays::FilterArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::FilterVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
+
+pub fn vortex_array::arrays::FilterVTable::validity(array: &vortex_array::arrays::FilterArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub trait vortex_array::arrays::filter::FilterKernel: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::filter::FilterKernel::filter(array: &Self::Array, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub trait vortex_array::arrays::filter::FilterReduce: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::filter::FilterReduce::filter(array: &Self::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub mod vortex_array::arrays::fixed_size_list
+
+pub struct vortex_array::arrays::fixed_size_list::FixedSizeListArray
+
+impl vortex_array::arrays::FixedSizeListArray
+
+pub fn vortex_array::arrays::FixedSizeListArray::elements(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::FixedSizeListArray::fixed_size_list_elements_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::FixedSizeListArray::into_parts(self) -> (vortex_array::ArrayRef, vortex_array::validity::Validity, vortex_array::dtype::DType)
+
+pub const fn vortex_array::arrays::FixedSizeListArray::list_size(&self) -> u32
+
+pub fn vortex_array::arrays::FixedSizeListArray::new(elements: vortex_array::ArrayRef, list_size: u32, validity: vortex_array::validity::Validity, len: usize) -> Self
+
+pub unsafe fn vortex_array::arrays::FixedSizeListArray::new_unchecked(elements: vortex_array::ArrayRef, list_size: u32, validity: vortex_array::validity::Validity, len: usize) -> Self
+
+pub fn vortex_array::arrays::FixedSizeListArray::try_new(elements: vortex_array::ArrayRef, list_size: u32, validity: vortex_array::validity::Validity, len: usize) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::FixedSizeListArray::validate(elements: &vortex_array::ArrayRef, len: usize, list_size: u32, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+
+impl vortex_array::arrays::FixedSizeListArray
+
+pub fn vortex_array::arrays::FixedSizeListArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::FixedSizeListArray
+
+pub fn vortex_array::arrays::FixedSizeListArray::clone(&self) -> vortex_array::arrays::FixedSizeListArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::FixedSizeListArray
+
+pub fn vortex_array::arrays::FixedSizeListArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::FixedSizeListArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::FixedSizeListArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::FixedSizeListArray
+
+pub fn vortex_array::arrays::FixedSizeListArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::FixedSizeListArray
+
+pub type vortex_array::arrays::FixedSizeListArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::FixedSizeListArray::deref(&self) -> &Self::Target
+
+impl vortex_array::Executable for vortex_array::arrays::FixedSizeListArray
+
+pub fn vortex_array::arrays::FixedSizeListArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::IntoArray for vortex_array::arrays::FixedSizeListArray
+
+pub fn vortex_array::arrays::FixedSizeListArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::FixedSizeListArray
+
+pub fn vortex_array::arrays::FixedSizeListArray::validity(&self) -> &vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::fixed_size_list::FixedSizeListVTable
+
+impl vortex_array::arrays::FixedSizeListVTable
+
+pub const vortex_array::arrays::FixedSizeListVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::is_constant(&self, array: &vortex_array::arrays::FixedSizeListArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::is_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::min_max(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::cast(array: &vortex_array::arrays::FixedSizeListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::mask(array: &vortex_array::arrays::FixedSizeListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FixedSizeListVTable> for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::FixedSizeListVTable
+
+pub type vortex_array::arrays::FixedSizeListVTable::Array = vortex_array::arrays::FixedSizeListArray
+
+pub type vortex_array::arrays::FixedSizeListVTable::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::FixedSizeListVTable::OperationsVTable = vortex_array::arrays::FixedSizeListVTable
+
+pub type vortex_array::arrays::FixedSizeListVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::FixedSizeListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::array_eq(array: &vortex_array::arrays::FixedSizeListArray, other: &vortex_array::arrays::FixedSizeListArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::FixedSizeListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FixedSizeListArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::FixedSizeListVTable::buffer(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::FixedSizeListVTable::buffer_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::FixedSizeListArray>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::child(array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::FixedSizeListVTable::child_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::FixedSizeListVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::dtype(array: &vortex_array::arrays::FixedSizeListArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::FixedSizeListVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::FixedSizeListVTable::len(array: &vortex_array::arrays::FixedSizeListArray) -> usize
+
+pub fn vortex_array::arrays::FixedSizeListVTable::metadata(_array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::nbuffers(_array: &vortex_array::arrays::FixedSizeListArray) -> usize
+
+pub fn vortex_array::arrays::FixedSizeListVTable::nchildren(array: &vortex_array::arrays::FixedSizeListArray) -> usize
+
+pub fn vortex_array::arrays::FixedSizeListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::stats(array: &vortex_array::arrays::FixedSizeListArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::FixedSizeListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+pub mod vortex_array::arrays::list
+
+pub struct vortex_array::arrays::list::ListArray
+
+impl vortex_array::arrays::ListArray
+
+pub fn vortex_array::arrays::ListArray::element_dtype(&self) -> &alloc::sync::Arc<vortex_array::dtype::DType>
+
+pub fn vortex_array::arrays::ListArray::elements(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ListArray::into_parts(self) -> vortex_array::arrays::list::ListArrayParts
+
+pub fn vortex_array::arrays::ListArray::list_elements_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::ListArray::new(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::ListArray::new_unchecked(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::ListArray::offset_at(&self, index: usize) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::arrays::ListArray::offsets(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ListArray::reset_offsets(&self, recurse: bool) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::ListArray::sliced_elements(&self) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::ListArray::try_new(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::ListArray::validate(elements: &vortex_array::ArrayRef, offsets: &vortex_array::ArrayRef, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+
+impl vortex_array::arrays::ListArray
+
+pub fn vortex_array::arrays::ListArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::ListArray
+
+pub fn vortex_array::arrays::ListArray::clone(&self) -> vortex_array::arrays::ListArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ListArray
+
+pub fn vortex_array::arrays::ListArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::ListArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ListArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::ListArray
+
+pub fn vortex_array::arrays::ListArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::ListArray
+
+pub type vortex_array::arrays::ListArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::ListArray::deref(&self) -> &Self::Target
+
+impl vortex_array::IntoArray for vortex_array::arrays::ListArray
+
+pub fn vortex_array::arrays::ListArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::ListArray
+
+pub fn vortex_array::arrays::ListArray::validity(&self) -> &vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::list::ListArrayParts
+
+pub vortex_array::arrays::list::ListArrayParts::dtype: vortex_array::dtype::DType
+
+pub vortex_array::arrays::list::ListArrayParts::elements: vortex_array::ArrayRef
+
+pub vortex_array::arrays::list::ListArrayParts::offsets: vortex_array::ArrayRef
+
+pub vortex_array::arrays::list::ListArrayParts::validity: vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::list::ListVTable
+
+impl vortex_array::arrays::ListVTable
+
+pub const vortex_array::arrays::ListVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::is_constant(&self, array: &vortex_array::arrays::ListArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::is_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::ListVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::min_max(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::cast(array: &vortex_array::arrays::ListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::mask(array: &vortex_array::arrays::ListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListVTable> for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::scalar_at(array: &vortex_array::arrays::ListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::ListVTable
+
+pub type vortex_array::arrays::ListVTable::Array = vortex_array::arrays::ListArray
+
+pub type vortex_array::arrays::ListVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::list::vtable::ListMetadata>
+
+pub type vortex_array::arrays::ListVTable::OperationsVTable = vortex_array::arrays::ListVTable
+
+pub type vortex_array::arrays::ListVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::ListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::ListVTable::array_eq(array: &vortex_array::arrays::ListArray, other: &vortex_array::arrays::ListArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::ListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::ListVTable::buffer(_array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::ListVTable::buffer_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::ListVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
+
+pub fn vortex_array::arrays::ListVTable::child(array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ListVTable::child_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::ListVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ListVTable::dtype(array: &vortex_array::arrays::ListArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::ListVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::ListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ListVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::ListVTable::len(array: &vortex_array::arrays::ListArray) -> usize
+
+pub fn vortex_array::arrays::ListVTable::metadata(array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ListVTable::nbuffers(_array: &vortex_array::arrays::ListArray) -> usize
+
+pub fn vortex_array::arrays::ListVTable::nchildren(array: &vortex_array::arrays::ListArray) -> usize
+
+pub fn vortex_array::arrays::ListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ListVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::ListVTable::stats(array: &vortex_array::arrays::ListArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::ListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+pub mod vortex_array::arrays::listview
+
+pub enum vortex_array::arrays::listview::ListViewRebuildMode
+
+pub vortex_array::arrays::listview::ListViewRebuildMode::MakeExact
+
+pub vortex_array::arrays::listview::ListViewRebuildMode::MakeZeroCopyToList
+
+pub vortex_array::arrays::listview::ListViewRebuildMode::OverlapCompression
+
+pub vortex_array::arrays::listview::ListViewRebuildMode::TrimElements
+
+pub struct vortex_array::arrays::listview::ListViewArray
+
+impl vortex_array::arrays::ListViewArray
+
+pub fn vortex_array::arrays::ListViewArray::elements(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ListViewArray::into_parts(self) -> vortex_array::arrays::listview::ListViewArrayParts
+
+pub fn vortex_array::arrays::ListViewArray::is_zero_copy_to_list(&self) -> bool
+
+pub fn vortex_array::arrays::ListViewArray::list_elements_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::ListViewArray::new(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, sizes: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::ListViewArray::new_unchecked(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, sizes: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::ListViewArray::offset_at(&self, index: usize) -> usize
+
+pub fn vortex_array::arrays::ListViewArray::offsets(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ListViewArray::size_at(&self, index: usize) -> usize
+
+pub fn vortex_array::arrays::ListViewArray::sizes(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ListViewArray::try_new(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, sizes: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::ListViewArray::validate(elements: &vortex_array::ArrayRef, offsets: &vortex_array::ArrayRef, sizes: &vortex_array::ArrayRef, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::ListViewArray::verify_is_zero_copy_to_list(&self) -> bool
+
+pub unsafe fn vortex_array::arrays::ListViewArray::with_zero_copy_to_list(self, is_zctl: bool) -> Self
+
+impl vortex_array::arrays::ListViewArray
+
+pub fn vortex_array::arrays::ListViewArray::rebuild(&self, mode: vortex_array::arrays::listview::ListViewRebuildMode) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
+
+impl vortex_array::arrays::ListViewArray
+
+pub fn vortex_array::arrays::ListViewArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::ListViewArray
+
+pub fn vortex_array::arrays::ListViewArray::clone(&self) -> vortex_array::arrays::ListViewArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ListViewArray
+
+pub fn vortex_array::arrays::ListViewArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::ListViewArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ListViewArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::ListViewArray
+
+pub fn vortex_array::arrays::ListViewArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::ListViewArray
+
+pub type vortex_array::arrays::ListViewArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::ListViewArray::deref(&self) -> &Self::Target
+
+impl vortex_array::Executable for vortex_array::arrays::ListViewArray
+
+pub fn vortex_array::arrays::ListViewArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::IntoArray for vortex_array::arrays::ListViewArray
+
+pub fn vortex_array::arrays::ListViewArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::ListViewArray
+
+pub fn vortex_array::arrays::ListViewArray::validity(&self) -> &vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::listview::ListViewArrayParts
+
+pub vortex_array::arrays::listview::ListViewArrayParts::elements: vortex_array::ArrayRef
+
+pub vortex_array::arrays::listview::ListViewArrayParts::elements_dtype: alloc::sync::Arc<vortex_array::dtype::DType>
+
+pub vortex_array::arrays::listview::ListViewArrayParts::offsets: vortex_array::ArrayRef
+
+pub vortex_array::arrays::listview::ListViewArrayParts::sizes: vortex_array::ArrayRef
+
+pub vortex_array::arrays::listview::ListViewArrayParts::validity: vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::listview::ListViewVTable
+
+impl vortex_array::arrays::ListViewVTable
+
+pub const vortex_array::arrays::ListViewVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::is_constant(&self, array: &vortex_array::arrays::ListViewArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::is_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::ListViewVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::min_max(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::cast(array: &vortex_array::arrays::ListViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::mask(array: &vortex_array::arrays::ListViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListViewVTable> for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::ListViewVTable
+
+pub type vortex_array::arrays::ListViewVTable::Array = vortex_array::arrays::ListViewArray
+
+pub type vortex_array::arrays::ListViewVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::listview::vtable::ListViewMetadata>
+
+pub type vortex_array::arrays::ListViewVTable::OperationsVTable = vortex_array::arrays::ListViewVTable
+
+pub type vortex_array::arrays::ListViewVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::ListViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::ListViewVTable::array_eq(array: &vortex_array::arrays::ListViewArray, other: &vortex_array::arrays::ListViewArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::ListViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListViewArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::ListViewVTable::buffer(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::ListViewVTable::buffer_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::ListViewVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
+
+pub fn vortex_array::arrays::ListViewVTable::child(array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ListViewVTable::child_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::ListViewVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ListViewVTable::dtype(array: &vortex_array::arrays::ListViewArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::ListViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::ListViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ListViewVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::ListViewVTable::len(array: &vortex_array::arrays::ListViewArray) -> usize
+
+pub fn vortex_array::arrays::ListViewVTable::metadata(array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ListViewVTable::nbuffers(_array: &vortex_array::arrays::ListViewArray) -> usize
+
+pub fn vortex_array::arrays::ListViewVTable::nchildren(array: &vortex_array::arrays::ListViewArray) -> usize
+
+pub fn vortex_array::arrays::ListViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ListViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ListViewVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::ListViewVTable::stats(array: &vortex_array::arrays::ListViewArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::ListViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::listview::list_from_list_view(list_view: vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
+
+pub fn vortex_array::arrays::listview::list_view_from_list(list: vortex_array::arrays::ListArray, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
+
+pub fn vortex_array::arrays::listview::recursive_list_from_list_view(array: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub mod vortex_array::arrays::masked
+
+pub struct vortex_array::arrays::masked::MaskedArray
+
+impl vortex_array::arrays::MaskedArray
+
+pub fn vortex_array::arrays::MaskedArray::child(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::MaskedArray::try_new(child: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::arrays::MaskedArray
+
+pub fn vortex_array::arrays::MaskedArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::MaskedArray
+
+pub fn vortex_array::arrays::MaskedArray::clone(&self) -> vortex_array::arrays::MaskedArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::MaskedArray
+
+pub fn vortex_array::arrays::MaskedArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::MaskedArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::MaskedArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::MaskedArray
+
+pub fn vortex_array::arrays::MaskedArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::MaskedArray
+
+pub type vortex_array::arrays::MaskedArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::MaskedArray::deref(&self) -> &Self::Target
+
+impl vortex_array::IntoArray for vortex_array::arrays::MaskedArray
+
+pub fn vortex_array::arrays::MaskedArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::MaskedArray
+
+pub fn vortex_array::arrays::MaskedArray::validity(&self) -> &vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::masked::MaskedVTable
+
+impl vortex_array::arrays::MaskedVTable
+
+pub const vortex_array::arrays::MaskedVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::mask(array: &vortex_array::arrays::MaskedArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::MaskedVTable> for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::MaskedVTable
+
+pub type vortex_array::arrays::MaskedVTable::Array = vortex_array::arrays::MaskedArray
+
+pub type vortex_array::arrays::MaskedVTable::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::MaskedVTable::OperationsVTable = vortex_array::arrays::MaskedVTable
+
+pub type vortex_array::arrays::MaskedVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::MaskedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::MaskedVTable::array_eq(array: &vortex_array::arrays::MaskedArray, other: &vortex_array::arrays::MaskedArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::MaskedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::MaskedArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::MaskedVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::MaskedVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::MaskedVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::MaskedArray>
+
+pub fn vortex_array::arrays::MaskedVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::MaskedVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::MaskedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::MaskedVTable::dtype(array: &vortex_array::arrays::MaskedArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::MaskedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::MaskedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::MaskedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::MaskedVTable::len(array: &vortex_array::arrays::MaskedArray) -> usize
+
+pub fn vortex_array::arrays::MaskedVTable::metadata(_array: &vortex_array::arrays::MaskedArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::MaskedVTable::nbuffers(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::MaskedVTable::nchildren(array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::MaskedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::MaskedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::MaskedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::MaskedVTable::stats(array: &vortex_array::arrays::MaskedArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::MaskedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::masked::mask_validity_canonical(canonical: vortex_array::Canonical, validity_mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::Canonical>
+
+pub mod vortex_array::arrays::null
+
+pub struct vortex_array::arrays::null::NullArray
+
+impl vortex_array::arrays::null::NullArray
+
+pub fn vortex_array::arrays::null::NullArray::new(len: usize) -> Self
+
+impl vortex_array::arrays::null::NullArray
+
+pub fn vortex_array::arrays::null::NullArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::null::NullArray
+
+pub fn vortex_array::arrays::null::NullArray::clone(&self) -> vortex_array::arrays::null::NullArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::null::NullArray
+
+pub fn vortex_array::arrays::null::NullArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::null::NullArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::null::NullArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::null::NullArray
+
+pub fn vortex_array::arrays::null::NullArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::null::NullArray
+
+pub type vortex_array::arrays::null::NullArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::null::NullArray::deref(&self) -> &Self::Target
+
+impl vortex_array::Executable for vortex_array::arrays::null::NullArray
+
+pub fn vortex_array::arrays::null::NullArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::IntoArray for vortex_array::arrays::null::NullArray
+
+pub fn vortex_array::arrays::null::NullArray::into_array(self) -> vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::null::NullVTable
+
+impl vortex_array::arrays::null::NullVTable
+
+pub const vortex_array::arrays::null::NullVTable::ID: vortex_array::vtable::ArrayId
+
+impl vortex_array::arrays::null::NullVTable
+
+pub const vortex_array::arrays::null::NullVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
+
+impl core::fmt::Debug for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::null::NullVTable
+
+pub type vortex_array::arrays::null::NullVTable::Array = vortex_array::arrays::null::NullArray
+
+pub type vortex_array::arrays::null::NullVTable::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::null::NullVTable::OperationsVTable = vortex_array::arrays::null::NullVTable
+
+pub type vortex_array::arrays::null::NullVTable::ValidityVTable = vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::null::NullVTable::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::null::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::null::NullVTable::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::null::NullVTable::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::null::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
+
+pub fn vortex_array::arrays::null::NullVTable::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::null::NullVTable::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::null::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::null::NullVTable::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::null::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::null::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::null::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::null::NullVTable::len(array: &vortex_array::arrays::null::NullArray) -> usize
+
+pub fn vortex_array::arrays::null::NullVTable::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::null::NullVTable::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
+
+pub fn vortex_array::arrays::null::NullVTable::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
+
+pub fn vortex_array::arrays::null::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::null::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::null::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::null::NullVTable::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::null::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub mod vortex_array::arrays::primitive
+
+#[repr(transparent)] pub struct vortex_array::arrays::primitive::NativeValue<T>(pub T)
+
+impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<f32>
+
+pub fn vortex_array::arrays::primitive::NativeValue<f32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<f64>
+
+pub fn vortex_array::arrays::primitive::NativeValue<f64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<half::binary16::f16>
+
+pub fn vortex_array::arrays::primitive::NativeValue<half::binary16::f16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<i16>
+
+pub fn vortex_array::arrays::primitive::NativeValue<i16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<i32>
+
+pub fn vortex_array::arrays::primitive::NativeValue<i32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<i64>
+
+pub fn vortex_array::arrays::primitive::NativeValue<i64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<i8>
+
+pub fn vortex_array::arrays::primitive::NativeValue<i8>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<u16>
+
+pub fn vortex_array::arrays::primitive::NativeValue<u16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<u32>
+
+pub fn vortex_array::arrays::primitive::NativeValue<u32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<u64>
+
+pub fn vortex_array::arrays::primitive::NativeValue<u64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<u8>
+
+pub fn vortex_array::arrays::primitive::NativeValue<u8>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl<T: core::clone::Clone> core::clone::Clone for vortex_array::arrays::primitive::NativeValue<T>
+
+pub fn vortex_array::arrays::primitive::NativeValue<T>::clone(&self) -> vortex_array::arrays::primitive::NativeValue<T>
+
+impl<T: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::primitive::NativeValue<T>
+
+pub fn vortex_array::arrays::primitive::NativeValue<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<T: core::marker::Copy> core::marker::Copy for vortex_array::arrays::primitive::NativeValue<T>
+
+impl<T: vortex_array::dtype::NativePType> core::cmp::Eq for vortex_array::arrays::primitive::NativeValue<T>
+
+impl<T: vortex_array::dtype::NativePType> core::cmp::PartialEq for vortex_array::arrays::primitive::NativeValue<T>
+
+pub fn vortex_array::arrays::primitive::NativeValue<T>::eq(&self, other: &vortex_array::arrays::primitive::NativeValue<T>) -> bool
+
+impl<T: vortex_array::dtype::NativePType> core::cmp::PartialOrd for vortex_array::arrays::primitive::NativeValue<T>
+
+pub fn vortex_array::arrays::primitive::NativeValue<T>::partial_cmp(&self, other: &vortex_array::arrays::primitive::NativeValue<T>) -> core::option::Option<core::cmp::Ordering>
+
+pub struct vortex_array::arrays::primitive::PrimitiveArray
+
+impl vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::as_slice<T: vortex_array::dtype::NativePType>(&self) -> &[T]
+
+pub fn vortex_array::arrays::PrimitiveArray::narrow(&self) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
+
+pub fn vortex_array::arrays::PrimitiveArray::reinterpret_cast(&self, ptype: vortex_array::dtype::PType) -> Self
+
+impl vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::buffer_handle(&self) -> &vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::PrimitiveArray::from_buffer_handle(handle: vortex_array::buffer::BufferHandle, ptype: vortex_array::dtype::PType, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::PrimitiveArray::from_byte_buffer(buffer: vortex_buffer::ByteBuffer, ptype: vortex_array::dtype::PType, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::PrimitiveArray::from_values_byte_buffer(valid_elems_buffer: vortex_buffer::ByteBuffer, ptype: vortex_array::dtype::PType, validity: vortex_array::validity::Validity, n_rows: usize) -> Self
+
+pub fn vortex_array::arrays::PrimitiveArray::map_each<T, R, F>(self, f: F) -> vortex_array::arrays::PrimitiveArray where T: vortex_array::dtype::NativePType, R: vortex_array::dtype::NativePType, F: core::ops::function::FnMut(T) -> R
+
+pub fn vortex_array::arrays::PrimitiveArray::map_each_with_validity<T, R, F>(self, f: F) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray> where T: vortex_array::dtype::NativePType, R: vortex_array::dtype::NativePType, F: core::ops::function::FnMut((T, bool)) -> R
+
+pub fn vortex_array::arrays::PrimitiveArray::ptype(&self) -> vortex_array::dtype::PType
+
+impl vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::empty<T: vortex_array::dtype::NativePType>(nullability: vortex_array::dtype::Nullability) -> Self
+
+pub fn vortex_array::arrays::PrimitiveArray::new<T: vortex_array::dtype::NativePType>(buffer: impl core::convert::Into<vortex_buffer::buffer::Buffer<T>>, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::PrimitiveArray::new_unchecked<T: vortex_array::dtype::NativePType>(buffer: vortex_buffer::buffer::Buffer<T>, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::PrimitiveArray::new_unchecked_from_handle(handle: vortex_array::buffer::BufferHandle, ptype: vortex_array::dtype::PType, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::PrimitiveArray::try_new<T: vortex_array::dtype::NativePType>(buffer: vortex_buffer::buffer::Buffer<T>, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::PrimitiveArray::validate<T: vortex_array::dtype::NativePType>(buffer: &vortex_buffer::buffer::Buffer<T>, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+
+impl vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::from_option_iter<T: vortex_array::dtype::NativePType, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I) -> Self
+
+pub fn vortex_array::arrays::PrimitiveArray::into_buffer<T: vortex_array::dtype::NativePType>(self) -> vortex_buffer::buffer::Buffer<T>
+
+pub fn vortex_array::arrays::PrimitiveArray::into_buffer_mut<T: vortex_array::dtype::NativePType>(self) -> vortex_buffer::buffer_mut::BufferMut<T>
+
+pub fn vortex_array::arrays::PrimitiveArray::to_buffer<T: vortex_array::dtype::NativePType>(&self) -> vortex_buffer::buffer::Buffer<T>
+
+pub fn vortex_array::arrays::PrimitiveArray::try_into_buffer_mut<T: vortex_array::dtype::NativePType>(self) -> core::result::Result<vortex_buffer::buffer_mut::BufferMut<T>, vortex_buffer::buffer::Buffer<T>>
+
+impl vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::into_parts(self) -> vortex_array::arrays::primitive::PrimitiveArrayParts
+
+impl vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::patch(self, patches: &vortex_array::patches::Patches, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::top_value(&self) -> vortex_error::VortexResult<core::option::Option<(vortex_array::scalar::PValue, usize)>>
+
+impl core::clone::Clone for vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::clone(&self) -> vortex_array::arrays::PrimitiveArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::PrimitiveArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::PrimitiveArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::PrimitiveArray
+
+pub type vortex_array::arrays::PrimitiveArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::PrimitiveArray::deref(&self) -> &Self::Target
+
+impl vortex_array::Executable for vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::IntoArray for vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::validity(&self) -> &vortex_array::validity::Validity
+
+impl<T: vortex_array::dtype::NativePType> core::iter::traits::collect::FromIterator<T> for vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::from_iter<I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self
+
+impl<T: vortex_array::dtype::NativePType> vortex_array::accessor::ArrayAccessor<T> for vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::with_iterator<F, R>(&self, f: F) -> R where F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a T>>) -> R
+
+pub struct vortex_array::arrays::primitive::PrimitiveArrayParts
+
+pub vortex_array::arrays::primitive::PrimitiveArrayParts::buffer: vortex_array::buffer::BufferHandle
+
+pub vortex_array::arrays::primitive::PrimitiveArrayParts::ptype: vortex_array::dtype::PType
+
+pub vortex_array::arrays::primitive::PrimitiveArrayParts::validity: vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
+
+impl core::default::Default for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
+
+pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::default() -> vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
+
+impl core::fmt::Debug for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
+
+pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
+
+pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub struct vortex_array::arrays::primitive::PrimitiveVTable
+
+impl vortex_array::arrays::PrimitiveVTable
+
+pub const vortex_array::arrays::PrimitiveVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::is_constant(&self, array: &vortex_array::arrays::PrimitiveArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::is_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::PrimitiveVTable::is_strict_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::min_max(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::NaNCountKernel for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::nan_count(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<usize>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
+
+pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::cast(array: &vortex_array::arrays::PrimitiveArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::fill_null(array: &vortex_array::arrays::PrimitiveArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::mask(array: &vortex_array::arrays::PrimitiveArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::PrimitiveVTable
+
+pub type vortex_array::arrays::PrimitiveVTable::Array = vortex_array::arrays::PrimitiveArray
+
+pub type vortex_array::arrays::PrimitiveVTable::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::PrimitiveVTable::OperationsVTable = vortex_array::arrays::PrimitiveVTable
+
+pub type vortex_array::arrays::PrimitiveVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::PrimitiveVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::PrimitiveVTable::array_eq(array: &vortex_array::arrays::PrimitiveArray, other: &vortex_array::arrays::PrimitiveArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::PrimitiveVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::PrimitiveArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::PrimitiveVTable::buffer(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::PrimitiveVTable::buffer_name(_array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::PrimitiveVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
+
+pub fn vortex_array::arrays::PrimitiveVTable::child(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::PrimitiveVTable::child_name(_array: &vortex_array::arrays::PrimitiveArray, _idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::PrimitiveVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::PrimitiveVTable::dtype(array: &vortex_array::arrays::PrimitiveArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::PrimitiveVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::PrimitiveVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::PrimitiveVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::PrimitiveVTable::len(array: &vortex_array::arrays::PrimitiveArray) -> usize
+
+pub fn vortex_array::arrays::PrimitiveVTable::metadata(_array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::PrimitiveVTable::nbuffers(_array: &vortex_array::arrays::PrimitiveArray) -> usize
+
+pub fn vortex_array::arrays::PrimitiveVTable::nchildren(array: &vortex_array::arrays::PrimitiveArray) -> usize
+
+pub fn vortex_array::arrays::PrimitiveVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::PrimitiveVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::PrimitiveVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::PrimitiveVTable::stats(array: &vortex_array::arrays::PrimitiveArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::PrimitiveVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+pub const vortex_array::arrays::primitive::IS_CONST_LANE_WIDTH: usize
+
+pub fn vortex_array::arrays::primitive::chunk_range(chunk_idx: usize, offset: usize, array_len: usize) -> core::ops::range::Range<usize>
+
+pub fn vortex_array::arrays::primitive::compute_is_constant<T: vortex_array::dtype::NativePType, const WIDTH: usize>(values: &[T]) -> bool
+
+pub fn vortex_array::arrays::primitive::patch_chunk<T, I, C>(decoded_values: &mut [T], patches_indices: &[I], patches_values: &[T], patches_offset: usize, chunk_offsets_slice: &[C], chunk_idx: usize, offset_within_chunk: usize) where T: vortex_array::dtype::NativePType, I: vortex_array::dtype::UnsignedPType, C: vortex_array::dtype::UnsignedPType
+
+pub mod vortex_array::arrays::scalar_fn
+
+pub struct vortex_array::arrays::scalar_fn::AnyScalarFn
+
+impl core::fmt::Debug for vortex_array::arrays::scalar_fn::AnyScalarFn
+
+pub fn vortex_array::arrays::scalar_fn::AnyScalarFn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::matcher::Matcher for vortex_array::arrays::scalar_fn::AnyScalarFn
+
+pub type vortex_array::arrays::scalar_fn::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub fn vortex_array::arrays::scalar_fn::AnyScalarFn::matches(array: &dyn vortex_array::DynArray) -> bool
+
+pub fn vortex_array::arrays::scalar_fn::AnyScalarFn::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+
+pub struct vortex_array::arrays::scalar_fn::ExactScalarFn<F: vortex_array::scalar_fn::ScalarFnVTable>(_)
+
+impl<F: core::default::Default + vortex_array::scalar_fn::ScalarFnVTable> core::default::Default for vortex_array::arrays::scalar_fn::ExactScalarFn<F>
+
+pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::default() -> vortex_array::arrays::scalar_fn::ExactScalarFn<F>
+
+impl<F: core::fmt::Debug + vortex_array::scalar_fn::ScalarFnVTable> core::fmt::Debug for vortex_array::arrays::scalar_fn::ExactScalarFn<F>
+
+pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<F: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::matcher::Matcher for vortex_array::arrays::scalar_fn::ExactScalarFn<F>
+
+pub type vortex_array::arrays::scalar_fn::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::scalar_fn::ScalarFnArrayView<'a, F>
+
+pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::matches(array: &dyn vortex_array::DynArray) -> bool
+
+pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+
+pub struct vortex_array::arrays::scalar_fn::ScalarFnArray
+
+impl vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::children(&self) -> &[vortex_array::ArrayRef]
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::scalar_fn(&self) -> &vortex_array::scalar_fn::ScalarFnRef
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::try_new(bound: vortex_array::scalar_fn::ScalarFnRef, children: alloc::vec::Vec<vortex_array::ArrayRef>, len: usize) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::clone(&self) -> vortex_array::arrays::scalar_fn::ScalarFnArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::scalar_fn::ScalarFnArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub type vortex_array::arrays::scalar_fn::ScalarFnArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::deref(&self) -> &Self::Target
+
+impl vortex_array::IntoArray for vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child_count(&self) -> usize
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::node_dtype(&self) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
+
+pub struct vortex_array::arrays::scalar_fn::ScalarFnArrayView<'a, F: vortex_array::scalar_fn::ScalarFnVTable>
+
+pub vortex_array::arrays::scalar_fn::ScalarFnArrayView::options: &'a <F as vortex_array::scalar_fn::ScalarFnVTable>::Options
+
+pub vortex_array::arrays::scalar_fn::ScalarFnArrayView::vtable: &'a F
+
+impl<F: vortex_array::scalar_fn::ScalarFnVTable> core::ops::deref::Deref for vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, F>
+
+pub type vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, F>::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, F>::deref(&self) -> &Self::Target
+
+pub struct vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+impl core::clone::Clone for vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::clone(&self) -> vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+impl core::fmt::Debug for vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Array = vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Metadata = vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata
+
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::OperationsVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::ValidityVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_eq(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, other: &vortex_array::arrays::scalar_fn::ScalarFnArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer_name(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child_name(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::dtype(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::len(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nchildren(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::stats(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::validity(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub trait vortex_array::arrays::scalar_fn::ScalarFnArrayExt: vortex_array::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArrayExt::try_new_array(&self, len: usize, options: Self::Options, children: impl core::convert::Into<alloc::vec::Vec<vortex_array::ArrayRef>>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+impl<V: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::arrays::scalar_fn::ScalarFnArrayExt for V
+
+pub fn V::try_new_array(&self, len: usize, options: Self::Options, children: impl core::convert::Into<alloc::vec::Vec<vortex_array::ArrayRef>>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub mod vortex_array::arrays::shared
+
+pub struct vortex_array::arrays::shared::SharedArray
+
+impl vortex_array::arrays::SharedArray
+
+pub fn vortex_array::arrays::SharedArray::get_or_compute(&self, f: impl core::ops::function::FnOnce(&vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::Canonical>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub async fn vortex_array::arrays::SharedArray::get_or_compute_async<F, Fut>(&self, f: F) -> vortex_error::VortexResult<vortex_array::ArrayRef> where F: core::ops::function::FnOnce(vortex_array::ArrayRef) -> Fut, Fut: core::future::future::Future<Output = vortex_error::VortexResult<vortex_array::Canonical>>
+
+pub fn vortex_array::arrays::SharedArray::new(source: vortex_array::ArrayRef) -> Self
+
+impl vortex_array::arrays::SharedArray
+
+pub fn vortex_array::arrays::SharedArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::SharedArray
+
+pub fn vortex_array::arrays::SharedArray::clone(&self) -> vortex_array::arrays::SharedArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::SharedArray
+
+pub fn vortex_array::arrays::SharedArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::SharedArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::SharedArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::SharedArray
+
+pub fn vortex_array::arrays::SharedArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::SharedArray
+
+pub type vortex_array::arrays::SharedArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::SharedArray::deref(&self) -> &Self::Target
+
+impl vortex_array::IntoArray for vortex_array::arrays::SharedArray
+
+pub fn vortex_array::arrays::SharedArray::into_array(self) -> vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::shared::SharedVTable
+
+impl vortex_array::arrays::SharedVTable
+
+pub const vortex_array::arrays::SharedVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::SharedVTable
+
+pub fn vortex_array::arrays::SharedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
+
+pub fn vortex_array::arrays::SharedVTable::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::SharedVTable
+
+pub type vortex_array::arrays::SharedVTable::Array = vortex_array::arrays::SharedArray
+
+pub type vortex_array::arrays::SharedVTable::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::SharedVTable::OperationsVTable = vortex_array::arrays::SharedVTable
+
+pub type vortex_array::arrays::SharedVTable::ValidityVTable = vortex_array::arrays::SharedVTable
+
+pub fn vortex_array::arrays::SharedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::SharedVTable::array_eq(array: &vortex_array::arrays::SharedArray, other: &vortex_array::arrays::SharedArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::SharedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SharedArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::SharedVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::SharedVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::SharedVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::SharedArray>
+
+pub fn vortex_array::arrays::SharedVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::SharedVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::SharedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::SharedVTable::dtype(array: &vortex_array::arrays::SharedArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::SharedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::SharedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::SharedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::SharedVTable::len(array: &vortex_array::arrays::SharedArray) -> usize
+
+pub fn vortex_array::arrays::SharedVTable::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::SharedVTable::nbuffers(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::SharedVTable::nchildren(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::SharedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::SharedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::SharedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::SharedVTable::stats(array: &vortex_array::arrays::SharedArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::SharedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
+
+pub fn vortex_array::arrays::SharedVTable::validity(array: &vortex_array::arrays::SharedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub mod vortex_array::arrays::slice
+
+pub struct vortex_array::arrays::slice::SliceArray
+
+impl vortex_array::arrays::slice::SliceArray
+
+pub fn vortex_array::arrays::slice::SliceArray::child(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::slice::SliceArray::into_parts(self) -> vortex_array::arrays::slice::SliceArrayParts
+
+pub fn vortex_array::arrays::slice::SliceArray::new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> Self
+
+pub fn vortex_array::arrays::slice::SliceArray::slice_range(&self) -> &core::ops::range::Range<usize>
+
+pub fn vortex_array::arrays::slice::SliceArray::try_new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::arrays::slice::SliceArray
+
+pub fn vortex_array::arrays::slice::SliceArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::slice::SliceArray
+
+pub fn vortex_array::arrays::slice::SliceArray::clone(&self) -> vortex_array::arrays::slice::SliceArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::slice::SliceArray
+
+pub fn vortex_array::arrays::slice::SliceArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::slice::SliceArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::slice::SliceArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::slice::SliceArray
+
+pub fn vortex_array::arrays::slice::SliceArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::slice::SliceArray
+
+pub type vortex_array::arrays::slice::SliceArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::slice::SliceArray::deref(&self) -> &Self::Target
+
+impl vortex_array::IntoArray for vortex_array::arrays::slice::SliceArray
+
+pub fn vortex_array::arrays::slice::SliceArray::into_array(self) -> vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::slice::SliceArrayParts
+
+pub vortex_array::arrays::slice::SliceArrayParts::child: vortex_array::ArrayRef
+
+pub vortex_array::arrays::slice::SliceArrayParts::range: core::ops::range::Range<usize>
+
+pub struct vortex_array::arrays::slice::SliceExecuteAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::slice::SliceExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::slice::SliceExecuteAdaptor<V>::default() -> vortex_array::arrays::slice::SliceExecuteAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::slice::SliceExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::slice::SliceExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::slice::SliceExecuteAdaptor<V> where V: vortex_array::arrays::slice::SliceKernel
+
+pub type vortex_array::arrays::slice::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
+
+pub fn vortex_array::arrays::slice::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub struct vortex_array::arrays::slice::SliceMetadata(_)
+
+impl core::fmt::Debug for vortex_array::arrays::slice::SliceMetadata
+
+pub fn vortex_array::arrays::slice::SliceMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub struct vortex_array::arrays::slice::SliceReduceAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::slice::SliceReduceAdaptor<V>
+
+pub fn vortex_array::arrays::slice::SliceReduceAdaptor<V>::default() -> vortex_array::arrays::slice::SliceReduceAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::slice::SliceReduceAdaptor<V>
+
+pub fn vortex_array::arrays::slice::SliceReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::slice::SliceReduceAdaptor<V> where V: vortex_array::arrays::slice::SliceReduce
+
+pub type vortex_array::arrays::slice::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
+
+pub fn vortex_array::arrays::slice::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub struct vortex_array::arrays::slice::SliceVTable
+
+impl vortex_array::arrays::slice::SliceVTable
+
+pub const vortex_array::arrays::slice::SliceVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::slice::SliceVTable
+
+pub fn vortex_array::arrays::slice::SliceVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::SliceVTable
+
+pub fn vortex_array::arrays::slice::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
+
+pub fn vortex_array::arrays::slice::SliceVTable::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::slice::SliceVTable
+
+pub type vortex_array::arrays::slice::SliceVTable::Array = vortex_array::arrays::slice::SliceArray
+
+pub type vortex_array::arrays::slice::SliceVTable::Metadata = vortex_array::arrays::slice::SliceMetadata
+
+pub type vortex_array::arrays::slice::SliceVTable::OperationsVTable = vortex_array::arrays::slice::SliceVTable
+
+pub type vortex_array::arrays::slice::SliceVTable::ValidityVTable = vortex_array::arrays::slice::SliceVTable
+
+pub fn vortex_array::arrays::slice::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::slice::SliceVTable::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::slice::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::slice::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::slice::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::slice::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+
+pub fn vortex_array::arrays::slice::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::slice::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::slice::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::slice::SliceVTable::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::slice::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::slice::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::slice::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::slice::SliceVTable::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
+
+pub fn vortex_array::arrays::slice::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::slice::SliceVTable::nbuffers(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::slice::SliceVTable::nchildren(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::slice::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::slice::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::slice::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::slice::SliceVTable::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::slice::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
+
+pub fn vortex_array::arrays::slice::SliceVTable::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub trait vortex_array::arrays::slice::SliceKernel: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::slice::SliceKernel::slice(array: &Self::Array, range: core::ops::range::Range<usize>, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub trait vortex_array::arrays::slice::SliceReduce: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::slice::SliceReduce::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::SliceVTable
+
+pub fn vortex_array::arrays::slice::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub mod vortex_array::arrays::struct_
+
+pub struct vortex_array::arrays::struct_::StructArray
+
+impl vortex_array::arrays::StructArray
+
+pub fn vortex_array::arrays::StructArray::from_fields<N: core::convert::AsRef<str>>(items: &[(N, vortex_array::ArrayRef)]) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::StructArray::into_fields(self) -> alloc::vec::Vec<vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::StructArray::into_parts(self) -> vortex_array::arrays::struct_::StructArrayParts
+
+pub fn vortex_array::arrays::StructArray::names(&self) -> &vortex_array::dtype::FieldNames
+
+pub fn vortex_array::arrays::StructArray::new(names: vortex_array::dtype::FieldNames, fields: impl core::convert::Into<alloc::sync::Arc<[vortex_array::ArrayRef]>>, length: usize, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::StructArray::new_fieldless_with_len(len: usize) -> Self
+
+pub unsafe fn vortex_array::arrays::StructArray::new_unchecked(fields: impl core::convert::Into<alloc::sync::Arc<[vortex_array::ArrayRef]>>, dtype: vortex_array::dtype::StructFields, length: usize, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::StructArray::project(&self, projection: &[vortex_array::dtype::FieldName]) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::StructArray::remove_column(&mut self, name: impl core::convert::Into<vortex_array::dtype::FieldName>) -> core::option::Option<vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::StructArray::struct_fields(&self) -> &vortex_array::dtype::StructFields
+
+pub fn vortex_array::arrays::StructArray::try_from_iter<N: core::convert::AsRef<str>, A: vortex_array::IntoArray, T: core::iter::traits::collect::IntoIterator<Item = (N, A)>>(iter: T) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::StructArray::try_from_iter_with_validity<N: core::convert::AsRef<str>, A: vortex_array::IntoArray, T: core::iter::traits::collect::IntoIterator<Item = (N, A)>>(iter: T, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::StructArray::try_new(names: vortex_array::dtype::FieldNames, fields: impl core::convert::Into<alloc::sync::Arc<[vortex_array::ArrayRef]>>, length: usize, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::StructArray::try_new_with_dtype(fields: impl core::convert::Into<alloc::sync::Arc<[vortex_array::ArrayRef]>>, dtype: vortex_array::dtype::StructFields, length: usize, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::StructArray::unmasked_field_by_name(&self, name: impl core::convert::AsRef<str>) -> vortex_error::VortexResult<&vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::StructArray::unmasked_field_by_name_opt(&self, name: impl core::convert::AsRef<str>) -> core::option::Option<&vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::StructArray::unmasked_fields(&self) -> &alloc::sync::Arc<[vortex_array::ArrayRef]>
+
+pub fn vortex_array::arrays::StructArray::validate(fields: &[vortex_array::ArrayRef], dtype: &vortex_array::dtype::StructFields, length: usize, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::StructArray::with_column(&self, name: impl core::convert::Into<vortex_array::dtype::FieldName>, array: vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::arrays::StructArray
+
+pub fn vortex_array::arrays::StructArray::into_record_batch_with_schema(self, schema: impl core::convert::AsRef<arrow_schema::schema::Schema>) -> vortex_error::VortexResult<arrow_array::record_batch::RecordBatch>
+
+impl vortex_array::arrays::StructArray
+
+pub fn vortex_array::arrays::StructArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::StructArray
+
+pub fn vortex_array::arrays::StructArray::clone(&self) -> vortex_array::arrays::StructArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::StructArray
+
+pub fn vortex_array::arrays::StructArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::StructArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::StructArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::StructArray
+
+pub fn vortex_array::arrays::StructArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::ops::deref::Deref for vortex_array::arrays::StructArray
+
+pub type vortex_array::arrays::StructArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::StructArray::deref(&self) -> &Self::Target
+
+impl vortex_array::Executable for vortex_array::arrays::StructArray
+
+pub fn vortex_array::arrays::StructArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::IntoArray for vortex_array::arrays::StructArray
+
+pub fn vortex_array::arrays::StructArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::StructArray
+
+pub fn vortex_array::arrays::StructArray::validity(&self) -> &vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::struct_::StructArrayParts
+
+pub vortex_array::arrays::struct_::StructArrayParts::fields: alloc::sync::Arc<[vortex_array::ArrayRef]>
+
+pub vortex_array::arrays::struct_::StructArrayParts::struct_fields: vortex_array::dtype::StructFields
+
+pub vortex_array::arrays::struct_::StructArrayParts::validity: vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::struct_::StructVTable
+
+impl vortex_array::arrays::StructVTable
+
+pub const vortex_array::arrays::StructVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::is_constant(&self, array: &vortex_array::arrays::StructArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::min_max(&self, _array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::cast(array: &vortex_array::arrays::StructArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::mask(array: &vortex_array::arrays::StructArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::scalar_at(array: &vortex_array::arrays::StructArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::StructVTable
+
+pub type vortex_array::arrays::StructVTable::Array = vortex_array::arrays::StructArray
+
+pub type vortex_array::arrays::StructVTable::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::StructVTable::OperationsVTable = vortex_array::arrays::StructVTable
+
+pub type vortex_array::arrays::StructVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::StructVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::StructVTable::array_eq(array: &vortex_array::arrays::StructArray, other: &vortex_array::arrays::StructArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::StructVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::StructArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::StructVTable::buffer(_array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::StructVTable::buffer_name(_array: &vortex_array::arrays::StructArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::StructVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::StructArray>
+
+pub fn vortex_array::arrays::StructVTable::child(array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::StructVTable::child_name(array: &vortex_array::arrays::StructArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::StructVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::StructVTable::dtype(array: &vortex_array::arrays::StructArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::StructVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::StructVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::StructVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::StructVTable::len(array: &vortex_array::arrays::StructArray) -> usize
+
+pub fn vortex_array::arrays::StructVTable::metadata(_array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::StructVTable::nbuffers(_array: &vortex_array::arrays::StructArray) -> usize
+
+pub fn vortex_array::arrays::StructVTable::nchildren(array: &vortex_array::arrays::StructArray) -> usize
+
+pub fn vortex_array::arrays::StructVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::StructVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::StructVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::StructVTable::stats(array: &vortex_array::arrays::StructArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::StructVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+pub mod vortex_array::arrays::varbin
+
+pub mod vortex_array::arrays::varbin::builder
+
+pub struct vortex_array::arrays::varbin::builder::VarBinBuilder<O: vortex_array::dtype::IntegerPType>
+
+impl<O: vortex_array::dtype::IntegerPType> vortex_array::arrays::varbin::builder::VarBinBuilder<O>
+
+pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::append(&mut self, value: core::option::Option<&[u8]>)
+
+pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::append_n_nulls(&mut self, n: usize)
+
+pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::append_null(&mut self)
+
+pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::append_value(&mut self, value: impl core::convert::AsRef<[u8]>)
+
+pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::append_values(&mut self, values: &[u8], end_offsets: impl core::iter::traits::iterator::Iterator<Item = O>, num: usize) where O: 'static, usize: num_traits::cast::AsPrimitive<O>
+
+pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::finish(self, dtype: vortex_array::dtype::DType) -> vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::new() -> Self
+
+pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::with_capacity(len: usize) -> Self
+
+impl<O: vortex_array::dtype::IntegerPType> core::default::Default for vortex_array::arrays::varbin::builder::VarBinBuilder<O>
+
+pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::default() -> Self
+
+pub struct vortex_array::arrays::varbin::VarBinArray
+
+impl vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::bytes(&self) -> &vortex_buffer::ByteBuffer
+
+pub fn vortex_array::arrays::VarBinArray::bytes_at(&self, index: usize) -> vortex_buffer::ByteBuffer
+
+pub fn vortex_array::arrays::VarBinArray::bytes_handle(&self) -> &vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I, dtype: vortex_array::dtype::DType) -> Self
+
+pub fn vortex_array::arrays::VarBinArray::from_iter_nonnull<T: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I, dtype: vortex_array::dtype::DType) -> Self
+
+pub fn vortex_array::arrays::VarBinArray::from_vec<T: core::convert::AsRef<[u8]>>(vec: alloc::vec::Vec<T>, dtype: vortex_array::dtype::DType) -> Self
+
+pub fn vortex_array::arrays::VarBinArray::into_parts(self) -> (vortex_array::dtype::DType, vortex_array::buffer::BufferHandle, vortex_array::ArrayRef, vortex_array::validity::Validity)
+
+pub fn vortex_array::arrays::VarBinArray::new(offsets: vortex_array::ArrayRef, bytes: vortex_buffer::ByteBuffer, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::VarBinArray::new_from_handle(offset: vortex_array::ArrayRef, bytes: vortex_array::buffer::BufferHandle, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::VarBinArray::new_unchecked(offsets: vortex_array::ArrayRef, bytes: vortex_buffer::ByteBuffer, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::VarBinArray::new_unchecked_from_handle(offsets: vortex_array::ArrayRef, bytes: vortex_array::buffer::BufferHandle, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::VarBinArray::offset_at(&self, index: usize) -> usize
+
+pub fn vortex_array::arrays::VarBinArray::offsets(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::VarBinArray::sliced_bytes(&self) -> vortex_buffer::ByteBuffer
+
+pub fn vortex_array::arrays::VarBinArray::try_new(offsets: vortex_array::ArrayRef, bytes: vortex_buffer::ByteBuffer, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::VarBinArray::try_new_from_handle(offsets: vortex_array::ArrayRef, bytes: vortex_array::buffer::BufferHandle, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::VarBinArray::validate(offsets: &vortex_array::ArrayRef, bytes: &vortex_array::buffer::BufferHandle, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+
+impl vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::clone(&self) -> vortex_array::arrays::VarBinArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<alloc::vec::Vec<&[u8]>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<&[u8]>) -> Self
+
+impl core::convert::From<alloc::vec::Vec<&str>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<&str>) -> Self
+
+impl core::convert::From<alloc::vec::Vec<alloc::string::String>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<alloc::string::String>) -> Self
+
+impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<alloc::vec::Vec<u8>>) -> Self
+
+impl core::convert::From<alloc::vec::Vec<core::option::Option<&[u8]>>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<core::option::Option<&[u8]>>) -> Self
+
+impl core::convert::From<alloc::vec::Vec<core::option::Option<&str>>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<core::option::Option<&str>>) -> Self
+
+impl core::convert::From<alloc::vec::Vec<core::option::Option<alloc::string::String>>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<core::option::Option<alloc::string::String>>) -> Self
+
+impl core::convert::From<alloc::vec::Vec<core::option::Option<alloc::vec::Vec<u8>>>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<core::option::Option<alloc::vec::Vec<u8>>>) -> Self
+
+impl core::convert::From<vortex_array::arrays::VarBinArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::VarBinArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::iter::traits::collect::FromIterator<core::option::Option<alloc::string::String>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<alloc::string::String>>>(iter: T) -> Self
+
+impl core::iter::traits::collect::FromIterator<core::option::Option<alloc::vec::Vec<u8>>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<alloc::vec::Vec<u8>>>>(iter: T) -> Self
+
+impl core::ops::deref::Deref for vortex_array::arrays::VarBinArray
+
+pub type vortex_array::arrays::VarBinArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::VarBinArray::deref(&self) -> &Self::Target
+
+impl vortex_array::IntoArray for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::accessor::ArrayAccessor<[u8]> for &vortex_array::arrays::VarBinArray
+
+pub fn &vortex_array::arrays::VarBinArray::with_iterator<F, R>(&self, f: F) -> R where F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a [u8]>>) -> R
+
+impl vortex_array::accessor::ArrayAccessor<[u8]> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::with_iterator<F, R>(&self, f: F) -> R where F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a [u8]>>) -> R
+
+impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::validity(&self) -> &vortex_array::validity::Validity
+
+impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a [u8]>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a [u8]>>>(iter: T) -> Self
+
+impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a str>> for vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a str>>>(iter: T) -> Self
+
+pub struct vortex_array::arrays::varbin::VarBinVTable
+
+impl vortex_array::arrays::VarBinVTable
+
+pub const vortex_array::arrays::VarBinVTable::ID: vortex_array::vtable::ArrayId
+
+impl vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::_slice(array: &vortex_array::arrays::VarBinArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+impl core::fmt::Debug for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::is_constant(&self, array: &vortex_array::arrays::VarBinArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::VarBinVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::min_max(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::cast(array: &vortex_array::arrays::VarBinArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::mask(array: &vortex_array::arrays::VarBinArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinVTable> for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinVTable
+
+pub type vortex_array::arrays::VarBinVTable::Array = vortex_array::arrays::VarBinArray
+
+pub type vortex_array::arrays::VarBinVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::varbin::vtable::VarBinMetadata>
+
+pub type vortex_array::arrays::VarBinVTable::OperationsVTable = vortex_array::arrays::VarBinVTable
+
+pub type vortex_array::arrays::VarBinVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::VarBinVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::VarBinVTable::array_eq(array: &vortex_array::arrays::VarBinArray, other: &vortex_array::arrays::VarBinArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::VarBinVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::VarBinVTable::buffer(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::VarBinVTable::buffer_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::VarBinVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinArray>
+
+pub fn vortex_array::arrays::VarBinVTable::child(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::VarBinVTable::child_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::VarBinVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBinVTable::dtype(array: &vortex_array::arrays::VarBinArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::VarBinVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::VarBinVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBinVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::VarBinVTable::len(array: &vortex_array::arrays::VarBinArray) -> usize
+
+pub fn vortex_array::arrays::VarBinVTable::metadata(array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBinVTable::nbuffers(_array: &vortex_array::arrays::VarBinArray) -> usize
+
+pub fn vortex_array::arrays::VarBinVTable::nchildren(array: &vortex_array::arrays::VarBinArray) -> usize
+
+pub fn vortex_array::arrays::VarBinVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBinVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBinVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::VarBinVTable::stats(array: &vortex_array::arrays::VarBinArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::VarBinVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::varbin::varbin_scalar(value: vortex_buffer::ByteBuffer, dtype: &vortex_array::dtype::DType) -> vortex_array::scalar::Scalar
+
+pub mod vortex_array::arrays::varbinview
+
+pub mod vortex_array::arrays::varbinview::build_views
+
+#[repr(C, align(16))] pub union vortex_array::arrays::varbinview::build_views::BinaryView
+
+impl vortex_array::arrays::varbinview::BinaryView
+
+pub const vortex_array::arrays::varbinview::BinaryView::MAX_INLINED_SIZE: usize
+
+pub fn vortex_array::arrays::varbinview::BinaryView::as_inlined(&self) -> &vortex_array::arrays::varbinview::Inlined
+
+pub fn vortex_array::arrays::varbinview::BinaryView::as_u128(&self) -> u128
+
+pub fn vortex_array::arrays::varbinview::BinaryView::as_view(&self) -> &vortex_array::arrays::varbinview::Ref
+
+pub fn vortex_array::arrays::varbinview::BinaryView::as_view_mut(&mut self) -> &mut vortex_array::arrays::varbinview::Ref
+
+pub fn vortex_array::arrays::varbinview::BinaryView::empty_view() -> Self
+
+pub fn vortex_array::arrays::varbinview::BinaryView::is_empty(&self) -> bool
+
+pub fn vortex_array::arrays::varbinview::BinaryView::is_inlined(&self) -> bool
+
+pub fn vortex_array::arrays::varbinview::BinaryView::len(&self) -> u32
+
+pub fn vortex_array::arrays::varbinview::BinaryView::make_view(value: &[u8], block: u32, offset: u32) -> Self
+
+pub fn vortex_array::arrays::varbinview::BinaryView::new_inlined(value: &[u8]) -> Self
+
+impl core::clone::Clone for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::clone(&self) -> vortex_array::arrays::varbinview::BinaryView
+
+impl core::cmp::Eq for vortex_array::arrays::varbinview::BinaryView
+
+impl core::cmp::PartialEq for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::eq(&self, other: &Self) -> bool
+
+impl core::convert::From<u128> for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::from(value: u128) -> Self
+
+impl core::convert::From<vortex_array::arrays::varbinview::Ref> for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::from(value: vortex_array::arrays::varbinview::Ref) -> Self
+
+impl core::default::Default for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::default() -> Self
+
+impl core::fmt::Debug for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::marker::Copy for vortex_array::arrays::varbinview::BinaryView
+
+pub const vortex_array::arrays::varbinview::build_views::MAX_BUFFER_LEN: usize
+
+pub fn vortex_array::arrays::varbinview::build_views::build_views<P: vortex_array::dtype::NativePType + num_traits::cast::AsPrimitive<usize>>(start_buf_index: u32, max_buffer_len: usize, bytes: vortex_buffer::ByteBufferMut, lens: &[P]) -> (alloc::vec::Vec<vortex_buffer::ByteBuffer>, vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>)
+
+pub fn vortex_array::arrays::varbinview::build_views::offsets_to_lengths<P: vortex_array::dtype::NativePType>(offsets: &[P]) -> vortex_buffer::buffer::Buffer<P>
+
+#[repr(C, align(16))] pub union vortex_array::arrays::varbinview::BinaryView
+
+impl vortex_array::arrays::varbinview::BinaryView
+
+pub const vortex_array::arrays::varbinview::BinaryView::MAX_INLINED_SIZE: usize
+
+pub fn vortex_array::arrays::varbinview::BinaryView::as_inlined(&self) -> &vortex_array::arrays::varbinview::Inlined
+
+pub fn vortex_array::arrays::varbinview::BinaryView::as_u128(&self) -> u128
+
+pub fn vortex_array::arrays::varbinview::BinaryView::as_view(&self) -> &vortex_array::arrays::varbinview::Ref
+
+pub fn vortex_array::arrays::varbinview::BinaryView::as_view_mut(&mut self) -> &mut vortex_array::arrays::varbinview::Ref
+
+pub fn vortex_array::arrays::varbinview::BinaryView::empty_view() -> Self
+
+pub fn vortex_array::arrays::varbinview::BinaryView::is_empty(&self) -> bool
+
+pub fn vortex_array::arrays::varbinview::BinaryView::is_inlined(&self) -> bool
+
+pub fn vortex_array::arrays::varbinview::BinaryView::len(&self) -> u32
+
+pub fn vortex_array::arrays::varbinview::BinaryView::make_view(value: &[u8], block: u32, offset: u32) -> Self
+
+pub fn vortex_array::arrays::varbinview::BinaryView::new_inlined(value: &[u8]) -> Self
+
+impl core::clone::Clone for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::clone(&self) -> vortex_array::arrays::varbinview::BinaryView
+
+impl core::cmp::Eq for vortex_array::arrays::varbinview::BinaryView
+
+impl core::cmp::PartialEq for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::eq(&self, other: &Self) -> bool
+
+impl core::convert::From<u128> for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::from(value: u128) -> Self
+
+impl core::convert::From<vortex_array::arrays::varbinview::Ref> for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::from(value: vortex_array::arrays::varbinview::Ref) -> Self
+
+impl core::default::Default for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::default() -> Self
+
+impl core::fmt::Debug for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::marker::Copy for vortex_array::arrays::varbinview::BinaryView
+
+#[repr(C, align(8))] pub struct vortex_array::arrays::varbinview::Inlined
+
+pub vortex_array::arrays::varbinview::Inlined::data: [u8; 12]
+
+pub vortex_array::arrays::varbinview::Inlined::size: u32
+
+impl vortex_array::arrays::varbinview::Inlined
+
+pub fn vortex_array::arrays::varbinview::Inlined::value(&self) -> &[u8]
+
+impl core::clone::Clone for vortex_array::arrays::varbinview::Inlined
+
+pub fn vortex_array::arrays::varbinview::Inlined::clone(&self) -> vortex_array::arrays::varbinview::Inlined
+
+impl core::cmp::Eq for vortex_array::arrays::varbinview::Inlined
+
+impl core::cmp::PartialEq for vortex_array::arrays::varbinview::Inlined
+
+pub fn vortex_array::arrays::varbinview::Inlined::eq(&self, other: &vortex_array::arrays::varbinview::Inlined) -> bool
+
+impl core::fmt::Debug for vortex_array::arrays::varbinview::Inlined
+
+pub fn vortex_array::arrays::varbinview::Inlined::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::marker::Copy for vortex_array::arrays::varbinview::Inlined
+
+impl core::marker::StructuralPartialEq for vortex_array::arrays::varbinview::Inlined
+
+#[repr(C, align(8))] pub struct vortex_array::arrays::varbinview::Ref
+
+pub vortex_array::arrays::varbinview::Ref::buffer_index: u32
+
+pub vortex_array::arrays::varbinview::Ref::offset: u32
+
+pub vortex_array::arrays::varbinview::Ref::prefix: [u8; 4]
+
+pub vortex_array::arrays::varbinview::Ref::size: u32
+
+impl vortex_array::arrays::varbinview::Ref
+
+pub fn vortex_array::arrays::varbinview::Ref::as_range(&self) -> core::ops::range::Range<usize>
+
+pub fn vortex_array::arrays::varbinview::Ref::with_buffer_and_offset(&self, buffer_index: u32, offset: u32) -> vortex_array::arrays::varbinview::Ref
+
+impl core::clone::Clone for vortex_array::arrays::varbinview::Ref
+
+pub fn vortex_array::arrays::varbinview::Ref::clone(&self) -> vortex_array::arrays::varbinview::Ref
+
+impl core::convert::From<vortex_array::arrays::varbinview::Ref> for vortex_array::arrays::varbinview::BinaryView
+
+pub fn vortex_array::arrays::varbinview::BinaryView::from(value: vortex_array::arrays::varbinview::Ref) -> Self
+
+impl core::fmt::Debug for vortex_array::arrays::varbinview::Ref
+
+pub fn vortex_array::arrays::varbinview::Ref::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::marker::Copy for vortex_array::arrays::varbinview::Ref
+
+pub struct vortex_array::arrays::varbinview::VarBinViewArray
+
+impl vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::buffer(&self, idx: usize) -> &vortex_buffer::ByteBuffer
+
+pub fn vortex_array::arrays::VarBinViewArray::buffers(&self) -> &alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>
+
+pub fn vortex_array::arrays::VarBinViewArray::bytes_at(&self, index: usize) -> vortex_buffer::ByteBuffer
+
+pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I, dtype: vortex_array::dtype::DType) -> Self
+
+pub fn vortex_array::arrays::VarBinViewArray::from_iter_bin<T: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self
+
+pub fn vortex_array::arrays::VarBinViewArray::from_iter_nullable_bin<T: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I) -> Self
+
+pub fn vortex_array::arrays::VarBinViewArray::from_iter_nullable_str<T: core::convert::AsRef<str>, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I) -> Self
+
+pub fn vortex_array::arrays::VarBinViewArray::from_iter_str<T: core::convert::AsRef<str>, I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self
+
+pub fn vortex_array::arrays::VarBinViewArray::into_parts(self) -> vortex_array::arrays::varbinview::VarBinViewArrayParts
+
+pub fn vortex_array::arrays::VarBinViewArray::nbuffers(&self) -> usize
+
+pub fn vortex_array::arrays::VarBinViewArray::new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::VarBinViewArray::new_handle(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::VarBinViewArray::new_handle_unchecked(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::VarBinViewArray::new_unchecked(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::VarBinViewArray::try_new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::VarBinViewArray::try_new_handle(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::VarBinViewArray::validate(views: &vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: &alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::VarBinViewArray::views(&self) -> &[vortex_array::arrays::varbinview::BinaryView]
+
+pub fn vortex_array::arrays::VarBinViewArray::views_handle(&self) -> &vortex_array::buffer::BufferHandle
+
+impl vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::compact_buffers(&self) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
+
+pub fn vortex_array::arrays::VarBinViewArray::compact_with_threshold(&self, buffer_utilization_threshold: f64) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
+
+impl vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::clone(&self) -> vortex_array::arrays::VarBinViewArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::VarBinViewArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::VarBinViewArray) -> vortex_array::ArrayRef
+
+impl core::fmt::Debug for vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::iter::traits::collect::FromIterator<core::option::Option<alloc::string::String>> for vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<alloc::string::String>>>(iter: T) -> Self
+
+impl core::iter::traits::collect::FromIterator<core::option::Option<alloc::vec::Vec<u8>>> for vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<alloc::vec::Vec<u8>>>>(iter: T) -> Self
+
+impl core::ops::deref::Deref for vortex_array::arrays::VarBinViewArray
+
+pub type vortex_array::arrays::VarBinViewArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::VarBinViewArray::deref(&self) -> &Self::Target
+
+impl vortex_array::Executable for vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::IntoArray for vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::accessor::ArrayAccessor<[u8]> for &vortex_array::arrays::VarBinViewArray
+
+pub fn &vortex_array::arrays::VarBinViewArray::with_iterator<F, R>(&self, f: F) -> R where F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a [u8]>>) -> R
+
+impl vortex_array::accessor::ArrayAccessor<[u8]> for vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::with_iterator<F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a [u8]>>) -> R, R>(&self, f: F) -> R
+
+impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::validity(&self) -> &vortex_array::validity::Validity
+
+impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a [u8]>> for vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a [u8]>>>(iter: T) -> Self
+
+impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a str>> for vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a str>>>(iter: T) -> Self
+
+pub struct vortex_array::arrays::varbinview::VarBinViewArrayParts
+
+pub vortex_array::arrays::varbinview::VarBinViewArrayParts::buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>
+
+pub vortex_array::arrays::varbinview::VarBinViewArrayParts::dtype: vortex_array::dtype::DType
+
+pub vortex_array::arrays::varbinview::VarBinViewArrayParts::validity: vortex_array::validity::Validity
+
+pub vortex_array::arrays::varbinview::VarBinViewArrayParts::views: vortex_array::buffer::BufferHandle
+
+pub struct vortex_array::arrays::varbinview::VarBinViewVTable
+
+impl vortex_array::arrays::VarBinViewVTable
+
+pub const vortex_array::arrays::VarBinViewVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::is_constant(&self, array: &vortex_array::arrays::VarBinViewArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::VarBinViewVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::min_max(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::cast(array: &vortex_array::arrays::VarBinViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::mask(array: &vortex_array::arrays::VarBinViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinViewVTable> for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinViewVTable
+
+pub type vortex_array::arrays::VarBinViewVTable::Array = vortex_array::arrays::VarBinViewArray
+
+pub type vortex_array::arrays::VarBinViewVTable::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::VarBinViewVTable::OperationsVTable = vortex_array::arrays::VarBinViewVTable
+
+pub type vortex_array::arrays::VarBinViewVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::VarBinViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::VarBinViewVTable::array_eq(array: &vortex_array::arrays::VarBinViewArray, other: &vortex_array::arrays::VarBinViewArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::VarBinViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinViewArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::VarBinViewVTable::buffer(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::VarBinViewVTable::buffer_name(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::VarBinViewVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
+
+pub fn vortex_array::arrays::VarBinViewVTable::child(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::VarBinViewVTable::child_name(_array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::VarBinViewVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBinViewVTable::dtype(array: &vortex_array::arrays::VarBinViewArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::VarBinViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::VarBinViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBinViewVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::VarBinViewVTable::len(array: &vortex_array::arrays::VarBinViewArray) -> usize
+
+pub fn vortex_array::arrays::VarBinViewVTable::metadata(_array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBinViewVTable::nbuffers(array: &vortex_array::arrays::VarBinViewArray) -> usize
+
+pub fn vortex_array::arrays::VarBinViewVTable::nchildren(array: &vortex_array::arrays::VarBinViewArray) -> usize
+
+pub fn vortex_array::arrays::VarBinViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBinViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBinViewVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::VarBinViewVTable::stats(array: &vortex_array::arrays::VarBinViewArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::VarBinViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+pub struct vortex_array::arrays::BoolArray
+
+impl vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::from_indices<I: core::iter::traits::collect::IntoIterator<Item = usize>>(length: usize, indices: I, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::BoolArray::into_bit_buffer(self) -> vortex_buffer::bit::buf::BitBuffer
+
+pub fn vortex_array::arrays::BoolArray::into_parts(self) -> vortex_array::arrays::bool::BoolArrayParts
+
+pub fn vortex_array::arrays::BoolArray::maybe_to_mask(&self) -> vortex_error::VortexResult<core::option::Option<vortex_mask::Mask>>
+
+pub fn vortex_array::arrays::BoolArray::new(bits: vortex_buffer::bit::buf::BitBuffer, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::BoolArray::new_handle(handle: vortex_array::buffer::BufferHandle, offset: usize, len: usize, validity: vortex_array::validity::Validity) -> Self
+
+pub unsafe fn vortex_array::arrays::BoolArray::new_unchecked(bits: vortex_buffer::bit::buf::BitBuffer, validity: vortex_array::validity::Validity) -> Self
+
+pub fn vortex_array::arrays::BoolArray::to_bit_buffer(&self) -> vortex_buffer::bit::buf::BitBuffer
+
+pub fn vortex_array::arrays::BoolArray::to_mask(&self) -> vortex_mask::Mask
+
+pub fn vortex_array::arrays::BoolArray::to_mask_fill_null_false(&self) -> vortex_mask::Mask
+
+pub fn vortex_array::arrays::BoolArray::try_new(bits: vortex_buffer::bit::buf::BitBuffer, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::BoolArray::try_new_from_handle(bits: vortex_array::buffer::BufferHandle, offset: usize, len: usize, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+
+pub fn vortex_array::arrays::BoolArray::validate(bits: &vortex_buffer::bit::buf::BitBuffer, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+
+impl vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::patch(self, patches: &vortex_array::patches::Patches, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::to_array(&self) -> vortex_array::ArrayRef
+
+impl core::clone::Clone for vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::clone(&self) -> vortex_array::arrays::BoolArray
+
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::as_ref(&self) -> &dyn vortex_array::DynArray
+
+impl core::convert::From<vortex_array::arrays::BoolArray> for vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::BoolArray) -> vortex_array::ArrayRef
+
+impl core::convert::From<vortex_buffer::bit::buf::BitBuffer> for vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::from(value: vortex_buffer::bit::buf::BitBuffer) -> Self
+
+impl core::fmt::Debug for vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::iter::traits::collect::FromIterator<bool> for vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = bool>>(iter: T) -> Self
+
+impl core::iter::traits::collect::FromIterator<core::option::Option<bool>> for vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::from_iter<I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<bool>>>(iter: I) -> Self
+
+impl core::ops::deref::Deref for vortex_array::arrays::BoolArray
+
+pub type vortex_array::arrays::BoolArray::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::BoolArray::deref(&self) -> &Self::Target
+
+impl vortex_array::Executable for vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::IntoArray for vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::BoolArray
+
+pub fn vortex_array::arrays::BoolArray::validity(&self) -> &vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::BoolVTable
+
+impl vortex_array::arrays::BoolVTable
+
+pub const vortex_array::arrays::BoolVTable::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::is_constant(&self, array: &vortex_array::arrays::BoolArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::is_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::BoolVTable::is_strict_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::min_max(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::sum(&self, array: &vortex_array::arrays::BoolArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
+
+pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::BoolVTable
 
@@ -948,13 +4820,17 @@ pub fn vortex_array::arrays::ChunkedArray::try_new(chunks: alloc::vec::Vec<vorte
 
 pub fn vortex_array::arrays::ChunkedArray::validate(chunks: &[vortex_array::ArrayRef], dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
 
+impl vortex_array::arrays::ChunkedArray
+
+pub fn vortex_array::arrays::ChunkedArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::ChunkedArray
 
 pub fn vortex_array::arrays::ChunkedArray::clone(&self) -> vortex_array::arrays::ChunkedArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ChunkedArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ChunkedArray
 
-pub fn vortex_array::arrays::ChunkedArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::ChunkedArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::ChunkedArray> for vortex_array::ArrayRef
 
@@ -964,13 +4840,13 @@ impl core::fmt::Debug for vortex_array::arrays::ChunkedArray
 
 pub fn vortex_array::arrays::ChunkedArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl core::iter::traits::collect::FromIterator<alloc::sync::Arc<dyn vortex_array::Array>> for vortex_array::arrays::ChunkedArray
+impl core::iter::traits::collect::FromIterator<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::arrays::ChunkedArray
 
 pub fn vortex_array::arrays::ChunkedArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = vortex_array::ArrayRef>>(iter: T) -> Self
 
 impl core::ops::deref::Deref for vortex_array::arrays::ChunkedArray
 
-pub type vortex_array::arrays::ChunkedArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::ChunkedArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::ChunkedArray::deref(&self) -> &Self::Target
 
@@ -988,17 +4864,17 @@ impl core::fmt::Debug for vortex_array::arrays::ChunkedVTable
 
 pub fn vortex_array::arrays::ChunkedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::FilterKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ChunkedVTable
 
 pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::SliceKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::ChunkedVTable
 
 pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ChunkedVTable
 
@@ -1030,9 +4906,9 @@ impl vortex_array::scalar_fn::fns::mask::MaskKernel for vortex_array::arrays::Ch
 
 pub fn vortex_array::arrays::ChunkedVTable::mask(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::zip::ZipReduce for vortex_array::arrays::ChunkedVTable
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::ChunkedVTable
 
-pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
 
@@ -1106,13 +4982,17 @@ pub fn vortex_array::arrays::ConstantArray::new<S>(scalar: S, len: usize) -> Sel
 
 pub fn vortex_array::arrays::ConstantArray::scalar(&self) -> &vortex_array::scalar::Scalar
 
+impl vortex_array::arrays::ConstantArray
+
+pub fn vortex_array::arrays::ConstantArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::ConstantArray
 
 pub fn vortex_array::arrays::ConstantArray::clone(&self) -> vortex_array::arrays::ConstantArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ConstantArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ConstantArray
 
-pub fn vortex_array::arrays::ConstantArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::ConstantArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::ConstantArray> for vortex_array::ArrayRef
 
@@ -1124,7 +5004,7 @@ pub fn vortex_array::arrays::ConstantArray::fmt(&self, f: &mut core::fmt::Format
 
 impl core::ops::deref::Deref for vortex_array::arrays::ConstantArray
 
-pub type vortex_array::arrays::ConstantArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::ConstantArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::ConstantArray::deref(&self) -> &Self::Target
 
@@ -1146,17 +5026,17 @@ impl core::fmt::Debug for vortex_array::arrays::ConstantVTable
 
 pub fn vortex_array::arrays::ConstantVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ConstantVTable
 
 pub fn vortex_array::arrays::ConstantVTable::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ConstantVTable
 
 pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ConstantVTable
 
@@ -1190,13 +5070,13 @@ impl vortex_array::vtable::VTable for vortex_array::arrays::ConstantVTable
 
 pub type vortex_array::arrays::ConstantVTable::Array = vortex_array::arrays::ConstantArray
 
-pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::scalar::Scalar
 
 pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::arrays::ConstantVTable
 
 pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 
@@ -1206,13 +5086,13 @@ pub fn vortex_array::arrays::ConstantVTable::buffer(array: &vortex_array::arrays
 
 pub fn vortex_array::arrays::ConstantVTable::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ConstantVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
+pub fn vortex_array::arrays::ConstantVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
 
 pub fn vortex_array::arrays::ConstantVTable::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
 
 pub fn vortex_array::arrays::ConstantVTable::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
 
@@ -1224,7 +5104,7 @@ pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_
 
 pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::metadata(_array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
 
@@ -1258,7 +5138,7 @@ pub fn vortex_array::arrays::DecimalArray::from_iter<T: vortex_array::dtype::Nat
 
 pub fn vortex_array::arrays::DecimalArray::from_option_iter<T: vortex_array::dtype::NativeDecimalType, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I, decimal_dtype: vortex_array::dtype::DecimalDType) -> Self
 
-pub fn vortex_array::arrays::DecimalArray::into_parts(self) -> vortex_array::arrays::DecimalArrayParts
+pub fn vortex_array::arrays::DecimalArray::into_parts(self) -> vortex_array::arrays::decimal::DecimalArrayParts
 
 pub fn vortex_array::arrays::DecimalArray::new<T: vortex_array::dtype::NativeDecimalType>(buffer: vortex_buffer::buffer::Buffer<T>, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
 
@@ -1282,13 +5162,17 @@ pub fn vortex_array::arrays::DecimalArray::try_new_handle(values: vortex_array::
 
 pub fn vortex_array::arrays::DecimalArray::values_type(&self) -> vortex_array::dtype::DecimalType
 
+impl vortex_array::arrays::DecimalArray
+
+pub fn vortex_array::arrays::DecimalArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::DecimalArray
 
 pub fn vortex_array::arrays::DecimalArray::clone(&self) -> vortex_array::arrays::DecimalArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::DecimalArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::DecimalArray
 
-pub fn vortex_array::arrays::DecimalArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::DecimalArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::DecimalArray> for vortex_array::ArrayRef
 
@@ -1300,7 +5184,7 @@ pub fn vortex_array::arrays::DecimalArray::fmt(&self, f: &mut core::fmt::Formatt
 
 impl core::ops::deref::Deref for vortex_array::arrays::DecimalArray
 
-pub type vortex_array::arrays::DecimalArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::DecimalArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::DecimalArray::deref(&self) -> &Self::Target
 
@@ -1316,32 +5200,6 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::DecimalArray
 
 pub fn vortex_array::arrays::DecimalArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::DecimalArrayParts
-
-pub vortex_array::arrays::DecimalArrayParts::decimal_dtype: vortex_array::dtype::DecimalDType
-
-pub vortex_array::arrays::DecimalArrayParts::validity: vortex_array::validity::Validity
-
-pub vortex_array::arrays::DecimalArrayParts::values: vortex_array::buffer::BufferHandle
-
-pub vortex_array::arrays::DecimalArrayParts::values_type: vortex_array::dtype::DecimalType
-
-pub struct vortex_array::arrays::DecimalMaskedValidityRule
-
-impl core::default::Default for vortex_array::arrays::DecimalMaskedValidityRule
-
-pub fn vortex_array::arrays::DecimalMaskedValidityRule::default() -> vortex_array::arrays::DecimalMaskedValidityRule
-
-impl core::fmt::Debug for vortex_array::arrays::DecimalMaskedValidityRule
-
-pub fn vortex_array::arrays::DecimalMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalMaskedValidityRule
-
-pub type vortex_array::arrays::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
 pub struct vortex_array::arrays::DecimalVTable
 
 impl vortex_array::arrays::DecimalVTable
@@ -1352,13 +5210,13 @@ impl core::fmt::Debug for vortex_array::arrays::DecimalVTable
 
 pub fn vortex_array::arrays::DecimalVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DecimalVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::DecimalVTable
 
 pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DecimalVTable
 
@@ -1378,11 +5236,11 @@ impl vortex_array::compute::SumKernel for vortex_array::arrays::DecimalVTable
 
 pub fn vortex_array::arrays::DecimalVTable::sum(&self, array: &vortex_array::arrays::DecimalArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
 
-pub type vortex_array::arrays::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::DecimalVTable
 
@@ -1460,231 +5318,179 @@ pub fn vortex_array::arrays::DecimalVTable::with_children(array: &mut Self::Arra
 
 pub struct vortex_array::arrays::DictArray
 
-impl vortex_array::arrays::DictArray
+impl vortex_array::arrays::dict::DictArray
 
-pub fn vortex_array::arrays::DictArray::codes(&self) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::dict::DictArray::codes(&self) -> &vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::DictArray::compute_referenced_values_mask(&self, referenced: bool) -> vortex_error::VortexResult<vortex_buffer::bit::buf::BitBuffer>
+pub fn vortex_array::arrays::dict::DictArray::compute_referenced_values_mask(&self, referenced: bool) -> vortex_error::VortexResult<vortex_buffer::bit::buf::BitBuffer>
 
-pub fn vortex_array::arrays::DictArray::has_all_values_referenced(&self) -> bool
+pub fn vortex_array::arrays::dict::DictArray::has_all_values_referenced(&self) -> bool
 
-pub fn vortex_array::arrays::DictArray::into_parts(self) -> vortex_array::arrays::DictArrayParts
+pub fn vortex_array::arrays::dict::DictArray::into_parts(self) -> vortex_array::arrays::dict::DictArrayParts
 
-pub fn vortex_array::arrays::DictArray::new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
+pub fn vortex_array::arrays::dict::DictArray::new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
 
-pub unsafe fn vortex_array::arrays::DictArray::new_unchecked(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
+pub unsafe fn vortex_array::arrays::dict::DictArray::new_unchecked(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
 
-pub unsafe fn vortex_array::arrays::DictArray::set_all_values_referenced(self, all_values_referenced: bool) -> Self
+pub unsafe fn vortex_array::arrays::dict::DictArray::set_all_values_referenced(self, all_values_referenced: bool) -> Self
 
-pub fn vortex_array::arrays::DictArray::try_new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::dict::DictArray::try_new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrays::DictArray::validate_all_values_referenced(&self) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::dict::DictArray::validate_all_values_referenced(&self) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::DictArray::values(&self) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::dict::DictArray::values(&self) -> &vortex_array::ArrayRef
 
-impl core::clone::Clone for vortex_array::arrays::DictArray
+impl vortex_array::arrays::dict::DictArray
 
-pub fn vortex_array::arrays::DictArray::clone(&self) -> vortex_array::arrays::DictArray
+pub fn vortex_array::arrays::dict::DictArray::to_array(&self) -> vortex_array::ArrayRef
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::DictArray
+impl core::clone::Clone for vortex_array::arrays::dict::DictArray
 
-pub fn vortex_array::arrays::DictArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::dict::DictArray::clone(&self) -> vortex_array::arrays::dict::DictArray
 
-impl core::convert::From<vortex_array::arrays::DictArray> for vortex_array::ArrayRef
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::dict::DictArray
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::DictArray) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::dict::DictArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::fmt::Debug for vortex_array::arrays::DictArray
+impl core::convert::From<vortex_array::arrays::dict::DictArray> for vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::DictArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::dict::DictArray) -> vortex_array::ArrayRef
 
-impl core::ops::deref::Deref for vortex_array::arrays::DictArray
+impl core::fmt::Debug for vortex_array::arrays::dict::DictArray
 
-pub type vortex_array::arrays::DictArray::Target = dyn vortex_array::Array
+pub fn vortex_array::arrays::dict::DictArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-pub fn vortex_array::arrays::DictArray::deref(&self) -> &Self::Target
+impl core::ops::deref::Deref for vortex_array::arrays::dict::DictArray
 
-impl vortex_array::IntoArray for vortex_array::arrays::DictArray
+pub type vortex_array::arrays::dict::DictArray::Target = dyn vortex_array::DynArray
 
-pub fn vortex_array::arrays::DictArray::into_array(self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::dict::DictArray::deref(&self) -> &Self::Target
 
-impl<K: arrow_array::types::ArrowDictionaryKeyType> vortex_array::arrow::FromArrowArray<&arrow_array::array::dictionary_array::DictionaryArray<K>> for vortex_array::arrays::DictArray
+impl vortex_array::IntoArray for vortex_array::arrays::dict::DictArray
 
-pub fn vortex_array::arrays::DictArray::from_arrow(array: &arrow_array::array::dictionary_array::DictionaryArray<K>, nullable: bool) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::dict::DictArray::into_array(self) -> vortex_array::ArrayRef
 
-pub struct vortex_array::arrays::DictArrayParts
+impl<K: arrow_array::types::ArrowDictionaryKeyType> vortex_array::arrow::FromArrowArray<&arrow_array::array::dictionary_array::DictionaryArray<K>> for vortex_array::arrays::dict::DictArray
 
-pub vortex_array::arrays::DictArrayParts::codes: vortex_array::ArrayRef
-
-pub vortex_array::arrays::DictArrayParts::dtype: vortex_array::dtype::DType
-
-pub vortex_array::arrays::DictArrayParts::values: vortex_array::ArrayRef
-
-pub struct vortex_array::arrays::DictMetadata
-
-impl vortex_array::arrays::DictMetadata
-
-pub fn vortex_array::arrays::DictMetadata::all_values_referenced(&self) -> bool
-
-pub fn vortex_array::arrays::DictMetadata::codes_ptype(&self) -> vortex_array::dtype::PType
-
-pub fn vortex_array::arrays::DictMetadata::is_nullable_codes(&self) -> bool
-
-pub fn vortex_array::arrays::DictMetadata::set_codes_ptype(&mut self, value: vortex_array::dtype::PType)
-
-impl core::clone::Clone for vortex_array::arrays::DictMetadata
-
-pub fn vortex_array::arrays::DictMetadata::clone(&self) -> vortex_array::arrays::DictMetadata
-
-impl core::default::Default for vortex_array::arrays::DictMetadata
-
-pub fn vortex_array::arrays::DictMetadata::default() -> Self
-
-impl core::fmt::Debug for vortex_array::arrays::DictMetadata
-
-pub fn vortex_array::arrays::DictMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl prost::message::Message for vortex_array::arrays::DictMetadata
-
-pub fn vortex_array::arrays::DictMetadata::clear(&mut self)
-
-pub fn vortex_array::arrays::DictMetadata::encoded_len(&self) -> usize
+pub fn vortex_array::arrays::dict::DictArray::from_arrow(array: &arrow_array::array::dictionary_array::DictionaryArray<K>, nullable: bool) -> vortex_error::VortexResult<Self>
 
 pub struct vortex_array::arrays::DictVTable
 
-impl vortex_array::arrays::DictVTable
+impl vortex_array::arrays::dict::DictVTable
 
-pub const vortex_array::arrays::DictVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::dict::DictVTable::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::DictVTable
+impl core::fmt::Debug for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::dict::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::DictVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::filter(array: &vortex_array::arrays::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::DictVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DictVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DictVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::is_constant(&self, array: &vortex_array::arrays::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DictVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::is_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DictVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::min_max(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::DictVTable
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::DictVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::cast(array: &vortex_array::arrays::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::DictVTable
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::fill_null(array: &vortex_array::arrays::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::DictVTable
+impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DictVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::mask(array: &vortex_array::arrays::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::scalar_at(array: &vortex_array::arrays::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::DictVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
 
-pub type vortex_array::arrays::DictVTable::Array = vortex_array::arrays::DictArray
+pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
 
-pub type vortex_array::arrays::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::DictMetadata>
+pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
 
-pub type vortex_array::arrays::DictVTable::OperationsVTable = vortex_array::arrays::DictVTable
+pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
 
-pub type vortex_array::arrays::DictVTable::ValidityVTable = vortex_array::arrays::DictVTable
+pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::DictVTable::array_eq(array: &vortex_array::arrays::DictArray, other: &vortex_array::arrays::DictArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DictArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::DictVTable::buffer(_array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::DictVTable::buffer_name(_array: &vortex_array::arrays::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
+pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
 
-pub fn vortex_array::arrays::DictVTable::child(array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::DictVTable::child_name(_array: &vortex_array::arrays::DictArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::DictVTable::dtype(array: &vortex_array::arrays::DictArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::DictVTable::len(array: &vortex_array::arrays::DictArray) -> usize
+pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::DictVTable::metadata(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::DictVTable::nbuffers(_array: &vortex_array::arrays::DictArray) -> usize
+pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::DictVTable::nchildren(_array: &vortex_array::arrays::DictArray) -> usize
+pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::DictVTable::stats(array: &vortex_array::arrays::DictArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::validity(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub struct vortex_array::arrays::ExactScalarFn<F: vortex_array::scalar_fn::ScalarFnVTable>(_)
-
-impl<F: core::default::Default + vortex_array::scalar_fn::ScalarFnVTable> core::default::Default for vortex_array::arrays::ExactScalarFn<F>
-
-pub fn vortex_array::arrays::ExactScalarFn<F>::default() -> vortex_array::arrays::ExactScalarFn<F>
-
-impl<F: core::fmt::Debug + vortex_array::scalar_fn::ScalarFnVTable> core::fmt::Debug for vortex_array::arrays::ExactScalarFn<F>
-
-pub fn vortex_array::arrays::ExactScalarFn<F>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<F: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::matcher::Matcher for vortex_array::arrays::ExactScalarFn<F>
-
-pub type vortex_array::arrays::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::ScalarFnArrayView<'a, F>
-
-pub fn vortex_array::arrays::ExactScalarFn<F>::matches(array: &dyn vortex_array::Array) -> bool
-
-pub fn vortex_array::arrays::ExactScalarFn<F>::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::ExtensionArray
 
@@ -1698,31 +5504,35 @@ pub fn vortex_array::arrays::ExtensionArray::new(ext_dtype: vortex_array::dtype:
 
 pub fn vortex_array::arrays::ExtensionArray::storage(&self) -> &vortex_array::ArrayRef
 
+impl vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::ExtensionArray
 
 pub fn vortex_array::arrays::ExtensionArray::clone(&self) -> vortex_array::arrays::ExtensionArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ExtensionArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ExtensionArray
 
-pub fn vortex_array::arrays::ExtensionArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::ExtensionArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::convert::From<&vortex_array::arrays::TemporalArray> for vortex_array::arrays::ExtensionArray
+impl core::convert::From<&vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
 
-pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::TemporalArray) -> Self
+pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::datetime::TemporalArray) -> Self
 
 impl core::convert::From<vortex_array::arrays::ExtensionArray> for vortex_array::ArrayRef
 
 pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ExtensionArray) -> vortex_array::ArrayRef
 
-impl core::convert::From<vortex_array::arrays::TemporalArray> for vortex_array::arrays::ExtensionArray
+impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
 
-pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::TemporalArray) -> Self
+pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
 
-impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::TemporalArray
+impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::datetime::TemporalArray
 
-pub type vortex_array::arrays::TemporalArray::Error = vortex_error::VortexError
+pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
 
-pub fn vortex_array::arrays::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
+pub fn vortex_array::arrays::datetime::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
 
 impl core::fmt::Debug for vortex_array::arrays::ExtensionArray
 
@@ -1730,7 +5540,7 @@ pub fn vortex_array::arrays::ExtensionArray::fmt(&self, f: &mut core::fmt::Forma
 
 impl core::ops::deref::Deref for vortex_array::arrays::ExtensionArray
 
-pub type vortex_array::arrays::ExtensionArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::ExtensionArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::ExtensionArray::deref(&self) -> &Self::Target
 
@@ -1752,17 +5562,17 @@ impl core::fmt::Debug for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::ExtensionVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ExtensionVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ExtensionVTable
 
@@ -1864,19 +5674,23 @@ pub fn vortex_array::arrays::FilterArray::child(&self) -> &vortex_array::ArrayRe
 
 pub fn vortex_array::arrays::FilterArray::filter_mask(&self) -> &vortex_mask::Mask
 
-pub fn vortex_array::arrays::FilterArray::into_parts(self) -> vortex_array::arrays::FilterArrayParts
+pub fn vortex_array::arrays::FilterArray::into_parts(self) -> vortex_array::arrays::filter::FilterArrayParts
 
 pub fn vortex_array::arrays::FilterArray::new(array: vortex_array::ArrayRef, mask: vortex_mask::Mask) -> Self
 
 pub fn vortex_array::arrays::FilterArray::try_new(array: vortex_array::ArrayRef, mask: vortex_mask::Mask) -> vortex_error::VortexResult<Self>
 
+impl vortex_array::arrays::FilterArray
+
+pub fn vortex_array::arrays::FilterArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::FilterArray
 
 pub fn vortex_array::arrays::FilterArray::clone(&self) -> vortex_array::arrays::FilterArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::FilterArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::FilterArray
 
-pub fn vortex_array::arrays::FilterArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::FilterArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::FilterArray> for vortex_array::ArrayRef
 
@@ -1888,51 +5702,13 @@ pub fn vortex_array::arrays::FilterArray::fmt(&self, f: &mut core::fmt::Formatte
 
 impl core::ops::deref::Deref for vortex_array::arrays::FilterArray
 
-pub type vortex_array::arrays::FilterArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::FilterArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::FilterArray::deref(&self) -> &Self::Target
 
 impl vortex_array::IntoArray for vortex_array::arrays::FilterArray
 
 pub fn vortex_array::arrays::FilterArray::into_array(self) -> vortex_array::ArrayRef
-
-pub struct vortex_array::arrays::FilterArrayParts
-
-pub vortex_array::arrays::FilterArrayParts::child: vortex_array::ArrayRef
-
-pub vortex_array::arrays::FilterArrayParts::mask: vortex_mask::Mask
-
-pub struct vortex_array::arrays::FilterExecuteAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::FilterExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::default() -> vortex_array::arrays::FilterExecuteAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::FilterExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::FilterExecuteAdaptor<V> where V: vortex_array::arrays::FilterKernel
-
-pub type vortex_array::arrays::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::FilterReduceAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::FilterReduceAdaptor<V>
-
-pub fn vortex_array::arrays::FilterReduceAdaptor<V>::default() -> vortex_array::arrays::FilterReduceAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::FilterReduceAdaptor<V>
-
-pub fn vortex_array::arrays::FilterReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::FilterReduceAdaptor<V> where V: vortex_array::arrays::FilterReduce
-
-pub type vortex_array::arrays::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::FilterReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::FilterArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::arrays::FilterVTable
 
@@ -2026,13 +5802,17 @@ pub fn vortex_array::arrays::FixedSizeListArray::try_new(elements: vortex_array:
 
 pub fn vortex_array::arrays::FixedSizeListArray::validate(elements: &vortex_array::ArrayRef, len: usize, list_size: u32, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
+impl vortex_array::arrays::FixedSizeListArray
+
+pub fn vortex_array::arrays::FixedSizeListArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::FixedSizeListArray
 
 pub fn vortex_array::arrays::FixedSizeListArray::clone(&self) -> vortex_array::arrays::FixedSizeListArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::FixedSizeListArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::FixedSizeListArray
 
-pub fn vortex_array::arrays::FixedSizeListArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::FixedSizeListArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::FixedSizeListArray> for vortex_array::ArrayRef
 
@@ -2044,7 +5824,7 @@ pub fn vortex_array::arrays::FixedSizeListArray::fmt(&self, f: &mut core::fmt::F
 
 impl core::ops::deref::Deref for vortex_array::arrays::FixedSizeListArray
 
-pub type vortex_array::arrays::FixedSizeListArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::FixedSizeListArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::FixedSizeListArray::deref(&self) -> &Self::Target
 
@@ -2070,13 +5850,13 @@ impl core::fmt::Debug for vortex_array::arrays::FixedSizeListVTable
 
 pub fn vortex_array::arrays::FixedSizeListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeListVTable
 
 pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::FixedSizeListVTable
 
@@ -2158,34 +5938,6 @@ pub fn vortex_array::arrays::FixedSizeListVTable::stats(array: &vortex_array::ar
 
 pub fn vortex_array::arrays::FixedSizeListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-#[repr(C, align(8))] pub struct vortex_array::arrays::Inlined
-
-pub vortex_array::arrays::Inlined::data: [u8; 12]
-
-pub vortex_array::arrays::Inlined::size: u32
-
-impl vortex_array::arrays::Inlined
-
-pub fn vortex_array::arrays::Inlined::value(&self) -> &[u8]
-
-impl core::clone::Clone for vortex_array::arrays::Inlined
-
-pub fn vortex_array::arrays::Inlined::clone(&self) -> vortex_array::arrays::Inlined
-
-impl core::cmp::Eq for vortex_array::arrays::Inlined
-
-impl core::cmp::PartialEq for vortex_array::arrays::Inlined
-
-pub fn vortex_array::arrays::Inlined::eq(&self, other: &vortex_array::arrays::Inlined) -> bool
-
-impl core::fmt::Debug for vortex_array::arrays::Inlined
-
-pub fn vortex_array::arrays::Inlined::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::marker::Copy for vortex_array::arrays::Inlined
-
-impl core::marker::StructuralPartialEq for vortex_array::arrays::Inlined
-
 pub struct vortex_array::arrays::ListArray
 
 impl vortex_array::arrays::ListArray
@@ -2194,7 +5946,7 @@ pub fn vortex_array::arrays::ListArray::element_dtype(&self) -> &alloc::sync::Ar
 
 pub fn vortex_array::arrays::ListArray::elements(&self) -> &vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ListArray::into_parts(self) -> vortex_array::arrays::ListArrayParts
+pub fn vortex_array::arrays::ListArray::into_parts(self) -> vortex_array::arrays::list::ListArrayParts
 
 pub fn vortex_array::arrays::ListArray::list_elements_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -2214,13 +5966,17 @@ pub fn vortex_array::arrays::ListArray::try_new(elements: vortex_array::ArrayRef
 
 pub fn vortex_array::arrays::ListArray::validate(elements: &vortex_array::ArrayRef, offsets: &vortex_array::ArrayRef, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
+impl vortex_array::arrays::ListArray
+
+pub fn vortex_array::arrays::ListArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::ListArray
 
 pub fn vortex_array::arrays::ListArray::clone(&self) -> vortex_array::arrays::ListArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ListArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ListArray
 
-pub fn vortex_array::arrays::ListArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::ListArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::ListArray> for vortex_array::ArrayRef
 
@@ -2232,7 +5988,7 @@ pub fn vortex_array::arrays::ListArray::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl core::ops::deref::Deref for vortex_array::arrays::ListArray
 
-pub type vortex_array::arrays::ListArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::ListArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::ListArray::deref(&self) -> &Self::Target
 
@@ -2244,16 +6000,6 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::ListArray
 
 pub fn vortex_array::arrays::ListArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::ListArrayParts
-
-pub vortex_array::arrays::ListArrayParts::dtype: vortex_array::dtype::DType
-
-pub vortex_array::arrays::ListArrayParts::elements: vortex_array::ArrayRef
-
-pub vortex_array::arrays::ListArrayParts::offsets: vortex_array::ArrayRef
-
-pub vortex_array::arrays::ListArrayParts::validity: vortex_array::validity::Validity
-
 pub struct vortex_array::arrays::ListVTable
 
 impl vortex_array::arrays::ListVTable
@@ -2264,17 +6010,17 @@ impl core::fmt::Debug for vortex_array::arrays::ListVTable
 
 pub fn vortex_array::arrays::ListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::FilterKernel for vortex_array::arrays::ListVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ListVTable
 
 pub fn vortex_array::arrays::ListVTable::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ListVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListVTable
 
 pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListVTable
 
@@ -2362,7 +6108,7 @@ impl vortex_array::arrays::ListViewArray
 
 pub fn vortex_array::arrays::ListViewArray::elements(&self) -> &vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ListViewArray::into_parts(self) -> vortex_array::arrays::ListViewArrayParts
+pub fn vortex_array::arrays::ListViewArray::into_parts(self) -> vortex_array::arrays::listview::ListViewArrayParts
 
 pub fn vortex_array::arrays::ListViewArray::is_zero_copy_to_list(&self) -> bool
 
@@ -2390,15 +6136,19 @@ pub unsafe fn vortex_array::arrays::ListViewArray::with_zero_copy_to_list(self, 
 
 impl vortex_array::arrays::ListViewArray
 
-pub fn vortex_array::arrays::ListViewArray::rebuild(&self, mode: vortex_array::arrays::ListViewRebuildMode) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
+pub fn vortex_array::arrays::ListViewArray::rebuild(&self, mode: vortex_array::arrays::listview::ListViewRebuildMode) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
+
+impl vortex_array::arrays::ListViewArray
+
+pub fn vortex_array::arrays::ListViewArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl core::clone::Clone for vortex_array::arrays::ListViewArray
 
 pub fn vortex_array::arrays::ListViewArray::clone(&self) -> vortex_array::arrays::ListViewArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ListViewArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ListViewArray
 
-pub fn vortex_array::arrays::ListViewArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::ListViewArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::ListViewArray> for vortex_array::ArrayRef
 
@@ -2410,7 +6160,7 @@ pub fn vortex_array::arrays::ListViewArray::fmt(&self, f: &mut core::fmt::Format
 
 impl core::ops::deref::Deref for vortex_array::arrays::ListViewArray
 
-pub type vortex_array::arrays::ListViewArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::ListViewArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::ListViewArray::deref(&self) -> &Self::Target
 
@@ -2426,18 +6176,6 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::ListViewArra
 
 pub fn vortex_array::arrays::ListViewArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::ListViewArrayParts
-
-pub vortex_array::arrays::ListViewArrayParts::elements: vortex_array::ArrayRef
-
-pub vortex_array::arrays::ListViewArrayParts::elements_dtype: alloc::sync::Arc<vortex_array::dtype::DType>
-
-pub vortex_array::arrays::ListViewArrayParts::offsets: vortex_array::ArrayRef
-
-pub vortex_array::arrays::ListViewArrayParts::sizes: vortex_array::ArrayRef
-
-pub vortex_array::arrays::ListViewArrayParts::validity: vortex_array::validity::Validity
-
 pub struct vortex_array::arrays::ListViewVTable
 
 impl vortex_array::arrays::ListViewVTable
@@ -2448,13 +6186,13 @@ impl core::fmt::Debug for vortex_array::arrays::ListViewVTable
 
 pub fn vortex_array::arrays::ListViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeReduce for vortex_array::arrays::ListViewVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListViewVTable
 
 pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListViewVTable
 
@@ -2544,13 +6282,17 @@ pub fn vortex_array::arrays::MaskedArray::child(&self) -> &vortex_array::ArrayRe
 
 pub fn vortex_array::arrays::MaskedArray::try_new(child: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
 
+impl vortex_array::arrays::MaskedArray
+
+pub fn vortex_array::arrays::MaskedArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::MaskedArray
 
 pub fn vortex_array::arrays::MaskedArray::clone(&self) -> vortex_array::arrays::MaskedArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::MaskedArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::MaskedArray
 
-pub fn vortex_array::arrays::MaskedArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::MaskedArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::MaskedArray> for vortex_array::ArrayRef
 
@@ -2562,7 +6304,7 @@ pub fn vortex_array::arrays::MaskedArray::fmt(&self, f: &mut core::fmt::Formatte
 
 impl core::ops::deref::Deref for vortex_array::arrays::MaskedArray
 
-pub type vortex_array::arrays::MaskedArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::MaskedArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::MaskedArray::deref(&self) -> &Self::Target
 
@@ -2584,17 +6326,17 @@ impl core::fmt::Debug for vortex_array::arrays::MaskedVTable
 
 pub fn vortex_array::arrays::MaskedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::MaskedVTable
 
 pub fn vortex_array::arrays::MaskedVTable::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::MaskedVTable
 
 pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::MaskedVTable
 
@@ -2658,207 +6400,145 @@ pub fn vortex_array::arrays::MaskedVTable::stats(array: &vortex_array::arrays::M
 
 pub fn vortex_array::arrays::MaskedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-#[repr(transparent)] pub struct vortex_array::arrays::NativeValue<T>(pub T)
-
-impl core::hash::Hash for vortex_array::arrays::NativeValue<f32>
-
-pub fn vortex_array::arrays::NativeValue<f32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::NativeValue<f64>
-
-pub fn vortex_array::arrays::NativeValue<f64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::NativeValue<half::binary16::f16>
-
-pub fn vortex_array::arrays::NativeValue<half::binary16::f16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::NativeValue<i16>
-
-pub fn vortex_array::arrays::NativeValue<i16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::NativeValue<i32>
-
-pub fn vortex_array::arrays::NativeValue<i32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::NativeValue<i64>
-
-pub fn vortex_array::arrays::NativeValue<i64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::NativeValue<i8>
-
-pub fn vortex_array::arrays::NativeValue<i8>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::NativeValue<u16>
-
-pub fn vortex_array::arrays::NativeValue<u16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::NativeValue<u32>
-
-pub fn vortex_array::arrays::NativeValue<u32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::NativeValue<u64>
-
-pub fn vortex_array::arrays::NativeValue<u64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::NativeValue<u8>
-
-pub fn vortex_array::arrays::NativeValue<u8>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl<T: core::clone::Clone> core::clone::Clone for vortex_array::arrays::NativeValue<T>
-
-pub fn vortex_array::arrays::NativeValue<T>::clone(&self) -> vortex_array::arrays::NativeValue<T>
-
-impl<T: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::NativeValue<T>
-
-pub fn vortex_array::arrays::NativeValue<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<T: core::marker::Copy> core::marker::Copy for vortex_array::arrays::NativeValue<T>
-
-impl<T: vortex_array::dtype::NativePType> core::cmp::Eq for vortex_array::arrays::NativeValue<T>
-
-impl<T: vortex_array::dtype::NativePType> core::cmp::PartialEq for vortex_array::arrays::NativeValue<T>
-
-pub fn vortex_array::arrays::NativeValue<T>::eq(&self, other: &vortex_array::arrays::NativeValue<T>) -> bool
-
-impl<T: vortex_array::dtype::NativePType> core::cmp::PartialOrd for vortex_array::arrays::NativeValue<T>
-
-pub fn vortex_array::arrays::NativeValue<T>::partial_cmp(&self, other: &vortex_array::arrays::NativeValue<T>) -> core::option::Option<core::cmp::Ordering>
-
 pub struct vortex_array::arrays::NullArray
 
-impl vortex_array::arrays::NullArray
+impl vortex_array::arrays::null::NullArray
 
-pub fn vortex_array::arrays::NullArray::new(len: usize) -> Self
+pub fn vortex_array::arrays::null::NullArray::new(len: usize) -> Self
 
-impl core::clone::Clone for vortex_array::arrays::NullArray
+impl vortex_array::arrays::null::NullArray
 
-pub fn vortex_array::arrays::NullArray::clone(&self) -> vortex_array::arrays::NullArray
+pub fn vortex_array::arrays::null::NullArray::to_array(&self) -> vortex_array::ArrayRef
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::NullArray
+impl core::clone::Clone for vortex_array::arrays::null::NullArray
 
-pub fn vortex_array::arrays::NullArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::null::NullArray::clone(&self) -> vortex_array::arrays::null::NullArray
 
-impl core::convert::From<vortex_array::arrays::NullArray> for vortex_array::ArrayRef
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::null::NullArray
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::NullArray) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::null::NullArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::fmt::Debug for vortex_array::arrays::NullArray
+impl core::convert::From<vortex_array::arrays::null::NullArray> for vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::NullArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::null::NullArray) -> vortex_array::ArrayRef
 
-impl core::ops::deref::Deref for vortex_array::arrays::NullArray
+impl core::fmt::Debug for vortex_array::arrays::null::NullArray
 
-pub type vortex_array::arrays::NullArray::Target = dyn vortex_array::Array
+pub fn vortex_array::arrays::null::NullArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-pub fn vortex_array::arrays::NullArray::deref(&self) -> &Self::Target
+impl core::ops::deref::Deref for vortex_array::arrays::null::NullArray
 
-impl vortex_array::Executable for vortex_array::arrays::NullArray
+pub type vortex_array::arrays::null::NullArray::Target = dyn vortex_array::DynArray
 
-pub fn vortex_array::arrays::NullArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::null::NullArray::deref(&self) -> &Self::Target
 
-impl vortex_array::IntoArray for vortex_array::arrays::NullArray
+impl vortex_array::Executable for vortex_array::arrays::null::NullArray
 
-pub fn vortex_array::arrays::NullArray::into_array(self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::null::NullArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::IntoArray for vortex_array::arrays::null::NullArray
+
+pub fn vortex_array::arrays::null::NullArray::into_array(self) -> vortex_array::ArrayRef
 
 pub struct vortex_array::arrays::NullVTable
 
-impl vortex_array::arrays::NullVTable
+impl vortex_array::arrays::null::NullVTable
 
-pub const vortex_array::arrays::NullVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::null::NullVTable::ID: vortex_array::vtable::ArrayId
 
-impl vortex_array::arrays::NullVTable
+impl vortex_array::arrays::null::NullVTable
 
-pub const vortex_array::arrays::NullVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
+pub const vortex_array::arrays::null::NullVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
 
-impl core::fmt::Debug for vortex_array::arrays::NullVTable
+impl core::fmt::Debug for vortex_array::arrays::null::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::null::NullVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::NullVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::filter(_array: &vortex_array::arrays::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::NullVTable::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::NullVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::NullVTable::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::TakeReduce for vortex_array::arrays::NullVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::take(array: &vortex_array::arrays::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::NullVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::min_max(&self, _array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::null::NullVTable::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::NullVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::cast(array: &vortex_array::arrays::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::NullVTable::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::NullVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::mask(array: &vortex_array::arrays::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::NullVTable::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::NullVTable> for vortex_array::arrays::NullVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::scalar_at(_array: &vortex_array::arrays::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::null::NullVTable::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::NullVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::null::NullVTable
 
-pub type vortex_array::arrays::NullVTable::Array = vortex_array::arrays::NullArray
+pub type vortex_array::arrays::null::NullVTable::Array = vortex_array::arrays::null::NullArray
 
-pub type vortex_array::arrays::NullVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::null::NullVTable::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::NullVTable::OperationsVTable = vortex_array::arrays::NullVTable
+pub type vortex_array::arrays::null::NullVTable::OperationsVTable = vortex_array::arrays::null::NullVTable
 
-pub type vortex_array::arrays::NullVTable::ValidityVTable = vortex_array::arrays::NullVTable
+pub type vortex_array::arrays::null::NullVTable::ValidityVTable = vortex_array::arrays::null::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::null::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::NullVTable::array_eq(array: &vortex_array::arrays::NullArray, other: &vortex_array::arrays::NullArray, _precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::null::NullVTable::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::NullArray, state: &mut H, _precision: vortex_array::Precision)
+pub fn vortex_array::arrays::null::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::NullVTable::buffer(_array: &vortex_array::arrays::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::null::NullVTable::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::NullVTable::buffer_name(_array: &vortex_array::arrays::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::null::NullVTable::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::NullArray>
+pub fn vortex_array::arrays::null::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
 
-pub fn vortex_array::arrays::NullVTable::child(_array: &vortex_array::arrays::NullArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::null::NullVTable::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::NullVTable::child_name(_array: &vortex_array::arrays::NullArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::null::NullVTable::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::null::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::NullVTable::dtype(_array: &vortex_array::arrays::NullArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::null::NullVTable::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::null::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::null::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::NullVTable::len(array: &vortex_array::arrays::NullArray) -> usize
+pub fn vortex_array::arrays::null::NullVTable::len(array: &vortex_array::arrays::null::NullArray) -> usize
 
-pub fn vortex_array::arrays::NullVTable::metadata(_array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::null::NullVTable::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::NullVTable::nbuffers(_array: &vortex_array::arrays::NullArray) -> usize
+pub fn vortex_array::arrays::null::NullVTable::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
 
-pub fn vortex_array::arrays::NullVTable::nchildren(_array: &vortex_array::arrays::NullArray) -> usize
+pub fn vortex_array::arrays::null::NullVTable::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
 
-pub fn vortex_array::arrays::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::null::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::NullVTable::stats(array: &vortex_array::arrays::NullArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::null::NullVTable::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::null::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::NullVTable> for vortex_array::arrays::NullVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
 
-pub fn vortex_array::arrays::NullVTable::validity(_array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::null::NullVTable::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::PrimitiveArray
 
@@ -2914,11 +6594,15 @@ pub fn vortex_array::arrays::PrimitiveArray::try_into_buffer_mut<T: vortex_array
 
 impl vortex_array::arrays::PrimitiveArray
 
-pub fn vortex_array::arrays::PrimitiveArray::into_parts(self) -> vortex_array::arrays::PrimitiveArrayParts
+pub fn vortex_array::arrays::PrimitiveArray::into_parts(self) -> vortex_array::arrays::primitive::PrimitiveArrayParts
 
 impl vortex_array::arrays::PrimitiveArray
 
 pub fn vortex_array::arrays::PrimitiveArray::patch(self, patches: &vortex_array::patches::Patches, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::arrays::PrimitiveArray
+
+pub fn vortex_array::arrays::PrimitiveArray::to_array(&self) -> vortex_array::ArrayRef
 
 impl vortex_array::arrays::PrimitiveArray
 
@@ -2928,9 +6612,9 @@ impl core::clone::Clone for vortex_array::arrays::PrimitiveArray
 
 pub fn vortex_array::arrays::PrimitiveArray::clone(&self) -> vortex_array::arrays::PrimitiveArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::PrimitiveArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::PrimitiveArray
 
-pub fn vortex_array::arrays::PrimitiveArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::PrimitiveArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::PrimitiveArray> for vortex_array::ArrayRef
 
@@ -2942,7 +6626,7 @@ pub fn vortex_array::arrays::PrimitiveArray::fmt(&self, f: &mut core::fmt::Forma
 
 impl core::ops::deref::Deref for vortex_array::arrays::PrimitiveArray
 
-pub type vortex_array::arrays::PrimitiveArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::PrimitiveArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::PrimitiveArray::deref(&self) -> &Self::Target
 
@@ -2966,30 +6650,6 @@ impl<T: vortex_array::dtype::NativePType> vortex_array::accessor::ArrayAccessor<
 
 pub fn vortex_array::arrays::PrimitiveArray::with_iterator<F, R>(&self, f: F) -> R where F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a T>>) -> R
 
-pub struct vortex_array::arrays::PrimitiveArrayParts
-
-pub vortex_array::arrays::PrimitiveArrayParts::buffer: vortex_array::buffer::BufferHandle
-
-pub vortex_array::arrays::PrimitiveArrayParts::ptype: vortex_array::dtype::PType
-
-pub vortex_array::arrays::PrimitiveArrayParts::validity: vortex_array::validity::Validity
-
-pub struct vortex_array::arrays::PrimitiveMaskedValidityRule
-
-impl core::default::Default for vortex_array::arrays::PrimitiveMaskedValidityRule
-
-pub fn vortex_array::arrays::PrimitiveMaskedValidityRule::default() -> vortex_array::arrays::PrimitiveMaskedValidityRule
-
-impl core::fmt::Debug for vortex_array::arrays::PrimitiveMaskedValidityRule
-
-pub fn vortex_array::arrays::PrimitiveMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveMaskedValidityRule
-
-pub type vortex_array::arrays::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
 pub struct vortex_array::arrays::PrimitiveVTable
 
 impl vortex_array::arrays::PrimitiveVTable
@@ -3000,13 +6660,13 @@ impl core::fmt::Debug for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::PrimitiveVTable
 
@@ -3030,11 +6690,11 @@ impl vortex_array::compute::SumKernel for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
 
-pub type vortex_array::arrays::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::PrimitiveVTable
 
@@ -3110,171 +6770,133 @@ pub fn vortex_array::arrays::PrimitiveVTable::stats(array: &vortex_array::arrays
 
 pub fn vortex_array::arrays::PrimitiveVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-#[repr(C, align(8))] pub struct vortex_array::arrays::Ref
-
-pub vortex_array::arrays::Ref::buffer_index: u32
-
-pub vortex_array::arrays::Ref::offset: u32
-
-pub vortex_array::arrays::Ref::prefix: [u8; 4]
-
-pub vortex_array::arrays::Ref::size: u32
-
-impl vortex_array::arrays::Ref
-
-pub fn vortex_array::arrays::Ref::as_range(&self) -> core::ops::range::Range<usize>
-
-pub fn vortex_array::arrays::Ref::with_buffer_and_offset(&self, buffer_index: u32, offset: u32) -> vortex_array::arrays::Ref
-
-impl core::clone::Clone for vortex_array::arrays::Ref
-
-pub fn vortex_array::arrays::Ref::clone(&self) -> vortex_array::arrays::Ref
-
-impl core::convert::From<vortex_array::arrays::Ref> for vortex_array::arrays::BinaryView
-
-pub fn vortex_array::arrays::BinaryView::from(value: vortex_array::arrays::Ref) -> Self
-
-impl core::fmt::Debug for vortex_array::arrays::Ref
-
-pub fn vortex_array::arrays::Ref::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::marker::Copy for vortex_array::arrays::Ref
-
 pub struct vortex_array::arrays::ScalarFnArray
 
-impl vortex_array::arrays::ScalarFnArray
+impl vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub fn vortex_array::arrays::ScalarFnArray::children(&self) -> &[vortex_array::ArrayRef]
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::children(&self) -> &[vortex_array::ArrayRef]
 
-pub fn vortex_array::arrays::ScalarFnArray::scalar_fn(&self) -> &vortex_array::scalar_fn::ScalarFnRef
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::scalar_fn(&self) -> &vortex_array::scalar_fn::ScalarFnRef
 
-pub fn vortex_array::arrays::ScalarFnArray::try_new(bound: vortex_array::scalar_fn::ScalarFnRef, children: alloc::vec::Vec<vortex_array::ArrayRef>, len: usize) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::try_new(bound: vortex_array::scalar_fn::ScalarFnRef, children: alloc::vec::Vec<vortex_array::ArrayRef>, len: usize) -> vortex_error::VortexResult<Self>
 
-impl core::clone::Clone for vortex_array::arrays::ScalarFnArray
+impl vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub fn vortex_array::arrays::ScalarFnArray::clone(&self) -> vortex_array::arrays::ScalarFnArray
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::to_array(&self) -> vortex_array::ArrayRef
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ScalarFnArray
+impl core::clone::Clone for vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub fn vortex_array::arrays::ScalarFnArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::clone(&self) -> vortex_array::arrays::scalar_fn::ScalarFnArray
 
-impl core::convert::From<vortex_array::arrays::ScalarFnArray> for vortex_array::ArrayRef
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ScalarFnArray) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::fmt::Debug for vortex_array::arrays::ScalarFnArray
+impl core::convert::From<vortex_array::arrays::scalar_fn::ScalarFnArray> for vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ScalarFnArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_array::ArrayRef
 
-impl core::ops::deref::Deref for vortex_array::arrays::ScalarFnArray
+impl core::fmt::Debug for vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub type vortex_array::arrays::ScalarFnArray::Target = dyn vortex_array::Array
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-pub fn vortex_array::arrays::ScalarFnArray::deref(&self) -> &Self::Target
+impl core::ops::deref::Deref for vortex_array::arrays::scalar_fn::ScalarFnArray
 
-impl vortex_array::IntoArray for vortex_array::arrays::ScalarFnArray
+pub type vortex_array::arrays::scalar_fn::ScalarFnArray::Target = dyn vortex_array::DynArray
 
-pub fn vortex_array::arrays::ScalarFnArray::into_array(self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::deref(&self) -> &Self::Target
 
-impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::ScalarFnArray
+impl vortex_array::IntoArray for vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub fn vortex_array::arrays::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::into_array(self) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
+impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub fn vortex_array::arrays::ScalarFnArray::child_count(&self) -> usize
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
 
-pub fn vortex_array::arrays::ScalarFnArray::node_dtype(&self) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
-pub fn vortex_array::arrays::ScalarFnArray::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child_count(&self) -> usize
 
-pub struct vortex_array::arrays::ScalarFnArrayView<'a, F: vortex_array::scalar_fn::ScalarFnVTable>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::node_dtype(&self) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
-pub vortex_array::arrays::ScalarFnArrayView::options: &'a <F as vortex_array::scalar_fn::ScalarFnVTable>::Options
-
-pub vortex_array::arrays::ScalarFnArrayView::vtable: &'a F
-
-impl<F: vortex_array::scalar_fn::ScalarFnVTable> core::ops::deref::Deref for vortex_array::arrays::ScalarFnArrayView<'_, F>
-
-pub type vortex_array::arrays::ScalarFnArrayView<'_, F>::Target = dyn vortex_array::Array
-
-pub fn vortex_array::arrays::ScalarFnArrayView<'_, F>::deref(&self) -> &Self::Target
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
 
 pub struct vortex_array::arrays::ScalarFnVTable
 
-impl core::clone::Clone for vortex_array::arrays::ScalarFnVTable
+impl core::clone::Clone for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::ScalarFnVTable::clone(&self) -> vortex_array::arrays::ScalarFnVTable
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::clone(&self) -> vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-impl core::fmt::Debug for vortex_array::arrays::ScalarFnVTable
+impl core::fmt::Debug for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::ScalarFnVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ScalarFnVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::ScalarFnVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ScalarFnVTable> for vortex_array::arrays::ScalarFnVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ScalarFnVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub type vortex_array::arrays::ScalarFnVTable::Array = vortex_array::arrays::ScalarFnArray
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Array = vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub type vortex_array::arrays::ScalarFnVTable::Metadata = vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Metadata = vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata
 
-pub type vortex_array::arrays::ScalarFnVTable::OperationsVTable = vortex_array::arrays::ScalarFnVTable
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::OperationsVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub type vortex_array::arrays::ScalarFnVTable::ValidityVTable = vortex_array::arrays::ScalarFnVTable
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::ValidityVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::ScalarFnVTable::array_eq(array: &vortex_array::arrays::ScalarFnArray, other: &vortex_array::arrays::ScalarFnArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_eq(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, other: &vortex_array::arrays::scalar_fn::ScalarFnArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::ScalarFnVTable::buffer(_array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::ScalarFnVTable::buffer_name(_array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer_name(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ScalarFnVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
 
-pub fn vortex_array::arrays::ScalarFnVTable::child(array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ScalarFnVTable::child_name(array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child_name(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ScalarFnVTable::dtype(array: &vortex_array::arrays::ScalarFnArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::dtype(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::ScalarFnVTable::len(array: &vortex_array::arrays::ScalarFnArray) -> usize
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::len(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
 
-pub fn vortex_array::arrays::ScalarFnVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::ScalarFnArray) -> usize
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
 
-pub fn vortex_array::arrays::ScalarFnVTable::nchildren(array: &vortex_array::arrays::ScalarFnArray) -> usize
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nchildren(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
 
-pub fn vortex_array::arrays::ScalarFnVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ScalarFnVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ScalarFnVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::ScalarFnVTable::stats(array: &vortex_array::arrays::ScalarFnArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::stats(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::ScalarFnVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ScalarFnVTable> for vortex_array::arrays::ScalarFnVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::ScalarFnVTable::validity(array: &vortex_array::arrays::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::validity(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::SharedArray
 
@@ -3286,13 +6908,17 @@ pub async fn vortex_array::arrays::SharedArray::get_or_compute_async<F, Fut>(&se
 
 pub fn vortex_array::arrays::SharedArray::new(source: vortex_array::ArrayRef) -> Self
 
+impl vortex_array::arrays::SharedArray
+
+pub fn vortex_array::arrays::SharedArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::SharedArray
 
 pub fn vortex_array::arrays::SharedArray::clone(&self) -> vortex_array::arrays::SharedArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::SharedArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::SharedArray
 
-pub fn vortex_array::arrays::SharedArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::SharedArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::SharedArray> for vortex_array::ArrayRef
 
@@ -3304,7 +6930,7 @@ pub fn vortex_array::arrays::SharedArray::fmt(&self, f: &mut core::fmt::Formatte
 
 impl core::ops::deref::Deref for vortex_array::arrays::SharedArray
 
-pub type vortex_array::arrays::SharedArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::SharedArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::SharedArray::deref(&self) -> &Self::Target
 
@@ -3386,163 +7012,123 @@ pub fn vortex_array::arrays::SharedVTable::validity(array: &vortex_array::arrays
 
 pub struct vortex_array::arrays::SliceArray
 
-impl vortex_array::arrays::SliceArray
+impl vortex_array::arrays::slice::SliceArray
 
-pub fn vortex_array::arrays::SliceArray::child(&self) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::slice::SliceArray::child(&self) -> &vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::SliceArray::into_parts(self) -> vortex_array::arrays::SliceArrayParts
+pub fn vortex_array::arrays::slice::SliceArray::into_parts(self) -> vortex_array::arrays::slice::SliceArrayParts
 
-pub fn vortex_array::arrays::SliceArray::new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> Self
+pub fn vortex_array::arrays::slice::SliceArray::new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> Self
 
-pub fn vortex_array::arrays::SliceArray::slice_range(&self) -> &core::ops::range::Range<usize>
+pub fn vortex_array::arrays::slice::SliceArray::slice_range(&self) -> &core::ops::range::Range<usize>
 
-pub fn vortex_array::arrays::SliceArray::try_new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::slice::SliceArray::try_new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<Self>
 
-impl core::clone::Clone for vortex_array::arrays::SliceArray
+impl vortex_array::arrays::slice::SliceArray
 
-pub fn vortex_array::arrays::SliceArray::clone(&self) -> vortex_array::arrays::SliceArray
+pub fn vortex_array::arrays::slice::SliceArray::to_array(&self) -> vortex_array::ArrayRef
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::SliceArray
+impl core::clone::Clone for vortex_array::arrays::slice::SliceArray
 
-pub fn vortex_array::arrays::SliceArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::slice::SliceArray::clone(&self) -> vortex_array::arrays::slice::SliceArray
 
-impl core::convert::From<vortex_array::arrays::SliceArray> for vortex_array::ArrayRef
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::slice::SliceArray
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::SliceArray) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::slice::SliceArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::fmt::Debug for vortex_array::arrays::SliceArray
+impl core::convert::From<vortex_array::arrays::slice::SliceArray> for vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::SliceArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::slice::SliceArray) -> vortex_array::ArrayRef
 
-impl core::ops::deref::Deref for vortex_array::arrays::SliceArray
+impl core::fmt::Debug for vortex_array::arrays::slice::SliceArray
 
-pub type vortex_array::arrays::SliceArray::Target = dyn vortex_array::Array
+pub fn vortex_array::arrays::slice::SliceArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-pub fn vortex_array::arrays::SliceArray::deref(&self) -> &Self::Target
+impl core::ops::deref::Deref for vortex_array::arrays::slice::SliceArray
 
-impl vortex_array::IntoArray for vortex_array::arrays::SliceArray
+pub type vortex_array::arrays::slice::SliceArray::Target = dyn vortex_array::DynArray
 
-pub fn vortex_array::arrays::SliceArray::into_array(self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::slice::SliceArray::deref(&self) -> &Self::Target
 
-pub struct vortex_array::arrays::SliceArrayParts
+impl vortex_array::IntoArray for vortex_array::arrays::slice::SliceArray
 
-pub vortex_array::arrays::SliceArrayParts::child: vortex_array::ArrayRef
-
-pub vortex_array::arrays::SliceArrayParts::range: core::ops::range::Range<usize>
-
-pub struct vortex_array::arrays::SliceExecuteAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::SliceExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::default() -> vortex_array::arrays::SliceExecuteAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::SliceExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::SliceExecuteAdaptor<V> where V: vortex_array::arrays::SliceKernel
-
-pub type vortex_array::arrays::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
-
-pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::SliceMetadata(_)
-
-impl core::fmt::Debug for vortex_array::arrays::SliceMetadata
-
-pub fn vortex_array::arrays::SliceMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-pub struct vortex_array::arrays::SliceReduceAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::SliceReduceAdaptor<V>
-
-pub fn vortex_array::arrays::SliceReduceAdaptor<V>::default() -> vortex_array::arrays::SliceReduceAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::SliceReduceAdaptor<V>
-
-pub fn vortex_array::arrays::SliceReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::SliceReduceAdaptor<V> where V: vortex_array::arrays::SliceReduce
-
-pub type vortex_array::arrays::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
-
-pub fn vortex_array::arrays::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::SliceArray::into_array(self) -> vortex_array::ArrayRef
 
 pub struct vortex_array::arrays::SliceVTable
 
-impl vortex_array::arrays::SliceVTable
+impl vortex_array::arrays::slice::SliceVTable
 
-pub const vortex_array::arrays::SliceVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::slice::SliceVTable::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::SliceVTable
+impl core::fmt::Debug for vortex_array::arrays::slice::SliceVTable
 
-pub fn vortex_array::arrays::SliceVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::slice::SliceVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::SliceVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::SliceVTable
 
-pub fn vortex_array::arrays::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::SliceVTable> for vortex_array::arrays::SliceVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
 
-pub fn vortex_array::arrays::SliceVTable::scalar_at(array: &vortex_array::arrays::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::slice::SliceVTable::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::SliceVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::slice::SliceVTable
 
-pub type vortex_array::arrays::SliceVTable::Array = vortex_array::arrays::SliceArray
+pub type vortex_array::arrays::slice::SliceVTable::Array = vortex_array::arrays::slice::SliceArray
 
-pub type vortex_array::arrays::SliceVTable::Metadata = vortex_array::arrays::SliceMetadata
+pub type vortex_array::arrays::slice::SliceVTable::Metadata = vortex_array::arrays::slice::SliceMetadata
 
-pub type vortex_array::arrays::SliceVTable::OperationsVTable = vortex_array::arrays::SliceVTable
+pub type vortex_array::arrays::slice::SliceVTable::OperationsVTable = vortex_array::arrays::slice::SliceVTable
 
-pub type vortex_array::arrays::SliceVTable::ValidityVTable = vortex_array::arrays::SliceVTable
+pub type vortex_array::arrays::slice::SliceVTable::ValidityVTable = vortex_array::arrays::slice::SliceVTable
 
-pub fn vortex_array::arrays::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::slice::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::SliceVTable::array_eq(array: &vortex_array::arrays::SliceArray, other: &vortex_array::arrays::SliceArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::slice::SliceVTable::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SliceArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::slice::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::slice::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::slice::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+pub fn vortex_array::arrays::slice::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
 
-pub fn vortex_array::arrays::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::slice::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::slice::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::slice::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::SliceVTable::dtype(array: &vortex_array::arrays::SliceArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::slice::SliceVTable::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::slice::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::slice::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::SliceVTable::len(array: &vortex_array::arrays::SliceArray) -> usize
+pub fn vortex_array::arrays::slice::SliceVTable::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
 
-pub fn vortex_array::arrays::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::slice::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::SliceVTable::nbuffers(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::slice::SliceVTable::nbuffers(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::SliceVTable::nchildren(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::slice::SliceVTable::nchildren(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::slice::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::SliceVTable::stats(array: &vortex_array::arrays::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::slice::SliceVTable::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::slice::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::SliceVTable> for vortex_array::arrays::SliceVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
 
-pub fn vortex_array::arrays::SliceVTable::validity(array: &vortex_array::arrays::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::slice::SliceVTable::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::StructArray
 
@@ -3552,7 +7138,7 @@ pub fn vortex_array::arrays::StructArray::from_fields<N: core::convert::AsRef<st
 
 pub fn vortex_array::arrays::StructArray::into_fields(self) -> alloc::vec::Vec<vortex_array::ArrayRef>
 
-pub fn vortex_array::arrays::StructArray::into_parts(self) -> vortex_array::arrays::StructArrayParts
+pub fn vortex_array::arrays::StructArray::into_parts(self) -> vortex_array::arrays::struct_::StructArrayParts
 
 pub fn vortex_array::arrays::StructArray::names(&self) -> &vortex_array::dtype::FieldNames
 
@@ -3590,13 +7176,17 @@ impl vortex_array::arrays::StructArray
 
 pub fn vortex_array::arrays::StructArray::into_record_batch_with_schema(self, schema: impl core::convert::AsRef<arrow_schema::schema::Schema>) -> vortex_error::VortexResult<arrow_array::record_batch::RecordBatch>
 
+impl vortex_array::arrays::StructArray
+
+pub fn vortex_array::arrays::StructArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::StructArray
 
 pub fn vortex_array::arrays::StructArray::clone(&self) -> vortex_array::arrays::StructArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::StructArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::StructArray
 
-pub fn vortex_array::arrays::StructArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::StructArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::StructArray> for vortex_array::ArrayRef
 
@@ -3608,7 +7198,7 @@ pub fn vortex_array::arrays::StructArray::fmt(&self, f: &mut core::fmt::Formatte
 
 impl core::ops::deref::Deref for vortex_array::arrays::StructArray
 
-pub type vortex_array::arrays::StructArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::StructArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::StructArray::deref(&self) -> &Self::Target
 
@@ -3624,14 +7214,6 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::StructArray
 
 pub fn vortex_array::arrays::StructArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::StructArrayParts
-
-pub vortex_array::arrays::StructArrayParts::fields: alloc::sync::Arc<[vortex_array::ArrayRef]>
-
-pub vortex_array::arrays::StructArrayParts::struct_fields: vortex_array::dtype::StructFields
-
-pub vortex_array::arrays::StructArrayParts::validity: vortex_array::validity::Validity
-
 pub struct vortex_array::arrays::StructVTable
 
 impl vortex_array::arrays::StructVTable
@@ -3642,13 +7224,13 @@ impl core::fmt::Debug for vortex_array::arrays::StructVTable
 
 pub fn vortex_array::arrays::StructVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeReduce for vortex_array::arrays::StructVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::StructVTable
 
 pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::StructVTable
 
@@ -3668,7 +7250,7 @@ pub fn vortex_array::arrays::StructVTable::mask(array: &vortex_array::arrays::St
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::StructVTable
 
-pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
 
@@ -3728,97 +7310,65 @@ pub fn vortex_array::arrays::StructVTable::stats(array: &vortex_array::arrays::S
 
 pub fn vortex_array::arrays::StructVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-pub struct vortex_array::arrays::TakeExecuteAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::TakeExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::default() -> vortex_array::arrays::TakeExecuteAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::TakeExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::TakeExecuteAdaptor<V> where V: vortex_array::arrays::TakeExecute
-
-pub type vortex_array::arrays::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::TakeReduceAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::TakeReduceAdaptor<V>
-
-pub fn vortex_array::arrays::TakeReduceAdaptor<V>::default() -> vortex_array::arrays::TakeReduceAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::TakeReduceAdaptor<V>
-
-pub fn vortex_array::arrays::TakeReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::TakeReduceAdaptor<V> where V: vortex_array::arrays::TakeReduce
-
-pub type vortex_array::arrays::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::TakeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::DictArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
 pub struct vortex_array::arrays::TemporalArray
 
-impl vortex_array::arrays::TemporalArray
+impl vortex_array::arrays::datetime::TemporalArray
 
-pub fn vortex_array::arrays::TemporalArray::dtype(&self) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::datetime::TemporalArray::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::TemporalArray::ext_dtype(&self) -> vortex_array::dtype::extension::ExtDTypeRef
+pub fn vortex_array::arrays::datetime::TemporalArray::ext_dtype(&self) -> vortex_array::dtype::extension::ExtDTypeRef
 
-pub fn vortex_array::arrays::TemporalArray::temporal_metadata(&self) -> vortex_array::extension::datetime::TemporalMetadata<'_>
+pub fn vortex_array::arrays::datetime::TemporalArray::temporal_metadata(&self) -> vortex_array::extension::datetime::TemporalMetadata<'_>
 
-pub fn vortex_array::arrays::TemporalArray::temporal_values(&self) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::datetime::TemporalArray::temporal_values(&self) -> &vortex_array::ArrayRef
 
-impl vortex_array::arrays::TemporalArray
+impl vortex_array::arrays::datetime::TemporalArray
 
-pub fn vortex_array::arrays::TemporalArray::new_date(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
+pub fn vortex_array::arrays::datetime::TemporalArray::new_date(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
 
-pub fn vortex_array::arrays::TemporalArray::new_time(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
+pub fn vortex_array::arrays::datetime::TemporalArray::new_time(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
 
-pub fn vortex_array::arrays::TemporalArray::new_timestamp(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit, time_zone: core::option::Option<alloc::sync::Arc<str>>) -> Self
+pub fn vortex_array::arrays::datetime::TemporalArray::new_timestamp(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit, time_zone: core::option::Option<alloc::sync::Arc<str>>) -> Self
 
-impl core::clone::Clone for vortex_array::arrays::TemporalArray
+impl core::clone::Clone for vortex_array::arrays::datetime::TemporalArray
 
-pub fn vortex_array::arrays::TemporalArray::clone(&self) -> vortex_array::arrays::TemporalArray
+pub fn vortex_array::arrays::datetime::TemporalArray::clone(&self) -> vortex_array::arrays::datetime::TemporalArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::TemporalArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::datetime::TemporalArray
 
-pub fn vortex_array::arrays::TemporalArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::datetime::TemporalArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::convert::From<&vortex_array::arrays::TemporalArray> for vortex_array::arrays::ExtensionArray
+impl core::convert::From<&vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
 
-pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::TemporalArray) -> Self
+pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::datetime::TemporalArray) -> Self
 
-impl core::convert::From<vortex_array::arrays::TemporalArray> for vortex_array::ArrayRef
+impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::ArrayRef
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::TemporalArray) -> Self
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
 
-impl core::convert::From<vortex_array::arrays::TemporalArray> for vortex_array::arrays::ExtensionArray
+impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
 
-pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::TemporalArray) -> Self
+pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
 
-impl core::convert::TryFrom<alloc::sync::Arc<dyn vortex_array::Array>> for vortex_array::arrays::TemporalArray
+impl core::convert::TryFrom<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::arrays::datetime::TemporalArray
 
-pub type vortex_array::arrays::TemporalArray::Error = vortex_error::VortexError
+pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
 
-pub fn vortex_array::arrays::TemporalArray::try_from(value: vortex_array::ArrayRef) -> core::result::Result<Self, Self::Error>
+pub fn vortex_array::arrays::datetime::TemporalArray::try_from(value: vortex_array::ArrayRef) -> core::result::Result<Self, Self::Error>
 
-impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::TemporalArray
+impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::datetime::TemporalArray
 
-pub type vortex_array::arrays::TemporalArray::Error = vortex_error::VortexError
+pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
 
-pub fn vortex_array::arrays::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
+pub fn vortex_array::arrays::datetime::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
 
-impl core::fmt::Debug for vortex_array::arrays::TemporalArray
+impl core::fmt::Debug for vortex_array::arrays::datetime::TemporalArray
 
-pub fn vortex_array::arrays::TemporalArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::datetime::TemporalArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::IntoArray for vortex_array::arrays::TemporalArray
+impl vortex_array::IntoArray for vortex_array::arrays::datetime::TemporalArray
 
-pub fn vortex_array::arrays::TemporalArray::into_array(self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::datetime::TemporalArray::into_array(self) -> vortex_array::ArrayRef
 
 pub struct vortex_array::arrays::VarBinArray
 
@@ -3858,13 +7408,17 @@ pub fn vortex_array::arrays::VarBinArray::try_new_from_handle(offsets: vortex_ar
 
 pub fn vortex_array::arrays::VarBinArray::validate(offsets: &vortex_array::ArrayRef, bytes: &vortex_array::buffer::BufferHandle, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
+impl vortex_array::arrays::VarBinArray
+
+pub fn vortex_array::arrays::VarBinArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::VarBinArray
 
 pub fn vortex_array::arrays::VarBinArray::clone(&self) -> vortex_array::arrays::VarBinArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::VarBinArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::VarBinArray
 
-pub fn vortex_array::arrays::VarBinArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::VarBinArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<alloc::vec::Vec<&[u8]>> for vortex_array::arrays::VarBinArray
 
@@ -3916,7 +7470,7 @@ pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::colle
 
 impl core::ops::deref::Deref for vortex_array::arrays::VarBinArray
 
-pub type vortex_array::arrays::VarBinArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::VarBinArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::VarBinArray::deref(&self) -> &Self::Target
 
@@ -3958,17 +7512,17 @@ impl core::fmt::Debug for vortex_array::arrays::VarBinVTable
 
 pub fn vortex_array::arrays::VarBinVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::FilterKernel for vortex_array::arrays::VarBinVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBinVTable
 
 pub fn vortex_array::arrays::VarBinVTable::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::VarBinVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinVTable
 
 pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinVTable
 
@@ -4074,25 +7628,25 @@ pub fn vortex_array::arrays::VarBinViewArray::from_iter_nullable_str<T: core::co
 
 pub fn vortex_array::arrays::VarBinViewArray::from_iter_str<T: core::convert::AsRef<str>, I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self
 
-pub fn vortex_array::arrays::VarBinViewArray::into_parts(self) -> vortex_array::arrays::VarBinViewArrayParts
+pub fn vortex_array::arrays::VarBinViewArray::into_parts(self) -> vortex_array::arrays::varbinview::VarBinViewArrayParts
 
 pub fn vortex_array::arrays::VarBinViewArray::nbuffers(&self) -> usize
 
-pub fn vortex_array::arrays::VarBinViewArray::new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+pub fn vortex_array::arrays::VarBinViewArray::new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
 
 pub fn vortex_array::arrays::VarBinViewArray::new_handle(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
 
 pub unsafe fn vortex_array::arrays::VarBinViewArray::new_handle_unchecked(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
 
-pub unsafe fn vortex_array::arrays::VarBinViewArray::new_unchecked(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+pub unsafe fn vortex_array::arrays::VarBinViewArray::new_unchecked(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
 
-pub fn vortex_array::arrays::VarBinViewArray::try_new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::VarBinViewArray::try_new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_array::arrays::VarBinViewArray::try_new_handle(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrays::VarBinViewArray::validate(views: &vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>, buffers: &alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::VarBinViewArray::validate(views: &vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: &alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::VarBinViewArray::views(&self) -> &[vortex_array::arrays::BinaryView]
+pub fn vortex_array::arrays::VarBinViewArray::views(&self) -> &[vortex_array::arrays::varbinview::BinaryView]
 
 pub fn vortex_array::arrays::VarBinViewArray::views_handle(&self) -> &vortex_array::buffer::BufferHandle
 
@@ -4102,13 +7656,17 @@ pub fn vortex_array::arrays::VarBinViewArray::compact_buffers(&self) -> vortex_e
 
 pub fn vortex_array::arrays::VarBinViewArray::compact_with_threshold(&self, buffer_utilization_threshold: f64) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
 
+impl vortex_array::arrays::VarBinViewArray
+
+pub fn vortex_array::arrays::VarBinViewArray::to_array(&self) -> vortex_array::ArrayRef
+
 impl core::clone::Clone for vortex_array::arrays::VarBinViewArray
 
 pub fn vortex_array::arrays::VarBinViewArray::clone(&self) -> vortex_array::arrays::VarBinViewArray
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::VarBinViewArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::VarBinViewArray
 
-pub fn vortex_array::arrays::VarBinViewArray::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::arrays::VarBinViewArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::arrays::VarBinViewArray> for vortex_array::ArrayRef
 
@@ -4128,7 +7686,7 @@ pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::c
 
 impl core::ops::deref::Deref for vortex_array::arrays::VarBinViewArray
 
-pub type vortex_array::arrays::VarBinViewArray::Target = dyn vortex_array::Array
+pub type vortex_array::arrays::VarBinViewArray::Target = dyn vortex_array::DynArray
 
 pub fn vortex_array::arrays::VarBinViewArray::deref(&self) -> &Self::Target
 
@@ -4160,16 +7718,6 @@ impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a str>
 
 pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a str>>>(iter: T) -> Self
 
-pub struct vortex_array::arrays::VarBinViewArrayParts
-
-pub vortex_array::arrays::VarBinViewArrayParts::buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>
-
-pub vortex_array::arrays::VarBinViewArrayParts::dtype: vortex_array::dtype::DType
-
-pub vortex_array::arrays::VarBinViewArrayParts::validity: vortex_array::validity::Validity
-
-pub vortex_array::arrays::VarBinViewArrayParts::views: vortex_array::buffer::BufferHandle
-
 pub struct vortex_array::arrays::VarBinViewVTable
 
 impl vortex_array::arrays::VarBinViewVTable
@@ -4180,13 +7728,13 @@ impl core::fmt::Debug for vortex_array::arrays::VarBinViewVTable
 
 pub fn vortex_array::arrays::VarBinViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinViewVTable
 
 pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinViewVTable
 
@@ -4212,7 +7760,7 @@ pub fn vortex_array::arrays::VarBinViewVTable::mask(array: &vortex_array::arrays
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinViewVTable
 
-pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinViewVTable> for vortex_array::arrays::VarBinViewVTable
 
@@ -4272,224 +7820,6 @@ pub fn vortex_array::arrays::VarBinViewVTable::stats(array: &vortex_array::array
 
 pub fn vortex_array::arrays::VarBinViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-pub const vortex_array::arrays::IS_CONST_LANE_WIDTH: usize
-
-pub trait vortex_array::arrays::FilterKernel: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::FilterKernel::filter(array: &Self::Array, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::FilterKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::FilterKernel for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::FilterKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub trait vortex_array::arrays::FilterReduce: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::FilterReduce::filter(array: &Self::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::filter(array: &vortex_array::arrays::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::FilterReduce for vortex_array::arrays::NullVTable
-
-pub fn vortex_array::arrays::NullVTable::filter(_array: &vortex_array::arrays::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub trait vortex_array::arrays::ScalarFnArrayExt: vortex_array::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::ScalarFnArrayExt::try_new_array(&self, len: usize, options: Self::Options, children: impl core::convert::Into<alloc::vec::Vec<vortex_array::ArrayRef>>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-impl<V: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::arrays::ScalarFnArrayExt for V
-
-pub fn V::try_new_array(&self, len: usize, options: Self::Options, children: impl core::convert::Into<alloc::vec::Vec<vortex_array::ArrayRef>>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub trait vortex_array::arrays::SliceKernel: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::SliceKernel::slice(array: &Self::Array, range: core::ops::range::Range<usize>, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub trait vortex_array::arrays::SliceReduce: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::SliceReduce::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::NullVTable
-
-pub fn vortex_array::arrays::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ScalarFnVTable
-
-pub fn vortex_array::arrays::ScalarFnVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::SliceVTable
-
-pub fn vortex_array::arrays::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::SliceReduce for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub trait vortex_array::arrays::TakeExecute: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::TakeExecute::take(array: &Self::Array, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub trait vortex_array::arrays::TakeReduce: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::TakeReduce::take(array: &Self::Array, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeReduce for vortex_array::arrays::NullVTable
-
-pub fn vortex_array::arrays::NullVTable::take(array: &vortex_array::arrays::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::TakeReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::chunk_range(chunk_idx: usize, offset: usize, array_len: usize) -> core::ops::range::Range<usize>
-
-pub fn vortex_array::arrays::compute_is_constant<T: vortex_array::dtype::NativePType, const WIDTH: usize>(values: &[T]) -> bool
-
-pub fn vortex_array::arrays::list_from_list_view(list_view: vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
-
-pub fn vortex_array::arrays::list_view_from_list(list: vortex_array::arrays::ListArray, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
-
-pub fn vortex_array::arrays::mask_validity_canonical(canonical: vortex_array::Canonical, validity_mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::Canonical>
-
-pub fn vortex_array::arrays::narrowed_decimal(decimal_array: vortex_array::arrays::DecimalArray) -> vortex_array::arrays::DecimalArray
-
-pub fn vortex_array::arrays::patch_chunk<T, I, C>(decoded_values: &mut [T], patches_indices: &[I], patches_values: &[T], patches_offset: usize, chunk_offsets_slice: &[C], chunk_idx: usize, offset_within_chunk: usize) where T: vortex_array::dtype::NativePType, I: vortex_array::dtype::UnsignedPType, C: vortex_array::dtype::UnsignedPType
-
-pub fn vortex_array::arrays::recursive_list_from_list_view(array: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::take_canonical(values: vortex_array::Canonical, codes: &vortex_array::arrays::PrimitiveArray, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::Canonical>
-
-pub fn vortex_array::arrays::varbin_scalar(value: vortex_buffer::ByteBuffer, dtype: &vortex_array::dtype::DType) -> vortex_array::scalar::Scalar
-
 pub mod vortex_array::arrow
 
 pub mod vortex_array::arrow::bool
@@ -4504,7 +7834,7 @@ pub fn vortex_array::arrow::byte_view::execute_varbinview_to_arrow<T: arrow_arra
 
 pub mod vortex_array::arrow::null
 
-pub fn vortex_array::arrow::null::canonical_null_to_arrow(array: &vortex_array::arrays::NullArray) -> arrow_array::array::ArrayRef
+pub fn vortex_array::arrow::null::canonical_null_to_arrow(array: &vortex_array::arrays::null::NullArray) -> arrow_array::array::ArrayRef
 
 pub mod vortex_array::arrow::primitive
 
@@ -4518,7 +7848,7 @@ pub fn vortex_array::arrow::ArrowArrayStreamAdapter::new(stream: arrow_array::ff
 
 impl core::iter::traits::iterator::Iterator for vortex_array::arrow::ArrowArrayStreamAdapter
 
-pub type vortex_array::arrow::ArrowArrayStreamAdapter::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::Array>, vortex_error::VortexError>
+pub type vortex_array::arrow::ArrowArrayStreamAdapter::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::DynArray>, vortex_error::VortexError>
 
 pub fn vortex_array::arrow::ArrowArrayStreamAdapter::next(&mut self) -> core::option::Option<Self::Item>
 
@@ -4694,9 +8024,9 @@ impl vortex_array::arrow::FromArrowArray<arrow_array::record_batch::RecordBatch>
 
 pub fn vortex_array::ArrayRef::from_arrow(array: arrow_array::record_batch::RecordBatch, nullable: bool) -> vortex_error::VortexResult<Self>
 
-impl<K: arrow_array::types::ArrowDictionaryKeyType> vortex_array::arrow::FromArrowArray<&arrow_array::array::dictionary_array::DictionaryArray<K>> for vortex_array::arrays::DictArray
+impl<K: arrow_array::types::ArrowDictionaryKeyType> vortex_array::arrow::FromArrowArray<&arrow_array::array::dictionary_array::DictionaryArray<K>> for vortex_array::arrays::dict::DictArray
 
-pub fn vortex_array::arrays::DictArray::from_arrow(array: &arrow_array::array::dictionary_array::DictionaryArray<K>, nullable: bool) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::dict::DictArray::from_arrow(array: &arrow_array::array::dictionary_array::DictionaryArray<K>, nullable: bool) -> vortex_error::VortexResult<Self>
 
 impl<O: arrow_array::array::list_array::OffsetSizeTrait + vortex_array::dtype::NativePType> vortex_array::arrow::FromArrowArray<&arrow_array::array::list_view_array::GenericListViewArray<O>> for vortex_array::ArrayRef
 
@@ -4858,9 +8188,9 @@ pub fn vortex_array::builders::dict::DictEncoder::encode(&mut self, array: &vort
 
 pub fn vortex_array::builders::dict::DictEncoder::reset(&mut self) -> vortex_array::ArrayRef
 
-pub fn vortex_array::builders::dict::dict_encode(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
+pub fn vortex_array::builders::dict::dict_encode(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
 
-pub fn vortex_array::builders::dict::dict_encode_with_constraints(array: &vortex_array::ArrayRef, constraints: &vortex_array::builders::dict::DictConstraints) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
+pub fn vortex_array::builders::dict::dict_encode_with_constraints(array: &vortex_array::ArrayRef, constraints: &vortex_array::builders::dict::DictConstraints) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
 
 pub fn vortex_array::builders::dict::dict_encoder(array: &vortex_array::ArrayRef, constraints: &vortex_array::builders::dict::DictConstraints) -> alloc::boxed::Box<dyn vortex_array::builders::dict::DictEncoder>
 
@@ -4965,6 +8295,8 @@ pub unsafe fn vortex_array::builders::BoolBuilder::set_validity_unchecked(&mut s
 pub struct vortex_array::builders::DecimalBuilder
 
 impl vortex_array::builders::DecimalBuilder
+
+pub fn vortex_array::builders::DecimalBuilder::append_n_values<V: vortex_array::dtype::NativeDecimalType>(&mut self, value: V, n: usize)
 
 pub fn vortex_array::builders::DecimalBuilder::append_value<V: vortex_array::dtype::NativeDecimalType>(&mut self, value: V)
 
@@ -5310,6 +8642,8 @@ pub struct vortex_array::builders::PrimitiveBuilder<T>
 
 impl<T: vortex_array::dtype::NativePType> vortex_array::builders::PrimitiveBuilder<T>
 
+pub fn vortex_array::builders::PrimitiveBuilder<T>::append_n_values(&mut self, value: T, n: usize)
+
 pub fn vortex_array::builders::PrimitiveBuilder<T>::append_value(&mut self, value: T)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::extend_with_iterator(&mut self, iter: impl core::iter::traits::collect::IntoIterator<Item = T>, mask: vortex_mask::Mask)
@@ -5446,6 +8780,8 @@ pub struct vortex_array::builders::VarBinViewBuilder
 
 impl vortex_array::builders::VarBinViewBuilder
 
+pub fn vortex_array::builders::VarBinViewBuilder::append_n_values<S: core::convert::AsRef<[u8]>>(&mut self, value: S, n: usize)
+
 pub fn vortex_array::builders::VarBinViewBuilder::append_value<S: core::convert::AsRef<[u8]>>(&mut self, value: S)
 
 pub fn vortex_array::builders::VarBinViewBuilder::completed_block_count(&self) -> u32
@@ -5454,7 +8790,7 @@ pub fn vortex_array::builders::VarBinViewBuilder::finish_into_varbinview(&mut se
 
 pub fn vortex_array::builders::VarBinViewBuilder::new(dtype: vortex_array::dtype::DType, capacity: usize, completed: vortex_array::builders::CompletedBuffers, growth_strategy: vortex_array::builders::BufferGrowthStrategy, compaction_threshold: f64) -> Self
 
-pub fn vortex_array::builders::VarBinViewBuilder::push_buffer_and_adjusted_views(&mut self, buffers: &[vortex_buffer::ByteBuffer], views: &vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>, validity_mask: vortex_mask::Mask)
+pub fn vortex_array::builders::VarBinViewBuilder::push_buffer_and_adjusted_views(&mut self, buffers: &[vortex_buffer::ByteBuffer], views: &vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, validity_mask: vortex_mask::Mask)
 
 pub fn vortex_array::builders::VarBinViewBuilder::with_buffer_deduplication(dtype: vortex_array::dtype::DType, capacity: usize) -> Self
 
@@ -5992,7 +9328,7 @@ pub fn vortex_array::builtins::ArrayBuiltins::mask(self, mask: vortex_array::Arr
 
 pub fn vortex_array::builtins::ArrayBuiltins::not(&self) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::builtins::ArrayBuiltins::zip(&self, if_false: vortex_array::ArrayRef, mask: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::builtins::ArrayBuiltins::zip(&self, if_true: vortex_array::ArrayRef, if_false: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 impl vortex_array::builtins::ArrayBuiltins for vortex_array::ArrayRef
 
@@ -6014,7 +9350,7 @@ pub fn vortex_array::ArrayRef::mask(self, mask: vortex_array::ArrayRef) -> vorte
 
 pub fn vortex_array::ArrayRef::not(&self) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::ArrayRef::zip(&self, if_false: vortex_array::ArrayRef, mask: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::ArrayRef::zip(&self, if_true: vortex_array::ArrayRef, if_false: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub trait vortex_array::builtins::ExprBuiltins: core::marker::Sized
 
@@ -6034,7 +9370,7 @@ pub fn vortex_array::builtins::ExprBuiltins::mask(&self, mask: vortex_array::exp
 
 pub fn vortex_array::builtins::ExprBuiltins::not(&self) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
-pub fn vortex_array::builtins::ExprBuiltins::zip(&self, if_false: vortex_array::expr::Expression, mask: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+pub fn vortex_array::builtins::ExprBuiltins::zip(&self, if_true: vortex_array::expr::Expression, if_false: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 impl vortex_array::builtins::ExprBuiltins for vortex_array::expr::Expression
 
@@ -6054,7 +9390,7 @@ pub fn vortex_array::expr::Expression::mask(&self, mask: vortex_array::expr::Exp
 
 pub fn vortex_array::expr::Expression::not(&self) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
-pub fn vortex_array::expr::Expression::zip(&self, if_false: vortex_array::expr::Expression, mask: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+pub fn vortex_array::expr::Expression::zip(&self, if_true: vortex_array::expr::Expression, if_false: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub mod vortex_array::compute
 
@@ -6086,7 +9422,7 @@ impl core::marker::StructuralPartialEq for vortex_array::compute::Cost
 
 pub enum vortex_array::compute::Input<'a>
 
-pub vortex_array::compute::Input::Array(&'a dyn vortex_array::Array)
+pub vortex_array::compute::Input::Array(&'a dyn vortex_array::DynArray)
 
 pub vortex_array::compute::Input::Builder(&'a mut dyn vortex_array::builders::ArrayBuilder)
 
@@ -6098,7 +9434,7 @@ pub vortex_array::compute::Input::Scalar(&'a vortex_array::scalar::Scalar)
 
 impl<'a> vortex_array::compute::Input<'a>
 
-pub fn vortex_array::compute::Input<'a>::array(&self) -> core::option::Option<&'a dyn vortex_array::Array>
+pub fn vortex_array::compute::Input<'a>::array(&self) -> core::option::Option<&'a dyn vortex_array::DynArray>
 
 pub fn vortex_array::compute::Input<'a>::builder(&'a mut self) -> core::option::Option<&'a mut dyn vortex_array::builders::ArrayBuilder>
 
@@ -6112,11 +9448,11 @@ impl core::fmt::Debug for vortex_array::compute::Input<'_>
 
 pub fn vortex_array::compute::Input<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl<'a> core::convert::From<&'a (dyn vortex_array::Array + 'static)> for vortex_array::compute::Input<'a>
+impl<'a> core::convert::From<&'a (dyn vortex_array::DynArray + 'static)> for vortex_array::compute::Input<'a>
 
-pub fn vortex_array::compute::Input<'a>::from(value: &'a dyn vortex_array::Array) -> Self
+pub fn vortex_array::compute::Input<'a>::from(value: &'a dyn vortex_array::DynArray) -> Self
 
-impl<'a> core::convert::From<&'a alloc::sync::Arc<dyn vortex_array::Array>> for vortex_array::compute::Input<'a>
+impl<'a> core::convert::From<&'a alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::compute::Input<'a>
 
 pub fn vortex_array::compute::Input<'a>::from(value: &'a vortex_array::ArrayRef) -> Self
 
@@ -6148,7 +9484,7 @@ pub fn vortex_array::compute::Output::unwrap_array(self) -> vortex_error::Vortex
 
 pub fn vortex_array::compute::Output::unwrap_scalar(self) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl core::convert::From<alloc::sync::Arc<dyn vortex_array::Array>> for vortex_array::compute::Output
+impl core::convert::From<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::compute::Output
 
 pub fn vortex_array::compute::Output::from(value: vortex_array::ArrayRef) -> Self
 
@@ -6162,11 +9498,11 @@ pub fn vortex_array::compute::Output::fmt(&self, f: &mut core::fmt::Formatter<'_
 
 pub struct vortex_array::compute::BinaryArgs<'a, O: vortex_array::compute::Options>
 
-pub vortex_array::compute::BinaryArgs::lhs: &'a dyn vortex_array::Array
+pub vortex_array::compute::BinaryArgs::lhs: &'a dyn vortex_array::DynArray
 
 pub vortex_array::compute::BinaryArgs::options: &'a O
 
-pub vortex_array::compute::BinaryArgs::rhs: &'a dyn vortex_array::Array
+pub vortex_array::compute::BinaryArgs::rhs: &'a dyn vortex_array::DynArray
 
 impl<'a, O: vortex_array::compute::Options> core::convert::TryFrom<&vortex_array::compute::InvocationArgs<'a>> for vortex_array::compute::BinaryArgs<'a, O>
 
@@ -6360,7 +9696,7 @@ pub struct vortex_array::compute::SumArgs<'a>
 
 pub vortex_array::compute::SumArgs::accumulator: &'a vortex_array::scalar::Scalar
 
-pub vortex_array::compute::SumArgs::array: &'a dyn vortex_array::Array
+pub vortex_array::compute::SumArgs::array: &'a dyn vortex_array::DynArray
 
 impl<'a> core::convert::TryFrom<&vortex_array::compute::InvocationArgs<'a>> for vortex_array::compute::SumArgs<'a>
 
@@ -6388,7 +9724,7 @@ impl inventory::Collect for vortex_array::compute::SumKernelRef
 
 pub struct vortex_array::compute::UnaryArgs<'a, O: vortex_array::compute::Options>
 
-pub vortex_array::compute::UnaryArgs::array: &'a dyn vortex_array::Array
+pub vortex_array::compute::UnaryArgs::array: &'a dyn vortex_array::DynArray
 
 pub vortex_array::compute::UnaryArgs::options: &'a O
 
@@ -6434,10 +9770,6 @@ impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DecimalVT
 
 pub fn vortex_array::arrays::DecimalVTable::is_constant(&self, array: &vortex_array::arrays::DecimalArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::is_constant(&self, array: &vortex_array::arrays::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::is_constant(&self, array: &vortex_array::arrays::ExtensionArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
@@ -6470,6 +9802,10 @@ impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinVie
 
 pub fn vortex_array::arrays::VarBinViewVTable::is_constant(&self, array: &vortex_array::arrays::VarBinViewArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
 pub trait vortex_array::compute::IsSortedIteratorExt where <Self as core::iter::traits::iterator::Iterator>::Item: core::cmp::PartialOrd: core::iter::traits::iterator::Iterator
 
 pub fn vortex_array::compute::IsSortedIteratorExt::is_strict_sorted(self) -> bool where Self: core::marker::Sized, Self::Item: core::cmp::PartialOrd
@@ -6501,12 +9837,6 @@ impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DecimalVTab
 pub fn vortex_array::arrays::DecimalVTable::is_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 pub fn vortex_array::arrays::DecimalVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::is_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ExtensionVTable
 
@@ -6549,6 +9879,12 @@ impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinViewV
 pub fn vortex_array::arrays::VarBinViewVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 pub fn vortex_array::arrays::VarBinViewVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 pub trait vortex_array::compute::Kernel: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug
 
@@ -6594,10 +9930,6 @@ impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DecimalVTable
 
 pub fn vortex_array::arrays::DecimalVTable::min_max(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::min_max(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
 impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::min_max(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
@@ -6614,10 +9946,6 @@ impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListViewVTabl
 
 pub fn vortex_array::arrays::ListViewVTable::min_max(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::NullVTable
-
-pub fn vortex_array::arrays::NullVTable::min_max(&self, _array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
 impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::min_max(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
@@ -6633,6 +9961,14 @@ pub fn vortex_array::arrays::VarBinVTable::min_max(&self, array: &vortex_array::
 impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinViewVTable
 
 pub fn vortex_array::arrays::VarBinViewVTable::min_max(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
 pub trait vortex_array::compute::NaNCountKernel: vortex_array::vtable::VTable
 
@@ -6686,26 +10022,6 @@ impl vortex_array::compute::SumKernel for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::compute::add(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::add_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::and_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::arrow_filter_fn(array: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::cast(array: &dyn vortex_array::Array, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::div(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::div_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::fill_null(array: &vortex_array::ArrayRef, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::filter(array: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::invert(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
 pub fn vortex_array::compute::is_constant(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 pub fn vortex_array::compute::is_constant_opts(array: &vortex_array::ArrayRef, options: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
@@ -6716,33 +10032,15 @@ pub fn vortex_array::compute::is_sorted_opts(array: &vortex_array::ArrayRef, str
 
 pub fn vortex_array::compute::is_strict_sorted(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::compute::list_contains(array: &vortex_array::ArrayRef, value: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::mask(array: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
 pub fn vortex_array::compute::min_max(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-pub fn vortex_array::compute::mul(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::mul_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
 pub fn vortex_array::compute::nan_count(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<usize>
-
-pub fn vortex_array::compute::numeric(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef, op: vortex_array::scalar::NumericOperator) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::or_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::sub(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::compute::sub_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::compute::sum(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::compute::sum_impl(array: &vortex_array::ArrayRef, accumulator: &vortex_array::scalar::Scalar, kernels: &[arcref::ArcRef<dyn vortex_array::compute::Kernel>]) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::compute::warm_up_vtables()
-
-pub fn vortex_array::compute::zip(if_true: &vortex_array::ArrayRef, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub mod vortex_array::display
 
@@ -6766,7 +10064,7 @@ impl core::default::Default for vortex_array::display::DisplayOptions
 
 pub fn vortex_array::display::DisplayOptions::default() -> Self
 
-pub struct vortex_array::display::DisplayArrayAs<'a>(pub &'a dyn vortex_array::Array, pub vortex_array::display::DisplayOptions)
+pub struct vortex_array::display::DisplayArrayAs<'a>(pub &'a dyn vortex_array::DynArray, pub vortex_array::display::DisplayOptions)
 
 impl core::fmt::Display for vortex_array::display::DisplayArrayAs<'_>
 
@@ -8389,6 +11687,10 @@ pub fn vortex_array::dtype::i256::as_(self) -> i64
 impl num_traits::cast::AsPrimitive<i8> for vortex_array::dtype::i256
 
 pub fn vortex_array::dtype::i256::as_(self) -> i8
+
+impl num_traits::cast::AsPrimitive<vortex_array::dtype::i256> for bool
+
+pub fn bool::as_(self) -> vortex_array::dtype::i256
 
 impl num_traits::cast::AsPrimitive<vortex_array::dtype::i256> for i128
 
@@ -10460,7 +13762,7 @@ pub fn vortex_array::expr::Expression::mask(&self, mask: vortex_array::expr::Exp
 
 pub fn vortex_array::expr::Expression::not(&self) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
-pub fn vortex_array::expr::Expression::zip(&self, if_false: vortex_array::expr::Expression, mask: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+pub fn vortex_array::expr::Expression::zip(&self, if_true: vortex_array::expr::Expression, if_false: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 impl vortex_array::expr::VortexExprExt for vortex_array::expr::Expression
 
@@ -10516,6 +13818,10 @@ pub fn vortex_array::expr::and_collect<I>(iter: I) -> core::option::Option<vorte
 
 pub fn vortex_array::expr::between(arr: vortex_array::expr::Expression, lower: vortex_array::expr::Expression, upper: vortex_array::expr::Expression, options: vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_array::expr::Expression
 
+pub fn vortex_array::expr::case_when(condition: vortex_array::expr::Expression, then_value: vortex_array::expr::Expression, else_value: vortex_array::expr::Expression) -> vortex_array::expr::Expression
+
+pub fn vortex_array::expr::case_when_no_else(condition: vortex_array::expr::Expression, then_value: vortex_array::expr::Expression) -> vortex_array::expr::Expression
+
 pub fn vortex_array::expr::cast(child: vortex_array::expr::Expression, target: vortex_array::dtype::DType) -> vortex_array::expr::Expression
 
 pub fn vortex_array::expr::checked_add(lhs: vortex_array::expr::Expression, rhs: vortex_array::expr::Expression) -> vortex_array::expr::Expression
@@ -10570,6 +13876,8 @@ pub fn vortex_array::expr::merge(elements: impl core::iter::traits::collect::Int
 
 pub fn vortex_array::expr::merge_opts(elements: impl core::iter::traits::collect::IntoIterator<Item = impl core::convert::Into<vortex_array::expr::Expression>>, duplicate_handling: vortex_array::scalar_fn::fns::merge::DuplicateHandling) -> vortex_array::expr::Expression
 
+pub fn vortex_array::expr::nested_case_when(when_then_pairs: alloc::vec::Vec<(vortex_array::expr::Expression, vortex_array::expr::Expression)>, else_value: core::option::Option<vortex_array::expr::Expression>) -> vortex_array::expr::Expression
+
 pub fn vortex_array::expr::not(operand: vortex_array::expr::Expression) -> vortex_array::expr::Expression
 
 pub fn vortex_array::expr::not_eq(lhs: vortex_array::expr::Expression, rhs: vortex_array::expr::Expression) -> vortex_array::expr::Expression
@@ -10592,7 +13900,7 @@ pub fn vortex_array::expr::select_exclude(fields: impl core::convert::Into<vorte
 
 pub fn vortex_array::expr::split_conjunction(expr: &vortex_array::expr::Expression) -> alloc::vec::Vec<vortex_array::expr::Expression>
 
-pub fn vortex_array::expr::zip_expr(if_true: vortex_array::expr::Expression, if_false: vortex_array::expr::Expression, mask: vortex_array::expr::Expression) -> vortex_array::expr::Expression
+pub fn vortex_array::expr::zip_expr(mask: vortex_array::expr::Expression, if_true: vortex_array::expr::Expression, if_false: vortex_array::expr::Expression) -> vortex_array::expr::Expression
 
 pub type vortex_array::expr::Annotations<'a, A> = vortex_utils::aliases::hash_map::HashMap<&'a vortex_array::expr::Expression, vortex_utils::aliases::hash_set::HashSet<A>>
 
@@ -10988,7 +14296,7 @@ pub fn vortex_array::iter::ArrayIteratorAdapter<I>::new(dtype: vortex_array::dty
 
 impl<I> core::iter::traits::iterator::Iterator for vortex_array::iter::ArrayIteratorAdapter<I> where I: core::iter::traits::iterator::Iterator<Item = vortex_error::VortexResult<vortex_array::ArrayRef>>
 
-pub type vortex_array::iter::ArrayIteratorAdapter<I>::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::Array>, vortex_error::VortexError>
+pub type vortex_array::iter::ArrayIteratorAdapter<I>::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::DynArray>, vortex_error::VortexError>
 
 pub fn vortex_array::iter::ArrayIteratorAdapter<I>::next(&mut self) -> core::option::Option<Self::Item>
 
@@ -11066,77 +14374,77 @@ pub type vortex_array::kernel::ExecuteParentKernel::Parent: vortex_array::matche
 
 pub fn vortex_array::kernel::ExecuteParentKernel::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::FilterExecuteAdaptor<V> where V: vortex_array::arrays::FilterKernel
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::dict::TakeExecuteAdaptor<V> where V: vortex_array::arrays::dict::TakeExecute
 
-pub type vortex_array::arrays::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+pub type vortex_array::arrays::dict::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::SliceExecuteAdaptor<V> where V: vortex_array::arrays::SliceKernel
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::filter::FilterExecuteAdaptor<V> where V: vortex_array::arrays::filter::FilterKernel
 
-pub type vortex_array::arrays::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
+pub type vortex_array::arrays::filter::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
 
-pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::filter::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::TakeExecuteAdaptor<V> where V: vortex_array::arrays::TakeExecute
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::slice::SliceExecuteAdaptor<V> where V: vortex_array::arrays::slice::SliceKernel
 
-pub type vortex_array::arrays::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::DictVTable
+pub type vortex_array::arrays::slice::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
 
-pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::between::BetweenKernel
 
-pub type vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
+pub type vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
 
-pub fn vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::binary::CompareKernel
 
-pub type vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::binary::Binary>
+pub type vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::binary::Binary>
 
-pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::binary::Binary>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::binary::Binary>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::cast::CastKernel
 
-pub type vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
+pub type vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
 
 pub fn vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::fill_null::FillNullKernel
 
-pub type vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
+pub type vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
 
-pub fn vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::like::LikeKernel
 
-pub type vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
+pub type vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
 
-pub fn vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::list_contains::ListContainsElementKernel
 
-pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
+pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::mask::MaskKernel
 
-pub type vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
+pub type vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
 
-pub fn vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::not::NotKernel
 
-pub type vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
+pub type vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
 
-pub fn vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::zip::ZipKernel
 
-pub type vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
+pub type vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::mask
 
@@ -11150,67 +14458,67 @@ pub fn vortex_array::matcher::AnyArray::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl vortex_array::matcher::Matcher for vortex_array::matcher::AnyArray
 
-pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::Array + 'static)
+pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::DynArray + 'static)
 
-pub fn vortex_array::matcher::AnyArray::matches(_array: &dyn vortex_array::Array) -> bool
+pub fn vortex_array::matcher::AnyArray::matches(_array: &dyn vortex_array::DynArray) -> bool
 
-pub fn vortex_array::matcher::AnyArray::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn vortex_array::matcher::AnyArray::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 pub trait vortex_array::matcher::Matcher
 
 pub type vortex_array::matcher::Matcher::Match<'a>
 
-pub fn vortex_array::matcher::Matcher::matches(array: &dyn vortex_array::Array) -> bool
+pub fn vortex_array::matcher::Matcher::matches(array: &dyn vortex_array::DynArray) -> bool
 
-pub fn vortex_array::matcher::Matcher::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn vortex_array::matcher::Matcher::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 impl vortex_array::matcher::Matcher for vortex_array::AnyCanonical
 
 pub type vortex_array::AnyCanonical::Match<'a> = vortex_array::CanonicalView<'a>
 
-pub fn vortex_array::AnyCanonical::matches(array: &dyn vortex_array::Array) -> bool
+pub fn vortex_array::AnyCanonical::matches(array: &dyn vortex_array::DynArray) -> bool
 
-pub fn vortex_array::AnyCanonical::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn vortex_array::AnyCanonical::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 impl vortex_array::matcher::Matcher for vortex_array::AnyColumnar
 
 pub type vortex_array::AnyColumnar::Match<'a> = vortex_array::ColumnarView<'a>
 
-pub fn vortex_array::AnyColumnar::matches(array: &dyn vortex_array::Array) -> bool
+pub fn vortex_array::AnyColumnar::matches(array: &dyn vortex_array::DynArray) -> bool
 
-pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
-impl vortex_array::matcher::Matcher for vortex_array::arrays::AnyScalarFn
+impl vortex_array::matcher::Matcher for vortex_array::arrays::scalar_fn::AnyScalarFn
 
-pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
+pub type vortex_array::arrays::scalar_fn::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub fn vortex_array::arrays::AnyScalarFn::matches(array: &dyn vortex_array::Array) -> bool
+pub fn vortex_array::arrays::scalar_fn::AnyScalarFn::matches(array: &dyn vortex_array::DynArray) -> bool
 
-pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn vortex_array::arrays::scalar_fn::AnyScalarFn::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 impl vortex_array::matcher::Matcher for vortex_array::matcher::AnyArray
 
-pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::Array + 'static)
+pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::DynArray + 'static)
 
-pub fn vortex_array::matcher::AnyArray::matches(_array: &dyn vortex_array::Array) -> bool
+pub fn vortex_array::matcher::AnyArray::matches(_array: &dyn vortex_array::DynArray) -> bool
 
-pub fn vortex_array::matcher::AnyArray::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn vortex_array::matcher::AnyArray::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
-impl<F: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::matcher::Matcher for vortex_array::arrays::ExactScalarFn<F>
+impl<F: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::matcher::Matcher for vortex_array::arrays::scalar_fn::ExactScalarFn<F>
 
-pub type vortex_array::arrays::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::ScalarFnArrayView<'a, F>
+pub type vortex_array::arrays::scalar_fn::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::scalar_fn::ScalarFnArrayView<'a, F>
 
-pub fn vortex_array::arrays::ExactScalarFn<F>::matches(array: &dyn vortex_array::Array) -> bool
+pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::matches(array: &dyn vortex_array::DynArray) -> bool
 
-pub fn vortex_array::arrays::ExactScalarFn<F>::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::matcher::Matcher for V
 
 pub type V::Match<'a> = &'a <V as vortex_array::vtable::VTable>::Array
 
-pub fn V::matches(array: &dyn vortex_array::Array) -> bool
+pub fn V::matches(array: &dyn vortex_array::DynArray) -> bool
 
-pub fn V::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn V::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 pub mod vortex_array::normalize
 
@@ -11264,89 +14572,89 @@ pub type vortex_array::optimizer::rules::ArrayParentReduceRule::Parent: vortex_a
 
 pub fn vortex_array::optimizer::rules::ArrayParentReduceRule::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
 
-pub type vortex_array::arrays::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
 
-pub type vortex_array::arrays::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
 
-pub type vortex_array::arrays::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::FilterReduceAdaptor<V> where V: vortex_array::arrays::FilterReduce
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::dict::TakeReduceAdaptor<V> where V: vortex_array::arrays::dict::TakeReduce
 
-pub type vortex_array::arrays::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+pub type vortex_array::arrays::dict::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::FilterReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::FilterArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::TakeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::dict::DictArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::SliceReduceAdaptor<V> where V: vortex_array::arrays::SliceReduce
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::filter::FilterReduceAdaptor<V> where V: vortex_array::arrays::filter::FilterReduce
 
-pub type vortex_array::arrays::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
+pub type vortex_array::arrays::filter::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
 
-pub fn vortex_array::arrays::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::filter::FilterReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::FilterArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::TakeReduceAdaptor<V> where V: vortex_array::arrays::TakeReduce
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::slice::SliceReduceAdaptor<V> where V: vortex_array::arrays::slice::SliceReduce
 
-pub type vortex_array::arrays::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::DictVTable
+pub type vortex_array::arrays::slice::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
 
-pub fn vortex_array::arrays::TakeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::DictArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::between::BetweenReduce
 
-pub type vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
+pub type vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
 
-pub fn vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::cast::CastReduce
 
-pub type vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
+pub type vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
 
-pub fn vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::cast::Cast>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::cast::Cast>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::fill_null::FillNullReduce
 
-pub type vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
+pub type vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
 
-pub fn vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::like::LikeReduce
 
-pub type vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
+pub type vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
 
-pub fn vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduce
 
-pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
+pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::mask::MaskReduce
 
-pub type vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
+pub type vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
 
-pub fn vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::not::NotReduce
 
-pub type vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
+pub type vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
 
-pub fn vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::zip::ZipReduce
 
-pub type vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
+pub type vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::optimizer::rules::ArrayReduceRule<V: vortex_array::vtable::VTable>: core::fmt::Debug + core::marker::Send + core::marker::Sync + 'static
 
@@ -11952,9 +15260,9 @@ pub fn vortex_array::scalar::ScalarValue::into_utf8(self) -> vortex_buffer::stri
 
 impl vortex_array::scalar::ScalarValue
 
-pub fn vortex_array::scalar::ScalarValue::from_proto(value: &vortex_proto::scalar::ScalarValue, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<Self>>
+pub fn vortex_array::scalar::ScalarValue::from_proto(value: &vortex_proto::scalar::ScalarValue, dtype: &vortex_array::dtype::DType, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<core::option::Option<Self>>
 
-pub fn vortex_array::scalar::ScalarValue::from_proto_bytes(bytes: &[u8], dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<Self>>
+pub fn vortex_array::scalar::ScalarValue::from_proto_bytes(bytes: &[u8], dtype: &vortex_array::dtype::DType, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<core::option::Option<Self>>
 
 impl vortex_array::scalar::ScalarValue
 
@@ -12660,11 +15968,13 @@ impl vortex_array::scalar::Scalar
 
 pub fn vortex_array::scalar::Scalar::from_proto(value: &vortex_proto::scalar::Scalar, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::scalar::Scalar::from_proto_value(value: &vortex_proto::scalar::ScalarValue, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::scalar::Scalar::from_proto_value(value: &vortex_proto::scalar::ScalarValue, dtype: &vortex_array::dtype::DType, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self>
 
 impl vortex_array::scalar::Scalar
 
-pub fn vortex_array::scalar::Scalar::struct_(dtype: vortex_array::dtype::DType, children: alloc::vec::Vec<vortex_array::scalar::Scalar>) -> Self
+pub fn vortex_array::scalar::Scalar::struct_(dtype: vortex_array::dtype::DType, children: impl core::iter::traits::collect::IntoIterator<Item = vortex_array::scalar::Scalar>) -> Self
+
+pub unsafe fn vortex_array::scalar::Scalar::struct_unchecked(dtype: vortex_array::dtype::DType, children: impl core::iter::traits::collect::IntoIterator<Item = vortex_array::scalar::Scalar>) -> Self
 
 impl vortex_array::scalar::Scalar
 
@@ -13092,19 +16402,19 @@ impl core::hash::Hash for vortex_array::scalar::Scalar
 
 pub fn vortex_array::scalar::Scalar::hash<H: core::hash::Hasher>(&self, state: &mut H)
 
-impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::Scalar> for (dyn vortex_array::Array + '_)
+impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::Scalar> for (dyn vortex_array::DynArray + '_)
 
-pub fn (dyn vortex_array::Array + '_)::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
+pub fn (dyn vortex_array::DynArray + '_)::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
-pub fn (dyn vortex_array::Array + '_)::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::DynArray + '_)::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::Array + '_)::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::DynArray + '_)::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::Array + '_)::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::DynArray + '_)::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::Array + '_)::index_len(&self) -> usize
+pub fn (dyn vortex_array::DynArray + '_)::index_len(&self) -> usize
 
-pub fn (dyn vortex_array::Array + '_)::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::DynArray + '_)::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 impl<'a, T> core::convert::TryFrom<&'a vortex_array::scalar::Scalar> for alloc::vec::Vec<T> where T: for<'b> core::convert::TryFrom<&'b vortex_array::scalar::Scalar, Error = vortex_error::VortexError>
 
@@ -13460,9 +16770,9 @@ pub fn vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::fmt(&sel
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::between::BetweenKernel
 
-pub type vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
+pub type vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
 
-pub fn vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::between::BetweenOptions
 
@@ -13510,9 +16820,9 @@ pub fn vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::fmt(&self
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::between::BetweenReduce
 
-pub type vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
+pub type vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
 
-pub fn vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::between::BetweenKernel: vortex_array::vtable::VTable
 
@@ -13590,17 +16900,13 @@ pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::fmt(&self
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::binary::CompareKernel
 
-pub type vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::binary::Binary>
+pub type vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::binary::Binary>
 
-pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::binary::Binary>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::binary::Binary>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::binary::CompareKernel: vortex_array::vtable::VTable
 
 pub fn vortex_array::scalar_fn::fns::binary::CompareKernel::compare(lhs: &Self::Array, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::ExtensionVTable
 
@@ -13610,6 +16916,10 @@ impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::array
 
 pub fn vortex_array::arrays::VarBinVTable::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::scalar_fn::fns::binary::and_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::compare_nested_arrow_arrays(lhs: &dyn arrow_array::array::Array, rhs: &dyn arrow_array::array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator) -> vortex_error::VortexResult<arrow_array::array::boolean_array::BooleanArray>
@@ -13617,6 +16927,86 @@ pub fn vortex_array::scalar_fn::fns::binary::compare_nested_arrow_arrays(lhs: &d
 pub fn vortex_array::scalar_fn::fns::binary::or_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::scalar_cmp(lhs: &vortex_array::scalar::Scalar, rhs: &vortex_array::scalar::Scalar, operator: vortex_array::scalar_fn::fns::operators::CompareOperator) -> vortex_array::scalar::Scalar
+
+pub mod vortex_array::scalar_fn::fns::case_when
+
+pub struct vortex_array::scalar_fn::fns::case_when::CaseWhen
+
+impl core::clone::Clone for vortex_array::scalar_fn::fns::case_when::CaseWhen
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::clone(&self) -> vortex_array::scalar_fn::fns::case_when::CaseWhen
+
+impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::case_when::CaseWhen
+
+pub type vortex_array::scalar_fn::fns::case_when::CaseWhen::Options = vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::arity(&self, options: &Self::Options) -> vortex_array::scalar_fn::Arity
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::child_name(&self, options: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::deserialize(&self, metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::id(&self) -> vortex_array::scalar_fn::ScalarFnId
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::is_fallible(&self, _options: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::is_null_sensitive(&self, _options: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::return_dtype(&self, options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub struct vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+pub vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::has_else: bool
+
+pub vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::num_when_then_pairs: u32
+
+impl vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::num_children(&self) -> usize
+
+impl core::clone::Clone for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::clone(&self) -> vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+impl core::cmp::Eq for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+impl core::cmp::PartialEq for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::eq(&self, other: &vortex_array::scalar_fn::fns::case_when::CaseWhenOptions) -> bool
+
+impl core::fmt::Debug for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::fmt::Display for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+impl core::marker::StructuralPartialEq for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
 
 pub mod vortex_array::scalar_fn::fns::cast
 
@@ -13674,7 +17064,7 @@ pub fn vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::fmt(&self, f: 
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::cast::CastKernel
 
-pub type vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
+pub type vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
 
 pub fn vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -13690,9 +17080,9 @@ pub fn vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::fmt(&self, f: &
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::cast::CastReduce
 
-pub type vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
+pub type vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
 
-pub fn vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::cast::Cast>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::cast::Cast>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::cast::CastKernel: vortex_array::vtable::VTable
 
@@ -13726,10 +17116,6 @@ impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Co
 
 pub fn vortex_array::arrays::ConstantVTable::cast(array: &vortex_array::arrays::ConstantArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::cast(array: &vortex_array::arrays::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::cast(array: &vortex_array::arrays::ExtensionArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
@@ -13746,10 +17132,6 @@ impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Li
 
 pub fn vortex_array::arrays::ListViewVTable::cast(array: &vortex_array::arrays::ListViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::NullVTable
-
-pub fn vortex_array::arrays::NullVTable::cast(array: &vortex_array::arrays::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinVTable
 
 pub fn vortex_array::arrays::VarBinVTable::cast(array: &vortex_array::arrays::VarBinArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
@@ -13757,6 +17139,14 @@ pub fn vortex_array::arrays::VarBinVTable::cast(array: &vortex_array::arrays::Va
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinViewVTable
 
 pub fn vortex_array::arrays::VarBinViewVTable::cast(array: &vortex_array::arrays::VarBinViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::dynamic
 
@@ -13894,9 +17284,9 @@ pub fn vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::fmt(&
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::fill_null::FillNullKernel
 
-pub type vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
+pub type vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
 
-pub fn vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>(pub V)
 
@@ -13910,9 +17300,9 @@ pub fn vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::fmt(&s
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::fill_null::FillNullReduce
 
-pub type vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
+pub type vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
 
-pub fn vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::fill_null::FillNullKernel: vortex_array::vtable::VTable
 
@@ -13926,13 +17316,13 @@ impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::a
 
 pub fn vortex_array::arrays::DecimalVTable::fill_null(array: &vortex_array::arrays::DecimalArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::fill_null(array: &vortex_array::arrays::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
 impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::fill_null(array: &vortex_array::arrays::PrimitiveArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::fill_null::FillNullReduce: vortex_array::vtable::VTable
 
@@ -14090,9 +17480,9 @@ pub fn vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::fmt(&self, f: 
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::like::LikeKernel
 
-pub type vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
+pub type vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
 
-pub fn vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::like::LikeOptions
 
@@ -14142,9 +17532,9 @@ pub fn vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::fmt(&self, f: &
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::like::LikeReduce
 
-pub type vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
+pub type vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
 
-pub fn vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::like::LikeKernel: vortex_array::vtable::VTable
 
@@ -14154,9 +17544,9 @@ pub trait vortex_array::scalar_fn::fns::like::LikeReduce: vortex_array::vtable::
 
 pub fn vortex_array::scalar_fn::fns::like::LikeReduce::like(array: &Self::Array, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::DictVTable
+impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::list_contains
 
@@ -14176,7 +17566,7 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::child_name(&se
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -14214,9 +17604,9 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAd
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::list_contains::ListContainsElementKernel
 
-pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
+pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>(pub V)
 
@@ -14230,9 +17620,9 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAda
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduce
 
-pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
+pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::list_contains::ListContainsElementKernel: vortex_array::vtable::VTable
 
@@ -14342,9 +17732,9 @@ pub fn vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::fmt(&self, f: 
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::mask::MaskKernel
 
-pub type vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
+pub type vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
 
-pub fn vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>(pub V)
 
@@ -14358,9 +17748,9 @@ pub fn vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::fmt(&self, f: &
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::mask::MaskReduce
 
-pub type vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
+pub type vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
 
-pub fn vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::mask::MaskKernel: vortex_array::vtable::VTable
 
@@ -14382,10 +17772,6 @@ impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::De
 
 pub fn vortex_array::arrays::DecimalVTable::mask(array: &vortex_array::arrays::DecimalArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::mask(array: &vortex_array::arrays::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
 impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::mask(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
@@ -14406,10 +17792,6 @@ impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Ma
 
 pub fn vortex_array::arrays::MaskedVTable::mask(array: &vortex_array::arrays::MaskedArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::NullVTable
-
-pub fn vortex_array::arrays::NullVTable::mask(array: &vortex_array::arrays::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
 impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::mask(array: &vortex_array::arrays::PrimitiveArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
@@ -14425,6 +17807,14 @@ pub fn vortex_array::arrays::VarBinVTable::mask(array: &vortex_array::arrays::Va
 impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinViewVTable
 
 pub fn vortex_array::arrays::VarBinViewVTable::mask(array: &vortex_array::arrays::VarBinViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::merge
 
@@ -14562,9 +17952,9 @@ pub fn vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::fmt(&self, f: &m
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::not::NotKernel
 
-pub type vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
+pub type vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
 
-pub fn vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>(pub V)
 
@@ -14578,9 +17968,9 @@ pub fn vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::fmt(&self, f: &mu
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::not::NotReduce
 
-pub type vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
+pub type vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
 
-pub fn vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::not::NotKernel: vortex_array::vtable::VTable
 
@@ -15018,9 +18408,9 @@ pub fn vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::fmt(&self, f: &m
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::zip::ZipKernel
 
-pub type vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
+pub type vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>(pub V)
 
@@ -15034,29 +18424,29 @@ pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::fmt(&self, f: &mu
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::zip::ZipReduce
 
-pub type vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
+pub type vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::zip::ZipKernel: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipKernel::zip(array: &Self::Array, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipKernel::zip(array: &Self::Array, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::StructVTable
 
-pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinViewVTable
 
-pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::zip::ZipReduce: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipReduce::zip(array: &Self::Array, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::zip::ZipReduce for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipReduce::zip(array: &Self::Array, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::session
 
@@ -15306,17 +18696,17 @@ pub fn vortex_array::ArrayRef::node_dtype(&self) -> vortex_error::VortexResult<v
 
 pub fn vortex_array::ArrayRef::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
 
-impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::ScalarFnArray
+impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub fn vortex_array::arrays::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
 
-pub fn vortex_array::arrays::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
-pub fn vortex_array::arrays::ScalarFnArray::child_count(&self) -> usize
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child_count(&self) -> usize
 
-pub fn vortex_array::arrays::ScalarFnArray::node_dtype(&self) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::node_dtype(&self) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
-pub fn vortex_array::arrays::ScalarFnArray::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::scalar_fn::ReduceNode for vortex_array::ArrayAdapter<V>
 
@@ -15449,6 +18839,42 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_expression(&self, opti
 pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_falsification(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::validity(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::case_when::CaseWhen
+
+pub type vortex_array::scalar_fn::fns::case_when::CaseWhen::Options = vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::arity(&self, options: &Self::Options) -> vortex_array::scalar_fn::Arity
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::child_name(&self, options: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::deserialize(&self, metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::id(&self) -> vortex_array::scalar_fn::ScalarFnId
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::is_fallible(&self, _options: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::is_null_sensitive(&self, _options: &Self::Options) -> bool
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::return_dtype(&self, options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::cast::Cast
 
@@ -15676,7 +19102,7 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::child_name(&se
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -16128,19 +19554,19 @@ pub fn vortex_array::variants::PrimitiveTyped<'_>::index_len(&self) -> usize
 
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::Scalar> for (dyn vortex_array::Array + '_)
+impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::Scalar> for (dyn vortex_array::DynArray + '_)
 
-pub fn (dyn vortex_array::Array + '_)::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
+pub fn (dyn vortex_array::DynArray + '_)::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
-pub fn (dyn vortex_array::Array + '_)::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::DynArray + '_)::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::Array + '_)::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::DynArray + '_)::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::Array + '_)::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::DynArray + '_)::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::Array + '_)::index_len(&self) -> usize
+pub fn (dyn vortex_array::DynArray + '_)::index_len(&self) -> usize
 
-pub fn (dyn vortex_array::Array + '_)::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::DynArray + '_)::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 impl<T: core::cmp::PartialOrd> vortex_array::search_sorted::IndexOrd<T> for [T]
 
@@ -16174,7 +19600,7 @@ pub struct vortex_array::serde::ArrayNodeFlatBuffer<'a>
 
 impl<'a> vortex_array::serde::ArrayNodeFlatBuffer<'a>
 
-pub fn vortex_array::serde::ArrayNodeFlatBuffer<'a>::try_new(ctx: &'a vortex_array::ArrayContext, array: &'a dyn vortex_array::Array) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::serde::ArrayNodeFlatBuffer<'a>::try_new(ctx: &'a vortex_array::ArrayContext, array: &'a dyn vortex_array::DynArray) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_array::serde::ArrayNodeFlatBuffer<'a>::try_write_flatbuffer<'fb>(&self, fbb: &mut flatbuffers::builder::FlatBufferBuilder<'fb>) -> vortex_error::VortexResult<flatbuffers::primitives::WIPOffset<vortex_flatbuffers::array::ArrayNode<'fb>>>
 
@@ -16298,7 +19724,7 @@ pub fn vortex_array::stats::ArrayStats::retain(&self, stats: &[vortex_array::exp
 
 pub fn vortex_array::stats::ArrayStats::set(&self, stat: vortex_array::expr::stats::Stat, value: vortex_array::expr::stats::Precision<vortex_array::scalar::ScalarValue>)
 
-pub fn vortex_array::stats::ArrayStats::to_ref<'a>(&'a self, array: &'a dyn vortex_array::Array) -> vortex_array::stats::StatsSetRef<'a>
+pub fn vortex_array::stats::ArrayStats::to_ref<'a>(&'a self, array: &'a dyn vortex_array::DynArray) -> vortex_array::stats::StatsSetRef<'a>
 
 impl core::clone::Clone for vortex_array::stats::ArrayStats
 
@@ -16388,7 +19814,7 @@ pub fn vortex_array::stats::StatsSet::merge_unordered(self, other: &Self, dtype:
 
 impl vortex_array::stats::StatsSet
 
-pub fn vortex_array::stats::StatsSet::from_flatbuffer<'a>(fb: &vortex_flatbuffers::array::ArrayStats<'a>, array_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::stats::StatsSet::from_flatbuffer<'a>(fb: &vortex_flatbuffers::array::ArrayStats<'a>, array_dtype: &vortex_array::dtype::DType, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self>
 
 impl core::clone::Clone for vortex_array::stats::StatsSet
 
@@ -16530,7 +19956,7 @@ impl<'__pin, S> core::marker::Unpin for vortex_array::stream::ArrayStreamAdapter
 
 impl<S> futures_core::stream::Stream for vortex_array::stream::ArrayStreamAdapter<S> where S: futures_core::stream::Stream<Item = vortex_error::VortexResult<vortex_array::ArrayRef>>
 
-pub type vortex_array::stream::ArrayStreamAdapter<S>::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::Array>, vortex_error::VortexError>
+pub type vortex_array::stream::ArrayStreamAdapter<S>::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::DynArray>, vortex_error::VortexError>
 
 pub fn vortex_array::stream::ArrayStreamAdapter<S>::poll_next(self: core::pin::Pin<&mut Self>, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::option::Option<Self::Item>>
 
@@ -16822,10 +20248,6 @@ impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DecimalVTable>
 
 pub fn vortex_array::arrays::DecimalVTable::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::scalar_at(array: &vortex_array::arrays::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
@@ -16850,25 +20272,13 @@ impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::MaskedVTable> 
 
 pub fn vortex_array::arrays::MaskedVTable::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::NullVTable> for vortex_array::arrays::NullVTable
-
-pub fn vortex_array::arrays::NullVTable::scalar_at(_array: &vortex_array::arrays::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ScalarFnVTable> for vortex_array::arrays::ScalarFnVTable
-
-pub fn vortex_array::arrays::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
 
 pub fn vortex_array::arrays::SharedVTable::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::SliceVTable> for vortex_array::arrays::SliceVTable
-
-pub fn vortex_array::arrays::SliceVTable::scalar_at(array: &vortex_array::arrays::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
 
@@ -16882,13 +20292,29 @@ impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinViewVTab
 
 pub fn vortex_array::arrays::VarBinViewVTable::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
+
+pub fn vortex_array::arrays::slice::SliceVTable::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
 impl<V: vortex_array::vtable::VTable> vortex_array::vtable::OperationsVTable<V> for vortex_array::vtable::NotSupported
 
 pub fn vortex_array::vtable::NotSupported::scalar_at(array: &<V as vortex_array::vtable::VTable>::Array, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub trait vortex_array::vtable::VTable: 'static + core::marker::Sized + core::marker::Send + core::marker::Sync + core::fmt::Debug
 
-pub type vortex_array::vtable::VTable::Array: 'static + core::marker::Send + core::marker::Sync + core::clone::Clone + core::fmt::Debug + core::ops::deref::Deref<Target = dyn vortex_array::Array> + vortex_array::IntoArray
+pub type vortex_array::vtable::VTable::Array: 'static + core::marker::Send + core::marker::Sync + core::clone::Clone + core::fmt::Debug + core::ops::deref::Deref<Target = dyn vortex_array::DynArray> + vortex_array::IntoArray
 
 pub type vortex_array::vtable::VTable::Metadata: core::fmt::Debug
 
@@ -17052,13 +20478,13 @@ impl vortex_array::vtable::VTable for vortex_array::arrays::ConstantVTable
 
 pub type vortex_array::arrays::ConstantVTable::Array = vortex_array::arrays::ConstantArray
 
-pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::scalar::Scalar
 
 pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::arrays::ConstantVTable
 
 pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 
@@ -17068,13 +20494,13 @@ pub fn vortex_array::arrays::ConstantVTable::buffer(array: &vortex_array::arrays
 
 pub fn vortex_array::arrays::ConstantVTable::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ConstantVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
+pub fn vortex_array::arrays::ConstantVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
 
 pub fn vortex_array::arrays::ConstantVTable::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
 
 pub fn vortex_array::arrays::ConstantVTable::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
 
@@ -17086,7 +20512,7 @@ pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_
 
 pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::metadata(_array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
 
@@ -17155,60 +20581,6 @@ pub fn vortex_array::arrays::DecimalVTable::serialize(metadata: Self::Metadata) 
 pub fn vortex_array::arrays::DecimalVTable::stats(array: &vortex_array::arrays::DecimalArray) -> vortex_array::stats::StatsSetRef<'_>
 
 pub fn vortex_array::arrays::DecimalVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::DictVTable
-
-pub type vortex_array::arrays::DictVTable::Array = vortex_array::arrays::DictArray
-
-pub type vortex_array::arrays::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::DictMetadata>
-
-pub type vortex_array::arrays::DictVTable::OperationsVTable = vortex_array::arrays::DictVTable
-
-pub type vortex_array::arrays::DictVTable::ValidityVTable = vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::DictVTable::array_eq(array: &vortex_array::arrays::DictArray, other: &vortex_array::arrays::DictArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DictArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::DictVTable::buffer(_array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::DictVTable::buffer_name(_array: &vortex_array::arrays::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
-
-pub fn vortex_array::arrays::DictVTable::child(array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::DictVTable::child_name(_array: &vortex_array::arrays::DictArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::DictVTable::dtype(array: &vortex_array::arrays::DictArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::DictVTable::len(array: &vortex_array::arrays::DictArray) -> usize
-
-pub fn vortex_array::arrays::DictVTable::metadata(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::DictVTable::nbuffers(_array: &vortex_array::arrays::DictArray) -> usize
-
-pub fn vortex_array::arrays::DictVTable::nchildren(_array: &vortex_array::arrays::DictArray) -> usize
-
-pub fn vortex_array::arrays::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::DictVTable::stats(array: &vortex_array::arrays::DictArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::ExtensionVTable
 
@@ -17534,60 +20906,6 @@ pub fn vortex_array::arrays::MaskedVTable::stats(array: &vortex_array::arrays::M
 
 pub fn vortex_array::arrays::MaskedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::NullVTable
-
-pub type vortex_array::arrays::NullVTable::Array = vortex_array::arrays::NullArray
-
-pub type vortex_array::arrays::NullVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::NullVTable::OperationsVTable = vortex_array::arrays::NullVTable
-
-pub type vortex_array::arrays::NullVTable::ValidityVTable = vortex_array::arrays::NullVTable
-
-pub fn vortex_array::arrays::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::NullVTable::array_eq(array: &vortex_array::arrays::NullArray, other: &vortex_array::arrays::NullArray, _precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::NullArray, state: &mut H, _precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::NullVTable::buffer(_array: &vortex_array::arrays::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::NullVTable::buffer_name(_array: &vortex_array::arrays::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::NullArray>
-
-pub fn vortex_array::arrays::NullVTable::child(_array: &vortex_array::arrays::NullArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::NullVTable::child_name(_array: &vortex_array::arrays::NullArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::NullVTable::dtype(_array: &vortex_array::arrays::NullArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::NullVTable::len(array: &vortex_array::arrays::NullArray) -> usize
-
-pub fn vortex_array::arrays::NullVTable::metadata(_array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::NullVTable::nbuffers(_array: &vortex_array::arrays::NullArray) -> usize
-
-pub fn vortex_array::arrays::NullVTable::nchildren(_array: &vortex_array::arrays::NullArray) -> usize
-
-pub fn vortex_array::arrays::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::NullVTable::stats(array: &vortex_array::arrays::NullArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
 impl vortex_array::vtable::VTable for vortex_array::arrays::PrimitiveVTable
 
 pub type vortex_array::arrays::PrimitiveVTable::Array = vortex_array::arrays::PrimitiveArray
@@ -17642,60 +20960,6 @@ pub fn vortex_array::arrays::PrimitiveVTable::stats(array: &vortex_array::arrays
 
 pub fn vortex_array::arrays::PrimitiveVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ScalarFnVTable
-
-pub type vortex_array::arrays::ScalarFnVTable::Array = vortex_array::arrays::ScalarFnArray
-
-pub type vortex_array::arrays::ScalarFnVTable::Metadata = vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata
-
-pub type vortex_array::arrays::ScalarFnVTable::OperationsVTable = vortex_array::arrays::ScalarFnVTable
-
-pub type vortex_array::arrays::ScalarFnVTable::ValidityVTable = vortex_array::arrays::ScalarFnVTable
-
-pub fn vortex_array::arrays::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ScalarFnVTable::array_eq(array: &vortex_array::arrays::ScalarFnArray, other: &vortex_array::arrays::ScalarFnArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ScalarFnVTable::buffer(_array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ScalarFnVTable::buffer_name(_array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ScalarFnVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
-
-pub fn vortex_array::arrays::ScalarFnVTable::child(array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ScalarFnVTable::child_name(array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ScalarFnVTable::dtype(array: &vortex_array::arrays::ScalarFnArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ScalarFnVTable::len(array: &vortex_array::arrays::ScalarFnArray) -> usize
-
-pub fn vortex_array::arrays::ScalarFnVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::ScalarFnArray) -> usize
-
-pub fn vortex_array::arrays::ScalarFnVTable::nchildren(array: &vortex_array::arrays::ScalarFnArray) -> usize
-
-pub fn vortex_array::arrays::ScalarFnVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ScalarFnVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ScalarFnVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ScalarFnVTable::stats(array: &vortex_array::arrays::ScalarFnArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ScalarFnVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
 impl vortex_array::vtable::VTable for vortex_array::arrays::SharedVTable
 
 pub type vortex_array::arrays::SharedVTable::Array = vortex_array::arrays::SharedArray
@@ -17749,60 +21013,6 @@ pub fn vortex_array::arrays::SharedVTable::serialize(_metadata: Self::Metadata) 
 pub fn vortex_array::arrays::SharedVTable::stats(array: &vortex_array::arrays::SharedArray) -> vortex_array::stats::StatsSetRef<'_>
 
 pub fn vortex_array::arrays::SharedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::SliceVTable
-
-pub type vortex_array::arrays::SliceVTable::Array = vortex_array::arrays::SliceArray
-
-pub type vortex_array::arrays::SliceVTable::Metadata = vortex_array::arrays::SliceMetadata
-
-pub type vortex_array::arrays::SliceVTable::OperationsVTable = vortex_array::arrays::SliceVTable
-
-pub type vortex_array::arrays::SliceVTable::ValidityVTable = vortex_array::arrays::SliceVTable
-
-pub fn vortex_array::arrays::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::SliceVTable::array_eq(array: &vortex_array::arrays::SliceArray, other: &vortex_array::arrays::SliceArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SliceArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
-
-pub fn vortex_array::arrays::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::SliceVTable::dtype(array: &vortex_array::arrays::SliceArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::SliceVTable::len(array: &vortex_array::arrays::SliceArray) -> usize
-
-pub fn vortex_array::arrays::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::SliceVTable::nbuffers(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::SliceVTable::nchildren(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::SliceVTable::stats(array: &vortex_array::arrays::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::StructVTable
 
@@ -17966,6 +21176,222 @@ pub fn vortex_array::arrays::VarBinViewVTable::stats(array: &vortex_array::array
 
 pub fn vortex_array::arrays::VarBinViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
+impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
+
+pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
+
+pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
+
+pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
+
+pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
+
+pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+
+pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::null::NullVTable
+
+pub type vortex_array::arrays::null::NullVTable::Array = vortex_array::arrays::null::NullArray
+
+pub type vortex_array::arrays::null::NullVTable::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::null::NullVTable::OperationsVTable = vortex_array::arrays::null::NullVTable
+
+pub type vortex_array::arrays::null::NullVTable::ValidityVTable = vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::null::NullVTable::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::null::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::null::NullVTable::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::null::NullVTable::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::null::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
+
+pub fn vortex_array::arrays::null::NullVTable::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::null::NullVTable::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::null::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::null::NullVTable::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::null::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::null::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::null::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::null::NullVTable::len(array: &vortex_array::arrays::null::NullArray) -> usize
+
+pub fn vortex_array::arrays::null::NullVTable::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::null::NullVTable::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
+
+pub fn vortex_array::arrays::null::NullVTable::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
+
+pub fn vortex_array::arrays::null::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::null::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::null::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::null::NullVTable::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::null::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Array = vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Metadata = vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata
+
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::OperationsVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::ValidityVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_eq(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, other: &vortex_array::arrays::scalar_fn::ScalarFnArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer_name(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child_name(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::dtype(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::len(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nchildren(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::stats(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::slice::SliceVTable
+
+pub type vortex_array::arrays::slice::SliceVTable::Array = vortex_array::arrays::slice::SliceArray
+
+pub type vortex_array::arrays::slice::SliceVTable::Metadata = vortex_array::arrays::slice::SliceMetadata
+
+pub type vortex_array::arrays::slice::SliceVTable::OperationsVTable = vortex_array::arrays::slice::SliceVTable
+
+pub type vortex_array::arrays::slice::SliceVTable::ValidityVTable = vortex_array::arrays::slice::SliceVTable
+
+pub fn vortex_array::arrays::slice::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::slice::SliceVTable::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::slice::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::slice::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::slice::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::slice::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+
+pub fn vortex_array::arrays::slice::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::slice::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::slice::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::slice::SliceVTable::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::slice::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::slice::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::slice::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::slice::SliceVTable::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
+
+pub fn vortex_array::arrays::slice::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::slice::SliceVTable::nbuffers(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::slice::SliceVTable::nchildren(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::slice::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::slice::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::slice::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::slice::SliceVTable::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::slice::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
 pub trait vortex_array::vtable::ValidityChild<V: vortex_array::vtable::VTable>
 
 pub fn vortex_array::vtable::ValidityChild::validity_child(array: &<V as vortex_array::vtable::VTable>::Array) -> &vortex_array::ArrayRef
@@ -18042,29 +21468,29 @@ impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ConstantVTable> 
 
 pub fn vortex_array::arrays::ConstantVTable::validity(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
-
-pub fn vortex_array::arrays::DictVTable::validity(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
 impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
 
 pub fn vortex_array::arrays::FilterVTable::validity(array: &vortex_array::arrays::FilterArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::NullVTable> for vortex_array::arrays::NullVTable
-
-pub fn vortex_array::arrays::NullVTable::validity(_array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ScalarFnVTable> for vortex_array::arrays::ScalarFnVTable
-
-pub fn vortex_array::arrays::ScalarFnVTable::validity(array: &vortex_array::arrays::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
 
 pub fn vortex_array::arrays::SharedVTable::validity(array: &vortex_array::arrays::SharedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::SliceVTable> for vortex_array::arrays::SliceVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
 
-pub fn vortex_array::arrays::SliceVTable::validity(array: &vortex_array::arrays::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
+
+pub fn vortex_array::arrays::null::NullVTable::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::validity(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
+
+pub fn vortex_array::arrays::slice::SliceVTable::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::vtable::ValidityVTable<V> for vortex_array::vtable::ValidityVTableFromChildSliceHelper where <V as vortex_array::vtable::VTable>::Array: vortex_array::vtable::ValidityChildSliceHelper
 
@@ -18132,7 +21558,7 @@ pub vortex_array::Canonical::FixedSizeList(vortex_array::arrays::FixedSizeListAr
 
 pub vortex_array::Canonical::List(vortex_array::arrays::ListViewArray)
 
-pub vortex_array::Canonical::Null(vortex_array::arrays::NullArray)
+pub vortex_array::Canonical::Null(vortex_array::arrays::null::NullArray)
 
 pub vortex_array::Canonical::Primitive(vortex_array::arrays::PrimitiveArray)
 
@@ -18152,7 +21578,7 @@ pub fn vortex_array::Canonical::as_fixed_size_list(&self) -> &vortex_array::arra
 
 pub fn vortex_array::Canonical::as_listview(&self) -> &vortex_array::arrays::ListViewArray
 
-pub fn vortex_array::Canonical::as_null(&self) -> &vortex_array::arrays::NullArray
+pub fn vortex_array::Canonical::as_null(&self) -> &vortex_array::arrays::null::NullArray
 
 pub fn vortex_array::Canonical::as_primitive(&self) -> &vortex_array::arrays::PrimitiveArray
 
@@ -18170,7 +21596,7 @@ pub fn vortex_array::Canonical::into_fixed_size_list(self) -> vortex_array::arra
 
 pub fn vortex_array::Canonical::into_listview(self) -> vortex_array::arrays::ListViewArray
 
-pub fn vortex_array::Canonical::into_null(self) -> vortex_array::arrays::NullArray
+pub fn vortex_array::Canonical::into_null(self) -> vortex_array::arrays::null::NullArray
 
 pub fn vortex_array::Canonical::into_primitive(self) -> vortex_array::arrays::PrimitiveArray
 
@@ -18196,9 +21622,9 @@ impl core::clone::Clone for vortex_array::Canonical
 
 pub fn vortex_array::Canonical::clone(&self) -> vortex_array::Canonical
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::Canonical
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::Canonical
 
-pub fn vortex_array::Canonical::as_ref(&self) -> &(dyn vortex_array::Array + 'static)
+pub fn vortex_array::Canonical::as_ref(&self) -> &(dyn vortex_array::DynArray + 'static)
 
 impl core::convert::From<vortex_array::Canonical> for vortex_array::ArrayRef
 
@@ -18232,7 +21658,7 @@ pub vortex_array::CanonicalView::FixedSizeList(&'a vortex_array::arrays::FixedSi
 
 pub vortex_array::CanonicalView::List(&'a vortex_array::arrays::ListViewArray)
 
-pub vortex_array::CanonicalView::Null(&'a vortex_array::arrays::NullArray)
+pub vortex_array::CanonicalView::Null(&'a vortex_array::arrays::null::NullArray)
 
 pub vortex_array::CanonicalView::Primitive(&'a vortex_array::arrays::PrimitiveArray)
 
@@ -18240,9 +21666,9 @@ pub vortex_array::CanonicalView::Struct(&'a vortex_array::arrays::StructArray)
 
 pub vortex_array::CanonicalView::VarBinView(&'a vortex_array::arrays::VarBinViewArray)
 
-impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::CanonicalView<'_>
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::CanonicalView<'_>
 
-pub fn vortex_array::CanonicalView<'_>::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::CanonicalView<'_>::as_ref(&self) -> &dyn vortex_array::DynArray
 
 impl core::convert::From<vortex_array::CanonicalView<'_>> for vortex_array::Canonical
 
@@ -18286,9 +21712,9 @@ pub vortex_array::ColumnarView::Canonical(vortex_array::CanonicalView<'a>)
 
 pub vortex_array::ColumnarView::Constant(&'a vortex_array::arrays::ConstantArray)
 
-impl<'a> core::convert::AsRef<dyn vortex_array::Array> for vortex_array::ColumnarView<'a>
+impl<'a> core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::ColumnarView<'a>
 
-pub fn vortex_array::ColumnarView<'a>::as_ref(&self) -> &dyn vortex_array::Array
+pub fn vortex_array::ColumnarView<'a>::as_ref(&self) -> &dyn vortex_array::DynArray
 
 pub enum vortex_array::ExecutionStep
 
@@ -18328,9 +21754,9 @@ impl vortex_array::matcher::Matcher for vortex_array::AnyCanonical
 
 pub type vortex_array::AnyCanonical::Match<'a> = vortex_array::CanonicalView<'a>
 
-pub fn vortex_array::AnyCanonical::matches(array: &dyn vortex_array::Array) -> bool
+pub fn vortex_array::AnyCanonical::matches(array: &dyn vortex_array::DynArray) -> bool
 
-pub fn vortex_array::AnyCanonical::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn vortex_array::AnyCanonical::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 pub struct vortex_array::AnyColumnar
 
@@ -18338,9 +21764,9 @@ impl vortex_array::matcher::Matcher for vortex_array::AnyColumnar
 
 pub type vortex_array::AnyColumnar::Match<'a> = vortex_array::ColumnarView<'a>
 
-pub fn vortex_array::AnyColumnar::matches(array: &dyn vortex_array::Array) -> bool
+pub fn vortex_array::AnyColumnar::matches(array: &dyn vortex_array::DynArray) -> bool
 
-pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
+pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 #[repr(transparent)] pub struct vortex_array::ArrayAdapter<V: vortex_array::vtable::VTable>(_)
 
@@ -18352,7 +21778,43 @@ impl<V: vortex_array::vtable::VTable> core::fmt::Debug for vortex_array::ArrayAd
 
 pub fn vortex_array::ArrayAdapter<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl<V: vortex_array::vtable::VTable> vortex_array::Array for vortex_array::ArrayAdapter<V>
+impl<V: vortex_array::vtable::VTable> vortex_array::ArrayEq for vortex_array::ArrayAdapter<V>
+
+pub fn vortex_array::ArrayAdapter<V>::array_eq(&self, other: &Self, precision: vortex_array::Precision) -> bool
+
+impl<V: vortex_array::vtable::VTable> vortex_array::ArrayHash for vortex_array::ArrayAdapter<V>
+
+pub fn vortex_array::ArrayAdapter<V>::array_hash<H: core::hash::Hasher>(&self, state: &mut H, precision: vortex_array::Precision)
+
+impl<V: vortex_array::vtable::VTable> vortex_array::ArrayVisitor for vortex_array::ArrayAdapter<V>
+
+pub fn vortex_array::ArrayAdapter<V>::buffer_handles(&self) -> alloc::vec::Vec<vortex_array::buffer::BufferHandle>
+
+pub fn vortex_array::ArrayAdapter<V>::buffer_names(&self) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::ArrayAdapter<V>::buffers(&self) -> alloc::vec::Vec<vortex_buffer::ByteBuffer>
+
+pub fn vortex_array::ArrayAdapter<V>::children(&self) -> alloc::vec::Vec<vortex_array::ArrayRef>
+
+pub fn vortex_array::ArrayAdapter<V>::children_names(&self) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::ArrayAdapter<V>::is_host(&self) -> bool
+
+pub fn vortex_array::ArrayAdapter<V>::metadata(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::ArrayAdapter<V>::metadata_fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub fn vortex_array::ArrayAdapter<V>::named_buffers(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::buffer::BufferHandle)>
+
+pub fn vortex_array::ArrayAdapter<V>::named_children(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::ArrayRef)>
+
+pub fn vortex_array::ArrayAdapter<V>::nbuffers(&self) -> usize
+
+pub fn vortex_array::ArrayAdapter<V>::nchildren(&self) -> usize
+
+pub fn vortex_array::ArrayAdapter<V>::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
+
+impl<V: vortex_array::vtable::VTable> vortex_array::DynArray for vortex_array::ArrayAdapter<V>
 
 pub fn vortex_array::ArrayAdapter<V>::all_invalid(&self) -> vortex_error::VortexResult<bool>
 
@@ -18401,42 +21863,6 @@ pub fn vortex_array::ArrayAdapter<V>::validity_mask(&self) -> vortex_error::Vort
 pub fn vortex_array::ArrayAdapter<V>::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
 
 pub fn vortex_array::ArrayAdapter<V>::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-impl<V: vortex_array::vtable::VTable> vortex_array::ArrayEq for vortex_array::ArrayAdapter<V>
-
-pub fn vortex_array::ArrayAdapter<V>::array_eq(&self, other: &Self, precision: vortex_array::Precision) -> bool
-
-impl<V: vortex_array::vtable::VTable> vortex_array::ArrayHash for vortex_array::ArrayAdapter<V>
-
-pub fn vortex_array::ArrayAdapter<V>::array_hash<H: core::hash::Hasher>(&self, state: &mut H, precision: vortex_array::Precision)
-
-impl<V: vortex_array::vtable::VTable> vortex_array::ArrayVisitor for vortex_array::ArrayAdapter<V>
-
-pub fn vortex_array::ArrayAdapter<V>::buffer_handles(&self) -> alloc::vec::Vec<vortex_array::buffer::BufferHandle>
-
-pub fn vortex_array::ArrayAdapter<V>::buffer_names(&self) -> alloc::vec::Vec<alloc::string::String>
-
-pub fn vortex_array::ArrayAdapter<V>::buffers(&self) -> alloc::vec::Vec<vortex_buffer::ByteBuffer>
-
-pub fn vortex_array::ArrayAdapter<V>::children(&self) -> alloc::vec::Vec<vortex_array::ArrayRef>
-
-pub fn vortex_array::ArrayAdapter<V>::children_names(&self) -> alloc::vec::Vec<alloc::string::String>
-
-pub fn vortex_array::ArrayAdapter<V>::is_host(&self) -> bool
-
-pub fn vortex_array::ArrayAdapter<V>::metadata(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::ArrayAdapter<V>::metadata_fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-pub fn vortex_array::ArrayAdapter<V>::named_buffers(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::buffer::BufferHandle)>
-
-pub fn vortex_array::ArrayAdapter<V>::named_children(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::ArrayRef)>
-
-pub fn vortex_array::ArrayAdapter<V>::nbuffers(&self) -> usize
-
-pub fn vortex_array::ArrayAdapter<V>::nchildren(&self) -> usize
-
-pub fn vortex_array::ArrayAdapter<V>::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::scalar_fn::ReduceNode for vortex_array::ArrayAdapter<V>
 
@@ -18564,163 +21990,13 @@ pub fn vortex_array::RecursiveCanonical::execute(array: vortex_array::ArrayRef, 
 
 pub static vortex_array::LEGACY_SESSION: std::sync::lazy_lock::LazyLock<vortex_session::VortexSession>
 
-pub trait vortex_array::Array: 'static + vortex_array::array::private::Sealed + core::marker::Send + core::marker::Sync + core::fmt::Debug + vortex_array::DynArrayEq + vortex_array::DynArrayHash + vortex_array::ArrayVisitor + vortex_array::scalar_fn::ReduceNode
-
-pub fn vortex_array::Array::all_invalid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::Array::all_valid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::Array::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::Array::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::Array::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
-
-pub fn vortex_array::Array::dtype(&self) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::Array::encoding_id(&self) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::Array::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::Array::invalid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn vortex_array::Array::is_empty(&self) -> bool
-
-pub fn vortex_array::Array::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::Array::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::Array::len(&self) -> usize
-
-pub fn vortex_array::Array::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-pub fn vortex_array::Array::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::Array::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::Array::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::Array::to_array(&self) -> vortex_array::ArrayRef
-
-pub fn vortex_array::Array::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
-
-pub fn vortex_array::Array::valid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn vortex_array::Array::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub fn vortex_array::Array::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
-
-pub fn vortex_array::Array::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
-
-pub fn vortex_array::Array::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-impl vortex_array::Array for alloc::sync::Arc<dyn vortex_array::Array>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::all_invalid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::all_valid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::as_any(&self) -> &dyn core::any::Any
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::dtype(&self) -> &vortex_array::dtype::DType
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::encoding_id(&self) -> vortex_array::vtable::ArrayId
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::invalid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::is_empty(&self) -> bool
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::len(&self) -> usize
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::to_array(&self) -> vortex_array::ArrayRef
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::valid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
-
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-impl<V: vortex_array::vtable::VTable> vortex_array::Array for vortex_array::ArrayAdapter<V>
-
-pub fn vortex_array::ArrayAdapter<V>::all_invalid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::ArrayAdapter<V>::all_valid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::ArrayAdapter<V>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::ArrayAdapter<V>::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::ArrayAdapter<V>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
-
-pub fn vortex_array::ArrayAdapter<V>::dtype(&self) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::ArrayAdapter<V>::encoding_id(&self) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::ArrayAdapter<V>::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::ArrayAdapter<V>::invalid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn vortex_array::ArrayAdapter<V>::is_empty(&self) -> bool
-
-pub fn vortex_array::ArrayAdapter<V>::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::ArrayAdapter<V>::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::ArrayAdapter<V>::len(&self) -> usize
-
-pub fn vortex_array::ArrayAdapter<V>::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-pub fn vortex_array::ArrayAdapter<V>::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::ArrayAdapter<V>::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::ArrayAdapter<V>::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::ArrayAdapter<V>::to_array(&self) -> vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayAdapter<V>::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
-
-pub fn vortex_array::ArrayAdapter<V>::valid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn vortex_array::ArrayAdapter<V>::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub fn vortex_array::ArrayAdapter<V>::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
-
-pub fn vortex_array::ArrayAdapter<V>::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
-
-pub fn vortex_array::ArrayAdapter<V>::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
 pub trait vortex_array::ArrayEq
 
 pub fn vortex_array::ArrayEq::array_eq(&self, other: &Self, precision: vortex_array::Precision) -> bool
 
-impl vortex_array::ArrayEq for (dyn vortex_array::Array + '_)
+impl vortex_array::ArrayEq for (dyn vortex_array::DynArray + '_)
 
-pub fn (dyn vortex_array::Array + '_)::array_eq(&self, other: &Self, precision: vortex_array::Precision) -> bool
+pub fn (dyn vortex_array::DynArray + '_)::array_eq(&self, other: &Self, precision: vortex_array::Precision) -> bool
 
 impl vortex_array::ArrayEq for vortex_array::ArrayRef
 
@@ -18762,9 +22038,9 @@ pub trait vortex_array::ArrayHash
 
 pub fn vortex_array::ArrayHash::array_hash<H: core::hash::Hasher>(&self, state: &mut H, precision: vortex_array::Precision)
 
-impl vortex_array::ArrayHash for (dyn vortex_array::Array + '_)
+impl vortex_array::ArrayHash for (dyn vortex_array::DynArray + '_)
 
-pub fn (dyn vortex_array::Array + '_)::array_hash<H: core::hash::Hasher>(&self, state: &mut H, precision: vortex_array::Precision)
+pub fn (dyn vortex_array::DynArray + '_)::array_hash<H: core::hash::Hasher>(&self, state: &mut H, precision: vortex_array::Precision)
 
 impl vortex_array::ArrayHash for vortex_array::ArrayRef
 
@@ -18830,33 +22106,33 @@ pub fn vortex_array::ArrayVisitor::nchildren(&self) -> usize
 
 pub fn vortex_array::ArrayVisitor::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
 
-impl vortex_array::ArrayVisitor for alloc::sync::Arc<dyn vortex_array::Array>
+impl vortex_array::ArrayVisitor for alloc::sync::Arc<dyn vortex_array::DynArray>
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::buffer_handles(&self) -> alloc::vec::Vec<vortex_array::buffer::BufferHandle>
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::buffer_handles(&self) -> alloc::vec::Vec<vortex_array::buffer::BufferHandle>
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::buffer_names(&self) -> alloc::vec::Vec<alloc::string::String>
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::buffer_names(&self) -> alloc::vec::Vec<alloc::string::String>
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::buffers(&self) -> alloc::vec::Vec<vortex_buffer::ByteBuffer>
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::buffers(&self) -> alloc::vec::Vec<vortex_buffer::ByteBuffer>
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::children(&self) -> alloc::vec::Vec<vortex_array::ArrayRef>
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::children(&self) -> alloc::vec::Vec<vortex_array::ArrayRef>
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::children_names(&self) -> alloc::vec::Vec<alloc::string::String>
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::children_names(&self) -> alloc::vec::Vec<alloc::string::String>
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::is_host(&self) -> bool
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::is_host(&self) -> bool
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::metadata(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::metadata(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::metadata_fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::metadata_fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::named_buffers(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::buffer::BufferHandle)>
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::named_buffers(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::buffer::BufferHandle)>
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::named_children(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::ArrayRef)>
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::named_children(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::ArrayRef)>
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::nbuffers(&self) -> usize
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::nbuffers(&self) -> usize
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::nchildren(&self) -> usize
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::nchildren(&self) -> usize
 
-pub fn alloc::sync::Arc<dyn vortex_array::Array>::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::ArrayVisitor for vortex_array::ArrayAdapter<V>
 
@@ -18886,13 +22162,13 @@ pub fn vortex_array::ArrayAdapter<V>::nchildren(&self) -> usize
 
 pub fn vortex_array::ArrayAdapter<V>::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
 
-pub trait vortex_array::ArrayVisitorExt: vortex_array::Array
+pub trait vortex_array::ArrayVisitorExt: vortex_array::DynArray
 
 pub fn vortex_array::ArrayVisitorExt::depth_first_traversal(&self) -> impl core::iter::traits::iterator::Iterator<Item = vortex_array::ArrayRef>
 
 pub fn vortex_array::ArrayVisitorExt::nbuffers_recursive(&self) -> usize
 
-impl<A: vortex_array::Array + ?core::marker::Sized> vortex_array::ArrayVisitorExt for A
+impl<A: vortex_array::DynArray + ?core::marker::Sized> vortex_array::ArrayVisitorExt for A
 
 pub fn A::depth_first_traversal(&self) -> impl core::iter::traits::iterator::Iterator<Item = vortex_array::ArrayRef>
 
@@ -18921,6 +22197,156 @@ impl<M> vortex_array::DeserializeMetadata for vortex_array::ProstMetadata<M> whe
 pub type vortex_array::ProstMetadata<M>::Output = M
 
 pub fn vortex_array::ProstMetadata<M>::deserialize(metadata: &[u8]) -> vortex_error::VortexResult<Self::Output>
+
+pub trait vortex_array::DynArray: 'static + vortex_array::array::private::Sealed + core::marker::Send + core::marker::Sync + core::fmt::Debug + vortex_array::DynArrayEq + vortex_array::DynArrayHash + vortex_array::ArrayVisitor + vortex_array::scalar_fn::ReduceNode
+
+pub fn vortex_array::DynArray::all_invalid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::DynArray::all_valid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::DynArray::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::DynArray::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_array::DynArray::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
+
+pub fn vortex_array::DynArray::dtype(&self) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::DynArray::encoding_id(&self) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::DynArray::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::DynArray::invalid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::DynArray::is_empty(&self) -> bool
+
+pub fn vortex_array::DynArray::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::DynArray::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::DynArray::len(&self) -> usize
+
+pub fn vortex_array::DynArray::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+pub fn vortex_array::DynArray::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::DynArray::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::DynArray::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::DynArray::to_array(&self) -> vortex_array::ArrayRef
+
+pub fn vortex_array::DynArray::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
+
+pub fn vortex_array::DynArray::valid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::DynArray::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub fn vortex_array::DynArray::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
+
+pub fn vortex_array::DynArray::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
+
+pub fn vortex_array::DynArray::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+impl vortex_array::DynArray for alloc::sync::Arc<dyn vortex_array::DynArray>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::all_invalid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::all_valid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::as_any(&self) -> &dyn core::any::Any
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::dtype(&self) -> &vortex_array::dtype::DType
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::encoding_id(&self) -> vortex_array::vtable::ArrayId
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::invalid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::is_empty(&self) -> bool
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::len(&self) -> usize
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::to_array(&self) -> vortex_array::ArrayRef
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::valid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
+
+pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+impl<V: vortex_array::vtable::VTable> vortex_array::DynArray for vortex_array::ArrayAdapter<V>
+
+pub fn vortex_array::ArrayAdapter<V>::all_invalid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::ArrayAdapter<V>::all_valid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::ArrayAdapter<V>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::ArrayAdapter<V>::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_array::ArrayAdapter<V>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
+
+pub fn vortex_array::ArrayAdapter<V>::dtype(&self) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::ArrayAdapter<V>::encoding_id(&self) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::ArrayAdapter<V>::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::ArrayAdapter<V>::invalid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::ArrayAdapter<V>::is_empty(&self) -> bool
+
+pub fn vortex_array::ArrayAdapter<V>::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::ArrayAdapter<V>::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::ArrayAdapter<V>::len(&self) -> usize
+
+pub fn vortex_array::ArrayAdapter<V>::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+pub fn vortex_array::ArrayAdapter<V>::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::ArrayAdapter<V>::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::ArrayAdapter<V>::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::ArrayAdapter<V>::to_array(&self) -> vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayAdapter<V>::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
+
+pub fn vortex_array::ArrayAdapter<V>::valid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::ArrayAdapter<V>::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub fn vortex_array::ArrayAdapter<V>::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
+
+pub fn vortex_array::ArrayAdapter<V>::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
+
+pub fn vortex_array::ArrayAdapter<V>::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub trait vortex_array::DynArrayEq: vortex_array::hash::private::SealedEq
 
@@ -18982,10 +22408,6 @@ impl vortex_array::Executable for vortex_array::arrays::ListViewArray
 
 pub fn vortex_array::arrays::ListViewArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
-impl vortex_array::Executable for vortex_array::arrays::NullArray
-
-pub fn vortex_array::arrays::NullArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
 impl vortex_array::Executable for vortex_array::arrays::PrimitiveArray
 
 pub fn vortex_array::arrays::PrimitiveArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
@@ -18997,6 +22419,10 @@ pub fn vortex_array::arrays::StructArray::execute(array: vortex_array::ArrayRef,
 impl vortex_array::Executable for vortex_array::arrays::VarBinViewArray
 
 pub fn vortex_array::arrays::VarBinViewArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
+impl vortex_array::Executable for vortex_array::arrays::null::NullArray
+
+pub fn vortex_array::arrays::null::NullArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 impl vortex_array::Executable for vortex_buffer::bit::buf::BitBuffer
 
@@ -19054,10 +22480,6 @@ impl vortex_array::IntoArray for vortex_array::arrays::DecimalArray
 
 pub fn vortex_array::arrays::DecimalArray::into_array(self) -> vortex_array::ArrayRef
 
-impl vortex_array::IntoArray for vortex_array::arrays::DictArray
-
-pub fn vortex_array::arrays::DictArray::into_array(self) -> vortex_array::ArrayRef
-
 impl vortex_array::IntoArray for vortex_array::arrays::ExtensionArray
 
 pub fn vortex_array::arrays::ExtensionArray::into_array(self) -> vortex_array::ArrayRef
@@ -19082,33 +22504,17 @@ impl vortex_array::IntoArray for vortex_array::arrays::MaskedArray
 
 pub fn vortex_array::arrays::MaskedArray::into_array(self) -> vortex_array::ArrayRef
 
-impl vortex_array::IntoArray for vortex_array::arrays::NullArray
-
-pub fn vortex_array::arrays::NullArray::into_array(self) -> vortex_array::ArrayRef
-
 impl vortex_array::IntoArray for vortex_array::arrays::PrimitiveArray
 
 pub fn vortex_array::arrays::PrimitiveArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::IntoArray for vortex_array::arrays::ScalarFnArray
-
-pub fn vortex_array::arrays::ScalarFnArray::into_array(self) -> vortex_array::ArrayRef
 
 impl vortex_array::IntoArray for vortex_array::arrays::SharedArray
 
 pub fn vortex_array::arrays::SharedArray::into_array(self) -> vortex_array::ArrayRef
 
-impl vortex_array::IntoArray for vortex_array::arrays::SliceArray
-
-pub fn vortex_array::arrays::SliceArray::into_array(self) -> vortex_array::ArrayRef
-
 impl vortex_array::IntoArray for vortex_array::arrays::StructArray
 
 pub fn vortex_array::arrays::StructArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::IntoArray for vortex_array::arrays::TemporalArray
-
-pub fn vortex_array::arrays::TemporalArray::into_array(self) -> vortex_array::ArrayRef
 
 impl vortex_array::IntoArray for vortex_array::arrays::VarBinArray
 
@@ -19117,6 +22523,26 @@ pub fn vortex_array::arrays::VarBinArray::into_array(self) -> vortex_array::Arra
 impl vortex_array::IntoArray for vortex_array::arrays::VarBinViewArray
 
 pub fn vortex_array::arrays::VarBinViewArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::IntoArray for vortex_array::arrays::datetime::TemporalArray
+
+pub fn vortex_array::arrays::datetime::TemporalArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::IntoArray for vortex_array::arrays::dict::DictArray
+
+pub fn vortex_array::arrays::dict::DictArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::IntoArray for vortex_array::arrays::null::NullArray
+
+pub fn vortex_array::arrays::null::NullArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::IntoArray for vortex_array::arrays::scalar_fn::ScalarFnArray
+
+pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::IntoArray for vortex_array::arrays::slice::SliceArray
+
+pub fn vortex_array::arrays::slice::SliceArray::into_array(self) -> vortex_array::ArrayRef
 
 impl vortex_array::IntoArray for vortex_buffer::bit::buf::BitBuffer
 
@@ -19174,7 +22600,7 @@ pub fn vortex_array::ToCanonical::to_fixed_size_list(&self) -> vortex_array::arr
 
 pub fn vortex_array::ToCanonical::to_listview(&self) -> vortex_array::arrays::ListViewArray
 
-pub fn vortex_array::ToCanonical::to_null(&self) -> vortex_array::arrays::NullArray
+pub fn vortex_array::ToCanonical::to_null(&self) -> vortex_array::arrays::null::NullArray
 
 pub fn vortex_array::ToCanonical::to_primitive(&self) -> vortex_array::arrays::PrimitiveArray
 
@@ -19182,7 +22608,7 @@ pub fn vortex_array::ToCanonical::to_struct(&self) -> vortex_array::arrays::Stru
 
 pub fn vortex_array::ToCanonical::to_varbinview(&self) -> vortex_array::arrays::VarBinViewArray
 
-impl<A: vortex_array::Array + ?core::marker::Sized> vortex_array::ToCanonical for A
+impl<A: vortex_array::DynArray + ?core::marker::Sized> vortex_array::ToCanonical for A
 
 pub fn A::to_bool(&self) -> vortex_array::arrays::BoolArray
 
@@ -19194,7 +22620,7 @@ pub fn A::to_fixed_size_list(&self) -> vortex_array::arrays::FixedSizeListArray
 
 pub fn A::to_listview(&self) -> vortex_array::arrays::ListViewArray
 
-pub fn A::to_null(&self) -> vortex_array::arrays::NullArray
+pub fn A::to_null(&self) -> vortex_array::arrays::null::NullArray
 
 pub fn A::to_primitive(&self) -> vortex_array::arrays::PrimitiveArray
 
@@ -19212,6 +22638,6 @@ pub fn vortex_session::VortexSession::create_execution_ctx(&self) -> vortex_arra
 
 pub type vortex_array::ArrayContext = vortex_session::registry::Context<&'static dyn vortex_array::vtable::DynVTable>
 
-pub type vortex_array::ArrayRef = alloc::sync::Arc<dyn vortex_array::Array>
+pub type vortex_array::ArrayRef = alloc::sync::Arc<dyn vortex_array::DynArray>
 
-pub type vortex_array::DonePredicate = fn(&dyn vortex_array::Array) -> bool
+pub type vortex_array::DonePredicate = fn(&dyn vortex_array::DynArray) -> bool

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -54,47 +54,61 @@ pub fn vortex_array::aggregate_fn::fns::sum::Sum::fmt(&self, f: &mut core::fmt::
 
 impl vortex_array::aggregate_fn::AggregateFnVTable for vortex_array::aggregate_fn::fns::sum::Sum
 
-pub type vortex_array::aggregate_fn::fns::sum::Sum::Options = vortex_array::aggregate_fn::EmptyOptions
+pub type vortex_array::aggregate_fn::fns::sum::Sum::GroupState = vortex_array::aggregate_fn::fns::sum::SumGroupState
 
-pub type vortex_array::aggregate_fn::fns::sum::Sum::Partial = vortex_array::aggregate_fn::fns::sum::SumPartial
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::accumulate(&self, partial: &mut Self::Partial, batch: &vortex_array::Canonical, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::combine_partials(&self, partial: &mut Self::Partial, other: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+pub type vortex_array::aggregate_fn::fns::sum::Sum::Options = vortex_array::aggregate_fn::fns::sum::SumOptions
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::empty_partial(&self, _options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::Partial>
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize(&self, states: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize(&self, partials: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize_scalar(&self, partial: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::flush(&self, partial: &mut Self::Partial) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize_scalar(&self, state: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::id(&self) -> vortex_array::aggregate_fn::AggregateFnId
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::is_saturated(&self, partial: &Self::Partial) -> bool
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::partial_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::return_dtype(&self, _options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub struct vortex_array::aggregate_fn::fns::sum::SumPartial
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_accumulate(&self, state: &mut Self::GroupState, batch: &vortex_array::Canonical, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub mod vortex_array::aggregate_fn::kernels
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
-pub trait vortex_array::aggregate_fn::kernels::DynAggregateKernel: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_flush(&self, state: &mut Self::GroupState) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::aggregate_fn::kernels::DynAggregateKernel::aggregate(&self, aggregate_fn: &vortex_array::aggregate_fn::AggregateFnRef, batch: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar::Scalar>>
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_is_saturated(&self, state: &Self::GroupState) -> bool
 
-pub trait vortex_array::aggregate_fn::kernels::DynGroupedAggregateKernel: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_merge(&self, state: &mut Self::GroupState, other: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::aggregate_fn::kernels::DynGroupedAggregateKernel::grouped_aggregate(&self, aggregate_fn: &vortex_array::aggregate_fn::AggregateFnRef, groups: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_new(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::GroupState>
 
-pub fn vortex_array::aggregate_fn::kernels::DynGroupedAggregateKernel::grouped_aggregate_fixed_size(&self, aggregate_fn: &vortex_array::aggregate_fn::AggregateFnRef, groups: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub struct vortex_array::aggregate_fn::fns::sum::SumGroupState
+
+pub struct vortex_array::aggregate_fn::fns::sum::SumOptions
+
+impl core::clone::Clone for vortex_array::aggregate_fn::fns::sum::SumOptions
+
+pub fn vortex_array::aggregate_fn::fns::sum::SumOptions::clone(&self) -> vortex_array::aggregate_fn::fns::sum::SumOptions
+
+impl core::cmp::Eq for vortex_array::aggregate_fn::fns::sum::SumOptions
+
+impl core::cmp::PartialEq for vortex_array::aggregate_fn::fns::sum::SumOptions
+
+pub fn vortex_array::aggregate_fn::fns::sum::SumOptions::eq(&self, other: &vortex_array::aggregate_fn::fns::sum::SumOptions) -> bool
+
+impl core::fmt::Debug for vortex_array::aggregate_fn::fns::sum::SumOptions
+
+pub fn vortex_array::aggregate_fn::fns::sum::SumOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::fmt::Display for vortex_array::aggregate_fn::fns::sum::SumOptions
+
+pub fn vortex_array::aggregate_fn::fns::sum::SumOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_array::aggregate_fn::fns::sum::SumOptions
+
+pub fn vortex_array::aggregate_fn::fns::sum::SumOptions::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::StructuralPartialEq for vortex_array::aggregate_fn::fns::sum::SumOptions
 
 pub mod vortex_array::aggregate_fn::session
 
@@ -104,13 +118,11 @@ impl vortex_array::aggregate_fn::session::AggregateFnSession
 
 pub fn vortex_array::aggregate_fn::session::AggregateFnSession::register<V: vortex_array::aggregate_fn::AggregateFnVTable>(&self, vtable: V)
 
-pub fn vortex_array::aggregate_fn::session::AggregateFnSession::register_aggregate_kernel(&self, array_id: vortex_array::vtable::ArrayId, agg_fn_id: core::option::Option<vortex_array::aggregate_fn::AggregateFnId>, kernel: &'static dyn vortex_array::aggregate_fn::kernels::DynAggregateKernel)
-
 pub fn vortex_array::aggregate_fn::session::AggregateFnSession::registry(&self) -> &vortex_array::aggregate_fn::session::AggregateFnRegistry
 
 impl core::default::Default for vortex_array::aggregate_fn::session::AggregateFnSession
 
-pub fn vortex_array::aggregate_fn::session::AggregateFnSession::default() -> Self
+pub fn vortex_array::aggregate_fn::session::AggregateFnSession::default() -> vortex_array::aggregate_fn::session::AggregateFnSession
 
 impl core::fmt::Debug for vortex_array::aggregate_fn::session::AggregateFnSession
 
@@ -282,63 +294,63 @@ pub fn V::id(&self) -> arcref::ArcRef<str>
 
 pub trait vortex_array::aggregate_fn::AggregateFnVTable: 'static + core::marker::Sized + core::clone::Clone + core::marker::Send + core::marker::Sync
 
+pub type vortex_array::aggregate_fn::AggregateFnVTable::GroupState: 'static + core::marker::Send
+
 pub type vortex_array::aggregate_fn::AggregateFnVTable::Options: 'static + core::marker::Send + core::marker::Sync + core::clone::Clone + core::fmt::Debug + core::fmt::Display + core::cmp::PartialEq + core::cmp::Eq + core::hash::Hash
 
-pub type vortex_array::aggregate_fn::AggregateFnVTable::Partial: 'static + core::marker::Send
-
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::accumulate(&self, state: &mut Self::Partial, batch: &vortex_array::Canonical, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::combine_partials(&self, partial: &mut Self::Partial, other: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
-
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
-
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::empty_partial(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::Partial>
 
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::finalize(&self, states: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::finalize_scalar(&self, state: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::flush(&self, partial: &mut Self::Partial) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::id(&self) -> vortex_array::aggregate_fn::AggregateFnId
-
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::is_saturated(&self, state: &Self::Partial) -> bool
-
-pub fn vortex_array::aggregate_fn::AggregateFnVTable::partial_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::return_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::AggregateFnVTable::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_accumulate(&self, state: &mut Self::GroupState, batch: &vortex_array::Canonical, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_flush(&self, state: &mut Self::GroupState) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_is_saturated(&self, state: &Self::GroupState) -> bool
+
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_merge(&self, state: &mut Self::GroupState, partial: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::AggregateFnVTable::state_new(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::GroupState>
+
 impl vortex_array::aggregate_fn::AggregateFnVTable for vortex_array::aggregate_fn::fns::sum::Sum
 
-pub type vortex_array::aggregate_fn::fns::sum::Sum::Options = vortex_array::aggregate_fn::EmptyOptions
+pub type vortex_array::aggregate_fn::fns::sum::Sum::GroupState = vortex_array::aggregate_fn::fns::sum::SumGroupState
 
-pub type vortex_array::aggregate_fn::fns::sum::Sum::Partial = vortex_array::aggregate_fn::fns::sum::SumPartial
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::accumulate(&self, partial: &mut Self::Partial, batch: &vortex_array::Canonical, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::combine_partials(&self, partial: &mut Self::Partial, other: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+pub type vortex_array::aggregate_fn::fns::sum::Sum::Options = vortex_array::aggregate_fn::fns::sum::SumOptions
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::empty_partial(&self, _options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::Partial>
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize(&self, states: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize(&self, partials: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize_scalar(&self, partial: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::flush(&self, partial: &mut Self::Partial) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::finalize_scalar(&self, state: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::id(&self) -> vortex_array::aggregate_fn::AggregateFnId
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::is_saturated(&self, partial: &Self::Partial) -> bool
-
-pub fn vortex_array::aggregate_fn::fns::sum::Sum::partial_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::return_dtype(&self, _options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_array::aggregate_fn::fns::sum::Sum::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_accumulate(&self, state: &mut Self::GroupState, batch: &vortex_array::Canonical, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_dtype(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_flush(&self, state: &mut Self::GroupState) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_is_saturated(&self, state: &Self::GroupState) -> bool
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_merge(&self, state: &mut Self::GroupState, other: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::aggregate_fn::fns::sum::Sum::state_new(&self, options: &Self::Options, input_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self::GroupState>
 
 pub trait vortex_array::aggregate_fn::AggregateFnVTableExt: vortex_array::aggregate_fn::AggregateFnVTable
 
@@ -394,4205 +406,299 @@ pub type vortex_array::aggregate_fn::GroupedAccumulatorRef = alloc::boxed::Box<d
 
 pub mod vortex_array::arrays
 
-pub mod vortex_array::arrays::bool
+pub mod vortex_array::arrays::build_views
 
-pub struct vortex_array::arrays::bool::BoolArray
+#[repr(C, align(16))] pub union vortex_array::arrays::build_views::BinaryView
 
-impl vortex_array::arrays::BoolArray
+impl vortex_array::arrays::BinaryView
 
-pub fn vortex_array::arrays::BoolArray::from_indices<I: core::iter::traits::collect::IntoIterator<Item = usize>>(length: usize, indices: I, validity: vortex_array::validity::Validity) -> Self
+pub const vortex_array::arrays::BinaryView::MAX_INLINED_SIZE: usize
 
-pub fn vortex_array::arrays::BoolArray::into_bit_buffer(self) -> vortex_buffer::bit::buf::BitBuffer
+pub fn vortex_array::arrays::BinaryView::as_inlined(&self) -> &vortex_array::arrays::Inlined
 
-pub fn vortex_array::arrays::BoolArray::into_parts(self) -> vortex_array::arrays::bool::BoolArrayParts
+pub fn vortex_array::arrays::BinaryView::as_u128(&self) -> u128
 
-pub fn vortex_array::arrays::BoolArray::maybe_to_mask(&self) -> vortex_error::VortexResult<core::option::Option<vortex_mask::Mask>>
+pub fn vortex_array::arrays::BinaryView::as_view(&self) -> &vortex_array::arrays::Ref
 
-pub fn vortex_array::arrays::BoolArray::new(bits: vortex_buffer::bit::buf::BitBuffer, validity: vortex_array::validity::Validity) -> Self
+pub fn vortex_array::arrays::BinaryView::as_view_mut(&mut self) -> &mut vortex_array::arrays::Ref
 
-pub fn vortex_array::arrays::BoolArray::new_handle(handle: vortex_array::buffer::BufferHandle, offset: usize, len: usize, validity: vortex_array::validity::Validity) -> Self
+pub fn vortex_array::arrays::BinaryView::empty_view() -> Self
 
-pub unsafe fn vortex_array::arrays::BoolArray::new_unchecked(bits: vortex_buffer::bit::buf::BitBuffer, validity: vortex_array::validity::Validity) -> Self
+pub fn vortex_array::arrays::BinaryView::is_empty(&self) -> bool
 
-pub fn vortex_array::arrays::BoolArray::to_bit_buffer(&self) -> vortex_buffer::bit::buf::BitBuffer
+pub fn vortex_array::arrays::BinaryView::is_inlined(&self) -> bool
 
-pub fn vortex_array::arrays::BoolArray::to_mask(&self) -> vortex_mask::Mask
+pub fn vortex_array::arrays::BinaryView::len(&self) -> u32
 
-pub fn vortex_array::arrays::BoolArray::to_mask_fill_null_false(&self) -> vortex_mask::Mask
+pub fn vortex_array::arrays::BinaryView::make_view(value: &[u8], block: u32, offset: u32) -> Self
 
-pub fn vortex_array::arrays::BoolArray::try_new(bits: vortex_buffer::bit::buf::BitBuffer, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::BinaryView::new_inlined(value: &[u8]) -> Self
 
-pub fn vortex_array::arrays::BoolArray::try_new_from_handle(bits: vortex_array::buffer::BufferHandle, offset: usize, len: usize, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+impl core::clone::Clone for vortex_array::arrays::BinaryView
 
-pub fn vortex_array::arrays::BoolArray::validate(bits: &vortex_buffer::bit::buf::BitBuffer, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::BinaryView::clone(&self) -> vortex_array::arrays::BinaryView
 
-impl vortex_array::arrays::BoolArray
+impl core::cmp::Eq for vortex_array::arrays::BinaryView
 
-pub fn vortex_array::arrays::BoolArray::patch(self, patches: &vortex_array::patches::Patches, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+impl core::cmp::PartialEq for vortex_array::arrays::BinaryView
 
-impl vortex_array::arrays::BoolArray
+pub fn vortex_array::arrays::BinaryView::eq(&self, other: &Self) -> bool
 
-pub fn vortex_array::arrays::BoolArray::to_array(&self) -> vortex_array::ArrayRef
+impl core::convert::From<u128> for vortex_array::arrays::BinaryView
 
-impl core::clone::Clone for vortex_array::arrays::BoolArray
+pub fn vortex_array::arrays::BinaryView::from(value: u128) -> Self
 
-pub fn vortex_array::arrays::BoolArray::clone(&self) -> vortex_array::arrays::BoolArray
+impl core::convert::From<vortex_array::arrays::Ref> for vortex_array::arrays::BinaryView
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::BoolArray
+pub fn vortex_array::arrays::BinaryView::from(value: vortex_array::arrays::Ref) -> Self
 
-pub fn vortex_array::arrays::BoolArray::as_ref(&self) -> &dyn vortex_array::DynArray
+impl core::default::Default for vortex_array::arrays::BinaryView
 
-impl core::convert::From<vortex_array::arrays::BoolArray> for vortex_array::ArrayRef
+pub fn vortex_array::arrays::BinaryView::default() -> Self
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::BoolArray) -> vortex_array::ArrayRef
+impl core::fmt::Debug for vortex_array::arrays::BinaryView
 
-impl core::convert::From<vortex_buffer::bit::buf::BitBuffer> for vortex_array::arrays::BoolArray
+pub fn vortex_array::arrays::BinaryView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-pub fn vortex_array::arrays::BoolArray::from(value: vortex_buffer::bit::buf::BitBuffer) -> Self
+impl core::hash::Hash for vortex_array::arrays::BinaryView
 
-impl core::fmt::Debug for vortex_array::arrays::BoolArray
+pub fn vortex_array::arrays::BinaryView::hash<H: core::hash::Hasher>(&self, state: &mut H)
 
-pub fn vortex_array::arrays::BoolArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::marker::Copy for vortex_array::arrays::BinaryView
 
-impl core::iter::traits::collect::FromIterator<bool> for vortex_array::arrays::BoolArray
+pub const vortex_array::arrays::build_views::MAX_BUFFER_LEN: usize
 
-pub fn vortex_array::arrays::BoolArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = bool>>(iter: T) -> Self
+pub fn vortex_array::arrays::build_views::build_views<P: vortex_array::dtype::NativePType + num_traits::cast::AsPrimitive<usize>>(start_buf_index: u32, max_buffer_len: usize, bytes: vortex_buffer::ByteBufferMut, lens: &[P]) -> (alloc::vec::Vec<vortex_buffer::ByteBuffer>, vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>)
 
-impl core::iter::traits::collect::FromIterator<core::option::Option<bool>> for vortex_array::arrays::BoolArray
+pub fn vortex_array::arrays::build_views::offsets_to_lengths<P: vortex_array::dtype::NativePType>(offsets: &[P]) -> vortex_buffer::buffer::Buffer<P>
 
-pub fn vortex_array::arrays::BoolArray::from_iter<I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<bool>>>(iter: I) -> Self
+pub mod vortex_array::arrays::builder
 
-impl core::ops::deref::Deref for vortex_array::arrays::BoolArray
+pub struct vortex_array::arrays::builder::VarBinBuilder<O: vortex_array::dtype::IntegerPType>
 
-pub type vortex_array::arrays::BoolArray::Target = dyn vortex_array::DynArray
+impl<O: vortex_array::dtype::IntegerPType> vortex_array::arrays::builder::VarBinBuilder<O>
 
-pub fn vortex_array::arrays::BoolArray::deref(&self) -> &Self::Target
+pub fn vortex_array::arrays::builder::VarBinBuilder<O>::append(&mut self, value: core::option::Option<&[u8]>)
 
-impl vortex_array::Executable for vortex_array::arrays::BoolArray
+pub fn vortex_array::arrays::builder::VarBinBuilder<O>::append_n_nulls(&mut self, n: usize)
 
-pub fn vortex_array::arrays::BoolArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::builder::VarBinBuilder<O>::append_null(&mut self)
 
-impl vortex_array::IntoArray for vortex_array::arrays::BoolArray
+pub fn vortex_array::arrays::builder::VarBinBuilder<O>::append_value(&mut self, value: impl core::convert::AsRef<[u8]>)
 
-pub fn vortex_array::arrays::BoolArray::into_array(self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::builder::VarBinBuilder<O>::append_values(&mut self, values: &[u8], end_offsets: impl core::iter::traits::iterator::Iterator<Item = O>, num: usize) where O: 'static, usize: num_traits::cast::AsPrimitive<O>
 
-impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::BoolArray
+pub fn vortex_array::arrays::builder::VarBinBuilder<O>::finish(self, dtype: vortex_array::dtype::DType) -> vortex_array::arrays::VarBinArray
 
-pub fn vortex_array::arrays::BoolArray::validity(&self) -> &vortex_array::validity::Validity
+pub fn vortex_array::arrays::builder::VarBinBuilder<O>::new() -> Self
 
-pub struct vortex_array::arrays::bool::BoolArrayParts
+pub fn vortex_array::arrays::builder::VarBinBuilder<O>::with_capacity(len: usize) -> Self
 
-pub vortex_array::arrays::bool::BoolArrayParts::bits: vortex_array::buffer::BufferHandle
+impl<O: vortex_array::dtype::IntegerPType> core::default::Default for vortex_array::arrays::builder::VarBinBuilder<O>
 
-pub vortex_array::arrays::bool::BoolArrayParts::len: usize
+pub fn vortex_array::arrays::builder::VarBinBuilder<O>::default() -> Self
 
-pub vortex_array::arrays::bool::BoolArrayParts::offset: usize
+pub mod vortex_array::arrays::vtable
 
-pub vortex_array::arrays::bool::BoolArrayParts::validity: vortex_array::validity::Validity
+pub struct vortex_array::arrays::vtable::DictVTable
 
-pub struct vortex_array::arrays::bool::BoolMaskedValidityRule
+impl vortex_array::arrays::DictVTable
 
-impl core::default::Default for vortex_array::arrays::bool::BoolMaskedValidityRule
+pub const vortex_array::arrays::DictVTable::ID: vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::default() -> vortex_array::arrays::bool::BoolMaskedValidityRule
+impl core::fmt::Debug for vortex_array::arrays::DictVTable
 
-impl core::fmt::Debug for vortex_array::arrays::bool::BoolMaskedValidityRule
+pub fn vortex_array::arrays::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::DictVTable
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
+pub fn vortex_array::arrays::DictVTable::filter(array: &vortex_array::arrays::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub struct vortex_array::arrays::bool::BoolVTable
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DictVTable
 
-impl vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub const vortex_array::arrays::BoolVTable::ID: vortex_array::vtable::ArrayId
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DictVTable
 
-impl core::fmt::Debug for vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::DictVTable::is_constant(&self, array: &vortex_array::arrays::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::BoolVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DictVTable
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::DictVTable::is_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::BoolVTable::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::min_max(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::BoolVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::BoolVTable::is_constant(&self, array: &vortex_array::arrays::BoolArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::DictVTable::cast(array: &vortex_array::arrays::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::BoolVTable
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::BoolVTable::is_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::DictVTable::fill_null(array: &vortex_array::arrays::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::is_strict_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::DictVTable
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::min_max(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DictVTable
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::DictVTable::mask(array: &vortex_array::arrays::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::sum(&self, array: &vortex_array::arrays::BoolArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
+pub fn vortex_array::arrays::DictVTable::scalar_at(array: &vortex_array::arrays::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub type vortex_array::arrays::DictVTable::Array = vortex_array::arrays::DictArray
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::BoolVTable
+pub type vortex_array::arrays::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::DictMetadata>
 
-pub fn vortex_array::arrays::BoolVTable::cast(array: &vortex_array::arrays::BoolArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub type vortex_array::arrays::DictVTable::OperationsVTable = vortex_array::arrays::DictVTable
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::BoolVTable
+pub type vortex_array::arrays::DictVTable::ValidityVTable = vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::BoolVTable::fill_null(array: &vortex_array::arrays::BoolArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::DictVTable::array_eq(array: &vortex_array::arrays::DictArray, other: &vortex_array::arrays::DictArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::BoolVTable::mask(array: &vortex_array::arrays::BoolArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DictArray, state: &mut H, precision: vortex_array::Precision)
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::DictVTable::buffer(_array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::BoolVTable::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::DictVTable::buffer_name(_array: &vortex_array::arrays::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
 
-pub type vortex_array::arrays::BoolVTable::Array = vortex_array::arrays::BoolArray
+pub fn vortex_array::arrays::DictVTable::child(array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::ArrayRef
 
-pub type vortex_array::arrays::BoolVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::bool::vtable::BoolMetadata>
+pub fn vortex_array::arrays::DictVTable::child_name(_array: &vortex_array::arrays::DictArray, idx: usize) -> alloc::string::String
 
-pub type vortex_array::arrays::BoolVTable::OperationsVTable = vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub type vortex_array::arrays::BoolVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub fn vortex_array::arrays::DictVTable::dtype(array: &vortex_array::arrays::DictArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::BoolVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::BoolVTable::array_eq(array: &vortex_array::arrays::BoolArray, other: &vortex_array::arrays::BoolArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::BoolArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::BoolVTable::buffer(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::DictVTable::len(array: &vortex_array::arrays::DictArray) -> usize
 
-pub fn vortex_array::arrays::BoolVTable::buffer_name(_array: &vortex_array::arrays::BoolArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::DictVTable::metadata(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::BoolVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::BoolArray>
+pub fn vortex_array::arrays::DictVTable::nbuffers(_array: &vortex_array::arrays::DictArray) -> usize
 
-pub fn vortex_array::arrays::BoolVTable::child(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::DictVTable::nchildren(_array: &vortex_array::arrays::DictArray) -> usize
 
-pub fn vortex_array::arrays::BoolVTable::child_name(_array: &vortex_array::arrays::BoolArray, _idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::dtype(array: &vortex_array::arrays::BoolArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::BoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::DictVTable::stats(array: &vortex_array::arrays::DictArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::BoolVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::BoolVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::BoolVTable::len(array: &vortex_array::arrays::BoolArray) -> usize
+pub fn vortex_array::arrays::DictVTable::validity(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-pub fn vortex_array::arrays::BoolVTable::metadata(array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<Self::Metadata>
+pub enum vortex_array::arrays::ListViewRebuildMode
 
-pub fn vortex_array::arrays::BoolVTable::nbuffers(_array: &vortex_array::arrays::BoolArray) -> usize
+pub vortex_array::arrays::ListViewRebuildMode::MakeExact
 
-pub fn vortex_array::arrays::BoolVTable::nchildren(array: &vortex_array::arrays::BoolArray) -> usize
+pub vortex_array::arrays::ListViewRebuildMode::MakeZeroCopyToList
 
-pub fn vortex_array::arrays::BoolVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub vortex_array::arrays::ListViewRebuildMode::OverlapCompression
 
-pub fn vortex_array::arrays::BoolVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub vortex_array::arrays::ListViewRebuildMode::TrimElements
 
-pub fn vortex_array::arrays::BoolVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+#[repr(C, align(16))] pub union vortex_array::arrays::BinaryView
 
-pub fn vortex_array::arrays::BoolVTable::stats(array: &vortex_array::arrays::BoolArray) -> vortex_array::stats::StatsSetRef<'_>
+impl vortex_array::arrays::BinaryView
 
-pub fn vortex_array::arrays::BoolVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub const vortex_array::arrays::BinaryView::MAX_INLINED_SIZE: usize
 
-pub mod vortex_array::arrays::chunked
+pub fn vortex_array::arrays::BinaryView::as_inlined(&self) -> &vortex_array::arrays::Inlined
 
-pub struct vortex_array::arrays::chunked::ChunkedArray
+pub fn vortex_array::arrays::BinaryView::as_u128(&self) -> u128
 
-impl vortex_array::arrays::ChunkedArray
+pub fn vortex_array::arrays::BinaryView::as_view(&self) -> &vortex_array::arrays::Ref
 
-pub fn vortex_array::arrays::ChunkedArray::array_iterator(&self) -> impl vortex_array::iter::ArrayIterator + '_
+pub fn vortex_array::arrays::BinaryView::as_view_mut(&mut self) -> &mut vortex_array::arrays::Ref
 
-pub fn vortex_array::arrays::ChunkedArray::array_stream(&self) -> impl vortex_array::stream::ArrayStream + '_
+pub fn vortex_array::arrays::BinaryView::empty_view() -> Self
 
-pub fn vortex_array::arrays::ChunkedArray::chunk(&self, idx: usize) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::BinaryView::is_empty(&self) -> bool
 
-pub fn vortex_array::arrays::ChunkedArray::chunk_offsets(&self) -> vortex_buffer::buffer::Buffer<u64>
+pub fn vortex_array::arrays::BinaryView::is_inlined(&self) -> bool
 
-pub fn vortex_array::arrays::ChunkedArray::chunks(&self) -> &[vortex_array::ArrayRef]
+pub fn vortex_array::arrays::BinaryView::len(&self) -> u32
 
-pub fn vortex_array::arrays::ChunkedArray::nchunks(&self) -> usize
+pub fn vortex_array::arrays::BinaryView::make_view(value: &[u8], block: u32, offset: u32) -> Self
 
-pub unsafe fn vortex_array::arrays::ChunkedArray::new_unchecked(chunks: alloc::vec::Vec<vortex_array::ArrayRef>, dtype: vortex_array::dtype::DType) -> Self
+pub fn vortex_array::arrays::BinaryView::new_inlined(value: &[u8]) -> Self
 
-pub fn vortex_array::arrays::ChunkedArray::non_empty_chunks(&self) -> impl core::iter::traits::iterator::Iterator<Item = &vortex_array::ArrayRef> + '_
+impl core::clone::Clone for vortex_array::arrays::BinaryView
 
-pub fn vortex_array::arrays::ChunkedArray::rechunk(&self, target_bytesize: u64, target_rowsize: usize) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::BinaryView::clone(&self) -> vortex_array::arrays::BinaryView
 
-pub fn vortex_array::arrays::ChunkedArray::try_new(chunks: alloc::vec::Vec<vortex_array::ArrayRef>, dtype: vortex_array::dtype::DType) -> vortex_error::VortexResult<Self>
+impl core::cmp::Eq for vortex_array::arrays::BinaryView
 
-pub fn vortex_array::arrays::ChunkedArray::validate(chunks: &[vortex_array::ArrayRef], dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
+impl core::cmp::PartialEq for vortex_array::arrays::BinaryView
 
-impl vortex_array::arrays::ChunkedArray
+pub fn vortex_array::arrays::BinaryView::eq(&self, other: &Self) -> bool
 
-pub fn vortex_array::arrays::ChunkedArray::to_array(&self) -> vortex_array::ArrayRef
+impl core::convert::From<u128> for vortex_array::arrays::BinaryView
 
-impl core::clone::Clone for vortex_array::arrays::ChunkedArray
+pub fn vortex_array::arrays::BinaryView::from(value: u128) -> Self
 
-pub fn vortex_array::arrays::ChunkedArray::clone(&self) -> vortex_array::arrays::ChunkedArray
+impl core::convert::From<vortex_array::arrays::Ref> for vortex_array::arrays::BinaryView
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ChunkedArray
+pub fn vortex_array::arrays::BinaryView::from(value: vortex_array::arrays::Ref) -> Self
 
-pub fn vortex_array::arrays::ChunkedArray::as_ref(&self) -> &dyn vortex_array::DynArray
+impl core::default::Default for vortex_array::arrays::BinaryView
 
-impl core::convert::From<vortex_array::arrays::ChunkedArray> for vortex_array::ArrayRef
+pub fn vortex_array::arrays::BinaryView::default() -> Self
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ChunkedArray) -> vortex_array::ArrayRef
+impl core::fmt::Debug for vortex_array::arrays::BinaryView
 
-impl core::fmt::Debug for vortex_array::arrays::ChunkedArray
+pub fn vortex_array::arrays::BinaryView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-pub fn vortex_array::arrays::ChunkedArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::hash::Hash for vortex_array::arrays::BinaryView
 
-impl core::iter::traits::collect::FromIterator<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::arrays::ChunkedArray
+pub fn vortex_array::arrays::BinaryView::hash<H: core::hash::Hasher>(&self, state: &mut H)
 
-pub fn vortex_array::arrays::ChunkedArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = vortex_array::ArrayRef>>(iter: T) -> Self
+impl core::marker::Copy for vortex_array::arrays::BinaryView
 
-impl core::ops::deref::Deref for vortex_array::arrays::ChunkedArray
+pub struct vortex_array::arrays::AnyScalarFn
 
-pub type vortex_array::arrays::ChunkedArray::Target = dyn vortex_array::DynArray
+impl core::fmt::Debug for vortex_array::arrays::AnyScalarFn
 
-pub fn vortex_array::arrays::ChunkedArray::deref(&self) -> &Self::Target
+pub fn vortex_array::arrays::AnyScalarFn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::IntoArray for vortex_array::arrays::ChunkedArray
+impl vortex_array::matcher::Matcher for vortex_array::arrays::AnyScalarFn
 
-pub fn vortex_array::arrays::ChunkedArray::into_array(self) -> vortex_array::ArrayRef
+pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
 
-pub struct vortex_array::arrays::chunked::ChunkedVTable
+pub fn vortex_array::arrays::AnyScalarFn::matches(array: &dyn vortex_array::DynArray) -> bool
 
-impl vortex_array::arrays::ChunkedVTable
-
-pub const vortex_array::arrays::ChunkedVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::is_constant(&self, array: &vortex_array::arrays::ChunkedArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::is_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::ChunkedVTable::is_strict_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::min_max(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::sum(&self, array: &vortex_array::arrays::ChunkedArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::cast(array: &vortex_array::arrays::ChunkedArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::fill_null(array: &vortex_array::arrays::ChunkedArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::mask(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::ChunkedVTable
-
-pub type vortex_array::arrays::ChunkedVTable::Array = vortex_array::arrays::ChunkedArray
-
-pub type vortex_array::arrays::ChunkedVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::ChunkedVTable::OperationsVTable = vortex_array::arrays::ChunkedVTable
-
-pub type vortex_array::arrays::ChunkedVTable::ValidityVTable = vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::append_to_builder(array: &vortex_array::arrays::ChunkedArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ChunkedVTable::array_eq(array: &vortex_array::arrays::ChunkedArray, other: &vortex_array::arrays::ChunkedArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::ChunkedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ChunkedArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ChunkedVTable::buffer(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ChunkedVTable::buffer_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ChunkedVTable::build(dtype: &vortex_array::dtype::DType, _len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ChunkedArray>
-
-pub fn vortex_array::arrays::ChunkedVTable::child(array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ChunkedVTable::child_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ChunkedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ChunkedVTable::dtype(array: &vortex_array::arrays::ChunkedArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ChunkedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::ChunkedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ChunkedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ChunkedVTable::len(array: &vortex_array::arrays::ChunkedArray) -> usize
-
-pub fn vortex_array::arrays::ChunkedVTable::metadata(_array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ChunkedVTable::nbuffers(_array: &vortex_array::arrays::ChunkedArray) -> usize
-
-pub fn vortex_array::arrays::ChunkedVTable::nchildren(array: &vortex_array::arrays::ChunkedArray) -> usize
-
-pub fn vortex_array::arrays::ChunkedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ChunkedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ChunkedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ChunkedVTable::stats(array: &vortex_array::arrays::ChunkedArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ChunkedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::validity(array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub mod vortex_array::arrays::constant
-
-pub struct vortex_array::arrays::constant::ConstantArray
-
-impl vortex_array::arrays::ConstantArray
-
-pub fn vortex_array::arrays::ConstantArray::into_parts(self) -> vortex_array::scalar::Scalar
-
-pub fn vortex_array::arrays::ConstantArray::new<S>(scalar: S, len: usize) -> Self where S: core::convert::Into<vortex_array::scalar::Scalar>
-
-pub fn vortex_array::arrays::ConstantArray::scalar(&self) -> &vortex_array::scalar::Scalar
-
-impl vortex_array::arrays::ConstantArray
-
-pub fn vortex_array::arrays::ConstantArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::ConstantArray
-
-pub fn vortex_array::arrays::ConstantArray::clone(&self) -> vortex_array::arrays::ConstantArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ConstantArray
-
-pub fn vortex_array::arrays::ConstantArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::ConstantArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ConstantArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::ConstantArray
-
-pub fn vortex_array::arrays::ConstantArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::ConstantArray
-
-pub type vortex_array::arrays::ConstantArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::ConstantArray::deref(&self) -> &Self::Target
-
-impl vortex_array::IntoArray for vortex_array::arrays::ConstantArray
-
-pub fn vortex_array::arrays::ConstantArray::into_array(self) -> vortex_array::ArrayRef
-
-pub struct vortex_array::arrays::constant::ConstantVTable
-
-impl vortex_array::arrays::ConstantVTable
-
-pub const vortex_array::arrays::ConstantVTable::ID: vortex_array::vtable::ArrayId
-
-impl vortex_array::arrays::ConstantVTable
-
-pub const vortex_array::arrays::ConstantVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
-
-impl core::fmt::Debug for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::min_max(&self, array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::sum(&self, array: &vortex_array::arrays::ConstantArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::between(array: &vortex_array::arrays::ConstantArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::cast(array: &vortex_array::arrays::ConstantArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::fill_null(array: &vortex_array::arrays::ConstantArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::not::NotReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::invert(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::ConstantVTable
-
-pub type vortex_array::arrays::ConstantVTable::Array = vortex_array::arrays::ConstantArray
-
-pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::scalar::Scalar
-
-pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::arrays::ConstantVTable
-
-pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::ConstantVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ConstantArray, state: &mut H, _precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ConstantVTable::buffer(array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ConstantVTable::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ConstantVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
-
-pub fn vortex_array::arrays::ConstantVTable::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ConstantVTable::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ConstantVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::ConstantVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
-
-pub fn vortex_array::arrays::ConstantVTable::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
-
-pub fn vortex_array::arrays::ConstantVTable::nchildren(_array: &vortex_array::arrays::ConstantArray) -> usize
-
-pub fn vortex_array::arrays::ConstantVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ConstantVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ConstantVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ConstantVTable::stats(array: &vortex_array::arrays::ConstantArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ConstantVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::validity(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub mod vortex_array::arrays::datetime
-
-pub struct vortex_array::arrays::datetime::TemporalArray
-
-impl vortex_array::arrays::datetime::TemporalArray
-
-pub fn vortex_array::arrays::datetime::TemporalArray::dtype(&self) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::datetime::TemporalArray::ext_dtype(&self) -> vortex_array::dtype::extension::ExtDTypeRef
-
-pub fn vortex_array::arrays::datetime::TemporalArray::temporal_metadata(&self) -> vortex_array::extension::datetime::TemporalMetadata<'_>
-
-pub fn vortex_array::arrays::datetime::TemporalArray::temporal_values(&self) -> &vortex_array::ArrayRef
-
-impl vortex_array::arrays::datetime::TemporalArray
-
-pub fn vortex_array::arrays::datetime::TemporalArray::new_date(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
-
-pub fn vortex_array::arrays::datetime::TemporalArray::new_time(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
-
-pub fn vortex_array::arrays::datetime::TemporalArray::new_timestamp(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit, time_zone: core::option::Option<alloc::sync::Arc<str>>) -> Self
-
-impl core::clone::Clone for vortex_array::arrays::datetime::TemporalArray
-
-pub fn vortex_array::arrays::datetime::TemporalArray::clone(&self) -> vortex_array::arrays::datetime::TemporalArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::datetime::TemporalArray
-
-pub fn vortex_array::arrays::datetime::TemporalArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<&vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::datetime::TemporalArray) -> Self
-
-impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
-
-impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
-
-impl core::convert::TryFrom<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::arrays::datetime::TemporalArray
-
-pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
-
-pub fn vortex_array::arrays::datetime::TemporalArray::try_from(value: vortex_array::ArrayRef) -> core::result::Result<Self, Self::Error>
-
-impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::datetime::TemporalArray
-
-pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
-
-pub fn vortex_array::arrays::datetime::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
-
-impl core::fmt::Debug for vortex_array::arrays::datetime::TemporalArray
-
-pub fn vortex_array::arrays::datetime::TemporalArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::IntoArray for vortex_array::arrays::datetime::TemporalArray
-
-pub fn vortex_array::arrays::datetime::TemporalArray::into_array(self) -> vortex_array::ArrayRef
-
-pub mod vortex_array::arrays::decimal
-
-pub struct vortex_array::arrays::decimal::DecimalArray
-
-impl vortex_array::arrays::DecimalArray
-
-pub fn vortex_array::arrays::DecimalArray::buffer<T: vortex_array::dtype::NativeDecimalType>(&self) -> vortex_buffer::buffer::Buffer<T>
-
-pub fn vortex_array::arrays::DecimalArray::buffer_handle(&self) -> &vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::DecimalArray::decimal_dtype(&self) -> vortex_array::dtype::DecimalDType
-
-pub fn vortex_array::arrays::DecimalArray::from_iter<T: vortex_array::dtype::NativeDecimalType, I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I, decimal_dtype: vortex_array::dtype::DecimalDType) -> Self
-
-pub fn vortex_array::arrays::DecimalArray::from_option_iter<T: vortex_array::dtype::NativeDecimalType, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I, decimal_dtype: vortex_array::dtype::DecimalDType) -> Self
-
-pub fn vortex_array::arrays::DecimalArray::into_parts(self) -> vortex_array::arrays::decimal::DecimalArrayParts
-
-pub fn vortex_array::arrays::DecimalArray::new<T: vortex_array::dtype::NativeDecimalType>(buffer: vortex_buffer::buffer::Buffer<T>, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::DecimalArray::new_handle(values: vortex_array::buffer::BufferHandle, values_type: vortex_array::dtype::DecimalType, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
-
-pub unsafe fn vortex_array::arrays::DecimalArray::new_unchecked<T: vortex_array::dtype::NativeDecimalType>(buffer: vortex_buffer::buffer::Buffer<T>, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
-
-pub unsafe fn vortex_array::arrays::DecimalArray::new_unchecked_from_byte_buffer(byte_buffer: vortex_buffer::ByteBuffer, values_type: vortex_array::dtype::DecimalType, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
-
-pub unsafe fn vortex_array::arrays::DecimalArray::new_unchecked_handle(values: vortex_array::buffer::BufferHandle, values_type: vortex_array::dtype::DecimalType, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::DecimalArray::patch(self, patches: &vortex_array::patches::Patches, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::DecimalArray::precision(&self) -> u8
-
-pub fn vortex_array::arrays::DecimalArray::scale(&self) -> i8
-
-pub fn vortex_array::arrays::DecimalArray::try_new<T: vortex_array::dtype::NativeDecimalType>(buffer: vortex_buffer::buffer::Buffer<T>, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::DecimalArray::try_new_handle(values: vortex_array::buffer::BufferHandle, values_type: vortex_array::dtype::DecimalType, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::DecimalArray::values_type(&self) -> vortex_array::dtype::DecimalType
-
-impl vortex_array::arrays::DecimalArray
-
-pub fn vortex_array::arrays::DecimalArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::DecimalArray
-
-pub fn vortex_array::arrays::DecimalArray::clone(&self) -> vortex_array::arrays::DecimalArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::DecimalArray
-
-pub fn vortex_array::arrays::DecimalArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::DecimalArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::DecimalArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::DecimalArray
-
-pub fn vortex_array::arrays::DecimalArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::DecimalArray
-
-pub type vortex_array::arrays::DecimalArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::DecimalArray::deref(&self) -> &Self::Target
-
-impl vortex_array::Executable for vortex_array::arrays::DecimalArray
-
-pub fn vortex_array::arrays::DecimalArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::IntoArray for vortex_array::arrays::DecimalArray
-
-pub fn vortex_array::arrays::DecimalArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::DecimalArray
-
-pub fn vortex_array::arrays::DecimalArray::validity(&self) -> &vortex_array::validity::Validity
-
-pub struct vortex_array::arrays::decimal::DecimalArrayParts
-
-pub vortex_array::arrays::decimal::DecimalArrayParts::decimal_dtype: vortex_array::dtype::DecimalDType
-
-pub vortex_array::arrays::decimal::DecimalArrayParts::validity: vortex_array::validity::Validity
-
-pub vortex_array::arrays::decimal::DecimalArrayParts::values: vortex_array::buffer::BufferHandle
-
-pub vortex_array::arrays::decimal::DecimalArrayParts::values_type: vortex_array::dtype::DecimalType
-
-pub struct vortex_array::arrays::decimal::DecimalMaskedValidityRule
-
-impl core::default::Default for vortex_array::arrays::decimal::DecimalMaskedValidityRule
-
-pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::default() -> vortex_array::arrays::decimal::DecimalMaskedValidityRule
-
-impl core::fmt::Debug for vortex_array::arrays::decimal::DecimalMaskedValidityRule
-
-pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
-
-pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::decimal::DecimalVTable
-
-impl vortex_array::arrays::DecimalVTable
-
-pub const vortex_array::arrays::DecimalVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::is_constant(&self, array: &vortex_array::arrays::DecimalArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::is_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::DecimalVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::min_max(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::sum(&self, array: &vortex_array::arrays::DecimalArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
-
-pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::between(arr: &vortex_array::arrays::DecimalArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::cast(array: &vortex_array::arrays::DecimalArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::fill_null(array: &vortex_array::arrays::DecimalArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::mask(array: &vortex_array::arrays::DecimalArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::DecimalVTable
-
-pub type vortex_array::arrays::DecimalVTable::Array = vortex_array::arrays::DecimalArray
-
-pub type vortex_array::arrays::DecimalVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::decimal::vtable::DecimalMetadata>
-
-pub type vortex_array::arrays::DecimalVTable::OperationsVTable = vortex_array::arrays::DecimalVTable
-
-pub type vortex_array::arrays::DecimalVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::DecimalVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::DecimalVTable::array_eq(array: &vortex_array::arrays::DecimalArray, other: &vortex_array::arrays::DecimalArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::DecimalVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DecimalArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::DecimalVTable::buffer(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::DecimalVTable::buffer_name(_array: &vortex_array::arrays::DecimalArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::DecimalVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DecimalArray>
-
-pub fn vortex_array::arrays::DecimalVTable::child(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::DecimalVTable::child_name(_array: &vortex_array::arrays::DecimalArray, _idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::DecimalVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::DecimalVTable::dtype(array: &vortex_array::arrays::DecimalArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::DecimalVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::DecimalVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DecimalVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::DecimalVTable::len(array: &vortex_array::arrays::DecimalArray) -> usize
-
-pub fn vortex_array::arrays::DecimalVTable::metadata(array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::DecimalVTable::nbuffers(_array: &vortex_array::arrays::DecimalArray) -> usize
-
-pub fn vortex_array::arrays::DecimalVTable::nchildren(array: &vortex_array::arrays::DecimalArray) -> usize
-
-pub fn vortex_array::arrays::DecimalVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DecimalVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DecimalVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::DecimalVTable::stats(array: &vortex_array::arrays::DecimalArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::DecimalVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::decimal::narrowed_decimal(decimal_array: vortex_array::arrays::DecimalArray) -> vortex_array::arrays::DecimalArray
-
-pub mod vortex_array::arrays::dict
-
-pub mod vortex_array::arrays::dict::vtable
-
-pub struct vortex_array::arrays::dict::vtable::DictVTable
-
-impl vortex_array::arrays::dict::DictVTable
-
-pub const vortex_array::arrays::dict::DictVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
-
-pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
-
-pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
-
-pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
-
-pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
-
-pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub struct vortex_array::arrays::dict::DictArray
-
-impl vortex_array::arrays::dict::DictArray
-
-pub fn vortex_array::arrays::dict::DictArray::codes(&self) -> &vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::dict::DictArray::compute_referenced_values_mask(&self, referenced: bool) -> vortex_error::VortexResult<vortex_buffer::bit::buf::BitBuffer>
-
-pub fn vortex_array::arrays::dict::DictArray::has_all_values_referenced(&self) -> bool
-
-pub fn vortex_array::arrays::dict::DictArray::into_parts(self) -> vortex_array::arrays::dict::DictArrayParts
-
-pub fn vortex_array::arrays::dict::DictArray::new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
-
-pub unsafe fn vortex_array::arrays::dict::DictArray::new_unchecked(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
-
-pub unsafe fn vortex_array::arrays::dict::DictArray::set_all_values_referenced(self, all_values_referenced: bool) -> Self
-
-pub fn vortex_array::arrays::dict::DictArray::try_new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::dict::DictArray::validate_all_values_referenced(&self) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::dict::DictArray::values(&self) -> &vortex_array::ArrayRef
-
-impl vortex_array::arrays::dict::DictArray
-
-pub fn vortex_array::arrays::dict::DictArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::dict::DictArray
-
-pub fn vortex_array::arrays::dict::DictArray::clone(&self) -> vortex_array::arrays::dict::DictArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::dict::DictArray
-
-pub fn vortex_array::arrays::dict::DictArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::dict::DictArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::dict::DictArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::dict::DictArray
-
-pub fn vortex_array::arrays::dict::DictArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::dict::DictArray
-
-pub type vortex_array::arrays::dict::DictArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::dict::DictArray::deref(&self) -> &Self::Target
-
-impl vortex_array::IntoArray for vortex_array::arrays::dict::DictArray
-
-pub fn vortex_array::arrays::dict::DictArray::into_array(self) -> vortex_array::ArrayRef
-
-impl<K: arrow_array::types::ArrowDictionaryKeyType> vortex_array::arrow::FromArrowArray<&arrow_array::array::dictionary_array::DictionaryArray<K>> for vortex_array::arrays::dict::DictArray
-
-pub fn vortex_array::arrays::dict::DictArray::from_arrow(array: &arrow_array::array::dictionary_array::DictionaryArray<K>, nullable: bool) -> vortex_error::VortexResult<Self>
-
-pub struct vortex_array::arrays::dict::DictArrayParts
-
-pub vortex_array::arrays::dict::DictArrayParts::codes: vortex_array::ArrayRef
-
-pub vortex_array::arrays::dict::DictArrayParts::dtype: vortex_array::dtype::DType
-
-pub vortex_array::arrays::dict::DictArrayParts::values: vortex_array::ArrayRef
-
-pub struct vortex_array::arrays::dict::DictMetadata
-
-impl vortex_array::arrays::dict::DictMetadata
-
-pub fn vortex_array::arrays::dict::DictMetadata::all_values_referenced(&self) -> bool
-
-pub fn vortex_array::arrays::dict::DictMetadata::codes_ptype(&self) -> vortex_array::dtype::PType
-
-pub fn vortex_array::arrays::dict::DictMetadata::is_nullable_codes(&self) -> bool
-
-pub fn vortex_array::arrays::dict::DictMetadata::set_codes_ptype(&mut self, value: vortex_array::dtype::PType)
-
-impl core::clone::Clone for vortex_array::arrays::dict::DictMetadata
-
-pub fn vortex_array::arrays::dict::DictMetadata::clone(&self) -> vortex_array::arrays::dict::DictMetadata
-
-impl core::default::Default for vortex_array::arrays::dict::DictMetadata
-
-pub fn vortex_array::arrays::dict::DictMetadata::default() -> Self
-
-impl core::fmt::Debug for vortex_array::arrays::dict::DictMetadata
-
-pub fn vortex_array::arrays::dict::DictMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl prost::message::Message for vortex_array::arrays::dict::DictMetadata
-
-pub fn vortex_array::arrays::dict::DictMetadata::clear(&mut self)
-
-pub fn vortex_array::arrays::dict::DictMetadata::encoded_len(&self) -> usize
-
-pub struct vortex_array::arrays::dict::DictVTable
-
-impl vortex_array::arrays::dict::DictVTable
-
-pub const vortex_array::arrays::dict::DictVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
-
-pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
-
-pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
-
-pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
-
-pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
-
-pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub struct vortex_array::arrays::dict::TakeExecuteAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::dict::TakeExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::dict::TakeExecuteAdaptor<V>::default() -> vortex_array::arrays::dict::TakeExecuteAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::dict::TakeExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::dict::TakeExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::dict::TakeExecuteAdaptor<V> where V: vortex_array::arrays::dict::TakeExecute
-
-pub type vortex_array::arrays::dict::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::dict::TakeReduceAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::dict::TakeReduceAdaptor<V>
-
-pub fn vortex_array::arrays::dict::TakeReduceAdaptor<V>::default() -> vortex_array::arrays::dict::TakeReduceAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::dict::TakeReduceAdaptor<V>
-
-pub fn vortex_array::arrays::dict::TakeReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::dict::TakeReduceAdaptor<V> where V: vortex_array::arrays::dict::TakeReduce
-
-pub type vortex_array::arrays::dict::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::TakeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::dict::DictArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub trait vortex_array::arrays::dict::TakeExecute: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::dict::TakeExecute::take(array: &Self::Array, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub trait vortex_array::arrays::dict::TakeReduce: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::dict::TakeReduce::take(array: &Self::Array, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::take_canonical(values: vortex_array::Canonical, codes: &vortex_array::arrays::PrimitiveArray, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::Canonical>
-
-pub mod vortex_array::arrays::extension
-
-pub struct vortex_array::arrays::extension::ExtensionArray
-
-impl vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::ext_dtype(&self) -> &vortex_array::dtype::extension::ExtDTypeRef
-
-pub fn vortex_array::arrays::ExtensionArray::id(&self) -> vortex_array::dtype::extension::ExtId
-
-pub fn vortex_array::arrays::ExtensionArray::new(ext_dtype: vortex_array::dtype::extension::ExtDTypeRef, storage: vortex_array::ArrayRef) -> Self
-
-pub fn vortex_array::arrays::ExtensionArray::storage(&self) -> &vortex_array::ArrayRef
-
-impl vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::clone(&self) -> vortex_array::arrays::ExtensionArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<&vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::datetime::TemporalArray) -> Self
-
-impl core::convert::From<vortex_array::arrays::ExtensionArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ExtensionArray) -> vortex_array::ArrayRef
-
-impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
-
-impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::datetime::TemporalArray
-
-pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
-
-pub fn vortex_array::arrays::datetime::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
-
-impl core::fmt::Debug for vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::ExtensionArray
-
-pub type vortex_array::arrays::ExtensionArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::ExtensionArray::deref(&self) -> &Self::Target
-
-impl vortex_array::Executable for vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::IntoArray for vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::into_array(self) -> vortex_array::ArrayRef
-
-pub struct vortex_array::arrays::extension::ExtensionVTable
-
-impl vortex_array::arrays::ExtensionVTable
-
-pub const vortex_array::arrays::ExtensionVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::is_constant(&self, array: &vortex_array::arrays::ExtensionArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::is_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::ExtensionVTable::is_strict_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::min_max(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::sum(&self, array: &vortex_array::arrays::ExtensionArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::cast(array: &vortex_array::arrays::ExtensionArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::mask(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::ExtensionVTable
-
-pub type vortex_array::arrays::ExtensionVTable::Array = vortex_array::arrays::ExtensionArray
-
-pub type vortex_array::arrays::ExtensionVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::ExtensionVTable::OperationsVTable = vortex_array::arrays::ExtensionVTable
-
-pub type vortex_array::arrays::ExtensionVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromChild
-
-pub fn vortex_array::arrays::ExtensionVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ExtensionVTable::array_eq(array: &vortex_array::arrays::ExtensionArray, other: &vortex_array::arrays::ExtensionArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::ExtensionVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ExtensionArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ExtensionVTable::buffer(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ExtensionVTable::buffer_name(_array: &vortex_array::arrays::ExtensionArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ExtensionVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ExtensionArray>
-
-pub fn vortex_array::arrays::ExtensionVTable::child(array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ExtensionVTable::child_name(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ExtensionVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ExtensionVTable::dtype(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ExtensionVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::ExtensionVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ExtensionVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ExtensionVTable::len(array: &vortex_array::arrays::ExtensionArray) -> usize
-
-pub fn vortex_array::arrays::ExtensionVTable::metadata(_array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ExtensionVTable::nbuffers(_array: &vortex_array::arrays::ExtensionArray) -> usize
-
-pub fn vortex_array::arrays::ExtensionVTable::nchildren(_array: &vortex_array::arrays::ExtensionArray) -> usize
-
-pub fn vortex_array::arrays::ExtensionVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ExtensionVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ExtensionVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ExtensionVTable::stats(array: &vortex_array::arrays::ExtensionArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ExtensionVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityChild<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::validity_child(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::ArrayRef
-
-pub mod vortex_array::arrays::filter
-
-pub struct vortex_array::arrays::filter::FilterArray
-
-impl vortex_array::arrays::FilterArray
-
-pub fn vortex_array::arrays::FilterArray::child(&self) -> &vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::FilterArray::filter_mask(&self) -> &vortex_mask::Mask
-
-pub fn vortex_array::arrays::FilterArray::into_parts(self) -> vortex_array::arrays::filter::FilterArrayParts
-
-pub fn vortex_array::arrays::FilterArray::new(array: vortex_array::ArrayRef, mask: vortex_mask::Mask) -> Self
-
-pub fn vortex_array::arrays::FilterArray::try_new(array: vortex_array::ArrayRef, mask: vortex_mask::Mask) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::arrays::FilterArray
-
-pub fn vortex_array::arrays::FilterArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::FilterArray
-
-pub fn vortex_array::arrays::FilterArray::clone(&self) -> vortex_array::arrays::FilterArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::FilterArray
-
-pub fn vortex_array::arrays::FilterArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::FilterArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::FilterArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::FilterArray
-
-pub fn vortex_array::arrays::FilterArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::FilterArray
-
-pub type vortex_array::arrays::FilterArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::FilterArray::deref(&self) -> &Self::Target
-
-impl vortex_array::IntoArray for vortex_array::arrays::FilterArray
-
-pub fn vortex_array::arrays::FilterArray::into_array(self) -> vortex_array::ArrayRef
-
-pub struct vortex_array::arrays::filter::FilterArrayParts
-
-pub vortex_array::arrays::filter::FilterArrayParts::child: vortex_array::ArrayRef
-
-pub vortex_array::arrays::filter::FilterArrayParts::mask: vortex_mask::Mask
-
-pub struct vortex_array::arrays::filter::FilterExecuteAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::filter::FilterExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::filter::FilterExecuteAdaptor<V>::default() -> vortex_array::arrays::filter::FilterExecuteAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::filter::FilterExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::filter::FilterExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::filter::FilterExecuteAdaptor<V> where V: vortex_array::arrays::filter::FilterKernel
-
-pub type vortex_array::arrays::filter::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::filter::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::filter::FilterReduceAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::filter::FilterReduceAdaptor<V>
-
-pub fn vortex_array::arrays::filter::FilterReduceAdaptor<V>::default() -> vortex_array::arrays::filter::FilterReduceAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::filter::FilterReduceAdaptor<V>
-
-pub fn vortex_array::arrays::filter::FilterReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::filter::FilterReduceAdaptor<V> where V: vortex_array::arrays::filter::FilterReduce
-
-pub type vortex_array::arrays::filter::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::filter::FilterReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::FilterArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::filter::FilterVTable
-
-impl vortex_array::arrays::FilterVTable
-
-pub const vortex_array::arrays::FilterVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::FilterVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::FilterVTable::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::FilterVTable
-
-pub type vortex_array::arrays::FilterVTable::Array = vortex_array::arrays::FilterArray
-
-pub type vortex_array::arrays::FilterVTable::Metadata = vortex_array::arrays::filter::vtable::FilterMetadata
-
-pub type vortex_array::arrays::FilterVTable::OperationsVTable = vortex_array::arrays::FilterVTable
-
-pub type vortex_array::arrays::FilterVTable::ValidityVTable = vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::FilterVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::FilterVTable::array_eq(array: &vortex_array::arrays::FilterArray, other: &vortex_array::arrays::FilterArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::FilterVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FilterArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::FilterVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::FilterVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::FilterVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::filter::vtable::FilterMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
-
-pub fn vortex_array::arrays::FilterVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::FilterVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::FilterVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::FilterVTable::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::FilterVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::FilterVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FilterVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::FilterVTable::len(array: &vortex_array::arrays::FilterArray) -> usize
-
-pub fn vortex_array::arrays::FilterVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::FilterVTable::nbuffers(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::FilterVTable::nchildren(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::FilterVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FilterVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FilterVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::FilterVTable::stats(array: &vortex_array::arrays::FilterArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::FilterVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::FilterVTable::validity(array: &vortex_array::arrays::FilterArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub trait vortex_array::arrays::filter::FilterKernel: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::filter::FilterKernel::filter(array: &Self::Array, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub trait vortex_array::arrays::filter::FilterReduce: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::filter::FilterReduce::filter(array: &Self::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub mod vortex_array::arrays::fixed_size_list
-
-pub struct vortex_array::arrays::fixed_size_list::FixedSizeListArray
-
-impl vortex_array::arrays::FixedSizeListArray
-
-pub fn vortex_array::arrays::FixedSizeListArray::elements(&self) -> &vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::FixedSizeListArray::fixed_size_list_elements_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::FixedSizeListArray::into_parts(self) -> (vortex_array::ArrayRef, vortex_array::validity::Validity, vortex_array::dtype::DType)
-
-pub const fn vortex_array::arrays::FixedSizeListArray::list_size(&self) -> u32
-
-pub fn vortex_array::arrays::FixedSizeListArray::new(elements: vortex_array::ArrayRef, list_size: u32, validity: vortex_array::validity::Validity, len: usize) -> Self
-
-pub unsafe fn vortex_array::arrays::FixedSizeListArray::new_unchecked(elements: vortex_array::ArrayRef, list_size: u32, validity: vortex_array::validity::Validity, len: usize) -> Self
-
-pub fn vortex_array::arrays::FixedSizeListArray::try_new(elements: vortex_array::ArrayRef, list_size: u32, validity: vortex_array::validity::Validity, len: usize) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::FixedSizeListArray::validate(elements: &vortex_array::ArrayRef, len: usize, list_size: u32, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
-
-impl vortex_array::arrays::FixedSizeListArray
-
-pub fn vortex_array::arrays::FixedSizeListArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::FixedSizeListArray
-
-pub fn vortex_array::arrays::FixedSizeListArray::clone(&self) -> vortex_array::arrays::FixedSizeListArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::FixedSizeListArray
-
-pub fn vortex_array::arrays::FixedSizeListArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::FixedSizeListArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::FixedSizeListArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::FixedSizeListArray
-
-pub fn vortex_array::arrays::FixedSizeListArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::FixedSizeListArray
-
-pub type vortex_array::arrays::FixedSizeListArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::FixedSizeListArray::deref(&self) -> &Self::Target
-
-impl vortex_array::Executable for vortex_array::arrays::FixedSizeListArray
-
-pub fn vortex_array::arrays::FixedSizeListArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::IntoArray for vortex_array::arrays::FixedSizeListArray
-
-pub fn vortex_array::arrays::FixedSizeListArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::FixedSizeListArray
-
-pub fn vortex_array::arrays::FixedSizeListArray::validity(&self) -> &vortex_array::validity::Validity
-
-pub struct vortex_array::arrays::fixed_size_list::FixedSizeListVTable
-
-impl vortex_array::arrays::FixedSizeListVTable
-
-pub const vortex_array::arrays::FixedSizeListVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::is_constant(&self, array: &vortex_array::arrays::FixedSizeListArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::is_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::min_max(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::cast(array: &vortex_array::arrays::FixedSizeListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::mask(array: &vortex_array::arrays::FixedSizeListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FixedSizeListVTable> for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::FixedSizeListVTable
-
-pub type vortex_array::arrays::FixedSizeListVTable::Array = vortex_array::arrays::FixedSizeListArray
-
-pub type vortex_array::arrays::FixedSizeListVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::FixedSizeListVTable::OperationsVTable = vortex_array::arrays::FixedSizeListVTable
-
-pub type vortex_array::arrays::FixedSizeListVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::FixedSizeListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::array_eq(array: &vortex_array::arrays::FixedSizeListArray, other: &vortex_array::arrays::FixedSizeListArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::FixedSizeListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FixedSizeListArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::FixedSizeListVTable::buffer(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::FixedSizeListVTable::buffer_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::FixedSizeListArray>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::child(array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::FixedSizeListVTable::child_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::FixedSizeListVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::dtype(array: &vortex_array::arrays::FixedSizeListArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::FixedSizeListVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::FixedSizeListVTable::len(array: &vortex_array::arrays::FixedSizeListArray) -> usize
-
-pub fn vortex_array::arrays::FixedSizeListVTable::metadata(_array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::nbuffers(_array: &vortex_array::arrays::FixedSizeListArray) -> usize
-
-pub fn vortex_array::arrays::FixedSizeListVTable::nchildren(array: &vortex_array::arrays::FixedSizeListArray) -> usize
-
-pub fn vortex_array::arrays::FixedSizeListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::stats(array: &vortex_array::arrays::FixedSizeListArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-pub mod vortex_array::arrays::list
-
-pub struct vortex_array::arrays::list::ListArray
-
-impl vortex_array::arrays::ListArray
-
-pub fn vortex_array::arrays::ListArray::element_dtype(&self) -> &alloc::sync::Arc<vortex_array::dtype::DType>
-
-pub fn vortex_array::arrays::ListArray::elements(&self) -> &vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ListArray::into_parts(self) -> vortex_array::arrays::list::ListArrayParts
-
-pub fn vortex_array::arrays::ListArray::list_elements_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::ListArray::new(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> Self
-
-pub unsafe fn vortex_array::arrays::ListArray::new_unchecked(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::ListArray::offset_at(&self, index: usize) -> vortex_error::VortexResult<usize>
-
-pub fn vortex_array::arrays::ListArray::offsets(&self) -> &vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ListArray::reset_offsets(&self, recurse: bool) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::ListArray::sliced_elements(&self) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::ListArray::try_new(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::ListArray::validate(elements: &vortex_array::ArrayRef, offsets: &vortex_array::ArrayRef, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
-
-impl vortex_array::arrays::ListArray
-
-pub fn vortex_array::arrays::ListArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::ListArray
-
-pub fn vortex_array::arrays::ListArray::clone(&self) -> vortex_array::arrays::ListArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ListArray
-
-pub fn vortex_array::arrays::ListArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::ListArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ListArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::ListArray
-
-pub fn vortex_array::arrays::ListArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::ListArray
-
-pub type vortex_array::arrays::ListArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::ListArray::deref(&self) -> &Self::Target
-
-impl vortex_array::IntoArray for vortex_array::arrays::ListArray
-
-pub fn vortex_array::arrays::ListArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::ListArray
-
-pub fn vortex_array::arrays::ListArray::validity(&self) -> &vortex_array::validity::Validity
-
-pub struct vortex_array::arrays::list::ListArrayParts
-
-pub vortex_array::arrays::list::ListArrayParts::dtype: vortex_array::dtype::DType
-
-pub vortex_array::arrays::list::ListArrayParts::elements: vortex_array::ArrayRef
-
-pub vortex_array::arrays::list::ListArrayParts::offsets: vortex_array::ArrayRef
-
-pub vortex_array::arrays::list::ListArrayParts::validity: vortex_array::validity::Validity
-
-pub struct vortex_array::arrays::list::ListVTable
-
-impl vortex_array::arrays::ListVTable
-
-pub const vortex_array::arrays::ListVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::is_constant(&self, array: &vortex_array::arrays::ListArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::is_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::ListVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::min_max(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::cast(array: &vortex_array::arrays::ListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::mask(array: &vortex_array::arrays::ListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListVTable> for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::scalar_at(array: &vortex_array::arrays::ListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::ListVTable
-
-pub type vortex_array::arrays::ListVTable::Array = vortex_array::arrays::ListArray
-
-pub type vortex_array::arrays::ListVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::list::vtable::ListMetadata>
-
-pub type vortex_array::arrays::ListVTable::OperationsVTable = vortex_array::arrays::ListVTable
-
-pub type vortex_array::arrays::ListVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::ListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ListVTable::array_eq(array: &vortex_array::arrays::ListArray, other: &vortex_array::arrays::ListArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::ListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ListVTable::buffer(_array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ListVTable::buffer_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ListVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
-
-pub fn vortex_array::arrays::ListVTable::child(array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ListVTable::child_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ListVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ListVTable::dtype(array: &vortex_array::arrays::ListArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ListVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::ListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ListVTable::len(array: &vortex_array::arrays::ListArray) -> usize
-
-pub fn vortex_array::arrays::ListVTable::metadata(array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ListVTable::nbuffers(_array: &vortex_array::arrays::ListArray) -> usize
-
-pub fn vortex_array::arrays::ListVTable::nchildren(array: &vortex_array::arrays::ListArray) -> usize
-
-pub fn vortex_array::arrays::ListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ListVTable::stats(array: &vortex_array::arrays::ListArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-pub mod vortex_array::arrays::listview
-
-pub enum vortex_array::arrays::listview::ListViewRebuildMode
-
-pub vortex_array::arrays::listview::ListViewRebuildMode::MakeExact
-
-pub vortex_array::arrays::listview::ListViewRebuildMode::MakeZeroCopyToList
-
-pub vortex_array::arrays::listview::ListViewRebuildMode::OverlapCompression
-
-pub vortex_array::arrays::listview::ListViewRebuildMode::TrimElements
-
-pub struct vortex_array::arrays::listview::ListViewArray
-
-impl vortex_array::arrays::ListViewArray
-
-pub fn vortex_array::arrays::ListViewArray::elements(&self) -> &vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ListViewArray::into_parts(self) -> vortex_array::arrays::listview::ListViewArrayParts
-
-pub fn vortex_array::arrays::ListViewArray::is_zero_copy_to_list(&self) -> bool
-
-pub fn vortex_array::arrays::ListViewArray::list_elements_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::ListViewArray::new(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, sizes: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> Self
-
-pub unsafe fn vortex_array::arrays::ListViewArray::new_unchecked(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, sizes: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::ListViewArray::offset_at(&self, index: usize) -> usize
-
-pub fn vortex_array::arrays::ListViewArray::offsets(&self) -> &vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ListViewArray::size_at(&self, index: usize) -> usize
-
-pub fn vortex_array::arrays::ListViewArray::sizes(&self) -> &vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ListViewArray::try_new(elements: vortex_array::ArrayRef, offsets: vortex_array::ArrayRef, sizes: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::ListViewArray::validate(elements: &vortex_array::ArrayRef, offsets: &vortex_array::ArrayRef, sizes: &vortex_array::ArrayRef, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ListViewArray::verify_is_zero_copy_to_list(&self) -> bool
-
-pub unsafe fn vortex_array::arrays::ListViewArray::with_zero_copy_to_list(self, is_zctl: bool) -> Self
-
-impl vortex_array::arrays::ListViewArray
-
-pub fn vortex_array::arrays::ListViewArray::rebuild(&self, mode: vortex_array::arrays::listview::ListViewRebuildMode) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
-
-impl vortex_array::arrays::ListViewArray
-
-pub fn vortex_array::arrays::ListViewArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::ListViewArray
-
-pub fn vortex_array::arrays::ListViewArray::clone(&self) -> vortex_array::arrays::ListViewArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ListViewArray
-
-pub fn vortex_array::arrays::ListViewArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::ListViewArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ListViewArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::ListViewArray
-
-pub fn vortex_array::arrays::ListViewArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::ListViewArray
-
-pub type vortex_array::arrays::ListViewArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::ListViewArray::deref(&self) -> &Self::Target
-
-impl vortex_array::Executable for vortex_array::arrays::ListViewArray
-
-pub fn vortex_array::arrays::ListViewArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::IntoArray for vortex_array::arrays::ListViewArray
-
-pub fn vortex_array::arrays::ListViewArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::ListViewArray
-
-pub fn vortex_array::arrays::ListViewArray::validity(&self) -> &vortex_array::validity::Validity
-
-pub struct vortex_array::arrays::listview::ListViewArrayParts
-
-pub vortex_array::arrays::listview::ListViewArrayParts::elements: vortex_array::ArrayRef
-
-pub vortex_array::arrays::listview::ListViewArrayParts::elements_dtype: alloc::sync::Arc<vortex_array::dtype::DType>
-
-pub vortex_array::arrays::listview::ListViewArrayParts::offsets: vortex_array::ArrayRef
-
-pub vortex_array::arrays::listview::ListViewArrayParts::sizes: vortex_array::ArrayRef
-
-pub vortex_array::arrays::listview::ListViewArrayParts::validity: vortex_array::validity::Validity
-
-pub struct vortex_array::arrays::listview::ListViewVTable
-
-impl vortex_array::arrays::ListViewVTable
-
-pub const vortex_array::arrays::ListViewVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::is_constant(&self, array: &vortex_array::arrays::ListViewArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::is_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::ListViewVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::min_max(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::cast(array: &vortex_array::arrays::ListViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::mask(array: &vortex_array::arrays::ListViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListViewVTable> for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::ListViewVTable
-
-pub type vortex_array::arrays::ListViewVTable::Array = vortex_array::arrays::ListViewArray
-
-pub type vortex_array::arrays::ListViewVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::listview::vtable::ListViewMetadata>
-
-pub type vortex_array::arrays::ListViewVTable::OperationsVTable = vortex_array::arrays::ListViewVTable
-
-pub type vortex_array::arrays::ListViewVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::ListViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ListViewVTable::array_eq(array: &vortex_array::arrays::ListViewArray, other: &vortex_array::arrays::ListViewArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::ListViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListViewArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ListViewVTable::buffer(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ListViewVTable::buffer_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ListViewVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
-
-pub fn vortex_array::arrays::ListViewVTable::child(array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ListViewVTable::child_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ListViewVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ListViewVTable::dtype(array: &vortex_array::arrays::ListViewArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ListViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::ListViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListViewVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ListViewVTable::len(array: &vortex_array::arrays::ListViewArray) -> usize
-
-pub fn vortex_array::arrays::ListViewVTable::metadata(array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ListViewVTable::nbuffers(_array: &vortex_array::arrays::ListViewArray) -> usize
-
-pub fn vortex_array::arrays::ListViewVTable::nchildren(array: &vortex_array::arrays::ListViewArray) -> usize
-
-pub fn vortex_array::arrays::ListViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListViewVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ListViewVTable::stats(array: &vortex_array::arrays::ListViewArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ListViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::listview::list_from_list_view(list_view: vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
-
-pub fn vortex_array::arrays::listview::list_view_from_list(list: vortex_array::arrays::ListArray, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
-
-pub fn vortex_array::arrays::listview::recursive_list_from_list_view(array: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub mod vortex_array::arrays::masked
-
-pub struct vortex_array::arrays::masked::MaskedArray
-
-impl vortex_array::arrays::MaskedArray
-
-pub fn vortex_array::arrays::MaskedArray::child(&self) -> &vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::MaskedArray::try_new(child: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::arrays::MaskedArray
-
-pub fn vortex_array::arrays::MaskedArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::MaskedArray
-
-pub fn vortex_array::arrays::MaskedArray::clone(&self) -> vortex_array::arrays::MaskedArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::MaskedArray
-
-pub fn vortex_array::arrays::MaskedArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::MaskedArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::MaskedArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::MaskedArray
-
-pub fn vortex_array::arrays::MaskedArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::MaskedArray
-
-pub type vortex_array::arrays::MaskedArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::MaskedArray::deref(&self) -> &Self::Target
-
-impl vortex_array::IntoArray for vortex_array::arrays::MaskedArray
-
-pub fn vortex_array::arrays::MaskedArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::MaskedArray
-
-pub fn vortex_array::arrays::MaskedArray::validity(&self) -> &vortex_array::validity::Validity
-
-pub struct vortex_array::arrays::masked::MaskedVTable
-
-impl vortex_array::arrays::MaskedVTable
-
-pub const vortex_array::arrays::MaskedVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::mask(array: &vortex_array::arrays::MaskedArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::MaskedVTable> for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::MaskedVTable
-
-pub type vortex_array::arrays::MaskedVTable::Array = vortex_array::arrays::MaskedArray
-
-pub type vortex_array::arrays::MaskedVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::MaskedVTable::OperationsVTable = vortex_array::arrays::MaskedVTable
-
-pub type vortex_array::arrays::MaskedVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::MaskedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::MaskedVTable::array_eq(array: &vortex_array::arrays::MaskedArray, other: &vortex_array::arrays::MaskedArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::MaskedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::MaskedArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::MaskedVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::MaskedVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::MaskedVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::MaskedArray>
-
-pub fn vortex_array::arrays::MaskedVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::MaskedVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::MaskedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::MaskedVTable::dtype(array: &vortex_array::arrays::MaskedArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::MaskedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::MaskedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::MaskedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::MaskedVTable::len(array: &vortex_array::arrays::MaskedArray) -> usize
-
-pub fn vortex_array::arrays::MaskedVTable::metadata(_array: &vortex_array::arrays::MaskedArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::MaskedVTable::nbuffers(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::MaskedVTable::nchildren(array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::MaskedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::MaskedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::MaskedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::MaskedVTable::stats(array: &vortex_array::arrays::MaskedArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::MaskedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::masked::mask_validity_canonical(canonical: vortex_array::Canonical, validity_mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::Canonical>
-
-pub mod vortex_array::arrays::null
-
-pub struct vortex_array::arrays::null::NullArray
-
-impl vortex_array::arrays::null::NullArray
-
-pub fn vortex_array::arrays::null::NullArray::new(len: usize) -> Self
-
-impl vortex_array::arrays::null::NullArray
-
-pub fn vortex_array::arrays::null::NullArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::null::NullArray
-
-pub fn vortex_array::arrays::null::NullArray::clone(&self) -> vortex_array::arrays::null::NullArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::null::NullArray
-
-pub fn vortex_array::arrays::null::NullArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::null::NullArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::null::NullArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::null::NullArray
-
-pub fn vortex_array::arrays::null::NullArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::null::NullArray
-
-pub type vortex_array::arrays::null::NullArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::null::NullArray::deref(&self) -> &Self::Target
-
-impl vortex_array::Executable for vortex_array::arrays::null::NullArray
-
-pub fn vortex_array::arrays::null::NullArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::IntoArray for vortex_array::arrays::null::NullArray
-
-pub fn vortex_array::arrays::null::NullArray::into_array(self) -> vortex_array::ArrayRef
-
-pub struct vortex_array::arrays::null::NullVTable
-
-impl vortex_array::arrays::null::NullVTable
-
-pub const vortex_array::arrays::null::NullVTable::ID: vortex_array::vtable::ArrayId
-
-impl vortex_array::arrays::null::NullVTable
-
-pub const vortex_array::arrays::null::NullVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
-
-impl core::fmt::Debug for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::null::NullVTable
-
-pub type vortex_array::arrays::null::NullVTable::Array = vortex_array::arrays::null::NullArray
-
-pub type vortex_array::arrays::null::NullVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::null::NullVTable::OperationsVTable = vortex_array::arrays::null::NullVTable
-
-pub type vortex_array::arrays::null::NullVTable::ValidityVTable = vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::null::NullVTable::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::null::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::null::NullVTable::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::null::NullVTable::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::null::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
-
-pub fn vortex_array::arrays::null::NullVTable::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::null::NullVTable::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::null::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::null::NullVTable::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::null::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::null::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::null::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::null::NullVTable::len(array: &vortex_array::arrays::null::NullArray) -> usize
-
-pub fn vortex_array::arrays::null::NullVTable::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::null::NullVTable::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
-
-pub fn vortex_array::arrays::null::NullVTable::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
-
-pub fn vortex_array::arrays::null::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::null::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::null::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::null::NullVTable::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::null::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub mod vortex_array::arrays::primitive
-
-#[repr(transparent)] pub struct vortex_array::arrays::primitive::NativeValue<T>(pub T)
-
-impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<f32>
-
-pub fn vortex_array::arrays::primitive::NativeValue<f32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<f64>
-
-pub fn vortex_array::arrays::primitive::NativeValue<f64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<half::binary16::f16>
-
-pub fn vortex_array::arrays::primitive::NativeValue<half::binary16::f16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<i16>
-
-pub fn vortex_array::arrays::primitive::NativeValue<i16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<i32>
-
-pub fn vortex_array::arrays::primitive::NativeValue<i32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<i64>
-
-pub fn vortex_array::arrays::primitive::NativeValue<i64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<i8>
-
-pub fn vortex_array::arrays::primitive::NativeValue<i8>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<u16>
-
-pub fn vortex_array::arrays::primitive::NativeValue<u16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<u32>
-
-pub fn vortex_array::arrays::primitive::NativeValue<u32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<u64>
-
-pub fn vortex_array::arrays::primitive::NativeValue<u64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::hash::Hash for vortex_array::arrays::primitive::NativeValue<u8>
-
-pub fn vortex_array::arrays::primitive::NativeValue<u8>::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl<T: core::clone::Clone> core::clone::Clone for vortex_array::arrays::primitive::NativeValue<T>
-
-pub fn vortex_array::arrays::primitive::NativeValue<T>::clone(&self) -> vortex_array::arrays::primitive::NativeValue<T>
-
-impl<T: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::primitive::NativeValue<T>
-
-pub fn vortex_array::arrays::primitive::NativeValue<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<T: core::marker::Copy> core::marker::Copy for vortex_array::arrays::primitive::NativeValue<T>
-
-impl<T: vortex_array::dtype::NativePType> core::cmp::Eq for vortex_array::arrays::primitive::NativeValue<T>
-
-impl<T: vortex_array::dtype::NativePType> core::cmp::PartialEq for vortex_array::arrays::primitive::NativeValue<T>
-
-pub fn vortex_array::arrays::primitive::NativeValue<T>::eq(&self, other: &vortex_array::arrays::primitive::NativeValue<T>) -> bool
-
-impl<T: vortex_array::dtype::NativePType> core::cmp::PartialOrd for vortex_array::arrays::primitive::NativeValue<T>
-
-pub fn vortex_array::arrays::primitive::NativeValue<T>::partial_cmp(&self, other: &vortex_array::arrays::primitive::NativeValue<T>) -> core::option::Option<core::cmp::Ordering>
-
-pub struct vortex_array::arrays::primitive::PrimitiveArray
-
-impl vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::as_slice<T: vortex_array::dtype::NativePType>(&self) -> &[T]
-
-pub fn vortex_array::arrays::PrimitiveArray::narrow(&self) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
-
-pub fn vortex_array::arrays::PrimitiveArray::reinterpret_cast(&self, ptype: vortex_array::dtype::PType) -> Self
-
-impl vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::buffer_handle(&self) -> &vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::PrimitiveArray::from_buffer_handle(handle: vortex_array::buffer::BufferHandle, ptype: vortex_array::dtype::PType, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::PrimitiveArray::from_byte_buffer(buffer: vortex_buffer::ByteBuffer, ptype: vortex_array::dtype::PType, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::PrimitiveArray::from_values_byte_buffer(valid_elems_buffer: vortex_buffer::ByteBuffer, ptype: vortex_array::dtype::PType, validity: vortex_array::validity::Validity, n_rows: usize) -> Self
-
-pub fn vortex_array::arrays::PrimitiveArray::map_each<T, R, F>(self, f: F) -> vortex_array::arrays::PrimitiveArray where T: vortex_array::dtype::NativePType, R: vortex_array::dtype::NativePType, F: core::ops::function::FnMut(T) -> R
-
-pub fn vortex_array::arrays::PrimitiveArray::map_each_with_validity<T, R, F>(self, f: F) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray> where T: vortex_array::dtype::NativePType, R: vortex_array::dtype::NativePType, F: core::ops::function::FnMut((T, bool)) -> R
-
-pub fn vortex_array::arrays::PrimitiveArray::ptype(&self) -> vortex_array::dtype::PType
-
-impl vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::empty<T: vortex_array::dtype::NativePType>(nullability: vortex_array::dtype::Nullability) -> Self
-
-pub fn vortex_array::arrays::PrimitiveArray::new<T: vortex_array::dtype::NativePType>(buffer: impl core::convert::Into<vortex_buffer::buffer::Buffer<T>>, validity: vortex_array::validity::Validity) -> Self
-
-pub unsafe fn vortex_array::arrays::PrimitiveArray::new_unchecked<T: vortex_array::dtype::NativePType>(buffer: vortex_buffer::buffer::Buffer<T>, validity: vortex_array::validity::Validity) -> Self
-
-pub unsafe fn vortex_array::arrays::PrimitiveArray::new_unchecked_from_handle(handle: vortex_array::buffer::BufferHandle, ptype: vortex_array::dtype::PType, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::PrimitiveArray::try_new<T: vortex_array::dtype::NativePType>(buffer: vortex_buffer::buffer::Buffer<T>, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::PrimitiveArray::validate<T: vortex_array::dtype::NativePType>(buffer: &vortex_buffer::buffer::Buffer<T>, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
-
-impl vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::from_option_iter<T: vortex_array::dtype::NativePType, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I) -> Self
-
-pub fn vortex_array::arrays::PrimitiveArray::into_buffer<T: vortex_array::dtype::NativePType>(self) -> vortex_buffer::buffer::Buffer<T>
-
-pub fn vortex_array::arrays::PrimitiveArray::into_buffer_mut<T: vortex_array::dtype::NativePType>(self) -> vortex_buffer::buffer_mut::BufferMut<T>
-
-pub fn vortex_array::arrays::PrimitiveArray::to_buffer<T: vortex_array::dtype::NativePType>(&self) -> vortex_buffer::buffer::Buffer<T>
-
-pub fn vortex_array::arrays::PrimitiveArray::try_into_buffer_mut<T: vortex_array::dtype::NativePType>(self) -> core::result::Result<vortex_buffer::buffer_mut::BufferMut<T>, vortex_buffer::buffer::Buffer<T>>
-
-impl vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::into_parts(self) -> vortex_array::arrays::primitive::PrimitiveArrayParts
-
-impl vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::patch(self, patches: &vortex_array::patches::Patches, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::top_value(&self) -> vortex_error::VortexResult<core::option::Option<(vortex_array::scalar::PValue, usize)>>
-
-impl core::clone::Clone for vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::clone(&self) -> vortex_array::arrays::PrimitiveArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::PrimitiveArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::PrimitiveArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::PrimitiveArray
-
-pub type vortex_array::arrays::PrimitiveArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::PrimitiveArray::deref(&self) -> &Self::Target
-
-impl vortex_array::Executable for vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::IntoArray for vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::validity(&self) -> &vortex_array::validity::Validity
-
-impl<T: vortex_array::dtype::NativePType> core::iter::traits::collect::FromIterator<T> for vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::from_iter<I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self
-
-impl<T: vortex_array::dtype::NativePType> vortex_array::accessor::ArrayAccessor<T> for vortex_array::arrays::PrimitiveArray
-
-pub fn vortex_array::arrays::PrimitiveArray::with_iterator<F, R>(&self, f: F) -> R where F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a T>>) -> R
-
-pub struct vortex_array::arrays::primitive::PrimitiveArrayParts
-
-pub vortex_array::arrays::primitive::PrimitiveArrayParts::buffer: vortex_array::buffer::BufferHandle
-
-pub vortex_array::arrays::primitive::PrimitiveArrayParts::ptype: vortex_array::dtype::PType
-
-pub vortex_array::arrays::primitive::PrimitiveArrayParts::validity: vortex_array::validity::Validity
-
-pub struct vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
-
-impl core::default::Default for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
-
-pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::default() -> vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
-
-impl core::fmt::Debug for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
-
-pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
-
-pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::primitive::PrimitiveVTable
-
-impl vortex_array::arrays::PrimitiveVTable
-
-pub const vortex_array::arrays::PrimitiveVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::is_constant(&self, array: &vortex_array::arrays::PrimitiveArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::is_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::is_strict_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::min_max(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::NaNCountKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::nan_count(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<usize>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
-
-pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::cast(array: &vortex_array::arrays::PrimitiveArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::fill_null(array: &vortex_array::arrays::PrimitiveArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::mask(array: &vortex_array::arrays::PrimitiveArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::PrimitiveVTable
-
-pub type vortex_array::arrays::PrimitiveVTable::Array = vortex_array::arrays::PrimitiveArray
-
-pub type vortex_array::arrays::PrimitiveVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::PrimitiveVTable::OperationsVTable = vortex_array::arrays::PrimitiveVTable
-
-pub type vortex_array::arrays::PrimitiveVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::PrimitiveVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::PrimitiveVTable::array_eq(array: &vortex_array::arrays::PrimitiveArray, other: &vortex_array::arrays::PrimitiveArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::PrimitiveVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::PrimitiveArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::PrimitiveVTable::buffer(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::PrimitiveVTable::buffer_name(_array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::PrimitiveVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
-
-pub fn vortex_array::arrays::PrimitiveVTable::child(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::PrimitiveVTable::child_name(_array: &vortex_array::arrays::PrimitiveArray, _idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::PrimitiveVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::PrimitiveVTable::dtype(array: &vortex_array::arrays::PrimitiveArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::PrimitiveVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::PrimitiveVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::PrimitiveVTable::len(array: &vortex_array::arrays::PrimitiveArray) -> usize
-
-pub fn vortex_array::arrays::PrimitiveVTable::metadata(_array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::PrimitiveVTable::nbuffers(_array: &vortex_array::arrays::PrimitiveArray) -> usize
-
-pub fn vortex_array::arrays::PrimitiveVTable::nchildren(array: &vortex_array::arrays::PrimitiveArray) -> usize
-
-pub fn vortex_array::arrays::PrimitiveVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::stats(array: &vortex_array::arrays::PrimitiveArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::PrimitiveVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-pub const vortex_array::arrays::primitive::IS_CONST_LANE_WIDTH: usize
-
-pub fn vortex_array::arrays::primitive::chunk_range(chunk_idx: usize, offset: usize, array_len: usize) -> core::ops::range::Range<usize>
-
-pub fn vortex_array::arrays::primitive::compute_is_constant<T: vortex_array::dtype::NativePType, const WIDTH: usize>(values: &[T]) -> bool
-
-pub fn vortex_array::arrays::primitive::patch_chunk<T, I, C>(decoded_values: &mut [T], patches_indices: &[I], patches_values: &[T], patches_offset: usize, chunk_offsets_slice: &[C], chunk_idx: usize, offset_within_chunk: usize) where T: vortex_array::dtype::NativePType, I: vortex_array::dtype::UnsignedPType, C: vortex_array::dtype::UnsignedPType
-
-pub mod vortex_array::arrays::scalar_fn
-
-pub struct vortex_array::arrays::scalar_fn::AnyScalarFn
-
-impl core::fmt::Debug for vortex_array::arrays::scalar_fn::AnyScalarFn
-
-pub fn vortex_array::arrays::scalar_fn::AnyScalarFn::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::matcher::Matcher for vortex_array::arrays::scalar_fn::AnyScalarFn
-
-pub type vortex_array::arrays::scalar_fn::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub fn vortex_array::arrays::scalar_fn::AnyScalarFn::matches(array: &dyn vortex_array::DynArray) -> bool
-
-pub fn vortex_array::arrays::scalar_fn::AnyScalarFn::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
-
-pub struct vortex_array::arrays::scalar_fn::ExactScalarFn<F: vortex_array::scalar_fn::ScalarFnVTable>(_)
-
-impl<F: core::default::Default + vortex_array::scalar_fn::ScalarFnVTable> core::default::Default for vortex_array::arrays::scalar_fn::ExactScalarFn<F>
-
-pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::default() -> vortex_array::arrays::scalar_fn::ExactScalarFn<F>
-
-impl<F: core::fmt::Debug + vortex_array::scalar_fn::ScalarFnVTable> core::fmt::Debug for vortex_array::arrays::scalar_fn::ExactScalarFn<F>
-
-pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<F: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::matcher::Matcher for vortex_array::arrays::scalar_fn::ExactScalarFn<F>
-
-pub type vortex_array::arrays::scalar_fn::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::scalar_fn::ScalarFnArrayView<'a, F>
-
-pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::matches(array: &dyn vortex_array::DynArray) -> bool
-
-pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
-
-pub struct vortex_array::arrays::scalar_fn::ScalarFnArray
-
-impl vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::children(&self) -> &[vortex_array::ArrayRef]
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::scalar_fn(&self) -> &vortex_array::scalar_fn::ScalarFnRef
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::try_new(bound: vortex_array::scalar_fn::ScalarFnRef, children: alloc::vec::Vec<vortex_array::ArrayRef>, len: usize) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::clone(&self) -> vortex_array::arrays::scalar_fn::ScalarFnArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::scalar_fn::ScalarFnArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub type vortex_array::arrays::scalar_fn::ScalarFnArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::deref(&self) -> &Self::Target
-
-impl vortex_array::IntoArray for vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child_count(&self) -> usize
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::node_dtype(&self) -> vortex_error::VortexResult<vortex_array::dtype::DType>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
-
-pub struct vortex_array::arrays::scalar_fn::ScalarFnArrayView<'a, F: vortex_array::scalar_fn::ScalarFnVTable>
-
-pub vortex_array::arrays::scalar_fn::ScalarFnArrayView::options: &'a <F as vortex_array::scalar_fn::ScalarFnVTable>::Options
-
-pub vortex_array::arrays::scalar_fn::ScalarFnArrayView::vtable: &'a F
-
-impl<F: vortex_array::scalar_fn::ScalarFnVTable> core::ops::deref::Deref for vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, F>
-
-pub type vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, F>::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, F>::deref(&self) -> &Self::Target
-
-pub struct vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-impl core::clone::Clone for vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::clone(&self) -> vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-impl core::fmt::Debug for vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Array = vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Metadata = vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata
-
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::OperationsVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::ValidityVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_eq(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, other: &vortex_array::arrays::scalar_fn::ScalarFnArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer_name(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child_name(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::dtype(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::len(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nchildren(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::stats(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::validity(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub trait vortex_array::arrays::scalar_fn::ScalarFnArrayExt: vortex_array::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArrayExt::try_new_array(&self, len: usize, options: Self::Options, children: impl core::convert::Into<alloc::vec::Vec<vortex_array::ArrayRef>>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-impl<V: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::arrays::scalar_fn::ScalarFnArrayExt for V
-
-pub fn V::try_new_array(&self, len: usize, options: Self::Options, children: impl core::convert::Into<alloc::vec::Vec<vortex_array::ArrayRef>>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub mod vortex_array::arrays::shared
-
-pub struct vortex_array::arrays::shared::SharedArray
-
-impl vortex_array::arrays::SharedArray
-
-pub fn vortex_array::arrays::SharedArray::get_or_compute(&self, f: impl core::ops::function::FnOnce(&vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::Canonical>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub async fn vortex_array::arrays::SharedArray::get_or_compute_async<F, Fut>(&self, f: F) -> vortex_error::VortexResult<vortex_array::ArrayRef> where F: core::ops::function::FnOnce(vortex_array::ArrayRef) -> Fut, Fut: core::future::future::Future<Output = vortex_error::VortexResult<vortex_array::Canonical>>
-
-pub fn vortex_array::arrays::SharedArray::new(source: vortex_array::ArrayRef) -> Self
-
-impl vortex_array::arrays::SharedArray
-
-pub fn vortex_array::arrays::SharedArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::SharedArray
-
-pub fn vortex_array::arrays::SharedArray::clone(&self) -> vortex_array::arrays::SharedArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::SharedArray
-
-pub fn vortex_array::arrays::SharedArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::SharedArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::SharedArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::SharedArray
-
-pub fn vortex_array::arrays::SharedArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::SharedArray
-
-pub type vortex_array::arrays::SharedArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::SharedArray::deref(&self) -> &Self::Target
-
-impl vortex_array::IntoArray for vortex_array::arrays::SharedArray
-
-pub fn vortex_array::arrays::SharedArray::into_array(self) -> vortex_array::ArrayRef
-
-pub struct vortex_array::arrays::shared::SharedVTable
-
-impl vortex_array::arrays::SharedVTable
-
-pub const vortex_array::arrays::SharedVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::SharedVTable
-
-pub fn vortex_array::arrays::SharedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
-
-pub fn vortex_array::arrays::SharedVTable::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::SharedVTable
-
-pub type vortex_array::arrays::SharedVTable::Array = vortex_array::arrays::SharedArray
-
-pub type vortex_array::arrays::SharedVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::SharedVTable::OperationsVTable = vortex_array::arrays::SharedVTable
-
-pub type vortex_array::arrays::SharedVTable::ValidityVTable = vortex_array::arrays::SharedVTable
-
-pub fn vortex_array::arrays::SharedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::SharedVTable::array_eq(array: &vortex_array::arrays::SharedArray, other: &vortex_array::arrays::SharedArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::SharedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SharedArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::SharedVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::SharedVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::SharedVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::SharedArray>
-
-pub fn vortex_array::arrays::SharedVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::SharedVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::SharedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::SharedVTable::dtype(array: &vortex_array::arrays::SharedArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::SharedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::SharedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::SharedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::SharedVTable::len(array: &vortex_array::arrays::SharedArray) -> usize
-
-pub fn vortex_array::arrays::SharedVTable::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::SharedVTable::nbuffers(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::SharedVTable::nchildren(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::SharedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::SharedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::SharedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::SharedVTable::stats(array: &vortex_array::arrays::SharedArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::SharedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
-
-pub fn vortex_array::arrays::SharedVTable::validity(array: &vortex_array::arrays::SharedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub mod vortex_array::arrays::slice
-
-pub struct vortex_array::arrays::slice::SliceArray
-
-impl vortex_array::arrays::slice::SliceArray
-
-pub fn vortex_array::arrays::slice::SliceArray::child(&self) -> &vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::slice::SliceArray::into_parts(self) -> vortex_array::arrays::slice::SliceArrayParts
-
-pub fn vortex_array::arrays::slice::SliceArray::new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> Self
-
-pub fn vortex_array::arrays::slice::SliceArray::slice_range(&self) -> &core::ops::range::Range<usize>
-
-pub fn vortex_array::arrays::slice::SliceArray::try_new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::arrays::slice::SliceArray
-
-pub fn vortex_array::arrays::slice::SliceArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::slice::SliceArray
-
-pub fn vortex_array::arrays::slice::SliceArray::clone(&self) -> vortex_array::arrays::slice::SliceArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::slice::SliceArray
-
-pub fn vortex_array::arrays::slice::SliceArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::slice::SliceArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::slice::SliceArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::slice::SliceArray
-
-pub fn vortex_array::arrays::slice::SliceArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::slice::SliceArray
-
-pub type vortex_array::arrays::slice::SliceArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::slice::SliceArray::deref(&self) -> &Self::Target
-
-impl vortex_array::IntoArray for vortex_array::arrays::slice::SliceArray
-
-pub fn vortex_array::arrays::slice::SliceArray::into_array(self) -> vortex_array::ArrayRef
-
-pub struct vortex_array::arrays::slice::SliceArrayParts
-
-pub vortex_array::arrays::slice::SliceArrayParts::child: vortex_array::ArrayRef
-
-pub vortex_array::arrays::slice::SliceArrayParts::range: core::ops::range::Range<usize>
-
-pub struct vortex_array::arrays::slice::SliceExecuteAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::slice::SliceExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::slice::SliceExecuteAdaptor<V>::default() -> vortex_array::arrays::slice::SliceExecuteAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::slice::SliceExecuteAdaptor<V>
-
-pub fn vortex_array::arrays::slice::SliceExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::slice::SliceExecuteAdaptor<V> where V: vortex_array::arrays::slice::SliceKernel
-
-pub type vortex_array::arrays::slice::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::slice::SliceMetadata(_)
-
-impl core::fmt::Debug for vortex_array::arrays::slice::SliceMetadata
-
-pub fn vortex_array::arrays::slice::SliceMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-pub struct vortex_array::arrays::slice::SliceReduceAdaptor<V>(pub V)
-
-impl<V: core::default::Default> core::default::Default for vortex_array::arrays::slice::SliceReduceAdaptor<V>
-
-pub fn vortex_array::arrays::slice::SliceReduceAdaptor<V>::default() -> vortex_array::arrays::slice::SliceReduceAdaptor<V>
-
-impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::slice::SliceReduceAdaptor<V>
-
-pub fn vortex_array::arrays::slice::SliceReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::slice::SliceReduceAdaptor<V> where V: vortex_array::arrays::slice::SliceReduce
-
-pub type vortex_array::arrays::slice::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::slice::SliceVTable
-
-impl vortex_array::arrays::slice::SliceVTable
-
-pub const vortex_array::arrays::slice::SliceVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::slice::SliceVTable
-
-pub type vortex_array::arrays::slice::SliceVTable::Array = vortex_array::arrays::slice::SliceArray
-
-pub type vortex_array::arrays::slice::SliceVTable::Metadata = vortex_array::arrays::slice::SliceMetadata
-
-pub type vortex_array::arrays::slice::SliceVTable::OperationsVTable = vortex_array::arrays::slice::SliceVTable
-
-pub type vortex_array::arrays::slice::SliceVTable::ValidityVTable = vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::slice::SliceVTable::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::slice::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::slice::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::slice::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::slice::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
-
-pub fn vortex_array::arrays::slice::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::slice::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::slice::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::slice::SliceVTable::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::slice::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::slice::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::slice::SliceVTable::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
-
-pub fn vortex_array::arrays::slice::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::slice::SliceVTable::nbuffers(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::slice::SliceVTable::nchildren(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::slice::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::slice::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub trait vortex_array::arrays::slice::SliceKernel: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::slice::SliceKernel::slice(array: &Self::Array, range: core::ops::range::Range<usize>, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub trait vortex_array::arrays::slice::SliceReduce: vortex_array::vtable::VTable
-
-pub fn vortex_array::arrays::slice::SliceReduce::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub mod vortex_array::arrays::struct_
-
-pub struct vortex_array::arrays::struct_::StructArray
-
-impl vortex_array::arrays::StructArray
-
-pub fn vortex_array::arrays::StructArray::from_fields<N: core::convert::AsRef<str>>(items: &[(N, vortex_array::ArrayRef)]) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::StructArray::into_fields(self) -> alloc::vec::Vec<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::StructArray::into_parts(self) -> vortex_array::arrays::struct_::StructArrayParts
-
-pub fn vortex_array::arrays::StructArray::names(&self) -> &vortex_array::dtype::FieldNames
-
-pub fn vortex_array::arrays::StructArray::new(names: vortex_array::dtype::FieldNames, fields: impl core::convert::Into<alloc::sync::Arc<[vortex_array::ArrayRef]>>, length: usize, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::StructArray::new_fieldless_with_len(len: usize) -> Self
-
-pub unsafe fn vortex_array::arrays::StructArray::new_unchecked(fields: impl core::convert::Into<alloc::sync::Arc<[vortex_array::ArrayRef]>>, dtype: vortex_array::dtype::StructFields, length: usize, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::StructArray::project(&self, projection: &[vortex_array::dtype::FieldName]) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::StructArray::remove_column(&mut self, name: impl core::convert::Into<vortex_array::dtype::FieldName>) -> core::option::Option<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::StructArray::struct_fields(&self) -> &vortex_array::dtype::StructFields
-
-pub fn vortex_array::arrays::StructArray::try_from_iter<N: core::convert::AsRef<str>, A: vortex_array::IntoArray, T: core::iter::traits::collect::IntoIterator<Item = (N, A)>>(iter: T) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::StructArray::try_from_iter_with_validity<N: core::convert::AsRef<str>, A: vortex_array::IntoArray, T: core::iter::traits::collect::IntoIterator<Item = (N, A)>>(iter: T, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::StructArray::try_new(names: vortex_array::dtype::FieldNames, fields: impl core::convert::Into<alloc::sync::Arc<[vortex_array::ArrayRef]>>, length: usize, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::StructArray::try_new_with_dtype(fields: impl core::convert::Into<alloc::sync::Arc<[vortex_array::ArrayRef]>>, dtype: vortex_array::dtype::StructFields, length: usize, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::StructArray::unmasked_field_by_name(&self, name: impl core::convert::AsRef<str>) -> vortex_error::VortexResult<&vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::StructArray::unmasked_field_by_name_opt(&self, name: impl core::convert::AsRef<str>) -> core::option::Option<&vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::StructArray::unmasked_fields(&self) -> &alloc::sync::Arc<[vortex_array::ArrayRef]>
-
-pub fn vortex_array::arrays::StructArray::validate(fields: &[vortex_array::ArrayRef], dtype: &vortex_array::dtype::StructFields, length: usize, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::StructArray::with_column(&self, name: impl core::convert::Into<vortex_array::dtype::FieldName>, array: vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::arrays::StructArray
-
-pub fn vortex_array::arrays::StructArray::into_record_batch_with_schema(self, schema: impl core::convert::AsRef<arrow_schema::schema::Schema>) -> vortex_error::VortexResult<arrow_array::record_batch::RecordBatch>
-
-impl vortex_array::arrays::StructArray
-
-pub fn vortex_array::arrays::StructArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::StructArray
-
-pub fn vortex_array::arrays::StructArray::clone(&self) -> vortex_array::arrays::StructArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::StructArray
-
-pub fn vortex_array::arrays::StructArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::StructArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::StructArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::StructArray
-
-pub fn vortex_array::arrays::StructArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::ops::deref::Deref for vortex_array::arrays::StructArray
-
-pub type vortex_array::arrays::StructArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::StructArray::deref(&self) -> &Self::Target
-
-impl vortex_array::Executable for vortex_array::arrays::StructArray
-
-pub fn vortex_array::arrays::StructArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::IntoArray for vortex_array::arrays::StructArray
-
-pub fn vortex_array::arrays::StructArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::StructArray
-
-pub fn vortex_array::arrays::StructArray::validity(&self) -> &vortex_array::validity::Validity
-
-pub struct vortex_array::arrays::struct_::StructArrayParts
-
-pub vortex_array::arrays::struct_::StructArrayParts::fields: alloc::sync::Arc<[vortex_array::ArrayRef]>
-
-pub vortex_array::arrays::struct_::StructArrayParts::struct_fields: vortex_array::dtype::StructFields
-
-pub vortex_array::arrays::struct_::StructArrayParts::validity: vortex_array::validity::Validity
-
-pub struct vortex_array::arrays::struct_::StructVTable
-
-impl vortex_array::arrays::StructVTable
-
-pub const vortex_array::arrays::StructVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::is_constant(&self, array: &vortex_array::arrays::StructArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::min_max(&self, _array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::cast(array: &vortex_array::arrays::StructArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::mask(array: &vortex_array::arrays::StructArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::scalar_at(array: &vortex_array::arrays::StructArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::StructVTable
-
-pub type vortex_array::arrays::StructVTable::Array = vortex_array::arrays::StructArray
-
-pub type vortex_array::arrays::StructVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::StructVTable::OperationsVTable = vortex_array::arrays::StructVTable
-
-pub type vortex_array::arrays::StructVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::StructVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::StructVTable::array_eq(array: &vortex_array::arrays::StructArray, other: &vortex_array::arrays::StructArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::StructVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::StructArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::StructVTable::buffer(_array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::StructVTable::buffer_name(_array: &vortex_array::arrays::StructArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::StructVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::StructArray>
-
-pub fn vortex_array::arrays::StructVTable::child(array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::StructVTable::child_name(array: &vortex_array::arrays::StructArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::StructVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::StructVTable::dtype(array: &vortex_array::arrays::StructArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::StructVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::StructVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::StructVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::StructVTable::len(array: &vortex_array::arrays::StructArray) -> usize
-
-pub fn vortex_array::arrays::StructVTable::metadata(_array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::StructVTable::nbuffers(_array: &vortex_array::arrays::StructArray) -> usize
-
-pub fn vortex_array::arrays::StructVTable::nchildren(array: &vortex_array::arrays::StructArray) -> usize
-
-pub fn vortex_array::arrays::StructVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::StructVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::StructVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::StructVTable::stats(array: &vortex_array::arrays::StructArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::StructVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-pub mod vortex_array::arrays::varbin
-
-pub mod vortex_array::arrays::varbin::builder
-
-pub struct vortex_array::arrays::varbin::builder::VarBinBuilder<O: vortex_array::dtype::IntegerPType>
-
-impl<O: vortex_array::dtype::IntegerPType> vortex_array::arrays::varbin::builder::VarBinBuilder<O>
-
-pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::append(&mut self, value: core::option::Option<&[u8]>)
-
-pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::append_n_nulls(&mut self, n: usize)
-
-pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::append_null(&mut self)
-
-pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::append_value(&mut self, value: impl core::convert::AsRef<[u8]>)
-
-pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::append_values(&mut self, values: &[u8], end_offsets: impl core::iter::traits::iterator::Iterator<Item = O>, num: usize) where O: 'static, usize: num_traits::cast::AsPrimitive<O>
-
-pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::finish(self, dtype: vortex_array::dtype::DType) -> vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::new() -> Self
-
-pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::with_capacity(len: usize) -> Self
-
-impl<O: vortex_array::dtype::IntegerPType> core::default::Default for vortex_array::arrays::varbin::builder::VarBinBuilder<O>
-
-pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::default() -> Self
-
-pub struct vortex_array::arrays::varbin::VarBinArray
-
-impl vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::bytes(&self) -> &vortex_buffer::ByteBuffer
-
-pub fn vortex_array::arrays::VarBinArray::bytes_at(&self, index: usize) -> vortex_buffer::ByteBuffer
-
-pub fn vortex_array::arrays::VarBinArray::bytes_handle(&self) -> &vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I, dtype: vortex_array::dtype::DType) -> Self
-
-pub fn vortex_array::arrays::VarBinArray::from_iter_nonnull<T: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I, dtype: vortex_array::dtype::DType) -> Self
-
-pub fn vortex_array::arrays::VarBinArray::from_vec<T: core::convert::AsRef<[u8]>>(vec: alloc::vec::Vec<T>, dtype: vortex_array::dtype::DType) -> Self
-
-pub fn vortex_array::arrays::VarBinArray::into_parts(self) -> (vortex_array::dtype::DType, vortex_array::buffer::BufferHandle, vortex_array::ArrayRef, vortex_array::validity::Validity)
-
-pub fn vortex_array::arrays::VarBinArray::new(offsets: vortex_array::ArrayRef, bytes: vortex_buffer::ByteBuffer, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::VarBinArray::new_from_handle(offset: vortex_array::ArrayRef, bytes: vortex_array::buffer::BufferHandle, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
-
-pub unsafe fn vortex_array::arrays::VarBinArray::new_unchecked(offsets: vortex_array::ArrayRef, bytes: vortex_buffer::ByteBuffer, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
-
-pub unsafe fn vortex_array::arrays::VarBinArray::new_unchecked_from_handle(offsets: vortex_array::ArrayRef, bytes: vortex_array::buffer::BufferHandle, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::VarBinArray::offset_at(&self, index: usize) -> usize
-
-pub fn vortex_array::arrays::VarBinArray::offsets(&self) -> &vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::VarBinArray::sliced_bytes(&self) -> vortex_buffer::ByteBuffer
-
-pub fn vortex_array::arrays::VarBinArray::try_new(offsets: vortex_array::ArrayRef, bytes: vortex_buffer::ByteBuffer, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::VarBinArray::try_new_from_handle(offsets: vortex_array::ArrayRef, bytes: vortex_array::buffer::BufferHandle, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::VarBinArray::validate(offsets: &vortex_array::ArrayRef, bytes: &vortex_array::buffer::BufferHandle, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
-
-impl vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::clone(&self) -> vortex_array::arrays::VarBinArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<alloc::vec::Vec<&[u8]>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<&[u8]>) -> Self
-
-impl core::convert::From<alloc::vec::Vec<&str>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<&str>) -> Self
-
-impl core::convert::From<alloc::vec::Vec<alloc::string::String>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<alloc::string::String>) -> Self
-
-impl core::convert::From<alloc::vec::Vec<alloc::vec::Vec<u8>>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<alloc::vec::Vec<u8>>) -> Self
-
-impl core::convert::From<alloc::vec::Vec<core::option::Option<&[u8]>>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<core::option::Option<&[u8]>>) -> Self
-
-impl core::convert::From<alloc::vec::Vec<core::option::Option<&str>>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<core::option::Option<&str>>) -> Self
-
-impl core::convert::From<alloc::vec::Vec<core::option::Option<alloc::string::String>>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<core::option::Option<alloc::string::String>>) -> Self
-
-impl core::convert::From<alloc::vec::Vec<core::option::Option<alloc::vec::Vec<u8>>>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from(value: alloc::vec::Vec<core::option::Option<alloc::vec::Vec<u8>>>) -> Self
-
-impl core::convert::From<vortex_array::arrays::VarBinArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::VarBinArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::iter::traits::collect::FromIterator<core::option::Option<alloc::string::String>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<alloc::string::String>>>(iter: T) -> Self
-
-impl core::iter::traits::collect::FromIterator<core::option::Option<alloc::vec::Vec<u8>>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<alloc::vec::Vec<u8>>>>(iter: T) -> Self
-
-impl core::ops::deref::Deref for vortex_array::arrays::VarBinArray
-
-pub type vortex_array::arrays::VarBinArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::VarBinArray::deref(&self) -> &Self::Target
-
-impl vortex_array::IntoArray for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::accessor::ArrayAccessor<[u8]> for &vortex_array::arrays::VarBinArray
-
-pub fn &vortex_array::arrays::VarBinArray::with_iterator<F, R>(&self, f: F) -> R where F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a [u8]>>) -> R
-
-impl vortex_array::accessor::ArrayAccessor<[u8]> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::with_iterator<F, R>(&self, f: F) -> R where F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a [u8]>>) -> R
-
-impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::validity(&self) -> &vortex_array::validity::Validity
-
-impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a [u8]>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a [u8]>>>(iter: T) -> Self
-
-impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a str>> for vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a str>>>(iter: T) -> Self
-
-pub struct vortex_array::arrays::varbin::VarBinVTable
-
-impl vortex_array::arrays::VarBinVTable
-
-pub const vortex_array::arrays::VarBinVTable::ID: vortex_array::vtable::ArrayId
-
-impl vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::_slice(array: &vortex_array::arrays::VarBinArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-impl core::fmt::Debug for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::is_constant(&self, array: &vortex_array::arrays::VarBinArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::VarBinVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::min_max(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::cast(array: &vortex_array::arrays::VarBinArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::mask(array: &vortex_array::arrays::VarBinArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinVTable> for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinVTable
-
-pub type vortex_array::arrays::VarBinVTable::Array = vortex_array::arrays::VarBinArray
-
-pub type vortex_array::arrays::VarBinVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::varbin::vtable::VarBinMetadata>
-
-pub type vortex_array::arrays::VarBinVTable::OperationsVTable = vortex_array::arrays::VarBinVTable
-
-pub type vortex_array::arrays::VarBinVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::VarBinVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::VarBinVTable::array_eq(array: &vortex_array::arrays::VarBinArray, other: &vortex_array::arrays::VarBinArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::VarBinVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::VarBinVTable::buffer(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::VarBinVTable::buffer_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::VarBinVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinArray>
-
-pub fn vortex_array::arrays::VarBinVTable::child(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::VarBinVTable::child_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::VarBinVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::VarBinVTable::dtype(array: &vortex_array::arrays::VarBinArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::VarBinVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::VarBinVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::VarBinVTable::len(array: &vortex_array::arrays::VarBinArray) -> usize
-
-pub fn vortex_array::arrays::VarBinVTable::metadata(array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::VarBinVTable::nbuffers(_array: &vortex_array::arrays::VarBinArray) -> usize
-
-pub fn vortex_array::arrays::VarBinVTable::nchildren(array: &vortex_array::arrays::VarBinArray) -> usize
-
-pub fn vortex_array::arrays::VarBinVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::VarBinVTable::stats(array: &vortex_array::arrays::VarBinArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::VarBinVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::varbin::varbin_scalar(value: vortex_buffer::ByteBuffer, dtype: &vortex_array::dtype::DType) -> vortex_array::scalar::Scalar
-
-pub mod vortex_array::arrays::varbinview
-
-pub mod vortex_array::arrays::varbinview::build_views
-
-#[repr(C, align(16))] pub union vortex_array::arrays::varbinview::build_views::BinaryView
-
-impl vortex_array::arrays::varbinview::BinaryView
-
-pub const vortex_array::arrays::varbinview::BinaryView::MAX_INLINED_SIZE: usize
-
-pub fn vortex_array::arrays::varbinview::BinaryView::as_inlined(&self) -> &vortex_array::arrays::varbinview::Inlined
-
-pub fn vortex_array::arrays::varbinview::BinaryView::as_u128(&self) -> u128
-
-pub fn vortex_array::arrays::varbinview::BinaryView::as_view(&self) -> &vortex_array::arrays::varbinview::Ref
-
-pub fn vortex_array::arrays::varbinview::BinaryView::as_view_mut(&mut self) -> &mut vortex_array::arrays::varbinview::Ref
-
-pub fn vortex_array::arrays::varbinview::BinaryView::empty_view() -> Self
-
-pub fn vortex_array::arrays::varbinview::BinaryView::is_empty(&self) -> bool
-
-pub fn vortex_array::arrays::varbinview::BinaryView::is_inlined(&self) -> bool
-
-pub fn vortex_array::arrays::varbinview::BinaryView::len(&self) -> u32
-
-pub fn vortex_array::arrays::varbinview::BinaryView::make_view(value: &[u8], block: u32, offset: u32) -> Self
-
-pub fn vortex_array::arrays::varbinview::BinaryView::new_inlined(value: &[u8]) -> Self
-
-impl core::clone::Clone for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::clone(&self) -> vortex_array::arrays::varbinview::BinaryView
-
-impl core::cmp::Eq for vortex_array::arrays::varbinview::BinaryView
-
-impl core::cmp::PartialEq for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::eq(&self, other: &Self) -> bool
-
-impl core::convert::From<u128> for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::from(value: u128) -> Self
-
-impl core::convert::From<vortex_array::arrays::varbinview::Ref> for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::from(value: vortex_array::arrays::varbinview::Ref) -> Self
-
-impl core::default::Default for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::default() -> Self
-
-impl core::fmt::Debug for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::hash::Hash for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::marker::Copy for vortex_array::arrays::varbinview::BinaryView
-
-pub const vortex_array::arrays::varbinview::build_views::MAX_BUFFER_LEN: usize
-
-pub fn vortex_array::arrays::varbinview::build_views::build_views<P: vortex_array::dtype::NativePType + num_traits::cast::AsPrimitive<usize>>(start_buf_index: u32, max_buffer_len: usize, bytes: vortex_buffer::ByteBufferMut, lens: &[P]) -> (alloc::vec::Vec<vortex_buffer::ByteBuffer>, vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>)
-
-pub fn vortex_array::arrays::varbinview::build_views::offsets_to_lengths<P: vortex_array::dtype::NativePType>(offsets: &[P]) -> vortex_buffer::buffer::Buffer<P>
-
-#[repr(C, align(16))] pub union vortex_array::arrays::varbinview::BinaryView
-
-impl vortex_array::arrays::varbinview::BinaryView
-
-pub const vortex_array::arrays::varbinview::BinaryView::MAX_INLINED_SIZE: usize
-
-pub fn vortex_array::arrays::varbinview::BinaryView::as_inlined(&self) -> &vortex_array::arrays::varbinview::Inlined
-
-pub fn vortex_array::arrays::varbinview::BinaryView::as_u128(&self) -> u128
-
-pub fn vortex_array::arrays::varbinview::BinaryView::as_view(&self) -> &vortex_array::arrays::varbinview::Ref
-
-pub fn vortex_array::arrays::varbinview::BinaryView::as_view_mut(&mut self) -> &mut vortex_array::arrays::varbinview::Ref
-
-pub fn vortex_array::arrays::varbinview::BinaryView::empty_view() -> Self
-
-pub fn vortex_array::arrays::varbinview::BinaryView::is_empty(&self) -> bool
-
-pub fn vortex_array::arrays::varbinview::BinaryView::is_inlined(&self) -> bool
-
-pub fn vortex_array::arrays::varbinview::BinaryView::len(&self) -> u32
-
-pub fn vortex_array::arrays::varbinview::BinaryView::make_view(value: &[u8], block: u32, offset: u32) -> Self
-
-pub fn vortex_array::arrays::varbinview::BinaryView::new_inlined(value: &[u8]) -> Self
-
-impl core::clone::Clone for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::clone(&self) -> vortex_array::arrays::varbinview::BinaryView
-
-impl core::cmp::Eq for vortex_array::arrays::varbinview::BinaryView
-
-impl core::cmp::PartialEq for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::eq(&self, other: &Self) -> bool
-
-impl core::convert::From<u128> for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::from(value: u128) -> Self
-
-impl core::convert::From<vortex_array::arrays::varbinview::Ref> for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::from(value: vortex_array::arrays::varbinview::Ref) -> Self
-
-impl core::default::Default for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::default() -> Self
-
-impl core::fmt::Debug for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::hash::Hash for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::hash<H: core::hash::Hasher>(&self, state: &mut H)
-
-impl core::marker::Copy for vortex_array::arrays::varbinview::BinaryView
-
-#[repr(C, align(8))] pub struct vortex_array::arrays::varbinview::Inlined
-
-pub vortex_array::arrays::varbinview::Inlined::data: [u8; 12]
-
-pub vortex_array::arrays::varbinview::Inlined::size: u32
-
-impl vortex_array::arrays::varbinview::Inlined
-
-pub fn vortex_array::arrays::varbinview::Inlined::value(&self) -> &[u8]
-
-impl core::clone::Clone for vortex_array::arrays::varbinview::Inlined
-
-pub fn vortex_array::arrays::varbinview::Inlined::clone(&self) -> vortex_array::arrays::varbinview::Inlined
-
-impl core::cmp::Eq for vortex_array::arrays::varbinview::Inlined
-
-impl core::cmp::PartialEq for vortex_array::arrays::varbinview::Inlined
-
-pub fn vortex_array::arrays::varbinview::Inlined::eq(&self, other: &vortex_array::arrays::varbinview::Inlined) -> bool
-
-impl core::fmt::Debug for vortex_array::arrays::varbinview::Inlined
-
-pub fn vortex_array::arrays::varbinview::Inlined::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::marker::Copy for vortex_array::arrays::varbinview::Inlined
-
-impl core::marker::StructuralPartialEq for vortex_array::arrays::varbinview::Inlined
-
-#[repr(C, align(8))] pub struct vortex_array::arrays::varbinview::Ref
-
-pub vortex_array::arrays::varbinview::Ref::buffer_index: u32
-
-pub vortex_array::arrays::varbinview::Ref::offset: u32
-
-pub vortex_array::arrays::varbinview::Ref::prefix: [u8; 4]
-
-pub vortex_array::arrays::varbinview::Ref::size: u32
-
-impl vortex_array::arrays::varbinview::Ref
-
-pub fn vortex_array::arrays::varbinview::Ref::as_range(&self) -> core::ops::range::Range<usize>
-
-pub fn vortex_array::arrays::varbinview::Ref::with_buffer_and_offset(&self, buffer_index: u32, offset: u32) -> vortex_array::arrays::varbinview::Ref
-
-impl core::clone::Clone for vortex_array::arrays::varbinview::Ref
-
-pub fn vortex_array::arrays::varbinview::Ref::clone(&self) -> vortex_array::arrays::varbinview::Ref
-
-impl core::convert::From<vortex_array::arrays::varbinview::Ref> for vortex_array::arrays::varbinview::BinaryView
-
-pub fn vortex_array::arrays::varbinview::BinaryView::from(value: vortex_array::arrays::varbinview::Ref) -> Self
-
-impl core::fmt::Debug for vortex_array::arrays::varbinview::Ref
-
-pub fn vortex_array::arrays::varbinview::Ref::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::marker::Copy for vortex_array::arrays::varbinview::Ref
-
-pub struct vortex_array::arrays::varbinview::VarBinViewArray
-
-impl vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::buffer(&self, idx: usize) -> &vortex_buffer::ByteBuffer
-
-pub fn vortex_array::arrays::VarBinViewArray::buffers(&self) -> &alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>
-
-pub fn vortex_array::arrays::VarBinViewArray::bytes_at(&self, index: usize) -> vortex_buffer::ByteBuffer
-
-pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I, dtype: vortex_array::dtype::DType) -> Self
-
-pub fn vortex_array::arrays::VarBinViewArray::from_iter_bin<T: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self
-
-pub fn vortex_array::arrays::VarBinViewArray::from_iter_nullable_bin<T: core::convert::AsRef<[u8]>, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I) -> Self
-
-pub fn vortex_array::arrays::VarBinViewArray::from_iter_nullable_str<T: core::convert::AsRef<str>, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I) -> Self
-
-pub fn vortex_array::arrays::VarBinViewArray::from_iter_str<T: core::convert::AsRef<str>, I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self
-
-pub fn vortex_array::arrays::VarBinViewArray::into_parts(self) -> vortex_array::arrays::varbinview::VarBinViewArrayParts
-
-pub fn vortex_array::arrays::VarBinViewArray::nbuffers(&self) -> usize
-
-pub fn vortex_array::arrays::VarBinViewArray::new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::VarBinViewArray::new_handle(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
-
-pub unsafe fn vortex_array::arrays::VarBinViewArray::new_handle_unchecked(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
-
-pub unsafe fn vortex_array::arrays::VarBinViewArray::new_unchecked(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::VarBinViewArray::try_new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::VarBinViewArray::try_new_handle(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
-
-pub fn vortex_array::arrays::VarBinViewArray::validate(views: &vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: &alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::VarBinViewArray::views(&self) -> &[vortex_array::arrays::varbinview::BinaryView]
-
-pub fn vortex_array::arrays::VarBinViewArray::views_handle(&self) -> &vortex_array::buffer::BufferHandle
-
-impl vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::compact_buffers(&self) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
-
-pub fn vortex_array::arrays::VarBinViewArray::compact_with_threshold(&self, buffer_utilization_threshold: f64) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
-
-impl vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl core::clone::Clone for vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::clone(&self) -> vortex_array::arrays::VarBinViewArray
-
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::as_ref(&self) -> &dyn vortex_array::DynArray
-
-impl core::convert::From<vortex_array::arrays::VarBinViewArray> for vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::VarBinViewArray) -> vortex_array::ArrayRef
-
-impl core::fmt::Debug for vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::iter::traits::collect::FromIterator<core::option::Option<alloc::string::String>> for vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<alloc::string::String>>>(iter: T) -> Self
-
-impl core::iter::traits::collect::FromIterator<core::option::Option<alloc::vec::Vec<u8>>> for vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<alloc::vec::Vec<u8>>>>(iter: T) -> Self
-
-impl core::ops::deref::Deref for vortex_array::arrays::VarBinViewArray
-
-pub type vortex_array::arrays::VarBinViewArray::Target = dyn vortex_array::DynArray
-
-pub fn vortex_array::arrays::VarBinViewArray::deref(&self) -> &Self::Target
-
-impl vortex_array::Executable for vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::IntoArray for vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::accessor::ArrayAccessor<[u8]> for &vortex_array::arrays::VarBinViewArray
-
-pub fn &vortex_array::arrays::VarBinViewArray::with_iterator<F, R>(&self, f: F) -> R where F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a [u8]>>) -> R
-
-impl vortex_array::accessor::ArrayAccessor<[u8]> for vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::with_iterator<F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a [u8]>>) -> R, R>(&self, f: F) -> R
-
-impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::validity(&self) -> &vortex_array::validity::Validity
-
-impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a [u8]>> for vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a [u8]>>>(iter: T) -> Self
-
-impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a str>> for vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a str>>>(iter: T) -> Self
-
-pub struct vortex_array::arrays::varbinview::VarBinViewArrayParts
-
-pub vortex_array::arrays::varbinview::VarBinViewArrayParts::buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>
-
-pub vortex_array::arrays::varbinview::VarBinViewArrayParts::dtype: vortex_array::dtype::DType
-
-pub vortex_array::arrays::varbinview::VarBinViewArrayParts::validity: vortex_array::validity::Validity
-
-pub vortex_array::arrays::varbinview::VarBinViewArrayParts::views: vortex_array::buffer::BufferHandle
-
-pub struct vortex_array::arrays::varbinview::VarBinViewVTable
-
-impl vortex_array::arrays::VarBinViewVTable
-
-pub const vortex_array::arrays::VarBinViewVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::is_constant(&self, array: &vortex_array::arrays::VarBinViewArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::VarBinViewVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::min_max(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::cast(array: &vortex_array::arrays::VarBinViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::mask(array: &vortex_array::arrays::VarBinViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinViewVTable> for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinViewVTable
-
-pub type vortex_array::arrays::VarBinViewVTable::Array = vortex_array::arrays::VarBinViewArray
-
-pub type vortex_array::arrays::VarBinViewVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::VarBinViewVTable::OperationsVTable = vortex_array::arrays::VarBinViewVTable
-
-pub type vortex_array::arrays::VarBinViewVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::VarBinViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::VarBinViewVTable::array_eq(array: &vortex_array::arrays::VarBinViewArray, other: &vortex_array::arrays::VarBinViewArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::VarBinViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinViewArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::VarBinViewVTable::buffer(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::VarBinViewVTable::buffer_name(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::VarBinViewVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
-
-pub fn vortex_array::arrays::VarBinViewVTable::child(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::VarBinViewVTable::child_name(_array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::VarBinViewVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::VarBinViewVTable::dtype(array: &vortex_array::arrays::VarBinViewArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::VarBinViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::VarBinViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinViewVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::VarBinViewVTable::len(array: &vortex_array::arrays::VarBinViewArray) -> usize
-
-pub fn vortex_array::arrays::VarBinViewVTable::metadata(_array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::VarBinViewVTable::nbuffers(array: &vortex_array::arrays::VarBinViewArray) -> usize
-
-pub fn vortex_array::arrays::VarBinViewVTable::nchildren(array: &vortex_array::arrays::VarBinViewArray) -> usize
-
-pub fn vortex_array::arrays::VarBinViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinViewVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::VarBinViewVTable::stats(array: &vortex_array::arrays::VarBinViewArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::VarBinViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 pub struct vortex_array::arrays::BoolArray
 
@@ -4602,7 +708,7 @@ pub fn vortex_array::arrays::BoolArray::from_indices<I: core::iter::traits::coll
 
 pub fn vortex_array::arrays::BoolArray::into_bit_buffer(self) -> vortex_buffer::bit::buf::BitBuffer
 
-pub fn vortex_array::arrays::BoolArray::into_parts(self) -> vortex_array::arrays::bool::BoolArrayParts
+pub fn vortex_array::arrays::BoolArray::into_parts(self) -> vortex_array::arrays::BoolArrayParts
 
 pub fn vortex_array::arrays::BoolArray::maybe_to_mask(&self) -> vortex_error::VortexResult<core::option::Option<vortex_mask::Mask>>
 
@@ -4677,6 +783,32 @@ pub fn vortex_array::arrays::BoolArray::into_array(self) -> vortex_array::ArrayR
 impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::BoolArray
 
 pub fn vortex_array::arrays::BoolArray::validity(&self) -> &vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::BoolArrayParts
+
+pub vortex_array::arrays::BoolArrayParts::bits: vortex_array::buffer::BufferHandle
+
+pub vortex_array::arrays::BoolArrayParts::len: usize
+
+pub vortex_array::arrays::BoolArrayParts::offset: usize
+
+pub vortex_array::arrays::BoolArrayParts::validity: vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::BoolMaskedValidityRule
+
+impl core::default::Default for vortex_array::arrays::BoolMaskedValidityRule
+
+pub fn vortex_array::arrays::BoolMaskedValidityRule::default() -> vortex_array::arrays::BoolMaskedValidityRule
+
+impl core::fmt::Debug for vortex_array::arrays::BoolMaskedValidityRule
+
+pub fn vortex_array::arrays::BoolMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolMaskedValidityRule
+
+pub type vortex_array::arrays::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::arrays::BoolVTable
 
@@ -4688,17 +820,17 @@ impl core::fmt::Debug for vortex_array::arrays::BoolVTable
 
 pub fn vortex_array::arrays::BoolVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::BoolVTable
 
 pub fn vortex_array::arrays::BoolVTable::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::BoolVTable
 
 pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::BoolVTable
 
@@ -4718,11 +850,11 @@ impl vortex_array::compute::SumKernel for vortex_array::arrays::BoolVTable
 
 pub fn vortex_array::arrays::BoolVTable::sum(&self, array: &vortex_array::arrays::BoolArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolMaskedValidityRule
 
-pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::BoolVTable
 
@@ -4770,7 +902,7 @@ pub fn vortex_array::arrays::BoolVTable::deserialize(bytes: &[u8], _dtype: &vort
 
 pub fn vortex_array::arrays::BoolVTable::dtype(array: &vortex_array::arrays::BoolArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::BoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::BoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::BoolVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -4864,17 +996,17 @@ impl core::fmt::Debug for vortex_array::arrays::ChunkedVTable
 
 pub fn vortex_array::arrays::ChunkedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::FilterKernel for vortex_array::arrays::ChunkedVTable
 
 pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::SliceKernel for vortex_array::arrays::ChunkedVTable
 
 pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ChunkedVTable
 
@@ -4944,7 +1076,7 @@ pub fn vortex_array::arrays::ChunkedVTable::deserialize(_bytes: &[u8], _dtype: &
 
 pub fn vortex_array::arrays::ChunkedVTable::dtype(array: &vortex_array::arrays::ChunkedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ChunkedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::ChunkedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::ChunkedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -5026,17 +1158,17 @@ impl core::fmt::Debug for vortex_array::arrays::ConstantVTable
 
 pub fn vortex_array::arrays::ConstantVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::ConstantVTable
 
 pub fn vortex_array::arrays::ConstantVTable::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ConstantVTable
 
 pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ConstantVTable
 
@@ -5096,7 +1228,7 @@ pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &
 
 pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ConstantVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::ConstantVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::ConstantVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -5138,7 +1270,7 @@ pub fn vortex_array::arrays::DecimalArray::from_iter<T: vortex_array::dtype::Nat
 
 pub fn vortex_array::arrays::DecimalArray::from_option_iter<T: vortex_array::dtype::NativeDecimalType, I: core::iter::traits::collect::IntoIterator<Item = core::option::Option<T>>>(iter: I, decimal_dtype: vortex_array::dtype::DecimalDType) -> Self
 
-pub fn vortex_array::arrays::DecimalArray::into_parts(self) -> vortex_array::arrays::decimal::DecimalArrayParts
+pub fn vortex_array::arrays::DecimalArray::into_parts(self) -> vortex_array::arrays::DecimalArrayParts
 
 pub fn vortex_array::arrays::DecimalArray::new<T: vortex_array::dtype::NativeDecimalType>(buffer: vortex_buffer::buffer::Buffer<T>, decimal_dtype: vortex_array::dtype::DecimalDType, validity: vortex_array::validity::Validity) -> Self
 
@@ -5200,6 +1332,32 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::DecimalArray
 
 pub fn vortex_array::arrays::DecimalArray::validity(&self) -> &vortex_array::validity::Validity
 
+pub struct vortex_array::arrays::DecimalArrayParts
+
+pub vortex_array::arrays::DecimalArrayParts::decimal_dtype: vortex_array::dtype::DecimalDType
+
+pub vortex_array::arrays::DecimalArrayParts::validity: vortex_array::validity::Validity
+
+pub vortex_array::arrays::DecimalArrayParts::values: vortex_array::buffer::BufferHandle
+
+pub vortex_array::arrays::DecimalArrayParts::values_type: vortex_array::dtype::DecimalType
+
+pub struct vortex_array::arrays::DecimalMaskedValidityRule
+
+impl core::default::Default for vortex_array::arrays::DecimalMaskedValidityRule
+
+pub fn vortex_array::arrays::DecimalMaskedValidityRule::default() -> vortex_array::arrays::DecimalMaskedValidityRule
+
+impl core::fmt::Debug for vortex_array::arrays::DecimalMaskedValidityRule
+
+pub fn vortex_array::arrays::DecimalMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalMaskedValidityRule
+
+pub type vortex_array::arrays::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub struct vortex_array::arrays::DecimalVTable
 
 impl vortex_array::arrays::DecimalVTable
@@ -5210,13 +1368,13 @@ impl core::fmt::Debug for vortex_array::arrays::DecimalVTable
 
 pub fn vortex_array::arrays::DecimalVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::DecimalVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::DecimalVTable
 
 pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DecimalVTable
 
@@ -5236,11 +1394,11 @@ impl vortex_array::compute::SumKernel for vortex_array::arrays::DecimalVTable
 
 pub fn vortex_array::arrays::DecimalVTable::sum(&self, array: &vortex_array::arrays::DecimalArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalMaskedValidityRule
 
-pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::DecimalVTable
 
@@ -5292,7 +1450,7 @@ pub fn vortex_array::arrays::DecimalVTable::deserialize(bytes: &[u8], _dtype: &v
 
 pub fn vortex_array::arrays::DecimalVTable::dtype(array: &vortex_array::arrays::DecimalArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::DecimalVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::DecimalVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::DecimalVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -5318,179 +1476,235 @@ pub fn vortex_array::arrays::DecimalVTable::with_children(array: &mut Self::Arra
 
 pub struct vortex_array::arrays::DictArray
 
-impl vortex_array::arrays::dict::DictArray
+impl vortex_array::arrays::DictArray
 
-pub fn vortex_array::arrays::dict::DictArray::codes(&self) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::DictArray::codes(&self) -> &vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::dict::DictArray::compute_referenced_values_mask(&self, referenced: bool) -> vortex_error::VortexResult<vortex_buffer::bit::buf::BitBuffer>
+pub fn vortex_array::arrays::DictArray::compute_referenced_values_mask(&self, referenced: bool) -> vortex_error::VortexResult<vortex_buffer::bit::buf::BitBuffer>
 
-pub fn vortex_array::arrays::dict::DictArray::has_all_values_referenced(&self) -> bool
+pub fn vortex_array::arrays::DictArray::has_all_values_referenced(&self) -> bool
 
-pub fn vortex_array::arrays::dict::DictArray::into_parts(self) -> vortex_array::arrays::dict::DictArrayParts
+pub fn vortex_array::arrays::DictArray::into_parts(self) -> vortex_array::arrays::DictArrayParts
 
-pub fn vortex_array::arrays::dict::DictArray::new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
+pub fn vortex_array::arrays::DictArray::new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
 
-pub unsafe fn vortex_array::arrays::dict::DictArray::new_unchecked(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
+pub unsafe fn vortex_array::arrays::DictArray::new_unchecked(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> Self
 
-pub unsafe fn vortex_array::arrays::dict::DictArray::set_all_values_referenced(self, all_values_referenced: bool) -> Self
+pub unsafe fn vortex_array::arrays::DictArray::set_all_values_referenced(self, all_values_referenced: bool) -> Self
 
-pub fn vortex_array::arrays::dict::DictArray::try_new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::DictArray::try_new(codes: vortex_array::ArrayRef, values: vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrays::dict::DictArray::validate_all_values_referenced(&self) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::DictArray::validate_all_values_referenced(&self) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::dict::DictArray::values(&self) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::DictArray::values(&self) -> &vortex_array::ArrayRef
 
-impl vortex_array::arrays::dict::DictArray
+impl vortex_array::arrays::DictArray
 
-pub fn vortex_array::arrays::dict::DictArray::to_array(&self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::DictArray::to_array(&self) -> vortex_array::ArrayRef
 
-impl core::clone::Clone for vortex_array::arrays::dict::DictArray
+impl core::clone::Clone for vortex_array::arrays::DictArray
 
-pub fn vortex_array::arrays::dict::DictArray::clone(&self) -> vortex_array::arrays::dict::DictArray
+pub fn vortex_array::arrays::DictArray::clone(&self) -> vortex_array::arrays::DictArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::dict::DictArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::DictArray
 
-pub fn vortex_array::arrays::dict::DictArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::DictArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::convert::From<vortex_array::arrays::dict::DictArray> for vortex_array::ArrayRef
+impl core::convert::From<vortex_array::arrays::DictArray> for vortex_array::ArrayRef
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::dict::DictArray) -> vortex_array::ArrayRef
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::DictArray) -> vortex_array::ArrayRef
 
-impl core::fmt::Debug for vortex_array::arrays::dict::DictArray
+impl core::fmt::Debug for vortex_array::arrays::DictArray
 
-pub fn vortex_array::arrays::dict::DictArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::DictArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl core::ops::deref::Deref for vortex_array::arrays::dict::DictArray
+impl core::ops::deref::Deref for vortex_array::arrays::DictArray
 
-pub type vortex_array::arrays::dict::DictArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::DictArray::Target = dyn vortex_array::DynArray
 
-pub fn vortex_array::arrays::dict::DictArray::deref(&self) -> &Self::Target
+pub fn vortex_array::arrays::DictArray::deref(&self) -> &Self::Target
 
-impl vortex_array::IntoArray for vortex_array::arrays::dict::DictArray
+impl vortex_array::IntoArray for vortex_array::arrays::DictArray
 
-pub fn vortex_array::arrays::dict::DictArray::into_array(self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::DictArray::into_array(self) -> vortex_array::ArrayRef
 
-impl<K: arrow_array::types::ArrowDictionaryKeyType> vortex_array::arrow::FromArrowArray<&arrow_array::array::dictionary_array::DictionaryArray<K>> for vortex_array::arrays::dict::DictArray
+impl<K: arrow_array::types::ArrowDictionaryKeyType> vortex_array::arrow::FromArrowArray<&arrow_array::array::dictionary_array::DictionaryArray<K>> for vortex_array::arrays::DictArray
 
-pub fn vortex_array::arrays::dict::DictArray::from_arrow(array: &arrow_array::array::dictionary_array::DictionaryArray<K>, nullable: bool) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::DictArray::from_arrow(array: &arrow_array::array::dictionary_array::DictionaryArray<K>, nullable: bool) -> vortex_error::VortexResult<Self>
+
+pub struct vortex_array::arrays::DictArrayParts
+
+pub vortex_array::arrays::DictArrayParts::codes: vortex_array::ArrayRef
+
+pub vortex_array::arrays::DictArrayParts::dtype: vortex_array::dtype::DType
+
+pub vortex_array::arrays::DictArrayParts::values: vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::DictMetadata
+
+impl vortex_array::arrays::DictMetadata
+
+pub fn vortex_array::arrays::DictMetadata::all_values_referenced(&self) -> bool
+
+pub fn vortex_array::arrays::DictMetadata::codes_ptype(&self) -> vortex_array::dtype::PType
+
+pub fn vortex_array::arrays::DictMetadata::is_nullable_codes(&self) -> bool
+
+pub fn vortex_array::arrays::DictMetadata::set_codes_ptype(&mut self, value: vortex_array::dtype::PType)
+
+impl core::clone::Clone for vortex_array::arrays::DictMetadata
+
+pub fn vortex_array::arrays::DictMetadata::clone(&self) -> vortex_array::arrays::DictMetadata
+
+impl core::default::Default for vortex_array::arrays::DictMetadata
+
+pub fn vortex_array::arrays::DictMetadata::default() -> Self
+
+impl core::fmt::Debug for vortex_array::arrays::DictMetadata
+
+pub fn vortex_array::arrays::DictMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl prost::message::Message for vortex_array::arrays::DictMetadata
+
+pub fn vortex_array::arrays::DictMetadata::clear(&mut self)
+
+pub fn vortex_array::arrays::DictMetadata::encoded_len(&self) -> usize
 
 pub struct vortex_array::arrays::DictVTable
 
-impl vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::DictVTable
 
-pub const vortex_array::arrays::dict::DictVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::DictVTable::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::dict::DictVTable
+impl core::fmt::Debug for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::filter(array: &vortex_array::arrays::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::DictVTable::is_constant(&self, array: &vortex_array::arrays::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::DictVTable::is_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::DictVTable::min_max(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::cast(array: &vortex_array::arrays::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::fill_null(array: &vortex_array::arrays::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::mask(array: &vortex_array::arrays::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::DictVTable::scalar_at(array: &vortex_array::arrays::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::DictVTable
 
-pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
+pub type vortex_array::arrays::DictVTable::Array = vortex_array::arrays::DictArray
 
-pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
+pub type vortex_array::arrays::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::DictMetadata>
 
-pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::DictVTable::OperationsVTable = vortex_array::arrays::DictVTable
 
-pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::DictVTable::ValidityVTable = vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::DictVTable::array_eq(array: &vortex_array::arrays::DictArray, other: &vortex_array::arrays::DictArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DictArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::DictVTable::buffer(_array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::DictVTable::buffer_name(_array: &vortex_array::arrays::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+pub fn vortex_array::arrays::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
 
-pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::DictVTable::child(array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::DictVTable::child_name(_array: &vortex_array::arrays::DictArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::DictVTable::dtype(array: &vortex_array::arrays::DictArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::DictVTable::len(array: &vortex_array::arrays::DictArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::DictVTable::metadata(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::DictVTable::nbuffers(_array: &vortex_array::arrays::DictArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::DictVTable::nchildren(_array: &vortex_array::arrays::DictArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::DictVTable::stats(array: &vortex_array::arrays::DictArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::DictVTable::validity(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub struct vortex_array::arrays::ExactScalarFn<F: vortex_array::scalar_fn::ScalarFnVTable>(_)
+
+impl<F: core::default::Default + vortex_array::scalar_fn::ScalarFnVTable> core::default::Default for vortex_array::arrays::ExactScalarFn<F>
+
+pub fn vortex_array::arrays::ExactScalarFn<F>::default() -> vortex_array::arrays::ExactScalarFn<F>
+
+impl<F: core::fmt::Debug + vortex_array::scalar_fn::ScalarFnVTable> core::fmt::Debug for vortex_array::arrays::ExactScalarFn<F>
+
+pub fn vortex_array::arrays::ExactScalarFn<F>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<F: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::matcher::Matcher for vortex_array::arrays::ExactScalarFn<F>
+
+pub type vortex_array::arrays::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::ScalarFnArrayView<'a, F>
+
+pub fn vortex_array::arrays::ExactScalarFn<F>::matches(array: &dyn vortex_array::DynArray) -> bool
+
+pub fn vortex_array::arrays::ExactScalarFn<F>::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 pub struct vortex_array::arrays::ExtensionArray
 
@@ -5516,23 +1730,23 @@ impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::
 
 pub fn vortex_array::arrays::ExtensionArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::convert::From<&vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
+impl core::convert::From<&vortex_array::arrays::TemporalArray> for vortex_array::arrays::ExtensionArray
 
-pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::datetime::TemporalArray) -> Self
+pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::TemporalArray) -> Self
 
 impl core::convert::From<vortex_array::arrays::ExtensionArray> for vortex_array::ArrayRef
 
 pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ExtensionArray) -> vortex_array::ArrayRef
 
-impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
+impl core::convert::From<vortex_array::arrays::TemporalArray> for vortex_array::arrays::ExtensionArray
 
-pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
+pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::TemporalArray) -> Self
 
-impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::datetime::TemporalArray
+impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::TemporalArray
 
-pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
+pub type vortex_array::arrays::TemporalArray::Error = vortex_error::VortexError
 
-pub fn vortex_array::arrays::datetime::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
+pub fn vortex_array::arrays::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
 
 impl core::fmt::Debug for vortex_array::arrays::ExtensionArray
 
@@ -5562,17 +1776,17 @@ impl core::fmt::Debug for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ExtensionVTable
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ExtensionVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ExtensionVTable
 
@@ -5638,7 +1852,7 @@ pub fn vortex_array::arrays::ExtensionVTable::deserialize(_bytes: &[u8], _dtype:
 
 pub fn vortex_array::arrays::ExtensionVTable::dtype(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ExtensionVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::ExtensionVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::ExtensionVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -5674,7 +1888,7 @@ pub fn vortex_array::arrays::FilterArray::child(&self) -> &vortex_array::ArrayRe
 
 pub fn vortex_array::arrays::FilterArray::filter_mask(&self) -> &vortex_mask::Mask
 
-pub fn vortex_array::arrays::FilterArray::into_parts(self) -> vortex_array::arrays::filter::FilterArrayParts
+pub fn vortex_array::arrays::FilterArray::into_parts(self) -> vortex_array::arrays::FilterArrayParts
 
 pub fn vortex_array::arrays::FilterArray::new(array: vortex_array::ArrayRef, mask: vortex_mask::Mask) -> Self
 
@@ -5709,6 +1923,44 @@ pub fn vortex_array::arrays::FilterArray::deref(&self) -> &Self::Target
 impl vortex_array::IntoArray for vortex_array::arrays::FilterArray
 
 pub fn vortex_array::arrays::FilterArray::into_array(self) -> vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::FilterArrayParts
+
+pub vortex_array::arrays::FilterArrayParts::child: vortex_array::ArrayRef
+
+pub vortex_array::arrays::FilterArrayParts::mask: vortex_mask::Mask
+
+pub struct vortex_array::arrays::FilterExecuteAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::FilterExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::default() -> vortex_array::arrays::FilterExecuteAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::FilterExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::FilterExecuteAdaptor<V> where V: vortex_array::arrays::FilterKernel
+
+pub type vortex_array::arrays::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+
+pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub struct vortex_array::arrays::FilterReduceAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::FilterReduceAdaptor<V>
+
+pub fn vortex_array::arrays::FilterReduceAdaptor<V>::default() -> vortex_array::arrays::FilterReduceAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::FilterReduceAdaptor<V>
+
+pub fn vortex_array::arrays::FilterReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::FilterReduceAdaptor<V> where V: vortex_array::arrays::FilterReduce
+
+pub type vortex_array::arrays::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+
+pub fn vortex_array::arrays::FilterReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::FilterArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::arrays::FilterVTable
 
@@ -5754,7 +2006,7 @@ pub fn vortex_array::arrays::FilterVTable::deserialize(_bytes: &[u8], _dtype: &v
 
 pub fn vortex_array::arrays::FilterVTable::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::FilterVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::FilterVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::FilterVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -5850,13 +2102,13 @@ impl core::fmt::Debug for vortex_array::arrays::FixedSizeListVTable
 
 pub fn vortex_array::arrays::FixedSizeListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::FixedSizeListVTable
 
 pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::FixedSizeListVTable
 
@@ -5914,7 +2166,7 @@ pub fn vortex_array::arrays::FixedSizeListVTable::deserialize(_bytes: &[u8], _dt
 
 pub fn vortex_array::arrays::FixedSizeListVTable::dtype(array: &vortex_array::arrays::FixedSizeListArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::FixedSizeListVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::FixedSizeListVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::FixedSizeListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -5938,6 +2190,34 @@ pub fn vortex_array::arrays::FixedSizeListVTable::stats(array: &vortex_array::ar
 
 pub fn vortex_array::arrays::FixedSizeListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
+#[repr(C, align(8))] pub struct vortex_array::arrays::Inlined
+
+pub vortex_array::arrays::Inlined::data: [u8; 12]
+
+pub vortex_array::arrays::Inlined::size: u32
+
+impl vortex_array::arrays::Inlined
+
+pub fn vortex_array::arrays::Inlined::value(&self) -> &[u8]
+
+impl core::clone::Clone for vortex_array::arrays::Inlined
+
+pub fn vortex_array::arrays::Inlined::clone(&self) -> vortex_array::arrays::Inlined
+
+impl core::cmp::Eq for vortex_array::arrays::Inlined
+
+impl core::cmp::PartialEq for vortex_array::arrays::Inlined
+
+pub fn vortex_array::arrays::Inlined::eq(&self, other: &vortex_array::arrays::Inlined) -> bool
+
+impl core::fmt::Debug for vortex_array::arrays::Inlined
+
+pub fn vortex_array::arrays::Inlined::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::marker::Copy for vortex_array::arrays::Inlined
+
+impl core::marker::StructuralPartialEq for vortex_array::arrays::Inlined
+
 pub struct vortex_array::arrays::ListArray
 
 impl vortex_array::arrays::ListArray
@@ -5946,7 +2226,7 @@ pub fn vortex_array::arrays::ListArray::element_dtype(&self) -> &alloc::sync::Ar
 
 pub fn vortex_array::arrays::ListArray::elements(&self) -> &vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ListArray::into_parts(self) -> vortex_array::arrays::list::ListArrayParts
+pub fn vortex_array::arrays::ListArray::into_parts(self) -> vortex_array::arrays::ListArrayParts
 
 pub fn vortex_array::arrays::ListArray::list_elements_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -6000,6 +2280,16 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::ListArray
 
 pub fn vortex_array::arrays::ListArray::validity(&self) -> &vortex_array::validity::Validity
 
+pub struct vortex_array::arrays::ListArrayParts
+
+pub vortex_array::arrays::ListArrayParts::dtype: vortex_array::dtype::DType
+
+pub vortex_array::arrays::ListArrayParts::elements: vortex_array::ArrayRef
+
+pub vortex_array::arrays::ListArrayParts::offsets: vortex_array::ArrayRef
+
+pub vortex_array::arrays::ListArrayParts::validity: vortex_array::validity::Validity
+
 pub struct vortex_array::arrays::ListVTable
 
 impl vortex_array::arrays::ListVTable
@@ -6010,17 +2300,17 @@ impl core::fmt::Debug for vortex_array::arrays::ListVTable
 
 pub fn vortex_array::arrays::ListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ListVTable
+impl vortex_array::arrays::FilterKernel for vortex_array::arrays::ListVTable
 
 pub fn vortex_array::arrays::ListVTable::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ListVTable
 
 pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListVTable
 
@@ -6078,7 +2368,7 @@ pub fn vortex_array::arrays::ListVTable::deserialize(bytes: &[u8], _dtype: &vort
 
 pub fn vortex_array::arrays::ListVTable::dtype(array: &vortex_array::arrays::ListArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ListVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::ListVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::ListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -6108,7 +2398,7 @@ impl vortex_array::arrays::ListViewArray
 
 pub fn vortex_array::arrays::ListViewArray::elements(&self) -> &vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ListViewArray::into_parts(self) -> vortex_array::arrays::listview::ListViewArrayParts
+pub fn vortex_array::arrays::ListViewArray::into_parts(self) -> vortex_array::arrays::ListViewArrayParts
 
 pub fn vortex_array::arrays::ListViewArray::is_zero_copy_to_list(&self) -> bool
 
@@ -6136,7 +2426,7 @@ pub unsafe fn vortex_array::arrays::ListViewArray::with_zero_copy_to_list(self, 
 
 impl vortex_array::arrays::ListViewArray
 
-pub fn vortex_array::arrays::ListViewArray::rebuild(&self, mode: vortex_array::arrays::listview::ListViewRebuildMode) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
+pub fn vortex_array::arrays::ListViewArray::rebuild(&self, mode: vortex_array::arrays::ListViewRebuildMode) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
 
 impl vortex_array::arrays::ListViewArray
 
@@ -6176,6 +2466,18 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::ListViewArra
 
 pub fn vortex_array::arrays::ListViewArray::validity(&self) -> &vortex_array::validity::Validity
 
+pub struct vortex_array::arrays::ListViewArrayParts
+
+pub vortex_array::arrays::ListViewArrayParts::elements: vortex_array::ArrayRef
+
+pub vortex_array::arrays::ListViewArrayParts::elements_dtype: alloc::sync::Arc<vortex_array::dtype::DType>
+
+pub vortex_array::arrays::ListViewArrayParts::offsets: vortex_array::ArrayRef
+
+pub vortex_array::arrays::ListViewArrayParts::sizes: vortex_array::ArrayRef
+
+pub vortex_array::arrays::ListViewArrayParts::validity: vortex_array::validity::Validity
+
 pub struct vortex_array::arrays::ListViewVTable
 
 impl vortex_array::arrays::ListViewVTable
@@ -6186,13 +2488,13 @@ impl core::fmt::Debug for vortex_array::arrays::ListViewVTable
 
 pub fn vortex_array::arrays::ListViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListViewVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ListViewVTable
 
 pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeReduce for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListViewVTable
 
@@ -6250,7 +2552,7 @@ pub fn vortex_array::arrays::ListViewVTable::deserialize(bytes: &[u8], _dtype: &
 
 pub fn vortex_array::arrays::ListViewVTable::dtype(array: &vortex_array::arrays::ListViewArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ListViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::ListViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::ListViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -6326,17 +2628,17 @@ impl core::fmt::Debug for vortex_array::arrays::MaskedVTable
 
 pub fn vortex_array::arrays::MaskedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::MaskedVTable
 
 pub fn vortex_array::arrays::MaskedVTable::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::MaskedVTable
 
 pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::MaskedVTable
 
@@ -6376,7 +2678,7 @@ pub fn vortex_array::arrays::MaskedVTable::deserialize(_bytes: &[u8], _dtype: &v
 
 pub fn vortex_array::arrays::MaskedVTable::dtype(array: &vortex_array::arrays::MaskedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::MaskedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::MaskedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::MaskedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -6400,145 +2702,211 @@ pub fn vortex_array::arrays::MaskedVTable::stats(array: &vortex_array::arrays::M
 
 pub fn vortex_array::arrays::MaskedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
+#[repr(transparent)] pub struct vortex_array::arrays::NativeValue<T>(pub T)
+
+impl core::hash::Hash for vortex_array::arrays::NativeValue<f32>
+
+pub fn vortex_array::arrays::NativeValue<f32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::NativeValue<f64>
+
+pub fn vortex_array::arrays::NativeValue<f64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::NativeValue<half::binary16::f16>
+
+pub fn vortex_array::arrays::NativeValue<half::binary16::f16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::NativeValue<i16>
+
+pub fn vortex_array::arrays::NativeValue<i16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::NativeValue<i32>
+
+pub fn vortex_array::arrays::NativeValue<i32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::NativeValue<i64>
+
+pub fn vortex_array::arrays::NativeValue<i64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::NativeValue<i8>
+
+pub fn vortex_array::arrays::NativeValue<i8>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::NativeValue<u16>
+
+pub fn vortex_array::arrays::NativeValue<u16>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::NativeValue<u32>
+
+pub fn vortex_array::arrays::NativeValue<u32>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::NativeValue<u64>
+
+pub fn vortex_array::arrays::NativeValue<u64>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl core::hash::Hash for vortex_array::arrays::NativeValue<u8>
+
+pub fn vortex_array::arrays::NativeValue<u8>::hash<H: core::hash::Hasher>(&self, state: &mut H)
+
+impl<T: core::clone::Clone> core::clone::Clone for vortex_array::arrays::NativeValue<T>
+
+pub fn vortex_array::arrays::NativeValue<T>::clone(&self) -> vortex_array::arrays::NativeValue<T>
+
+impl<T: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::NativeValue<T>
+
+pub fn vortex_array::arrays::NativeValue<T>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<T: core::marker::Copy> core::marker::Copy for vortex_array::arrays::NativeValue<T>
+
+impl<T: vortex_array::dtype::NativePType> core::cmp::Eq for vortex_array::arrays::NativeValue<T>
+
+impl<T: vortex_array::dtype::NativePType> core::cmp::PartialEq for vortex_array::arrays::NativeValue<T>
+
+pub fn vortex_array::arrays::NativeValue<T>::eq(&self, other: &vortex_array::arrays::NativeValue<T>) -> bool
+
+impl<T: vortex_array::dtype::NativePType> core::cmp::PartialOrd for vortex_array::arrays::NativeValue<T>
+
+pub fn vortex_array::arrays::NativeValue<T>::partial_cmp(&self, other: &vortex_array::arrays::NativeValue<T>) -> core::option::Option<core::cmp::Ordering>
+
 pub struct vortex_array::arrays::NullArray
 
-impl vortex_array::arrays::null::NullArray
+impl vortex_array::arrays::NullArray
 
-pub fn vortex_array::arrays::null::NullArray::new(len: usize) -> Self
+pub fn vortex_array::arrays::NullArray::new(len: usize) -> Self
 
-impl vortex_array::arrays::null::NullArray
+impl vortex_array::arrays::NullArray
 
-pub fn vortex_array::arrays::null::NullArray::to_array(&self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::NullArray::to_array(&self) -> vortex_array::ArrayRef
 
-impl core::clone::Clone for vortex_array::arrays::null::NullArray
+impl core::clone::Clone for vortex_array::arrays::NullArray
 
-pub fn vortex_array::arrays::null::NullArray::clone(&self) -> vortex_array::arrays::null::NullArray
+pub fn vortex_array::arrays::NullArray::clone(&self) -> vortex_array::arrays::NullArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::null::NullArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::NullArray
 
-pub fn vortex_array::arrays::null::NullArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::NullArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::convert::From<vortex_array::arrays::null::NullArray> for vortex_array::ArrayRef
+impl core::convert::From<vortex_array::arrays::NullArray> for vortex_array::ArrayRef
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::null::NullArray) -> vortex_array::ArrayRef
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::NullArray) -> vortex_array::ArrayRef
 
-impl core::fmt::Debug for vortex_array::arrays::null::NullArray
+impl core::fmt::Debug for vortex_array::arrays::NullArray
 
-pub fn vortex_array::arrays::null::NullArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::NullArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl core::ops::deref::Deref for vortex_array::arrays::null::NullArray
+impl core::ops::deref::Deref for vortex_array::arrays::NullArray
 
-pub type vortex_array::arrays::null::NullArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::NullArray::Target = dyn vortex_array::DynArray
 
-pub fn vortex_array::arrays::null::NullArray::deref(&self) -> &Self::Target
+pub fn vortex_array::arrays::NullArray::deref(&self) -> &Self::Target
 
-impl vortex_array::Executable for vortex_array::arrays::null::NullArray
+impl vortex_array::Executable for vortex_array::arrays::NullArray
 
-pub fn vortex_array::arrays::null::NullArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::NullArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
-impl vortex_array::IntoArray for vortex_array::arrays::null::NullArray
+impl vortex_array::IntoArray for vortex_array::arrays::NullArray
 
-pub fn vortex_array::arrays::null::NullArray::into_array(self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::NullArray::into_array(self) -> vortex_array::ArrayRef
 
 pub struct vortex_array::arrays::NullVTable
 
-impl vortex_array::arrays::null::NullVTable
+impl vortex_array::arrays::NullVTable
 
-pub const vortex_array::arrays::null::NullVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::NullVTable::ID: vortex_array::vtable::ArrayId
 
-impl vortex_array::arrays::null::NullVTable
+impl vortex_array::arrays::NullVTable
 
-pub const vortex_array::arrays::null::NullVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
+pub const vortex_array::arrays::NullVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
 
-impl core::fmt::Debug for vortex_array::arrays::null::NullVTable
+impl core::fmt::Debug for vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::null::NullVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::NullVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::null::NullVTable::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::NullVTable::filter(_array: &vortex_array::arrays::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::null::NullVTable::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::arrays::TakeReduce for vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::null::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::NullVTable::take(array: &vortex_array::arrays::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::NullVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::null::NullVTable::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::NullVTable::min_max(&self, _array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::null::NullVTable::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::NullVTable::cast(array: &vortex_array::arrays::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::null::NullVTable::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::NullVTable::mask(array: &vortex_array::arrays::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::NullVTable> for vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::null::NullVTable::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::NullVTable::scalar_at(_array: &vortex_array::arrays::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::null::NullVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::NullVTable
 
-pub type vortex_array::arrays::null::NullVTable::Array = vortex_array::arrays::null::NullArray
+pub type vortex_array::arrays::NullVTable::Array = vortex_array::arrays::NullArray
 
-pub type vortex_array::arrays::null::NullVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::NullVTable::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::null::NullVTable::OperationsVTable = vortex_array::arrays::null::NullVTable
+pub type vortex_array::arrays::NullVTable::OperationsVTable = vortex_array::arrays::NullVTable
 
-pub type vortex_array::arrays::null::NullVTable::ValidityVTable = vortex_array::arrays::null::NullVTable
+pub type vortex_array::arrays::NullVTable::ValidityVTable = vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::null::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::null::NullVTable::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::NullVTable::array_eq(array: &vortex_array::arrays::NullArray, other: &vortex_array::arrays::NullArray, _precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::null::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
+pub fn vortex_array::arrays::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::NullArray, state: &mut H, _precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::null::NullVTable::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::NullVTable::buffer(_array: &vortex_array::arrays::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::null::NullVTable::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::NullVTable::buffer_name(_array: &vortex_array::arrays::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::null::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
+pub fn vortex_array::arrays::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::NullArray>
 
-pub fn vortex_array::arrays::null::NullVTable::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::NullVTable::child(_array: &vortex_array::arrays::NullArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::null::NullVTable::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::NullVTable::child_name(_array: &vortex_array::arrays::NullArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::null::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::null::NullVTable::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::NullVTable::dtype(_array: &vortex_array::arrays::NullArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::null::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::null::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::null::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::null::NullVTable::len(array: &vortex_array::arrays::null::NullArray) -> usize
+pub fn vortex_array::arrays::NullVTable::len(array: &vortex_array::arrays::NullArray) -> usize
 
-pub fn vortex_array::arrays::null::NullVTable::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::NullVTable::metadata(_array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::null::NullVTable::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
+pub fn vortex_array::arrays::NullVTable::nbuffers(_array: &vortex_array::arrays::NullArray) -> usize
 
-pub fn vortex_array::arrays::null::NullVTable::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
+pub fn vortex_array::arrays::NullVTable::nchildren(_array: &vortex_array::arrays::NullArray) -> usize
 
-pub fn vortex_array::arrays::null::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::null::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::null::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::null::NullVTable::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::NullVTable::stats(array: &vortex_array::arrays::NullArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::null::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::NullVTable> for vortex_array::arrays::NullVTable
 
-pub fn vortex_array::arrays::null::NullVTable::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::NullVTable::validity(_array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::PrimitiveArray
 
@@ -6594,7 +2962,7 @@ pub fn vortex_array::arrays::PrimitiveArray::try_into_buffer_mut<T: vortex_array
 
 impl vortex_array::arrays::PrimitiveArray
 
-pub fn vortex_array::arrays::PrimitiveArray::into_parts(self) -> vortex_array::arrays::primitive::PrimitiveArrayParts
+pub fn vortex_array::arrays::PrimitiveArray::into_parts(self) -> vortex_array::arrays::PrimitiveArrayParts
 
 impl vortex_array::arrays::PrimitiveArray
 
@@ -6650,6 +3018,30 @@ impl<T: vortex_array::dtype::NativePType> vortex_array::accessor::ArrayAccessor<
 
 pub fn vortex_array::arrays::PrimitiveArray::with_iterator<F, R>(&self, f: F) -> R where F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a T>>) -> R
 
+pub struct vortex_array::arrays::PrimitiveArrayParts
+
+pub vortex_array::arrays::PrimitiveArrayParts::buffer: vortex_array::buffer::BufferHandle
+
+pub vortex_array::arrays::PrimitiveArrayParts::ptype: vortex_array::dtype::PType
+
+pub vortex_array::arrays::PrimitiveArrayParts::validity: vortex_array::validity::Validity
+
+pub struct vortex_array::arrays::PrimitiveMaskedValidityRule
+
+impl core::default::Default for vortex_array::arrays::PrimitiveMaskedValidityRule
+
+pub fn vortex_array::arrays::PrimitiveMaskedValidityRule::default() -> vortex_array::arrays::PrimitiveMaskedValidityRule
+
+impl core::fmt::Debug for vortex_array::arrays::PrimitiveMaskedValidityRule
+
+pub fn vortex_array::arrays::PrimitiveMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveMaskedValidityRule
+
+pub type vortex_array::arrays::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub struct vortex_array::arrays::PrimitiveVTable
 
 impl vortex_array::arrays::PrimitiveVTable
@@ -6660,13 +3052,13 @@ impl core::fmt::Debug for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::PrimitiveVTable
 
@@ -6690,11 +3082,11 @@ impl vortex_array::compute::SumKernel for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveMaskedValidityRule
 
-pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::PrimitiveVTable
 
@@ -6746,7 +3138,7 @@ pub fn vortex_array::arrays::PrimitiveVTable::deserialize(_bytes: &[u8], _dtype:
 
 pub fn vortex_array::arrays::PrimitiveVTable::dtype(array: &vortex_array::arrays::PrimitiveArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::PrimitiveVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::PrimitiveVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::PrimitiveVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -6770,133 +3162,175 @@ pub fn vortex_array::arrays::PrimitiveVTable::stats(array: &vortex_array::arrays
 
 pub fn vortex_array::arrays::PrimitiveVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
+#[repr(C, align(8))] pub struct vortex_array::arrays::Ref
+
+pub vortex_array::arrays::Ref::buffer_index: u32
+
+pub vortex_array::arrays::Ref::offset: u32
+
+pub vortex_array::arrays::Ref::prefix: [u8; 4]
+
+pub vortex_array::arrays::Ref::size: u32
+
+impl vortex_array::arrays::Ref
+
+pub fn vortex_array::arrays::Ref::as_range(&self) -> core::ops::range::Range<usize>
+
+pub fn vortex_array::arrays::Ref::with_buffer_and_offset(&self, buffer_index: u32, offset: u32) -> vortex_array::arrays::Ref
+
+impl core::clone::Clone for vortex_array::arrays::Ref
+
+pub fn vortex_array::arrays::Ref::clone(&self) -> vortex_array::arrays::Ref
+
+impl core::convert::From<vortex_array::arrays::Ref> for vortex_array::arrays::BinaryView
+
+pub fn vortex_array::arrays::BinaryView::from(value: vortex_array::arrays::Ref) -> Self
+
+impl core::fmt::Debug for vortex_array::arrays::Ref
+
+pub fn vortex_array::arrays::Ref::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::marker::Copy for vortex_array::arrays::Ref
+
 pub struct vortex_array::arrays::ScalarFnArray
 
-impl vortex_array::arrays::scalar_fn::ScalarFnArray
+impl vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::children(&self) -> &[vortex_array::ArrayRef]
+pub fn vortex_array::arrays::ScalarFnArray::children(&self) -> &[vortex_array::ArrayRef]
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::scalar_fn(&self) -> &vortex_array::scalar_fn::ScalarFnRef
+pub fn vortex_array::arrays::ScalarFnArray::scalar_fn(&self) -> &vortex_array::scalar_fn::ScalarFnRef
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::try_new(bound: vortex_array::scalar_fn::ScalarFnRef, children: alloc::vec::Vec<vortex_array::ArrayRef>, len: usize) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::ScalarFnArray::try_new(bound: vortex_array::scalar_fn::ScalarFnRef, children: alloc::vec::Vec<vortex_array::ArrayRef>, len: usize) -> vortex_error::VortexResult<Self>
 
-impl vortex_array::arrays::scalar_fn::ScalarFnArray
+impl vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::to_array(&self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::ScalarFnArray::to_array(&self) -> vortex_array::ArrayRef
 
-impl core::clone::Clone for vortex_array::arrays::scalar_fn::ScalarFnArray
+impl core::clone::Clone for vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::clone(&self) -> vortex_array::arrays::scalar_fn::ScalarFnArray
+pub fn vortex_array::arrays::ScalarFnArray::clone(&self) -> vortex_array::arrays::ScalarFnArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::scalar_fn::ScalarFnArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::ScalarFnArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::convert::From<vortex_array::arrays::scalar_fn::ScalarFnArray> for vortex_array::ArrayRef
+impl core::convert::From<vortex_array::arrays::ScalarFnArray> for vortex_array::ArrayRef
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_array::ArrayRef
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::ScalarFnArray) -> vortex_array::ArrayRef
 
-impl core::fmt::Debug for vortex_array::arrays::scalar_fn::ScalarFnArray
+impl core::fmt::Debug for vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::ScalarFnArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl core::ops::deref::Deref for vortex_array::arrays::scalar_fn::ScalarFnArray
+impl core::ops::deref::Deref for vortex_array::arrays::ScalarFnArray
 
-pub type vortex_array::arrays::scalar_fn::ScalarFnArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::ScalarFnArray::Target = dyn vortex_array::DynArray
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::deref(&self) -> &Self::Target
+pub fn vortex_array::arrays::ScalarFnArray::deref(&self) -> &Self::Target
 
-impl vortex_array::IntoArray for vortex_array::arrays::scalar_fn::ScalarFnArray
+impl vortex_array::IntoArray for vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::into_array(self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::ScalarFnArray::into_array(self) -> vortex_array::ArrayRef
 
-impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::scalar_fn::ScalarFnArray
+impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
+pub fn vortex_array::arrays::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
+pub fn vortex_array::arrays::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child_count(&self) -> usize
+pub fn vortex_array::arrays::ScalarFnArray::child_count(&self) -> usize
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::node_dtype(&self) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+pub fn vortex_array::arrays::ScalarFnArray::node_dtype(&self) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
+pub fn vortex_array::arrays::ScalarFnArray::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
+
+pub struct vortex_array::arrays::ScalarFnArrayView<'a, F: vortex_array::scalar_fn::ScalarFnVTable>
+
+pub vortex_array::arrays::ScalarFnArrayView::options: &'a <F as vortex_array::scalar_fn::ScalarFnVTable>::Options
+
+pub vortex_array::arrays::ScalarFnArrayView::vtable: &'a F
+
+impl<F: vortex_array::scalar_fn::ScalarFnVTable> core::ops::deref::Deref for vortex_array::arrays::ScalarFnArrayView<'_, F>
+
+pub type vortex_array::arrays::ScalarFnArrayView<'_, F>::Target = dyn vortex_array::DynArray
+
+pub fn vortex_array::arrays::ScalarFnArrayView<'_, F>::deref(&self) -> &Self::Target
 
 pub struct vortex_array::arrays::ScalarFnVTable
 
-impl core::clone::Clone for vortex_array::arrays::scalar_fn::ScalarFnVTable
+impl core::clone::Clone for vortex_array::arrays::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::clone(&self) -> vortex_array::arrays::scalar_fn::ScalarFnVTable
+pub fn vortex_array::arrays::ScalarFnVTable::clone(&self) -> vortex_array::arrays::ScalarFnVTable
 
-impl core::fmt::Debug for vortex_array::arrays::scalar_fn::ScalarFnVTable
+impl core::fmt::Debug for vortex_array::arrays::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::ScalarFnVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::scalar_fn::ScalarFnVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ScalarFnVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ScalarFnVTable> for vortex_array::arrays::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::scalar_fn::ScalarFnVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::ScalarFnVTable
 
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Array = vortex_array::arrays::scalar_fn::ScalarFnArray
+pub type vortex_array::arrays::ScalarFnVTable::Array = vortex_array::arrays::ScalarFnArray
 
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Metadata = vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata
+pub type vortex_array::arrays::ScalarFnVTable::Metadata = vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata
 
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::OperationsVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
+pub type vortex_array::arrays::ScalarFnVTable::OperationsVTable = vortex_array::arrays::ScalarFnVTable
 
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::ValidityVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
+pub type vortex_array::arrays::ScalarFnVTable::ValidityVTable = vortex_array::arrays::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_eq(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, other: &vortex_array::arrays::scalar_fn::ScalarFnArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::ScalarFnVTable::array_eq(array: &vortex_array::arrays::ScalarFnArray, other: &vortex_array::arrays::ScalarFnArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::ScalarFnVTable::buffer(_array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer_name(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::ScalarFnVTable::buffer_name(_array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+pub fn vortex_array::arrays::ScalarFnVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::ScalarFnVTable::child(array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child_name(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::ScalarFnVTable::child_name(array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::dtype(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::ScalarFnVTable::dtype(array: &vortex_array::arrays::ScalarFnArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::len(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
+pub fn vortex_array::arrays::ScalarFnVTable::len(array: &vortex_array::arrays::ScalarFnArray) -> usize
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ScalarFnVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
+pub fn vortex_array::arrays::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::ScalarFnArray) -> usize
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nchildren(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
+pub fn vortex_array::arrays::ScalarFnVTable::nchildren(array: &vortex_array::arrays::ScalarFnArray) -> usize
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ScalarFnVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ScalarFnVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::ScalarFnVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::stats(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::ScalarFnVTable::stats(array: &vortex_array::arrays::ScalarFnArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ScalarFnVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ScalarFnVTable> for vortex_array::arrays::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::validity(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::ScalarFnVTable::validity(array: &vortex_array::arrays::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::SharedArray
 
@@ -6982,7 +3416,7 @@ pub fn vortex_array::arrays::SharedVTable::deserialize(_bytes: &[u8], _dtype: &v
 
 pub fn vortex_array::arrays::SharedVTable::dtype(array: &vortex_array::arrays::SharedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::SharedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::SharedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::SharedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -7012,123 +3446,167 @@ pub fn vortex_array::arrays::SharedVTable::validity(array: &vortex_array::arrays
 
 pub struct vortex_array::arrays::SliceArray
 
-impl vortex_array::arrays::slice::SliceArray
+impl vortex_array::arrays::SliceArray
 
-pub fn vortex_array::arrays::slice::SliceArray::child(&self) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::SliceArray::child(&self) -> &vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::slice::SliceArray::into_parts(self) -> vortex_array::arrays::slice::SliceArrayParts
+pub fn vortex_array::arrays::SliceArray::into_parts(self) -> vortex_array::arrays::SliceArrayParts
 
-pub fn vortex_array::arrays::slice::SliceArray::new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> Self
+pub fn vortex_array::arrays::SliceArray::new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> Self
 
-pub fn vortex_array::arrays::slice::SliceArray::slice_range(&self) -> &core::ops::range::Range<usize>
+pub fn vortex_array::arrays::SliceArray::slice_range(&self) -> &core::ops::range::Range<usize>
 
-pub fn vortex_array::arrays::slice::SliceArray::try_new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::SliceArray::try_new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<Self>
 
-impl vortex_array::arrays::slice::SliceArray
+impl vortex_array::arrays::SliceArray
 
-pub fn vortex_array::arrays::slice::SliceArray::to_array(&self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::SliceArray::to_array(&self) -> vortex_array::ArrayRef
 
-impl core::clone::Clone for vortex_array::arrays::slice::SliceArray
+impl core::clone::Clone for vortex_array::arrays::SliceArray
 
-pub fn vortex_array::arrays::slice::SliceArray::clone(&self) -> vortex_array::arrays::slice::SliceArray
+pub fn vortex_array::arrays::SliceArray::clone(&self) -> vortex_array::arrays::SliceArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::slice::SliceArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::SliceArray
 
-pub fn vortex_array::arrays::slice::SliceArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::SliceArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::convert::From<vortex_array::arrays::slice::SliceArray> for vortex_array::ArrayRef
+impl core::convert::From<vortex_array::arrays::SliceArray> for vortex_array::ArrayRef
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::slice::SliceArray) -> vortex_array::ArrayRef
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::SliceArray) -> vortex_array::ArrayRef
 
-impl core::fmt::Debug for vortex_array::arrays::slice::SliceArray
+impl core::fmt::Debug for vortex_array::arrays::SliceArray
 
-pub fn vortex_array::arrays::slice::SliceArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::SliceArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl core::ops::deref::Deref for vortex_array::arrays::slice::SliceArray
+impl core::ops::deref::Deref for vortex_array::arrays::SliceArray
 
-pub type vortex_array::arrays::slice::SliceArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::SliceArray::Target = dyn vortex_array::DynArray
 
-pub fn vortex_array::arrays::slice::SliceArray::deref(&self) -> &Self::Target
+pub fn vortex_array::arrays::SliceArray::deref(&self) -> &Self::Target
 
-impl vortex_array::IntoArray for vortex_array::arrays::slice::SliceArray
+impl vortex_array::IntoArray for vortex_array::arrays::SliceArray
 
-pub fn vortex_array::arrays::slice::SliceArray::into_array(self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::SliceArray::into_array(self) -> vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::SliceArrayParts
+
+pub vortex_array::arrays::SliceArrayParts::child: vortex_array::ArrayRef
+
+pub vortex_array::arrays::SliceArrayParts::range: core::ops::range::Range<usize>
+
+pub struct vortex_array::arrays::SliceExecuteAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::SliceExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::default() -> vortex_array::arrays::SliceExecuteAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::SliceExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::SliceExecuteAdaptor<V> where V: vortex_array::arrays::SliceKernel
+
+pub type vortex_array::arrays::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
+
+pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub struct vortex_array::arrays::SliceMetadata(_)
+
+impl core::fmt::Debug for vortex_array::arrays::SliceMetadata
+
+pub fn vortex_array::arrays::SliceMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub struct vortex_array::arrays::SliceReduceAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::SliceReduceAdaptor<V>
+
+pub fn vortex_array::arrays::SliceReduceAdaptor<V>::default() -> vortex_array::arrays::SliceReduceAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::SliceReduceAdaptor<V>
+
+pub fn vortex_array::arrays::SliceReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::SliceReduceAdaptor<V> where V: vortex_array::arrays::SliceReduce
+
+pub type vortex_array::arrays::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
+
+pub fn vortex_array::arrays::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::arrays::SliceVTable
 
-impl vortex_array::arrays::slice::SliceVTable
+impl vortex_array::arrays::SliceVTable
 
-pub const vortex_array::arrays::slice::SliceVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::SliceVTable::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::slice::SliceVTable
+impl core::fmt::Debug for vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::slice::SliceVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::SliceVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::SliceVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::slice::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::SliceVTable> for vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::slice::SliceVTable::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::SliceVTable::scalar_at(array: &vortex_array::arrays::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::slice::SliceVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::SliceVTable
 
-pub type vortex_array::arrays::slice::SliceVTable::Array = vortex_array::arrays::slice::SliceArray
+pub type vortex_array::arrays::SliceVTable::Array = vortex_array::arrays::SliceArray
 
-pub type vortex_array::arrays::slice::SliceVTable::Metadata = vortex_array::arrays::slice::SliceMetadata
+pub type vortex_array::arrays::SliceVTable::Metadata = vortex_array::arrays::SliceMetadata
 
-pub type vortex_array::arrays::slice::SliceVTable::OperationsVTable = vortex_array::arrays::slice::SliceVTable
+pub type vortex_array::arrays::SliceVTable::OperationsVTable = vortex_array::arrays::SliceVTable
 
-pub type vortex_array::arrays::slice::SliceVTable::ValidityVTable = vortex_array::arrays::slice::SliceVTable
+pub type vortex_array::arrays::SliceVTable::ValidityVTable = vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::slice::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::slice::SliceVTable::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::SliceVTable::array_eq(array: &vortex_array::arrays::SliceArray, other: &vortex_array::arrays::SliceArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::slice::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SliceArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::slice::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::slice::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::slice::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+pub fn vortex_array::arrays::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
 
-pub fn vortex_array::arrays::slice::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::slice::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::slice::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::slice::SliceVTable::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::SliceVTable::dtype(array: &vortex_array::arrays::SliceArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::slice::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::slice::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::slice::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::slice::SliceVTable::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
+pub fn vortex_array::arrays::SliceVTable::len(array: &vortex_array::arrays::SliceArray) -> usize
 
-pub fn vortex_array::arrays::slice::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::slice::SliceVTable::nbuffers(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::SliceVTable::nbuffers(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::slice::SliceVTable::nchildren(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::SliceVTable::nchildren(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::slice::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::slice::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::slice::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::slice::SliceVTable::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::SliceVTable::stats(array: &vortex_array::arrays::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::slice::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::SliceVTable> for vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::slice::SliceVTable::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::SliceVTable::validity(array: &vortex_array::arrays::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::StructArray
 
@@ -7138,7 +3616,7 @@ pub fn vortex_array::arrays::StructArray::from_fields<N: core::convert::AsRef<st
 
 pub fn vortex_array::arrays::StructArray::into_fields(self) -> alloc::vec::Vec<vortex_array::ArrayRef>
 
-pub fn vortex_array::arrays::StructArray::into_parts(self) -> vortex_array::arrays::struct_::StructArrayParts
+pub fn vortex_array::arrays::StructArray::into_parts(self) -> vortex_array::arrays::StructArrayParts
 
 pub fn vortex_array::arrays::StructArray::names(&self) -> &vortex_array::dtype::FieldNames
 
@@ -7214,6 +3692,14 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::StructArray
 
 pub fn vortex_array::arrays::StructArray::validity(&self) -> &vortex_array::validity::Validity
 
+pub struct vortex_array::arrays::StructArrayParts
+
+pub vortex_array::arrays::StructArrayParts::fields: alloc::sync::Arc<[vortex_array::ArrayRef]>
+
+pub vortex_array::arrays::StructArrayParts::struct_fields: vortex_array::dtype::StructFields
+
+pub vortex_array::arrays::StructArrayParts::validity: vortex_array::validity::Validity
+
 pub struct vortex_array::arrays::StructVTable
 
 impl vortex_array::arrays::StructVTable
@@ -7224,13 +3710,13 @@ impl core::fmt::Debug for vortex_array::arrays::StructVTable
 
 pub fn vortex_array::arrays::StructVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::StructVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::StructVTable
 
 pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeReduce for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::StructVTable
 
@@ -7286,7 +3772,7 @@ pub fn vortex_array::arrays::StructVTable::deserialize(_bytes: &[u8], _dtype: &v
 
 pub fn vortex_array::arrays::StructVTable::dtype(array: &vortex_array::arrays::StructArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::StructVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::StructVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::StructVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -7310,65 +3796,97 @@ pub fn vortex_array::arrays::StructVTable::stats(array: &vortex_array::arrays::S
 
 pub fn vortex_array::arrays::StructVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
+pub struct vortex_array::arrays::TakeExecuteAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::TakeExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::default() -> vortex_array::arrays::TakeExecuteAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::TakeExecuteAdaptor<V>
+
+pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::TakeExecuteAdaptor<V> where V: vortex_array::arrays::TakeExecute
+
+pub type vortex_array::arrays::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub struct vortex_array::arrays::TakeReduceAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::arrays::TakeReduceAdaptor<V>
+
+pub fn vortex_array::arrays::TakeReduceAdaptor<V>::default() -> vortex_array::arrays::TakeReduceAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::arrays::TakeReduceAdaptor<V>
+
+pub fn vortex_array::arrays::TakeReduceAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::TakeReduceAdaptor<V> where V: vortex_array::arrays::TakeReduce
+
+pub type vortex_array::arrays::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::TakeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::DictArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub struct vortex_array::arrays::TemporalArray
 
-impl vortex_array::arrays::datetime::TemporalArray
+impl vortex_array::arrays::TemporalArray
 
-pub fn vortex_array::arrays::datetime::TemporalArray::dtype(&self) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::TemporalArray::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::datetime::TemporalArray::ext_dtype(&self) -> vortex_array::dtype::extension::ExtDTypeRef
+pub fn vortex_array::arrays::TemporalArray::ext_dtype(&self) -> vortex_array::dtype::extension::ExtDTypeRef
 
-pub fn vortex_array::arrays::datetime::TemporalArray::temporal_metadata(&self) -> vortex_array::extension::datetime::TemporalMetadata<'_>
+pub fn vortex_array::arrays::TemporalArray::temporal_metadata(&self) -> vortex_array::extension::datetime::TemporalMetadata<'_>
 
-pub fn vortex_array::arrays::datetime::TemporalArray::temporal_values(&self) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::TemporalArray::temporal_values(&self) -> &vortex_array::ArrayRef
 
-impl vortex_array::arrays::datetime::TemporalArray
+impl vortex_array::arrays::TemporalArray
 
-pub fn vortex_array::arrays::datetime::TemporalArray::new_date(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
+pub fn vortex_array::arrays::TemporalArray::new_date(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
 
-pub fn vortex_array::arrays::datetime::TemporalArray::new_time(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
+pub fn vortex_array::arrays::TemporalArray::new_time(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit) -> Self
 
-pub fn vortex_array::arrays::datetime::TemporalArray::new_timestamp(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit, time_zone: core::option::Option<alloc::sync::Arc<str>>) -> Self
+pub fn vortex_array::arrays::TemporalArray::new_timestamp(array: vortex_array::ArrayRef, time_unit: vortex_array::extension::datetime::TimeUnit, time_zone: core::option::Option<alloc::sync::Arc<str>>) -> Self
 
-impl core::clone::Clone for vortex_array::arrays::datetime::TemporalArray
+impl core::clone::Clone for vortex_array::arrays::TemporalArray
 
-pub fn vortex_array::arrays::datetime::TemporalArray::clone(&self) -> vortex_array::arrays::datetime::TemporalArray
+pub fn vortex_array::arrays::TemporalArray::clone(&self) -> vortex_array::arrays::TemporalArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::datetime::TemporalArray
+impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::TemporalArray
 
-pub fn vortex_array::arrays::datetime::TemporalArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::TemporalArray::as_ref(&self) -> &dyn vortex_array::DynArray
 
-impl core::convert::From<&vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
+impl core::convert::From<&vortex_array::arrays::TemporalArray> for vortex_array::arrays::ExtensionArray
 
-pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::datetime::TemporalArray) -> Self
+pub fn vortex_array::arrays::ExtensionArray::from(value: &vortex_array::arrays::TemporalArray) -> Self
 
-impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::ArrayRef
+impl core::convert::From<vortex_array::arrays::TemporalArray> for vortex_array::ArrayRef
 
-pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
+pub fn vortex_array::ArrayRef::from(value: vortex_array::arrays::TemporalArray) -> Self
 
-impl core::convert::From<vortex_array::arrays::datetime::TemporalArray> for vortex_array::arrays::ExtensionArray
+impl core::convert::From<vortex_array::arrays::TemporalArray> for vortex_array::arrays::ExtensionArray
 
-pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::datetime::TemporalArray) -> Self
+pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::TemporalArray) -> Self
 
-impl core::convert::TryFrom<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::arrays::datetime::TemporalArray
+impl core::convert::TryFrom<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::arrays::TemporalArray
 
-pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
+pub type vortex_array::arrays::TemporalArray::Error = vortex_error::VortexError
 
-pub fn vortex_array::arrays::datetime::TemporalArray::try_from(value: vortex_array::ArrayRef) -> core::result::Result<Self, Self::Error>
+pub fn vortex_array::arrays::TemporalArray::try_from(value: vortex_array::ArrayRef) -> core::result::Result<Self, Self::Error>
 
-impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::datetime::TemporalArray
+impl core::convert::TryFrom<vortex_array::arrays::ExtensionArray> for vortex_array::arrays::TemporalArray
 
-pub type vortex_array::arrays::datetime::TemporalArray::Error = vortex_error::VortexError
+pub type vortex_array::arrays::TemporalArray::Error = vortex_error::VortexError
 
-pub fn vortex_array::arrays::datetime::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
+pub fn vortex_array::arrays::TemporalArray::try_from(ext: vortex_array::arrays::ExtensionArray) -> core::result::Result<Self, Self::Error>
 
-impl core::fmt::Debug for vortex_array::arrays::datetime::TemporalArray
+impl core::fmt::Debug for vortex_array::arrays::TemporalArray
 
-pub fn vortex_array::arrays::datetime::TemporalArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::TemporalArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::IntoArray for vortex_array::arrays::datetime::TemporalArray
+impl vortex_array::IntoArray for vortex_array::arrays::TemporalArray
 
-pub fn vortex_array::arrays::datetime::TemporalArray::into_array(self) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::TemporalArray::into_array(self) -> vortex_array::ArrayRef
 
 pub struct vortex_array::arrays::VarBinArray
 
@@ -7512,17 +4030,17 @@ impl core::fmt::Debug for vortex_array::arrays::VarBinVTable
 
 pub fn vortex_array::arrays::VarBinVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBinVTable
+impl vortex_array::arrays::FilterKernel for vortex_array::arrays::VarBinVTable
 
 pub fn vortex_array::arrays::VarBinVTable::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::VarBinVTable
 
 pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinVTable
 
@@ -7584,7 +4102,7 @@ pub fn vortex_array::arrays::VarBinVTable::deserialize(bytes: &[u8], _dtype: &vo
 
 pub fn vortex_array::arrays::VarBinVTable::dtype(array: &vortex_array::arrays::VarBinArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::VarBinVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::VarBinVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::VarBinVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -7628,25 +4146,25 @@ pub fn vortex_array::arrays::VarBinViewArray::from_iter_nullable_str<T: core::co
 
 pub fn vortex_array::arrays::VarBinViewArray::from_iter_str<T: core::convert::AsRef<str>, I: core::iter::traits::collect::IntoIterator<Item = T>>(iter: I) -> Self
 
-pub fn vortex_array::arrays::VarBinViewArray::into_parts(self) -> vortex_array::arrays::varbinview::VarBinViewArrayParts
+pub fn vortex_array::arrays::VarBinViewArray::into_parts(self) -> vortex_array::arrays::VarBinViewArrayParts
 
 pub fn vortex_array::arrays::VarBinViewArray::nbuffers(&self) -> usize
 
-pub fn vortex_array::arrays::VarBinViewArray::new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+pub fn vortex_array::arrays::VarBinViewArray::new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
 
 pub fn vortex_array::arrays::VarBinViewArray::new_handle(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
 
 pub unsafe fn vortex_array::arrays::VarBinViewArray::new_handle_unchecked(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
 
-pub unsafe fn vortex_array::arrays::VarBinViewArray::new_unchecked(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
+pub unsafe fn vortex_array::arrays::VarBinViewArray::new_unchecked(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> Self
 
-pub fn vortex_array::arrays::VarBinViewArray::try_new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::VarBinViewArray::try_new(views: vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>, buffers: alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_array::arrays::VarBinViewArray::try_new_handle(views: vortex_array::buffer::BufferHandle, buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>, dtype: vortex_array::dtype::DType, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::arrays::VarBinViewArray::validate(views: &vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, buffers: &alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::VarBinViewArray::validate(views: &vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>, buffers: &alloc::sync::Arc<[vortex_buffer::ByteBuffer]>, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::VarBinViewArray::views(&self) -> &[vortex_array::arrays::varbinview::BinaryView]
+pub fn vortex_array::arrays::VarBinViewArray::views(&self) -> &[vortex_array::arrays::BinaryView]
 
 pub fn vortex_array::arrays::VarBinViewArray::views_handle(&self) -> &vortex_array::buffer::BufferHandle
 
@@ -7718,6 +4236,16 @@ impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a str>
 
 pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a str>>>(iter: T) -> Self
 
+pub struct vortex_array::arrays::VarBinViewArrayParts
+
+pub vortex_array::arrays::VarBinViewArrayParts::buffers: alloc::sync::Arc<[vortex_array::buffer::BufferHandle]>
+
+pub vortex_array::arrays::VarBinViewArrayParts::dtype: vortex_array::dtype::DType
+
+pub vortex_array::arrays::VarBinViewArrayParts::validity: vortex_array::validity::Validity
+
+pub vortex_array::arrays::VarBinViewArrayParts::views: vortex_array::buffer::BufferHandle
+
 pub struct vortex_array::arrays::VarBinViewVTable
 
 impl vortex_array::arrays::VarBinViewVTable
@@ -7728,13 +4256,13 @@ impl core::fmt::Debug for vortex_array::arrays::VarBinViewVTable
 
 pub fn vortex_array::arrays::VarBinViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::VarBinViewVTable
 
 pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinViewVTable
 
@@ -7796,7 +4324,7 @@ pub fn vortex_array::arrays::VarBinViewVTable::deserialize(_bytes: &[u8], _dtype
 
 pub fn vortex_array::arrays::VarBinViewVTable::dtype(array: &vortex_array::arrays::VarBinViewArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::VarBinViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::VarBinViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::VarBinViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -7820,6 +4348,224 @@ pub fn vortex_array::arrays::VarBinViewVTable::stats(array: &vortex_array::array
 
 pub fn vortex_array::arrays::VarBinViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
+pub const vortex_array::arrays::IS_CONST_LANE_WIDTH: usize
+
+pub trait vortex_array::arrays::FilterKernel: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::FilterKernel::filter(array: &Self::Array, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::FilterKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::FilterKernel for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::FilterKernel for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub trait vortex_array::arrays::FilterReduce: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::FilterReduce::filter(array: &Self::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::filter(array: &vortex_array::arrays::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::FilterReduce for vortex_array::arrays::NullVTable
+
+pub fn vortex_array::arrays::NullVTable::filter(_array: &vortex_array::arrays::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub trait vortex_array::arrays::ScalarFnArrayExt: vortex_array::scalar_fn::ScalarFnVTable
+
+pub fn vortex_array::arrays::ScalarFnArrayExt::try_new_array(&self, len: usize, options: Self::Options, children: impl core::convert::Into<alloc::vec::Vec<vortex_array::ArrayRef>>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+impl<V: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::arrays::ScalarFnArrayExt for V
+
+pub fn V::try_new_array(&self, len: usize, options: Self::Options, children: impl core::convert::Into<alloc::vec::Vec<vortex_array::ArrayRef>>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub trait vortex_array::arrays::SliceKernel: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::SliceKernel::slice(array: &Self::Array, range: core::ops::range::Range<usize>, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceKernel for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub trait vortex_array::arrays::SliceReduce: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::SliceReduce::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::NullVTable
+
+pub fn vortex_array::arrays::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::ScalarFnVTable
+
+pub fn vortex_array::arrays::ScalarFnVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::SliceVTable
+
+pub fn vortex_array::arrays::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::SliceReduce for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub trait vortex_array::arrays::TakeExecute: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::TakeExecute::take(array: &Self::Array, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::BoolVTable
+
+pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DecimalVTable
+
+pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::take(array: &vortex_array::arrays::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ExtensionVTable
+
+pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::FixedSizeListVTable
+
+pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::ListVTable
+
+pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::PrimitiveVTable
+
+pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinVTable
+
+pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeExecute for vortex_array::arrays::VarBinViewVTable
+
+pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub trait vortex_array::arrays::TakeReduce: vortex_array::vtable::VTable
+
+pub fn vortex_array::arrays::TakeReduce::take(array: &Self::Array, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeReduce for vortex_array::arrays::ConstantVTable
+
+pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeReduce for vortex_array::arrays::ListViewVTable
+
+pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeReduce for vortex_array::arrays::MaskedVTable
+
+pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeReduce for vortex_array::arrays::NullVTable
+
+pub fn vortex_array::arrays::NullVTable::take(array: &vortex_array::arrays::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::TakeReduce for vortex_array::arrays::StructVTable
+
+pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::chunk_range(chunk_idx: usize, offset: usize, array_len: usize) -> core::ops::range::Range<usize>
+
+pub fn vortex_array::arrays::compute_is_constant<T: vortex_array::dtype::NativePType, const WIDTH: usize>(values: &[T]) -> bool
+
+pub fn vortex_array::arrays::list_from_list_view(list_view: vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
+
+pub fn vortex_array::arrays::list_view_from_list(list: vortex_array::arrays::ListArray, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
+
+pub fn vortex_array::arrays::mask_validity_canonical(canonical: vortex_array::Canonical, validity_mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::Canonical>
+
+pub fn vortex_array::arrays::narrowed_decimal(decimal_array: vortex_array::arrays::DecimalArray) -> vortex_array::arrays::DecimalArray
+
+pub fn vortex_array::arrays::patch_chunk<T, I, C>(decoded_values: &mut [T], patches_indices: &[I], patches_values: &[T], patches_offset: usize, chunk_offsets_slice: &[C], chunk_idx: usize, offset_within_chunk: usize) where T: vortex_array::dtype::NativePType, I: vortex_array::dtype::UnsignedPType, C: vortex_array::dtype::UnsignedPType
+
+pub fn vortex_array::arrays::recursive_list_from_list_view(array: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::arrays::take_canonical(values: vortex_array::Canonical, codes: &vortex_array::arrays::PrimitiveArray, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::Canonical>
+
+pub fn vortex_array::arrays::varbin_scalar(value: vortex_buffer::ByteBuffer, dtype: &vortex_array::dtype::DType) -> vortex_array::scalar::Scalar
+
 pub mod vortex_array::arrow
 
 pub mod vortex_array::arrow::bool
@@ -7834,7 +4580,7 @@ pub fn vortex_array::arrow::byte_view::execute_varbinview_to_arrow<T: arrow_arra
 
 pub mod vortex_array::arrow::null
 
-pub fn vortex_array::arrow::null::canonical_null_to_arrow(array: &vortex_array::arrays::null::NullArray) -> arrow_array::array::ArrayRef
+pub fn vortex_array::arrow::null::canonical_null_to_arrow(array: &vortex_array::arrays::NullArray) -> arrow_array::array::ArrayRef
 
 pub mod vortex_array::arrow::primitive
 
@@ -8024,9 +4770,9 @@ impl vortex_array::arrow::FromArrowArray<arrow_array::record_batch::RecordBatch>
 
 pub fn vortex_array::ArrayRef::from_arrow(array: arrow_array::record_batch::RecordBatch, nullable: bool) -> vortex_error::VortexResult<Self>
 
-impl<K: arrow_array::types::ArrowDictionaryKeyType> vortex_array::arrow::FromArrowArray<&arrow_array::array::dictionary_array::DictionaryArray<K>> for vortex_array::arrays::dict::DictArray
+impl<K: arrow_array::types::ArrowDictionaryKeyType> vortex_array::arrow::FromArrowArray<&arrow_array::array::dictionary_array::DictionaryArray<K>> for vortex_array::arrays::DictArray
 
-pub fn vortex_array::arrays::dict::DictArray::from_arrow(array: &arrow_array::array::dictionary_array::DictionaryArray<K>, nullable: bool) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::arrays::DictArray::from_arrow(array: &arrow_array::array::dictionary_array::DictionaryArray<K>, nullable: bool) -> vortex_error::VortexResult<Self>
 
 impl<O: arrow_array::array::list_array::OffsetSizeTrait + vortex_array::dtype::NativePType> vortex_array::arrow::FromArrowArray<&arrow_array::array::list_view_array::GenericListViewArray<O>> for vortex_array::ArrayRef
 
@@ -8188,9 +4934,9 @@ pub fn vortex_array::builders::dict::DictEncoder::encode(&mut self, array: &vort
 
 pub fn vortex_array::builders::dict::DictEncoder::reset(&mut self) -> vortex_array::ArrayRef
 
-pub fn vortex_array::builders::dict::dict_encode(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+pub fn vortex_array::builders::dict::dict_encode(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
 
-pub fn vortex_array::builders::dict::dict_encode_with_constraints(array: &vortex_array::ArrayRef, constraints: &vortex_array::builders::dict::DictConstraints) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+pub fn vortex_array::builders::dict::dict_encode_with_constraints(array: &vortex_array::ArrayRef, constraints: &vortex_array::builders::dict::DictConstraints) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
 
 pub fn vortex_array::builders::dict::dict_encoder(array: &vortex_array::ArrayRef, constraints: &vortex_array::builders::dict::DictConstraints) -> alloc::boxed::Box<dyn vortex_array::builders::dict::DictEncoder>
 
@@ -8790,7 +5536,7 @@ pub fn vortex_array::builders::VarBinViewBuilder::finish_into_varbinview(&mut se
 
 pub fn vortex_array::builders::VarBinViewBuilder::new(dtype: vortex_array::dtype::DType, capacity: usize, completed: vortex_array::builders::CompletedBuffers, growth_strategy: vortex_array::builders::BufferGrowthStrategy, compaction_threshold: f64) -> Self
 
-pub fn vortex_array::builders::VarBinViewBuilder::push_buffer_and_adjusted_views(&mut self, buffers: &[vortex_buffer::ByteBuffer], views: &vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::BinaryView>, validity_mask: vortex_mask::Mask)
+pub fn vortex_array::builders::VarBinViewBuilder::push_buffer_and_adjusted_views(&mut self, buffers: &[vortex_buffer::ByteBuffer], views: &vortex_buffer::buffer::Buffer<vortex_array::arrays::BinaryView>, validity_mask: vortex_mask::Mask)
 
 pub fn vortex_array::builders::VarBinViewBuilder::with_buffer_deduplication(dtype: vortex_array::dtype::DType, capacity: usize) -> Self
 
@@ -9770,6 +6516,10 @@ impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DecimalVT
 
 pub fn vortex_array::arrays::DecimalVTable::is_constant(&self, array: &vortex_array::arrays::DecimalArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::is_constant(&self, array: &vortex_array::arrays::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
 impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::is_constant(&self, array: &vortex_array::arrays::ExtensionArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
@@ -9802,10 +6552,6 @@ impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinVie
 
 pub fn vortex_array::arrays::VarBinViewVTable::is_constant(&self, array: &vortex_array::arrays::VarBinViewArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
 pub trait vortex_array::compute::IsSortedIteratorExt where <Self as core::iter::traits::iterator::Iterator>::Item: core::cmp::PartialOrd: core::iter::traits::iterator::Iterator
 
 pub fn vortex_array::compute::IsSortedIteratorExt::is_strict_sorted(self) -> bool where Self: core::marker::Sized, Self::Item: core::cmp::PartialOrd
@@ -9837,6 +6583,12 @@ impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DecimalVTab
 pub fn vortex_array::arrays::DecimalVTable::is_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 pub fn vortex_array::arrays::DecimalVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::is_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ExtensionVTable
 
@@ -9879,12 +6631,6 @@ impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinViewV
 pub fn vortex_array::arrays::VarBinViewVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 pub fn vortex_array::arrays::VarBinViewVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 pub trait vortex_array::compute::Kernel: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug
 
@@ -9930,6 +6676,10 @@ impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DecimalVTable
 
 pub fn vortex_array::arrays::DecimalVTable::min_max(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::min_max(&self, array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
 impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::min_max(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
@@ -9946,6 +6696,10 @@ impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListViewVTabl
 
 pub fn vortex_array::arrays::ListViewVTable::min_max(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::NullVTable
+
+pub fn vortex_array::arrays::NullVTable::min_max(&self, _array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
 impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::min_max(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
@@ -9961,14 +6715,6 @@ pub fn vortex_array::arrays::VarBinVTable::min_max(&self, array: &vortex_array::
 impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinViewVTable
 
 pub fn vortex_array::arrays::VarBinViewVTable::min_max(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
 pub trait vortex_array::compute::NaNCountKernel: vortex_array::vtable::VTable
 
@@ -14374,77 +11120,77 @@ pub type vortex_array::kernel::ExecuteParentKernel::Parent: vortex_array::matche
 
 pub fn vortex_array::kernel::ExecuteParentKernel::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::dict::TakeExecuteAdaptor<V> where V: vortex_array::arrays::dict::TakeExecute
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::FilterExecuteAdaptor<V> where V: vortex_array::arrays::FilterKernel
 
-pub type vortex_array::arrays::dict::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
 
-pub fn vortex_array::arrays::dict::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::filter::FilterExecuteAdaptor<V> where V: vortex_array::arrays::filter::FilterKernel
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::SliceExecuteAdaptor<V> where V: vortex_array::arrays::SliceKernel
 
-pub type vortex_array::arrays::filter::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+pub type vortex_array::arrays::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::filter::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::slice::SliceExecuteAdaptor<V> where V: vortex_array::arrays::slice::SliceKernel
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::TakeExecuteAdaptor<V> where V: vortex_array::arrays::TakeExecute
 
-pub type vortex_array::arrays::slice::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
+pub type vortex_array::arrays::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::slice::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::between::BetweenKernel
 
-pub type vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
+pub type vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
 
-pub fn vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::binary::CompareKernel
 
-pub type vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::binary::Binary>
+pub type vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::binary::Binary>
 
-pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::binary::Binary>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::binary::Binary>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::cast::CastKernel
 
-pub type vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
+pub type vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
 
 pub fn vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::fill_null::FillNullKernel
 
-pub type vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
+pub type vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
 
-pub fn vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::like::LikeKernel
 
-pub type vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
+pub type vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
 
-pub fn vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::list_contains::ListContainsElementKernel
 
-pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
+pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::mask::MaskKernel
 
-pub type vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
+pub type vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
 
-pub fn vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::not::NotKernel
 
-pub type vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
+pub type vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
 
-pub fn vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::zip::ZipKernel
 
-pub type vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
+pub type vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::mask
 
@@ -14488,13 +11234,13 @@ pub fn vortex_array::AnyColumnar::matches(array: &dyn vortex_array::DynArray) ->
 
 pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
-impl vortex_array::matcher::Matcher for vortex_array::arrays::scalar_fn::AnyScalarFn
+impl vortex_array::matcher::Matcher for vortex_array::arrays::AnyScalarFn
 
-pub type vortex_array::arrays::scalar_fn::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::scalar_fn::ScalarFnArray
+pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::scalar_fn::AnyScalarFn::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::arrays::AnyScalarFn::matches(array: &dyn vortex_array::DynArray) -> bool
 
-pub fn vortex_array::arrays::scalar_fn::AnyScalarFn::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 impl vortex_array::matcher::Matcher for vortex_array::matcher::AnyArray
 
@@ -14504,13 +11250,13 @@ pub fn vortex_array::matcher::AnyArray::matches(_array: &dyn vortex_array::DynAr
 
 pub fn vortex_array::matcher::AnyArray::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
-impl<F: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::matcher::Matcher for vortex_array::arrays::scalar_fn::ExactScalarFn<F>
+impl<F: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::matcher::Matcher for vortex_array::arrays::ExactScalarFn<F>
 
-pub type vortex_array::arrays::scalar_fn::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::scalar_fn::ScalarFnArrayView<'a, F>
+pub type vortex_array::arrays::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::ScalarFnArrayView<'a, F>
 
-pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::arrays::ExactScalarFn<F>::matches(array: &dyn vortex_array::DynArray) -> bool
 
-pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::arrays::ExactScalarFn<F>::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::matcher::Matcher for V
 
@@ -14572,89 +11318,89 @@ pub type vortex_array::optimizer::rules::ArrayParentReduceRule::Parent: vortex_a
 
 pub fn vortex_array::optimizer::rules::ArrayParentReduceRule::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolMaskedValidityRule
 
-pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalMaskedValidityRule
 
-pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveMaskedValidityRule
 
-pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
 
-pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::dict::TakeReduceAdaptor<V> where V: vortex_array::arrays::dict::TakeReduce
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::FilterReduceAdaptor<V> where V: vortex_array::arrays::FilterReduce
 
-pub type vortex_array::arrays::dict::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
 
-pub fn vortex_array::arrays::dict::TakeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::dict::DictArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FilterReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::FilterArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::filter::FilterReduceAdaptor<V> where V: vortex_array::arrays::filter::FilterReduce
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::SliceReduceAdaptor<V> where V: vortex_array::arrays::SliceReduce
 
-pub type vortex_array::arrays::filter::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+pub type vortex_array::arrays::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::filter::FilterReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::FilterArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::slice::SliceReduceAdaptor<V> where V: vortex_array::arrays::slice::SliceReduce
+impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::TakeReduceAdaptor<V> where V: vortex_array::arrays::TakeReduce
 
-pub type vortex_array::arrays::slice::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
+pub type vortex_array::arrays::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::slice::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::TakeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::DictArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::between::BetweenReduce
 
-pub type vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
+pub type vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
 
-pub fn vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::cast::CastReduce
 
-pub type vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
+pub type vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
 
-pub fn vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::cast::Cast>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::cast::Cast>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::fill_null::FillNullReduce
 
-pub type vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
+pub type vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
 
-pub fn vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::like::LikeReduce
 
-pub type vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
+pub type vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
 
-pub fn vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduce
 
-pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
+pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::mask::MaskReduce
 
-pub type vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
+pub type vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
 
-pub fn vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::not::NotReduce
 
-pub type vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
+pub type vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
 
-pub fn vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::zip::ZipReduce
 
-pub type vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
+pub type vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::optimizer::rules::ArrayReduceRule<V: vortex_array::vtable::VTable>: core::fmt::Debug + core::marker::Send + core::marker::Sync + 'static
 
@@ -16770,9 +13516,9 @@ pub fn vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::fmt(&sel
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::between::BetweenKernel
 
-pub type vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
+pub type vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
 
-pub fn vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::between::BetweenOptions
 
@@ -16820,9 +13566,9 @@ pub fn vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::fmt(&self
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::between::BetweenReduce
 
-pub type vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
+pub type vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::between::Between>
 
-pub fn vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::between::BetweenReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::between::Between>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::between::BetweenKernel: vortex_array::vtable::VTable
 
@@ -16900,13 +13646,17 @@ pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::fmt(&self
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::binary::CompareKernel
 
-pub type vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::binary::Binary>
+pub type vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::binary::Binary>
 
-pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::binary::Binary>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::binary::Binary>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::binary::CompareKernel: vortex_array::vtable::VTable
 
 pub fn vortex_array::scalar_fn::fns::binary::CompareKernel::compare(lhs: &Self::Array, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::compare(lhs: &vortex_array::arrays::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::ExtensionVTable
 
@@ -16915,10 +13665,6 @@ pub fn vortex_array::arrays::ExtensionVTable::compare(lhs: &vortex_array::arrays
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBinVTable
 
 pub fn vortex_array::arrays::VarBinVTable::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::scalar_fn::fns::binary::and_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -17064,7 +13810,7 @@ pub fn vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::fmt(&self, f: 
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::cast::CastKernel
 
-pub type vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
+pub type vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
 
 pub fn vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -17080,9 +13826,9 @@ pub fn vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::fmt(&self, f: &
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::cast::CastReduce
 
-pub type vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
+pub type vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
 
-pub fn vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::cast::Cast>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::cast::CastReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::cast::Cast>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::cast::CastKernel: vortex_array::vtable::VTable
 
@@ -17116,6 +13862,10 @@ impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Co
 
 pub fn vortex_array::arrays::ConstantVTable::cast(array: &vortex_array::arrays::ConstantArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::cast(array: &vortex_array::arrays::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::cast(array: &vortex_array::arrays::ExtensionArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
@@ -17132,6 +13882,10 @@ impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Li
 
 pub fn vortex_array::arrays::ListViewVTable::cast(array: &vortex_array::arrays::ListViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::NullVTable
+
+pub fn vortex_array::arrays::NullVTable::cast(array: &vortex_array::arrays::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinVTable
 
 pub fn vortex_array::arrays::VarBinVTable::cast(array: &vortex_array::arrays::VarBinArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
@@ -17139,14 +13893,6 @@ pub fn vortex_array::arrays::VarBinVTable::cast(array: &vortex_array::arrays::Va
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinViewVTable
 
 pub fn vortex_array::arrays::VarBinViewVTable::cast(array: &vortex_array::arrays::VarBinViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::dynamic
 
@@ -17284,9 +14030,9 @@ pub fn vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::fmt(&
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::fill_null::FillNullKernel
 
-pub type vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
+pub type vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
 
-pub fn vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNullExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>(pub V)
 
@@ -17300,9 +14046,9 @@ pub fn vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::fmt(&s
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::fill_null::FillNullReduce
 
-pub type vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
+pub type vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::fill_null::FillNull>
 
-pub fn vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::fill_null::FillNull>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::fill_null::FillNullKernel: vortex_array::vtable::VTable
 
@@ -17316,13 +14062,13 @@ impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::a
 
 pub fn vortex_array::arrays::DecimalVTable::fill_null(array: &vortex_array::arrays::DecimalArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::fill_null(array: &vortex_array::arrays::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::fill_null(array: &vortex_array::arrays::PrimitiveArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::fill_null::FillNullReduce: vortex_array::vtable::VTable
 
@@ -17480,9 +14226,9 @@ pub fn vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::fmt(&self, f: 
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::like::LikeKernel
 
-pub type vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
+pub type vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
 
-pub fn vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::like::LikeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::like::LikeOptions
 
@@ -17532,9 +14278,9 @@ pub fn vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::fmt(&self, f: &
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::like::LikeReduce
 
-pub type vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
+pub type vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::like::Like>
 
-pub fn vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::like::LikeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::like::Like>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::like::LikeKernel: vortex_array::vtable::VTable
 
@@ -17544,9 +14290,9 @@ pub trait vortex_array::scalar_fn::fns::like::LikeReduce: vortex_array::vtable::
 
 pub fn vortex_array::scalar_fn::fns::like::LikeReduce::like(array: &Self::Array, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::DictVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::DictVTable::like(array: &vortex_array::arrays::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::list_contains
 
@@ -17604,9 +14350,9 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAd
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::list_contains::ListContainsElementKernel
 
-pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
+pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>(pub V)
 
@@ -17620,9 +14366,9 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAda
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduce
 
-pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
+pub type vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::list_contains::ListContains>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::list_contains::ListContains>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::list_contains::ListContainsElementKernel: vortex_array::vtable::VTable
 
@@ -17732,9 +14478,9 @@ pub fn vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::fmt(&self, f: 
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::mask::MaskKernel
 
-pub type vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
+pub type vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
 
-pub fn vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>(pub V)
 
@@ -17748,9 +14494,9 @@ pub fn vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::fmt(&self, f: &
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::mask::MaskReduce
 
-pub type vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
+pub type vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::mask::Mask>
 
-pub fn vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::mask::Mask>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::mask::MaskKernel: vortex_array::vtable::VTable
 
@@ -17772,6 +14518,10 @@ impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::De
 
 pub fn vortex_array::arrays::DecimalVTable::mask(array: &vortex_array::arrays::DecimalArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::mask(array: &vortex_array::arrays::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::mask(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
@@ -17792,6 +14542,10 @@ impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Ma
 
 pub fn vortex_array::arrays::MaskedVTable::mask(array: &vortex_array::arrays::MaskedArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::NullVTable
+
+pub fn vortex_array::arrays::NullVTable::mask(array: &vortex_array::arrays::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::mask(array: &vortex_array::arrays::PrimitiveArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
@@ -17807,14 +14561,6 @@ pub fn vortex_array::arrays::VarBinVTable::mask(array: &vortex_array::arrays::Va
 impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinViewVTable
 
 pub fn vortex_array::arrays::VarBinViewVTable::mask(array: &vortex_array::arrays::VarBinViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::merge
 
@@ -17952,9 +14698,9 @@ pub fn vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::fmt(&self, f: &m
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::not::NotKernel
 
-pub type vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
+pub type vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
 
-pub fn vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::not::NotExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>(pub V)
 
@@ -17968,9 +14714,9 @@ pub fn vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::fmt(&self, f: &mu
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::not::NotReduce
 
-pub type vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
+pub type vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::not::Not>
 
-pub fn vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::not::NotReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, _parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::not::Not>, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::not::NotKernel: vortex_array::vtable::VTable
 
@@ -18408,9 +15154,9 @@ pub fn vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::fmt(&self, f: &m
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::zip::ZipKernel
 
-pub type vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
+pub type vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub struct vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>(pub V)
 
@@ -18424,9 +15170,9 @@ pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::fmt(&self, f: &mu
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V> where V: vortex_array::scalar_fn::fns::zip::ZipReduce
 
-pub type vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
+pub type vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::Parent = vortex_array::arrays::ExactScalarFn<vortex_array::scalar_fn::fns::zip::Zip>
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::zip::Zip>, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::zip::ZipKernel: vortex_array::vtable::VTable
 
@@ -18696,17 +15442,17 @@ pub fn vortex_array::ArrayRef::node_dtype(&self) -> vortex_error::VortexResult<v
 
 pub fn vortex_array::ArrayRef::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
 
-impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::scalar_fn::ScalarFnArray
+impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
+pub fn vortex_array::arrays::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
+pub fn vortex_array::arrays::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child_count(&self) -> usize
+pub fn vortex_array::arrays::ScalarFnArray::child_count(&self) -> usize
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::node_dtype(&self) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+pub fn vortex_array::arrays::ScalarFnArray::node_dtype(&self) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
+pub fn vortex_array::arrays::ScalarFnArray::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::scalar_fn::ReduceNode for vortex_array::ArrayAdapter<V>
 
@@ -20218,7 +16964,7 @@ pub trait vortex_array::vtable::DynVTable: 'static + vortex_array::vtable::dyn_:
 
 pub fn vortex_array::vtable::DynVTable::build(&self, id: vortex_array::vtable::ArrayId, dtype: &vortex_array::dtype::DType, len: usize, metadata: &[u8], buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::vtable::DynVTable::execute(&self, array: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::vtable::DynVTable::execute(&self, array: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::vtable::DynVTable::execute_parent(&self, array: &vortex_array::ArrayRef, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20248,6 +16994,10 @@ impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DecimalVTable>
 
 pub fn vortex_array::arrays::DecimalVTable::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::scalar_at(array: &vortex_array::arrays::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
 
 pub fn vortex_array::arrays::ExtensionVTable::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
@@ -20272,13 +17022,25 @@ impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::MaskedVTable> 
 
 pub fn vortex_array::arrays::MaskedVTable::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::NullVTable> for vortex_array::arrays::NullVTable
+
+pub fn vortex_array::arrays::NullVTable::scalar_at(_array: &vortex_array::arrays::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ScalarFnVTable> for vortex_array::arrays::ScalarFnVTable
+
+pub fn vortex_array::arrays::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
 
 pub fn vortex_array::arrays::SharedVTable::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::SliceVTable> for vortex_array::arrays::SliceVTable
+
+pub fn vortex_array::arrays::SliceVTable::scalar_at(array: &vortex_array::arrays::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
 
@@ -20291,22 +17053,6 @@ pub fn vortex_array::arrays::VarBinVTable::scalar_at(array: &vortex_array::array
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinViewVTable> for vortex_array::arrays::VarBinViewVTable
 
 pub fn vortex_array::arrays::VarBinViewVTable::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::vtable::OperationsVTable<V> for vortex_array::vtable::NotSupported
 
@@ -20342,7 +17088,7 @@ pub fn vortex_array::vtable::VTable::deserialize(bytes: &[u8], _dtype: &vortex_a
 
 pub fn vortex_array::vtable::VTable::dtype(array: &Self::Array) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::vtable::VTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::vtable::VTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::vtable::VTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20396,7 +17142,7 @@ pub fn vortex_array::arrays::BoolVTable::deserialize(bytes: &[u8], _dtype: &vort
 
 pub fn vortex_array::arrays::BoolVTable::dtype(array: &vortex_array::arrays::BoolArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::BoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::BoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::BoolVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20450,7 +17196,7 @@ pub fn vortex_array::arrays::ChunkedVTable::deserialize(_bytes: &[u8], _dtype: &
 
 pub fn vortex_array::arrays::ChunkedVTable::dtype(array: &vortex_array::arrays::ChunkedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ChunkedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::ChunkedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::ChunkedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20504,7 +17250,7 @@ pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &
 
 pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ConstantVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::ConstantVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::ConstantVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20558,7 +17304,7 @@ pub fn vortex_array::arrays::DecimalVTable::deserialize(bytes: &[u8], _dtype: &v
 
 pub fn vortex_array::arrays::DecimalVTable::dtype(array: &vortex_array::arrays::DecimalArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::DecimalVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::DecimalVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::DecimalVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20581,6 +17327,60 @@ pub fn vortex_array::arrays::DecimalVTable::serialize(metadata: Self::Metadata) 
 pub fn vortex_array::arrays::DecimalVTable::stats(array: &vortex_array::arrays::DecimalArray) -> vortex_array::stats::StatsSetRef<'_>
 
 pub fn vortex_array::arrays::DecimalVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::DictVTable
+
+pub type vortex_array::arrays::DictVTable::Array = vortex_array::arrays::DictArray
+
+pub type vortex_array::arrays::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::DictMetadata>
+
+pub type vortex_array::arrays::DictVTable::OperationsVTable = vortex_array::arrays::DictVTable
+
+pub type vortex_array::arrays::DictVTable::ValidityVTable = vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::DictVTable::array_eq(array: &vortex_array::arrays::DictArray, other: &vortex_array::arrays::DictArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DictArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::DictVTable::buffer(_array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::DictVTable::buffer_name(_array: &vortex_array::arrays::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DictArray>
+
+pub fn vortex_array::arrays::DictVTable::child(array: &vortex_array::arrays::DictArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::DictVTable::child_name(_array: &vortex_array::arrays::DictArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::DictVTable::dtype(array: &vortex_array::arrays::DictArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::DictVTable::len(array: &vortex_array::arrays::DictArray) -> usize
+
+pub fn vortex_array::arrays::DictVTable::metadata(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::DictVTable::nbuffers(_array: &vortex_array::arrays::DictArray) -> usize
+
+pub fn vortex_array::arrays::DictVTable::nchildren(_array: &vortex_array::arrays::DictArray) -> usize
+
+pub fn vortex_array::arrays::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::DictVTable::stats(array: &vortex_array::arrays::DictArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::ExtensionVTable
 
@@ -20612,7 +17412,7 @@ pub fn vortex_array::arrays::ExtensionVTable::deserialize(_bytes: &[u8], _dtype:
 
 pub fn vortex_array::arrays::ExtensionVTable::dtype(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ExtensionVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::ExtensionVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::ExtensionVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20666,7 +17466,7 @@ pub fn vortex_array::arrays::FilterVTable::deserialize(_bytes: &[u8], _dtype: &v
 
 pub fn vortex_array::arrays::FilterVTable::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::FilterVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::FilterVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::FilterVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20720,7 +17520,7 @@ pub fn vortex_array::arrays::FixedSizeListVTable::deserialize(_bytes: &[u8], _dt
 
 pub fn vortex_array::arrays::FixedSizeListVTable::dtype(array: &vortex_array::arrays::FixedSizeListArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::FixedSizeListVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::FixedSizeListVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::FixedSizeListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20774,7 +17574,7 @@ pub fn vortex_array::arrays::ListVTable::deserialize(bytes: &[u8], _dtype: &vort
 
 pub fn vortex_array::arrays::ListVTable::dtype(array: &vortex_array::arrays::ListArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ListVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::ListVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::ListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20828,7 +17628,7 @@ pub fn vortex_array::arrays::ListViewVTable::deserialize(bytes: &[u8], _dtype: &
 
 pub fn vortex_array::arrays::ListViewVTable::dtype(array: &vortex_array::arrays::ListViewArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ListViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::ListViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::ListViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20882,7 +17682,7 @@ pub fn vortex_array::arrays::MaskedVTable::deserialize(_bytes: &[u8], _dtype: &v
 
 pub fn vortex_array::arrays::MaskedVTable::dtype(array: &vortex_array::arrays::MaskedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::MaskedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::MaskedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::MaskedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20905,6 +17705,60 @@ pub fn vortex_array::arrays::MaskedVTable::serialize(_metadata: Self::Metadata) 
 pub fn vortex_array::arrays::MaskedVTable::stats(array: &vortex_array::arrays::MaskedArray) -> vortex_array::stats::StatsSetRef<'_>
 
 pub fn vortex_array::arrays::MaskedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::NullVTable
+
+pub type vortex_array::arrays::NullVTable::Array = vortex_array::arrays::NullArray
+
+pub type vortex_array::arrays::NullVTable::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::NullVTable::OperationsVTable = vortex_array::arrays::NullVTable
+
+pub type vortex_array::arrays::NullVTable::ValidityVTable = vortex_array::arrays::NullVTable
+
+pub fn vortex_array::arrays::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::NullVTable::array_eq(array: &vortex_array::arrays::NullArray, other: &vortex_array::arrays::NullArray, _precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::NullArray, state: &mut H, _precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::NullVTable::buffer(_array: &vortex_array::arrays::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::NullVTable::buffer_name(_array: &vortex_array::arrays::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::NullArray>
+
+pub fn vortex_array::arrays::NullVTable::child(_array: &vortex_array::arrays::NullArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::NullVTable::child_name(_array: &vortex_array::arrays::NullArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::NullVTable::dtype(_array: &vortex_array::arrays::NullArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::NullVTable::len(array: &vortex_array::arrays::NullArray) -> usize
+
+pub fn vortex_array::arrays::NullVTable::metadata(_array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::NullVTable::nbuffers(_array: &vortex_array::arrays::NullArray) -> usize
+
+pub fn vortex_array::arrays::NullVTable::nchildren(_array: &vortex_array::arrays::NullArray) -> usize
+
+pub fn vortex_array::arrays::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::NullVTable::stats(array: &vortex_array::arrays::NullArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::PrimitiveVTable
 
@@ -20936,7 +17790,7 @@ pub fn vortex_array::arrays::PrimitiveVTable::deserialize(_bytes: &[u8], _dtype:
 
 pub fn vortex_array::arrays::PrimitiveVTable::dtype(array: &vortex_array::arrays::PrimitiveArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::PrimitiveVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::PrimitiveVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::PrimitiveVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -20959,6 +17813,60 @@ pub fn vortex_array::arrays::PrimitiveVTable::serialize(_metadata: Self::Metadat
 pub fn vortex_array::arrays::PrimitiveVTable::stats(array: &vortex_array::arrays::PrimitiveArray) -> vortex_array::stats::StatsSetRef<'_>
 
 pub fn vortex_array::arrays::PrimitiveVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::ScalarFnVTable
+
+pub type vortex_array::arrays::ScalarFnVTable::Array = vortex_array::arrays::ScalarFnArray
+
+pub type vortex_array::arrays::ScalarFnVTable::Metadata = vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata
+
+pub type vortex_array::arrays::ScalarFnVTable::OperationsVTable = vortex_array::arrays::ScalarFnVTable
+
+pub type vortex_array::arrays::ScalarFnVTable::ValidityVTable = vortex_array::arrays::ScalarFnVTable
+
+pub fn vortex_array::arrays::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::ScalarFnVTable::array_eq(array: &vortex_array::arrays::ScalarFnArray, other: &vortex_array::arrays::ScalarFnArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::ScalarFnVTable::buffer(_array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::ScalarFnVTable::buffer_name(_array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::ScalarFnVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+
+pub fn vortex_array::arrays::ScalarFnVTable::child(array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ScalarFnVTable::child_name(array: &vortex_array::arrays::ScalarFnArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ScalarFnVTable::dtype(array: &vortex_array::arrays::ScalarFnArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::ScalarFnVTable::len(array: &vortex_array::arrays::ScalarFnArray) -> usize
+
+pub fn vortex_array::arrays::ScalarFnVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::ScalarFnArray) -> usize
+
+pub fn vortex_array::arrays::ScalarFnVTable::nchildren(array: &vortex_array::arrays::ScalarFnArray) -> usize
+
+pub fn vortex_array::arrays::ScalarFnVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ScalarFnVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ScalarFnVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::ScalarFnVTable::stats(array: &vortex_array::arrays::ScalarFnArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::ScalarFnVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::SharedVTable
 
@@ -20990,7 +17898,7 @@ pub fn vortex_array::arrays::SharedVTable::deserialize(_bytes: &[u8], _dtype: &v
 
 pub fn vortex_array::arrays::SharedVTable::dtype(array: &vortex_array::arrays::SharedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::SharedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::SharedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::SharedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -21013,6 +17921,60 @@ pub fn vortex_array::arrays::SharedVTable::serialize(_metadata: Self::Metadata) 
 pub fn vortex_array::arrays::SharedVTable::stats(array: &vortex_array::arrays::SharedArray) -> vortex_array::stats::StatsSetRef<'_>
 
 pub fn vortex_array::arrays::SharedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::SliceVTable
+
+pub type vortex_array::arrays::SliceVTable::Array = vortex_array::arrays::SliceArray
+
+pub type vortex_array::arrays::SliceVTable::Metadata = vortex_array::arrays::SliceMetadata
+
+pub type vortex_array::arrays::SliceVTable::OperationsVTable = vortex_array::arrays::SliceVTable
+
+pub type vortex_array::arrays::SliceVTable::ValidityVTable = vortex_array::arrays::SliceVTable
+
+pub fn vortex_array::arrays::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::SliceVTable::array_eq(array: &vortex_array::arrays::SliceArray, other: &vortex_array::arrays::SliceArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SliceArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+
+pub fn vortex_array::arrays::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::SliceVTable::dtype(array: &vortex_array::arrays::SliceArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::SliceVTable::len(array: &vortex_array::arrays::SliceArray) -> usize
+
+pub fn vortex_array::arrays::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::SliceVTable::nbuffers(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::SliceVTable::nchildren(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::SliceVTable::stats(array: &vortex_array::arrays::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::StructVTable
 
@@ -21044,7 +18006,7 @@ pub fn vortex_array::arrays::StructVTable::deserialize(_bytes: &[u8], _dtype: &v
 
 pub fn vortex_array::arrays::StructVTable::dtype(array: &vortex_array::arrays::StructArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::StructVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::StructVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::StructVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -21098,7 +18060,7 @@ pub fn vortex_array::arrays::VarBinVTable::deserialize(bytes: &[u8], _dtype: &vo
 
 pub fn vortex_array::arrays::VarBinVTable::dtype(array: &vortex_array::arrays::VarBinArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::VarBinVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::VarBinVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::VarBinVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -21152,7 +18114,7 @@ pub fn vortex_array::arrays::VarBinViewVTable::deserialize(_bytes: &[u8], _dtype
 
 pub fn vortex_array::arrays::VarBinViewVTable::dtype(array: &vortex_array::arrays::VarBinViewArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::VarBinViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::VarBinViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
 pub fn vortex_array::arrays::VarBinViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -21175,222 +18137,6 @@ pub fn vortex_array::arrays::VarBinViewVTable::serialize(_metadata: Self::Metada
 pub fn vortex_array::arrays::VarBinViewVTable::stats(array: &vortex_array::arrays::VarBinViewArray) -> vortex_array::stats::StatsSetRef<'_>
 
 pub fn vortex_array::arrays::VarBinViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
-
-pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
-
-pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
-
-pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
-
-pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
-
-pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::null::NullVTable
-
-pub type vortex_array::arrays::null::NullVTable::Array = vortex_array::arrays::null::NullArray
-
-pub type vortex_array::arrays::null::NullVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::null::NullVTable::OperationsVTable = vortex_array::arrays::null::NullVTable
-
-pub type vortex_array::arrays::null::NullVTable::ValidityVTable = vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::null::NullVTable::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::null::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::null::NullVTable::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::null::NullVTable::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::null::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
-
-pub fn vortex_array::arrays::null::NullVTable::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::null::NullVTable::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::null::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::null::NullVTable::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::null::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::null::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::null::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::null::NullVTable::len(array: &vortex_array::arrays::null::NullArray) -> usize
-
-pub fn vortex_array::arrays::null::NullVTable::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::null::NullVTable::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
-
-pub fn vortex_array::arrays::null::NullVTable::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
-
-pub fn vortex_array::arrays::null::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::null::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::null::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::null::NullVTable::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::null::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Array = vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::Metadata = vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata
-
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::OperationsVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub type vortex_array::arrays::scalar_fn::ScalarFnVTable::ValidityVTable = vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_eq(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, other: &vortex_array::arrays::scalar_fn::ScalarFnArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::buffer_name(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::scalar_fn::metadata::ScalarFnMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::child_name(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::dtype(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::id(array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::len(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nbuffers(_array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::nchildren(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> usize
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::stats(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::slice::SliceVTable
-
-pub type vortex_array::arrays::slice::SliceVTable::Array = vortex_array::arrays::slice::SliceArray
-
-pub type vortex_array::arrays::slice::SliceVTable::Metadata = vortex_array::arrays::slice::SliceMetadata
-
-pub type vortex_array::arrays::slice::SliceVTable::OperationsVTable = vortex_array::arrays::slice::SliceVTable
-
-pub type vortex_array::arrays::slice::SliceVTable::ValidityVTable = vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::slice::SliceVTable::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::slice::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::slice::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::slice::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::slice::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
-
-pub fn vortex_array::arrays::slice::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::slice::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::slice::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::slice::SliceVTable::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::slice::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::arrays::slice::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::slice::SliceVTable::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
-
-pub fn vortex_array::arrays::slice::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::slice::SliceVTable::nbuffers(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::slice::SliceVTable::nchildren(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::slice::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::slice::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub trait vortex_array::vtable::ValidityChild<V: vortex_array::vtable::VTable>
 
@@ -21468,29 +18214,29 @@ impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ConstantVTable> 
 
 pub fn vortex_array::arrays::ConstantVTable::validity(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::DictVTable> for vortex_array::arrays::DictVTable
+
+pub fn vortex_array::arrays::DictVTable::validity(array: &vortex_array::arrays::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
 impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
 
 pub fn vortex_array::arrays::FilterVTable::validity(array: &vortex_array::arrays::FilterArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::NullVTable> for vortex_array::arrays::NullVTable
+
+pub fn vortex_array::arrays::NullVTable::validity(_array: &vortex_array::arrays::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ScalarFnVTable> for vortex_array::arrays::ScalarFnVTable
+
+pub fn vortex_array::arrays::ScalarFnVTable::validity(array: &vortex_array::arrays::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
 
 pub fn vortex_array::arrays::SharedVTable::validity(array: &vortex_array::arrays::SharedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::SliceVTable> for vortex_array::arrays::SliceVTable
 
-pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::validity(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::SliceVTable::validity(array: &vortex_array::arrays::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::vtable::ValidityVTable<V> for vortex_array::vtable::ValidityVTableFromChildSliceHelper where <V as vortex_array::vtable::VTable>::Array: vortex_array::vtable::ValidityChildSliceHelper
 
@@ -21558,7 +18304,7 @@ pub vortex_array::Canonical::FixedSizeList(vortex_array::arrays::FixedSizeListAr
 
 pub vortex_array::Canonical::List(vortex_array::arrays::ListViewArray)
 
-pub vortex_array::Canonical::Null(vortex_array::arrays::null::NullArray)
+pub vortex_array::Canonical::Null(vortex_array::arrays::NullArray)
 
 pub vortex_array::Canonical::Primitive(vortex_array::arrays::PrimitiveArray)
 
@@ -21578,7 +18324,7 @@ pub fn vortex_array::Canonical::as_fixed_size_list(&self) -> &vortex_array::arra
 
 pub fn vortex_array::Canonical::as_listview(&self) -> &vortex_array::arrays::ListViewArray
 
-pub fn vortex_array::Canonical::as_null(&self) -> &vortex_array::arrays::null::NullArray
+pub fn vortex_array::Canonical::as_null(&self) -> &vortex_array::arrays::NullArray
 
 pub fn vortex_array::Canonical::as_primitive(&self) -> &vortex_array::arrays::PrimitiveArray
 
@@ -21596,7 +18342,7 @@ pub fn vortex_array::Canonical::into_fixed_size_list(self) -> vortex_array::arra
 
 pub fn vortex_array::Canonical::into_listview(self) -> vortex_array::arrays::ListViewArray
 
-pub fn vortex_array::Canonical::into_null(self) -> vortex_array::arrays::null::NullArray
+pub fn vortex_array::Canonical::into_null(self) -> vortex_array::arrays::NullArray
 
 pub fn vortex_array::Canonical::into_primitive(self) -> vortex_array::arrays::PrimitiveArray
 
@@ -21658,7 +18404,7 @@ pub vortex_array::CanonicalView::FixedSizeList(&'a vortex_array::arrays::FixedSi
 
 pub vortex_array::CanonicalView::List(&'a vortex_array::arrays::ListViewArray)
 
-pub vortex_array::CanonicalView::Null(&'a vortex_array::arrays::null::NullArray)
+pub vortex_array::CanonicalView::Null(&'a vortex_array::arrays::NullArray)
 
 pub vortex_array::CanonicalView::Primitive(&'a vortex_array::arrays::PrimitiveArray)
 
@@ -21700,7 +18446,7 @@ pub fn vortex_array::Columnar::len(&self) -> usize
 
 impl vortex_array::Executable for vortex_array::Columnar
 
-pub fn vortex_array::Columnar::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::Columnar::execute(root: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 impl vortex_array::IntoArray for vortex_array::Columnar
 
@@ -21715,6 +18461,16 @@ pub vortex_array::ColumnarView::Constant(&'a vortex_array::arrays::ConstantArray
 impl<'a> core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::ColumnarView<'a>
 
 pub fn vortex_array::ColumnarView<'a>::as_ref(&self) -> &dyn vortex_array::DynArray
+
+pub enum vortex_array::ExecutionStep
+
+pub vortex_array::ExecutionStep::Done(vortex_array::ArrayRef)
+
+pub vortex_array::ExecutionStep::ExecuteChild(usize)
+
+impl core::fmt::Debug for vortex_array::ExecutionStep
+
+pub fn vortex_array::ExecutionStep::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
 pub enum vortex_array::Precision
 
@@ -22366,7 +19122,7 @@ pub fn vortex_array::CanonicalValidity::execute(array: vortex_array::ArrayRef, c
 
 impl vortex_array::Executable for vortex_array::Columnar
 
-pub fn vortex_array::Columnar::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::Columnar::execute(root: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 impl vortex_array::Executable for vortex_array::RecursiveCanonical
 
@@ -22392,6 +19148,10 @@ impl vortex_array::Executable for vortex_array::arrays::ListViewArray
 
 pub fn vortex_array::arrays::ListViewArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
+impl vortex_array::Executable for vortex_array::arrays::NullArray
+
+pub fn vortex_array::arrays::NullArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+
 impl vortex_array::Executable for vortex_array::arrays::PrimitiveArray
 
 pub fn vortex_array::arrays::PrimitiveArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
@@ -22403,10 +19163,6 @@ pub fn vortex_array::arrays::StructArray::execute(array: vortex_array::ArrayRef,
 impl vortex_array::Executable for vortex_array::arrays::VarBinViewArray
 
 pub fn vortex_array::arrays::VarBinViewArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
-
-impl vortex_array::Executable for vortex_array::arrays::null::NullArray
-
-pub fn vortex_array::arrays::null::NullArray::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 impl vortex_array::Executable for vortex_buffer::bit::buf::BitBuffer
 
@@ -22464,6 +19220,10 @@ impl vortex_array::IntoArray for vortex_array::arrays::DecimalArray
 
 pub fn vortex_array::arrays::DecimalArray::into_array(self) -> vortex_array::ArrayRef
 
+impl vortex_array::IntoArray for vortex_array::arrays::DictArray
+
+pub fn vortex_array::arrays::DictArray::into_array(self) -> vortex_array::ArrayRef
+
 impl vortex_array::IntoArray for vortex_array::arrays::ExtensionArray
 
 pub fn vortex_array::arrays::ExtensionArray::into_array(self) -> vortex_array::ArrayRef
@@ -22488,17 +19248,33 @@ impl vortex_array::IntoArray for vortex_array::arrays::MaskedArray
 
 pub fn vortex_array::arrays::MaskedArray::into_array(self) -> vortex_array::ArrayRef
 
+impl vortex_array::IntoArray for vortex_array::arrays::NullArray
+
+pub fn vortex_array::arrays::NullArray::into_array(self) -> vortex_array::ArrayRef
+
 impl vortex_array::IntoArray for vortex_array::arrays::PrimitiveArray
 
 pub fn vortex_array::arrays::PrimitiveArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::IntoArray for vortex_array::arrays::ScalarFnArray
+
+pub fn vortex_array::arrays::ScalarFnArray::into_array(self) -> vortex_array::ArrayRef
 
 impl vortex_array::IntoArray for vortex_array::arrays::SharedArray
 
 pub fn vortex_array::arrays::SharedArray::into_array(self) -> vortex_array::ArrayRef
 
+impl vortex_array::IntoArray for vortex_array::arrays::SliceArray
+
+pub fn vortex_array::arrays::SliceArray::into_array(self) -> vortex_array::ArrayRef
+
 impl vortex_array::IntoArray for vortex_array::arrays::StructArray
 
 pub fn vortex_array::arrays::StructArray::into_array(self) -> vortex_array::ArrayRef
+
+impl vortex_array::IntoArray for vortex_array::arrays::TemporalArray
+
+pub fn vortex_array::arrays::TemporalArray::into_array(self) -> vortex_array::ArrayRef
 
 impl vortex_array::IntoArray for vortex_array::arrays::VarBinArray
 
@@ -22507,26 +19283,6 @@ pub fn vortex_array::arrays::VarBinArray::into_array(self) -> vortex_array::Arra
 impl vortex_array::IntoArray for vortex_array::arrays::VarBinViewArray
 
 pub fn vortex_array::arrays::VarBinViewArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::IntoArray for vortex_array::arrays::datetime::TemporalArray
-
-pub fn vortex_array::arrays::datetime::TemporalArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::IntoArray for vortex_array::arrays::dict::DictArray
-
-pub fn vortex_array::arrays::dict::DictArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::IntoArray for vortex_array::arrays::null::NullArray
-
-pub fn vortex_array::arrays::null::NullArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::IntoArray for vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::into_array(self) -> vortex_array::ArrayRef
-
-impl vortex_array::IntoArray for vortex_array::arrays::slice::SliceArray
-
-pub fn vortex_array::arrays::slice::SliceArray::into_array(self) -> vortex_array::ArrayRef
 
 impl vortex_array::IntoArray for vortex_buffer::bit::buf::BitBuffer
 
@@ -22584,7 +19340,7 @@ pub fn vortex_array::ToCanonical::to_fixed_size_list(&self) -> vortex_array::arr
 
 pub fn vortex_array::ToCanonical::to_listview(&self) -> vortex_array::arrays::ListViewArray
 
-pub fn vortex_array::ToCanonical::to_null(&self) -> vortex_array::arrays::null::NullArray
+pub fn vortex_array::ToCanonical::to_null(&self) -> vortex_array::arrays::NullArray
 
 pub fn vortex_array::ToCanonical::to_primitive(&self) -> vortex_array::arrays::PrimitiveArray
 
@@ -22604,7 +19360,7 @@ pub fn A::to_fixed_size_list(&self) -> vortex_array::arrays::FixedSizeListArray
 
 pub fn A::to_listview(&self) -> vortex_array::arrays::ListViewArray
 
-pub fn A::to_null(&self) -> vortex_array::arrays::null::NullArray
+pub fn A::to_null(&self) -> vortex_array::arrays::NullArray
 
 pub fn A::to_primitive(&self) -> vortex_array::arrays::PrimitiveArray
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -696,9 +696,9 @@ impl vortex_array::matcher::Matcher for vortex_array::arrays::AnyScalarFn
 
 pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::AnyScalarFn::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::arrays::AnyScalarFn::matches(array: &dyn vortex_array::Array) -> bool
 
-pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 pub struct vortex_array::arrays::BoolArray
 
@@ -734,17 +734,13 @@ impl vortex_array::arrays::BoolArray
 
 pub fn vortex_array::arrays::BoolArray::patch(self, patches: &vortex_array::patches::Patches, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
-impl vortex_array::arrays::BoolArray
-
-pub fn vortex_array::arrays::BoolArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::BoolArray
 
 pub fn vortex_array::arrays::BoolArray::clone(&self) -> vortex_array::arrays::BoolArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::BoolArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::BoolArray
 
-pub fn vortex_array::arrays::BoolArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::BoolArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::BoolArray> for vortex_array::ArrayRef
 
@@ -768,7 +764,7 @@ pub fn vortex_array::arrays::BoolArray::from_iter<I: core::iter::traits::collect
 
 impl core::ops::deref::Deref for vortex_array::arrays::BoolArray
 
-pub type vortex_array::arrays::BoolArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::BoolArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::BoolArray::deref(&self) -> &Self::Target
 
@@ -952,17 +948,13 @@ pub fn vortex_array::arrays::ChunkedArray::try_new(chunks: alloc::vec::Vec<vorte
 
 pub fn vortex_array::arrays::ChunkedArray::validate(chunks: &[vortex_array::ArrayRef], dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<()>
 
-impl vortex_array::arrays::ChunkedArray
-
-pub fn vortex_array::arrays::ChunkedArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::ChunkedArray
 
 pub fn vortex_array::arrays::ChunkedArray::clone(&self) -> vortex_array::arrays::ChunkedArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ChunkedArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ChunkedArray
 
-pub fn vortex_array::arrays::ChunkedArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::ChunkedArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::ChunkedArray> for vortex_array::ArrayRef
 
@@ -972,13 +964,13 @@ impl core::fmt::Debug for vortex_array::arrays::ChunkedArray
 
 pub fn vortex_array::arrays::ChunkedArray::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl core::iter::traits::collect::FromIterator<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::arrays::ChunkedArray
+impl core::iter::traits::collect::FromIterator<alloc::sync::Arc<dyn vortex_array::Array>> for vortex_array::arrays::ChunkedArray
 
 pub fn vortex_array::arrays::ChunkedArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = vortex_array::ArrayRef>>(iter: T) -> Self
 
 impl core::ops::deref::Deref for vortex_array::arrays::ChunkedArray
 
-pub type vortex_array::arrays::ChunkedArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::ChunkedArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::ChunkedArray::deref(&self) -> &Self::Target
 
@@ -1038,9 +1030,9 @@ impl vortex_array::scalar_fn::fns::mask::MaskKernel for vortex_array::arrays::Ch
 
 pub fn vortex_array::arrays::ChunkedVTable::mask(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::scalar_fn::fns::zip::ZipReduce for vortex_array::arrays::ChunkedVTable
 
-pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
 
@@ -1114,17 +1106,13 @@ pub fn vortex_array::arrays::ConstantArray::new<S>(scalar: S, len: usize) -> Sel
 
 pub fn vortex_array::arrays::ConstantArray::scalar(&self) -> &vortex_array::scalar::Scalar
 
-impl vortex_array::arrays::ConstantArray
-
-pub fn vortex_array::arrays::ConstantArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::ConstantArray
 
 pub fn vortex_array::arrays::ConstantArray::clone(&self) -> vortex_array::arrays::ConstantArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ConstantArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ConstantArray
 
-pub fn vortex_array::arrays::ConstantArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::ConstantArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::ConstantArray> for vortex_array::ArrayRef
 
@@ -1136,7 +1124,7 @@ pub fn vortex_array::arrays::ConstantArray::fmt(&self, f: &mut core::fmt::Format
 
 impl core::ops::deref::Deref for vortex_array::arrays::ConstantArray
 
-pub type vortex_array::arrays::ConstantArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::ConstantArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::ConstantArray::deref(&self) -> &Self::Target
 
@@ -1202,13 +1190,13 @@ impl vortex_array::vtable::VTable for vortex_array::arrays::ConstantVTable
 
 pub type vortex_array::arrays::ConstantVTable::Array = vortex_array::arrays::ConstantArray
 
-pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::scalar::Scalar
+pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::EmptyMetadata
 
 pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::arrays::ConstantVTable
 
 pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 
@@ -1218,13 +1206,13 @@ pub fn vortex_array::arrays::ConstantVTable::buffer(array: &vortex_array::arrays
 
 pub fn vortex_array::arrays::ConstantVTable::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ConstantVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
+pub fn vortex_array::arrays::ConstantVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
 
 pub fn vortex_array::arrays::ConstantVTable::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
 
 pub fn vortex_array::arrays::ConstantVTable::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
 
@@ -1236,7 +1224,7 @@ pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_
 
 pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::metadata(_array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
 
@@ -1294,17 +1282,13 @@ pub fn vortex_array::arrays::DecimalArray::try_new_handle(values: vortex_array::
 
 pub fn vortex_array::arrays::DecimalArray::values_type(&self) -> vortex_array::dtype::DecimalType
 
-impl vortex_array::arrays::DecimalArray
-
-pub fn vortex_array::arrays::DecimalArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::DecimalArray
 
 pub fn vortex_array::arrays::DecimalArray::clone(&self) -> vortex_array::arrays::DecimalArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::DecimalArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::DecimalArray
 
-pub fn vortex_array::arrays::DecimalArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::DecimalArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::DecimalArray> for vortex_array::ArrayRef
 
@@ -1316,7 +1300,7 @@ pub fn vortex_array::arrays::DecimalArray::fmt(&self, f: &mut core::fmt::Formatt
 
 impl core::ops::deref::Deref for vortex_array::arrays::DecimalArray
 
-pub type vortex_array::arrays::DecimalArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::DecimalArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::DecimalArray::deref(&self) -> &Self::Target
 
@@ -1498,17 +1482,13 @@ pub fn vortex_array::arrays::DictArray::validate_all_values_referenced(&self) ->
 
 pub fn vortex_array::arrays::DictArray::values(&self) -> &vortex_array::ArrayRef
 
-impl vortex_array::arrays::DictArray
-
-pub fn vortex_array::arrays::DictArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::DictArray
 
 pub fn vortex_array::arrays::DictArray::clone(&self) -> vortex_array::arrays::DictArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::DictArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::DictArray
 
-pub fn vortex_array::arrays::DictArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::DictArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::DictArray> for vortex_array::ArrayRef
 
@@ -1520,7 +1500,7 @@ pub fn vortex_array::arrays::DictArray::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl core::ops::deref::Deref for vortex_array::arrays::DictArray
 
-pub type vortex_array::arrays::DictArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::DictArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::DictArray::deref(&self) -> &Self::Target
 
@@ -1702,9 +1682,9 @@ impl<F: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::matcher::Matcher 
 
 pub type vortex_array::arrays::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::ScalarFnArrayView<'a, F>
 
-pub fn vortex_array::arrays::ExactScalarFn<F>::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::arrays::ExactScalarFn<F>::matches(array: &dyn vortex_array::Array) -> bool
 
-pub fn vortex_array::arrays::ExactScalarFn<F>::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::arrays::ExactScalarFn<F>::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 pub struct vortex_array::arrays::ExtensionArray
 
@@ -1718,17 +1698,13 @@ pub fn vortex_array::arrays::ExtensionArray::new(ext_dtype: vortex_array::dtype:
 
 pub fn vortex_array::arrays::ExtensionArray::storage(&self) -> &vortex_array::ArrayRef
 
-impl vortex_array::arrays::ExtensionArray
-
-pub fn vortex_array::arrays::ExtensionArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::ExtensionArray
 
 pub fn vortex_array::arrays::ExtensionArray::clone(&self) -> vortex_array::arrays::ExtensionArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ExtensionArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ExtensionArray
 
-pub fn vortex_array::arrays::ExtensionArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::ExtensionArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<&vortex_array::arrays::TemporalArray> for vortex_array::arrays::ExtensionArray
 
@@ -1754,7 +1730,7 @@ pub fn vortex_array::arrays::ExtensionArray::fmt(&self, f: &mut core::fmt::Forma
 
 impl core::ops::deref::Deref for vortex_array::arrays::ExtensionArray
 
-pub type vortex_array::arrays::ExtensionArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::ExtensionArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::ExtensionArray::deref(&self) -> &Self::Target
 
@@ -1894,17 +1870,13 @@ pub fn vortex_array::arrays::FilterArray::new(array: vortex_array::ArrayRef, mas
 
 pub fn vortex_array::arrays::FilterArray::try_new(array: vortex_array::ArrayRef, mask: vortex_mask::Mask) -> vortex_error::VortexResult<Self>
 
-impl vortex_array::arrays::FilterArray
-
-pub fn vortex_array::arrays::FilterArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::FilterArray
 
 pub fn vortex_array::arrays::FilterArray::clone(&self) -> vortex_array::arrays::FilterArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::FilterArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::FilterArray
 
-pub fn vortex_array::arrays::FilterArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::FilterArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::FilterArray> for vortex_array::ArrayRef
 
@@ -1916,7 +1888,7 @@ pub fn vortex_array::arrays::FilterArray::fmt(&self, f: &mut core::fmt::Formatte
 
 impl core::ops::deref::Deref for vortex_array::arrays::FilterArray
 
-pub type vortex_array::arrays::FilterArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::FilterArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::FilterArray::deref(&self) -> &Self::Target
 
@@ -2054,17 +2026,13 @@ pub fn vortex_array::arrays::FixedSizeListArray::try_new(elements: vortex_array:
 
 pub fn vortex_array::arrays::FixedSizeListArray::validate(elements: &vortex_array::ArrayRef, len: usize, list_size: u32, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
-impl vortex_array::arrays::FixedSizeListArray
-
-pub fn vortex_array::arrays::FixedSizeListArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::FixedSizeListArray
 
 pub fn vortex_array::arrays::FixedSizeListArray::clone(&self) -> vortex_array::arrays::FixedSizeListArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::FixedSizeListArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::FixedSizeListArray
 
-pub fn vortex_array::arrays::FixedSizeListArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::FixedSizeListArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::FixedSizeListArray> for vortex_array::ArrayRef
 
@@ -2076,7 +2044,7 @@ pub fn vortex_array::arrays::FixedSizeListArray::fmt(&self, f: &mut core::fmt::F
 
 impl core::ops::deref::Deref for vortex_array::arrays::FixedSizeListArray
 
-pub type vortex_array::arrays::FixedSizeListArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::FixedSizeListArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::FixedSizeListArray::deref(&self) -> &Self::Target
 
@@ -2246,17 +2214,13 @@ pub fn vortex_array::arrays::ListArray::try_new(elements: vortex_array::ArrayRef
 
 pub fn vortex_array::arrays::ListArray::validate(elements: &vortex_array::ArrayRef, offsets: &vortex_array::ArrayRef, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
-impl vortex_array::arrays::ListArray
-
-pub fn vortex_array::arrays::ListArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::ListArray
 
 pub fn vortex_array::arrays::ListArray::clone(&self) -> vortex_array::arrays::ListArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ListArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ListArray
 
-pub fn vortex_array::arrays::ListArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::ListArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::ListArray> for vortex_array::ArrayRef
 
@@ -2268,7 +2232,7 @@ pub fn vortex_array::arrays::ListArray::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl core::ops::deref::Deref for vortex_array::arrays::ListArray
 
-pub type vortex_array::arrays::ListArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::ListArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::ListArray::deref(&self) -> &Self::Target
 
@@ -2428,17 +2392,13 @@ impl vortex_array::arrays::ListViewArray
 
 pub fn vortex_array::arrays::ListViewArray::rebuild(&self, mode: vortex_array::arrays::ListViewRebuildMode) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
 
-impl vortex_array::arrays::ListViewArray
-
-pub fn vortex_array::arrays::ListViewArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::ListViewArray
 
 pub fn vortex_array::arrays::ListViewArray::clone(&self) -> vortex_array::arrays::ListViewArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ListViewArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ListViewArray
 
-pub fn vortex_array::arrays::ListViewArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::ListViewArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::ListViewArray> for vortex_array::ArrayRef
 
@@ -2450,7 +2410,7 @@ pub fn vortex_array::arrays::ListViewArray::fmt(&self, f: &mut core::fmt::Format
 
 impl core::ops::deref::Deref for vortex_array::arrays::ListViewArray
 
-pub type vortex_array::arrays::ListViewArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::ListViewArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::ListViewArray::deref(&self) -> &Self::Target
 
@@ -2584,17 +2544,13 @@ pub fn vortex_array::arrays::MaskedArray::child(&self) -> &vortex_array::ArrayRe
 
 pub fn vortex_array::arrays::MaskedArray::try_new(child: vortex_array::ArrayRef, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<Self>
 
-impl vortex_array::arrays::MaskedArray
-
-pub fn vortex_array::arrays::MaskedArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::MaskedArray
 
 pub fn vortex_array::arrays::MaskedArray::clone(&self) -> vortex_array::arrays::MaskedArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::MaskedArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::MaskedArray
 
-pub fn vortex_array::arrays::MaskedArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::MaskedArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::MaskedArray> for vortex_array::ArrayRef
 
@@ -2606,7 +2562,7 @@ pub fn vortex_array::arrays::MaskedArray::fmt(&self, f: &mut core::fmt::Formatte
 
 impl core::ops::deref::Deref for vortex_array::arrays::MaskedArray
 
-pub type vortex_array::arrays::MaskedArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::MaskedArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::MaskedArray::deref(&self) -> &Self::Target
 
@@ -2774,17 +2730,13 @@ impl vortex_array::arrays::NullArray
 
 pub fn vortex_array::arrays::NullArray::new(len: usize) -> Self
 
-impl vortex_array::arrays::NullArray
-
-pub fn vortex_array::arrays::NullArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::NullArray
 
 pub fn vortex_array::arrays::NullArray::clone(&self) -> vortex_array::arrays::NullArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::NullArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::NullArray
 
-pub fn vortex_array::arrays::NullArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::NullArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::NullArray> for vortex_array::ArrayRef
 
@@ -2796,7 +2748,7 @@ pub fn vortex_array::arrays::NullArray::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl core::ops::deref::Deref for vortex_array::arrays::NullArray
 
-pub type vortex_array::arrays::NullArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::NullArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::NullArray::deref(&self) -> &Self::Target
 
@@ -2970,19 +2922,15 @@ pub fn vortex_array::arrays::PrimitiveArray::patch(self, patches: &vortex_array:
 
 impl vortex_array::arrays::PrimitiveArray
 
-pub fn vortex_array::arrays::PrimitiveArray::to_array(&self) -> vortex_array::ArrayRef
-
-impl vortex_array::arrays::PrimitiveArray
-
 pub fn vortex_array::arrays::PrimitiveArray::top_value(&self) -> vortex_error::VortexResult<core::option::Option<(vortex_array::scalar::PValue, usize)>>
 
 impl core::clone::Clone for vortex_array::arrays::PrimitiveArray
 
 pub fn vortex_array::arrays::PrimitiveArray::clone(&self) -> vortex_array::arrays::PrimitiveArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::PrimitiveArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::PrimitiveArray
 
-pub fn vortex_array::arrays::PrimitiveArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::PrimitiveArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::PrimitiveArray> for vortex_array::ArrayRef
 
@@ -2994,7 +2942,7 @@ pub fn vortex_array::arrays::PrimitiveArray::fmt(&self, f: &mut core::fmt::Forma
 
 impl core::ops::deref::Deref for vortex_array::arrays::PrimitiveArray
 
-pub type vortex_array::arrays::PrimitiveArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::PrimitiveArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::PrimitiveArray::deref(&self) -> &Self::Target
 
@@ -3202,17 +3150,13 @@ pub fn vortex_array::arrays::ScalarFnArray::scalar_fn(&self) -> &vortex_array::s
 
 pub fn vortex_array::arrays::ScalarFnArray::try_new(bound: vortex_array::scalar_fn::ScalarFnRef, children: alloc::vec::Vec<vortex_array::ArrayRef>, len: usize) -> vortex_error::VortexResult<Self>
 
-impl vortex_array::arrays::ScalarFnArray
-
-pub fn vortex_array::arrays::ScalarFnArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::ScalarFnArray
 
 pub fn vortex_array::arrays::ScalarFnArray::clone(&self) -> vortex_array::arrays::ScalarFnArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::ScalarFnArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::ScalarFnArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::ScalarFnArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::ScalarFnArray> for vortex_array::ArrayRef
 
@@ -3224,7 +3168,7 @@ pub fn vortex_array::arrays::ScalarFnArray::fmt(&self, f: &mut core::fmt::Format
 
 impl core::ops::deref::Deref for vortex_array::arrays::ScalarFnArray
 
-pub type vortex_array::arrays::ScalarFnArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::ScalarFnArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::ScalarFnArray::deref(&self) -> &Self::Target
 
@@ -3252,7 +3196,7 @@ pub vortex_array::arrays::ScalarFnArrayView::vtable: &'a F
 
 impl<F: vortex_array::scalar_fn::ScalarFnVTable> core::ops::deref::Deref for vortex_array::arrays::ScalarFnArrayView<'_, F>
 
-pub type vortex_array::arrays::ScalarFnArrayView<'_, F>::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::ScalarFnArrayView<'_, F>::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::ScalarFnArrayView<'_, F>::deref(&self) -> &Self::Target
 
@@ -3342,17 +3286,13 @@ pub async fn vortex_array::arrays::SharedArray::get_or_compute_async<F, Fut>(&se
 
 pub fn vortex_array::arrays::SharedArray::new(source: vortex_array::ArrayRef) -> Self
 
-impl vortex_array::arrays::SharedArray
-
-pub fn vortex_array::arrays::SharedArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::SharedArray
 
 pub fn vortex_array::arrays::SharedArray::clone(&self) -> vortex_array::arrays::SharedArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::SharedArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::SharedArray
 
-pub fn vortex_array::arrays::SharedArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::SharedArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::SharedArray> for vortex_array::ArrayRef
 
@@ -3364,7 +3304,7 @@ pub fn vortex_array::arrays::SharedArray::fmt(&self, f: &mut core::fmt::Formatte
 
 impl core::ops::deref::Deref for vortex_array::arrays::SharedArray
 
-pub type vortex_array::arrays::SharedArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::SharedArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::SharedArray::deref(&self) -> &Self::Target
 
@@ -3458,17 +3398,13 @@ pub fn vortex_array::arrays::SliceArray::slice_range(&self) -> &core::ops::range
 
 pub fn vortex_array::arrays::SliceArray::try_new(child: vortex_array::ArrayRef, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<Self>
 
-impl vortex_array::arrays::SliceArray
-
-pub fn vortex_array::arrays::SliceArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::SliceArray
 
 pub fn vortex_array::arrays::SliceArray::clone(&self) -> vortex_array::arrays::SliceArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::SliceArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::SliceArray
 
-pub fn vortex_array::arrays::SliceArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::SliceArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::SliceArray> for vortex_array::ArrayRef
 
@@ -3480,7 +3416,7 @@ pub fn vortex_array::arrays::SliceArray::fmt(&self, f: &mut core::fmt::Formatter
 
 impl core::ops::deref::Deref for vortex_array::arrays::SliceArray
 
-pub type vortex_array::arrays::SliceArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::SliceArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::SliceArray::deref(&self) -> &Self::Target
 
@@ -3654,17 +3590,13 @@ impl vortex_array::arrays::StructArray
 
 pub fn vortex_array::arrays::StructArray::into_record_batch_with_schema(self, schema: impl core::convert::AsRef<arrow_schema::schema::Schema>) -> vortex_error::VortexResult<arrow_array::record_batch::RecordBatch>
 
-impl vortex_array::arrays::StructArray
-
-pub fn vortex_array::arrays::StructArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::StructArray
 
 pub fn vortex_array::arrays::StructArray::clone(&self) -> vortex_array::arrays::StructArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::StructArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::StructArray
 
-pub fn vortex_array::arrays::StructArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::StructArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::StructArray> for vortex_array::ArrayRef
 
@@ -3676,7 +3608,7 @@ pub fn vortex_array::arrays::StructArray::fmt(&self, f: &mut core::fmt::Formatte
 
 impl core::ops::deref::Deref for vortex_array::arrays::StructArray
 
-pub type vortex_array::arrays::StructArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::StructArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::StructArray::deref(&self) -> &Self::Target
 
@@ -3736,7 +3668,7 @@ pub fn vortex_array::arrays::StructVTable::mask(array: &vortex_array::arrays::St
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::StructVTable
 
-pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
 
@@ -3852,9 +3784,9 @@ impl core::clone::Clone for vortex_array::arrays::TemporalArray
 
 pub fn vortex_array::arrays::TemporalArray::clone(&self) -> vortex_array::arrays::TemporalArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::TemporalArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::TemporalArray
 
-pub fn vortex_array::arrays::TemporalArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::TemporalArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<&vortex_array::arrays::TemporalArray> for vortex_array::arrays::ExtensionArray
 
@@ -3868,7 +3800,7 @@ impl core::convert::From<vortex_array::arrays::TemporalArray> for vortex_array::
 
 pub fn vortex_array::arrays::ExtensionArray::from(value: vortex_array::arrays::TemporalArray) -> Self
 
-impl core::convert::TryFrom<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::arrays::TemporalArray
+impl core::convert::TryFrom<alloc::sync::Arc<dyn vortex_array::Array>> for vortex_array::arrays::TemporalArray
 
 pub type vortex_array::arrays::TemporalArray::Error = vortex_error::VortexError
 
@@ -3926,17 +3858,13 @@ pub fn vortex_array::arrays::VarBinArray::try_new_from_handle(offsets: vortex_ar
 
 pub fn vortex_array::arrays::VarBinArray::validate(offsets: &vortex_array::ArrayRef, bytes: &vortex_array::buffer::BufferHandle, dtype: &vortex_array::dtype::DType, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
 
-impl vortex_array::arrays::VarBinArray
-
-pub fn vortex_array::arrays::VarBinArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::VarBinArray
 
 pub fn vortex_array::arrays::VarBinArray::clone(&self) -> vortex_array::arrays::VarBinArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::VarBinArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::VarBinArray
 
-pub fn vortex_array::arrays::VarBinArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::VarBinArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<alloc::vec::Vec<&[u8]>> for vortex_array::arrays::VarBinArray
 
@@ -3988,7 +3916,7 @@ pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::colle
 
 impl core::ops::deref::Deref for vortex_array::arrays::VarBinArray
 
-pub type vortex_array::arrays::VarBinArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::VarBinArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::VarBinArray::deref(&self) -> &Self::Target
 
@@ -4174,17 +4102,13 @@ pub fn vortex_array::arrays::VarBinViewArray::compact_buffers(&self) -> vortex_e
 
 pub fn vortex_array::arrays::VarBinViewArray::compact_with_threshold(&self, buffer_utilization_threshold: f64) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
 
-impl vortex_array::arrays::VarBinViewArray
-
-pub fn vortex_array::arrays::VarBinViewArray::to_array(&self) -> vortex_array::ArrayRef
-
 impl core::clone::Clone for vortex_array::arrays::VarBinViewArray
 
 pub fn vortex_array::arrays::VarBinViewArray::clone(&self) -> vortex_array::arrays::VarBinViewArray
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::arrays::VarBinViewArray
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::arrays::VarBinViewArray
 
-pub fn vortex_array::arrays::VarBinViewArray::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::arrays::VarBinViewArray::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::arrays::VarBinViewArray> for vortex_array::ArrayRef
 
@@ -4204,7 +4128,7 @@ pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::c
 
 impl core::ops::deref::Deref for vortex_array::arrays::VarBinViewArray
 
-pub type vortex_array::arrays::VarBinViewArray::Target = dyn vortex_array::DynArray
+pub type vortex_array::arrays::VarBinViewArray::Target = dyn vortex_array::Array
 
 pub fn vortex_array::arrays::VarBinViewArray::deref(&self) -> &Self::Target
 
@@ -4288,7 +4212,7 @@ pub fn vortex_array::arrays::VarBinViewVTable::mask(array: &vortex_array::arrays
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinViewVTable
 
-pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinViewVTable> for vortex_array::arrays::VarBinViewVTable
 
@@ -4594,7 +4518,7 @@ pub fn vortex_array::arrow::ArrowArrayStreamAdapter::new(stream: arrow_array::ff
 
 impl core::iter::traits::iterator::Iterator for vortex_array::arrow::ArrowArrayStreamAdapter
 
-pub type vortex_array::arrow::ArrowArrayStreamAdapter::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::DynArray>, vortex_error::VortexError>
+pub type vortex_array::arrow::ArrowArrayStreamAdapter::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::Array>, vortex_error::VortexError>
 
 pub fn vortex_array::arrow::ArrowArrayStreamAdapter::next(&mut self) -> core::option::Option<Self::Item>
 
@@ -5042,8 +4966,6 @@ pub struct vortex_array::builders::DecimalBuilder
 
 impl vortex_array::builders::DecimalBuilder
 
-pub fn vortex_array::builders::DecimalBuilder::append_n_values<V: vortex_array::dtype::NativeDecimalType>(&mut self, value: V, n: usize)
-
 pub fn vortex_array::builders::DecimalBuilder::append_value<V: vortex_array::dtype::NativeDecimalType>(&mut self, value: V)
 
 pub fn vortex_array::builders::DecimalBuilder::decimal_dtype(&self) -> &vortex_array::dtype::DecimalDType
@@ -5388,8 +5310,6 @@ pub struct vortex_array::builders::PrimitiveBuilder<T>
 
 impl<T: vortex_array::dtype::NativePType> vortex_array::builders::PrimitiveBuilder<T>
 
-pub fn vortex_array::builders::PrimitiveBuilder<T>::append_n_values(&mut self, value: T, n: usize)
-
 pub fn vortex_array::builders::PrimitiveBuilder<T>::append_value(&mut self, value: T)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::extend_with_iterator(&mut self, iter: impl core::iter::traits::collect::IntoIterator<Item = T>, mask: vortex_mask::Mask)
@@ -5525,8 +5445,6 @@ pub unsafe fn vortex_array::builders::UninitRange<'_, T>::slice_uninit_mut(&mut 
 pub struct vortex_array::builders::VarBinViewBuilder
 
 impl vortex_array::builders::VarBinViewBuilder
-
-pub fn vortex_array::builders::VarBinViewBuilder::append_n_values<S: core::convert::AsRef<[u8]>>(&mut self, value: S, n: usize)
 
 pub fn vortex_array::builders::VarBinViewBuilder::append_value<S: core::convert::AsRef<[u8]>>(&mut self, value: S)
 
@@ -6074,7 +5992,7 @@ pub fn vortex_array::builtins::ArrayBuiltins::mask(self, mask: vortex_array::Arr
 
 pub fn vortex_array::builtins::ArrayBuiltins::not(&self) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::builtins::ArrayBuiltins::zip(&self, if_true: vortex_array::ArrayRef, if_false: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::builtins::ArrayBuiltins::zip(&self, if_false: vortex_array::ArrayRef, mask: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 impl vortex_array::builtins::ArrayBuiltins for vortex_array::ArrayRef
 
@@ -6096,7 +6014,7 @@ pub fn vortex_array::ArrayRef::mask(self, mask: vortex_array::ArrayRef) -> vorte
 
 pub fn vortex_array::ArrayRef::not(&self) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
-pub fn vortex_array::ArrayRef::zip(&self, if_true: vortex_array::ArrayRef, if_false: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::ArrayRef::zip(&self, if_false: vortex_array::ArrayRef, mask: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub trait vortex_array::builtins::ExprBuiltins: core::marker::Sized
 
@@ -6116,7 +6034,7 @@ pub fn vortex_array::builtins::ExprBuiltins::mask(&self, mask: vortex_array::exp
 
 pub fn vortex_array::builtins::ExprBuiltins::not(&self) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
-pub fn vortex_array::builtins::ExprBuiltins::zip(&self, if_true: vortex_array::expr::Expression, if_false: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+pub fn vortex_array::builtins::ExprBuiltins::zip(&self, if_false: vortex_array::expr::Expression, mask: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 impl vortex_array::builtins::ExprBuiltins for vortex_array::expr::Expression
 
@@ -6136,7 +6054,7 @@ pub fn vortex_array::expr::Expression::mask(&self, mask: vortex_array::expr::Exp
 
 pub fn vortex_array::expr::Expression::not(&self) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
-pub fn vortex_array::expr::Expression::zip(&self, if_true: vortex_array::expr::Expression, if_false: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+pub fn vortex_array::expr::Expression::zip(&self, if_false: vortex_array::expr::Expression, mask: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub mod vortex_array::compute
 
@@ -6168,7 +6086,7 @@ impl core::marker::StructuralPartialEq for vortex_array::compute::Cost
 
 pub enum vortex_array::compute::Input<'a>
 
-pub vortex_array::compute::Input::Array(&'a dyn vortex_array::DynArray)
+pub vortex_array::compute::Input::Array(&'a dyn vortex_array::Array)
 
 pub vortex_array::compute::Input::Builder(&'a mut dyn vortex_array::builders::ArrayBuilder)
 
@@ -6180,7 +6098,7 @@ pub vortex_array::compute::Input::Scalar(&'a vortex_array::scalar::Scalar)
 
 impl<'a> vortex_array::compute::Input<'a>
 
-pub fn vortex_array::compute::Input<'a>::array(&self) -> core::option::Option<&'a dyn vortex_array::DynArray>
+pub fn vortex_array::compute::Input<'a>::array(&self) -> core::option::Option<&'a dyn vortex_array::Array>
 
 pub fn vortex_array::compute::Input<'a>::builder(&'a mut self) -> core::option::Option<&'a mut dyn vortex_array::builders::ArrayBuilder>
 
@@ -6194,11 +6112,11 @@ impl core::fmt::Debug for vortex_array::compute::Input<'_>
 
 pub fn vortex_array::compute::Input<'_>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl<'a> core::convert::From<&'a (dyn vortex_array::DynArray + 'static)> for vortex_array::compute::Input<'a>
+impl<'a> core::convert::From<&'a (dyn vortex_array::Array + 'static)> for vortex_array::compute::Input<'a>
 
-pub fn vortex_array::compute::Input<'a>::from(value: &'a dyn vortex_array::DynArray) -> Self
+pub fn vortex_array::compute::Input<'a>::from(value: &'a dyn vortex_array::Array) -> Self
 
-impl<'a> core::convert::From<&'a alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::compute::Input<'a>
+impl<'a> core::convert::From<&'a alloc::sync::Arc<dyn vortex_array::Array>> for vortex_array::compute::Input<'a>
 
 pub fn vortex_array::compute::Input<'a>::from(value: &'a vortex_array::ArrayRef) -> Self
 
@@ -6230,7 +6148,7 @@ pub fn vortex_array::compute::Output::unwrap_array(self) -> vortex_error::Vortex
 
 pub fn vortex_array::compute::Output::unwrap_scalar(self) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl core::convert::From<alloc::sync::Arc<dyn vortex_array::DynArray>> for vortex_array::compute::Output
+impl core::convert::From<alloc::sync::Arc<dyn vortex_array::Array>> for vortex_array::compute::Output
 
 pub fn vortex_array::compute::Output::from(value: vortex_array::ArrayRef) -> Self
 
@@ -6244,11 +6162,11 @@ pub fn vortex_array::compute::Output::fmt(&self, f: &mut core::fmt::Formatter<'_
 
 pub struct vortex_array::compute::BinaryArgs<'a, O: vortex_array::compute::Options>
 
-pub vortex_array::compute::BinaryArgs::lhs: &'a dyn vortex_array::DynArray
+pub vortex_array::compute::BinaryArgs::lhs: &'a dyn vortex_array::Array
 
 pub vortex_array::compute::BinaryArgs::options: &'a O
 
-pub vortex_array::compute::BinaryArgs::rhs: &'a dyn vortex_array::DynArray
+pub vortex_array::compute::BinaryArgs::rhs: &'a dyn vortex_array::Array
 
 impl<'a, O: vortex_array::compute::Options> core::convert::TryFrom<&vortex_array::compute::InvocationArgs<'a>> for vortex_array::compute::BinaryArgs<'a, O>
 
@@ -6442,7 +6360,7 @@ pub struct vortex_array::compute::SumArgs<'a>
 
 pub vortex_array::compute::SumArgs::accumulator: &'a vortex_array::scalar::Scalar
 
-pub vortex_array::compute::SumArgs::array: &'a dyn vortex_array::DynArray
+pub vortex_array::compute::SumArgs::array: &'a dyn vortex_array::Array
 
 impl<'a> core::convert::TryFrom<&vortex_array::compute::InvocationArgs<'a>> for vortex_array::compute::SumArgs<'a>
 
@@ -6470,7 +6388,7 @@ impl inventory::Collect for vortex_array::compute::SumKernelRef
 
 pub struct vortex_array::compute::UnaryArgs<'a, O: vortex_array::compute::Options>
 
-pub vortex_array::compute::UnaryArgs::array: &'a dyn vortex_array::DynArray
+pub vortex_array::compute::UnaryArgs::array: &'a dyn vortex_array::Array
 
 pub vortex_array::compute::UnaryArgs::options: &'a O
 
@@ -6768,6 +6686,26 @@ impl vortex_array::compute::SumKernel for vortex_array::arrays::PrimitiveVTable
 
 pub fn vortex_array::arrays::PrimitiveVTable::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
+pub fn vortex_array::compute::add(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::add_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::and_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::arrow_filter_fn(array: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::cast(array: &dyn vortex_array::Array, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::div(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::div_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::fill_null(array: &vortex_array::ArrayRef, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::filter(array: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::invert(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
 pub fn vortex_array::compute::is_constant(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 pub fn vortex_array::compute::is_constant_opts(array: &vortex_array::ArrayRef, options: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
@@ -6778,15 +6716,33 @@ pub fn vortex_array::compute::is_sorted_opts(array: &vortex_array::ArrayRef, str
 
 pub fn vortex_array::compute::is_strict_sorted(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<bool>>
 
+pub fn vortex_array::compute::list_contains(array: &vortex_array::ArrayRef, value: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::mask(array: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
 pub fn vortex_array::compute::min_max(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
+pub fn vortex_array::compute::mul(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::mul_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
 pub fn vortex_array::compute::nan_count(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::compute::numeric(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef, op: vortex_array::scalar::NumericOperator) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::or_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::sub(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::compute::sub_scalar(lhs: &vortex_array::ArrayRef, rhs: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::compute::sum(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::compute::sum_impl(array: &vortex_array::ArrayRef, accumulator: &vortex_array::scalar::Scalar, kernels: &[arcref::ArcRef<dyn vortex_array::compute::Kernel>]) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::compute::warm_up_vtables()
+
+pub fn vortex_array::compute::zip(if_true: &vortex_array::ArrayRef, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub mod vortex_array::display
 
@@ -6810,7 +6766,7 @@ impl core::default::Default for vortex_array::display::DisplayOptions
 
 pub fn vortex_array::display::DisplayOptions::default() -> Self
 
-pub struct vortex_array::display::DisplayArrayAs<'a>(pub &'a dyn vortex_array::DynArray, pub vortex_array::display::DisplayOptions)
+pub struct vortex_array::display::DisplayArrayAs<'a>(pub &'a dyn vortex_array::Array, pub vortex_array::display::DisplayOptions)
 
 impl core::fmt::Display for vortex_array::display::DisplayArrayAs<'_>
 
@@ -8433,10 +8389,6 @@ pub fn vortex_array::dtype::i256::as_(self) -> i64
 impl num_traits::cast::AsPrimitive<i8> for vortex_array::dtype::i256
 
 pub fn vortex_array::dtype::i256::as_(self) -> i8
-
-impl num_traits::cast::AsPrimitive<vortex_array::dtype::i256> for bool
-
-pub fn bool::as_(self) -> vortex_array::dtype::i256
 
 impl num_traits::cast::AsPrimitive<vortex_array::dtype::i256> for i128
 
@@ -10508,7 +10460,7 @@ pub fn vortex_array::expr::Expression::mask(&self, mask: vortex_array::expr::Exp
 
 pub fn vortex_array::expr::Expression::not(&self) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
-pub fn vortex_array::expr::Expression::zip(&self, if_true: vortex_array::expr::Expression, if_false: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+pub fn vortex_array::expr::Expression::zip(&self, if_false: vortex_array::expr::Expression, mask: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 impl vortex_array::expr::VortexExprExt for vortex_array::expr::Expression
 
@@ -10564,10 +10516,6 @@ pub fn vortex_array::expr::and_collect<I>(iter: I) -> core::option::Option<vorte
 
 pub fn vortex_array::expr::between(arr: vortex_array::expr::Expression, lower: vortex_array::expr::Expression, upper: vortex_array::expr::Expression, options: vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_array::expr::Expression
 
-pub fn vortex_array::expr::case_when(condition: vortex_array::expr::Expression, then_value: vortex_array::expr::Expression, else_value: vortex_array::expr::Expression) -> vortex_array::expr::Expression
-
-pub fn vortex_array::expr::case_when_no_else(condition: vortex_array::expr::Expression, then_value: vortex_array::expr::Expression) -> vortex_array::expr::Expression
-
 pub fn vortex_array::expr::cast(child: vortex_array::expr::Expression, target: vortex_array::dtype::DType) -> vortex_array::expr::Expression
 
 pub fn vortex_array::expr::checked_add(lhs: vortex_array::expr::Expression, rhs: vortex_array::expr::Expression) -> vortex_array::expr::Expression
@@ -10622,8 +10570,6 @@ pub fn vortex_array::expr::merge(elements: impl core::iter::traits::collect::Int
 
 pub fn vortex_array::expr::merge_opts(elements: impl core::iter::traits::collect::IntoIterator<Item = impl core::convert::Into<vortex_array::expr::Expression>>, duplicate_handling: vortex_array::scalar_fn::fns::merge::DuplicateHandling) -> vortex_array::expr::Expression
 
-pub fn vortex_array::expr::nested_case_when(when_then_pairs: alloc::vec::Vec<(vortex_array::expr::Expression, vortex_array::expr::Expression)>, else_value: core::option::Option<vortex_array::expr::Expression>) -> vortex_array::expr::Expression
-
 pub fn vortex_array::expr::not(operand: vortex_array::expr::Expression) -> vortex_array::expr::Expression
 
 pub fn vortex_array::expr::not_eq(lhs: vortex_array::expr::Expression, rhs: vortex_array::expr::Expression) -> vortex_array::expr::Expression
@@ -10646,7 +10592,7 @@ pub fn vortex_array::expr::select_exclude(fields: impl core::convert::Into<vorte
 
 pub fn vortex_array::expr::split_conjunction(expr: &vortex_array::expr::Expression) -> alloc::vec::Vec<vortex_array::expr::Expression>
 
-pub fn vortex_array::expr::zip_expr(mask: vortex_array::expr::Expression, if_true: vortex_array::expr::Expression, if_false: vortex_array::expr::Expression) -> vortex_array::expr::Expression
+pub fn vortex_array::expr::zip_expr(if_true: vortex_array::expr::Expression, if_false: vortex_array::expr::Expression, mask: vortex_array::expr::Expression) -> vortex_array::expr::Expression
 
 pub type vortex_array::expr::Annotations<'a, A> = vortex_utils::aliases::hash_map::HashMap<&'a vortex_array::expr::Expression, vortex_utils::aliases::hash_set::HashSet<A>>
 
@@ -11042,7 +10988,7 @@ pub fn vortex_array::iter::ArrayIteratorAdapter<I>::new(dtype: vortex_array::dty
 
 impl<I> core::iter::traits::iterator::Iterator for vortex_array::iter::ArrayIteratorAdapter<I> where I: core::iter::traits::iterator::Iterator<Item = vortex_error::VortexResult<vortex_array::ArrayRef>>
 
-pub type vortex_array::iter::ArrayIteratorAdapter<I>::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::DynArray>, vortex_error::VortexError>
+pub type vortex_array::iter::ArrayIteratorAdapter<I>::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::Array>, vortex_error::VortexError>
 
 pub fn vortex_array::iter::ArrayIteratorAdapter<I>::next(&mut self) -> core::option::Option<Self::Item>
 
@@ -11204,67 +11150,67 @@ pub fn vortex_array::matcher::AnyArray::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl vortex_array::matcher::Matcher for vortex_array::matcher::AnyArray
 
-pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::DynArray + 'static)
+pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::Array + 'static)
 
-pub fn vortex_array::matcher::AnyArray::matches(_array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::matcher::AnyArray::matches(_array: &dyn vortex_array::Array) -> bool
 
-pub fn vortex_array::matcher::AnyArray::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::matcher::AnyArray::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 pub trait vortex_array::matcher::Matcher
 
 pub type vortex_array::matcher::Matcher::Match<'a>
 
-pub fn vortex_array::matcher::Matcher::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::matcher::Matcher::matches(array: &dyn vortex_array::Array) -> bool
 
-pub fn vortex_array::matcher::Matcher::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::matcher::Matcher::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 impl vortex_array::matcher::Matcher for vortex_array::AnyCanonical
 
 pub type vortex_array::AnyCanonical::Match<'a> = vortex_array::CanonicalView<'a>
 
-pub fn vortex_array::AnyCanonical::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::AnyCanonical::matches(array: &dyn vortex_array::Array) -> bool
 
-pub fn vortex_array::AnyCanonical::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::AnyCanonical::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 impl vortex_array::matcher::Matcher for vortex_array::AnyColumnar
 
 pub type vortex_array::AnyColumnar::Match<'a> = vortex_array::ColumnarView<'a>
 
-pub fn vortex_array::AnyColumnar::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::AnyColumnar::matches(array: &dyn vortex_array::Array) -> bool
 
-pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 impl vortex_array::matcher::Matcher for vortex_array::arrays::AnyScalarFn
 
 pub type vortex_array::arrays::AnyScalarFn::Match<'a> = &'a vortex_array::arrays::ScalarFnArray
 
-pub fn vortex_array::arrays::AnyScalarFn::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::arrays::AnyScalarFn::matches(array: &dyn vortex_array::Array) -> bool
 
-pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::arrays::AnyScalarFn::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 impl vortex_array::matcher::Matcher for vortex_array::matcher::AnyArray
 
-pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::DynArray + 'static)
+pub type vortex_array::matcher::AnyArray::Match<'a> = &'a (dyn vortex_array::Array + 'static)
 
-pub fn vortex_array::matcher::AnyArray::matches(_array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::matcher::AnyArray::matches(_array: &dyn vortex_array::Array) -> bool
 
-pub fn vortex_array::matcher::AnyArray::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::matcher::AnyArray::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 impl<F: vortex_array::scalar_fn::ScalarFnVTable> vortex_array::matcher::Matcher for vortex_array::arrays::ExactScalarFn<F>
 
 pub type vortex_array::arrays::ExactScalarFn<F>::Match<'a> = vortex_array::arrays::ScalarFnArrayView<'a, F>
 
-pub fn vortex_array::arrays::ExactScalarFn<F>::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::arrays::ExactScalarFn<F>::matches(array: &dyn vortex_array::Array) -> bool
 
-pub fn vortex_array::arrays::ExactScalarFn<F>::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::arrays::ExactScalarFn<F>::try_match(array: &dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::matcher::Matcher for V
 
 pub type V::Match<'a> = &'a <V as vortex_array::vtable::VTable>::Array
 
-pub fn V::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn V::matches(array: &dyn vortex_array::Array) -> bool
 
-pub fn V::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn V::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 pub mod vortex_array::normalize
 
@@ -12006,9 +11952,9 @@ pub fn vortex_array::scalar::ScalarValue::into_utf8(self) -> vortex_buffer::stri
 
 impl vortex_array::scalar::ScalarValue
 
-pub fn vortex_array::scalar::ScalarValue::from_proto(value: &vortex_proto::scalar::ScalarValue, dtype: &vortex_array::dtype::DType, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<core::option::Option<Self>>
+pub fn vortex_array::scalar::ScalarValue::from_proto(value: &vortex_proto::scalar::ScalarValue, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<Self>>
 
-pub fn vortex_array::scalar::ScalarValue::from_proto_bytes(bytes: &[u8], dtype: &vortex_array::dtype::DType, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<core::option::Option<Self>>
+pub fn vortex_array::scalar::ScalarValue::from_proto_bytes(bytes: &[u8], dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<Self>>
 
 impl vortex_array::scalar::ScalarValue
 
@@ -12714,13 +12660,11 @@ impl vortex_array::scalar::Scalar
 
 pub fn vortex_array::scalar::Scalar::from_proto(value: &vortex_proto::scalar::Scalar, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_array::scalar::Scalar::from_proto_value(value: &vortex_proto::scalar::ScalarValue, dtype: &vortex_array::dtype::DType, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::scalar::Scalar::from_proto_value(value: &vortex_proto::scalar::ScalarValue, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self>
 
 impl vortex_array::scalar::Scalar
 
-pub fn vortex_array::scalar::Scalar::struct_(dtype: vortex_array::dtype::DType, children: impl core::iter::traits::collect::IntoIterator<Item = vortex_array::scalar::Scalar>) -> Self
-
-pub unsafe fn vortex_array::scalar::Scalar::struct_unchecked(dtype: vortex_array::dtype::DType, children: impl core::iter::traits::collect::IntoIterator<Item = vortex_array::scalar::Scalar>) -> Self
+pub fn vortex_array::scalar::Scalar::struct_(dtype: vortex_array::dtype::DType, children: alloc::vec::Vec<vortex_array::scalar::Scalar>) -> Self
 
 impl vortex_array::scalar::Scalar
 
@@ -13148,19 +13092,19 @@ impl core::hash::Hash for vortex_array::scalar::Scalar
 
 pub fn vortex_array::scalar::Scalar::hash<H: core::hash::Hasher>(&self, state: &mut H)
 
-impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::Scalar> for (dyn vortex_array::DynArray + '_)
+impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::Scalar> for (dyn vortex_array::Array + '_)
 
-pub fn (dyn vortex_array::DynArray + '_)::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
+pub fn (dyn vortex_array::Array + '_)::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
-pub fn (dyn vortex_array::DynArray + '_)::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::Array + '_)::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::DynArray + '_)::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::Array + '_)::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::DynArray + '_)::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::Array + '_)::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::DynArray + '_)::index_len(&self) -> usize
+pub fn (dyn vortex_array::Array + '_)::index_len(&self) -> usize
 
-pub fn (dyn vortex_array::DynArray + '_)::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::Array + '_)::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 impl<'a, T> core::convert::TryFrom<&'a vortex_array::scalar::Scalar> for alloc::vec::Vec<T> where T: for<'b> core::convert::TryFrom<&'b vortex_array::scalar::Scalar, Error = vortex_error::VortexError>
 
@@ -13673,86 +13617,6 @@ pub fn vortex_array::scalar_fn::fns::binary::compare_nested_arrow_arrays(lhs: &d
 pub fn vortex_array::scalar_fn::fns::binary::or_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::scalar_cmp(lhs: &vortex_array::scalar::Scalar, rhs: &vortex_array::scalar::Scalar, operator: vortex_array::scalar_fn::fns::operators::CompareOperator) -> vortex_array::scalar::Scalar
-
-pub mod vortex_array::scalar_fn::fns::case_when
-
-pub struct vortex_array::scalar_fn::fns::case_when::CaseWhen
-
-impl core::clone::Clone for vortex_array::scalar_fn::fns::case_when::CaseWhen
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::clone(&self) -> vortex_array::scalar_fn::fns::case_when::CaseWhen
-
-impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::case_when::CaseWhen
-
-pub type vortex_array::scalar_fn::fns::case_when::CaseWhen::Options = vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::arity(&self, options: &Self::Options) -> vortex_array::scalar_fn::Arity
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::child_name(&self, options: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::deserialize(&self, metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::id(&self) -> vortex_array::scalar_fn::ScalarFnId
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::is_fallible(&self, _options: &Self::Options) -> bool
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::is_null_sensitive(&self, _options: &Self::Options) -> bool
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::return_dtype(&self, options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
-
-pub struct vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-pub vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::has_else: bool
-
-pub vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::num_when_then_pairs: u32
-
-impl vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::num_children(&self) -> usize
-
-impl core::clone::Clone for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::clone(&self) -> vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-impl core::cmp::Eq for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-impl core::cmp::PartialEq for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::eq(&self, other: &vortex_array::scalar_fn::fns::case_when::CaseWhenOptions) -> bool
-
-impl core::fmt::Debug for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::fmt::Display for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl core::hash::Hash for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhenOptions::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-
-impl core::marker::Copy for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-impl core::marker::StructuralPartialEq for vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
 
 pub mod vortex_array::scalar_fn::fns::cast
 
@@ -14312,7 +14176,7 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::child_name(&se
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -15176,23 +15040,23 @@ pub fn vortex_array::scalar_fn::fns::zip::ZipReduceAdaptor<V>::reduce_parent(&se
 
 pub trait vortex_array::scalar_fn::fns::zip::ZipKernel: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipKernel::zip(array: &Self::Array, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipKernel::zip(array: &Self::Array, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::StructVTable
 
-pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinViewVTable
 
-pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::zip::ZipReduce: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::zip::ZipReduce::zip(array: &Self::Array, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::zip::ZipReduce::zip(array: &Self::Array, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::zip::ZipReduce for vortex_array::arrays::ChunkedVTable
+
+pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::session
 
@@ -15586,42 +15450,6 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_falsification(&self, o
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::validity(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
-impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::case_when::CaseWhen
-
-pub type vortex_array::scalar_fn::fns::case_when::CaseWhen::Options = vortex_array::scalar_fn::fns::case_when::CaseWhenOptions
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::arity(&self, options: &Self::Options) -> vortex_array::scalar_fn::Arity
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::child_name(&self, options: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::deserialize(&self, metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::execute(&self, options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::fmt_sql(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::id(&self) -> vortex_array::scalar_fn::ScalarFnId
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::is_fallible(&self, _options: &Self::Options) -> bool
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::is_null_sensitive(&self, _options: &Self::Options) -> bool
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::return_dtype(&self, options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::serialize(&self, _options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
-
-pub fn vortex_array::scalar_fn::fns::case_when::CaseWhen::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
-
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::cast::Cast
 
 pub type vortex_array::scalar_fn::fns::cast::Cast::Options = vortex_array::dtype::DType
@@ -15848,7 +15676,7 @@ pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::child_name(&se
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::execute(&self, _options: &Self::Options, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::list_contains::ListContains::fmt_sql(&self, _options: &Self::Options, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -16300,19 +16128,19 @@ pub fn vortex_array::variants::PrimitiveTyped<'_>::index_len(&self) -> usize
 
 pub fn vortex_array::variants::PrimitiveTyped<'_>::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::Scalar> for (dyn vortex_array::DynArray + '_)
+impl vortex_array::search_sorted::IndexOrd<vortex_array::scalar::Scalar> for (dyn vortex_array::Array + '_)
 
-pub fn (dyn vortex_array::DynArray + '_)::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
+pub fn (dyn vortex_array::Array + '_)::index_cmp(&self, idx: usize, elem: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<core::cmp::Ordering>>
 
-pub fn (dyn vortex_array::DynArray + '_)::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::Array + '_)::index_ge(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::DynArray + '_)::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::Array + '_)::index_gt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::DynArray + '_)::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::Array + '_)::index_le(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
-pub fn (dyn vortex_array::DynArray + '_)::index_len(&self) -> usize
+pub fn (dyn vortex_array::Array + '_)::index_len(&self) -> usize
 
-pub fn (dyn vortex_array::DynArray + '_)::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
+pub fn (dyn vortex_array::Array + '_)::index_lt(&self, idx: usize, elem: &V) -> vortex_error::VortexResult<bool>
 
 impl<T: core::cmp::PartialOrd> vortex_array::search_sorted::IndexOrd<T> for [T]
 
@@ -16346,7 +16174,7 @@ pub struct vortex_array::serde::ArrayNodeFlatBuffer<'a>
 
 impl<'a> vortex_array::serde::ArrayNodeFlatBuffer<'a>
 
-pub fn vortex_array::serde::ArrayNodeFlatBuffer<'a>::try_new(ctx: &'a vortex_array::ArrayContext, array: &'a dyn vortex_array::DynArray) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::serde::ArrayNodeFlatBuffer<'a>::try_new(ctx: &'a vortex_array::ArrayContext, array: &'a dyn vortex_array::Array) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_array::serde::ArrayNodeFlatBuffer<'a>::try_write_flatbuffer<'fb>(&self, fbb: &mut flatbuffers::builder::FlatBufferBuilder<'fb>) -> vortex_error::VortexResult<flatbuffers::primitives::WIPOffset<vortex_flatbuffers::array::ArrayNode<'fb>>>
 
@@ -16470,7 +16298,7 @@ pub fn vortex_array::stats::ArrayStats::retain(&self, stats: &[vortex_array::exp
 
 pub fn vortex_array::stats::ArrayStats::set(&self, stat: vortex_array::expr::stats::Stat, value: vortex_array::expr::stats::Precision<vortex_array::scalar::ScalarValue>)
 
-pub fn vortex_array::stats::ArrayStats::to_ref<'a>(&'a self, array: &'a dyn vortex_array::DynArray) -> vortex_array::stats::StatsSetRef<'a>
+pub fn vortex_array::stats::ArrayStats::to_ref<'a>(&'a self, array: &'a dyn vortex_array::Array) -> vortex_array::stats::StatsSetRef<'a>
 
 impl core::clone::Clone for vortex_array::stats::ArrayStats
 
@@ -16560,7 +16388,7 @@ pub fn vortex_array::stats::StatsSet::merge_unordered(self, other: &Self, dtype:
 
 impl vortex_array::stats::StatsSet
 
-pub fn vortex_array::stats::StatsSet::from_flatbuffer<'a>(fb: &vortex_flatbuffers::array::ArrayStats<'a>, array_dtype: &vortex_array::dtype::DType, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::stats::StatsSet::from_flatbuffer<'a>(fb: &vortex_flatbuffers::array::ArrayStats<'a>, array_dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<Self>
 
 impl core::clone::Clone for vortex_array::stats::StatsSet
 
@@ -16702,7 +16530,7 @@ impl<'__pin, S> core::marker::Unpin for vortex_array::stream::ArrayStreamAdapter
 
 impl<S> futures_core::stream::Stream for vortex_array::stream::ArrayStreamAdapter<S> where S: futures_core::stream::Stream<Item = vortex_error::VortexResult<vortex_array::ArrayRef>>
 
-pub type vortex_array::stream::ArrayStreamAdapter<S>::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::DynArray>, vortex_error::VortexError>
+pub type vortex_array::stream::ArrayStreamAdapter<S>::Item = core::result::Result<alloc::sync::Arc<dyn vortex_array::Array>, vortex_error::VortexError>
 
 pub fn vortex_array::stream::ArrayStreamAdapter<S>::poll_next(self: core::pin::Pin<&mut Self>, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::option::Option<Self::Item>>
 
@@ -17060,7 +16888,7 @@ pub fn vortex_array::vtable::NotSupported::scalar_at(array: &<V as vortex_array:
 
 pub trait vortex_array::vtable::VTable: 'static + core::marker::Sized + core::marker::Send + core::marker::Sync + core::fmt::Debug
 
-pub type vortex_array::vtable::VTable::Array: 'static + core::marker::Send + core::marker::Sync + core::clone::Clone + core::fmt::Debug + core::ops::deref::Deref<Target = dyn vortex_array::DynArray> + vortex_array::IntoArray
+pub type vortex_array::vtable::VTable::Array: 'static + core::marker::Send + core::marker::Sync + core::clone::Clone + core::fmt::Debug + core::ops::deref::Deref<Target = dyn vortex_array::Array> + vortex_array::IntoArray
 
 pub type vortex_array::vtable::VTable::Metadata: core::fmt::Debug
 
@@ -17224,13 +17052,13 @@ impl vortex_array::vtable::VTable for vortex_array::arrays::ConstantVTable
 
 pub type vortex_array::arrays::ConstantVTable::Array = vortex_array::arrays::ConstantArray
 
-pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::scalar::Scalar
+pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::EmptyMetadata
 
 pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::arrays::ConstantVTable
 
 pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
 
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 
@@ -17240,13 +17068,13 @@ pub fn vortex_array::arrays::ConstantVTable::buffer(array: &vortex_array::arrays
 
 pub fn vortex_array::arrays::ConstantVTable::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ConstantVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
+pub fn vortex_array::arrays::ConstantVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
 
 pub fn vortex_array::arrays::ConstantVTable::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
 
 pub fn vortex_array::arrays::ConstantVTable::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
 
@@ -17258,7 +17086,7 @@ pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_
 
 pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ConstantVTable::metadata(_array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
 
 pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
 
@@ -18368,9 +18196,9 @@ impl core::clone::Clone for vortex_array::Canonical
 
 pub fn vortex_array::Canonical::clone(&self) -> vortex_array::Canonical
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::Canonical
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::Canonical
 
-pub fn vortex_array::Canonical::as_ref(&self) -> &(dyn vortex_array::DynArray + 'static)
+pub fn vortex_array::Canonical::as_ref(&self) -> &(dyn vortex_array::Array + 'static)
 
 impl core::convert::From<vortex_array::Canonical> for vortex_array::ArrayRef
 
@@ -18412,9 +18240,9 @@ pub vortex_array::CanonicalView::Struct(&'a vortex_array::arrays::StructArray)
 
 pub vortex_array::CanonicalView::VarBinView(&'a vortex_array::arrays::VarBinViewArray)
 
-impl core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::CanonicalView<'_>
+impl core::convert::AsRef<dyn vortex_array::Array> for vortex_array::CanonicalView<'_>
 
-pub fn vortex_array::CanonicalView<'_>::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::CanonicalView<'_>::as_ref(&self) -> &dyn vortex_array::Array
 
 impl core::convert::From<vortex_array::CanonicalView<'_>> for vortex_array::Canonical
 
@@ -18446,7 +18274,7 @@ pub fn vortex_array::Columnar::len(&self) -> usize
 
 impl vortex_array::Executable for vortex_array::Columnar
 
-pub fn vortex_array::Columnar::execute(root: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::Columnar::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 impl vortex_array::IntoArray for vortex_array::Columnar
 
@@ -18458,15 +18286,21 @@ pub vortex_array::ColumnarView::Canonical(vortex_array::CanonicalView<'a>)
 
 pub vortex_array::ColumnarView::Constant(&'a vortex_array::arrays::ConstantArray)
 
-impl<'a> core::convert::AsRef<dyn vortex_array::DynArray> for vortex_array::ColumnarView<'a>
+impl<'a> core::convert::AsRef<dyn vortex_array::Array> for vortex_array::ColumnarView<'a>
 
-pub fn vortex_array::ColumnarView<'a>::as_ref(&self) -> &dyn vortex_array::DynArray
+pub fn vortex_array::ColumnarView<'a>::as_ref(&self) -> &dyn vortex_array::Array
 
 pub enum vortex_array::ExecutionStep
 
 pub vortex_array::ExecutionStep::Done(vortex_array::ArrayRef)
 
-pub vortex_array::ExecutionStep::ExecuteChild(usize)
+pub vortex_array::ExecutionStep::ExecuteChild(usize, vortex_array::DonePredicate)
+
+impl vortex_array::ExecutionStep
+
+pub fn vortex_array::ExecutionStep::done(result: vortex_array::ArrayRef) -> Self
+
+pub fn vortex_array::ExecutionStep::execute_child<M: vortex_array::matcher::Matcher>(child_idx: usize) -> Self
 
 impl core::fmt::Debug for vortex_array::ExecutionStep
 
@@ -18494,9 +18328,9 @@ impl vortex_array::matcher::Matcher for vortex_array::AnyCanonical
 
 pub type vortex_array::AnyCanonical::Match<'a> = vortex_array::CanonicalView<'a>
 
-pub fn vortex_array::AnyCanonical::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::AnyCanonical::matches(array: &dyn vortex_array::Array) -> bool
 
-pub fn vortex_array::AnyCanonical::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::AnyCanonical::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 pub struct vortex_array::AnyColumnar
 
@@ -18504,9 +18338,9 @@ impl vortex_array::matcher::Matcher for vortex_array::AnyColumnar
 
 pub type vortex_array::AnyColumnar::Match<'a> = vortex_array::ColumnarView<'a>
 
-pub fn vortex_array::AnyColumnar::matches(array: &dyn vortex_array::DynArray) -> bool
+pub fn vortex_array::AnyColumnar::matches(array: &dyn vortex_array::Array) -> bool
 
-pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+pub fn vortex_array::AnyColumnar::try_match<'a>(array: &'a dyn vortex_array::Array) -> core::option::Option<Self::Match>
 
 #[repr(transparent)] pub struct vortex_array::ArrayAdapter<V: vortex_array::vtable::VTable>(_)
 
@@ -18518,43 +18352,7 @@ impl<V: vortex_array::vtable::VTable> core::fmt::Debug for vortex_array::ArrayAd
 
 pub fn vortex_array::ArrayAdapter<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl<V: vortex_array::vtable::VTable> vortex_array::ArrayEq for vortex_array::ArrayAdapter<V>
-
-pub fn vortex_array::ArrayAdapter<V>::array_eq(&self, other: &Self, precision: vortex_array::Precision) -> bool
-
-impl<V: vortex_array::vtable::VTable> vortex_array::ArrayHash for vortex_array::ArrayAdapter<V>
-
-pub fn vortex_array::ArrayAdapter<V>::array_hash<H: core::hash::Hasher>(&self, state: &mut H, precision: vortex_array::Precision)
-
-impl<V: vortex_array::vtable::VTable> vortex_array::ArrayVisitor for vortex_array::ArrayAdapter<V>
-
-pub fn vortex_array::ArrayAdapter<V>::buffer_handles(&self) -> alloc::vec::Vec<vortex_array::buffer::BufferHandle>
-
-pub fn vortex_array::ArrayAdapter<V>::buffer_names(&self) -> alloc::vec::Vec<alloc::string::String>
-
-pub fn vortex_array::ArrayAdapter<V>::buffers(&self) -> alloc::vec::Vec<vortex_buffer::ByteBuffer>
-
-pub fn vortex_array::ArrayAdapter<V>::children(&self) -> alloc::vec::Vec<vortex_array::ArrayRef>
-
-pub fn vortex_array::ArrayAdapter<V>::children_names(&self) -> alloc::vec::Vec<alloc::string::String>
-
-pub fn vortex_array::ArrayAdapter<V>::is_host(&self) -> bool
-
-pub fn vortex_array::ArrayAdapter<V>::metadata(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::ArrayAdapter<V>::metadata_fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-pub fn vortex_array::ArrayAdapter<V>::named_buffers(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::buffer::BufferHandle)>
-
-pub fn vortex_array::ArrayAdapter<V>::named_children(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::ArrayRef)>
-
-pub fn vortex_array::ArrayAdapter<V>::nbuffers(&self) -> usize
-
-pub fn vortex_array::ArrayAdapter<V>::nchildren(&self) -> usize
-
-pub fn vortex_array::ArrayAdapter<V>::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
-
-impl<V: vortex_array::vtable::VTable> vortex_array::DynArray for vortex_array::ArrayAdapter<V>
+impl<V: vortex_array::vtable::VTable> vortex_array::Array for vortex_array::ArrayAdapter<V>
 
 pub fn vortex_array::ArrayAdapter<V>::all_invalid(&self) -> vortex_error::VortexResult<bool>
 
@@ -18603,6 +18401,42 @@ pub fn vortex_array::ArrayAdapter<V>::validity_mask(&self) -> vortex_error::Vort
 pub fn vortex_array::ArrayAdapter<V>::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
 
 pub fn vortex_array::ArrayAdapter<V>::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+impl<V: vortex_array::vtable::VTable> vortex_array::ArrayEq for vortex_array::ArrayAdapter<V>
+
+pub fn vortex_array::ArrayAdapter<V>::array_eq(&self, other: &Self, precision: vortex_array::Precision) -> bool
+
+impl<V: vortex_array::vtable::VTable> vortex_array::ArrayHash for vortex_array::ArrayAdapter<V>
+
+pub fn vortex_array::ArrayAdapter<V>::array_hash<H: core::hash::Hasher>(&self, state: &mut H, precision: vortex_array::Precision)
+
+impl<V: vortex_array::vtable::VTable> vortex_array::ArrayVisitor for vortex_array::ArrayAdapter<V>
+
+pub fn vortex_array::ArrayAdapter<V>::buffer_handles(&self) -> alloc::vec::Vec<vortex_array::buffer::BufferHandle>
+
+pub fn vortex_array::ArrayAdapter<V>::buffer_names(&self) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::ArrayAdapter<V>::buffers(&self) -> alloc::vec::Vec<vortex_buffer::ByteBuffer>
+
+pub fn vortex_array::ArrayAdapter<V>::children(&self) -> alloc::vec::Vec<vortex_array::ArrayRef>
+
+pub fn vortex_array::ArrayAdapter<V>::children_names(&self) -> alloc::vec::Vec<alloc::string::String>
+
+pub fn vortex_array::ArrayAdapter<V>::is_host(&self) -> bool
+
+pub fn vortex_array::ArrayAdapter<V>::metadata(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::ArrayAdapter<V>::metadata_fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub fn vortex_array::ArrayAdapter<V>::named_buffers(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::buffer::BufferHandle)>
+
+pub fn vortex_array::ArrayAdapter<V>::named_children(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::ArrayRef)>
+
+pub fn vortex_array::ArrayAdapter<V>::nbuffers(&self) -> usize
+
+pub fn vortex_array::ArrayAdapter<V>::nchildren(&self) -> usize
+
+pub fn vortex_array::ArrayAdapter<V>::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::scalar_fn::ReduceNode for vortex_array::ArrayAdapter<V>
 
@@ -18730,13 +18564,163 @@ pub fn vortex_array::RecursiveCanonical::execute(array: vortex_array::ArrayRef, 
 
 pub static vortex_array::LEGACY_SESSION: std::sync::lazy_lock::LazyLock<vortex_session::VortexSession>
 
+pub trait vortex_array::Array: 'static + vortex_array::array::private::Sealed + core::marker::Send + core::marker::Sync + core::fmt::Debug + vortex_array::DynArrayEq + vortex_array::DynArrayHash + vortex_array::ArrayVisitor + vortex_array::scalar_fn::ReduceNode
+
+pub fn vortex_array::Array::all_invalid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::Array::all_valid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::Array::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::Array::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_array::Array::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
+
+pub fn vortex_array::Array::dtype(&self) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::Array::encoding_id(&self) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::Array::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::Array::invalid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::Array::is_empty(&self) -> bool
+
+pub fn vortex_array::Array::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::Array::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::Array::len(&self) -> usize
+
+pub fn vortex_array::Array::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+pub fn vortex_array::Array::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::Array::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::Array::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::Array::to_array(&self) -> vortex_array::ArrayRef
+
+pub fn vortex_array::Array::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
+
+pub fn vortex_array::Array::valid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::Array::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub fn vortex_array::Array::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
+
+pub fn vortex_array::Array::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
+
+pub fn vortex_array::Array::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+impl vortex_array::Array for alloc::sync::Arc<dyn vortex_array::Array>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::all_invalid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::all_valid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::as_any(&self) -> &dyn core::any::Any
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::dtype(&self) -> &vortex_array::dtype::DType
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::encoding_id(&self) -> vortex_array::vtable::ArrayId
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::invalid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::is_empty(&self) -> bool
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::len(&self) -> usize
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::to_array(&self) -> vortex_array::ArrayRef
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::valid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
+
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+impl<V: vortex_array::vtable::VTable> vortex_array::Array for vortex_array::ArrayAdapter<V>
+
+pub fn vortex_array::ArrayAdapter<V>::all_invalid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::ArrayAdapter<V>::all_valid(&self) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::ArrayAdapter<V>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::ArrayAdapter<V>::as_any(&self) -> &dyn core::any::Any
+
+pub fn vortex_array::ArrayAdapter<V>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
+
+pub fn vortex_array::ArrayAdapter<V>::dtype(&self) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::ArrayAdapter<V>::encoding_id(&self) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::ArrayAdapter<V>::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::ArrayAdapter<V>::invalid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::ArrayAdapter<V>::is_empty(&self) -> bool
+
+pub fn vortex_array::ArrayAdapter<V>::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::ArrayAdapter<V>::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
+
+pub fn vortex_array::ArrayAdapter<V>::len(&self) -> usize
+
+pub fn vortex_array::ArrayAdapter<V>::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+pub fn vortex_array::ArrayAdapter<V>::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::ArrayAdapter<V>::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::ArrayAdapter<V>::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::ArrayAdapter<V>::to_array(&self) -> vortex_array::ArrayRef
+
+pub fn vortex_array::ArrayAdapter<V>::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
+
+pub fn vortex_array::ArrayAdapter<V>::valid_count(&self) -> vortex_error::VortexResult<usize>
+
+pub fn vortex_array::ArrayAdapter<V>::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub fn vortex_array::ArrayAdapter<V>::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
+
+pub fn vortex_array::ArrayAdapter<V>::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
+
+pub fn vortex_array::ArrayAdapter<V>::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
 pub trait vortex_array::ArrayEq
 
 pub fn vortex_array::ArrayEq::array_eq(&self, other: &Self, precision: vortex_array::Precision) -> bool
 
-impl vortex_array::ArrayEq for (dyn vortex_array::DynArray + '_)
+impl vortex_array::ArrayEq for (dyn vortex_array::Array + '_)
 
-pub fn (dyn vortex_array::DynArray + '_)::array_eq(&self, other: &Self, precision: vortex_array::Precision) -> bool
+pub fn (dyn vortex_array::Array + '_)::array_eq(&self, other: &Self, precision: vortex_array::Precision) -> bool
 
 impl vortex_array::ArrayEq for vortex_array::ArrayRef
 
@@ -18778,9 +18762,9 @@ pub trait vortex_array::ArrayHash
 
 pub fn vortex_array::ArrayHash::array_hash<H: core::hash::Hasher>(&self, state: &mut H, precision: vortex_array::Precision)
 
-impl vortex_array::ArrayHash for (dyn vortex_array::DynArray + '_)
+impl vortex_array::ArrayHash for (dyn vortex_array::Array + '_)
 
-pub fn (dyn vortex_array::DynArray + '_)::array_hash<H: core::hash::Hasher>(&self, state: &mut H, precision: vortex_array::Precision)
+pub fn (dyn vortex_array::Array + '_)::array_hash<H: core::hash::Hasher>(&self, state: &mut H, precision: vortex_array::Precision)
 
 impl vortex_array::ArrayHash for vortex_array::ArrayRef
 
@@ -18846,33 +18830,33 @@ pub fn vortex_array::ArrayVisitor::nchildren(&self) -> usize
 
 pub fn vortex_array::ArrayVisitor::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
 
-impl vortex_array::ArrayVisitor for alloc::sync::Arc<dyn vortex_array::DynArray>
+impl vortex_array::ArrayVisitor for alloc::sync::Arc<dyn vortex_array::Array>
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::buffer_handles(&self) -> alloc::vec::Vec<vortex_array::buffer::BufferHandle>
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::buffer_handles(&self) -> alloc::vec::Vec<vortex_array::buffer::BufferHandle>
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::buffer_names(&self) -> alloc::vec::Vec<alloc::string::String>
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::buffer_names(&self) -> alloc::vec::Vec<alloc::string::String>
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::buffers(&self) -> alloc::vec::Vec<vortex_buffer::ByteBuffer>
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::buffers(&self) -> alloc::vec::Vec<vortex_buffer::ByteBuffer>
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::children(&self) -> alloc::vec::Vec<vortex_array::ArrayRef>
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::children(&self) -> alloc::vec::Vec<vortex_array::ArrayRef>
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::children_names(&self) -> alloc::vec::Vec<alloc::string::String>
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::children_names(&self) -> alloc::vec::Vec<alloc::string::String>
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::is_host(&self) -> bool
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::is_host(&self) -> bool
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::metadata(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::metadata(&self) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::metadata_fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::metadata_fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::named_buffers(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::buffer::BufferHandle)>
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::named_buffers(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::buffer::BufferHandle)>
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::named_children(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::ArrayRef)>
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::named_children(&self) -> alloc::vec::Vec<(alloc::string::String, vortex_array::ArrayRef)>
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::nbuffers(&self) -> usize
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::nbuffers(&self) -> usize
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::nchildren(&self) -> usize
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::nchildren(&self) -> usize
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
+pub fn alloc::sync::Arc<dyn vortex_array::Array>::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::ArrayVisitor for vortex_array::ArrayAdapter<V>
 
@@ -18902,13 +18886,13 @@ pub fn vortex_array::ArrayAdapter<V>::nchildren(&self) -> usize
 
 pub fn vortex_array::ArrayAdapter<V>::nth_child(&self, idx: usize) -> core::option::Option<vortex_array::ArrayRef>
 
-pub trait vortex_array::ArrayVisitorExt: vortex_array::DynArray
+pub trait vortex_array::ArrayVisitorExt: vortex_array::Array
 
 pub fn vortex_array::ArrayVisitorExt::depth_first_traversal(&self) -> impl core::iter::traits::iterator::Iterator<Item = vortex_array::ArrayRef>
 
 pub fn vortex_array::ArrayVisitorExt::nbuffers_recursive(&self) -> usize
 
-impl<A: vortex_array::DynArray + ?core::marker::Sized> vortex_array::ArrayVisitorExt for A
+impl<A: vortex_array::Array + ?core::marker::Sized> vortex_array::ArrayVisitorExt for A
 
 pub fn A::depth_first_traversal(&self) -> impl core::iter::traits::iterator::Iterator<Item = vortex_array::ArrayRef>
 
@@ -18937,156 +18921,6 @@ impl<M> vortex_array::DeserializeMetadata for vortex_array::ProstMetadata<M> whe
 pub type vortex_array::ProstMetadata<M>::Output = M
 
 pub fn vortex_array::ProstMetadata<M>::deserialize(metadata: &[u8]) -> vortex_error::VortexResult<Self::Output>
-
-pub trait vortex_array::DynArray: 'static + vortex_array::array::private::Sealed + core::marker::Send + core::marker::Sync + core::fmt::Debug + vortex_array::DynArrayEq + vortex_array::DynArrayHash + vortex_array::ArrayVisitor + vortex_array::scalar_fn::ReduceNode
-
-pub fn vortex_array::DynArray::all_invalid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::DynArray::all_valid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::DynArray::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::DynArray::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::DynArray::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
-
-pub fn vortex_array::DynArray::dtype(&self) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::DynArray::encoding_id(&self) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::DynArray::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::DynArray::invalid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn vortex_array::DynArray::is_empty(&self) -> bool
-
-pub fn vortex_array::DynArray::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::DynArray::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::DynArray::len(&self) -> usize
-
-pub fn vortex_array::DynArray::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-pub fn vortex_array::DynArray::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::DynArray::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::DynArray::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::DynArray::to_array(&self) -> vortex_array::ArrayRef
-
-pub fn vortex_array::DynArray::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
-
-pub fn vortex_array::DynArray::valid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn vortex_array::DynArray::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub fn vortex_array::DynArray::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
-
-pub fn vortex_array::DynArray::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
-
-pub fn vortex_array::DynArray::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-impl vortex_array::DynArray for alloc::sync::Arc<dyn vortex_array::DynArray>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::all_invalid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::all_valid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::as_any(&self) -> &dyn core::any::Any
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::dtype(&self) -> &vortex_array::dtype::DType
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::encoding_id(&self) -> vortex_array::vtable::ArrayId
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::invalid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::is_empty(&self) -> bool
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::len(&self) -> usize
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::to_array(&self) -> vortex_array::ArrayRef
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::valid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
-
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-impl<V: vortex_array::vtable::VTable> vortex_array::DynArray for vortex_array::ArrayAdapter<V>
-
-pub fn vortex_array::ArrayAdapter<V>::all_invalid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::ArrayAdapter<V>::all_valid(&self) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::ArrayAdapter<V>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::ArrayAdapter<V>::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::ArrayAdapter<V>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
-
-pub fn vortex_array::ArrayAdapter<V>::dtype(&self) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::ArrayAdapter<V>::encoding_id(&self) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::ArrayAdapter<V>::filter(&self, mask: vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::ArrayAdapter<V>::invalid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn vortex_array::ArrayAdapter<V>::is_empty(&self) -> bool
-
-pub fn vortex_array::ArrayAdapter<V>::is_invalid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::ArrayAdapter<V>::is_valid(&self, index: usize) -> vortex_error::VortexResult<bool>
-
-pub fn vortex_array::ArrayAdapter<V>::len(&self) -> usize
-
-pub fn vortex_array::ArrayAdapter<V>::scalar_at(&self, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-pub fn vortex_array::ArrayAdapter<V>::slice(&self, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::ArrayAdapter<V>::statistics(&self) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::ArrayAdapter<V>::take(&self, indices: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::ArrayAdapter<V>::to_array(&self) -> vortex_array::ArrayRef
-
-pub fn vortex_array::ArrayAdapter<V>::to_canonical(&self) -> vortex_error::VortexResult<vortex_array::Canonical>
-
-pub fn vortex_array::ArrayAdapter<V>::valid_count(&self) -> vortex_error::VortexResult<usize>
-
-pub fn vortex_array::ArrayAdapter<V>::validity(&self) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
-pub fn vortex_array::ArrayAdapter<V>::validity_mask(&self) -> vortex_error::VortexResult<vortex_mask::Mask>
-
-pub fn vortex_array::ArrayAdapter<V>::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
-
-pub fn vortex_array::ArrayAdapter<V>::with_children(&self, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub trait vortex_array::DynArrayEq: vortex_array::hash::private::SealedEq
 
@@ -19122,7 +18956,7 @@ pub fn vortex_array::CanonicalValidity::execute(array: vortex_array::ArrayRef, c
 
 impl vortex_array::Executable for vortex_array::Columnar
 
-pub fn vortex_array::Columnar::execute(root: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
+pub fn vortex_array::Columnar::execute(array: vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 impl vortex_array::Executable for vortex_array::RecursiveCanonical
 
@@ -19348,7 +19182,7 @@ pub fn vortex_array::ToCanonical::to_struct(&self) -> vortex_array::arrays::Stru
 
 pub fn vortex_array::ToCanonical::to_varbinview(&self) -> vortex_array::arrays::VarBinViewArray
 
-impl<A: vortex_array::DynArray + ?core::marker::Sized> vortex_array::ToCanonical for A
+impl<A: vortex_array::Array + ?core::marker::Sized> vortex_array::ToCanonical for A
 
 pub fn A::to_bool(&self) -> vortex_array::arrays::BoolArray
 
@@ -19378,4 +19212,6 @@ pub fn vortex_session::VortexSession::create_execution_ctx(&self) -> vortex_arra
 
 pub type vortex_array::ArrayContext = vortex_session::registry::Context<&'static dyn vortex_array::vtable::DynVTable>
 
-pub type vortex_array::ArrayRef = alloc::sync::Arc<dyn vortex_array::DynArray>
+pub type vortex_array::ArrayRef = alloc::sync::Arc<dyn vortex_array::Array>
+
+pub type vortex_array::DonePredicate = fn(&dyn vortex_array::Array) -> bool

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -353,6 +353,19 @@ impl dyn DynArray + '_ {
     pub fn is_canonical(&self) -> bool {
         self.is::<AnyCanonical>()
     }
+
+    /// Returns a new array with the child at `child_idx` replaced by `replacement`.
+    pub fn with_child(&self, child_idx: usize, replacement: ArrayRef) -> VortexResult<ArrayRef> {
+        let mut children: Vec<ArrayRef> = self.children();
+        vortex_ensure!(
+            child_idx < children.len(),
+            "child index {} out of bounds for array with {} children",
+            child_idx,
+            children.len()
+        );
+        children[child_idx] = replacement;
+        self.with_children(children)
+    }
 }
 
 /// Trait for converting a type into a Vortex [`ArrayRef`].

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -12,7 +12,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::DeserializeMetadata;
 use crate::ExecutionCtx;
-use crate::IntoArray;
+use crate::ExecutionStep;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
 use crate::arrays::BoolArray;
@@ -184,8 +184,8 @@ impl VTable for BoolVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.clone().into_array())
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(array.to_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -13,6 +13,7 @@ use crate::ArrayRef;
 use crate::DeserializeMetadata;
 use crate::ExecutionCtx;
 use crate::ExecutionStep;
+use crate::IntoArray;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
 use crate::arrays::BoolArray;
@@ -185,7 +186,7 @@ impl VTable for BoolVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
-        Ok(ExecutionStep::Done(array.to_array()))
+        Ok(ExecutionStep::Done(array.clone().into_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -15,6 +15,7 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
+use crate::ExecutionStep;
 use crate::IntoArray;
 use crate::Precision;
 use crate::ToCanonical;
@@ -239,8 +240,8 @@ impl VTable for ChunkedVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(_canonicalize(array, ctx)?.into_array())
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(_canonicalize(array, ctx)?.into_array()))
     }
 
     fn reduce(array: &Self::Array) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/constant/mod.rs
+++ b/vortex-array/src/arrays/constant/mod.rs
@@ -8,7 +8,6 @@ pub use arbitrary::ArbitraryConstantArray;
 
 mod array;
 pub use array::ConstantArray;
-pub(crate) use vtable::canonical::constant_canonicalize;
 
 pub(crate) mod compute;
 

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -13,6 +13,7 @@ use vortex_session::VortexSession;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::ExecutionStep;
 use crate::IntoArray;
 use crate::Precision;
 use crate::arrays::ConstantArray;
@@ -177,8 +178,10 @@ impl VTable for ConstantVTable {
         PARENT_RULES.evaluate(array, parent, child_idx)
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(constant_canonicalize(array)?.into_array())
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(
+            constant_canonicalize(array)?.into_array(),
+        ))
     }
 
     fn append_to_builder(

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -13,7 +13,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::DeserializeMetadata;
 use crate::ExecutionCtx;
-use crate::IntoArray;
+use crate::ExecutionStep;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
 use crate::arrays::DecimalArray;
@@ -206,8 +206,8 @@ impl VTable for DecimalVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.clone().into_array())
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(array.to_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -14,6 +14,7 @@ use crate::ArrayRef;
 use crate::DeserializeMetadata;
 use crate::ExecutionCtx;
 use crate::ExecutionStep;
+use crate::IntoArray;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
 use crate::arrays::DecimalArray;
@@ -207,7 +208,7 @@ impl VTable for DecimalVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
-        Ok(ExecutionStep::Done(array.to_array()))
+        Ok(ExecutionStep::Done(array.clone().into_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -29,6 +29,7 @@ use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::executor::ExecutionCtx;
+use crate::executor::ExecutionStep;
 use crate::hash::ArrayEq;
 use crate::hash::ArrayHash;
 use crate::scalar::Scalar;
@@ -190,9 +191,9 @@ impl VTable for DictVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
         if let Some(canonical) = execute_fast_path(array, ctx)? {
-            return Ok(canonical);
+            return Ok(ExecutionStep::Done(canonical));
         }
 
         // TODO(joe): if the values are constant return a constant
@@ -208,7 +209,9 @@ impl VTable for DictVTable {
         // TODO(ngates): if indices min is quite high, we could slice self and offset the indices
         //  such that canonicalize does less work.
 
-        Ok(take_canonical(values, &codes, ctx)?.into_array())
+        Ok(ExecutionStep::Done(
+            take_canonical(values, &codes, ctx)?.into_array(),
+        ))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -18,7 +18,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
-use crate::IntoArray;
+use crate::ExecutionStep;
 use crate::Precision;
 use crate::arrays::ExtensionArray;
 use crate::arrays::extension::compute::rules::PARENT_RULES;
@@ -149,8 +149,8 @@ impl VTable for ExtensionVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.clone().into_array())
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(array.to_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -19,6 +19,7 @@ use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
 use crate::ExecutionStep;
+use crate::IntoArray;
 use crate::Precision;
 use crate::arrays::ExtensionArray;
 use crate::arrays::extension::compute::rules::PARENT_RULES;
@@ -150,7 +151,7 @@ impl VTable for ExtensionVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
-        Ok(ExecutionStep::Done(array.to_array()))
+        Ok(ExecutionStep::Done(array.clone().into_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -27,6 +27,7 @@ use crate::arrays::filter::rules::RULES;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::executor::ExecutionCtx;
+use crate::executor::ExecutionStep;
 use crate::scalar::Scalar;
 use crate::serde::ArrayChildren;
 use crate::stats::StatsSetRef;
@@ -154,9 +155,9 @@ impl VTable for FilterVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
         if let Some(canonical) = execute_filter_fast_paths(array, ctx)? {
-            return Ok(canonical);
+            return Ok(ExecutionStep::Done(canonical));
         }
         let Mask::Values(mask_values) = &array.mask else {
             unreachable!("`execute_filter_fast_paths` handles AllTrue and AllFalse")
@@ -164,7 +165,9 @@ impl VTable for FilterVTable {
 
         // We rely on the optimization pass that runs prior to this execution for filter pushdown,
         // so now we can just execute the filter without worrying.
-        Ok(execute_filter(array.child.clone().execute(ctx)?, mask_values).into_array())
+        Ok(ExecutionStep::Done(
+            execute_filter(array.child.clone().execute(ctx)?, mask_values).into_array(),
+        ))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -13,7 +13,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
-use crate::IntoArray;
+use crate::ExecutionStep;
 use crate::Precision;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::fixed_size_list::compute::rules::PARENT_RULES;
@@ -218,7 +218,7 @@ impl VTable for FixedSizeListVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.clone().into_array())
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(array.to_array()))
     }
 }

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -14,6 +14,7 @@ use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
 use crate::ExecutionStep;
+use crate::IntoArray;
 use crate::Precision;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::fixed_size_list::compute::rules::PARENT_RULES;
@@ -219,6 +220,6 @@ impl VTable for FixedSizeListVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
-        Ok(ExecutionStep::Done(array.to_array()))
+        Ok(ExecutionStep::Done(array.clone().into_array()))
     }
 }

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -13,6 +13,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::ExecutionCtx;
+use crate::ExecutionStep;
 use crate::IntoArray;
 use crate::Precision;
 use crate::ProstMetadata;
@@ -210,8 +211,10 @@ impl VTable for ListVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(list_view_from_list(array.clone(), ctx)?.into_array())
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(
+            list_view_from_list(array.clone(), ctx)?.into_array(),
+        ))
     }
 
     fn execute_parent(

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -13,7 +13,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::DeserializeMetadata;
 use crate::ExecutionCtx;
-use crate::IntoArray;
+use crate::ExecutionStep;
 use crate::Precision;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
@@ -238,8 +238,8 @@ impl VTable for ListViewVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.clone().into_array())
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(array.to_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -14,6 +14,7 @@ use crate::ArrayRef;
 use crate::DeserializeMetadata;
 use crate::ExecutionCtx;
 use crate::ExecutionStep;
+use crate::IntoArray;
 use crate::Precision;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
@@ -239,7 +240,7 @@ impl VTable for ListViewVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
-        Ok(ExecutionStep::Done(array.to_array()))
+        Ok(ExecutionStep::Done(array.clone().into_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -25,6 +25,7 @@ use crate::arrays::masked::mask_validity_canonical;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::executor::ExecutionCtx;
+use crate::executor::ExecutionStep;
 use crate::hash::ArrayEq;
 use crate::hash::ArrayHash;
 use crate::scalar::Scalar;
@@ -160,15 +161,15 @@ impl VTable for MaskedVTable {
         MaskedArray::try_new(child, validity)
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
         let validity_mask = array.validity_mask()?;
 
         // Fast path: all masked means result is all nulls.
         if validity_mask.all_false() {
-            return Ok(
+            return Ok(ExecutionStep::Done(
                 ConstantArray::new(Scalar::null(array.dtype().as_nullable()), array.len())
                     .into_array(),
-            );
+            ));
         }
 
         // NB: We intentionally do NOT have a fast path for `validity_mask.all_true()`.
@@ -178,7 +179,9 @@ impl VTable for MaskedVTable {
         // `AllTrue` masks (no data copying), so there's no benefit.
 
         let child = array.child().clone().execute::<Canonical>(ctx)?;
-        Ok(mask_validity_canonical(child, &validity_mask, ctx)?.into_array())
+        Ok(ExecutionStep::Done(
+            mask_validity_canonical(child, &validity_mask, ctx)?.into_array(),
+        ))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -11,7 +11,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
-use crate::IntoArray;
+use crate::ExecutionStep;
 use crate::Precision;
 use crate::arrays::null::compute::rules::PARENT_RULES;
 use crate::buffer::BufferHandle;
@@ -131,8 +131,8 @@ impl VTable for NullVTable {
         PARENT_RULES.evaluate(array, parent, child_idx)
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.clone().into_array())
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(array.to_array()))
     }
 }
 

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -12,6 +12,7 @@ use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
 use crate::ExecutionStep;
+use crate::IntoArray;
 use crate::Precision;
 use crate::arrays::null::compute::rules::PARENT_RULES;
 use crate::buffer::BufferHandle;
@@ -132,7 +133,7 @@ impl VTable for NullVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
-        Ok(ExecutionStep::Done(array.to_array()))
+        Ok(ExecutionStep::Done(array.clone().into_array()))
     }
 }
 

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -11,7 +11,7 @@ use vortex_error::vortex_panic;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
-use crate::IntoArray;
+use crate::ExecutionStep;
 use crate::arrays::PrimitiveArray;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
@@ -198,8 +198,8 @@ impl VTable for PrimitiveVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.clone().into_array())
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(array.to_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -12,6 +12,7 @@ use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
 use crate::ExecutionStep;
+use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
@@ -199,7 +200,7 @@ impl VTable for PrimitiveVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
-        Ok(ExecutionStep::Done(array.to_array()))
+        Ok(ExecutionStep::Done(array.clone().into_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -30,6 +30,7 @@ use crate::arrays::scalar_fn::rules::RULES;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::executor::ExecutionCtx;
+use crate::executor::ExecutionStep;
 use crate::expr::Expression;
 use crate::matcher::Matcher;
 use crate::scalar_fn;
@@ -194,10 +195,10 @@ impl VTable for ScalarFnVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
         ctx.log(format_args!("scalar_fn({}): executing", array.scalar_fn));
         let args = VecExecutionArgs::new(array.children.clone(), array.len);
-        array.scalar_fn.execute(&args, ctx)
+        array.scalar_fn.execute(&args, ctx).map(ExecutionStep::Done)
     }
 
     fn reduce(array: &Self::Array) -> VortexResult<Option<ArrayRef>> {

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -12,6 +12,7 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
+use crate::ExecutionStep;
 use crate::Precision;
 use crate::arrays::SharedArray;
 use crate::buffer::BufferHandle;
@@ -144,8 +145,10 @@ impl VTable for SharedVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        array.get_or_compute(|source| source.clone().execute::<Canonical>(ctx))
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        array
+            .get_or_compute(|source| source.clone().execute::<Canonical>(ctx))
+            .map(ExecutionStep::Done)
     }
 }
 impl OperationsVTable<SharedVTable> for SharedVTable {

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -26,6 +26,7 @@ use crate::arrays::slice::rules::PARENT_RULES;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::executor::ExecutionCtx;
+use crate::executor::ExecutionStep;
 use crate::scalar::Scalar;
 use crate::serde::ArrayChildren;
 use crate::stats::StatsSetRef;
@@ -154,7 +155,7 @@ impl VTable for SliceVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
         // Execute the child to get canonical form, then slice it
         let Some(canonical) = array.child.as_opt::<AnyCanonical>() else {
             // If the child is not canonical, recurse.
@@ -162,13 +163,15 @@ impl VTable for SliceVTable {
                 .child
                 .clone()
                 .execute::<ArrayRef>(ctx)?
-                .slice(array.slice_range().clone());
+                .slice(array.slice_range().clone())
+                .map(ExecutionStep::Done);
         };
 
         // TODO(ngates): we should inline canonical slice logic here.
         Canonical::from(canonical)
             .as_ref()
             .slice(array.range.clone())
+            .map(ExecutionStep::Done)
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -15,6 +15,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
+use crate::ExecutionStep;
 use crate::IntoArray;
 use crate::arrays::StructArray;
 use crate::arrays::struct_::compute::rules::PARENT_RULES;
@@ -206,8 +207,8 @@ impl VTable for StructVTable {
         Ok(())
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.clone().into_array())
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(array.to_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -208,7 +208,7 @@ impl VTable for StructVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
-        Ok(ExecutionStep::Done(array.to_array()))
+        Ok(ExecutionStep::Done(array.clone().into_array()))
     }
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -10,6 +10,7 @@ use vortex_error::vortex_panic;
 use crate::ArrayRef;
 use crate::DeserializeMetadata;
 use crate::ExecutionCtx;
+use crate::ExecutionStep;
 use crate::IntoArray;
 use crate::ProstMetadata;
 use crate::SerializeMetadata;
@@ -218,8 +219,10 @@ impl VTable for VarBinVTable {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(varbin_to_canonical(array, ctx)?.into_array())
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(
+            varbin_to_canonical(array, ctx)?.into_array(),
+        ))
     }
 }
 

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -17,7 +17,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
-use crate::IntoArray;
+use crate::ExecutionStep;
 use crate::Precision;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::varbinview::BinaryView;
@@ -242,7 +242,7 @@ impl VTable for VarBinViewVTable {
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
     }
 
-    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        Ok(array.clone().into_array())
+    fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        Ok(ExecutionStep::Done(array.to_array()))
     }
 }

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -18,6 +18,7 @@ use crate::ArrayRef;
 use crate::EmptyMetadata;
 use crate::ExecutionCtx;
 use crate::ExecutionStep;
+use crate::IntoArray;
 use crate::Precision;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::varbinview::BinaryView;
@@ -243,6 +244,6 @@ impl VTable for VarBinViewVTable {
     }
 
     fn execute(array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
-        Ok(ExecutionStep::Done(array.to_array()))
+        Ok(ExecutionStep::Done(array.clone().into_array()))
     }
 }

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -13,7 +13,6 @@ use vortex_error::vortex_ensure;
 use vortex_error::vortex_panic;
 
 use crate::ArrayRef;
-use crate::Columnar;
 use crate::DynArray;
 use crate::Executable;
 use crate::ExecutionCtx;
@@ -37,7 +36,6 @@ use crate::arrays::StructVTable;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::VarBinViewVTable;
 use crate::arrays::bool::BoolArrayParts;
-use crate::arrays::constant::constant_canonicalize;
 use crate::arrays::decimal::DecimalArrayParts;
 use crate::arrays::listview::ListViewArrayParts;
 use crate::arrays::listview::ListViewRebuildMode;
@@ -518,28 +516,18 @@ impl From<Canonical> for ArrayRef {
     }
 }
 
-/// Recursively execute the array until it reaches canonical form.
+/// Execute into [`Canonical`] by running `execute_until` with the [`AnyCanonical`] matcher.
 ///
-/// Callers should prefer to execute into `Columnar` if they are able to optimize their use for
-/// constant arrays.
+/// Unlike executing into [`crate::Columnar`], this will fully expand constant arrays into their
+/// canonical form. Callers should prefer to execute into `Columnar` if they are able to optimize
+/// their use for constant arrays.
 impl Executable for Canonical {
     fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        if let Some(canonical) = array.as_opt::<AnyCanonical>() {
-            return Ok(canonical.into());
-        }
-
-        // Invoke execute directly to avoid logging the call in the execution context.
-        Ok(match Columnar::execute(array.clone(), ctx)? {
-            Columnar::Canonical(c) => c,
-            Columnar::Constant(s) => {
-                let canonical = constant_canonicalize(&s)?;
-                canonical
-                    .as_ref()
-                    .statistics()
-                    .inherit_from(array.statistics());
-                canonical
-            }
-        })
+        let result = array.execute_until::<AnyCanonical>(ctx)?;
+        Ok(result
+            .as_opt::<AnyCanonical>()
+            .map(Canonical::from)
+            .vortex_expect("execute_until::<AnyCanonical> must return a canonical array"))
     }
 }
 

--- a/vortex-array/src/columnar.rs
+++ b/vortex-array/src/columnar.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
 
 use crate::AnyCanonical;
 use crate::ArrayRef;
@@ -12,14 +11,11 @@ use crate::CanonicalView;
 use crate::DynArray;
 use crate::Executable;
 use crate::ExecutionCtx;
-use crate::ExecutionStep;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::ConstantVTable;
 use crate::dtype::DType;
-use crate::executor::MAX_ITERATIONS;
 use crate::matcher::Matcher;
-use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
 
 /// Represents a columnnar array of data, either in canonical form or as a constant array.
@@ -71,101 +67,21 @@ impl IntoArray for Columnar {
     }
 }
 
-/// Executing into a [`Columnar`] is implemented using an iterative scheduler with an explicit
-/// work stack.
-///
-/// The scheduler repeatedly:
-/// 1. Checks if the current array is columnar (constant or canonical) — if so, pops the stack.
-/// 2. Runs reduce/reduce_parent rules to fixpoint.
-/// 3. Tries execute_parent on each child.
-/// 4. Calls `execute` which returns an [`ExecutionStep`].
-///
-/// For safety, we will error when the number of execution iterations reaches 128. We may want this
-/// to be configurable in the future in case of highly complex array trees, but in practice we
-/// don't expect to ever reach this limit.
+/// Execute into [`Columnar`] by running `execute_until` with the [`AnyColumnar`] matcher.
 impl Executable for Columnar {
-    fn execute(root: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        let mut current = root.optimize()?;
-        let mut stack: Vec<(ArrayRef, usize)> = Vec::new();
-
-        for _ in 0..*MAX_ITERATIONS {
-            // Check for columnar termination (constant or canonical)
-            if let Some(columnar) = try_as_columnar(&current) {
-                match stack.pop() {
-                    None => {
-                        // Stack empty — we're done
-                        ctx.log(format_args!("-> columnar {}", current));
-                        return Ok(columnar);
-                    }
-                    Some((parent, child_idx)) => {
-                        // Replace the child in the parent and continue
-                        current = parent.with_child(child_idx, current)?;
-                        current = current.optimize()?;
-                        continue;
-                    }
-                }
-            }
-
-            // Try execute_parent (child-driven optimized execution)
-            if let Some(rewritten) = try_execute_parent(&current, ctx)? {
-                ctx.log(format_args!(
-                    "execute_parent rewrote {} -> {}",
-                    current, rewritten
-                ));
-                current = rewritten.optimize()?;
-                continue;
-            }
-
-            // Execute the array itself
-            match current.vtable().execute(&current, ctx)? {
-                ExecutionStep::ExecuteChild(i) => {
-                    let child = current
-                        .nth_child(i)
-                        .vortex_expect("ExecuteChild index in bounds");
-                    ctx.log(format_args!(
-                        "ExecuteChild({i}): pushing {}, focusing on {}",
-                        current, child
-                    ));
-                    stack.push((current, i));
-                    current = child.optimize()?;
-                }
-                ExecutionStep::Done(result) => {
-                    ctx.log(format_args!("Done: {} -> {}", current, result));
-                    current = result;
-                }
-            }
-        }
-
-        vortex_bail!("Exceeded maximum execution iterations while executing to Columnar")
-    }
-}
-
-/// Try to interpret an array as columnar (constant or canonical).
-fn try_as_columnar(array: &ArrayRef) -> Option<Columnar> {
-    if let Some(constant) = array.as_opt::<ConstantVTable>() {
-        Some(Columnar::Constant(constant.clone()))
-    } else {
-        array
-            .as_opt::<AnyCanonical>()
-            .map(|c| Columnar::Canonical(c.into()))
-    }
-}
-
-/// Try execute_parent on each child of the array.
-fn try_execute_parent(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Option<ArrayRef>> {
-    for child_idx in 0..array.nchildren() {
-        let child = array
-            .nth_child(child_idx)
-            .vortex_expect("checked nchildren");
-        if let Some(result) = child
-            .vtable()
-            .execute_parent(&child, array, child_idx, ctx)?
-        {
-            result.statistics().inherit_from(array.statistics());
-            return Ok(Some(result));
+    fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        let result = array.execute_until::<AnyColumnar>(ctx)?;
+        if let Some(constant) = result.as_opt::<ConstantVTable>() {
+            Ok(Columnar::Constant(constant.clone()))
+        } else {
+            Ok(Columnar::Canonical(
+                result
+                    .as_opt::<AnyCanonical>()
+                    .map(Canonical::from)
+                    .vortex_expect("execute_until::<AnyColumnar> must return a columnar array"),
+            ))
         }
     }
-    Ok(None)
 }
 
 pub enum ColumnarView<'a> {

--- a/vortex-array/src/columnar.rs
+++ b/vortex-array/src/columnar.rs
@@ -129,18 +129,6 @@ impl Executable for Columnar {
                     stack.push((current, i));
                     current = child.optimize()?;
                 }
-                ExecutionStep::ColumnarizeChild(i) => {
-                    let child = current
-                        .nth_child(i)
-                        .vortex_expect("ColumnarizeChild index in bounds");
-                    ctx.log(format_args!(
-                        "ColumnarizeChild({i}): pushing {}, focusing on {}",
-                        current, child
-                    ));
-                    stack.push((current, i));
-                    // No cross-step optimization for ColumnarizeChild
-                    current = child;
-                }
                 ExecutionStep::Done(result) => {
                     ctx.log(format_args!("Done: {} -> {}", current, result));
                     current = result;

--- a/vortex-array/src/columnar.rs
+++ b/vortex-array/src/columnar.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
@@ -11,12 +12,14 @@ use crate::CanonicalView;
 use crate::DynArray;
 use crate::Executable;
 use crate::ExecutionCtx;
+use crate::ExecutionStep;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::ConstantVTable;
 use crate::dtype::DType;
 use crate::executor::MAX_ITERATIONS;
 use crate::matcher::Matcher;
+use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
 
 /// Represents a columnnar array of data, either in canonical form or as a constant array.
@@ -68,32 +71,113 @@ impl IntoArray for Columnar {
     }
 }
 
-/// Executing into a [`Columnar`] is implemented by repeatedly executing the array until we
-/// converge on either a constant or canonical.
+/// Executing into a [`Columnar`] is implemented using an iterative scheduler with an explicit
+/// work stack.
+///
+/// The scheduler repeatedly:
+/// 1. Checks if the current array is columnar (constant or canonical) — if so, pops the stack.
+/// 2. Runs reduce/reduce_parent rules to fixpoint.
+/// 3. Tries execute_parent on each child.
+/// 4. Calls `execute` which returns an [`ExecutionStep`].
 ///
 /// For safety, we will error when the number of execution iterations reaches 128. We may want this
 /// to be configurable in the future in case of highly complex array trees, but in practice we
 /// don't expect to ever reach this limit.
 impl Executable for Columnar {
-    fn execute(mut array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+    fn execute(root: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
+        let mut current = root.optimize()?;
+        let mut stack: Vec<(ArrayRef, usize)> = Vec::new();
+
         for _ in 0..*MAX_ITERATIONS {
-            // Check for termination conditions
-            if let Some(constant) = array.as_opt::<ConstantVTable>() {
-                ctx.log(format_args!("-> constant({})", constant.scalar()));
-                return Ok(Columnar::Constant(constant.clone()));
-            }
-            if let Some(canonical) = array.as_opt::<AnyCanonical>() {
-                ctx.log(format_args!("-> canonical {}", array));
-                return Ok(Columnar::Canonical(canonical.into()));
+            // Check for columnar termination (constant or canonical)
+            if let Some(columnar) = try_as_columnar(&current) {
+                match stack.pop() {
+                    None => {
+                        // Stack empty — we're done
+                        ctx.log(format_args!("-> columnar {}", current));
+                        return Ok(columnar);
+                    }
+                    Some((parent, child_idx)) => {
+                        // Replace the child in the parent and continue
+                        current = parent.with_child(child_idx, current)?;
+                        current = current.optimize()?;
+                        continue;
+                    }
+                }
             }
 
-            // Otherwise execute the array one step
-            array = array.execute(ctx)?;
+            // Try execute_parent (child-driven optimized execution)
+            if let Some(rewritten) = try_execute_parent(&current, ctx)? {
+                ctx.log(format_args!(
+                    "execute_parent rewrote {} -> {}",
+                    current, rewritten
+                ));
+                current = rewritten.optimize()?;
+                continue;
+            }
+
+            // Execute the array itself
+            match current.vtable().execute(&current, ctx)? {
+                ExecutionStep::ExecuteChild(i) => {
+                    let child = current
+                        .nth_child(i)
+                        .vortex_expect("ExecuteChild index in bounds");
+                    ctx.log(format_args!(
+                        "ExecuteChild({i}): pushing {}, focusing on {}",
+                        current, child
+                    ));
+                    stack.push((current, i));
+                    current = child.optimize()?;
+                }
+                ExecutionStep::ColumnarizeChild(i) => {
+                    let child = current
+                        .nth_child(i)
+                        .vortex_expect("ColumnarizeChild index in bounds");
+                    ctx.log(format_args!(
+                        "ColumnarizeChild({i}): pushing {}, focusing on {}",
+                        current, child
+                    ));
+                    stack.push((current, i));
+                    // No cross-step optimization for ColumnarizeChild
+                    current = child;
+                }
+                ExecutionStep::Done(result) => {
+                    ctx.log(format_args!("Done: {} -> {}", current, result));
+                    current = result;
+                }
+            }
         }
 
-        // If we reach here, we exceeded the maximum number of iterations, so error.
         vortex_bail!("Exceeded maximum execution iterations while executing to Columnar")
     }
+}
+
+/// Try to interpret an array as columnar (constant or canonical).
+fn try_as_columnar(array: &ArrayRef) -> Option<Columnar> {
+    if let Some(constant) = array.as_opt::<ConstantVTable>() {
+        Some(Columnar::Constant(constant.clone()))
+    } else {
+        array
+            .as_opt::<AnyCanonical>()
+            .map(|c| Columnar::Canonical(c.into()))
+    }
+}
+
+/// Try execute_parent on each child of the array.
+fn try_execute_parent(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Option<ArrayRef>> {
+    for child_idx in 0..array.nchildren() {
+        let child = array
+            .nth_child(child_idx)
+            .vortex_expect("checked nchildren");
+        if let Some(result) = child
+            .vtable()
+            .execute_parent(&child, array, child_idx, ctx)?
+        {
+            result.statistics().inherit_from(array.statistics());
+            return Ok(Some(result));
+        }
+    }
+    Ok(None)
 }
 
 pub enum ColumnarView<'a> {

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -205,7 +205,7 @@ impl Executable for ArrayRef {
                 ctx.log(format_args!("-> {}", result.as_ref()));
                 Ok(result)
             }
-            ExecutionStep::ExecuteChild(i) | ExecutionStep::ColumnarizeChild(i) => {
+            ExecutionStep::ExecuteChild(i) => {
                 // For single-step execution, handle ExecuteChild by executing the child,
                 // replacing it, and returning the updated array.
                 let child = array.nth_child(i).vortex_expect("valid child index");
@@ -229,14 +229,6 @@ pub enum ExecutionStep {
     /// Between steps, the scheduler runs reduce/reduce_parent rules to fixpoint, enabling
     /// cross-step optimization (e.g., pushing scalar functions through newly-decoded children).
     ExecuteChild(usize),
-
-    /// Request that the scheduler execute child at index `i` to columnar form, replace it in
-    /// this array, then re-enter execution on the updated array.
-    ///
-    /// Unlike [`ExecuteChild`](Self::ExecuteChild), the scheduler does **not** run cross-step
-    /// optimizations when popping back up. Use this when the parent knows it will consume the
-    /// child directly (e.g., Dict taking from its values).
-    ColumnarizeChild(usize),
 
     /// Execution is complete. The result may be in any encoding — not necessarily canonical.
     /// The scheduler will continue executing the result if it is not yet columnar.

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::AtomicUsize;
 
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 
@@ -18,6 +19,8 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::matcher::Matcher;
+use crate::optimizer::ArrayOptimizer;
 
 /// Maximum number of iterations to attempt when executing an array before giving up and returning
 /// an error.
@@ -58,6 +61,110 @@ impl dyn DynArray + '_ {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<E> {
         E::execute(self, ctx)
+    }
+
+    /// Iteratively execute this array until the [`Matcher`] matches, using an explicit work
+    /// stack.
+    ///
+    /// The scheduler repeatedly:
+    /// 1. Checks if the current array matches `M` — if so, pops the stack or returns.
+    /// 2. Runs `execute_parent` on each child for child-driven optimizations.
+    /// 3. Calls `execute` which returns an [`ExecutionStep`].
+    ///
+    /// Note: the returned array may not match `M`. If execution converges to a canonical form
+    /// that does not match `M`, the canonical array is returned since no further execution
+    /// progress is possible.
+    ///
+    /// For safety, we will error when the number of execution iterations reaches a configurable
+    /// maximum (default 128, override with `VORTEX_MAX_ITERATIONS`).
+    pub fn execute_until<M: Matcher>(
+        self: Arc<Self>,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        static MAX_ITERATIONS: LazyLock<usize> =
+            LazyLock::new(|| match std::env::var("VORTEX_MAX_ITERATIONS") {
+                Ok(val) => val.parse::<usize>().unwrap_or_else(|e| {
+                    vortex_panic!("VORTEX_MAX_ITERATIONS is not a valid usize: {e}")
+                }),
+                Err(VarError::NotPresent) => 128,
+                Err(VarError::NotUnicode(_)) => {
+                    vortex_panic!("VORTEX_MAX_ITERATIONS is not a valid unicode string")
+                }
+            });
+
+        let mut current = self.optimize()?;
+        // Stack frames: (parent, child_idx, done_predicate_for_child)
+        let mut stack: Vec<(ArrayRef, usize, DonePredicate)> = Vec::new();
+
+        for _ in 0..*MAX_ITERATIONS {
+            // Check for termination: use the stack frame's done predicate, or the root matcher.
+            let is_done = stack
+                .last()
+                .map_or(M::matches as DonePredicate, |frame| frame.2);
+            if is_done(current.as_ref()) {
+                match stack.pop() {
+                    None => {
+                        ctx.log(format_args!("-> {}", current));
+                        return Ok(current);
+                    }
+                    Some((parent, child_idx, _)) => {
+                        current = parent.with_child(child_idx, current)?;
+                        current = current.optimize()?;
+                        continue;
+                    }
+                }
+            }
+
+            // If we've reached canonical form, we can't execute any further regardless
+            // of whether the matcher matched.
+            if AnyCanonical::matches(current.as_ref()) {
+                match stack.pop() {
+                    None => {
+                        ctx.log(format_args!("-> canonical (unmatched) {}", current));
+                        return Ok(current);
+                    }
+                    Some((parent, child_idx, _)) => {
+                        current = parent.with_child(child_idx, current)?;
+                        current = current.optimize()?;
+                        continue;
+                    }
+                }
+            }
+
+            // Try execute_parent (child-driven optimized execution)
+            if let Some(rewritten) = try_execute_parent(&current, ctx)? {
+                ctx.log(format_args!(
+                    "execute_parent rewrote {} -> {}",
+                    current, rewritten
+                ));
+                current = rewritten.optimize()?;
+                continue;
+            }
+
+            // Execute the array itself
+            match current.vtable().execute(&current, ctx)? {
+                ExecutionStep::ExecuteChild(i, done) => {
+                    let child = current
+                        .nth_child(i)
+                        .vortex_expect("ExecuteChild index in bounds");
+                    ctx.log(format_args!(
+                        "ExecuteChild({i}): pushing {}, focusing on {}",
+                        current, child
+                    ));
+                    stack.push((current, i, done));
+                    current = child.optimize()?;
+                }
+                ExecutionStep::Done(result) => {
+                    ctx.log(format_args!("Done: {} -> {}", current, result));
+                    current = result;
+                }
+            }
+        }
+
+        vortex_bail!(
+            "Exceeded maximum execution iterations ({}) while executing array",
+            *MAX_ITERATIONS,
+        )
     }
 }
 
@@ -205,7 +312,7 @@ impl Executable for ArrayRef {
                 ctx.log(format_args!("-> {}", result.as_ref()));
                 Ok(result)
             }
-            ExecutionStep::ExecuteChild(i) => {
+            ExecutionStep::ExecuteChild(i, _) => {
                 // For single-step execution, handle ExecuteChild by executing the child,
                 // replacing it, and returning the updated array.
                 let child = array.nth_child(i).vortex_expect("valid child index");
@@ -216,23 +323,68 @@ impl Executable for ArrayRef {
     }
 }
 
+/// Try execute_parent on each child of the array.
+fn try_execute_parent(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Option<ArrayRef>> {
+    for child_idx in 0..array.nchildren() {
+        let child = array
+            .nth_child(child_idx)
+            .vortex_expect("checked nchildren");
+        if let Some(result) = child
+            .vtable()
+            .execute_parent(&child, array, child_idx, ctx)?
+        {
+            result.statistics().inherit_from(array.statistics());
+            return Ok(Some(result));
+        }
+    }
+    Ok(None)
+}
+
+/// A predicate that determines when an array has reached a desired form during execution.
+pub type DonePredicate = fn(&dyn DynArray) -> bool;
+
 /// The result of a single execution step on an array encoding.
 ///
 /// Instead of recursively executing children, encodings return an `ExecutionStep` that tells the
 /// scheduler what to do next. This enables the scheduler to manage execution iteratively using
 /// an explicit work stack, run cross-step optimizations, and cache shared sub-expressions.
-#[derive(Debug)]
 pub enum ExecutionStep {
-    /// Request that the scheduler execute child at index `i` to columnar form, replace it in
-    /// this array, then re-enter execution on the updated array.
+    /// Request that the scheduler execute child at the given index, using the provided
+    /// [`DonePredicate`] to determine when the child is "done", then replace the child in this
+    /// array and re-enter execution.
     ///
     /// Between steps, the scheduler runs reduce/reduce_parent rules to fixpoint, enabling
     /// cross-step optimization (e.g., pushing scalar functions through newly-decoded children).
-    ExecuteChild(usize),
+    ///
+    /// Use [`ExecutionStep::execute_child`] instead of constructing this variant directly.
+    ExecuteChild(usize, DonePredicate),
 
     /// Execution is complete. The result may be in any encoding — not necessarily canonical.
-    /// The scheduler will continue executing the result if it is not yet columnar.
+    /// The scheduler will continue executing the result if it has not yet reached the target form.
     Done(ArrayRef),
+}
+
+impl ExecutionStep {
+    /// Request execution of child at `child_idx` until it matches the given [`Matcher`].
+    pub fn execute_child<M: Matcher>(child_idx: usize) -> Self {
+        ExecutionStep::ExecuteChild(child_idx, M::matches)
+    }
+
+    /// Signal that execution is complete with the given result.
+    pub fn done(result: ArrayRef) -> Self {
+        ExecutionStep::Done(result)
+    }
+}
+
+impl fmt::Debug for ExecutionStep {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExecutionStep::ExecuteChild(idx, _) => {
+                f.debug_tuple("ExecuteChild").field(idx).finish()
+            }
+            ExecutionStep::Done(result) => f.debug_tuple("Done").field(result).finish(),
+        }
+    }
 }
 
 /// Extension trait for creating an execution context from a session.

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -211,6 +211,33 @@ impl Executable for ArrayRef {
     }
 }
 
+/// The result of a single execution step on an array encoding.
+///
+/// Instead of recursively executing children, encodings return an `ExecutionStep` that tells the
+/// scheduler what to do next. This enables the scheduler to manage execution iteratively using
+/// an explicit work stack, run cross-step optimizations, and cache shared sub-expressions.
+#[derive(Debug)]
+pub enum ExecutionStep {
+    /// Request that the scheduler execute child at index `i` to columnar form, replace it in
+    /// this array, then re-enter execution on the updated array.
+    ///
+    /// Between steps, the scheduler runs reduce/reduce_parent rules to fixpoint, enabling
+    /// cross-step optimization (e.g., pushing scalar functions through newly-decoded children).
+    ExecuteChild(usize),
+
+    /// Request that the scheduler execute child at index `i` to columnar form, replace it in
+    /// this array, then re-enter execution on the updated array.
+    ///
+    /// Unlike [`ExecuteChild`](Self::ExecuteChild), the scheduler does **not** run cross-step
+    /// optimizations when popping back up. Use this when the parent knows it will consume the
+    /// child directly (e.g., Dict taking from its values).
+    ColumnarizeChild(usize),
+
+    /// Execution is complete. The result may be in any encoding — not necessarily canonical.
+    /// The scheduler will continue executing the result if it is not yet columnar.
+    Done(ArrayRef),
+}
+
 /// Extension trait for creating an execution context from a session.
 pub trait VortexSessionExecute {
     /// Create a new execution context from this session.

--- a/vortex-array/src/executor.rs
+++ b/vortex-array/src/executor.rs
@@ -138,10 +138,10 @@ impl Drop for ExecutionCtx {
 ///
 /// The execution steps are as follows:
 /// 0. Check for canonical.
-/// 1. Attempt to call `reduce_parent` on each child.
-/// 2. Attempt to `reduce` the array with metadata-only optimizations.
+/// 1. Attempt to `reduce` the array with metadata-only optimizations.
+/// 2. Attempt to call `reduce_parent` on each child.
 /// 3. Attempt to call `execute_parent` on each child.
-/// 4. Call `execute` on the array itself.
+/// 4. Call `execute` on the array itself (which returns an [`ExecutionStep`]).
 ///
 /// Most users will not call this method directly, instead preferring to specify an executable
 /// target such as [`crate::Columnar`], [`Canonical`], or any of the canonical array types (such as
@@ -198,16 +198,21 @@ impl Executable for ArrayRef {
             }
         }
 
-        // 4. execute (optimized execution)
+        // 4. execute (returns an ExecutionStep)
         ctx.log(format_args!("executing {}", array));
-        let array = array
-            .vtable()
-            .execute(&array, ctx)
-            .map(|c| c.into_array())?;
-        array.statistics().inherit_from(array.statistics());
-        ctx.log(format_args!("-> {}", array.as_ref()));
-
-        Ok(array)
+        match array.vtable().execute(&array, ctx)? {
+            ExecutionStep::Done(result) => {
+                ctx.log(format_args!("-> {}", result.as_ref()));
+                Ok(result)
+            }
+            ExecutionStep::ExecuteChild(i) | ExecutionStep::ColumnarizeChild(i) => {
+                // For single-step execution, handle ExecuteChild by executing the child,
+                // replacing it, and returning the updated array.
+                let child = array.nth_child(i).vortex_expect("valid child index");
+                let executed_child = child.execute::<ArrayRef>(ctx)?;
+                array.with_child(i, executed_child)
+            }
+        }
     }
 }
 

--- a/vortex-array/src/vtable/dyn_.rs
+++ b/vortex-array/src/vtable/dyn_.rs
@@ -16,6 +16,7 @@ use vortex_session::VortexSession;
 use crate::ArrayAdapter;
 use crate::ArrayRef;
 use crate::DynArray;
+use crate::ExecutionStep;
 use crate::IntoArray;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
@@ -60,7 +61,7 @@ pub trait DynVTable: 'static + private::Sealed + Send + Sync + Debug {
     ) -> VortexResult<Option<ArrayRef>>;
 
     /// See [`VTable::execute`]
-    fn execute(&self, array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef>;
+    fn execute(&self, array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep>;
 
     /// See [`VTable::execute_parent`]
     fn execute_parent(
@@ -145,29 +146,31 @@ impl<V: VTable> DynVTable for ArrayVTableAdapter<V> {
         Ok(Some(reduced))
     }
 
-    fn execute(&self, array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
-        let result = V::execute(downcast::<V>(array), ctx)?;
+    fn execute(&self, array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
+        let step = V::execute(downcast::<V>(array), ctx)?;
 
-        if cfg!(debug_assertions) {
-            vortex_ensure!(
-                result.as_ref().len() == array.len(),
-                "Result length mismatch for {:?}",
-                self
-            );
-            vortex_ensure!(
-                result.as_ref().dtype() == array.dtype(),
-                "Executed canonical dtype mismatch for {:?}",
-                self
-            );
+        if let ExecutionStep::Done(ref result) = step {
+            if cfg!(debug_assertions) {
+                vortex_ensure!(
+                    result.as_ref().len() == array.len(),
+                    "Result length mismatch for {:?}",
+                    self
+                );
+                vortex_ensure!(
+                    result.as_ref().dtype() == array.dtype(),
+                    "Executed canonical dtype mismatch for {:?}",
+                    self
+                );
+            }
+
+            // TODO(ngates): do we want to do this on every execution? We used to in to_canonical.
+            result
+                .as_ref()
+                .statistics()
+                .inherit_from(array.statistics());
         }
 
-        // TODO(ngates): do we want to do this on every execution? We used to in to_canonical.
-        result
-            .as_ref()
-            .statistics()
-            .inherit_from(array.statistics());
-
-        Ok(result)
+        Ok(step)
     }
 
     fn execute_parent(

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -185,8 +185,8 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
     /// do next.
     ///
     /// Instead of recursively executing children, implementations should return
-    /// [`ExecutionStep::ExecuteChild(i)`] or [`ExecutionStep::ColumnarizeChild(i)`] to request
-    /// that the scheduler execute a child first, or [`ExecutionStep::Done(result)`] when the
+    /// [`ExecutionStep::ExecuteChild(i)`] to request that the scheduler execute a child first,
+    /// or [`ExecutionStep::Done(result)`] when the
     /// encoding can produce a result directly.
     ///
     /// Array execution is designed such that repeated execution of an array will eventually

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -22,6 +22,7 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::DynArray;
+use crate::ExecutionStep;
 use crate::IntoArray;
 use crate::Precision;
 use crate::arrays::ConstantArray;
@@ -180,30 +181,24 @@ pub trait VTable: 'static + Sized + Send + Sync + Debug {
     /// of children must be expected.
     fn with_children(array: &mut Self::Array, children: Vec<ArrayRef>) -> VortexResult<()>;
 
-    /// Execute this array to produce an [`ArrayRef`].
+    /// Execute this array by returning an [`ExecutionStep`] that tells the scheduler what to
+    /// do next.
+    ///
+    /// Instead of recursively executing children, implementations should return
+    /// [`ExecutionStep::ExecuteChild(i)`] or [`ExecutionStep::ColumnarizeChild(i)`] to request
+    /// that the scheduler execute a child first, or [`ExecutionStep::Done(result)`] when the
+    /// encoding can produce a result directly.
     ///
     /// Array execution is designed such that repeated execution of an array will eventually
     /// converge to a canonical representation. Implementations of this function should therefore
     /// ensure they make progress towards that goal.
     ///
-    /// This includes fully evaluating the array, such us decoding run-end encoding, or executing
-    /// one of the array's children and re-building the array with the executed child.
-    ///
-    /// It is recommended to only perform a single step of execution per call to this function,
-    /// such that surrounding arrays have an opportunity to perform their own parent reduction
-    /// or execution logic.
-    ///
-    /// The returned array must be logically equivalent to the input array. In other words, the
-    /// recursively canonicalized forms of both arrays must be equal.
+    /// The returned array (in `Done`) must be logically equivalent to the input array. In other
+    /// words, the recursively canonicalized forms of both arrays must be equal.
     ///
     /// Debug builds will panic if the returned array is of the wrong type, wrong length, or
     /// incorrectly contains null values.
-    ///
-    // TODO(ngates): in the future, we may pass a "target encoding hint" such that this array
-    //  can produce a more optimal representation for the parent. This could be used to preserve
-    //  varbin vs varbinview or list vs listview encodings when the parent knows it prefers
-    //  one representation over another, such as when exporting to a specific Arrow array.
-    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef>;
+    fn execute(array: &Self::Array, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep>;
 
     /// Attempt to execute the parent of this array.
     ///

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -10,6 +10,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use vortex::array::ArrayRef;
 use vortex::array::ExecutionCtx;
+use vortex::array::ExecutionStep;
 use vortex::array::Precision;
 use vortex::array::RawMetadata;
 use vortex::array::SerializeMetadata;
@@ -155,7 +156,7 @@ impl VTable for PythonVTable {
         Ok(())
     }
 
-    fn execute(_array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
+    fn execute(_array: &Self::Array, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionStep> {
         todo!()
     }
 }


### PR DESCRIPTION
Changes the model of execution from internal iterator to external.

We go from a recursive execution to an iterative execution with a explicit stack and VTable requesting execution on a child.


This can help with stack overflow on high-depth array trees.

## Breaks
Changed the execute method. Likely unused externally. 

Follow ups:

- Will remove the usage of recursive calls from all arrays.
- Will change the execution method to take a Session so its easier to see internal execution. 
