### PR TITLE
stop showing Fuzz action failure on success

### DIFF
--- a/.github/workflows/run-fuzzer.yml
+++ b/.github/workflows/run-fuzzer.yml
@@ -121,21 +121,18 @@ jobs:
       - name: Check for crashes
         id: check
         run: |
-          if [ -d "fuzz/artifacts" ] && [ "$(ls -A fuzz/artifacts 2>/dev/null)" ]; then
+          # Find actual crash files, not just the directory structure
+          FIRST_CRASH=$(find fuzz/artifacts -type f \( -name "crash-*" -o -name "leak-*" -o -name "timeout-*" -o -name "oom-*" \) 2>/dev/null | head -1 || true)
+
+          if [ -n "$FIRST_CRASH" ]; then
             echo "crashes_found=true" >> $GITHUB_OUTPUT
+            echo "first_crash=$FIRST_CRASH" >> $GITHUB_OUTPUT
+            echo "first_crash_name=$(basename $FIRST_CRASH)" >> $GITHUB_OUTPUT
 
-            # Get the first crash file only
-            FIRST_CRASH=$(find fuzz/artifacts -type f \( -name "crash-*" -o -name "leak-*" -o -name "timeout-*" -o -name "oom-*" \) | head -1)
-
-            if [ -n "$FIRST_CRASH" ]; then
-              echo "first_crash=$FIRST_CRASH" >> $GITHUB_OUTPUT
-              echo "first_crash_name=$(basename $FIRST_CRASH)" >> $GITHUB_OUTPUT
-
-              # Count all crashes for reporting
-              CRASH_COUNT=$(find fuzz/artifacts -type f \( -name "crash-*" -o -name "leak-*" -o -name "timeout-*" -o -name "oom-*" \) | wc -l)
-              echo "crash_count=$CRASH_COUNT" >> $GITHUB_OUTPUT
-              echo "Found $CRASH_COUNT crash(es), will process first: $(basename $FIRST_CRASH)"
-            fi
+            # Count all crashes for reporting
+            CRASH_COUNT=$(find fuzz/artifacts -type f \( -name "crash-*" -o -name "leak-*" -o -name "timeout-*" -o -name "oom-*" \) | wc -l)
+            echo "crash_count=$CRASH_COUNT" >> $GITHUB_OUTPUT
+            echo "Found $CRASH_COUNT crash(es), will process first: $(basename $FIRST_CRASH)"
           else
             echo "crashes_found=false" >> $GITHUB_OUTPUT
             echo "crash_count=0" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Annoyingly, our Fuzz CI action always shows as failing even when it's succeeding:

<img width="1356" height="961" alt="image" src="https://github.com/user-attachments/assets/4bf98e7d-8249-41b6-84d4-8b2b9abcf448" />


We're checking for the wrong thing to determine if there were crashes. The `artifacts` dir is always created when you run the fuzzer.

We should be checking if there are any crash files in there.
