### PR TITLE
Fix projection pushdown SLT test

### DIFF
--- a/vortex-sqllogictest/slt/projection-pushdown.slt
+++ b/vortex-sqllogictest/slt/projection-pushdown.slt
@@ -104,8 +104,8 @@ SELECT * FROM (
     UNION ALL SELECT '' AS id, '' AS id2, 0 AS const
 )
 ----
-ololo  0
-  0
+ololo (empty) 0
+(empty) (empty) 0
 
 onlyif datafusion
 query TTI


### PR DESCRIPTION
The test itself was correct, it just renders differntly , making the empty values explicitly. I think this issue made itself into `develop` because the test isn't required, which @robert3005 will change soon.