### PR TITLE
chore: compile with C++ 20

### DIFF
--- a/docs/api/cpp/index.rst
+++ b/docs/api/cpp/index.rst
@@ -20,7 +20,7 @@ Installation
 The C++ bindings are built using CMake. Requirements:
 
 * CMake 3.22 or higher
-* C++17 compatible compiler
+* C++20 compatible compiler
 * Rust toolchain (for building the underlying Rust library)
 
 .. code-block:: bash

--- a/vortex-cuda/build.rs
+++ b/vortex-cuda/build.rs
@@ -138,7 +138,7 @@ fn nvcc_compile_ptx(
         .join(cu_path.file_name().unwrap())
         .with_extension("ptx");
 
-    cmd.arg("-std=c++17")
+    cmd.arg("-std=c++20")
         .arg("-arch=native")
         // Flags forwarded to Clang.
         .arg("--compiler-options=-Wall -Wextra -Wpedantic -Werror")

--- a/vortex-cuda/cub/build.rs
+++ b/vortex-cuda/cub/build.rs
@@ -57,7 +57,7 @@ fn is_cuda_available() -> bool {
 fn compile_shared_library(kernel_dir: &Path, sources: &[PathBuf], out_dir: &Path) {
     let lib_path = out_dir.join("libvortex_cub.so");
     let mut cmd = Command::new("nvcc");
-    cmd.args(["-std=c++17", "-arch=native"]);
+    cmd.args(["-std=c++20", "-arch=native"]);
 
     if env::var("PROFILE").unwrap() == "debug" {
         cmd.args(["-O0", "-g", "-G", "-lineinfo"]);

--- a/vortex-cxx/CMakeLists.txt
+++ b/vortex-cxx/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_policy(SET CMP0135 NEW)
 
 project(vortex)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_program(SCCACHE_PROGRAM sccache)
@@ -72,17 +72,17 @@ set(CPP_PRIVATE_INCLUDE_DIRS
 
 # Create the main library combining C++ and Rust code
 add_library(vortex STATIC ${CPP_SOURCE_FILE})
-target_include_directories(vortex PUBLIC ${CPP_INCLUDE_DIRS} 
+target_include_directories(vortex PUBLIC ${CPP_INCLUDE_DIRS}
     ${CMAKE_CURRENT_BINARY_DIR}/corrosion_generated/cxxbridge/vortex_cxx_bridge/include)
-target_include_directories(vortex PRIVATE 
+target_include_directories(vortex PRIVATE
     ${CPP_PRIVATE_INCLUDE_DIRS}
 )
-target_link_libraries(vortex 
+target_link_libraries(vortex
     PUBLIC nanoarrow_static
     PRIVATE vortex_cxx_bridge
 )
 
-if (VORTEX_ENABLE_ASAN) 
+if (VORTEX_ENABLE_ASAN)
     target_compile_options(vortex PRIVATE -fsanitize=leak,address,undefined -fno-omit-frame-pointer -fno-common -O1)
     target_link_options(vortex PRIVATE -fsanitize=leak,address,undefined)
 endif()
@@ -102,7 +102,7 @@ if (VORTEX_ENABLE_TESTING)
     target_include_directories(vortex_cxx_test PUBLIC ${CPP_INCLUDE_DIRS})
     target_include_directories(vortex_cxx_test PRIVATE cpp/tests)
     target_link_libraries(vortex_cxx_test PRIVATE gtest_main vortex nanoarrow_static)
-    target_include_directories(vortex_cxx_test PRIVATE 
+    target_include_directories(vortex_cxx_test PRIVATE
         ${CMAKE_CURRENT_BINARY_DIR}/corrosion_generated/cxxbridge/vortex_cxx_bridge/include
     )
     # Platform-specific configuration
@@ -110,7 +110,7 @@ if (VORTEX_ENABLE_TESTING)
         set(APPLE_LINK_FLAGS "-framework CoreFoundation -framework Security")
     endif()
     target_link_libraries(vortex_cxx_test PRIVATE vortex_cxx_bridge ${APPLE_LINK_FLAGS})
-    if (VORTEX_ENABLE_ASAN) 
+    if (VORTEX_ENABLE_ASAN)
         target_compile_options(vortex_cxx_test PRIVATE -fsanitize=leak,address,undefined -fno-omit-frame-pointer -fno-common -O1)
         target_link_options(vortex_cxx_test PRIVATE -fsanitize=leak,address,undefined)
     endif()

--- a/vortex-cxx/README.md
+++ b/vortex-cxx/README.md
@@ -7,7 +7,7 @@ This directory contains C++ bindings for Vortex using the [cxx](https://cxx.rs/)
 ### Requirements
 
 - CMake 3.22 or higher
-- C++17 compatible compiler
+- C++20 compatible compiler
 - Rust toolchain (for building the Rust components)
 - (optional) Ninja (`ninja-build`)
 

--- a/vortex-cxx/examples/CMakeLists.txt
+++ b/vortex-cxx/examples/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(vortex-examples)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 

--- a/vortex-duckdb/README.md
+++ b/vortex-duckdb/README.md
@@ -6,7 +6,7 @@ Rust bindings for DuckDB. Supports DuckDB precompiled libraries for fast builds 
 
 - **Ninja**: `brew install ninja` (macOS) | `apt-get install ninja-build` (Ubuntu)
 - **CMake**: `brew install cmake` (macOS) | `apt-get install cmake` (Ubuntu)
-- **C++17 compatible compiler**: GCC or Clang
+- **C++20 compatible compiler**: GCC or Clang
 
 ## Build Modes
 

--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -499,15 +499,11 @@ fn main() {
 
     // Compile our C++ code that exposes additional DuckDB functionality.
     cc::Build::new()
-        .std("c++17")
+        .std("c++20")
         // Enable compiler warnings.
         .flag("-Wall")
         .flag("-Wextra")
         .flag("-Wpedantic")
-        // Allow C++20 designator syntax even with C++17 std
-        .flag("-Wno-c++20-designator")
-        // Enable C++20 extensions
-        .flag("-Wno-c++20-extensions")
         // Unused parameter warnings are disabled as we include DuckDB
         // headers with implementations that have unused parameters.
         .flag("-Wno-unused-parameter")

--- a/vortex-duckdb/cpp/CMakeLists.txt
+++ b/vortex-duckdb/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(vortex_duckdb_cpp)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Default to debug if build config is not explicitly set.
@@ -23,7 +23,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif ()
 
 # Enable compiler warnings (matching build.rs flags).
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-c++20-designator -Wno-c++20-extensions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wno-unused-parameter")
 
 # Find DuckDB include directory via the symlink created by build.rs.
 # The symlink points to target/duckdb-source-vX.Y.Z which contains duckdb-X.Y.Z/


### PR DESCRIPTION
We can switch to C++20 as the latest DuckDB Docker image to build extensions now supports it: https://github.com/vortex-data/duckdb-vortex/actions/runs/22958627873/job/66642571037?pr=76