### PR TITLE
Fix empty zctl flag

### DIFF
--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -296,6 +296,7 @@ mod tests {
     use crate::arrays::ListViewArray;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::StructArray;
+    use crate::arrays::VarBinViewArray;
     use crate::arrays::listview::list_from_list_view;
     use crate::arrays::listview::list_view_from_list;
     use crate::assert_arrays_eq;
@@ -701,6 +702,26 @@ mod tests {
 
         assert_eq!(result.len(), 4);
         assert_arrays_eq!(struct_array.into_array(), result);
+        Ok(())
+    }
+
+    /// Regression test for <https://github.com/vortex-data/vortex/issues/6882>.
+    ///
+    /// An empty `ListViewArray` constructed via `try_new` has `is_zero_copy_to_list: false`.
+    /// `list_from_list_view` should still succeed because empty arrays are trivially
+    /// zero-copyable.
+    #[test]
+    fn test_empty_listview_to_list_without_zctl_flag() -> VortexResult<()> {
+        let elements = VarBinViewArray::from_iter_str(Vec::<&str>::new()).into_array();
+        let offsets = PrimitiveArray::from_iter(Vec::<i16>::new()).into_array();
+        let sizes = PrimitiveArray::from_iter(Vec::<i16>::new()).into_array();
+        let list_view = ListViewArray::try_new(elements, offsets, sizes, Validity::AllValid)?;
+
+        // `try_new` sets `is_zero_copy_to_list: false`.
+        assert!(!list_view.is_zero_copy_to_list());
+
+        let list_array = list_from_list_view(list_view)?;
+        assert_eq!(list_array.len(), 0);
         Ok(())
     }
 }

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -57,7 +57,8 @@ impl ListViewArray {
     /// Rebuilds the [`ListViewArray`] according to the specified mode.
     pub fn rebuild(&self, mode: ListViewRebuildMode) -> VortexResult<ListViewArray> {
         if self.is_empty() {
-            return Ok(self.clone());
+            // SAFETY: An empty array is trivially zero-copyable to a `ListArray`.
+            return Ok(unsafe { self.clone().with_zero_copy_to_list(true) });
         }
 
         match mode {

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -206,6 +206,7 @@ impl Canonical {
                         .into_array(),
                     Validity::from(n),
                 )
+                // An empty list view is trivially copyable to a list.
                 .with_zero_copy_to_list(true)
             }),
             DType::FixedSizeList(elem_dtype, list_size, null) => Canonical::FixedSizeList(unsafe {


### PR DESCRIPTION
## Summary

Closes: https://github.com/vortex-data/vortex/issues/6882

Didn't set the ZCTL flag for empty list view arrays after rebuilding. This can happen when we slice off everything.

Maybe we want to add checks on slice where if we slice into an empty array we add the flag? Rebuild is probably sufficient though.

## Testing

Added a regression test.