### PR TITLE
    duckdb: read from local path, correct err on invalid path

### DIFF
--- a/vortex-duckdb/src/copy.rs
+++ b/vortex-duckdb/src/copy.rs
@@ -95,7 +95,7 @@ impl CopyFunction for VortexCopyFunction {
             .clone();
         RUNTIME
             .block_on(sink.send(chunk))
-            .map_err(|e| vortex_err!("send error {}", e.to_string()))?;
+            .map_err(|e| vortex_err!("send error {e}"))?;
         Ok(())
     }
 
@@ -130,13 +130,13 @@ impl CopyFunction for VortexCopyFunction {
         // SAFETY: The ClientContext is owned by the Connection and lives for the duration of
         // query execution. DuckDB keeps the connection alive while this copy function runs.
         let ctx = unsafe { client_context.erase_lifetime() };
-        let write_task = handle.spawn(async move {
-            // Use DuckDB FS exclusively to match the DuckDB client context configuration.
-            let writer = DuckDbFsWriter::new(ctx, &file_path).map_err(|e| {
-                vortex_err!("Failed to create DuckDB FS writer for {file_path}: {e}")
-            })?;
-            SESSION.write_options().write(writer, array_stream).await
-        });
+
+        // Use DuckDB FS exclusively to match the DuckDB client context configuration.
+        let writer = DuckDbFsWriter::new(ctx, &file_path)
+            .map_err(|e| vortex_err!("Failed to create DuckDB FS writer for {file_path}: {e}"))?;
+
+        let write_task =
+            handle.spawn(async move { SESSION.write_options().write(writer, array_stream).await });
 
         let worker_pool = RUNTIME.new_pool();
         worker_pool.set_workers_to_available_parallelism();

--- a/vortex-duckdb/src/multi_file.rs
+++ b/vortex-duckdb/src/multi_file.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::path::Path;
+use std::path::absolute;
 use std::sync::Arc;
 
 use url::Url;
@@ -40,12 +41,12 @@ impl DataSourceTableFunction for VortexMultiFileScan {
         // Parse the URL and separate the base URL (keep scheme, host, etc.) from the path.
         let glob_url_str = glob_url_parameter.as_string();
 
-        let glob_url = match Url::parse(glob_url_str.as_str()) {
-            Ok(url) => Ok(url),
-            // TODO(myrrc): doesn't parse relative paths like FROM 'test.vortex'
-            Err(_) => Url::from_file_path(Path::new(glob_url_str.as_str()))
-                .map_err(|_| vortex_err!("Neither URL nor path: '{}' ", glob_url_str.as_str())),
-        }?;
+        let glob_url = Url::parse(&glob_url_str).or_else(|_| {
+            let glob_url = glob_url_str.as_str();
+            let path = absolute(Path::new(glob_url));
+            let path = path.map_err(|e| vortex_err!("Failed making {glob_url} absolute: {e}"))?;
+            Url::from_file_path(path).map_err(|_| vortex_err!("Neither URL nor path: {glob_url}"))
+        })?;
 
         let mut base_url = glob_url.clone();
         base_url.set_path("");


### PR DESCRIPTION
Fix two bugs for duckdb integration:
1. Allow relative path reads as in SELECT * FROM 'test.vortex'.
   Threw "neither url not a path" previously.
2. Show correct error when trying to write to a non-existent path.
   Threw "send error cannot send because receiver is gone".
