### PR TITLE
Validate extension dtype in extension scalar validation

### DIFF
--- a/vortex-array/src/dtype/extension/vtable.rs
+++ b/vortex-array/src/dtype/extension/vtable.rs
@@ -42,7 +42,12 @@ pub trait ExtVTable: 'static + Sized + Send + Sync + Clone + Debug + Eq + Hash {
 
     /// Validate the given storage value is compatible with the extension type.
     ///
-    /// By default, this calls [`unpack_native()`](ExtVTable::unpack_native) and discards the result.
+    /// By default, this calls [`unpack_native()`](ExtVTable::unpack_native) and discards the
+    /// result.
+    ///
+    /// Implementors should first validate that the dtype is compatible (with
+    /// [`ExtVTable::validate_dtype`]), and then further validate that the [`ScalarValue`] is
+    /// compatible.
     ///
     /// # Errors
     ///
@@ -59,9 +64,9 @@ pub trait ExtVTable: 'static + Sized + Send + Sync + Clone + Debug + Eq + Hash {
 
     /// Validate and unpack a native value from the storage [`ScalarValue`].
     ///
-    /// Note that [`ExtVTable::validate_dtype()`] is always called first to validate the storage
-    /// [`DType`], and the [`Scalar`](crate::scalar::Scalar) implementation will verify that the
-    /// storage value is compatible with the storage dtype on construction.
+    /// Implementors should first validate that the dtype is compatible (with
+    /// [`ExtVTable::validate_dtype`]), and then further validate that the [`ScalarValue`] is
+    /// compatible in order to unpack into a `NativeValue`.
     ///
     /// # Errors
     ///

--- a/vortex-array/src/extension/datetime/date.rs
+++ b/vortex-array/src/extension/datetime/date.rs
@@ -7,7 +7,7 @@ use jiff::Span;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
-use vortex_error::vortex_ensure;
+use vortex_error::vortex_ensure_eq;
 use vortex_error::vortex_err;
 
 use crate::dtype::DType;
@@ -95,11 +95,11 @@ impl ExtVTable for Date {
         let ptype = date_ptype(metadata)
             .ok_or_else(|| vortex_err!("Date type does not support time unit {}", metadata))?;
 
-        vortex_ensure!(
-            storage_dtype.as_ptype() == ptype,
-            "Date storage dtype for {} must be {}",
-            metadata,
-            ptype
+        vortex_ensure_eq!(
+            storage_dtype.as_ptype(),
+            ptype,
+            "Date storage dtype for {}[{metadata}] must be {ptype}",
+            self.id()
         );
 
         Ok(())
@@ -108,9 +108,11 @@ impl ExtVTable for Date {
     fn unpack_native(
         &self,
         metadata: &Self::Metadata,
-        _storage_dtype: &DType,
+        storage_dtype: &DType,
         storage_value: &ScalarValue,
     ) -> VortexResult<Self::NativeValue<'_>> {
+        self.validate_dtype(metadata, storage_dtype)?;
+
         match metadata {
             TimeUnit::Milliseconds => Ok(DateValue::Milliseconds(
                 storage_value.as_primitive().cast::<i64>()?,

--- a/vortex-array/src/extension/datetime/time.rs
+++ b/vortex-array/src/extension/datetime/time.rs
@@ -7,7 +7,7 @@ use jiff::Span;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
-use vortex_error::vortex_ensure;
+use vortex_error::vortex_ensure_eq;
 use vortex_error::vortex_err;
 
 use crate::dtype::DType;
@@ -96,11 +96,11 @@ impl ExtVTable for Time {
         let ptype = time_ptype(metadata)
             .ok_or_else(|| vortex_err!("Time type does not support time unit {}", metadata))?;
 
-        vortex_ensure!(
-            storage_dtype.as_ptype() == ptype,
-            "Time storage dtype for {} must be {}",
-            metadata,
-            ptype
+        vortex_ensure_eq!(
+            storage_dtype.as_ptype(),
+            ptype,
+            "Time storage dtype for {}[{metadata}] must be {ptype}",
+            self.id()
         );
 
         Ok(())
@@ -109,9 +109,11 @@ impl ExtVTable for Time {
     fn unpack_native(
         &self,
         metadata: &Self::Metadata,
-        _storage_dtype: &DType,
+        storage_dtype: &DType,
         storage_value: &ScalarValue,
     ) -> VortexResult<Self::NativeValue<'_>> {
+        self.validate_dtype(metadata, storage_dtype)?;
+
         let length_of_time = storage_value.as_primitive().cast::<i64>()?;
 
         let (span, value) = match *metadata {

--- a/vortex-array/src/extension/datetime/timestamp.rs
+++ b/vortex-array/src/extension/datetime/timestamp.rs
@@ -184,9 +184,11 @@ impl ExtVTable for Timestamp {
     fn unpack_native<'a>(
         &self,
         metadata: &'a Self::Metadata,
-        _storage_dtype: &'a DType,
+        storage_dtype: &'a DType,
         storage_value: &'a ScalarValue,
     ) -> VortexResult<Self::NativeValue<'a>> {
+        self.validate_dtype(metadata, storage_dtype)?;
+
         let ts_value = storage_value.as_primitive().cast::<i64>()?;
         let tz = metadata.tz.as_ref();
 

--- a/vortex-array/src/extension/tests/divisible_int.rs
+++ b/vortex-array/src/extension/tests/divisible_int.rs
@@ -66,9 +66,11 @@ impl ExtVTable for DivisibleInt {
     fn unpack_native(
         &self,
         metadata: &Self::Metadata,
-        _storage_dtype: &DType,
+        storage_dtype: &DType,
         storage_value: &ScalarValue,
     ) -> VortexResult<Self::NativeValue<'_>> {
+        self.validate_dtype(metadata, storage_dtype)?;
+
         let value = storage_value.as_primitive().cast::<u64>()?;
         if value % metadata.0 != 0 {
             vortex_bail!("{} is not divisible by {}", value, metadata.0);

--- a/vortex-array/src/extension/uuid/vtable.rs
+++ b/vortex-array/src/extension/uuid/vtable.rs
@@ -81,9 +81,11 @@ impl ExtVTable for Uuid {
     fn unpack_native<'a>(
         &self,
         metadata: &'a Self::Metadata,
-        _storage_dtype: &'a DType,
+        storage_dtype: &'a DType,
         storage_value: &'a ScalarValue,
     ) -> VortexResult<Self::NativeValue<'a>> {
+        self.validate_dtype(metadata, storage_dtype)?;
+
         let elements = storage_value.as_list();
         vortex_ensure_eq!(
             elements.len(),

--- a/vortex-tensor/src/fixed_shape/vtable.rs
+++ b/vortex-tensor/src/fixed_shape/vtable.rs
@@ -63,10 +63,12 @@ impl ExtVTable for FixedShapeTensor {
 
     fn unpack_native<'a>(
         &self,
-        _metadata: &'a Self::Metadata,
-        _storage_dtype: &'a DType,
+        metadata: &'a Self::Metadata,
+        storage_dtype: &'a DType,
         storage_value: &'a ScalarValue,
     ) -> VortexResult<Self::NativeValue<'a>> {
+        self.validate_dtype(metadata, storage_dtype)?;
+
         // TODO(connor): This is just a placeholder. However, even if we have a dedicated native
         // type for a singular tensor, we do not need to validate anything as any backing memory
         // should be valid for a given tensor.


### PR DESCRIPTION
## Summary

Tracking Issue: TODO

Right now, the `ExtVTable` has a leaky abstraction with respect to the `unpack_native` method. We thought that because the only important place we call it is within the `Scalar` logic, which by definition must have a valid `ExtDType` and `ScalarValue` combination, we technically do not need to validate the dtype inside `unpack_native`.

However, since the `ExtVTable` is public and the type that implements it is also public, there is nothing preventing someone from just calling this method directly. This means that it is very possible for someone to call this method without first calling `validate_dtype`.

So either we can make this method `unsafe` to make sure the caller knows what they are doing, or we can just say that implementors should call `validate_dtype`. This change proposes the latter.
 
## Testing

This change further validates correctness in exchange for (what is now a small amount of) performance