### PR TITLE
Use unaligned bit buffer iterators where possible

### DIFF
--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -101,11 +101,7 @@ impl BitBuffer {
         // Slice the buffer to ensure the offset is within the first byte
         let byte_offset = offset / 8;
         let offset = offset % 8;
-        let buffer = if byte_offset != 0 {
-            buffer.slice(byte_offset..)
-        } else {
-            buffer
-        };
+        let buffer = buffer.slice(byte_offset..);
 
         Self {
             buffer,

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -25,6 +25,7 @@ use crate::bit::get_bit_unchecked;
 use crate::bit::ops::bitwise_binary_op;
 use crate::bit::ops::bitwise_unary_op;
 use crate::buffer;
+use crate::trusted_len::TrustedLenExt;
 
 /// An immutable bitset stored as a packed byte buffer.
 #[derive(Debug, Clone, Eq)]
@@ -342,7 +343,12 @@ impl BitBuffer {
                 self.len,
             );
         }
-        bitwise_unary_op(self, |a| a)
+        // Use Chunk iterator here to reset offset to 0
+        let iter = self.chunks().iter_padded();
+        let iter = unsafe { iter.trusted_len() };
+        let result = Buffer::<u64>::from_trusted_len_iter(iter).into_byte_buffer();
+
+        BitBuffer::new(result, self.len())
     }
 }
 

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -101,7 +101,11 @@ impl BitBuffer {
         // Slice the buffer to ensure the offset is within the first byte
         let byte_offset = offset / 8;
         let offset = offset % 8;
-        let buffer = buffer.slice(byte_offset..);
+        let buffer = if byte_offset != 0 {
+            buffer.slice(byte_offset..)
+        } else {
+            buffer
+        };
 
         Self {
             buffer,

--- a/vortex-buffer/src/bit/ops.rs
+++ b/vortex-buffer/src/bit/ops.rs
@@ -8,12 +8,12 @@ use crate::trusted_len::TrustedLenExt;
 
 #[inline]
 pub(super) fn bitwise_unary_op<F: FnMut(u64) -> u64>(buffer: &BitBuffer, op: F) -> BitBuffer {
-    let iter = buffer.chunks().iter_padded().map(op);
+    let iter = buffer.unaligned_chunks().iter().map(op);
     let iter = unsafe { iter.trusted_len() };
 
     let result = Buffer::<u64>::from_trusted_len_iter(iter).into_byte_buffer();
 
-    BitBuffer::new(result, buffer.len())
+    BitBuffer::new_with_offset(result, buffer.len(), buffer.offset())
 }
 
 #[inline]
@@ -55,6 +55,25 @@ pub(super) fn bitwise_binary_op<F: FnMut(u64, u64) -> u64>(
     mut op: F,
 ) -> BitBuffer {
     assert_eq!(left.len(), right.len());
+
+    // If the buffers are aligned, we can use the fast path.
+    if left.offset().is_multiple_of(8) && right.offset().is_multiple_of(8) {
+        let left_chunks = left.unaligned_chunks();
+        let right_chunks = right.unaligned_chunks();
+        if left_chunks.lead_padding() == 0
+            && left_chunks.trailing_padding() == 0
+            && right_chunks.lead_padding() == 0
+            && right_chunks.trailing_padding() == 0
+        {
+            let iter = left_chunks
+                .iter()
+                .zip(right_chunks.iter())
+                .map(|(l, r)| op(l, r));
+            let iter = unsafe { iter.trusted_len() };
+            let result = Buffer::<u64>::from_trusted_len_iter(iter).into_byte_buffer();
+            return BitBuffer::new(result, left.len());
+        }
+    }
 
     let iter = left
         .chunks()

--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -309,10 +309,6 @@ impl<T> Buffer<T> {
             vortex_panic!("range end out of bounds: {:?} > {:?}", end, len);
         }
 
-        if begin == 0 && end == len {
-            return self.clone().aligned(alignment);
-        }
-
         if end == begin {
             // We prefer to return a new empty buffer instead of sharing this one and creating a
             // strong reference just to hold an empty slice.

--- a/vortex-buffer/src/buffer.rs
+++ b/vortex-buffer/src/buffer.rs
@@ -309,6 +309,10 @@ impl<T> Buffer<T> {
             vortex_panic!("range end out of bounds: {:?} > {:?}", end, len);
         }
 
+        if begin == 0 && end == len {
+            return self.clone().aligned(alignment);
+        }
+
         if end == begin {
             // We prefer to return a new empty buffer instead of sharing this one and creating a
             // strong reference just to hold an empty slice.


### PR DESCRIPTION
Use unalingned bit iterators where possible, they are faster as they avoid
unaligned reads. They're always fine to use for unary operations and can be used
for n-ary operations if all buffers are aligned

## Summary

We used to have this optimisation when we added BitBuffer but we reverted to
arrow implementation of bit iterators and it got lost in the process.

Closes: #6836

## Testing
Existing tests

Signed-off-by: Robert Kruszewski <github@robertk.io>
