### PR TITLE
ci: use pre-built AMI for arm64 CI and skip redundant setup

### DIFF
--- a/.github/actions/setup-prebuild/action.yml
+++ b/.github/actions/setup-prebuild/action.yml
@@ -1,0 +1,15 @@
+name: "Setup Prebuild"
+description: "Minimal setup for runners with pre-built Rust toolchain, nextest, and sccache"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure sccache timeout
+      shell: bash
+      run: |
+        mkdir -p ~/.config/sccache
+        echo 'server_startup_timeout_ms = 15000' > ~/.config/sccache/config
+
+    - name: Pre-start sccache server
+      shell: bash
+      run: sccache --start-server &

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,11 +1,6 @@
+_extends: .github-private
 images:
-  vortex-ci-amd64:
-    platform: "linux"
-    arch: "x64"
-    name: "vortex-ci-*"
-    owner: "245040174862"
-  vortex-ci-arm64:
+  ubuntu24-full-arm64-pre:
     platform: "linux"
     arch: "arm64"
-    name: "vortex-ci-*"
-    owner: "245040174862"
+    ami: "ami-08f97c6362847dc5d"

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,6 +1,1 @@
 _extends: .github-private
-images:
-  ubuntu24-full-arm64-pre:
-    platform: "linux"
-    arch: "arm64"
-    ami: "ami-08f97c6362847dc5d"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,8 +624,7 @@ jobs:
             runner: runs-on=${{ github.run_id }}/pool=windows-x64
             fallback_runner: windows-latest
           - os: linux-arm64
-            runner: runs-on=${{ github.run_id }}/runner=arm64-medium/tag=rust-test-linux-arm64
-            fallback_runner: ubuntu-24.04-arm
+            runner: runs-on=${{ github.run_id }}/runner=arm64-medium/image=ubuntu24-full-arm64-pre/tag=rust-test-linux-arm64
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && matrix.runner
@@ -649,13 +648,18 @@ jobs:
         with:
           python-version: "3.11"
       - id: setup-rust
+        if: matrix.os == 'windows-x64'
         uses: ./.github/actions/setup-rust
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install nextest
+        if: matrix.os == 'windows-x64'
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
+      - name: Setup Prebuild
+        if: matrix.os != 'windows-x64'
+        uses: ./.github/actions/setup-prebuild
       - name: Rust Tests (Windows)
         if: matrix.os == 'windows-x64'
         run: |


### PR DESCRIPTION
## Summary

Use the custom `ubuntu24-full-arm64-pre` AMI image for the arm64 test runner, which has the Rust toolchain and nextest pre-installed.

Changes:
- Add `image=ubuntu24-full-arm64-pre` to the arm64 runner config in CI
- Skip `setup-rust` and `nextest` install steps for arm64 (already in the AMI)
- Remove `fallback_runner` for arm64 (not needed since forks don't use runs-on runners)

## Testing

CI will validate the arm64 tests run correctly with the pre-built AMI.