### PR TITLE
Extension Array Cleanup

### DIFF
--- a/fuzz/src/array/mask.rs
+++ b/fuzz/src/array/mask.rs
@@ -125,7 +125,7 @@ pub fn mask_canonical_array(canonical: Canonical, mask: &Mask) -> VortexResult<A
         }
         Canonical::Extension(array) => {
             // Recursively mask the storage array
-            let masked_storage = mask_canonical_array(array.storage().to_canonical()?, mask)
+            let masked_storage = mask_canonical_array(array.storage_array().to_canonical()?, mask)
                 .vortex_expect("mask_canonical_array should succeed in fuzz test");
 
             let ext_dtype = array

--- a/fuzz/src/array/scalar_at.rs
+++ b/fuzz/src/array/scalar_at.rs
@@ -91,7 +91,8 @@ pub fn scalar_at_canonical_array(canonical: Canonical, index: usize) -> VortexRe
             Scalar::struct_(array.dtype().clone(), field_scalars)
         }
         Canonical::Extension(array) => {
-            let storage_scalar = scalar_at_canonical_array(array.storage().to_canonical()?, index)?;
+            let storage_scalar =
+                scalar_at_canonical_array(array.storage_array().to_canonical()?, index)?;
             Scalar::extension_ref(array.ext_dtype().clone(), storage_scalar)
         }
     })

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -1686,11 +1686,13 @@ impl vortex_array::arrays::ExtensionArray
 
 pub fn vortex_array::arrays::ExtensionArray::ext_dtype(&self) -> &vortex_array::dtype::extension::ExtDTypeRef
 
-pub fn vortex_array::arrays::ExtensionArray::id(&self) -> vortex_array::dtype::extension::ExtId
+pub fn vortex_array::arrays::ExtensionArray::new(ext_dtype: vortex_array::dtype::extension::ExtDTypeRef, storage_array: vortex_array::ArrayRef) -> Self
 
-pub fn vortex_array::arrays::ExtensionArray::new(ext_dtype: vortex_array::dtype::extension::ExtDTypeRef, storage: vortex_array::ArrayRef) -> Self
+pub unsafe fn vortex_array::arrays::ExtensionArray::new_unchecked(ext_dtype: vortex_array::dtype::extension::ExtDTypeRef, storage_array: vortex_array::ArrayRef) -> Self
 
-pub fn vortex_array::arrays::ExtensionArray::storage(&self) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::ExtensionArray::storage_array(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ExtensionArray::try_new(ext_dtype: vortex_array::dtype::extension::ExtDTypeRef, storage_array: vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
 
 impl vortex_array::arrays::ExtensionArray
 
@@ -5498,11 +5500,13 @@ impl vortex_array::arrays::ExtensionArray
 
 pub fn vortex_array::arrays::ExtensionArray::ext_dtype(&self) -> &vortex_array::dtype::extension::ExtDTypeRef
 
-pub fn vortex_array::arrays::ExtensionArray::id(&self) -> vortex_array::dtype::extension::ExtId
+pub fn vortex_array::arrays::ExtensionArray::new(ext_dtype: vortex_array::dtype::extension::ExtDTypeRef, storage_array: vortex_array::ArrayRef) -> Self
 
-pub fn vortex_array::arrays::ExtensionArray::new(ext_dtype: vortex_array::dtype::extension::ExtDTypeRef, storage: vortex_array::ArrayRef) -> Self
+pub unsafe fn vortex_array::arrays::ExtensionArray::new_unchecked(ext_dtype: vortex_array::dtype::extension::ExtDTypeRef, storage_array: vortex_array::ArrayRef) -> Self
 
-pub fn vortex_array::arrays::ExtensionArray::storage(&self) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::ExtensionArray::storage_array(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ExtensionArray::try_new(ext_dtype: vortex_array::dtype::extension::ExtDTypeRef, storage_array: vortex_array::ArrayRef) -> vortex_error::VortexResult<Self>
 
 impl vortex_array::arrays::ExtensionArray
 

--- a/vortex-array/src/arrays/datetime/mod.rs
+++ b/vortex-array/src/arrays/datetime/mod.rs
@@ -125,7 +125,7 @@ impl TemporalArray {
     /// These values are to be interpreted based on the time unit and optional time-zone stored
     /// in the TemporalMetadata.
     pub fn temporal_values(&self) -> &ArrayRef {
-        self.ext.storage()
+        self.ext.storage_array()
     }
 
     /// Retrieve the temporal metadata.

--- a/vortex-array/src/arrays/extension/array.rs
+++ b/vortex-array/src/arrays/extension/array.rs
@@ -53,7 +53,7 @@ pub struct ExtensionArray {
     pub(super) dtype: DType,
 
     /// The backing storage array for this extension array.
-    pub(super) storage: ArrayRef,
+    pub(super) storage_array: ArrayRef,
 
     /// The stats for this array.
     pub(super) stats_set: ArrayStats,
@@ -97,7 +97,7 @@ impl ExtensionArray {
 
         Self {
             dtype: DType::Extension(ext_dtype),
-            storage: storage_array,
+            storage_array,
             stats_set: ArrayStats::default(),
         }
     }
@@ -111,8 +111,7 @@ impl ExtensionArray {
         ext
     }
 
-    // TODO(connor): Rename to storage array
-    pub fn storage(&self) -> &ArrayRef {
-        &self.storage
+    pub fn storage_array(&self) -> &ArrayRef {
+        &self.storage_array
     }
 }

--- a/vortex-array/src/arrays/extension/array.rs
+++ b/vortex-array/src/arrays/extension/array.rs
@@ -75,7 +75,13 @@ impl ExtensionArray {
     ///
     /// Returns an error if the storage array in not compatible with the extension dtype.
     pub fn try_new(ext_dtype: ExtDTypeRef, storage_array: ArrayRef) -> VortexResult<Self> {
+        // TODO(connor): Replace these statements once we add `validate_storage_array`.
         // ext_dtype.validate_storage_array(&storage_array)?;
+        assert_eq!(
+            ext_dtype.storage_dtype(),
+            storage_array.dtype(),
+            "ExtensionArray: storage_dtype must match storage array DType",
+        );
 
         // SAFETY: we validate that the inputs are valid above.
         Ok(unsafe { Self::new_unchecked(ext_dtype, storage_array) })
@@ -89,11 +95,16 @@ impl ExtensionArray {
     /// other words, they must know that `ext_dtype.validate_storage_array(&storage_array)` has been
     /// called successfully on this storage array.
     pub unsafe fn new_unchecked(ext_dtype: ExtDTypeRef, storage_array: ArrayRef) -> Self {
-        // TODO(connor): Remove the comment once we add `validate_storage_array`.
+        // TODO(connor): Replace these statements once we add `validate_storage_array`.
         // #[cfg(debug_assertions)]
         // ext_dtype
         //     .validate_storage_array(&storage_array)
         //     .vortex_expect("[Debug Assertion]: Invalid storage array for `ExtensionArray`");
+        debug_assert_eq!(
+            ext_dtype.storage_dtype(),
+            storage_array.dtype(),
+            "ExtensionArray: storage_dtype must match storage array DType",
+        );
 
         Self {
             dtype: DType::Extension(ext_dtype),

--- a/vortex-array/src/arrays/extension/array.rs
+++ b/vortex-array/src/arrays/extension/array.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+
 use crate::ArrayRef;
 use crate::dtype::DType;
 use crate::dtype::extension::ExtDTypeRef;
-use crate::dtype::extension::ExtId;
 use crate::stats::ArrayStats;
 
 /// An extension array that wraps another array with additional type information.
@@ -47,38 +49,70 @@ use crate::stats::ArrayStats;
 /// - Scalar access wraps storage scalars with extension metadata
 #[derive(Clone, Debug)]
 pub struct ExtensionArray {
+    /// The storage dtype. This **must** be a [`Extension::DType`] variant.
     pub(super) dtype: DType,
+
+    /// The backing storage array for this extension array.
     pub(super) storage: ArrayRef,
+
+    /// The stats for this array.
     pub(super) stats_set: ArrayStats,
 }
 
 impl ExtensionArray {
-    pub fn new(ext_dtype: ExtDTypeRef, storage: ArrayRef) -> Self {
-        assert_eq!(
-            ext_dtype.storage_dtype(),
-            storage.dtype(),
-            "ExtensionArray: storage_dtype must match storage array DType",
-        );
+    /// Constructs a new `ExtensionArray`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the storage array in not compatible with the extension dtype.
+    pub fn new(ext_dtype: ExtDTypeRef, storage_array: ArrayRef) -> Self {
+        Self::try_new(ext_dtype, storage_array).vortex_expect("Failed to create `ExtensionArray`")
+    }
+
+    /// Tries to construct a new `ExtensionArray`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the storage array in not compatible with the extension dtype.
+    pub fn try_new(ext_dtype: ExtDTypeRef, storage_array: ArrayRef) -> VortexResult<Self> {
+        // ext_dtype.validate_storage_array(&storage_array)?;
+
+        // SAFETY: we validate that the inputs are valid above.
+        Ok(unsafe { Self::new_unchecked(ext_dtype, storage_array) })
+    }
+
+    /// Creates a new `ExtensionArray`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the storage array is compatible with the extension dtype. In
+    /// other words, they must know that `ext_dtype.validate_storage_array(&storage_array)` has been
+    /// called successfully on this storage array.
+    pub unsafe fn new_unchecked(ext_dtype: ExtDTypeRef, storage_array: ArrayRef) -> Self {
+        // TODO(connor): Remove the comment once we add `validate_storage_array`.
+        // #[cfg(debug_assertions)]
+        // ext_dtype
+        //     .validate_storage_array(&storage_array)
+        //     .vortex_expect("[Debug Assertion]: Invalid storage array for `ExtensionArray`");
+
         Self {
             dtype: DType::Extension(ext_dtype),
-            storage,
+            storage: storage_array,
             stats_set: ArrayStats::default(),
         }
     }
 
+    /// The extension dtype of this array.
     pub fn ext_dtype(&self) -> &ExtDTypeRef {
         let DType::Extension(ext) = &self.dtype else {
             unreachable!("ExtensionArray: dtype must be an ExtDType")
         };
+
         ext
     }
 
+    // TODO(connor): Rename to storage array
     pub fn storage(&self) -> &ArrayRef {
         &self.storage
-    }
-
-    #[inline]
-    pub fn id(&self) -> ExtId {
-        self.ext_dtype().id()
     }
 }

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -19,7 +19,10 @@ impl CastReduce for ExtensionVTable {
             unreachable!("Already verified we have an extension dtype");
         };
 
-        let new_storage = match array.storage().cast(ext_dtype.storage_dtype().clone()) {
+        let new_storage = match array
+            .storage_array()
+            .cast(ext_dtype.storage_dtype().clone())
+        {
             Ok(arr) => arr,
             Err(e) => {
                 tracing::warn!("Failed to cast storage array: {e}");

--- a/vortex-array/src/arrays/extension/compute/compare.rs
+++ b/vortex-array/src/arrays/extension/compute/compare.rs
@@ -26,7 +26,7 @@ impl CompareKernel for ExtensionVTable {
         if let Some(const_ext) = rhs.as_constant() {
             let storage_scalar = const_ext.as_extension().to_storage_scalar();
             return lhs
-                .storage()
+                .storage_array()
                 .to_array()
                 .binary(
                     ConstantArray::new(storage_scalar, lhs.len()).into_array(),
@@ -38,9 +38,9 @@ impl CompareKernel for ExtensionVTable {
         // If the RHS is an extension array matching ours, we can extract the storage.
         if let Some(rhs_ext) = rhs.as_opt::<ExtensionVTable>() {
             return lhs
-                .storage()
+                .storage_array()
                 .to_array()
-                .binary(rhs_ext.storage().to_array(), Operator::from(operator))
+                .binary(rhs_ext.storage_array().to_array(), Operator::from(operator))
                 .map(Some);
         }
 

--- a/vortex-array/src/arrays/extension/compute/filter.rs
+++ b/vortex-array/src/arrays/extension/compute/filter.rs
@@ -15,7 +15,7 @@ impl FilterReduce for ExtensionVTable {
         Ok(Some(
             ExtensionArray::new(
                 array.ext_dtype().clone(),
-                array.storage().filter(mask.clone())?,
+                array.storage_array().filter(mask.clone())?,
             )
             .into_array(),
         ))

--- a/vortex-array/src/arrays/extension/compute/is_constant.rs
+++ b/vortex-array/src/arrays/extension/compute/is_constant.rs
@@ -17,7 +17,7 @@ impl IsConstantKernel for ExtensionVTable {
         array: &ExtensionArray,
         opts: &IsConstantOpts,
     ) -> VortexResult<Option<bool>> {
-        compute::is_constant_opts(array.storage(), opts)
+        compute::is_constant_opts(array.storage_array(), opts)
     }
 }
 

--- a/vortex-array/src/arrays/extension/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/extension/compute/is_sorted.rs
@@ -12,11 +12,11 @@ use crate::register_kernel;
 
 impl IsSortedKernel for ExtensionVTable {
     fn is_sorted(&self, array: &ExtensionArray) -> VortexResult<Option<bool>> {
-        compute::is_sorted(array.storage())
+        compute::is_sorted(array.storage_array())
     }
 
     fn is_strict_sorted(&self, array: &ExtensionArray) -> VortexResult<Option<bool>> {
-        compute::is_strict_sorted(array.storage())
+        compute::is_strict_sorted(array.storage_array())
     }
 }
 

--- a/vortex-array/src/arrays/extension/compute/mask.rs
+++ b/vortex-array/src/arrays/extension/compute/mask.rs
@@ -15,9 +15,9 @@ use crate::scalar_fn::fns::mask::MaskReduce;
 impl MaskReduce for ExtensionVTable {
     fn mask(array: &ExtensionArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let masked_storage = MaskExpr.try_new_array(
-            array.storage().len(),
+            array.storage_array().len(),
             EmptyOptions,
-            [array.storage().clone(), mask.clone()],
+            [array.storage_array().clone(), mask.clone()],
         )?;
         Ok(Some(
             ExtensionArray::new(

--- a/vortex-array/src/arrays/extension/compute/min_max.rs
+++ b/vortex-array/src/arrays/extension/compute/min_max.rs
@@ -17,9 +17,11 @@ impl MinMaxKernel for ExtensionVTable {
     fn min_max(&self, array: &ExtensionArray) -> VortexResult<Option<MinMaxResult>> {
         let non_nullable_ext_dtype = array.ext_dtype().with_nullability(Nullability::NonNullable);
         Ok(
-            compute::min_max(array.storage())?.map(|MinMaxResult { min, max }| MinMaxResult {
-                min: Scalar::extension_ref(non_nullable_ext_dtype.clone(), min),
-                max: Scalar::extension_ref(non_nullable_ext_dtype, max),
+            compute::min_max(array.storage_array())?.map(|MinMaxResult { min, max }| {
+                MinMaxResult {
+                    min: Scalar::extension_ref(non_nullable_ext_dtype.clone(), min),
+                    max: Scalar::extension_ref(non_nullable_ext_dtype, max),
+                }
             }),
         )
     }

--- a/vortex-array/src/arrays/extension/compute/rules.rs
+++ b/vortex-array/src/arrays/extension/compute/rules.rs
@@ -39,7 +39,7 @@ impl ArrayParentReduceRule<ExtensionVTable> for ExtensionFilterPushDownRule {
     ) -> VortexResult<Option<ArrayRef>> {
         debug_assert_eq!(child_idx, 0);
         let filtered_storage = child
-            .storage()
+            .storage_array()
             .clone()
             .filter(parent.filter_mask().clone())?;
         Ok(Some(
@@ -147,7 +147,7 @@ mod tests {
         assert_eq!(ext_result.ext_dtype(), &ext_dtype);
 
         // Check the storage values
-        let storage_result: &[i64] = &ext_result.storage().to_primitive().to_buffer::<i64>();
+        let storage_result: &[i64] = &ext_result.storage_array().to_primitive().to_buffer::<i64>();
         assert_eq!(storage_result, &[1, 3, 5]);
     }
 
@@ -173,7 +173,7 @@ mod tests {
         assert_eq!(ext_result.len(), 3);
 
         // Check values: should be [Some(1), None, None]
-        let canonical = ext_result.storage().to_primitive();
+        let canonical = ext_result.storage_array().to_primitive();
         assert_eq!(canonical.len(), 3);
     }
 

--- a/vortex-array/src/arrays/extension/compute/slice.rs
+++ b/vortex-array/src/arrays/extension/compute/slice.rs
@@ -14,8 +14,11 @@ use crate::arrays::slice::SliceReduce;
 impl SliceReduce for ExtensionVTable {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
-            ExtensionArray::new(array.ext_dtype().clone(), array.storage().slice(range)?)
-                .into_array(),
+            ExtensionArray::new(
+                array.ext_dtype().clone(),
+                array.storage_array().slice(range)?,
+            )
+            .into_array(),
         ))
     }
 }

--- a/vortex-array/src/arrays/extension/compute/sum.rs
+++ b/vortex-array/src/arrays/extension/compute/sum.rs
@@ -13,7 +13,7 @@ use crate::scalar::Scalar;
 
 impl SumKernel for ExtensionVTable {
     fn sum(&self, array: &ExtensionArray, accumulator: &Scalar) -> VortexResult<Scalar> {
-        compute::sum_with_accumulator(array.storage(), accumulator)
+        compute::sum_with_accumulator(array.storage_array(), accumulator)
     }
 }
 

--- a/vortex-array/src/arrays/extension/compute/take.rs
+++ b/vortex-array/src/arrays/extension/compute/take.rs
@@ -17,7 +17,7 @@ impl TakeExecute for ExtensionVTable {
         indices: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let taken_storage = array.storage().take(indices.to_array())?;
+        let taken_storage = array.storage_array().take(indices.to_array())?;
         Ok(Some(
             ExtensionArray::new(
                 array

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -48,7 +48,7 @@ impl VTable for ExtensionVTable {
     }
 
     fn len(array: &ExtensionArray) -> usize {
-        array.storage.len()
+        array.storage_array.len()
     }
 
     fn dtype(array: &ExtensionArray) -> &DType {
@@ -65,11 +65,14 @@ impl VTable for ExtensionVTable {
         precision: Precision,
     ) {
         array.dtype.hash(state);
-        array.storage.array_hash(state, precision);
+        array.storage_array.array_hash(state, precision);
     }
 
     fn array_eq(array: &ExtensionArray, other: &ExtensionArray, precision: Precision) -> bool {
-        array.dtype == other.dtype && array.storage.array_eq(&other.storage, precision)
+        array.dtype == other.dtype
+            && array
+                .storage_array
+                .array_eq(&other.storage_array, precision)
     }
 
     fn nbuffers(_array: &ExtensionArray) -> usize {
@@ -90,7 +93,7 @@ impl VTable for ExtensionVTable {
 
     fn child(array: &ExtensionArray, idx: usize) -> ArrayRef {
         match idx {
-            0 => array.storage.clone(),
+            0 => array.storage_array.clone(),
             _ => vortex_panic!("ExtensionArray child index {idx} out of bounds"),
         }
     }
@@ -143,7 +146,7 @@ impl VTable for ExtensionVTable {
             "ExtensionArray expects exactly 1 child (storage), got {}",
             children.len()
         );
-        array.storage = children
+        array.storage_array = children
             .into_iter()
             .next()
             .vortex_expect("children length already validated");

--- a/vortex-array/src/arrays/extension/vtable/operations.rs
+++ b/vortex-array/src/arrays/extension/vtable/operations.rs
@@ -13,7 +13,7 @@ impl OperationsVTable<ExtensionVTable> for ExtensionVTable {
     fn scalar_at(array: &ExtensionArray, index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::extension_ref(
             array.ext_dtype().clone(),
-            array.storage().scalar_at(index)?,
+            array.storage_array().scalar_at(index)?,
         ))
     }
 }

--- a/vortex-array/src/arrays/extension/vtable/validity.rs
+++ b/vortex-array/src/arrays/extension/vtable/validity.rs
@@ -8,6 +8,6 @@ use crate::vtable::ValidityChild;
 
 impl ValidityChild<ExtensionVTable> for ExtensionVTable {
     fn validity_child(array: &ExtensionArray) -> &ArrayRef {
-        &array.storage
+        &array.storage_array
     }
 }

--- a/vortex-array/src/arrays/filter/execute/mod.rs
+++ b/vortex-array/src/arrays/filter/execute/mod.rs
@@ -89,7 +89,7 @@ pub(super) fn execute_filter(canonical: Canonical, mask: &Arc<MaskValues>) -> Ca
         Canonical::Struct(a) => Canonical::Struct(struct_::filter_struct(&a, mask)),
         Canonical::Extension(a) => {
             let filtered_storage = a
-                .storage()
+                .storage_array()
                 .filter(values_to_mask(mask))
                 .vortex_expect("ExtensionArray storage type somehow could not be filtered");
             Canonical::Extension(ExtensionArray::new(a.ext_dtype().clone(), filtered_storage))

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -261,10 +261,11 @@ pub fn recursive_list_from_list_view(array: ArrayRef) -> VortexResult<ArrayRef> 
             }
         }
         Canonical::Extension(ext_array) => {
-            let converted_storage = recursive_list_from_list_view(ext_array.storage().clone())?;
+            let converted_storage =
+                recursive_list_from_list_view(ext_array.storage_array().clone())?;
 
             // Avoid cloning if elements didn't change.
-            if !Arc::ptr_eq(&converted_storage, ext_array.storage()) {
+            if !Arc::ptr_eq(&converted_storage, ext_array.storage_array()) {
                 ExtensionArray::new(ext_array.ext_dtype().clone(), converted_storage).into_array()
             } else {
                 ext_array.into_array()

--- a/vortex-array/src/arrays/masked/execute.rs
+++ b/vortex-array/src/arrays/masked/execute.rs
@@ -151,7 +151,7 @@ fn mask_validity_extension(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ExtensionArray> {
     // For extension arrays, we need to mask the underlying storage
-    let storage = array.storage().clone().execute::<Canonical>(ctx)?;
+    let storage = array.storage_array().clone().execute::<Canonical>(ctx)?;
     let masked_storage = mask_validity_canonical(storage, mask, ctx)?;
     let masked_storage = masked_storage.into_array();
     Ok(ExtensionArray::new(

--- a/vortex-array/src/arrow/executor/temporal.rs
+++ b/vortex-array/src/arrow/executor/temporal.rs
@@ -147,7 +147,7 @@ where
 
     let ext_array = array.execute::<ExtensionArray>(ctx)?;
     let primitive = ext_array
-        .storage()
+        .storage_array()
         .clone()
         .execute::<VortexPrimitiveArray>(ctx)?;
     vortex_ensure!(

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -99,7 +99,7 @@ impl ArrayBuilder for ExtensionBuilder {
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
         let ext_array = array.to_extension();
-        self.storage.extend_from_array(ext_array.storage())
+        self.storage.extend_from_array(ext_array.storage_array())
     }
 
     fn reserve_exact(&mut self, capacity: usize) {

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -630,7 +630,7 @@ impl Executable for CanonicalValidity {
             Canonical::Extension(ext) => Ok(CanonicalValidity(Canonical::Extension(
                 ExtensionArray::new(
                     ext.ext_dtype().clone(),
-                    ext.storage()
+                    ext.storage_array()
                         .clone()
                         .execute::<CanonicalValidity>(ctx)?
                         .0
@@ -760,7 +760,7 @@ impl Executable for RecursiveCanonical {
             Canonical::Extension(ext) => Ok(RecursiveCanonical(Canonical::Extension(
                 ExtensionArray::new(
                     ext.ext_dtype().clone(),
-                    ext.storage()
+                    ext.storage_array()
                         .clone()
                         .execute::<RecursiveCanonical>(ctx)?
                         .0

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -299,7 +299,7 @@ impl CanonicalCompressor for BtrBlocksCompressor {
                 }
 
                 // Compress the underlying storage array.
-                let compressed_storage = self.compress(ext_array.storage())?;
+                let compressed_storage = self.compress(ext_array.storage_array())?;
 
                 Ok(
                     ExtensionArray::new(ext_array.ext_dtype().clone(), compressed_storage)

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -116,7 +116,7 @@ fn export_canonical(
                     vortex_bail!("only support temporal extension types currently");
                 }
 
-                let values = extension.storage().to_primitive();
+                let values = extension.storage_array().to_primitive();
                 let len = extension.len();
 
                 let PrimitiveArrayParts {

--- a/vortex-cuda/src/canonical.rs
+++ b/vortex-cuda/src/canonical.rs
@@ -133,7 +133,7 @@ impl CanonicalCudaExt for Canonical {
             Canonical::Extension(ext) => {
                 // Copy the storage array to host and rewrap in ExtensionArray.
                 let host_storage = ext
-                    .storage()
+                    .storage_array()
                     .to_canonical()?
                     .into_host()
                     .await?

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -294,7 +294,7 @@ macro_rules! get_primitive {
                     array_ref
                         .inner
                         .to_extension()
-                        .storage()
+                        .storage_array()
                         .scalar_at(index as usize)?
                 } else {
                     array_ref.inner.scalar_at(index as usize)?
@@ -333,7 +333,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getBigDecimal(
             array_ref
                 .inner
                 .to_extension()
-                .storage()
+                .storage_array()
                 .scalar_at(index as usize)?
         } else {
             array_ref.inner.scalar_at(index as usize)?

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -199,7 +199,7 @@ fn extension_storage(array: &ArrayRef) -> VortexResult<ArrayRef> {
     let ext = array
         .as_opt::<ExtensionVTable>()
         .ok_or_else(|| vortex_err!("cosine_similarity input must be an extension array"))?;
-    Ok(ext.storage().clone())
+    Ok(ext.storage_array().clone())
 }
 
 /// Extracts the flat primitive elements from a tensor storage array (FixedSizeList).


### PR DESCRIPTION
## Summary

Adds some missing constructors to `ExtensionArray` that we will want soon, as well as renames `storage` to `storage_array`.

## API Changes

The API changes are minimal, and nobody should really be using them anyways right now.

## Testing

N/A