### PR TITLE
Change benchmark display order

### DIFF
--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -207,6 +207,13 @@ def build_group_summary(group_df):
     return ratio_summary, significant_improvements, significant_regressions
 
 
+def format_integer_value(value):
+    if pd.isna(value):
+        return ""
+
+    return str(int(value))
+
+
 # Output complete formatted markdown
 print("\n".join(summary_lines))
 print("")
@@ -218,8 +225,8 @@ for engine, file_format in sorted(grouped_tables.groups.keys(), key=group_sort_k
     display_df = pd.DataFrame(
         {
             "name": group_df["name"],
-            f"PR {pr_commit_id[:8]} ({unit})": group_df["value_pr"],
-            f"base {base_commit_id[:8]} ({unit})": group_df["value_base"],
+            f"PR {pr_commit_id[:8]} ({unit})": group_df["value_pr"].map(format_integer_value),
+            f"base {base_commit_id[:8]} ({unit})": group_df["value_base"].map(format_integer_value),
             "ratio (PR/base)": group_df["ratio"],
         }
     )

--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -152,8 +152,6 @@ def format_performance(ratio, target_name):
 
 overall_performance = "no data" if pd.isna(geo_mean_ratio) else format_performance(geo_mean_ratio, "overall")
 vortex_performance = format_performance(vortex_geo_mean_ratio, "vortex")
-duckdb_vortex_performance = format_performance(duckdb_vortex_geo_mean_ratio, "duckdb:vortex")
-datafusion_vortex_performance = format_performance(datafusion_vortex_geo_mean_ratio, "datafusion:vortex")
 parquet_performance = format_performance(parquet_geo_mean_ratio, "parquet")
 
 
@@ -170,23 +168,6 @@ if len(vortex_df) > 0:
 if len(parquet_df) > 0:
     summary_lines.extend([f"- **Parquet**: {parquet_performance}"])
 
-# Only add duckdb:vortex section if we have that data
-if len(duckdb_vortex_df) > 0:
-    summary_lines.append(f"- **duckdb:vortex**: {duckdb_vortex_performance}")
-
-# Only add datafusion:vortex section if we have that data
-if len(datafusion_vortex_df) > 0:
-    summary_lines.append(f"- **datafusion:vortex**: {datafusion_vortex_performance}")
-
-# Only add best/worst if we have vortex data
-if len(vortex_df) > 0:
-    summary_lines.extend(
-        [
-            f"- **Best**: {best_improvement}",
-            f"- **Worst**: {worst_regression}",
-            f"- **Significant (>{threshold_pct}%)**: {significant_improvements}↑ {significant_regressions}↓",
-        ]
-    )
 
 ENGINE_ORDER = {
     "vortex": 0,
@@ -223,25 +204,7 @@ def build_group_summary(group_df):
     significant_improvements = (group_df["ratio"] < improvement_threshold).sum()
     significant_regressions = (group_df["ratio"] > regression_threshold).sum()
 
-    valid_ratios = group_df["ratio"].dropna()
-    if len(valid_ratios) > 0:
-        best_idx = valid_ratios.idxmin()
-        worst_idx = valid_ratios.idxmax()
-        best_change = f"{group_df.loc[best_idx, 'name']} ({group_df.loc[best_idx, 'ratio']:.3f}x)"
-        worst_change = f"{group_df.loc[worst_idx, 'name']} ({group_df.loc[worst_idx, 'ratio']:.3f}x)"
-    else:
-        best_change = "No valid comparisons"
-        worst_change = "No valid comparisons"
-
-    summary_lines = []
-
-    if significant_improvements > 0 or significant_regressions > 0:
-        summary_lines.append(f"Significant (>{threshold_pct}%): {significant_improvements}↑ {significant_regressions}↓")
-
-    if len(valid_ratios) > 0:
-        summary_lines.append(f"Best/Worst: {best_change} / {worst_change}")
-
-    return ratio_summary, significant_improvements, significant_regressions, summary_lines
+    return ratio_summary, significant_improvements, significant_regressions
 
 
 # Output complete formatted markdown
@@ -250,29 +213,24 @@ print("")
 grouped_tables = df3.groupby(["engine", "file_format"], dropna=False, sort=False)
 for engine, file_format in sorted(grouped_tables.groups.keys(), key=group_sort_key):
     group_df = grouped_tables.get_group((engine, file_format)).sort_values("name")
-    group_performance, significant_improvements, significant_regressions, group_summary_lines = build_group_summary(
-        group_df
-    )
+    group_performance, significant_improvements, significant_regressions = build_group_summary(group_df)
+    unit = group_df["unit_base"].dropna().iloc[0] if group_df["unit_base"].notna().any() else "unit"
     display_df = pd.DataFrame(
         {
             "name": group_df["name"],
-            f"PR {pr_commit_id[:8]}": group_df["value_pr"],
-            f"base {base_commit_id[:8]}": group_df["value_base"],
+            f"PR {pr_commit_id[:8]} ({unit})": group_df["value_pr"],
+            f"base {base_commit_id[:8]} ({unit})": group_df["value_base"],
             "ratio (PR/base)": group_df["ratio"],
-            "unit": group_df["unit_base"],
         }
     )
     print("<details>")
     summary_text = (
-        f"{engine} / {file_format} "
-        f"({len(group_df)} rows, {group_performance}, "
-        f"{significant_improvements}↑ {significant_regressions}↓)"
+        f"{engine} / {file_format} ({group_performance}, {significant_improvements}↑ {significant_regressions}↓)"
     )
     print(f"<summary>{summary_text}</summary>")
     print("")
-    if len(group_summary_lines) > 0:
-        print(" ".join(group_summary_lines))
-        print("")
+    print("<br>")
+    print("")
     print(
         display_df.to_markdown(
             index=False,

--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -188,20 +188,6 @@ if len(vortex_df) > 0:
         ]
     )
 
-# Build table
-table_df = pd.DataFrame(
-    {
-        "name": df3["name"],
-        "engine": df3["engine"],
-        "file format": df3["file_format"],
-        f"PR {pr_commit_id[:8]}": df3["value_pr"],
-        f"base {base_commit_id[:8]}": df3["value_base"],
-        "ratio (PR/base)": df3["ratio"],
-        "unit": df3["unit_base"],
-    }
-)
-
-
 ENGINE_ORDER = {
     "vortex": 0,
     "datafusion": 1,
@@ -247,28 +233,48 @@ def build_group_summary(group_df):
         best_change = "No valid comparisons"
         worst_change = "No valid comparisons"
 
-    return [
-        f"- **Performance**: {ratio_summary}",
-        f"- **Significant (>{threshold_pct}%)**: {significant_improvements}↑ {significant_regressions}↓",
-        f"- **Best**: {best_change}",
-        f"- **Worst**: {worst_change}",
-    ]
+    summary_lines = []
+
+    if significant_improvements > 0 or significant_regressions > 0:
+        summary_lines.append(f"Significant (>{threshold_pct}%): {significant_improvements}↑ {significant_regressions}↓")
+
+    if len(valid_ratios) > 0:
+        summary_lines.append(f"Best/Worst: {best_change} / {worst_change}")
+
+    return ratio_summary, significant_improvements, significant_regressions, summary_lines
 
 
 # Output complete formatted markdown
 print("\n".join(summary_lines))
 print("")
-grouped_tables = table_df.groupby(["engine", "file format"], dropna=False, sort=False)
+grouped_tables = df3.groupby(["engine", "file_format"], dropna=False, sort=False)
 for engine, file_format in sorted(grouped_tables.groups.keys(), key=group_sort_key):
     group_df = grouped_tables.get_group((engine, file_format)).sort_values("name")
-    group_performance = format_performance(calculate_geo_mean(group_df), "group")
+    group_performance, significant_improvements, significant_regressions, group_summary_lines = build_group_summary(
+        group_df
+    )
+    display_df = pd.DataFrame(
+        {
+            "name": group_df["name"],
+            f"PR {pr_commit_id[:8]}": group_df["value_pr"],
+            f"base {base_commit_id[:8]}": group_df["value_base"],
+            "ratio (PR/base)": group_df["ratio"],
+            "unit": group_df["unit_base"],
+        }
+    )
     print("<details>")
-    print(f"<summary>{engine} / {file_format} ({len(group_df)} rows, {group_performance})</summary>")
+    summary_text = (
+        f"{engine} / {file_format} "
+        f"({len(group_df)} rows, {group_performance}, "
+        f"{significant_improvements}↑ {significant_regressions}↓)"
+    )
+    print(f"<summary>{summary_text}</summary>")
     print("")
-    print("\n".join(build_group_summary(group_df)))
-    print("")
+    if len(group_summary_lines) > 0:
+        print(" ".join(group_summary_lines))
+        print("")
     print(
-        group_df.drop(columns=["engine", "file format"]).to_markdown(
+        display_df.to_markdown(
             index=False,
             tablefmt="github",
             floatfmt=".2f",

--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -214,6 +214,19 @@ def format_integer_value(value):
     return str(int(value))
 
 
+def format_name_with_highlight(name, ratio):
+    if pd.isna(ratio):
+        return name
+
+    if ratio <= improvement_threshold:
+        return f"🚀 {name}"
+
+    if ratio >= regression_threshold:
+        return f"🚨 {name}"
+
+    return name
+
+
 # Output complete formatted markdown
 print("\n".join(summary_lines))
 print("")
@@ -224,7 +237,9 @@ for engine, file_format in sorted(grouped_tables.groups.keys(), key=group_sort_k
     unit = group_df["unit_base"].dropna().iloc[0] if group_df["unit_base"].notna().any() else "unit"
     display_df = pd.DataFrame(
         {
-            "name": group_df["name"],
+            "name": [
+                format_name_with_highlight(name, ratio) for name, ratio in zip(group_df["name"], group_df["ratio"])
+            ],
             f"PR {pr_commit_id[:8]} ({unit})": group_df["value_pr"].map(format_integer_value),
             f"base {base_commit_id[:8]} ({unit})": group_df["value_base"].map(format_integer_value),
             "ratio (PR/base)": group_df["ratio"],

--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -73,6 +73,19 @@ df3["remark"] = df3["remark"].case_when(
     ]
 )
 
+
+def extract_engine_and_file_format(name):
+    if not isinstance(name, str) or "/" not in name or ":" not in name:
+        return pd.Series({"engine": "unknown", "file_format": "unknown"})
+
+    target = name.rsplit("/", 1)[-1]
+    engine, file_format = target.split(":", 1)
+    return pd.Series({"engine": engine, "file_format": file_format})
+
+
+df3[["engine", "file_format"]] = df3["name"].apply(extract_engine_and_file_format)
+
+
 # Filter for different target combinations for summary statistics
 vortex_df = df3[df3["name"].str.contains("vortex", case=False, na=False)]
 duckdb_vortex_df = df3[df3["name"].str.contains("duckdb.*vortex", case=False, na=False, regex=True)]
@@ -186,6 +199,8 @@ if len(vortex_df) > 0:
 table_df = pd.DataFrame(
     {
         "name": df3["name"],
+        "engine": df3["engine"],
+        "file format": df3["file_format"],
         f"PR {pr_commit_id[:8]}": df3["value_pr"],
         f"base {base_commit_id[:8]}": df3["value_base"],
         "ratio (PR/base)": df3["ratio"],
@@ -194,11 +209,54 @@ table_df = pd.DataFrame(
     }
 )
 
+
+ENGINE_ORDER = {
+    "vortex": 0,
+    "datafusion": 1,
+    "duckdb": 2,
+    "lance": 3,
+    "arrow": 4,
+}
+
+FILE_FORMAT_ORDER = {
+    "vortex-file-compressed": 0,
+    "vortex-compact": 1,
+    "parquet": 2,
+    "lance": 3,
+    "duckdb": 4,
+    "arrow": 5,
+}
+
+
+def group_sort_key(group_key):
+    engine, file_format = group_key
+    return (
+        ENGINE_ORDER.get(engine, len(ENGINE_ORDER)),
+        FILE_FORMAT_ORDER.get(file_format, len(FILE_FORMAT_ORDER)),
+        engine,
+        file_format,
+    )
+
+
 # Output complete formatted markdown
 print("\n".join(summary_lines))
 print("")
 print("<details>")
 print("<summary>Detailed Results Table</summary>")
 print("")
-print(table_df.to_markdown(index=False, tablefmt="github", floatfmt=".2f"))
+
+grouped_tables = table_df.groupby(["engine", "file format"], dropna=False, sort=False)
+for engine, file_format in sorted(grouped_tables.groups.keys(), key=group_sort_key):
+    print(f"### {engine} / {file_format}")
+    print("")
+    group_df = grouped_tables.get_group((engine, file_format)).sort_values("name")
+    print(
+        group_df.drop(columns=["engine", "file format"]).to_markdown(
+            index=False,
+            tablefmt="github",
+            floatfmt=".2f",
+        )
+    )
+    print("")
+
 print("</details>")

--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -261,10 +261,9 @@ print("")
 grouped_tables = table_df.groupby(["engine", "file format"], dropna=False, sort=False)
 for engine, file_format in sorted(grouped_tables.groups.keys(), key=group_sort_key):
     group_df = grouped_tables.get_group((engine, file_format)).sort_values("name")
+    group_performance = format_performance(calculate_geo_mean(group_df), "group")
     print("<details>")
-    print(
-        f"<summary>{engine} / {file_format} ({len(group_df)} rows, {format_performance(calculate_geo_mean(group_df), 'group')})</summary>"
-    )
+    print(f"<summary>{engine} / {file_format} ({len(group_df)} rows, {group_performance})</summary>")
     print("")
     print("\n".join(build_group_summary(group_df)))
     print("")

--- a/scripts/compare-benchmark-jsons.py
+++ b/scripts/compare-benchmark-jsons.py
@@ -65,13 +65,6 @@ regression_threshold = 1.0 + (threshold_pct / 100.0)  # e.g., 1.3 for 30%, 1.1 f
 
 # Generate summary statistics
 df3["ratio"] = df3["value_pr"] / df3["value_base"]
-df3["remark"] = pd.Series([""] * len(df3))
-df3["remark"] = df3["remark"].case_when(
-    [
-        (df3["ratio"] >= regression_threshold, "🚨"),
-        (df3["ratio"] <= improvement_threshold, "🚀"),
-    ]
-)
 
 
 def extract_engine_and_file_format(name):
@@ -205,7 +198,6 @@ table_df = pd.DataFrame(
         f"base {base_commit_id[:8]}": df3["value_base"],
         "ratio (PR/base)": df3["ratio"],
         "unit": df3["unit_base"],
-        "remark": df3["remark"],
     }
 )
 
@@ -238,18 +230,44 @@ def group_sort_key(group_key):
     )
 
 
+def build_group_summary(group_df):
+    geo_mean_ratio = calculate_geo_mean(group_df)
+    ratio_summary = format_performance(geo_mean_ratio, "group")
+
+    significant_improvements = (group_df["ratio"] < improvement_threshold).sum()
+    significant_regressions = (group_df["ratio"] > regression_threshold).sum()
+
+    valid_ratios = group_df["ratio"].dropna()
+    if len(valid_ratios) > 0:
+        best_idx = valid_ratios.idxmin()
+        worst_idx = valid_ratios.idxmax()
+        best_change = f"{group_df.loc[best_idx, 'name']} ({group_df.loc[best_idx, 'ratio']:.3f}x)"
+        worst_change = f"{group_df.loc[worst_idx, 'name']} ({group_df.loc[worst_idx, 'ratio']:.3f}x)"
+    else:
+        best_change = "No valid comparisons"
+        worst_change = "No valid comparisons"
+
+    return [
+        f"- **Performance**: {ratio_summary}",
+        f"- **Significant (>{threshold_pct}%)**: {significant_improvements}↑ {significant_regressions}↓",
+        f"- **Best**: {best_change}",
+        f"- **Worst**: {worst_change}",
+    ]
+
+
 # Output complete formatted markdown
 print("\n".join(summary_lines))
 print("")
-print("<details>")
-print("<summary>Detailed Results Table</summary>")
-print("")
-
 grouped_tables = table_df.groupby(["engine", "file format"], dropna=False, sort=False)
 for engine, file_format in sorted(grouped_tables.groups.keys(), key=group_sort_key):
-    print(f"### {engine} / {file_format}")
-    print("")
     group_df = grouped_tables.get_group((engine, file_format)).sort_values("name")
+    print("<details>")
+    print(
+        f"<summary>{engine} / {file_format} ({len(group_df)} rows, {format_performance(calculate_geo_mean(group_df), 'group')})</summary>"
+    )
+    print("")
+    print("\n".join(build_group_summary(group_df)))
+    print("")
     print(
         group_df.drop(columns=["engine", "file format"]).to_markdown(
             index=False,
@@ -258,5 +276,4 @@ for engine, file_format in sorted(grouped_tables.groups.keys(), key=group_sort_k
         )
     )
     print("")
-
-print("</details>")
+    print("</details>")


### PR DESCRIPTION
Changes how the benchmark display works, making every (engine, format) a separate table, removes the "remark" column and overall trying to have less visual noise.