### PR TITLE
Rename Array VTables

### DIFF
--- a/encodings/alp/public-api.lock
+++ b/encodings/alp/public-api.lock
@@ -2,6 +2,110 @@ pub mod vortex_alp
 
 pub macro vortex_alp::match_each_alp_float_ptype!
 
+pub struct vortex_alp::ALP
+
+impl vortex_alp::ALP
+
+pub const vortex_alp::ALP::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::take(array: &vortex_alp::ALPArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::filter(array: &vortex_alp::ALPArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceKernel for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::compute::nan_count::NaNCountKernel for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::nan_count(&self, array: &vortex_alp::ALPArray) -> vortex_error::VortexResult<usize>
+
+impl vortex_array::scalar_fn::fns::between::kernel::BetweenReduce for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::between(array: &vortex_alp::ALPArray, lower: &vortex_array::array::ArrayRef, upper: &vortex_array::array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::compare(lhs: &vortex_alp::ALPArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::cast(array: &vortex_alp::ALPArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::kernel::MaskKernel for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::mask(array: &vortex_alp::ALPArray, mask: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::mask(array: &vortex_alp::ALPArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_alp::ALP
+
+pub type vortex_alp::ALP::Array = vortex_alp::ALPArray
+
+pub type vortex_alp::ALP::Metadata = vortex_array::metadata::ProstMetadata<vortex_alp::ALPMetadata>
+
+pub type vortex_alp::ALP::OperationsVTable = vortex_alp::ALP
+
+pub type vortex_alp::ALP::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
+
+pub fn vortex_alp::ALP::array_eq(array: &vortex_alp::ALPArray, other: &vortex_alp::ALPArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_alp::ALP::array_hash<H: core::hash::Hasher>(array: &vortex_alp::ALPArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_alp::ALP::buffer(_array: &vortex_alp::ALPArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_alp::ALP::buffer_name(_array: &vortex_alp::ALPArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_alp::ALP::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_alp::ALPArray>
+
+pub fn vortex_alp::ALP::child(array: &vortex_alp::ALPArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_alp::ALP::child_name(array: &vortex_alp::ALPArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_alp::ALP::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_alp::ALP::dtype(array: &vortex_alp::ALPArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_alp::ALP::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_alp::ALP::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_alp::ALP::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_alp::ALP::len(array: &vortex_alp::ALPArray) -> usize
+
+pub fn vortex_alp::ALP::metadata(array: &vortex_alp::ALPArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_alp::ALP::nbuffers(_array: &vortex_alp::ALPArray) -> usize
+
+pub fn vortex_alp::ALP::nchildren(array: &vortex_alp::ALPArray) -> usize
+
+pub fn vortex_alp::ALP::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_alp::ALP::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_alp::ALP::stats(array: &vortex_alp::ALPArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_alp::ALP::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_alp::ALP> for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::scalar_at(array: &vortex_alp::ALPArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::validity::ValidityChild<vortex_alp::ALP> for vortex_alp::ALP
+
+pub fn vortex_alp::ALP::validity_child(array: &vortex_alp::ALPArray) -> &vortex_array::array::ArrayRef
+
 pub struct vortex_alp::ALPArray
 
 impl vortex_alp::ALPArray
@@ -69,6 +173,94 @@ impl prost::message::Message for vortex_alp::ALPMetadata
 pub fn vortex_alp::ALPMetadata::clear(&mut self)
 
 pub fn vortex_alp::ALPMetadata::encoded_len(&self) -> usize
+
+pub struct vortex_alp::ALPRD
+
+impl vortex_alp::ALPRD
+
+pub const vortex_alp::ALPRD::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_alp::ALPRD
+
+pub fn vortex_alp::ALPRD::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_alp::ALPRD
+
+pub fn vortex_alp::ALPRD::take(array: &vortex_alp::ALPRDArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_alp::ALPRD
+
+pub fn vortex_alp::ALPRD::filter(array: &vortex_alp::ALPRDArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceKernel for vortex_alp::ALPRD
+
+pub fn vortex_alp::ALPRD::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_alp::ALPRD
+
+pub fn vortex_alp::ALPRD::cast(array: &vortex_alp::ALPRDArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_alp::ALPRD
+
+pub fn vortex_alp::ALPRD::mask(array: &vortex_alp::ALPRDArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_alp::ALPRD
+
+pub type vortex_alp::ALPRD::Array = vortex_alp::ALPRDArray
+
+pub type vortex_alp::ALPRD::Metadata = vortex_array::metadata::ProstMetadata<vortex_alp::ALPRDMetadata>
+
+pub type vortex_alp::ALPRD::OperationsVTable = vortex_alp::ALPRD
+
+pub type vortex_alp::ALPRD::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
+
+pub fn vortex_alp::ALPRD::array_eq(array: &vortex_alp::ALPRDArray, other: &vortex_alp::ALPRDArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_alp::ALPRD::array_hash<H: core::hash::Hasher>(array: &vortex_alp::ALPRDArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_alp::ALPRD::buffer(_array: &vortex_alp::ALPRDArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_alp::ALPRD::buffer_name(_array: &vortex_alp::ALPRDArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_alp::ALPRD::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_alp::ALPRDArray>
+
+pub fn vortex_alp::ALPRD::child(array: &vortex_alp::ALPRDArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_alp::ALPRD::child_name(array: &vortex_alp::ALPRDArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_alp::ALPRD::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_alp::ALPRD::dtype(array: &vortex_alp::ALPRDArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_alp::ALPRD::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_alp::ALPRD::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_alp::ALPRD::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_alp::ALPRD::len(array: &vortex_alp::ALPRDArray) -> usize
+
+pub fn vortex_alp::ALPRD::metadata(array: &vortex_alp::ALPRDArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_alp::ALPRD::nbuffers(_array: &vortex_alp::ALPRDArray) -> usize
+
+pub fn vortex_alp::ALPRD::nchildren(array: &vortex_alp::ALPRDArray) -> usize
+
+pub fn vortex_alp::ALPRD::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_alp::ALPRD::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_alp::ALPRD::stats(array: &vortex_alp::ALPRDArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_alp::ALPRD::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_alp::ALPRD> for vortex_alp::ALPRD
+
+pub fn vortex_alp::ALPRD::scalar_at(array: &vortex_alp::ALPRDArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::validity::ValidityChild<vortex_alp::ALPRD> for vortex_alp::ALPRD
+
+pub fn vortex_alp::ALPRD::validity_child(array: &vortex_alp::ALPRDArray) -> &vortex_array::array::ArrayRef
 
 pub struct vortex_alp::ALPRDArray
 
@@ -145,198 +337,6 @@ impl prost::message::Message for vortex_alp::ALPRDMetadata
 pub fn vortex_alp::ALPRDMetadata::clear(&mut self)
 
 pub fn vortex_alp::ALPRDMetadata::encoded_len(&self) -> usize
-
-pub struct vortex_alp::ALPRDVTable
-
-impl vortex_alp::ALPRDVTable
-
-pub const vortex_alp::ALPRDVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_alp::ALPRDVTable
-
-pub fn vortex_alp::ALPRDVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_alp::ALPRDVTable
-
-pub fn vortex_alp::ALPRDVTable::take(array: &vortex_alp::ALPRDArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_alp::ALPRDVTable
-
-pub fn vortex_alp::ALPRDVTable::filter(array: &vortex_alp::ALPRDArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceKernel for vortex_alp::ALPRDVTable
-
-pub fn vortex_alp::ALPRDVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_alp::ALPRDVTable
-
-pub fn vortex_alp::ALPRDVTable::cast(array: &vortex_alp::ALPRDArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_alp::ALPRDVTable
-
-pub fn vortex_alp::ALPRDVTable::mask(array: &vortex_alp::ALPRDArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_alp::ALPRDVTable
-
-pub type vortex_alp::ALPRDVTable::Array = vortex_alp::ALPRDArray
-
-pub type vortex_alp::ALPRDVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_alp::ALPRDMetadata>
-
-pub type vortex_alp::ALPRDVTable::OperationsVTable = vortex_alp::ALPRDVTable
-
-pub type vortex_alp::ALPRDVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
-
-pub fn vortex_alp::ALPRDVTable::array_eq(array: &vortex_alp::ALPRDArray, other: &vortex_alp::ALPRDArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_alp::ALPRDVTable::array_hash<H: core::hash::Hasher>(array: &vortex_alp::ALPRDArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_alp::ALPRDVTable::buffer(_array: &vortex_alp::ALPRDArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_alp::ALPRDVTable::buffer_name(_array: &vortex_alp::ALPRDArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_alp::ALPRDVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_alp::ALPRDArray>
-
-pub fn vortex_alp::ALPRDVTable::child(array: &vortex_alp::ALPRDArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_alp::ALPRDVTable::child_name(array: &vortex_alp::ALPRDArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_alp::ALPRDVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_alp::ALPRDVTable::dtype(array: &vortex_alp::ALPRDArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_alp::ALPRDVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_alp::ALPRDVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_alp::ALPRDVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_alp::ALPRDVTable::len(array: &vortex_alp::ALPRDArray) -> usize
-
-pub fn vortex_alp::ALPRDVTable::metadata(array: &vortex_alp::ALPRDArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_alp::ALPRDVTable::nbuffers(_array: &vortex_alp::ALPRDArray) -> usize
-
-pub fn vortex_alp::ALPRDVTable::nchildren(array: &vortex_alp::ALPRDArray) -> usize
-
-pub fn vortex_alp::ALPRDVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_alp::ALPRDVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_alp::ALPRDVTable::stats(array: &vortex_alp::ALPRDArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_alp::ALPRDVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_alp::ALPRDVTable> for vortex_alp::ALPRDVTable
-
-pub fn vortex_alp::ALPRDVTable::scalar_at(array: &vortex_alp::ALPRDArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::validity::ValidityChild<vortex_alp::ALPRDVTable> for vortex_alp::ALPRDVTable
-
-pub fn vortex_alp::ALPRDVTable::validity_child(array: &vortex_alp::ALPRDArray) -> &vortex_array::array::ArrayRef
-
-pub struct vortex_alp::ALPVTable
-
-impl vortex_alp::ALPVTable
-
-pub const vortex_alp::ALPVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::take(array: &vortex_alp::ALPArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::filter(array: &vortex_alp::ALPArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceKernel for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::compute::nan_count::NaNCountKernel for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::nan_count(&self, array: &vortex_alp::ALPArray) -> vortex_error::VortexResult<usize>
-
-impl vortex_array::scalar_fn::fns::between::kernel::BetweenReduce for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::between(array: &vortex_alp::ALPArray, lower: &vortex_array::array::ArrayRef, upper: &vortex_array::array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::compare(lhs: &vortex_alp::ALPArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::cast(array: &vortex_alp::ALPArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::kernel::MaskKernel for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::mask(array: &vortex_alp::ALPArray, mask: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::mask(array: &vortex_alp::ALPArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_alp::ALPVTable
-
-pub type vortex_alp::ALPVTable::Array = vortex_alp::ALPArray
-
-pub type vortex_alp::ALPVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_alp::ALPMetadata>
-
-pub type vortex_alp::ALPVTable::OperationsVTable = vortex_alp::ALPVTable
-
-pub type vortex_alp::ALPVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
-
-pub fn vortex_alp::ALPVTable::array_eq(array: &vortex_alp::ALPArray, other: &vortex_alp::ALPArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_alp::ALPVTable::array_hash<H: core::hash::Hasher>(array: &vortex_alp::ALPArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_alp::ALPVTable::buffer(_array: &vortex_alp::ALPArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_alp::ALPVTable::buffer_name(_array: &vortex_alp::ALPArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_alp::ALPVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_alp::ALPArray>
-
-pub fn vortex_alp::ALPVTable::child(array: &vortex_alp::ALPArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_alp::ALPVTable::child_name(array: &vortex_alp::ALPArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_alp::ALPVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_alp::ALPVTable::dtype(array: &vortex_alp::ALPArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_alp::ALPVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_alp::ALPVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_alp::ALPVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_alp::ALPVTable::len(array: &vortex_alp::ALPArray) -> usize
-
-pub fn vortex_alp::ALPVTable::metadata(array: &vortex_alp::ALPArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_alp::ALPVTable::nbuffers(_array: &vortex_alp::ALPArray) -> usize
-
-pub fn vortex_alp::ALPVTable::nchildren(array: &vortex_alp::ALPArray) -> usize
-
-pub fn vortex_alp::ALPVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_alp::ALPVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_alp::ALPVTable::stats(array: &vortex_alp::ALPArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_alp::ALPVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_alp::ALPVTable> for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::scalar_at(array: &vortex_alp::ALPArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::validity::ValidityChild<vortex_alp::ALPVTable> for vortex_alp::ALPVTable
-
-pub fn vortex_alp::ALPVTable::validity_child(array: &vortex_alp::ALPArray) -> &vortex_array::array::ArrayRef
 
 pub struct vortex_alp::Exponents
 

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -47,7 +47,7 @@ use crate::alp::rules::RULES;
 
 vtable!(ALP);
 
-impl VTable for ALPVTable {
+impl VTable for ALP {
     type Array = ALPArray;
 
     type Metadata = ProstMetadata<ALPMetadata>;
@@ -270,9 +270,9 @@ pub struct ALPArray {
 }
 
 #[derive(Debug)]
-pub struct ALPVTable;
+pub struct ALP;
 
-impl ALPVTable {
+impl ALP {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.alp");
 }
 
@@ -483,7 +483,7 @@ impl ALPArray {
     }
 }
 
-impl ValidityChild<ALPVTable> for ALPVTable {
+impl ValidityChild<ALP> for ALP {
     fn validity_child(array: &ALPArray) -> &ArrayRef {
         array.encoded()
     }

--- a/encodings/alp/src/alp/compute/between.rs
+++ b/encodings/alp/src/alp/compute/between.rs
@@ -16,12 +16,12 @@ use vortex_array::scalar_fn::fns::between::BetweenReduce;
 use vortex_array::scalar_fn::fns::between::StrictComparison;
 use vortex_error::VortexResult;
 
+use crate::ALP;
 use crate::ALPArray;
 use crate::ALPFloat;
-use crate::ALPVTable;
 use crate::match_each_alp_float_ptype;
 
-impl BetweenReduce for ALPVTable {
+impl BetweenReduce for ALP {
     fn between(
         array: &ALPArray,
         lower: &ArrayRef,

--- a/encodings/alp/src/alp/compute/cast.rs
+++ b/encodings/alp/src/alp/compute/cast.rs
@@ -9,10 +9,10 @@ use vortex_array::patches::Patches;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::alp::ALP;
 use crate::alp::ALPArray;
-use crate::alp::ALPVTable;
 
-impl CastReduce for ALPVTable {
+impl CastReduce for ALP {
     fn cast(array: &ALPArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // Check if this is just a nullability change
         if array.dtype().eq_ignore_nullability(dtype) {

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -18,14 +18,14 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
+use crate::ALP;
 use crate::ALPArray;
 use crate::ALPFloat;
-use crate::ALPVTable;
 use crate::match_each_alp_float_ptype;
 
 // TODO(joe): add fuzzing.
 
-impl CompareKernel for ALPVTable {
+impl CompareKernel for ALP {
     fn compare(
         lhs: &ALPArray,
         rhs: &ArrayRef,

--- a/encodings/alp/src/alp/compute/filter.rs
+++ b/encodings/alp/src/alp/compute/filter.rs
@@ -8,10 +8,10 @@ use vortex_array::arrays::filter::FilterKernel;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::ALP;
 use crate::ALPArray;
-use crate::ALPVTable;
 
-impl FilterKernel for ALPVTable {
+impl FilterKernel for ALP {
     fn filter(
         array: &ALPArray,
         mask: &Mask,

--- a/encodings/alp/src/alp/compute/mask.rs
+++ b/encodings/alp/src/alp/compute/mask.rs
@@ -10,10 +10,10 @@ use vortex_array::scalar_fn::fns::mask::MaskReduce;
 use vortex_array::validity::Validity;
 use vortex_error::VortexResult;
 
+use crate::ALP;
 use crate::ALPArray;
-use crate::ALPVTable;
 
-impl MaskReduce for ALPVTable {
+impl MaskReduce for ALP {
     fn mask(array: &ALPArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         // Masking sparse patches requires reading indices, fall back to kernel.
         if array.patches().is_some() {
@@ -26,7 +26,7 @@ impl MaskReduce for ALPVTable {
     }
 }
 
-impl MaskKernel for ALPVTable {
+impl MaskKernel for ALP {
     fn mask(
         array: &ALPArray,
         mask: &ArrayRef,

--- a/encodings/alp/src/alp/compute/nan_count.rs
+++ b/encodings/alp/src/alp/compute/nan_count.rs
@@ -7,10 +7,10 @@ use vortex_array::compute::nan_count;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 
+use crate::ALP;
 use crate::ALPArray;
-use crate::ALPVTable;
 
-impl NaNCountKernel for ALPVTable {
+impl NaNCountKernel for ALP {
     fn nan_count(&self, array: &ALPArray) -> VortexResult<usize> {
         // NANs can only be in patches
         if let Some(patches) = array.patches() {
@@ -21,4 +21,4 @@ impl NaNCountKernel for ALPVTable {
     }
 }
 
-register_kernel!(NaNCountKernelAdapter(ALPVTable).lift());
+register_kernel!(NaNCountKernelAdapter(ALP).lift());

--- a/encodings/alp/src/alp/compute/slice.rs
+++ b/encodings/alp/src/alp/compute/slice.rs
@@ -9,10 +9,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::slice::SliceKernel;
 use vortex_error::VortexResult;
 
+use crate::ALP;
 use crate::ALPArray;
-use crate::ALPVTable;
 
-impl SliceKernel for ALPVTable {
+impl SliceKernel for ALP {
     fn slice(
         array: &Self::Array,
         range: Range<usize>,

--- a/encodings/alp/src/alp/compute/take.rs
+++ b/encodings/alp/src/alp/compute/take.rs
@@ -8,10 +8,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::dict::TakeExecute;
 use vortex_error::VortexResult;
 
+use crate::ALP;
 use crate::ALPArray;
-use crate::ALPVTable;
 
-impl TakeExecute for ALPVTable {
+impl TakeExecute for ALP {
     fn take(
         array: &ALPArray,
         indices: &ArrayRef,

--- a/encodings/alp/src/alp/ops.rs
+++ b/encodings/alp/src/alp/ops.rs
@@ -6,12 +6,12 @@ use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
+use crate::ALP;
 use crate::ALPArray;
 use crate::ALPFloat;
-use crate::ALPVTable;
 use crate::match_each_alp_float_ptype;
 
-impl OperationsVTable<ALPVTable> for ALPVTable {
+impl OperationsVTable<ALP> for ALP {
     fn scalar_at(array: &ALPArray, index: usize) -> VortexResult<Scalar> {
         if let Some(patches) = array.patches()
             && let Some(patch) = patches.get_patched(index)?

--- a/encodings/alp/src/alp/rules.rs
+++ b/encodings/alp/src/alp/rules.rs
@@ -12,18 +12,18 @@ use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 use vortex_array::scalar_fn::fns::mask::MaskExecuteAdaptor;
 use vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor;
 
-use crate::ALPVTable;
+use crate::ALP;
 
-pub(super) const PARENT_KERNELS: ParentKernelSet<ALPVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&CompareExecuteAdaptor(ALPVTable)),
-    ParentKernelSet::lift(&FilterExecuteAdaptor(ALPVTable)),
-    ParentKernelSet::lift(&MaskExecuteAdaptor(ALPVTable)),
-    ParentKernelSet::lift(&SliceExecuteAdaptor(ALPVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(ALPVTable)),
+pub(super) const PARENT_KERNELS: ParentKernelSet<ALP> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&CompareExecuteAdaptor(ALP)),
+    ParentKernelSet::lift(&FilterExecuteAdaptor(ALP)),
+    ParentKernelSet::lift(&MaskExecuteAdaptor(ALP)),
+    ParentKernelSet::lift(&SliceExecuteAdaptor(ALP)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(ALP)),
 ]);
 
-pub(super) const RULES: ParentRuleSet<ALPVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&BetweenReduceAdaptor(ALPVTable)),
-    ParentRuleSet::lift(&CastReduceAdaptor(ALPVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(ALPVTable)),
+pub(super) const RULES: ParentRuleSet<ALP> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&BetweenReduceAdaptor(ALP)),
+    ParentRuleSet::lift(&CastReduceAdaptor(ALP)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(ALP)),
 ]);

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -64,7 +64,7 @@ pub struct ALPRDMetadata {
     patches: Option<PatchesMetadata>,
 }
 
-impl VTable for ALPRDVTable {
+impl VTable for ALPRD {
     type Array = ALPRDArray;
 
     type Metadata = ProstMetadata<ALPRDMetadata>;
@@ -368,9 +368,9 @@ pub struct ALPRDArray {
 }
 
 #[derive(Debug)]
-pub struct ALPRDVTable;
+pub struct ALPRD;
 
-impl ALPRDVTable {
+impl ALPRD {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.alprd");
 }
 
@@ -503,7 +503,7 @@ impl ALPRDArray {
     }
 }
 
-impl ValidityChild<ALPRDVTable> for ALPRDVTable {
+impl ValidityChild<ALPRD> for ALPRD {
     fn validity_child(array: &ALPRDArray) -> &ArrayRef {
         array.left_parts()
     }

--- a/encodings/alp/src/alp_rd/compute/cast.rs
+++ b/encodings/alp/src/alp_rd/compute/cast.rs
@@ -8,10 +8,10 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::alp_rd::ALPRD;
 use crate::alp_rd::ALPRDArray;
-use crate::alp_rd::ALPRDVTable;
 
-impl CastReduce for ALPRDVTable {
+impl CastReduce for ALPRD {
     fn cast(array: &ALPRDArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // ALPRDArray stores floating-point values, so only cast between float types
         // or if just changing nullability

--- a/encodings/alp/src/alp_rd/compute/filter.rs
+++ b/encodings/alp/src/alp_rd/compute/filter.rs
@@ -8,10 +8,10 @@ use vortex_array::arrays::filter::FilterKernel;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::ALPRD;
 use crate::ALPRDArray;
-use crate::ALPRDVTable;
 
-impl FilterKernel for ALPRDVTable {
+impl FilterKernel for ALPRD {
     fn filter(
         array: &ALPRDArray,
         mask: &Mask,

--- a/encodings/alp/src/alp_rd/compute/mask.rs
+++ b/encodings/alp/src/alp_rd/compute/mask.rs
@@ -9,10 +9,10 @@ use vortex_array::scalar_fn::fns::mask::Mask as MaskExpr;
 use vortex_array::scalar_fn::fns::mask::MaskReduce;
 use vortex_error::VortexResult;
 
+use crate::ALPRD;
 use crate::ALPRDArray;
-use crate::ALPRDVTable;
 
-impl MaskReduce for ALPRDVTable {
+impl MaskReduce for ALPRD {
     fn mask(array: &ALPRDArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let masked_left_parts = MaskExpr.try_new_array(
             array.left_parts().len(),

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -10,10 +10,10 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::scalar::Scalar;
 use vortex_error::VortexResult;
 
+use crate::ALPRD;
 use crate::ALPRDArray;
-use crate::ALPRDVTable;
 
-impl TakeExecute for ALPRDVTable {
+impl TakeExecute for ALPRD {
     fn take(
         array: &ALPRDArray,
         indices: &ArrayRef,

--- a/encodings/alp/src/alp_rd/kernel.rs
+++ b/encodings/alp/src/alp_rd/kernel.rs
@@ -6,10 +6,10 @@ use vortex_array::arrays::filter::FilterExecuteAdaptor;
 use vortex_array::arrays::slice::SliceExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 
-use crate::alp_rd::ALPRDVTable;
+use crate::alp_rd::ALPRD;
 
-pub(crate) static PARENT_KERNELS: ParentKernelSet<ALPRDVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&SliceExecuteAdaptor(ALPRDVTable)),
-    ParentKernelSet::lift(&FilterExecuteAdaptor(ALPRDVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(ALPRDVTable)),
+pub(crate) static PARENT_KERNELS: ParentKernelSet<ALPRD> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&SliceExecuteAdaptor(ALPRD)),
+    ParentKernelSet::lift(&FilterExecuteAdaptor(ALPRD)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(ALPRD)),
 ]);

--- a/encodings/alp/src/alp_rd/ops.rs
+++ b/encodings/alp/src/alp_rd/ops.rs
@@ -7,10 +7,10 @@ use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
+use crate::ALPRD;
 use crate::ALPRDArray;
-use crate::ALPRDVTable;
 
-impl OperationsVTable<ALPRDVTable> for ALPRDVTable {
+impl OperationsVTable<ALPRD> for ALPRD {
     fn scalar_at(array: &ALPRDArray, index: usize) -> VortexResult<Scalar> {
         // The left value can either be a direct value, or an exception.
         // The exceptions array represents exception positions with non-null values.

--- a/encodings/alp/src/alp_rd/rules.rs
+++ b/encodings/alp/src/alp_rd/rules.rs
@@ -5,9 +5,9 @@ use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 use vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor;
 
-use crate::alp_rd::ALPRDVTable;
+use crate::alp_rd::ALPRD;
 
-pub(crate) static RULES: ParentRuleSet<ALPRDVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&CastReduceAdaptor(ALPRDVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(ALPRDVTable)),
+pub(crate) static RULES: ParentRuleSet<ALPRD> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(ALPRD)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(ALPRD)),
 ]);

--- a/encodings/alp/src/alp_rd/slice.rs
+++ b/encodings/alp/src/alp_rd/slice.rs
@@ -9,10 +9,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::slice::SliceKernel;
 use vortex_error::VortexResult;
 
+use crate::alp_rd::ALPRD;
 use crate::alp_rd::ALPRDArray;
-use crate::alp_rd::ALPRDVTable;
 
-impl SliceKernel for ALPRDVTable {
+impl SliceKernel for ALPRD {
     fn slice(
         array: &Self::Array,
         range: Range<usize>,

--- a/encodings/bytebool/public-api.lock
+++ b/encodings/bytebool/public-api.lock
@@ -1,5 +1,85 @@
 pub mod vortex_bytebool
 
+pub struct vortex_bytebool::ByteBool
+
+impl vortex_bytebool::ByteBool
+
+pub const vortex_bytebool::ByteBool::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_bytebool::ByteBool
+
+pub fn vortex_bytebool::ByteBool::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_bytebool::ByteBool
+
+pub fn vortex_bytebool::ByteBool::take(array: &vortex_bytebool::ByteBoolArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_bytebool::ByteBool
+
+pub fn vortex_bytebool::ByteBool::slice(array: &vortex_bytebool::ByteBoolArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_bytebool::ByteBool
+
+pub fn vortex_bytebool::ByteBool::cast(array: &vortex_bytebool::ByteBoolArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_bytebool::ByteBool
+
+pub fn vortex_bytebool::ByteBool::mask(array: &vortex_bytebool::ByteBoolArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_bytebool::ByteBool
+
+pub type vortex_bytebool::ByteBool::Array = vortex_bytebool::ByteBoolArray
+
+pub type vortex_bytebool::ByteBool::Metadata = vortex_array::metadata::EmptyMetadata
+
+pub type vortex_bytebool::ByteBool::OperationsVTable = vortex_bytebool::ByteBool
+
+pub type vortex_bytebool::ByteBool::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromValidityHelper
+
+pub fn vortex_bytebool::ByteBool::array_eq(array: &vortex_bytebool::ByteBoolArray, other: &vortex_bytebool::ByteBoolArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_bytebool::ByteBool::array_hash<H: core::hash::Hasher>(array: &vortex_bytebool::ByteBoolArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_bytebool::ByteBool::buffer(array: &vortex_bytebool::ByteBoolArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_bytebool::ByteBool::buffer_name(_array: &vortex_bytebool::ByteBoolArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_bytebool::ByteBool::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_bytebool::ByteBoolArray>
+
+pub fn vortex_bytebool::ByteBool::child(array: &vortex_bytebool::ByteBoolArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_bytebool::ByteBool::child_name(_array: &vortex_bytebool::ByteBoolArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_bytebool::ByteBool::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_bytebool::ByteBool::dtype(array: &vortex_bytebool::ByteBoolArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_bytebool::ByteBool::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_bytebool::ByteBool::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_bytebool::ByteBool::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_bytebool::ByteBool::len(array: &vortex_bytebool::ByteBoolArray) -> usize
+
+pub fn vortex_bytebool::ByteBool::metadata(_array: &vortex_bytebool::ByteBoolArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_bytebool::ByteBool::nbuffers(_array: &vortex_bytebool::ByteBoolArray) -> usize
+
+pub fn vortex_bytebool::ByteBool::nchildren(array: &vortex_bytebool::ByteBoolArray) -> usize
+
+pub fn vortex_bytebool::ByteBool::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_bytebool::ByteBool::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_bytebool::ByteBool::stats(array: &vortex_bytebool::ByteBoolArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_bytebool::ByteBool::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_bytebool::ByteBool> for vortex_bytebool::ByteBool
+
+pub fn vortex_bytebool::ByteBool::scalar_at(array: &vortex_bytebool::ByteBoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
 pub struct vortex_bytebool::ByteBoolArray
 
 impl vortex_bytebool::ByteBoolArray
@@ -53,83 +133,3 @@ pub fn vortex_bytebool::ByteBoolArray::into_array(self) -> vortex_array::array::
 impl vortex_array::vtable::validity::ValidityHelper for vortex_bytebool::ByteBoolArray
 
 pub fn vortex_bytebool::ByteBoolArray::validity(&self) -> &vortex_array::validity::Validity
-
-pub struct vortex_bytebool::ByteBoolVTable
-
-impl vortex_bytebool::ByteBoolVTable
-
-pub const vortex_bytebool::ByteBoolVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_bytebool::ByteBoolVTable
-
-pub fn vortex_bytebool::ByteBoolVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_bytebool::ByteBoolVTable
-
-pub fn vortex_bytebool::ByteBoolVTable::take(array: &vortex_bytebool::ByteBoolArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_bytebool::ByteBoolVTable
-
-pub fn vortex_bytebool::ByteBoolVTable::slice(array: &vortex_bytebool::ByteBoolArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_bytebool::ByteBoolVTable
-
-pub fn vortex_bytebool::ByteBoolVTable::cast(array: &vortex_bytebool::ByteBoolArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_bytebool::ByteBoolVTable
-
-pub fn vortex_bytebool::ByteBoolVTable::mask(array: &vortex_bytebool::ByteBoolArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_bytebool::ByteBoolVTable
-
-pub type vortex_bytebool::ByteBoolVTable::Array = vortex_bytebool::ByteBoolArray
-
-pub type vortex_bytebool::ByteBoolVTable::Metadata = vortex_array::metadata::EmptyMetadata
-
-pub type vortex_bytebool::ByteBoolVTable::OperationsVTable = vortex_bytebool::ByteBoolVTable
-
-pub type vortex_bytebool::ByteBoolVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromValidityHelper
-
-pub fn vortex_bytebool::ByteBoolVTable::array_eq(array: &vortex_bytebool::ByteBoolArray, other: &vortex_bytebool::ByteBoolArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_bytebool::ByteBoolVTable::array_hash<H: core::hash::Hasher>(array: &vortex_bytebool::ByteBoolArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_bytebool::ByteBoolVTable::buffer(array: &vortex_bytebool::ByteBoolArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_bytebool::ByteBoolVTable::buffer_name(_array: &vortex_bytebool::ByteBoolArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_bytebool::ByteBoolVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_bytebool::ByteBoolArray>
-
-pub fn vortex_bytebool::ByteBoolVTable::child(array: &vortex_bytebool::ByteBoolArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_bytebool::ByteBoolVTable::child_name(_array: &vortex_bytebool::ByteBoolArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_bytebool::ByteBoolVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_bytebool::ByteBoolVTable::dtype(array: &vortex_bytebool::ByteBoolArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_bytebool::ByteBoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_bytebool::ByteBoolVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_bytebool::ByteBoolVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_bytebool::ByteBoolVTable::len(array: &vortex_bytebool::ByteBoolArray) -> usize
-
-pub fn vortex_bytebool::ByteBoolVTable::metadata(_array: &vortex_bytebool::ByteBoolArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_bytebool::ByteBoolVTable::nbuffers(_array: &vortex_bytebool::ByteBoolArray) -> usize
-
-pub fn vortex_bytebool::ByteBoolVTable::nchildren(array: &vortex_bytebool::ByteBoolArray) -> usize
-
-pub fn vortex_bytebool::ByteBoolVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_bytebool::ByteBoolVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_bytebool::ByteBoolVTable::stats(array: &vortex_bytebool::ByteBoolArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_bytebool::ByteBoolVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_bytebool::ByteBoolVTable> for vortex_bytebool::ByteBoolVTable
-
-pub fn vortex_bytebool::ByteBoolVTable::scalar_at(array: &vortex_bytebool::ByteBoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -41,7 +41,7 @@ use crate::kernel::PARENT_KERNELS;
 
 vtable!(ByteBool);
 
-impl VTable for ByteBoolVTable {
+impl VTable for ByteBool {
     type Array = ByteBoolArray;
 
     type Metadata = EmptyMetadata;
@@ -210,9 +210,9 @@ pub struct ByteBoolArray {
 }
 
 #[derive(Debug)]
-pub struct ByteBoolVTable;
+pub struct ByteBool;
 
-impl ByteBoolVTable {
+impl ByteBool {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.bytebool");
 }
 
@@ -260,7 +260,7 @@ impl ValidityHelper for ByteBoolArray {
     }
 }
 
-impl OperationsVTable<ByteBoolVTable> for ByteBoolVTable {
+impl OperationsVTable<ByteBool> for ByteBool {
     fn scalar_at(array: &ByteBoolArray, index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::bool(
             array.buffer.as_host()[index] == 1,

--- a/encodings/bytebool/src/compute.rs
+++ b/encodings/bytebool/src/compute.rs
@@ -15,10 +15,10 @@ use vortex_array::validity::Validity;
 use vortex_array::vtable::ValidityHelper;
 use vortex_error::VortexResult;
 
+use super::ByteBool;
 use super::ByteBoolArray;
-use super::ByteBoolVTable;
 
-impl CastReduce for ByteBoolVTable {
+impl CastReduce for ByteBool {
     fn cast(array: &ByteBoolArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // ByteBool is essentially a bool array stored as bytes
         // The main difference from BoolArray is the storage format
@@ -41,7 +41,7 @@ impl CastReduce for ByteBoolVTable {
     }
 }
 
-impl MaskReduce for ByteBoolVTable {
+impl MaskReduce for ByteBool {
     fn mask(array: &ByteBoolArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             ByteBoolArray::new(
@@ -56,7 +56,7 @@ impl MaskReduce for ByteBoolVTable {
     }
 }
 
-impl TakeExecute for ByteBoolVTable {
+impl TakeExecute for ByteBool {
     fn take(
         array: &ByteBoolArray,
         indices: &ArrayRef,

--- a/encodings/bytebool/src/kernel.rs
+++ b/encodings/bytebool/src/kernel.rs
@@ -4,7 +4,7 @@
 use vortex_array::arrays::dict::TakeExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 
-use crate::ByteBoolVTable;
+use crate::ByteBool;
 
-pub(crate) const PARENT_KERNELS: ParentKernelSet<ByteBoolVTable> =
-    ParentKernelSet::new(&[ParentKernelSet::lift(&TakeExecuteAdaptor(ByteBoolVTable))]);
+pub(crate) const PARENT_KERNELS: ParentKernelSet<ByteBool> =
+    ParentKernelSet::new(&[ParentKernelSet::lift(&TakeExecuteAdaptor(ByteBool))]);

--- a/encodings/bytebool/src/rules.rs
+++ b/encodings/bytebool/src/rules.rs
@@ -6,10 +6,10 @@ use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 use vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor;
 
-use crate::ByteBoolVTable;
+use crate::ByteBool;
 
-pub(crate) static RULES: ParentRuleSet<ByteBoolVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&CastReduceAdaptor(ByteBoolVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(ByteBoolVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(ByteBoolVTable)),
+pub(crate) static RULES: ParentRuleSet<ByteBool> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(ByteBool)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(ByteBool)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(ByteBool)),
 ]);

--- a/encodings/bytebool/src/slice.rs
+++ b/encodings/bytebool/src/slice.rs
@@ -9,10 +9,10 @@ use vortex_array::arrays::slice::SliceReduce;
 use vortex_array::vtable::ValidityHelper;
 use vortex_error::VortexResult;
 
+use crate::ByteBool;
 use crate::ByteBoolArray;
-use crate::ByteBoolVTable;
 
-impl SliceReduce for ByteBoolVTable {
+impl SliceReduce for ByteBool {
     fn slice(array: &ByteBoolArray, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             ByteBoolArray::new(

--- a/encodings/datetime-parts/public-api.lock
+++ b/encodings/datetime-parts/public-api.lock
@@ -1,5 +1,101 @@
 pub mod vortex_datetime_parts
 
+pub struct vortex_datetime_parts::DateTimeParts
+
+impl vortex_datetime_parts::DateTimeParts
+
+pub const vortex_datetime_parts::DateTimeParts::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_datetime_parts::DateTimeParts
+
+pub fn vortex_datetime_parts::DateTimeParts::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_datetime_parts::DateTimeParts
+
+pub fn vortex_datetime_parts::DateTimeParts::take(array: &vortex_datetime_parts::DateTimePartsArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_datetime_parts::DateTimeParts
+
+pub fn vortex_datetime_parts::DateTimeParts::filter(array: &vortex_datetime_parts::DateTimePartsArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_datetime_parts::DateTimeParts
+
+pub fn vortex_datetime_parts::DateTimeParts::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::compute::is_constant::IsConstantKernel for vortex_datetime_parts::DateTimeParts
+
+pub fn vortex_datetime_parts::DateTimeParts::is_constant(&self, array: &vortex_datetime_parts::DateTimePartsArray, opts: &vortex_array::compute::is_constant::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_datetime_parts::DateTimeParts
+
+pub fn vortex_datetime_parts::DateTimeParts::compare(lhs: &vortex_datetime_parts::DateTimePartsArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_datetime_parts::DateTimeParts
+
+pub fn vortex_datetime_parts::DateTimeParts::cast(array: &vortex_datetime_parts::DateTimePartsArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_datetime_parts::DateTimeParts
+
+pub fn vortex_datetime_parts::DateTimeParts::mask(array: &vortex_datetime_parts::DateTimePartsArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_datetime_parts::DateTimeParts
+
+pub type vortex_datetime_parts::DateTimeParts::Array = vortex_datetime_parts::DateTimePartsArray
+
+pub type vortex_datetime_parts::DateTimeParts::Metadata = vortex_array::metadata::ProstMetadata<vortex_datetime_parts::DateTimePartsMetadata>
+
+pub type vortex_datetime_parts::DateTimeParts::OperationsVTable = vortex_datetime_parts::DateTimeParts
+
+pub type vortex_datetime_parts::DateTimeParts::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
+
+pub fn vortex_datetime_parts::DateTimeParts::array_eq(array: &vortex_datetime_parts::DateTimePartsArray, other: &vortex_datetime_parts::DateTimePartsArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_datetime_parts::DateTimeParts::array_hash<H: core::hash::Hasher>(array: &vortex_datetime_parts::DateTimePartsArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_datetime_parts::DateTimeParts::buffer(_array: &vortex_datetime_parts::DateTimePartsArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_datetime_parts::DateTimeParts::buffer_name(_array: &vortex_datetime_parts::DateTimePartsArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_datetime_parts::DateTimeParts::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_datetime_parts::DateTimePartsArray>
+
+pub fn vortex_datetime_parts::DateTimeParts::child(array: &vortex_datetime_parts::DateTimePartsArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_datetime_parts::DateTimeParts::child_name(_array: &vortex_datetime_parts::DateTimePartsArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_datetime_parts::DateTimeParts::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_datetime_parts::DateTimeParts::dtype(array: &vortex_datetime_parts::DateTimePartsArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_datetime_parts::DateTimeParts::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_datetime_parts::DateTimeParts::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_datetime_parts::DateTimeParts::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_datetime_parts::DateTimeParts::len(array: &vortex_datetime_parts::DateTimePartsArray) -> usize
+
+pub fn vortex_datetime_parts::DateTimeParts::metadata(array: &vortex_datetime_parts::DateTimePartsArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_datetime_parts::DateTimeParts::nbuffers(_array: &vortex_datetime_parts::DateTimePartsArray) -> usize
+
+pub fn vortex_datetime_parts::DateTimeParts::nchildren(_array: &vortex_datetime_parts::DateTimePartsArray) -> usize
+
+pub fn vortex_datetime_parts::DateTimeParts::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_datetime_parts::DateTimeParts::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_datetime_parts::DateTimeParts::stats(array: &vortex_datetime_parts::DateTimePartsArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_datetime_parts::DateTimeParts::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_datetime_parts::DateTimeParts> for vortex_datetime_parts::DateTimeParts
+
+pub fn vortex_datetime_parts::DateTimeParts::scalar_at(array: &vortex_datetime_parts::DateTimePartsArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::validity::ValidityChild<vortex_datetime_parts::DateTimeParts> for vortex_datetime_parts::DateTimeParts
+
+pub fn vortex_datetime_parts::DateTimeParts::validity_child(array: &vortex_datetime_parts::DateTimePartsArray) -> &vortex_array::array::ArrayRef
+
 pub struct vortex_datetime_parts::DateTimePartsArray
 
 impl vortex_datetime_parts::DateTimePartsArray
@@ -115,102 +211,6 @@ impl prost::message::Message for vortex_datetime_parts::DateTimePartsMetadata
 pub fn vortex_datetime_parts::DateTimePartsMetadata::clear(&mut self)
 
 pub fn vortex_datetime_parts::DateTimePartsMetadata::encoded_len(&self) -> usize
-
-pub struct vortex_datetime_parts::DateTimePartsVTable
-
-impl vortex_datetime_parts::DateTimePartsVTable
-
-pub const vortex_datetime_parts::DateTimePartsVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_datetime_parts::DateTimePartsVTable
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_datetime_parts::DateTimePartsVTable
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::take(array: &vortex_datetime_parts::DateTimePartsArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_datetime_parts::DateTimePartsVTable
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::filter(array: &vortex_datetime_parts::DateTimePartsArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_datetime_parts::DateTimePartsVTable
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::compute::is_constant::IsConstantKernel for vortex_datetime_parts::DateTimePartsVTable
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::is_constant(&self, array: &vortex_datetime_parts::DateTimePartsArray, opts: &vortex_array::compute::is_constant::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_datetime_parts::DateTimePartsVTable
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::compare(lhs: &vortex_datetime_parts::DateTimePartsArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_datetime_parts::DateTimePartsVTable
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::cast(array: &vortex_datetime_parts::DateTimePartsArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_datetime_parts::DateTimePartsVTable
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::mask(array: &vortex_datetime_parts::DateTimePartsArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_datetime_parts::DateTimePartsVTable
-
-pub type vortex_datetime_parts::DateTimePartsVTable::Array = vortex_datetime_parts::DateTimePartsArray
-
-pub type vortex_datetime_parts::DateTimePartsVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_datetime_parts::DateTimePartsMetadata>
-
-pub type vortex_datetime_parts::DateTimePartsVTable::OperationsVTable = vortex_datetime_parts::DateTimePartsVTable
-
-pub type vortex_datetime_parts::DateTimePartsVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::array_eq(array: &vortex_datetime_parts::DateTimePartsArray, other: &vortex_datetime_parts::DateTimePartsArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::array_hash<H: core::hash::Hasher>(array: &vortex_datetime_parts::DateTimePartsArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::buffer(_array: &vortex_datetime_parts::DateTimePartsArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::buffer_name(_array: &vortex_datetime_parts::DateTimePartsArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_datetime_parts::DateTimePartsArray>
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::child(array: &vortex_datetime_parts::DateTimePartsArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::child_name(_array: &vortex_datetime_parts::DateTimePartsArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::dtype(array: &vortex_datetime_parts::DateTimePartsArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::len(array: &vortex_datetime_parts::DateTimePartsArray) -> usize
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::metadata(array: &vortex_datetime_parts::DateTimePartsArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::nbuffers(_array: &vortex_datetime_parts::DateTimePartsArray) -> usize
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::nchildren(_array: &vortex_datetime_parts::DateTimePartsArray) -> usize
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::stats(array: &vortex_datetime_parts::DateTimePartsArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_datetime_parts::DateTimePartsVTable> for vortex_datetime_parts::DateTimePartsVTable
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::scalar_at(array: &vortex_datetime_parts::DateTimePartsArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::validity::ValidityChild<vortex_datetime_parts::DateTimePartsVTable> for vortex_datetime_parts::DateTimePartsVTable
-
-pub fn vortex_datetime_parts::DateTimePartsVTable::validity_child(array: &vortex_datetime_parts::DateTimePartsArray) -> &vortex_array::array::ArrayRef
 
 pub struct vortex_datetime_parts::TemporalParts
 

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -71,7 +71,7 @@ impl DateTimePartsMetadata {
     }
 }
 
-impl VTable for DateTimePartsVTable {
+impl VTable for DateTimeParts {
     type Array = DateTimePartsArray;
 
     type Metadata = ProstMetadata<DateTimePartsMetadata>;
@@ -264,9 +264,9 @@ pub struct DateTimePartsArrayParts {
 }
 
 #[derive(Debug)]
-pub struct DateTimePartsVTable;
+pub struct DateTimeParts;
 
-impl DateTimePartsVTable {
+impl DateTimeParts {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.datetimeparts");
 }
 
@@ -347,7 +347,7 @@ impl DateTimePartsArray {
     }
 }
 
-impl ValidityChild<DateTimePartsVTable> for DateTimePartsVTable {
+impl ValidityChild<DateTimeParts> for DateTimeParts {
     fn validity_child(array: &DateTimePartsArray) -> &ArrayRef {
         array.days()
     }

--- a/encodings/datetime-parts/src/compute/cast.rs
+++ b/encodings/datetime-parts/src/compute/cast.rs
@@ -9,10 +9,10 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::DateTimeParts;
 use crate::DateTimePartsArray;
-use crate::DateTimePartsVTable;
 
-impl CastReduce for DateTimePartsVTable {
+impl CastReduce for DateTimeParts {
     fn cast(array: &DateTimePartsArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !array.dtype().eq_ignore_nullability(dtype) {
             return Ok(None);

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -16,11 +16,11 @@ use vortex_array::scalar_fn::fns::operators::CompareOperator;
 use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_error::VortexResult;
 
+use crate::array::DateTimeParts;
 use crate::array::DateTimePartsArray;
-use crate::array::DateTimePartsVTable;
 use crate::timestamp;
 
-impl CompareKernel for DateTimePartsVTable {
+impl CompareKernel for DateTimeParts {
     fn compare(
         lhs: &DateTimePartsArray,
         rhs: &ArrayRef,

--- a/encodings/datetime-parts/src/compute/filter.rs
+++ b/encodings/datetime-parts/src/compute/filter.rs
@@ -7,10 +7,10 @@ use vortex_array::arrays::filter::FilterReduce;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::DateTimeParts;
 use crate::DateTimePartsArray;
-use crate::DateTimePartsVTable;
 
-impl FilterReduce for DateTimePartsVTable {
+impl FilterReduce for DateTimeParts {
     fn filter(array: &DateTimePartsArray, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             DateTimePartsArray::try_new(

--- a/encodings/datetime-parts/src/compute/is_constant.rs
+++ b/encodings/datetime-parts/src/compute/is_constant.rs
@@ -8,10 +8,10 @@ use vortex_array::compute::is_constant_opts;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 
+use crate::DateTimeParts;
 use crate::DateTimePartsArray;
-use crate::DateTimePartsVTable;
 
-impl IsConstantKernel for DateTimePartsVTable {
+impl IsConstantKernel for DateTimeParts {
     fn is_constant(
         &self,
         array: &DateTimePartsArray,
@@ -42,4 +42,4 @@ impl IsConstantKernel for DateTimePartsVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(DateTimePartsVTable).lift());
+register_kernel!(IsConstantKernelAdapter(DateTimeParts).lift());

--- a/encodings/datetime-parts/src/compute/kernel.rs
+++ b/encodings/datetime-parts/src/compute/kernel.rs
@@ -5,9 +5,9 @@ use vortex_array::arrays::dict::TakeExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 use vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor;
 
-use crate::DateTimePartsVTable;
+use crate::DateTimeParts;
 
-pub(crate) const PARENT_KERNELS: ParentKernelSet<DateTimePartsVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&CompareExecuteAdaptor(DateTimePartsVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(DateTimePartsVTable)),
+pub(crate) const PARENT_KERNELS: ParentKernelSet<DateTimeParts> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&CompareExecuteAdaptor(DateTimeParts)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(DateTimeParts)),
 ]);

--- a/encodings/datetime-parts/src/compute/mask.rs
+++ b/encodings/datetime-parts/src/compute/mask.rs
@@ -7,11 +7,11 @@ use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::scalar_fn::fns::mask::MaskReduce;
 use vortex_error::VortexResult;
 
+use crate::DateTimeParts;
 use crate::DateTimePartsArray;
 use crate::DateTimePartsArrayParts;
-use crate::DateTimePartsVTable;
 
-impl MaskReduce for DateTimePartsVTable {
+impl MaskReduce for DateTimeParts {
     fn mask(array: &DateTimePartsArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let DateTimePartsArrayParts {
             dtype,

--- a/encodings/datetime-parts/src/compute/rules.rs
+++ b/encodings/datetime-parts/src/compute/rules.rs
@@ -4,10 +4,10 @@
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
-use vortex_array::arrays::ConstantVTable;
+use vortex_array::arrays::Filter;
 use vortex_array::arrays::FilterArray;
-use vortex_array::arrays::FilterVTable;
 use vortex_array::arrays::ScalarFnArray;
 use vortex_array::arrays::filter::FilterReduceAdaptor;
 use vortex_array::arrays::scalar_fn::AnyScalarFn;
@@ -25,17 +25,17 @@ use vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
+use crate::DateTimeParts;
 use crate::DateTimePartsArray;
-use crate::DateTimePartsVTable;
 use crate::timestamp;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<DateTimePartsVTable> = ParentRuleSet::new(&[
+pub(crate) const PARENT_RULES: ParentRuleSet<DateTimeParts> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&DTPFilterPushDownRule),
     ParentRuleSet::lift(&DTPComparisonPushDownRule),
-    ParentRuleSet::lift(&CastReduceAdaptor(DateTimePartsVTable)),
-    ParentRuleSet::lift(&FilterReduceAdaptor(DateTimePartsVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(DateTimePartsVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(DateTimePartsVTable)),
+    ParentRuleSet::lift(&CastReduceAdaptor(DateTimeParts)),
+    ParentRuleSet::lift(&FilterReduceAdaptor(DateTimeParts)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(DateTimeParts)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(DateTimeParts)),
 ]);
 
 /// Push the filter into the days column of a date time parts, we could extend this to other fields
@@ -43,8 +43,8 @@ pub(crate) const PARENT_RULES: ParentRuleSet<DateTimePartsVTable> = ParentRuleSe
 #[derive(Debug)]
 struct DTPFilterPushDownRule;
 
-impl ArrayParentReduceRule<DateTimePartsVTable> for DTPFilterPushDownRule {
-    type Parent = FilterVTable;
+impl ArrayParentReduceRule<DateTimeParts> for DTPFilterPushDownRule {
+    type Parent = Filter;
 
     fn reduce_parent(
         &self,
@@ -54,7 +54,7 @@ impl ArrayParentReduceRule<DateTimePartsVTable> for DTPFilterPushDownRule {
     ) -> VortexResult<Option<ArrayRef>> {
         debug_assert_eq!(child_idx, 0);
 
-        if !child.seconds().is::<ConstantVTable>() || !child.subseconds().is::<ConstantVTable>() {
+        if !child.seconds().is::<Constant>() || !child.subseconds().is::<Constant>() {
             return Ok(None);
         }
 
@@ -89,7 +89,7 @@ impl ArrayParentReduceRule<DateTimePartsVTable> for DTPFilterPushDownRule {
 #[derive(Debug)]
 struct DTPComparisonPushDownRule;
 
-impl ArrayParentReduceRule<DateTimePartsVTable> for DTPComparisonPushDownRule {
+impl ArrayParentReduceRule<DateTimeParts> for DTPComparisonPushDownRule {
     type Parent = AnyScalarFn;
 
     fn reduce_parent(
@@ -174,7 +174,7 @@ fn try_extract_days_constant(array: &ArrayRef) -> Option<i64> {
 /// Check if an array is a constant with value zero.
 fn is_constant_zero(array: &ArrayRef) -> bool {
     array
-        .as_opt::<ConstantVTable>()
+        .as_opt::<Constant>()
         .is_some_and(|c| c.scalar().is_zero() == Some(true))
 }
 
@@ -276,7 +276,7 @@ mod tests {
 
         // The result should be a ScalarFn over primitive days, not over DTP
         assert!(
-            !optimized.is::<DateTimePartsVTable>(),
+            !optimized.is::<DateTimeParts>(),
             "Expected pushdown to remove DTP from expression"
         );
 

--- a/encodings/datetime-parts/src/compute/slice.rs
+++ b/encodings/datetime-parts/src/compute/slice.rs
@@ -8,10 +8,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::slice::SliceReduce;
 use vortex_error::VortexResult;
 
+use crate::DateTimeParts;
 use crate::DateTimePartsArray;
-use crate::DateTimePartsVTable;
 
-impl SliceReduce for DateTimePartsVTable {
+impl SliceReduce for DateTimeParts {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         // SAFETY: slicing all components preserves values
         Ok(Some(unsafe {

--- a/encodings/datetime-parts/src/compute/take.rs
+++ b/encodings/datetime-parts/src/compute/take.rs
@@ -15,8 +15,8 @@ use vortex_array::scalar::Scalar;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 
+use crate::DateTimeParts;
 use crate::DateTimePartsArray;
-use crate::DateTimePartsVTable;
 
 fn take_datetime_parts(array: &DateTimePartsArray, indices: &ArrayRef) -> VortexResult<ArrayRef> {
     // we go ahead and canonicalize here to avoid worst-case canonicalizing 3 separate times
@@ -85,7 +85,7 @@ fn take_datetime_parts(array: &DateTimePartsArray, indices: &ArrayRef) -> Vortex
     )
 }
 
-impl TakeExecute for DateTimePartsVTable {
+impl TakeExecute for DateTimeParts {
     fn take(
         array: &DateTimePartsArray,
         indices: &ArrayRef,

--- a/encodings/datetime-parts/src/ops.rs
+++ b/encodings/datetime-parts/src/ops.rs
@@ -10,12 +10,12 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 
+use crate::DateTimeParts;
 use crate::DateTimePartsArray;
-use crate::DateTimePartsVTable;
 use crate::timestamp;
 use crate::timestamp::TimestampParts;
 
-impl OperationsVTable<DateTimePartsVTable> for DateTimePartsVTable {
+impl OperationsVTable<DateTimeParts> for DateTimeParts {
     fn scalar_at(array: &DateTimePartsArray, index: usize) -> VortexResult<Scalar> {
         let DType::Extension(ext) = array.dtype().clone() else {
             vortex_panic!(

--- a/encodings/decimal-byte-parts/public-api.lock
+++ b/encodings/decimal-byte-parts/public-api.lock
@@ -1,5 +1,101 @@
 pub mod vortex_decimal_byte_parts
 
+pub struct vortex_decimal_byte_parts::DecimalByteParts
+
+impl vortex_decimal_byte_parts::DecimalByteParts
+
+pub const vortex_decimal_byte_parts::DecimalByteParts::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_decimal_byte_parts::DecimalByteParts
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_decimal_byte_parts::DecimalByteParts
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::take(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_decimal_byte_parts::DecimalByteParts
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::filter(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_decimal_byte_parts::DecimalByteParts
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::slice(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::compute::is_constant::IsConstantKernel for vortex_decimal_byte_parts::DecimalByteParts
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::is_constant(&self, array: &vortex_decimal_byte_parts::DecimalBytePartsArray, opts: &vortex_array::compute::is_constant::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_decimal_byte_parts::DecimalByteParts
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::compare(lhs: &Self::Array, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_decimal_byte_parts::DecimalByteParts
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::cast(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_decimal_byte_parts::DecimalByteParts
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::mask(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_decimal_byte_parts::DecimalByteParts
+
+pub type vortex_decimal_byte_parts::DecimalByteParts::Array = vortex_decimal_byte_parts::DecimalBytePartsArray
+
+pub type vortex_decimal_byte_parts::DecimalByteParts::Metadata = vortex_array::metadata::ProstMetadata<vortex_decimal_byte_parts::DecimalBytesPartsMetadata>
+
+pub type vortex_decimal_byte_parts::DecimalByteParts::OperationsVTable = vortex_decimal_byte_parts::DecimalByteParts
+
+pub type vortex_decimal_byte_parts::DecimalByteParts::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::array_eq(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, other: &vortex_decimal_byte_parts::DecimalBytePartsArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::array_hash<H: core::hash::Hasher>(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::buffer(_array: &vortex_decimal_byte_parts::DecimalBytePartsArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::buffer_name(_array: &vortex_decimal_byte_parts::DecimalBytePartsArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_decimal_byte_parts::DecimalBytePartsArray>
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::child(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::child_name(_array: &vortex_decimal_byte_parts::DecimalBytePartsArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::dtype(array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::len(array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> usize
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::metadata(array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::nbuffers(_array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> usize
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::nchildren(_array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> usize
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::stats(array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_decimal_byte_parts::DecimalByteParts> for vortex_decimal_byte_parts::DecimalByteParts
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::scalar_at(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::validity::ValidityChild<vortex_decimal_byte_parts::DecimalByteParts> for vortex_decimal_byte_parts::DecimalByteParts
+
+pub fn vortex_decimal_byte_parts::DecimalByteParts::validity_child(array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> &vortex_array::array::ArrayRef
+
 pub struct vortex_decimal_byte_parts::DecimalBytePartsArray
 
 impl vortex_decimal_byte_parts::DecimalBytePartsArray
@@ -45,102 +141,6 @@ pub struct vortex_decimal_byte_parts::DecimalBytePartsArrayParts
 pub vortex_decimal_byte_parts::DecimalBytePartsArrayParts::dtype: vortex_array::dtype::DType
 
 pub vortex_decimal_byte_parts::DecimalBytePartsArrayParts::msp: vortex_array::array::ArrayRef
-
-pub struct vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-impl vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub const vortex_decimal_byte_parts::DecimalBytePartsVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::take(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::filter(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::slice(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::compute::is_constant::IsConstantKernel for vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::is_constant(&self, array: &vortex_decimal_byte_parts::DecimalBytePartsArray, opts: &vortex_array::compute::is_constant::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::compare(lhs: &Self::Array, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::cast(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::mask(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub type vortex_decimal_byte_parts::DecimalBytePartsVTable::Array = vortex_decimal_byte_parts::DecimalBytePartsArray
-
-pub type vortex_decimal_byte_parts::DecimalBytePartsVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_decimal_byte_parts::DecimalBytesPartsMetadata>
-
-pub type vortex_decimal_byte_parts::DecimalBytePartsVTable::OperationsVTable = vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub type vortex_decimal_byte_parts::DecimalBytePartsVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::array_eq(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, other: &vortex_decimal_byte_parts::DecimalBytePartsArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::array_hash<H: core::hash::Hasher>(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::buffer(_array: &vortex_decimal_byte_parts::DecimalBytePartsArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::buffer_name(_array: &vortex_decimal_byte_parts::DecimalBytePartsArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_decimal_byte_parts::DecimalBytePartsArray>
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::child(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::child_name(_array: &vortex_decimal_byte_parts::DecimalBytePartsArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::dtype(array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::len(array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> usize
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::metadata(array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::nbuffers(_array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> usize
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::nchildren(_array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> usize
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::stats(array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_decimal_byte_parts::DecimalBytePartsVTable> for vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::scalar_at(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::validity::ValidityChild<vortex_decimal_byte_parts::DecimalBytePartsVTable> for vortex_decimal_byte_parts::DecimalBytePartsVTable
-
-pub fn vortex_decimal_byte_parts::DecimalBytePartsVTable::validity_child(array: &vortex_decimal_byte_parts::DecimalBytePartsArray) -> &vortex_array::array::ArrayRef
 
 pub struct vortex_decimal_byte_parts::DecimalBytesPartsMetadata
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/cast.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/cast.rs
@@ -9,10 +9,10 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::DecimalByteParts;
 use crate::DecimalBytePartsArray;
-use crate::DecimalBytePartsVTable;
 
-impl CastReduce for DecimalBytePartsVTable {
+impl CastReduce for DecimalByteParts {
     fn cast(array: &DecimalBytePartsArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // DecimalBytePartsArray can only have Decimal dtype, so we only handle decimal-to-decimal casts
         let DType::Decimal(target_decimal, target_nullability) = dtype else {

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/compare.rs
@@ -24,10 +24,10 @@ use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
-use crate::DecimalBytePartsVTable;
+use crate::DecimalByteParts;
 use crate::decimal_byte_parts::compute::compare::Sign::Positive;
 
-impl CompareKernel for DecimalBytePartsVTable {
+impl CompareKernel for DecimalByteParts {
     fn compare(
         lhs: &Self::Array,
         rhs: &ArrayRef,

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/filter.rs
@@ -7,10 +7,10 @@ use vortex_array::arrays::filter::FilterReduce;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::DecimalByteParts;
 use crate::DecimalBytePartsArray;
-use crate::DecimalBytePartsVTable;
 
-impl FilterReduce for DecimalBytePartsVTable {
+impl FilterReduce for DecimalByteParts {
     fn filter(array: &DecimalBytePartsArray, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
         DecimalBytePartsArray::try_new(array.msp.filter(mask.clone())?, *array.decimal_dtype())
             .map(|d| Some(d.into_array()))

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/is_constant.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/is_constant.rs
@@ -8,10 +8,10 @@ use vortex_array::compute::is_constant_opts;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 
+use crate::DecimalByteParts;
 use crate::DecimalBytePartsArray;
-use crate::DecimalBytePartsVTable;
 
-impl IsConstantKernel for DecimalBytePartsVTable {
+impl IsConstantKernel for DecimalByteParts {
     fn is_constant(
         &self,
         array: &DecimalBytePartsArray,
@@ -21,4 +21,4 @@ impl IsConstantKernel for DecimalBytePartsVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(DecimalBytePartsVTable).lift());
+register_kernel!(IsConstantKernelAdapter(DecimalByteParts).lift());

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/kernel.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/kernel.rs
@@ -5,9 +5,9 @@ use vortex_array::arrays::dict::TakeExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 use vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor;
 
-use crate::DecimalBytePartsVTable;
+use crate::DecimalByteParts;
 
-pub(crate) const PARENT_KERNELS: ParentKernelSet<DecimalBytePartsVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&CompareExecuteAdaptor(DecimalBytePartsVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(DecimalBytePartsVTable)),
+pub(crate) const PARENT_KERNELS: ParentKernelSet<DecimalByteParts> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&CompareExecuteAdaptor(DecimalByteParts)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(DecimalByteParts)),
 ]);

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/mask.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/mask.rs
@@ -9,10 +9,10 @@ use vortex_array::scalar_fn::fns::mask::Mask as MaskExpr;
 use vortex_array::scalar_fn::fns::mask::MaskReduce;
 use vortex_error::VortexResult;
 
+use crate::DecimalByteParts;
 use crate::DecimalBytePartsArray;
-use crate::DecimalBytePartsVTable;
 
-impl MaskReduce for DecimalBytePartsVTable {
+impl MaskReduce for DecimalByteParts {
     fn mask(array: &DecimalBytePartsArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let masked_msp = MaskExpr.try_new_array(
             array.msp.len(),

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/take.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/take.rs
@@ -8,10 +8,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::dict::TakeExecute;
 use vortex_error::VortexResult;
 
+use crate::DecimalByteParts;
 use crate::DecimalBytePartsArray;
-use crate::DecimalBytePartsVTable;
 
-impl TakeExecute for DecimalBytePartsVTable {
+impl TakeExecute for DecimalByteParts {
     fn take(
         array: &DecimalBytePartsArray,
         indices: &ArrayRef,

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -58,7 +58,7 @@ pub struct DecimalBytesPartsMetadata {
     lower_part_count: u32,
 }
 
-impl VTable for DecimalBytePartsVTable {
+impl VTable for DecimalByteParts {
     type Array = DecimalBytePartsArray;
 
     type Metadata = ProstMetadata<DecimalBytesPartsMetadata>;
@@ -271,9 +271,9 @@ impl DecimalBytePartsArray {
 }
 
 #[derive(Debug)]
-pub struct DecimalBytePartsVTable;
+pub struct DecimalByteParts;
 
-impl DecimalBytePartsVTable {
+impl DecimalByteParts {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.decimal_byte_parts");
 }
 
@@ -301,7 +301,7 @@ fn to_canonical_decimal(
     }))
 }
 
-impl OperationsVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
+impl OperationsVTable<DecimalByteParts> for DecimalByteParts {
     fn scalar_at(array: &DecimalBytePartsArray, index: usize) -> VortexResult<Scalar> {
         // TODO(joe): support parts len != 1
         let scalar = array.msp.scalar_at(index)?;
@@ -317,7 +317,7 @@ impl OperationsVTable<DecimalBytePartsVTable> for DecimalBytePartsVTable {
     }
 }
 
-impl ValidityChild<DecimalBytePartsVTable> for DecimalBytePartsVTable {
+impl ValidityChild<DecimalByteParts> for DecimalByteParts {
     fn validity_child(array: &DecimalBytePartsArray) -> &ArrayRef {
         // validity stored in 0th child
         &array.msp

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/rules.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/rules.rs
@@ -4,8 +4,8 @@
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Filter;
 use vortex_array::arrays::FilterArray;
-use vortex_array::arrays::FilterVTable;
 use vortex_array::arrays::filter::FilterReduceAdaptor;
 use vortex_array::arrays::slice::SliceReduceAdaptor;
 use vortex_array::optimizer::rules::ArrayParentReduceRule;
@@ -14,22 +14,22 @@ use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 use vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor;
 use vortex_error::VortexResult;
 
+use crate::DecimalByteParts;
 use crate::DecimalBytePartsArray;
-use crate::DecimalBytePartsVTable;
 
-pub(super) const PARENT_RULES: ParentRuleSet<DecimalBytePartsVTable> = ParentRuleSet::new(&[
+pub(super) const PARENT_RULES: ParentRuleSet<DecimalByteParts> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&DecimalBytePartsFilterPushDownRule),
-    ParentRuleSet::lift(&CastReduceAdaptor(DecimalBytePartsVTable)),
-    ParentRuleSet::lift(&FilterReduceAdaptor(DecimalBytePartsVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(DecimalBytePartsVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(DecimalBytePartsVTable)),
+    ParentRuleSet::lift(&CastReduceAdaptor(DecimalByteParts)),
+    ParentRuleSet::lift(&FilterReduceAdaptor(DecimalByteParts)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(DecimalByteParts)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(DecimalByteParts)),
 ]);
 
 #[derive(Debug)]
 struct DecimalBytePartsFilterPushDownRule;
 
-impl ArrayParentReduceRule<DecimalBytePartsVTable> for DecimalBytePartsFilterPushDownRule {
-    type Parent = FilterVTable;
+impl ArrayParentReduceRule<DecimalByteParts> for DecimalBytePartsFilterPushDownRule {
+    type Parent = Filter;
 
     fn reduce_parent(
         &self,

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/slice.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/slice.rs
@@ -8,10 +8,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::slice::SliceReduce;
 use vortex_error::VortexResult;
 
+use crate::DecimalByteParts;
 use crate::DecimalBytePartsArray;
-use crate::DecimalBytePartsVTable;
 
-impl SliceReduce for DecimalBytePartsVTable {
+impl SliceReduce for DecimalByteParts {
     fn slice(array: &DecimalBytePartsArray, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         // SAFETY: slicing encoded MSP does not change the encoded values
         Ok(Some(unsafe {

--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -106,6 +106,92 @@ pub unsafe fn vortex_fastlanes::unpack_iter::BitPackingStrategy::unpack_chunk(&s
 
 pub type vortex_fastlanes::unpack_iter::BitUnpackedChunks<T> = vortex_fastlanes::unpack_iter::UnpackedChunks<T, vortex_fastlanes::unpack_iter::BitPackingStrategy>
 
+pub struct vortex_fastlanes::BitPacked
+
+impl vortex_fastlanes::BitPacked
+
+pub const vortex_fastlanes::BitPacked::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_fastlanes::BitPacked
+
+pub fn vortex_fastlanes::BitPacked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_fastlanes::BitPacked
+
+pub fn vortex_fastlanes::BitPacked::take(array: &vortex_fastlanes::BitPackedArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_fastlanes::BitPacked
+
+pub fn vortex_fastlanes::BitPacked::filter(array: &vortex_fastlanes::BitPackedArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceKernel for vortex_fastlanes::BitPacked
+
+pub fn vortex_fastlanes::BitPacked::slice(array: &vortex_fastlanes::BitPackedArray, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::compute::is_constant::IsConstantKernel for vortex_fastlanes::BitPacked
+
+pub fn vortex_fastlanes::BitPacked::is_constant(&self, array: &vortex_fastlanes::BitPackedArray, opts: &vortex_array::compute::is_constant::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::BitPacked
+
+pub fn vortex_fastlanes::BitPacked::cast(array: &vortex_fastlanes::BitPackedArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_fastlanes::BitPacked
+
+pub type vortex_fastlanes::BitPacked::Array = vortex_fastlanes::BitPackedArray
+
+pub type vortex_fastlanes::BitPacked::Metadata = vortex_array::metadata::ProstMetadata<vortex_fastlanes::bitpacking::vtable::BitPackedMetadata>
+
+pub type vortex_fastlanes::BitPacked::OperationsVTable = vortex_fastlanes::BitPacked
+
+pub type vortex_fastlanes::BitPacked::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromValidityHelper
+
+pub fn vortex_fastlanes::BitPacked::append_to_builder(array: &vortex_fastlanes::BitPackedArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_fastlanes::BitPacked::array_eq(array: &vortex_fastlanes::BitPackedArray, other: &vortex_fastlanes::BitPackedArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_fastlanes::BitPacked::array_hash<H: core::hash::Hasher>(array: &vortex_fastlanes::BitPackedArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_fastlanes::BitPacked::buffer(array: &vortex_fastlanes::BitPackedArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_fastlanes::BitPacked::buffer_name(_array: &vortex_fastlanes::BitPackedArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_fastlanes::BitPacked::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_fastlanes::BitPackedArray>
+
+pub fn vortex_fastlanes::BitPacked::child(array: &vortex_fastlanes::BitPackedArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_fastlanes::BitPacked::child_name(array: &vortex_fastlanes::BitPackedArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_fastlanes::BitPacked::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_fastlanes::BitPacked::dtype(array: &vortex_fastlanes::BitPackedArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_fastlanes::BitPacked::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_fastlanes::BitPacked::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_fastlanes::BitPacked::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_fastlanes::BitPacked::len(array: &vortex_fastlanes::BitPackedArray) -> usize
+
+pub fn vortex_fastlanes::BitPacked::metadata(array: &vortex_fastlanes::BitPackedArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_fastlanes::BitPacked::nbuffers(_array: &vortex_fastlanes::BitPackedArray) -> usize
+
+pub fn vortex_fastlanes::BitPacked::nchildren(array: &vortex_fastlanes::BitPackedArray) -> usize
+
+pub fn vortex_fastlanes::BitPacked::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_fastlanes::BitPacked::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_fastlanes::BitPacked::stats(array: &vortex_fastlanes::BitPackedArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_fastlanes::BitPacked::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::BitPacked> for vortex_fastlanes::BitPacked
+
+pub fn vortex_fastlanes::BitPacked::scalar_at(array: &vortex_fastlanes::BitPackedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
 pub struct vortex_fastlanes::BitPackedArray
 
 impl vortex_fastlanes::BitPackedArray
@@ -182,91 +268,75 @@ pub vortex_fastlanes::BitPackedArrayParts::patches: core::option::Option<vortex_
 
 pub vortex_fastlanes::BitPackedArrayParts::validity: vortex_array::validity::Validity
 
-pub struct vortex_fastlanes::BitPackedVTable
+pub struct vortex_fastlanes::Delta
 
-impl vortex_fastlanes::BitPackedVTable
+impl vortex_fastlanes::Delta
 
-pub const vortex_fastlanes::BitPackedVTable::ID: vortex_array::vtable::dyn_::ArrayId
+pub const vortex_fastlanes::Delta::ID: vortex_array::vtable::dyn_::ArrayId
 
-impl core::fmt::Debug for vortex_fastlanes::BitPackedVTable
+impl core::fmt::Debug for vortex_fastlanes::Delta
 
-pub fn vortex_fastlanes::BitPackedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_fastlanes::Delta::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_fastlanes::BitPackedVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_fastlanes::Delta
 
-pub fn vortex_fastlanes::BitPackedVTable::take(array: &vortex_fastlanes::BitPackedArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::Delta::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_fastlanes::BitPackedVTable
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::Delta
 
-pub fn vortex_fastlanes::BitPackedVTable::filter(array: &vortex_fastlanes::BitPackedArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::Delta::cast(array: &vortex_fastlanes::DeltaArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceKernel for vortex_fastlanes::BitPackedVTable
+impl vortex_array::vtable::VTable for vortex_fastlanes::Delta
 
-pub fn vortex_fastlanes::BitPackedVTable::slice(array: &vortex_fastlanes::BitPackedArray, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub type vortex_fastlanes::Delta::Array = vortex_fastlanes::DeltaArray
 
-impl vortex_array::compute::is_constant::IsConstantKernel for vortex_fastlanes::BitPackedVTable
+pub type vortex_fastlanes::Delta::Metadata = vortex_array::metadata::ProstMetadata<vortex_fastlanes::delta::vtable::DeltaMetadata>
 
-pub fn vortex_fastlanes::BitPackedVTable::is_constant(&self, array: &vortex_fastlanes::BitPackedArray, opts: &vortex_array::compute::is_constant::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub type vortex_fastlanes::Delta::OperationsVTable = vortex_fastlanes::Delta
 
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::BitPackedVTable
+pub type vortex_fastlanes::Delta::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChildSliceHelper
 
-pub fn vortex_fastlanes::BitPackedVTable::cast(array: &vortex_fastlanes::BitPackedArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::Delta::array_eq(array: &vortex_fastlanes::DeltaArray, other: &vortex_fastlanes::DeltaArray, precision: vortex_array::hash::Precision) -> bool
 
-impl vortex_array::vtable::VTable for vortex_fastlanes::BitPackedVTable
+pub fn vortex_fastlanes::Delta::array_hash<H: core::hash::Hasher>(array: &vortex_fastlanes::DeltaArray, state: &mut H, precision: vortex_array::hash::Precision)
 
-pub type vortex_fastlanes::BitPackedVTable::Array = vortex_fastlanes::BitPackedArray
+pub fn vortex_fastlanes::Delta::buffer(_array: &vortex_fastlanes::DeltaArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub type vortex_fastlanes::BitPackedVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_fastlanes::bitpacking::vtable::BitPackedMetadata>
+pub fn vortex_fastlanes::Delta::buffer_name(_array: &vortex_fastlanes::DeltaArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub type vortex_fastlanes::BitPackedVTable::OperationsVTable = vortex_fastlanes::BitPackedVTable
+pub fn vortex_fastlanes::Delta::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_fastlanes::DeltaArray>
 
-pub type vortex_fastlanes::BitPackedVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromValidityHelper
+pub fn vortex_fastlanes::Delta::child(array: &vortex_fastlanes::DeltaArray, idx: usize) -> vortex_array::array::ArrayRef
 
-pub fn vortex_fastlanes::BitPackedVTable::append_to_builder(array: &vortex_fastlanes::BitPackedArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_fastlanes::Delta::child_name(_array: &vortex_fastlanes::DeltaArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_fastlanes::BitPackedVTable::array_eq(array: &vortex_fastlanes::BitPackedArray, other: &vortex_fastlanes::BitPackedArray, precision: vortex_array::hash::Precision) -> bool
+pub fn vortex_fastlanes::Delta::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_fastlanes::BitPackedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_fastlanes::BitPackedArray, state: &mut H, precision: vortex_array::hash::Precision)
+pub fn vortex_fastlanes::Delta::dtype(array: &vortex_fastlanes::DeltaArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_fastlanes::BitPackedVTable::buffer(array: &vortex_fastlanes::BitPackedArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_fastlanes::Delta::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
-pub fn vortex_fastlanes::BitPackedVTable::buffer_name(_array: &vortex_fastlanes::BitPackedArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_fastlanes::Delta::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
 
-pub fn vortex_fastlanes::BitPackedVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_fastlanes::BitPackedArray>
+pub fn vortex_fastlanes::Delta::len(array: &vortex_fastlanes::DeltaArray) -> usize
 
-pub fn vortex_fastlanes::BitPackedVTable::child(array: &vortex_fastlanes::BitPackedArray, idx: usize) -> vortex_array::array::ArrayRef
+pub fn vortex_fastlanes::Delta::metadata(array: &vortex_fastlanes::DeltaArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_fastlanes::BitPackedVTable::child_name(array: &vortex_fastlanes::BitPackedArray, idx: usize) -> alloc::string::String
+pub fn vortex_fastlanes::Delta::nbuffers(_array: &vortex_fastlanes::DeltaArray) -> usize
 
-pub fn vortex_fastlanes::BitPackedVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_fastlanes::Delta::nchildren(_array: &vortex_fastlanes::DeltaArray) -> usize
 
-pub fn vortex_fastlanes::BitPackedVTable::dtype(array: &vortex_fastlanes::BitPackedArray) -> &vortex_array::dtype::DType
+pub fn vortex_fastlanes::Delta::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-pub fn vortex_fastlanes::BitPackedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+pub fn vortex_fastlanes::Delta::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_fastlanes::BitPackedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::Delta::stats(array: &vortex_fastlanes::DeltaArray) -> vortex_array::stats::array::StatsSetRef<'_>
 
-pub fn vortex_fastlanes::BitPackedVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+pub fn vortex_fastlanes::Delta::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-pub fn vortex_fastlanes::BitPackedVTable::len(array: &vortex_fastlanes::BitPackedArray) -> usize
+impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::Delta> for vortex_fastlanes::Delta
 
-pub fn vortex_fastlanes::BitPackedVTable::metadata(array: &vortex_fastlanes::BitPackedArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_fastlanes::BitPackedVTable::nbuffers(_array: &vortex_fastlanes::BitPackedArray) -> usize
-
-pub fn vortex_fastlanes::BitPackedVTable::nchildren(array: &vortex_fastlanes::BitPackedArray) -> usize
-
-pub fn vortex_fastlanes::BitPackedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_fastlanes::BitPackedVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_fastlanes::BitPackedVTable::stats(array: &vortex_fastlanes::BitPackedArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_fastlanes::BitPackedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::BitPackedVTable> for vortex_fastlanes::BitPackedVTable
-
-pub fn vortex_fastlanes::BitPackedVTable::scalar_at(array: &vortex_fastlanes::BitPackedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fastlanes::Delta::scalar_at(array: &vortex_fastlanes::DeltaArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub struct vortex_fastlanes::DeltaArray
 
@@ -326,75 +396,103 @@ impl vortex_array::vtable::validity::ValidityChildSliceHelper for vortex_fastlan
 
 pub fn vortex_fastlanes::DeltaArray::unsliced_child_and_slice(&self) -> (&vortex_array::array::ArrayRef, usize, usize)
 
-pub struct vortex_fastlanes::DeltaVTable
+pub struct vortex_fastlanes::FoR
 
-impl vortex_fastlanes::DeltaVTable
+impl vortex_fastlanes::FoR
 
-pub const vortex_fastlanes::DeltaVTable::ID: vortex_array::vtable::dyn_::ArrayId
+pub const vortex_fastlanes::FoR::ID: vortex_array::vtable::dyn_::ArrayId
 
-impl core::fmt::Debug for vortex_fastlanes::DeltaVTable
+impl core::fmt::Debug for vortex_fastlanes::FoR
 
-pub fn vortex_fastlanes::DeltaVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_fastlanes::FoR::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_fastlanes::DeltaVTable
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_fastlanes::FoR
 
-pub fn vortex_fastlanes::DeltaVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::FoR::take(array: &vortex_fastlanes::FoRArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::DeltaVTable
+impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_fastlanes::FoR
 
-pub fn vortex_fastlanes::DeltaVTable::cast(array: &vortex_fastlanes::DeltaArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::FoR::filter(array: &vortex_fastlanes::FoRArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-impl vortex_array::vtable::VTable for vortex_fastlanes::DeltaVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_fastlanes::FoR
 
-pub type vortex_fastlanes::DeltaVTable::Array = vortex_fastlanes::DeltaArray
+pub fn vortex_fastlanes::FoR::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-pub type vortex_fastlanes::DeltaVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_fastlanes::delta::vtable::DeltaMetadata>
+impl vortex_array::compute::is_constant::IsConstantKernel for vortex_fastlanes::FoR
 
-pub type vortex_fastlanes::DeltaVTable::OperationsVTable = vortex_fastlanes::DeltaVTable
+pub fn vortex_fastlanes::FoR::is_constant(&self, array: &vortex_fastlanes::FoRArray, opts: &vortex_array::compute::is_constant::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub type vortex_fastlanes::DeltaVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChildSliceHelper
+impl vortex_array::compute::is_sorted::IsSortedKernel for vortex_fastlanes::FoR
 
-pub fn vortex_fastlanes::DeltaVTable::array_eq(array: &vortex_fastlanes::DeltaArray, other: &vortex_fastlanes::DeltaArray, precision: vortex_array::hash::Precision) -> bool
+pub fn vortex_fastlanes::FoR::is_sorted(&self, array: &vortex_fastlanes::FoRArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_fastlanes::DeltaVTable::array_hash<H: core::hash::Hasher>(array: &vortex_fastlanes::DeltaArray, state: &mut H, precision: vortex_array::hash::Precision)
+pub fn vortex_fastlanes::FoR::is_strict_sorted(&self, array: &vortex_fastlanes::FoRArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_fastlanes::DeltaVTable::buffer(_array: &vortex_fastlanes::DeltaArray, idx: usize) -> vortex_array::buffer::BufferHandle
+impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_fastlanes::FoR
 
-pub fn vortex_fastlanes::DeltaVTable::buffer_name(_array: &vortex_fastlanes::DeltaArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_fastlanes::FoR::compare(lhs: &vortex_fastlanes::FoRArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-pub fn vortex_fastlanes::DeltaVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_fastlanes::DeltaArray>
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::FoR
 
-pub fn vortex_fastlanes::DeltaVTable::child(array: &vortex_fastlanes::DeltaArray, idx: usize) -> vortex_array::array::ArrayRef
+pub fn vortex_fastlanes::FoR::cast(array: &vortex_fastlanes::FoRArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-pub fn vortex_fastlanes::DeltaVTable::child_name(_array: &vortex_fastlanes::DeltaArray, idx: usize) -> alloc::string::String
+impl vortex_array::vtable::VTable for vortex_fastlanes::FoR
 
-pub fn vortex_fastlanes::DeltaVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub type vortex_fastlanes::FoR::Array = vortex_fastlanes::FoRArray
 
-pub fn vortex_fastlanes::DeltaVTable::dtype(array: &vortex_fastlanes::DeltaArray) -> &vortex_array::dtype::DType
+pub type vortex_fastlanes::FoR::Metadata = vortex_array::scalar::Scalar
 
-pub fn vortex_fastlanes::DeltaVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+pub type vortex_fastlanes::FoR::OperationsVTable = vortex_fastlanes::FoR
 
-pub fn vortex_fastlanes::DeltaVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+pub type vortex_fastlanes::FoR::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
 
-pub fn vortex_fastlanes::DeltaVTable::len(array: &vortex_fastlanes::DeltaArray) -> usize
+pub fn vortex_fastlanes::FoR::array_eq(array: &vortex_fastlanes::FoRArray, other: &vortex_fastlanes::FoRArray, precision: vortex_array::hash::Precision) -> bool
 
-pub fn vortex_fastlanes::DeltaVTable::metadata(array: &vortex_fastlanes::DeltaArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_fastlanes::FoR::array_hash<H: core::hash::Hasher>(array: &vortex_fastlanes::FoRArray, state: &mut H, precision: vortex_array::hash::Precision)
 
-pub fn vortex_fastlanes::DeltaVTable::nbuffers(_array: &vortex_fastlanes::DeltaArray) -> usize
+pub fn vortex_fastlanes::FoR::buffer(_array: &vortex_fastlanes::FoRArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_fastlanes::DeltaVTable::nchildren(_array: &vortex_fastlanes::DeltaArray) -> usize
+pub fn vortex_fastlanes::FoR::buffer_name(_array: &vortex_fastlanes::FoRArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_fastlanes::DeltaVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::FoR::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_fastlanes::FoRArray>
 
-pub fn vortex_fastlanes::DeltaVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_fastlanes::FoR::child(array: &vortex_fastlanes::FoRArray, idx: usize) -> vortex_array::array::ArrayRef
 
-pub fn vortex_fastlanes::DeltaVTable::stats(array: &vortex_fastlanes::DeltaArray) -> vortex_array::stats::array::StatsSetRef<'_>
+pub fn vortex_fastlanes::FoR::child_name(_array: &vortex_fastlanes::FoRArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_fastlanes::DeltaVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_fastlanes::FoR::deserialize(bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::DeltaVTable> for vortex_fastlanes::DeltaVTable
+pub fn vortex_fastlanes::FoR::dtype(array: &vortex_fastlanes::FoRArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_fastlanes::DeltaVTable::scalar_at(array: &vortex_fastlanes::DeltaArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fastlanes::FoR::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_fastlanes::FoR::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_fastlanes::FoR::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_fastlanes::FoR::len(array: &vortex_fastlanes::FoRArray) -> usize
+
+pub fn vortex_fastlanes::FoR::metadata(array: &vortex_fastlanes::FoRArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_fastlanes::FoR::nbuffers(_array: &vortex_fastlanes::FoRArray) -> usize
+
+pub fn vortex_fastlanes::FoR::nchildren(_array: &vortex_fastlanes::FoRArray) -> usize
+
+pub fn vortex_fastlanes::FoR::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_fastlanes::FoR::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_fastlanes::FoR::stats(array: &vortex_fastlanes::FoRArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_fastlanes::FoR::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::FoR> for vortex_fastlanes::FoR
+
+pub fn vortex_fastlanes::FoR::scalar_at(array: &vortex_fastlanes::FoRArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::validity::ValidityChild<vortex_fastlanes::FoR> for vortex_fastlanes::FoR
+
+pub fn vortex_fastlanes::FoR::validity_child(array: &vortex_fastlanes::FoRArray) -> &vortex_array::array::ArrayRef
 
 pub struct vortex_fastlanes::FoRArray
 
@@ -442,103 +540,81 @@ impl vortex_array::array::IntoArray for vortex_fastlanes::FoRArray
 
 pub fn vortex_fastlanes::FoRArray::into_array(self) -> vortex_array::array::ArrayRef
 
-pub struct vortex_fastlanes::FoRVTable
+pub struct vortex_fastlanes::RLE
 
-impl vortex_fastlanes::FoRVTable
+impl vortex_fastlanes::RLE
 
-pub const vortex_fastlanes::FoRVTable::ID: vortex_array::vtable::dyn_::ArrayId
+pub const vortex_fastlanes::RLE::ID: vortex_array::vtable::dyn_::ArrayId
 
-impl core::fmt::Debug for vortex_fastlanes::FoRVTable
+impl core::fmt::Debug for vortex_fastlanes::RLE
 
-pub fn vortex_fastlanes::FoRVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_fastlanes::RLE::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_fastlanes::FoRVTable
+impl vortex_array::arrays::slice::SliceKernel for vortex_fastlanes::RLE
 
-pub fn vortex_fastlanes::FoRVTable::take(array: &vortex_fastlanes::FoRArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::RLE::slice(array: &vortex_fastlanes::RLEArray, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_fastlanes::FoRVTable
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::RLE
 
-pub fn vortex_fastlanes::FoRVTable::filter(array: &vortex_fastlanes::FoRArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::RLE::cast(array: &vortex_fastlanes::RLEArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_fastlanes::FoRVTable
+impl vortex_array::vtable::VTable for vortex_fastlanes::RLE
 
-pub fn vortex_fastlanes::FoRVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub type vortex_fastlanes::RLE::Array = vortex_fastlanes::RLEArray
 
-impl vortex_array::compute::is_constant::IsConstantKernel for vortex_fastlanes::FoRVTable
+pub type vortex_fastlanes::RLE::Metadata = vortex_array::metadata::ProstMetadata<vortex_fastlanes::rle::vtable::RLEMetadata>
 
-pub fn vortex_fastlanes::FoRVTable::is_constant(&self, array: &vortex_fastlanes::FoRArray, opts: &vortex_array::compute::is_constant::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub type vortex_fastlanes::RLE::OperationsVTable = vortex_fastlanes::RLE
 
-impl vortex_array::compute::is_sorted::IsSortedKernel for vortex_fastlanes::FoRVTable
+pub type vortex_fastlanes::RLE::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChildSliceHelper
 
-pub fn vortex_fastlanes::FoRVTable::is_sorted(&self, array: &vortex_fastlanes::FoRArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_fastlanes::RLE::array_eq(array: &vortex_fastlanes::RLEArray, other: &vortex_fastlanes::RLEArray, precision: vortex_array::hash::Precision) -> bool
 
-pub fn vortex_fastlanes::FoRVTable::is_strict_sorted(&self, array: &vortex_fastlanes::FoRArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_fastlanes::RLE::array_hash<H: core::hash::Hasher>(array: &vortex_fastlanes::RLEArray, state: &mut H, precision: vortex_array::hash::Precision)
 
-impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_fastlanes::FoRVTable
+pub fn vortex_fastlanes::RLE::buffer(_array: &vortex_fastlanes::RLEArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_fastlanes::FoRVTable::compare(lhs: &vortex_fastlanes::FoRArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::RLE::buffer_name(_array: &vortex_fastlanes::RLEArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::FoRVTable
+pub fn vortex_fastlanes::RLE::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_fastlanes::RLEArray>
 
-pub fn vortex_fastlanes::FoRVTable::cast(array: &vortex_fastlanes::FoRArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::RLE::child(array: &vortex_fastlanes::RLEArray, idx: usize) -> vortex_array::array::ArrayRef
 
-impl vortex_array::vtable::VTable for vortex_fastlanes::FoRVTable
+pub fn vortex_fastlanes::RLE::child_name(_array: &vortex_fastlanes::RLEArray, idx: usize) -> alloc::string::String
 
-pub type vortex_fastlanes::FoRVTable::Array = vortex_fastlanes::FoRArray
+pub fn vortex_fastlanes::RLE::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub type vortex_fastlanes::FoRVTable::Metadata = vortex_array::scalar::Scalar
+pub fn vortex_fastlanes::RLE::dtype(array: &vortex_fastlanes::RLEArray) -> &vortex_array::dtype::DType
 
-pub type vortex_fastlanes::FoRVTable::OperationsVTable = vortex_fastlanes::FoRVTable
+pub fn vortex_fastlanes::RLE::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
 
-pub type vortex_fastlanes::FoRVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
+pub fn vortex_fastlanes::RLE::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-pub fn vortex_fastlanes::FoRVTable::array_eq(array: &vortex_fastlanes::FoRArray, other: &vortex_fastlanes::FoRArray, precision: vortex_array::hash::Precision) -> bool
+pub fn vortex_fastlanes::RLE::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
 
-pub fn vortex_fastlanes::FoRVTable::array_hash<H: core::hash::Hasher>(array: &vortex_fastlanes::FoRArray, state: &mut H, precision: vortex_array::hash::Precision)
+pub fn vortex_fastlanes::RLE::len(array: &vortex_fastlanes::RLEArray) -> usize
 
-pub fn vortex_fastlanes::FoRVTable::buffer(_array: &vortex_fastlanes::FoRArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_fastlanes::RLE::metadata(array: &vortex_fastlanes::RLEArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_fastlanes::FoRVTable::buffer_name(_array: &vortex_fastlanes::FoRArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_fastlanes::RLE::nbuffers(_array: &vortex_fastlanes::RLEArray) -> usize
 
-pub fn vortex_fastlanes::FoRVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_fastlanes::FoRArray>
+pub fn vortex_fastlanes::RLE::nchildren(_array: &vortex_fastlanes::RLEArray) -> usize
 
-pub fn vortex_fastlanes::FoRVTable::child(array: &vortex_fastlanes::FoRArray, idx: usize) -> vortex_array::array::ArrayRef
+pub fn vortex_fastlanes::RLE::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-pub fn vortex_fastlanes::FoRVTable::child_name(_array: &vortex_fastlanes::FoRArray, idx: usize) -> alloc::string::String
+pub fn vortex_fastlanes::RLE::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_fastlanes::FoRVTable::deserialize(bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_fastlanes::RLE::stats(array: &vortex_fastlanes::RLEArray) -> vortex_array::stats::array::StatsSetRef<'_>
 
-pub fn vortex_fastlanes::FoRVTable::dtype(array: &vortex_fastlanes::FoRArray) -> &vortex_array::dtype::DType
+pub fn vortex_fastlanes::RLE::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-pub fn vortex_fastlanes::FoRVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::RLE> for vortex_fastlanes::RLE
 
-pub fn vortex_fastlanes::FoRVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::RLE::scalar_at(array: &vortex_fastlanes::RLEArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_fastlanes::FoRVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+impl vortex_array::vtable::validity::ValidityChild<vortex_fastlanes::RLE> for vortex_fastlanes::RLE
 
-pub fn vortex_fastlanes::FoRVTable::len(array: &vortex_fastlanes::FoRArray) -> usize
-
-pub fn vortex_fastlanes::FoRVTable::metadata(array: &vortex_fastlanes::FoRArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_fastlanes::FoRVTable::nbuffers(_array: &vortex_fastlanes::FoRArray) -> usize
-
-pub fn vortex_fastlanes::FoRVTable::nchildren(_array: &vortex_fastlanes::FoRArray) -> usize
-
-pub fn vortex_fastlanes::FoRVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_fastlanes::FoRVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_fastlanes::FoRVTable::stats(array: &vortex_fastlanes::FoRArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_fastlanes::FoRVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::FoRVTable> for vortex_fastlanes::FoRVTable
-
-pub fn vortex_fastlanes::FoRVTable::scalar_at(array: &vortex_fastlanes::FoRArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::validity::ValidityChild<vortex_fastlanes::FoRVTable> for vortex_fastlanes::FoRVTable
-
-pub fn vortex_fastlanes::FoRVTable::validity_child(array: &vortex_fastlanes::FoRArray) -> &vortex_array::array::ArrayRef
+pub fn vortex_fastlanes::RLE::validity_child(array: &vortex_fastlanes::RLEArray) -> &vortex_array::array::ArrayRef
 
 pub struct vortex_fastlanes::RLEArray
 
@@ -599,81 +675,5 @@ pub fn vortex_fastlanes::RLEArray::into_array(self) -> vortex_array::array::Arra
 impl vortex_array::vtable::validity::ValidityChildSliceHelper for vortex_fastlanes::RLEArray
 
 pub fn vortex_fastlanes::RLEArray::unsliced_child_and_slice(&self) -> (&vortex_array::array::ArrayRef, usize, usize)
-
-pub struct vortex_fastlanes::RLEVTable
-
-impl vortex_fastlanes::RLEVTable
-
-pub const vortex_fastlanes::RLEVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_fastlanes::RLEVTable
-
-pub fn vortex_fastlanes::RLEVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::slice::SliceKernel for vortex_fastlanes::RLEVTable
-
-pub fn vortex_fastlanes::RLEVTable::slice(array: &vortex_fastlanes::RLEArray, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::RLEVTable
-
-pub fn vortex_fastlanes::RLEVTable::cast(array: &vortex_fastlanes::RLEArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_fastlanes::RLEVTable
-
-pub type vortex_fastlanes::RLEVTable::Array = vortex_fastlanes::RLEArray
-
-pub type vortex_fastlanes::RLEVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_fastlanes::rle::vtable::RLEMetadata>
-
-pub type vortex_fastlanes::RLEVTable::OperationsVTable = vortex_fastlanes::RLEVTable
-
-pub type vortex_fastlanes::RLEVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChildSliceHelper
-
-pub fn vortex_fastlanes::RLEVTable::array_eq(array: &vortex_fastlanes::RLEArray, other: &vortex_fastlanes::RLEArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_fastlanes::RLEVTable::array_hash<H: core::hash::Hasher>(array: &vortex_fastlanes::RLEArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_fastlanes::RLEVTable::buffer(_array: &vortex_fastlanes::RLEArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_fastlanes::RLEVTable::buffer_name(_array: &vortex_fastlanes::RLEArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_fastlanes::RLEVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_fastlanes::RLEArray>
-
-pub fn vortex_fastlanes::RLEVTable::child(array: &vortex_fastlanes::RLEArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_fastlanes::RLEVTable::child_name(_array: &vortex_fastlanes::RLEArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_fastlanes::RLEVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_fastlanes::RLEVTable::dtype(array: &vortex_fastlanes::RLEArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_fastlanes::RLEVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_fastlanes::RLEVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_fastlanes::RLEVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_fastlanes::RLEVTable::len(array: &vortex_fastlanes::RLEArray) -> usize
-
-pub fn vortex_fastlanes::RLEVTable::metadata(array: &vortex_fastlanes::RLEArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_fastlanes::RLEVTable::nbuffers(_array: &vortex_fastlanes::RLEArray) -> usize
-
-pub fn vortex_fastlanes::RLEVTable::nchildren(_array: &vortex_fastlanes::RLEArray) -> usize
-
-pub fn vortex_fastlanes::RLEVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_fastlanes::RLEVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_fastlanes::RLEVTable::stats(array: &vortex_fastlanes::RLEArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_fastlanes::RLEVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::RLEVTable> for vortex_fastlanes::RLEVTable
-
-pub fn vortex_fastlanes::RLEVTable::scalar_at(array: &vortex_fastlanes::RLEArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::validity::ValidityChild<vortex_fastlanes::RLEVTable> for vortex_fastlanes::RLEVTable
-
-pub fn vortex_fastlanes::RLEVTable::validity_child(array: &vortex_fastlanes::RLEArray) -> &vortex_array::array::ArrayRef
 
 pub fn vortex_fastlanes::delta_compress(array: &vortex_array::arrays::primitive::array::PrimitiveArray) -> vortex_error::VortexResult<(vortex_array::arrays::primitive::array::PrimitiveArray, vortex_array::arrays::primitive::array::PrimitiveArray)>

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -3,7 +3,7 @@
 
 use fastlanes::BitPacking;
 use vortex_array::ArrayRef;
-use vortex_array::arrays::PrimitiveVTable;
+use vortex_array::arrays::Primitive;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
@@ -270,7 +270,7 @@ impl BitPackedArray {
     /// error will be returned.
     // FIXME(ngates): take a PrimitiveArray
     pub fn encode(array: &ArrayRef, bit_width: u8) -> VortexResult<Self> {
-        if let Some(parray) = array.as_opt::<PrimitiveVTable>() {
+        if let Some(parray) = array.as_opt::<Primitive>() {
             bitpack_encode(parray, bit_width, None)
         } else {
             vortex_bail!(InvalidArgument: "Bitpacking can only encode primitive arrays");

--- a/encodings/fastlanes/src/bitpacking/compute/cast.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/cast.rs
@@ -10,10 +10,10 @@ use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_array::vtable::ValidityHelper;
 use vortex_error::VortexResult;
 
+use crate::bitpacking::BitPacked;
 use crate::bitpacking::BitPackedArray;
-use crate::bitpacking::BitPackedVTable;
 
-impl CastReduce for BitPackedVTable {
+impl CastReduce for BitPacked {
     fn cast(array: &BitPackedArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if array.dtype().eq_ignore_nullability(dtype) {
             let new_validity = array

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -23,8 +23,8 @@ use vortex_mask::MaskValues;
 
 use super::chunked_indices;
 use super::take::UNPACK_CHUNK_THRESHOLD;
+use crate::BitPacked;
 use crate::BitPackedArray;
-use crate::BitPackedVTable;
 
 /// The threshold over which it is faster to fully unpack the entire [`BitPackedArray`] and then
 /// filter the result than to unpack only specific bitpacked values into the output buffer.
@@ -42,7 +42,7 @@ pub const fn unpack_then_filter_threshold(ptype: PType) -> f64 {
 }
 
 /// Kernel to execute filtering directly on a bit-packed array.
-impl FilterKernel for BitPackedVTable {
+impl FilterKernel for BitPacked {
     fn filter(
         array: &BitPackedArray,
         mask: &Mask,

--- a/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
@@ -18,11 +18,11 @@ use vortex_array::match_each_unsigned_integer_ptype;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 
+use crate::BitPacked;
 use crate::BitPackedArray;
-use crate::BitPackedVTable;
-use crate::unpack_iter::BitPacked;
+use crate::unpack_iter::BitPacked as BitPackedUnpack;
 
-impl IsConstantKernel for BitPackedVTable {
+impl IsConstantKernel for BitPacked {
     fn is_constant(
         &self,
         array: &BitPackedArray,
@@ -38,9 +38,9 @@ impl IsConstantKernel for BitPackedVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(BitPackedVTable).lift());
+register_kernel!(IsConstantKernelAdapter(BitPacked).lift());
 
-fn bitpacked_is_constant<T: BitPacked, const WIDTH: usize>(
+fn bitpacked_is_constant<T: BitPackedUnpack, const WIDTH: usize>(
     array: &BitPackedArray,
 ) -> VortexResult<bool> {
     let mut bit_unpack_iterator = array.unpacked_chunks::<T>();
@@ -131,7 +131,7 @@ fn bitpacked_is_constant<T: BitPacked, const WIDTH: usize>(
     Ok(true)
 }
 
-fn apply_patches<T: BitPacked>(
+fn apply_patches<T: BitPackedUnpack>(
     values: &mut [T],
     values_range: Range<usize>,
     patch_indices: &PrimitiveArray,
@@ -149,7 +149,7 @@ fn apply_patches<T: BitPacked>(
     });
 }
 
-fn apply_patches_idx_typed<T: BitPacked, I: IntegerPType>(
+fn apply_patches_idx_typed<T: BitPackedUnpack, I: IntegerPType>(
     values: &mut [T],
     values_range: Range<usize>,
     patch_indices: &[I],

--- a/encodings/fastlanes/src/bitpacking/compute/slice.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/slice.rs
@@ -10,10 +10,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::slice::SliceKernel;
 use vortex_error::VortexResult;
 
+use crate::BitPacked;
 use crate::BitPackedArray;
-use crate::BitPackedVTable;
 
-impl SliceKernel for BitPackedVTable {
+impl SliceKernel for BitPacked {
     fn slice(
         array: &BitPackedArray,
         range: Range<usize>,
@@ -63,7 +63,7 @@ mod tests {
     use vortex_error::VortexResult;
     use vortex_session::VortexSession;
 
-    use crate::BitPackedVTable;
+    use crate::BitPacked;
     use crate::bitpack_compress::bitpack_encode;
 
     static SESSION: LazyLock<VortexSession> =
@@ -77,7 +77,7 @@ mod tests {
         let slice_array = SliceArray::new(bitpacked.clone().into_array(), 500..1500);
 
         let mut ctx = SESSION.create_execution_ctx();
-        let reduced = <BitPackedVTable as VTable>::execute_parent(
+        let reduced = <BitPacked as VTable>::execute_parent(
             &bitpacked,
             &slice_array.into_array(),
             0,
@@ -85,8 +85,8 @@ mod tests {
         )?
         .expect("expected slice kernel to execute");
 
-        assert!(reduced.is::<BitPackedVTable>());
-        let reduced_bp = reduced.as_::<BitPackedVTable>();
+        assert!(reduced.is::<BitPacked>());
+        let reduced_bp = reduced.as_::<BitPacked>();
         assert_eq!(reduced_bp.offset(), 500);
         assert_eq!(reduced.len(), 1000);
 

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -24,8 +24,8 @@ use vortex_error::VortexExpect as _;
 use vortex_error::VortexResult;
 
 use super::chunked_indices;
+use crate::BitPacked;
 use crate::BitPackedArray;
-use crate::BitPackedVTable;
 use crate::bitpack_decompress;
 
 // TODO(connor): This is duplicated in `encodings/fastlanes/src/bitpacking/kernels/mod.rs`.
@@ -34,7 +34,7 @@ use crate::bitpack_decompress;
 /// see https://github.com/vortex-data/vortex/pull/190#issue-2223752833
 pub(super) const UNPACK_CHUNK_THRESHOLD: usize = 8;
 
-impl TakeExecute for BitPackedVTable {
+impl TakeExecute for BitPacked {
     fn take(
         array: &BitPackedArray,
         indices: &ArrayRef,

--- a/encodings/fastlanes/src/bitpacking/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/mod.rs
@@ -11,4 +11,4 @@ pub use array::unpack_iter;
 mod compute;
 
 mod vtable;
-pub use vtable::BitPackedVTable;
+pub use vtable::BitPacked;

--- a/encodings/fastlanes/src/bitpacking/vtable/kernels.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/kernels.rs
@@ -6,10 +6,10 @@ use vortex_array::arrays::filter::FilterExecuteAdaptor;
 use vortex_array::arrays::slice::SliceExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 
-use crate::BitPackedVTable;
+use crate::BitPacked;
 
-pub(crate) const PARENT_KERNELS: ParentKernelSet<BitPackedVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&FilterExecuteAdaptor(BitPackedVTable)),
-    ParentKernelSet::lift(&SliceExecuteAdaptor(BitPackedVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(BitPackedVTable)),
+pub(crate) const PARENT_KERNELS: ParentKernelSet<BitPacked> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&FilterExecuteAdaptor(BitPacked)),
+    ParentKernelSet::lift(&SliceExecuteAdaptor(BitPacked)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(BitPacked)),
 ]);

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -62,7 +62,7 @@ pub struct BitPackedMetadata {
     pub(crate) patches: Option<PatchesMetadata>,
 }
 
-impl VTable for BitPackedVTable {
+impl VTable for BitPacked {
     type Array = BitPackedArray;
 
     type Metadata = ProstMetadata<BitPackedMetadata>;
@@ -369,8 +369,8 @@ impl VTable for BitPackedVTable {
 }
 
 #[derive(Debug)]
-pub struct BitPackedVTable;
+pub struct BitPacked;
 
-impl BitPackedVTable {
+impl BitPacked {
     pub const ID: ArrayId = ArrayId::new_ref("fastlanes.bitpacked");
 }

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -5,11 +5,11 @@ use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexResult;
 
+use crate::BitPacked;
 use crate::BitPackedArray;
-use crate::BitPackedVTable;
 use crate::bitpack_decompress;
 
-impl OperationsVTable<BitPackedVTable> for BitPackedVTable {
+impl OperationsVTable<BitPacked> for BitPacked {
     fn scalar_at(array: &BitPackedArray, index: usize) -> VortexResult<Scalar> {
         Ok(
             if let Some(patches) = array.patches()
@@ -49,8 +49,8 @@ mod test {
     use vortex_buffer::ByteBuffer;
     use vortex_buffer::buffer;
 
+    use crate::BitPacked;
     use crate::BitPackedArray;
-    use crate::BitPackedVTable;
 
     static SESSION: LazyLock<vortex_session::VortexSession> =
         LazyLock::new(|| vortex_session::VortexSession::empty().with::<ArraySession>());
@@ -58,15 +58,11 @@ mod test {
     fn slice_via_kernel(array: &BitPackedArray, range: Range<usize>) -> BitPackedArray {
         let slice_array = SliceArray::new(array.clone().into_array(), range);
         let mut ctx = SESSION.create_execution_ctx();
-        let sliced = <BitPackedVTable as VTable>::execute_parent(
-            array,
-            &slice_array.into_array(),
-            0,
-            &mut ctx,
-        )
-        .expect("execute_parent failed")
-        .expect("expected slice kernel to execute");
-        sliced.as_::<BitPackedVTable>().clone()
+        let sliced =
+            <BitPacked as VTable>::execute_parent(array, &slice_array.into_array(), 0, &mut ctx)
+                .expect("execute_parent failed")
+                .expect("expected slice kernel to execute");
+        sliced.as_::<BitPacked>().clone()
     }
 
     #[test]

--- a/encodings/fastlanes/src/bitpacking/vtable/rules.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/rules.rs
@@ -4,7 +4,7 @@
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 
-use crate::BitPackedVTable;
+use crate::BitPacked;
 
-pub(crate) const RULES: ParentRuleSet<BitPackedVTable> =
-    ParentRuleSet::new(&[ParentRuleSet::lift(&CastReduceAdaptor(BitPackedVTable))]);
+pub(crate) const RULES: ParentRuleSet<BitPacked> =
+    ParentRuleSet::new(&[ParentRuleSet::lift(&CastReduceAdaptor(BitPacked))]);

--- a/encodings/fastlanes/src/delta/compute/cast.rs
+++ b/encodings/fastlanes/src/delta/compute/cast.rs
@@ -10,10 +10,10 @@ use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 
+use crate::delta::Delta;
 use crate::delta::DeltaArray;
-use crate::delta::DeltaVTable;
 
-impl CastReduce for DeltaVTable {
+impl CastReduce for Delta {
     fn cast(array: &DeltaArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // Delta encoding stores differences between consecutive values, which requires
         // unsigned integers to avoid overflow issues. Signed integers could produce

--- a/encodings/fastlanes/src/delta/mod.rs
+++ b/encodings/fastlanes/src/delta/mod.rs
@@ -8,4 +8,4 @@ pub use array::delta_compress::delta_compress;
 mod compute;
 
 mod vtable;
-pub use vtable::DeltaVTable;
+pub use vtable::Delta;

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -48,7 +48,7 @@ pub struct DeltaMetadata {
     offset: u32, // must be <1024
 }
 
-impl VTable for DeltaVTable {
+impl VTable for Delta {
     type Array = DeltaArray;
 
     type Metadata = ProstMetadata<DeltaMetadata>;
@@ -198,9 +198,9 @@ impl VTable for DeltaVTable {
 }
 
 #[derive(Debug)]
-pub struct DeltaVTable;
+pub struct Delta;
 
-impl DeltaVTable {
+impl Delta {
     pub const ID: ArrayId = ArrayId::new_ref("fastlanes.delta");
 }
 

--- a/encodings/fastlanes/src/delta/vtable/operations.rs
+++ b/encodings/fastlanes/src/delta/vtable/operations.rs
@@ -6,10 +6,10 @@ use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexResult;
 
-use super::DeltaVTable;
+use super::Delta;
 use crate::DeltaArray;
 
-impl OperationsVTable<DeltaVTable> for DeltaVTable {
+impl OperationsVTable<Delta> for Delta {
     fn scalar_at(array: &DeltaArray, index: usize) -> VortexResult<Scalar> {
         let decompressed = array.slice(index..index + 1)?.to_primitive();
         decompressed.scalar_at(0)

--- a/encodings/fastlanes/src/delta/vtable/rules.rs
+++ b/encodings/fastlanes/src/delta/vtable/rules.rs
@@ -5,9 +5,9 @@ use vortex_array::arrays::slice::SliceReduceAdaptor;
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 
-use crate::delta::vtable::DeltaVTable;
+use crate::delta::vtable::Delta;
 
-pub(crate) static RULES: ParentRuleSet<DeltaVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&SliceReduceAdaptor(DeltaVTable)),
-    ParentRuleSet::lift(&CastReduceAdaptor(DeltaVTable)),
+pub(crate) static RULES: ParentRuleSet<Delta> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&SliceReduceAdaptor(Delta)),
+    ParentRuleSet::lift(&CastReduceAdaptor(Delta)),
 ]);

--- a/encodings/fastlanes/src/delta/vtable/slice.rs
+++ b/encodings/fastlanes/src/delta/vtable/slice.rs
@@ -10,9 +10,9 @@ use vortex_array::arrays::slice::SliceReduce;
 use vortex_error::VortexResult;
 
 use crate::DeltaArray;
-use crate::delta::vtable::DeltaVTable;
+use crate::delta::vtable::Delta;
 
-impl SliceReduce for DeltaVTable {
+impl SliceReduce for Delta {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let physical_start = range.start + array.offset();
         let physical_stop = range.end + array.offset();

--- a/encodings/fastlanes/src/for/array/for_decompress.rs
+++ b/encodings/fastlanes/src/for/array/for_decompress.rs
@@ -18,8 +18,8 @@ use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
+use crate::BitPacked;
 use crate::BitPackedArray;
-use crate::BitPackedVTable;
 use crate::FoRArray;
 use crate::bitpack_decompress;
 use crate::unpack_iter::UnpackStrategy;
@@ -50,7 +50,7 @@ pub fn decompress(array: &FoRArray, ctx: &mut ExecutionCtx) -> VortexResult<Prim
 
     // Try to do fused unpack.
     if array.reference_scalar().dtype().is_unsigned_int()
-        && let Some(bp) = array.encoded().as_opt::<BitPackedVTable>()
+        && let Some(bp) = array.encoded().as_opt::<BitPacked>()
     {
         return match_each_unsigned_integer_ptype!(array.ptype(), |T| {
             fused_decompress::<T>(array, bp, ctx)

--- a/encodings/fastlanes/src/for/compute/cast.rs
+++ b/encodings/fastlanes/src/for/compute/cast.rs
@@ -8,10 +8,10 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::r#for::FoR;
 use crate::r#for::FoRArray;
-use crate::r#for::FoRVTable;
 
-impl CastReduce for FoRVTable {
+impl CastReduce for FoR {
     fn cast(array: &FoRArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // FoR only supports integer types
         if !dtype.is_int() {

--- a/encodings/fastlanes/src/for/compute/compare.rs
+++ b/encodings/fastlanes/src/for/compute/compare.rs
@@ -22,10 +22,10 @@ use vortex_error::VortexError;
 use vortex_error::VortexExpect as _;
 use vortex_error::VortexResult;
 
+use crate::FoR;
 use crate::FoRArray;
-use crate::FoRVTable;
 
-impl CompareKernel for FoRVTable {
+impl CompareKernel for FoR {
     fn compare(
         lhs: &FoRArray,
         rhs: &ArrayRef,

--- a/encodings/fastlanes/src/for/compute/is_constant.rs
+++ b/encodings/fastlanes/src/for/compute/is_constant.rs
@@ -8,13 +8,13 @@ use vortex_array::compute::is_constant_opts;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 
+use crate::FoR;
 use crate::FoRArray;
-use crate::FoRVTable;
 
-impl IsConstantKernel for FoRVTable {
+impl IsConstantKernel for FoR {
     fn is_constant(&self, array: &FoRArray, opts: &IsConstantOpts) -> VortexResult<Option<bool>> {
         is_constant_opts(array.encoded(), opts)
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(FoRVTable).lift());
+register_kernel!(IsConstantKernelAdapter(FoR).lift());

--- a/encodings/fastlanes/src/for/compute/is_sorted.rs
+++ b/encodings/fastlanes/src/for/compute/is_sorted.rs
@@ -10,8 +10,8 @@ use vortex_array::compute::is_strict_sorted;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 
+use crate::FoR;
 use crate::FoRArray;
-use crate::FoRVTable;
 
 /// FoR can express sortedness directly on its encoded form.
 ///
@@ -71,7 +71,7 @@ use crate::FoRVTable;
 /// Addition is order-preserving, so all the wrapped values preserve their order and they're all
 /// represented as unsigned values larger than 127 so they also preserve their order with the
 /// unwrapped values.
-impl IsSortedKernel for FoRVTable {
+impl IsSortedKernel for FoR {
     fn is_sorted(&self, array: &FoRArray) -> VortexResult<Option<bool>> {
         let encoded = array.encoded().to_primitive();
         is_sorted(
@@ -91,7 +91,7 @@ impl IsSortedKernel for FoRVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(FoRVTable).lift());
+register_kernel!(IsSortedKernelAdapter(FoR).lift());
 
 #[cfg(test)]
 mod test {

--- a/encodings/fastlanes/src/for/compute/mod.rs
+++ b/encodings/fastlanes/src/for/compute/mod.rs
@@ -15,10 +15,10 @@ use vortex_array::arrays::filter::FilterReduce;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::FoR;
 use crate::FoRArray;
-use crate::FoRVTable;
 
-impl TakeExecute for FoRVTable {
+impl TakeExecute for FoR {
     fn take(
         array: &FoRArray,
         indices: &ArrayRef,
@@ -34,7 +34,7 @@ impl TakeExecute for FoRVTable {
     }
 }
 
-impl FilterReduce for FoRVTable {
+impl FilterReduce for FoR {
     fn filter(array: &FoRArray, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
         FoRArray::try_new(
             array.encoded().filter(mask.clone())?,

--- a/encodings/fastlanes/src/for/mod.rs
+++ b/encodings/fastlanes/src/for/mod.rs
@@ -7,4 +7,4 @@ pub use array::FoRArray;
 mod compute;
 
 mod vtable;
-pub use vtable::FoRVTable;
+pub use vtable::FoR;

--- a/encodings/fastlanes/src/for/vtable/kernels.rs
+++ b/encodings/fastlanes/src/for/vtable/kernels.rs
@@ -5,9 +5,9 @@ use vortex_array::arrays::dict::TakeExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 use vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor;
 
-use crate::FoRVTable;
+use crate::FoR;
 
-pub(crate) const PARENT_KERNELS: ParentKernelSet<FoRVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&CompareExecuteAdaptor(FoRVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(FoRVTable)),
+pub(crate) const PARENT_KERNELS: ParentKernelSet<FoR> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&CompareExecuteAdaptor(FoR)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(FoR)),
 ]);

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -40,7 +40,7 @@ mod validity;
 
 vtable!(FoR);
 
-impl VTable for FoRVTable {
+impl VTable for FoR {
     type Array = FoRArray;
 
     type Metadata = Scalar;
@@ -181,8 +181,8 @@ impl VTable for FoRVTable {
 }
 
 #[derive(Debug)]
-pub struct FoRVTable;
+pub struct FoR;
 
-impl FoRVTable {
+impl FoR {
     pub const ID: ArrayId = ArrayId::new_ref("fastlanes.for");
 }

--- a/encodings/fastlanes/src/for/vtable/operations.rs
+++ b/encodings/fastlanes/src/for/vtable/operations.rs
@@ -7,10 +7,10 @@ use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
-use super::FoRVTable;
+use super::FoR;
 use crate::FoRArray;
 
-impl OperationsVTable<FoRVTable> for FoRVTable {
+impl OperationsVTable<FoR> for FoR {
     fn scalar_at(array: &FoRArray, index: usize) -> VortexResult<Scalar> {
         let encoded_pvalue = array.encoded().scalar_at(index)?;
         let encoded_pvalue = encoded_pvalue.as_primitive();

--- a/encodings/fastlanes/src/for/vtable/rules.rs
+++ b/encodings/fastlanes/src/for/vtable/rules.rs
@@ -4,8 +4,8 @@
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Filter;
 use vortex_array::arrays::FilterArray;
-use vortex_array::arrays::FilterVTable;
 use vortex_array::arrays::filter::FilterReduceAdaptor;
 use vortex_array::arrays::slice::SliceReduceAdaptor;
 use vortex_array::optimizer::rules::ArrayParentReduceRule;
@@ -13,22 +13,22 @@ use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 use vortex_error::VortexResult;
 
+use crate::FoR;
 use crate::FoRArray;
-use crate::FoRVTable;
 
-pub(super) const PARENT_RULES: ParentRuleSet<FoRVTable> = ParentRuleSet::new(&[
-    // TODO: add BetweenReduceAdaptor(FoRVTable)
+pub(super) const PARENT_RULES: ParentRuleSet<FoR> = ParentRuleSet::new(&[
+    // TODO: add BetweenReduceAdaptor(FoR)
     ParentRuleSet::lift(&FoRFilterPushDownRule),
-    ParentRuleSet::lift(&FilterReduceAdaptor(FoRVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(FoRVTable)),
-    ParentRuleSet::lift(&CastReduceAdaptor(FoRVTable)),
+    ParentRuleSet::lift(&FilterReduceAdaptor(FoR)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(FoR)),
+    ParentRuleSet::lift(&CastReduceAdaptor(FoR)),
 ]);
 
 #[derive(Debug)]
 struct FoRFilterPushDownRule;
 
-impl ArrayParentReduceRule<FoRVTable> for FoRFilterPushDownRule {
-    type Parent = FilterVTable;
+impl ArrayParentReduceRule<FoR> for FoRFilterPushDownRule {
+    type Parent = Filter;
 
     fn reduce_parent(
         &self,

--- a/encodings/fastlanes/src/for/vtable/slice.rs
+++ b/encodings/fastlanes/src/for/vtable/slice.rs
@@ -8,10 +8,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::slice::SliceReduce;
 use vortex_error::VortexResult;
 
+use crate::FoR;
 use crate::FoRArray;
-use crate::FoRVTable;
 
-impl SliceReduce for FoRVTable {
+impl SliceReduce for FoR {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         // SAFETY: Just slicing encoded data does not affect FOR.
         Ok(Some(unsafe {

--- a/encodings/fastlanes/src/for/vtable/validity.rs
+++ b/encodings/fastlanes/src/for/vtable/validity.rs
@@ -4,10 +4,10 @@
 use vortex_array::ArrayRef;
 use vortex_array::vtable::ValidityChild;
 
-use super::FoRVTable;
+use super::FoR;
 use crate::FoRArray;
 
-impl ValidityChild<FoRVTable> for FoRVTable {
+impl ValidityChild<FoR> for FoR {
     fn validity_child(array: &FoRArray) -> &ArrayRef {
         array.encoded()
     }

--- a/encodings/fastlanes/src/lib.rs
+++ b/encodings/fastlanes/src/lib.rs
@@ -26,12 +26,10 @@ mod test {
 
     pub static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
         let session = VortexSession::empty();
-        session
-            .arrays()
-            .register(BitPackedVTable::ID, BitPackedVTable);
-        session.arrays().register(DeltaVTable::ID, DeltaVTable);
-        session.arrays().register(FoRVTable::ID, FoRVTable);
-        session.arrays().register(RLEVTable::ID, RLEVTable);
+        session.arrays().register(BitPacked::ID, BitPacked);
+        session.arrays().register(Delta::ID, Delta);
+        session.arrays().register(FoR::ID, FoR);
+        session.arrays().register(RLE::ID, RLE);
         session
     });
 }

--- a/encodings/fastlanes/src/rle/compute/cast.rs
+++ b/encodings/fastlanes/src/rle/compute/cast.rs
@@ -8,10 +8,10 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::rle::RLE;
 use crate::rle::RLEArray;
-use crate::rle::RLEVTable;
 
-impl CastReduce for RLEVTable {
+impl CastReduce for RLE {
     fn cast(array: &RLEArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // Cast RLE values.
         let casted_values = array.values().cast(dtype.clone())?;

--- a/encodings/fastlanes/src/rle/kernel.rs
+++ b/encodings/fastlanes/src/rle/kernel.rs
@@ -12,13 +12,13 @@ use vortex_array::kernel::ParentKernelSet;
 use vortex_error::VortexResult;
 
 use crate::FL_CHUNK_SIZE;
+use crate::RLE;
 use crate::RLEArray;
-use crate::RLEVTable;
 
-pub(crate) static PARENT_KERNELS: ParentKernelSet<RLEVTable> =
-    ParentKernelSet::new(&[ParentKernelSet::lift(&SliceExecuteAdaptor(RLEVTable))]);
+pub(crate) static PARENT_KERNELS: ParentKernelSet<RLE> =
+    ParentKernelSet::new(&[ParentKernelSet::lift(&SliceExecuteAdaptor(RLE))]);
 
-impl SliceKernel for RLEVTable {
+impl SliceKernel for RLE {
     fn slice(
         array: &RLEArray,
         range: Range<usize>,

--- a/encodings/fastlanes/src/rle/mod.rs
+++ b/encodings/fastlanes/src/rle/mod.rs
@@ -8,4 +8,4 @@ mod compute;
 mod kernel;
 
 mod vtable;
-pub use vtable::RLEVTable;
+pub use vtable::RLE;

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -54,7 +54,7 @@ pub struct RLEMetadata {
     pub offset: u64,
 }
 
-impl VTable for RLEVTable {
+impl VTable for RLE {
     type Array = RLEArray;
 
     type Metadata = ProstMetadata<RLEMetadata>;
@@ -239,9 +239,9 @@ impl VTable for RLEVTable {
 }
 
 #[derive(Debug)]
-pub struct RLEVTable;
+pub struct RLE;
 
-impl RLEVTable {
+impl RLE {
     pub const ID: ArrayId = ArrayId::new_ref("fastlanes.rle");
 }
 

--- a/encodings/fastlanes/src/rle/vtable/operations.rs
+++ b/encodings/fastlanes/src/rle/vtable/operations.rs
@@ -6,11 +6,11 @@ use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
-use super::RLEVTable;
+use super::RLE;
 use crate::FL_CHUNK_SIZE;
 use crate::RLEArray;
 
-impl OperationsVTable<RLEVTable> for RLEVTable {
+impl OperationsVTable<RLE> for RLE {
     fn scalar_at(array: &RLEArray, index: usize) -> VortexResult<Scalar> {
         let offset_in_chunk = array.offset();
         let chunk_relative_idx = array.indices().scalar_at(offset_in_chunk + index)?;

--- a/encodings/fastlanes/src/rle/vtable/rules.rs
+++ b/encodings/fastlanes/src/rle/vtable/rules.rs
@@ -4,7 +4,7 @@
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 
-use crate::RLEVTable;
+use crate::RLE;
 
-pub(crate) const RULES: ParentRuleSet<RLEVTable> =
-    ParentRuleSet::new(&[ParentRuleSet::lift(&CastReduceAdaptor(RLEVTable))]);
+pub(crate) const RULES: ParentRuleSet<RLE> =
+    ParentRuleSet::new(&[ParentRuleSet::lift(&CastReduceAdaptor(RLE))]);

--- a/encodings/fastlanes/src/rle/vtable/validity.rs
+++ b/encodings/fastlanes/src/rle/vtable/validity.rs
@@ -5,10 +5,10 @@ use vortex_array::ArrayRef;
 use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityChildSliceHelper;
 
-use super::RLEVTable;
+use super::RLE;
 use crate::RLEArray;
 
-impl ValidityChild<RLEVTable> for RLEVTable {
+impl ValidityChild<RLE> for RLE {
     fn validity_child(array: &RLEArray) -> &ArrayRef {
         array.indices()
     }

--- a/encodings/fsst/public-api.lock
+++ b/encodings/fsst/public-api.lock
@@ -1,5 +1,95 @@
 pub mod vortex_fsst
 
+pub struct vortex_fsst::FSST
+
+impl vortex_fsst::FSST
+
+pub const vortex_fsst::FSST::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_fsst::FSST
+
+pub fn vortex_fsst::FSST::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_fsst::FSST
+
+pub fn vortex_fsst::FSST::take(array: &vortex_fsst::FSSTArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_fsst::FSST
+
+pub fn vortex_fsst::FSST::filter(array: &vortex_fsst::FSSTArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_fsst::FSST
+
+pub fn vortex_fsst::FSST::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_fsst::FSST
+
+pub fn vortex_fsst::FSST::compare(lhs: &vortex_fsst::FSSTArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fsst::FSST
+
+pub fn vortex_fsst::FSST::cast(array: &vortex_fsst::FSSTArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_fsst::FSST
+
+pub type vortex_fsst::FSST::Array = vortex_fsst::FSSTArray
+
+pub type vortex_fsst::FSST::Metadata = vortex_array::metadata::ProstMetadata<vortex_fsst::FSSTMetadata>
+
+pub type vortex_fsst::FSST::OperationsVTable = vortex_fsst::FSST
+
+pub type vortex_fsst::FSST::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
+
+pub fn vortex_fsst::FSST::append_to_builder(array: &vortex_fsst::FSSTArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_fsst::FSST::array_eq(array: &vortex_fsst::FSSTArray, other: &vortex_fsst::FSSTArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_fsst::FSST::array_hash<H: core::hash::Hasher>(array: &vortex_fsst::FSSTArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_fsst::FSST::buffer(array: &vortex_fsst::FSSTArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_fsst::FSST::buffer_name(_array: &vortex_fsst::FSSTArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_fsst::FSST::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_fsst::FSSTArray>
+
+pub fn vortex_fsst::FSST::child(array: &vortex_fsst::FSSTArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_fsst::FSST::child_name(_array: &vortex_fsst::FSSTArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_fsst::FSST::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_fsst::FSST::dtype(array: &vortex_fsst::FSSTArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_fsst::FSST::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_fsst::FSST::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_fsst::FSST::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_fsst::FSST::len(array: &vortex_fsst::FSSTArray) -> usize
+
+pub fn vortex_fsst::FSST::metadata(array: &vortex_fsst::FSSTArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_fsst::FSST::nbuffers(_array: &vortex_fsst::FSSTArray) -> usize
+
+pub fn vortex_fsst::FSST::nchildren(array: &vortex_fsst::FSSTArray) -> usize
+
+pub fn vortex_fsst::FSST::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_fsst::FSST::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_fsst::FSST::stats(array: &vortex_fsst::FSSTArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_fsst::FSST::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_fsst::FSST> for vortex_fsst::FSST
+
+pub fn vortex_fsst::FSST::scalar_at(array: &vortex_fsst::FSSTArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::validity::ValidityChild<vortex_fsst::FSST> for vortex_fsst::FSST
+
+pub fn vortex_fsst::FSST::validity_child(array: &vortex_fsst::FSSTArray) -> &vortex_array::array::ArrayRef
+
 pub struct vortex_fsst::FSSTArray
 
 impl vortex_fsst::FSSTArray
@@ -85,96 +175,6 @@ impl prost::message::Message for vortex_fsst::FSSTMetadata
 pub fn vortex_fsst::FSSTMetadata::clear(&mut self)
 
 pub fn vortex_fsst::FSSTMetadata::encoded_len(&self) -> usize
-
-pub struct vortex_fsst::FSSTVTable
-
-impl vortex_fsst::FSSTVTable
-
-pub const vortex_fsst::FSSTVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_fsst::FSSTVTable
-
-pub fn vortex_fsst::FSSTVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_fsst::FSSTVTable
-
-pub fn vortex_fsst::FSSTVTable::take(array: &vortex_fsst::FSSTArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_fsst::FSSTVTable
-
-pub fn vortex_fsst::FSSTVTable::filter(array: &vortex_fsst::FSSTArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_fsst::FSSTVTable
-
-pub fn vortex_fsst::FSSTVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_fsst::FSSTVTable
-
-pub fn vortex_fsst::FSSTVTable::compare(lhs: &vortex_fsst::FSSTArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fsst::FSSTVTable
-
-pub fn vortex_fsst::FSSTVTable::cast(array: &vortex_fsst::FSSTArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_fsst::FSSTVTable
-
-pub type vortex_fsst::FSSTVTable::Array = vortex_fsst::FSSTArray
-
-pub type vortex_fsst::FSSTVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_fsst::FSSTMetadata>
-
-pub type vortex_fsst::FSSTVTable::OperationsVTable = vortex_fsst::FSSTVTable
-
-pub type vortex_fsst::FSSTVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
-
-pub fn vortex_fsst::FSSTVTable::append_to_builder(array: &vortex_fsst::FSSTArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_fsst::FSSTVTable::array_eq(array: &vortex_fsst::FSSTArray, other: &vortex_fsst::FSSTArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_fsst::FSSTVTable::array_hash<H: core::hash::Hasher>(array: &vortex_fsst::FSSTArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_fsst::FSSTVTable::buffer(array: &vortex_fsst::FSSTArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_fsst::FSSTVTable::buffer_name(_array: &vortex_fsst::FSSTArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_fsst::FSSTVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_fsst::FSSTArray>
-
-pub fn vortex_fsst::FSSTVTable::child(array: &vortex_fsst::FSSTArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_fsst::FSSTVTable::child_name(_array: &vortex_fsst::FSSTArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_fsst::FSSTVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_fsst::FSSTVTable::dtype(array: &vortex_fsst::FSSTArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_fsst::FSSTVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_fsst::FSSTVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_fsst::FSSTVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_fsst::FSSTVTable::len(array: &vortex_fsst::FSSTArray) -> usize
-
-pub fn vortex_fsst::FSSTVTable::metadata(array: &vortex_fsst::FSSTArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_fsst::FSSTVTable::nbuffers(_array: &vortex_fsst::FSSTArray) -> usize
-
-pub fn vortex_fsst::FSSTVTable::nchildren(array: &vortex_fsst::FSSTArray) -> usize
-
-pub fn vortex_fsst::FSSTVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_fsst::FSSTVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_fsst::FSSTVTable::stats(array: &vortex_fsst::FSSTArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_fsst::FSSTVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_fsst::FSSTVTable> for vortex_fsst::FSSTVTable
-
-pub fn vortex_fsst::FSSTVTable::scalar_at(array: &vortex_fsst::FSSTArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::validity::ValidityChild<vortex_fsst::FSSTVTable> for vortex_fsst::FSSTVTable
-
-pub fn vortex_fsst::FSSTVTable::validity_child(array: &vortex_fsst::FSSTArray) -> &vortex_array::array::ArrayRef
 
 pub fn vortex_fsst::fsst_compress<A: vortex_array::accessor::ArrayAccessor<[u8]> + core::convert::AsRef<dyn vortex_array::array::DynArray>>(strings: A, compressor: &fsst::Compressor) -> vortex_fsst::FSSTArray
 

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -22,8 +22,8 @@ use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
+use vortex_array::arrays::VarBin;
 use vortex_array::arrays::VarBinArray;
-use vortex_array::arrays::VarBinVTable;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::builders::ArrayBuilder;
 use vortex_array::builders::VarBinViewBuilder;
@@ -74,7 +74,7 @@ impl FSSTMetadata {
     }
 }
 
-impl VTable for FSSTVTable {
+impl VTable for FSST {
     type Array = FSSTArray;
 
     type Metadata = ProstMetadata<FSSTMetadata>;
@@ -229,7 +229,7 @@ impl VTable for FSSTVTable {
             }
             let codes = children.get(0, &DType::Binary(dtype.nullability()), len)?;
             let codes = codes
-                .as_opt::<VarBinVTable>()
+                .as_opt::<VarBin>()
                 .ok_or_else(|| {
                     vortex_err!(
                         "Expected VarBinArray for codes, got {}",
@@ -321,7 +321,7 @@ impl VTable for FSSTVTable {
             .ok_or_else(|| vortex_err!("FSSTArray with_children missing codes"))?;
 
         let codes = codes
-            .as_opt::<VarBinVTable>()
+            .as_opt::<VarBin>()
             .ok_or_else(|| {
                 vortex_err!(
                     "Expected VarBinArray for codes, got {}",
@@ -390,9 +390,9 @@ impl Debug for FSSTArray {
 }
 
 #[derive(Debug)]
-pub struct FSSTVTable;
+pub struct FSST;
 
-impl FSSTVTable {
+impl FSST {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.fsst");
 }
 
@@ -516,7 +516,7 @@ impl FSSTArray {
     }
 }
 
-impl ValidityChild<FSSTVTable> for FSSTVTable {
+impl ValidityChild<FSST> for FSST {
     fn validity_child(array: &FSSTArray) -> &ArrayRef {
         &array.codes_array
     }
@@ -542,7 +542,7 @@ mod test {
     use vortex_buffer::Buffer;
     use vortex_error::VortexError;
 
-    use crate::FSSTVTable;
+    use crate::FSST;
     use crate::array::FSSTMetadata;
     use crate::fsst_compress_iter;
 
@@ -599,7 +599,7 @@ mod test {
             fsst_array.uncompressed_lengths().clone(),
         ];
 
-        let fsst = FSSTVTable::build(
+        let fsst = FSST::build(
             &DType::Utf8(Nullability::NonNullable),
             2,
             &ProstMetadata(FSSTMetadata {

--- a/encodings/fsst/src/compute/cast.rs
+++ b/encodings/fsst/src/compute/cast.rs
@@ -3,16 +3,16 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
-use vortex_array::arrays::VarBinVTable;
+use vortex_array::arrays::VarBin;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::FSST;
 use crate::FSSTArray;
-use crate::FSSTVTable;
 
-impl CastReduce for FSSTVTable {
+impl CastReduce for FSST {
     fn cast(array: &FSSTArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // FSST is a string compression encoding.
         // For nullability changes, we can cast the codes and symbols arrays
@@ -29,7 +29,7 @@ impl CastReduce for FSSTVTable {
                     dtype.clone(),
                     array.symbols().clone(),
                     array.symbol_lengths().clone(),
-                    new_codes.as_::<VarBinVTable>().clone(),
+                    new_codes.as_::<VarBin>().clone(),
                     array.uncompressed_lengths().clone(),
                 )?
                 .into_array(),

--- a/encodings/fsst/src/compute/compare.rs
+++ b/encodings/fsst/src/compute/compare.rs
@@ -19,10 +19,10 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
+use crate::FSST;
 use crate::FSSTArray;
-use crate::FSSTVTable;
 
-impl CompareKernel for FSSTVTable {
+impl CompareKernel for FSST {
     fn compare(
         lhs: &FSSTArray,
         rhs: &ArrayRef,

--- a/encodings/fsst/src/compute/filter.rs
+++ b/encodings/fsst/src/compute/filter.rs
@@ -4,27 +4,27 @@
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::arrays::VarBinVTable;
+use vortex_array::arrays::VarBin;
 use vortex_array::arrays::filter::FilterKernel;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::FSST;
 use crate::FSSTArray;
-use crate::FSSTVTable;
 
-impl FilterKernel for FSSTVTable {
+impl FilterKernel for FSST {
     fn filter(
         array: &FSSTArray,
         mask: &Mask,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         // Directly invoke VarBin's FilterKernel to get a concrete VarBinArray back.
-        let filtered_codes = <VarBinVTable as FilterKernel>::filter(array.codes(), mask, ctx)?
+        let filtered_codes = <VarBin as FilterKernel>::filter(array.codes(), mask, ctx)?
             .vortex_expect("VarBin filter kernel always returns Some")
-            .try_into::<VarBinVTable>()
+            .try_into::<VarBin>()
             .ok()
-            .vortex_expect("must be VarBinVTable");
+            .vortex_expect("must be VarBin");
 
         Ok(Some(
             FSSTArray::try_new(

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -9,7 +9,7 @@ use vortex_array::ArrayRef;
 use vortex_array::DynArray;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::arrays::VarBinVTable;
+use vortex_array::arrays::VarBin;
 use vortex_array::arrays::dict::TakeExecute;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::scalar::Scalar;
@@ -17,10 +17,10 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
+use crate::FSST;
 use crate::FSSTArray;
-use crate::FSSTVTable;
 
-impl TakeExecute for FSSTVTable {
+impl TakeExecute for FSST {
     fn take(
         array: &FSSTArray,
         indices: &ArrayRef,
@@ -34,9 +34,9 @@ impl TakeExecute for FSSTVTable {
                     .union_nullability(indices.dtype().nullability()),
                 array.symbols().clone(),
                 array.symbol_lengths().clone(),
-                VarBinVTable::take(array.codes(), indices, _ctx)?
+                VarBin::take(array.codes(), indices, _ctx)?
                     .vortex_expect("cannot fail")
-                    .try_into::<VarBinVTable>()
+                    .try_into::<VarBin>()
                     .map_err(|_| vortex_err!("take for codes must return varbin array"))?,
                 array
                     .uncompressed_lengths()

--- a/encodings/fsst/src/kernel.rs
+++ b/encodings/fsst/src/kernel.rs
@@ -6,12 +6,12 @@ use vortex_array::arrays::filter::FilterExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 use vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor;
 
-use crate::FSSTVTable;
+use crate::FSST;
 
-pub(super) const PARENT_KERNELS: ParentKernelSet<FSSTVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&CompareExecuteAdaptor(FSSTVTable)),
-    ParentKernelSet::lift(&FilterExecuteAdaptor(FSSTVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(FSSTVTable)),
+pub(super) const PARENT_KERNELS: ParentKernelSet<FSST> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&CompareExecuteAdaptor(FSST)),
+    ParentKernelSet::lift(&FilterExecuteAdaptor(FSST)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(FSST)),
 ]);
 
 #[cfg(test)]
@@ -33,7 +33,7 @@ mod tests {
     use vortex_mask::Mask;
     use vortex_session::VortexSession;
 
-    use crate::FSSTVTable;
+    use crate::FSST;
     use crate::fsst_compress;
     use crate::fsst_train_compressor;
 
@@ -61,7 +61,7 @@ mod tests {
     #[test]
     fn test_fsst_filter_simple() -> VortexResult<()> {
         let fsst_array = build_test_fsst_array();
-        assert!(fsst_array.is::<FSSTVTable>());
+        assert!(fsst_array.is::<FSST>());
         assert_eq!(fsst_array.len(), 10);
 
         // Filter 1/5 elements (every 5th element: indices 0 and 5)

--- a/encodings/fsst/src/ops.rs
+++ b/encodings/fsst/src/ops.rs
@@ -8,10 +8,10 @@ use vortex_buffer::ByteBuffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
+use crate::FSST;
 use crate::FSSTArray;
-use crate::FSSTVTable;
 
-impl OperationsVTable<FSSTVTable> for FSSTVTable {
+impl OperationsVTable<FSST> for FSST {
     fn scalar_at(array: &FSSTArray, index: usize) -> VortexResult<Scalar> {
         let compressed = array.codes().scalar_at(index)?;
         let binary_datum = compressed.as_binary().value().vortex_expect("non-null");

--- a/encodings/fsst/src/rules.rs
+++ b/encodings/fsst/src/rules.rs
@@ -5,9 +5,9 @@ use vortex_array::arrays::slice::SliceReduceAdaptor;
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 
-use crate::FSSTVTable;
+use crate::FSST;
 
-pub(crate) static RULES: ParentRuleSet<FSSTVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&SliceReduceAdaptor(FSSTVTable)),
-    ParentRuleSet::lift(&CastReduceAdaptor(FSSTVTable)),
+pub(crate) static RULES: ParentRuleSet<FSST> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&SliceReduceAdaptor(FSST)),
+    ParentRuleSet::lift(&CastReduceAdaptor(FSST)),
 ]);

--- a/encodings/fsst/src/slice.rs
+++ b/encodings/fsst/src/slice.rs
@@ -5,15 +5,15 @@ use std::ops::Range;
 
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
-use vortex_array::arrays::VarBinVTable;
+use vortex_array::arrays::VarBin;
 use vortex_array::arrays::slice::SliceReduce;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
+use crate::FSST;
 use crate::FSSTArray;
-use crate::FSSTVTable;
 
-impl SliceReduce for FSSTVTable {
+impl SliceReduce for FSST {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         // SAFETY: slicing the `codes` leaves the symbol table intact
         Ok(Some(
@@ -22,8 +22,8 @@ impl SliceReduce for FSSTVTable {
                     array.dtype().clone(),
                     array.symbols().clone(),
                     array.symbol_lengths().clone(),
-                    VarBinVTable::_slice(array.codes().as_::<VarBinVTable>(), range.clone())?
-                        .try_into::<VarBinVTable>()
+                    VarBin::_slice(array.codes().as_::<VarBin>(), range.clone())?
+                        .try_into::<VarBin>()
                         .map_err(|_| vortex_err!("cannot fail conversion"))?,
                     array.uncompressed_lengths().slice(range)?,
                 )

--- a/encodings/fsst/src/tests.rs
+++ b/encodings/fsst/src/tests.rs
@@ -13,7 +13,7 @@ use vortex_array::dtype::Nullability;
 use vortex_buffer::buffer;
 use vortex_mask::Mask;
 
-use crate::FSSTVTable;
+use crate::FSST;
 use crate::fsst_compress;
 use crate::fsst_train_compressor;
 
@@ -53,7 +53,7 @@ fn test_fsst_array_ops() {
 
     // test slice
     let fsst_sliced = fsst_array.slice(1..3).unwrap();
-    assert!(fsst_sliced.is::<FSSTVTable>());
+    assert!(fsst_sliced.is::<FSST>());
     assert_eq!(fsst_sliced.len(), 2);
     assert_nth_scalar!(
         fsst_sliced,

--- a/encodings/pco/public-api.lock
+++ b/encodings/pco/public-api.lock
@@ -1,5 +1,75 @@
 pub mod vortex_pco
 
+pub struct vortex_pco::Pco
+
+impl vortex_pco::Pco
+
+pub const vortex_pco::Pco::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_pco::Pco
+
+pub fn vortex_pco::Pco::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_pco::Pco
+
+pub fn vortex_pco::Pco::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_pco::Pco
+
+pub fn vortex_pco::Pco::cast(array: &vortex_pco::PcoArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_pco::Pco
+
+pub type vortex_pco::Pco::Array = vortex_pco::PcoArray
+
+pub type vortex_pco::Pco::Metadata = vortex_array::metadata::ProstMetadata<vortex_pco::PcoMetadata>
+
+pub type vortex_pco::Pco::OperationsVTable = vortex_pco::Pco
+
+pub type vortex_pco::Pco::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromValiditySliceHelper
+
+pub fn vortex_pco::Pco::array_eq(array: &vortex_pco::PcoArray, other: &vortex_pco::PcoArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_pco::Pco::array_hash<H: core::hash::Hasher>(array: &vortex_pco::PcoArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_pco::Pco::buffer(array: &vortex_pco::PcoArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_pco::Pco::buffer_name(array: &vortex_pco::PcoArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_pco::Pco::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_pco::PcoArray>
+
+pub fn vortex_pco::Pco::child(array: &vortex_pco::PcoArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_pco::Pco::child_name(_array: &vortex_pco::PcoArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_pco::Pco::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_pco::Pco::dtype(array: &vortex_pco::PcoArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_pco::Pco::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_pco::Pco::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_pco::Pco::len(array: &vortex_pco::PcoArray) -> usize
+
+pub fn vortex_pco::Pco::metadata(array: &vortex_pco::PcoArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_pco::Pco::nbuffers(array: &vortex_pco::PcoArray) -> usize
+
+pub fn vortex_pco::Pco::nchildren(array: &vortex_pco::PcoArray) -> usize
+
+pub fn vortex_pco::Pco::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_pco::Pco::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_pco::Pco::stats(array: &vortex_pco::PcoArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_pco::Pco::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_pco::Pco> for vortex_pco::Pco
+
+pub fn vortex_pco::Pco::scalar_at(array: &vortex_pco::PcoArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
 pub struct vortex_pco::PcoArray
 
 impl vortex_pco::PcoArray
@@ -113,73 +183,3 @@ impl prost::message::Message for vortex_pco::PcoPageInfo
 pub fn vortex_pco::PcoPageInfo::clear(&mut self)
 
 pub fn vortex_pco::PcoPageInfo::encoded_len(&self) -> usize
-
-pub struct vortex_pco::PcoVTable
-
-impl vortex_pco::PcoVTable
-
-pub const vortex_pco::PcoVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_pco::PcoVTable
-
-pub fn vortex_pco::PcoVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_pco::PcoVTable
-
-pub fn vortex_pco::PcoVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_pco::PcoVTable
-
-pub fn vortex_pco::PcoVTable::cast(array: &vortex_pco::PcoArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_pco::PcoVTable
-
-pub type vortex_pco::PcoVTable::Array = vortex_pco::PcoArray
-
-pub type vortex_pco::PcoVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_pco::PcoMetadata>
-
-pub type vortex_pco::PcoVTable::OperationsVTable = vortex_pco::PcoVTable
-
-pub type vortex_pco::PcoVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromValiditySliceHelper
-
-pub fn vortex_pco::PcoVTable::array_eq(array: &vortex_pco::PcoArray, other: &vortex_pco::PcoArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_pco::PcoVTable::array_hash<H: core::hash::Hasher>(array: &vortex_pco::PcoArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_pco::PcoVTable::buffer(array: &vortex_pco::PcoArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_pco::PcoVTable::buffer_name(array: &vortex_pco::PcoArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_pco::PcoVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_pco::PcoArray>
-
-pub fn vortex_pco::PcoVTable::child(array: &vortex_pco::PcoArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_pco::PcoVTable::child_name(_array: &vortex_pco::PcoArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_pco::PcoVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_pco::PcoVTable::dtype(array: &vortex_pco::PcoArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_pco::PcoVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_pco::PcoVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_pco::PcoVTable::len(array: &vortex_pco::PcoArray) -> usize
-
-pub fn vortex_pco::PcoVTable::metadata(array: &vortex_pco::PcoArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_pco::PcoVTable::nbuffers(array: &vortex_pco::PcoArray) -> usize
-
-pub fn vortex_pco::PcoVTable::nchildren(array: &vortex_pco::PcoArray) -> usize
-
-pub fn vortex_pco::PcoVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_pco::PcoVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_pco::PcoVTable::stats(array: &vortex_pco::PcoArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_pco::PcoVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_pco::PcoVTable> for vortex_pco::PcoVTable
-
-pub fn vortex_pco::PcoVTable::scalar_at(array: &vortex_pco::PcoArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -25,8 +25,8 @@ use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::ToCanonical;
+use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::PrimitiveVTable;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::PType;
@@ -83,7 +83,7 @@ const VALUES_PER_CHUNK: usize = pco::DEFAULT_MAX_PAGE_N;
 
 vtable!(Pco);
 
-impl VTable for PcoVTable {
+impl VTable for Pco {
     type Array = PcoArray;
 
     type Metadata = ProstMetadata<PcoMetadata>;
@@ -307,9 +307,9 @@ pub(crate) fn vortex_err_from_pco(err: PcoError) -> VortexError {
 }
 
 #[derive(Debug)]
-pub struct PcoVTable;
+pub struct Pco;
 
-impl PcoVTable {
+impl Pco {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.pco");
 }
 
@@ -430,7 +430,7 @@ impl PcoArray {
     }
 
     pub fn from_array(array: ArrayRef, level: usize, nums_per_page: usize) -> VortexResult<Self> {
-        if let Some(parray) = array.as_opt::<PrimitiveVTable>() {
+        if let Some(parray) = array.as_opt::<Primitive>() {
             Self::from_primitive(parray, level, nums_per_page)
         } else {
             Err(vortex_err!("Pco can only encode primitive arrays"))
@@ -562,7 +562,7 @@ impl ValiditySliceHelper for PcoArray {
     }
 }
 
-impl OperationsVTable<PcoVTable> for PcoVTable {
+impl OperationsVTable<Pco> for Pco {
     fn scalar_at(array: &PcoArray, index: usize) -> VortexResult<Scalar> {
         array._slice(index, index + 1).decompress()?.scalar_at(0)
     }

--- a/encodings/pco/src/compute/cast.rs
+++ b/encodings/pco/src/compute/cast.rs
@@ -7,10 +7,10 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::Pco;
 use crate::PcoArray;
-use crate::PcoVTable;
 
-impl CastReduce for PcoVTable {
+impl CastReduce for Pco {
     fn cast(array: &PcoArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !dtype.is_nullable() || !array.all_valid()? {
             // TODO(joe): fixme

--- a/encodings/pco/src/rules.rs
+++ b/encodings/pco/src/rules.rs
@@ -5,9 +5,9 @@ use vortex_array::arrays::slice::SliceReduceAdaptor;
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 
-use crate::PcoVTable;
+use crate::Pco;
 
-pub(crate) static RULES: ParentRuleSet<PcoVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&SliceReduceAdaptor(PcoVTable)),
-    ParentRuleSet::lift(&CastReduceAdaptor(PcoVTable)),
+pub(crate) static RULES: ParentRuleSet<Pco> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&SliceReduceAdaptor(Pco)),
+    ParentRuleSet::lift(&CastReduceAdaptor(Pco)),
 ]);

--- a/encodings/pco/src/slice.rs
+++ b/encodings/pco/src/slice.rs
@@ -8,9 +8,9 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::slice::SliceReduce;
 use vortex_error::VortexResult;
 
-use crate::PcoVTable;
+use crate::Pco;
 
-impl SliceReduce for PcoVTable {
+impl SliceReduce for Pco {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(array._slice(range.start, range.end).into_array()))
     }

--- a/encodings/pco/src/test.rs
+++ b/encodings/pco/src/test.rs
@@ -31,12 +31,12 @@ use vortex_session::registry::ReadContext;
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
     let session = VortexSession::empty().with::<ArraySession>();
-    session.arrays().register(PcoVTable::ID, PcoVTable);
+    session.arrays().register(Pco::ID, Pco);
     session
 });
 
+use crate::Pco;
 use crate::PcoArray;
-use crate::PcoVTable;
 
 #[test]
 fn test_compress_decompress() {

--- a/encodings/runend/public-api.lock
+++ b/encodings/runend/public-api.lock
@@ -16,6 +16,108 @@ pub fn vortex_runend::decompress_bool::runend_decode_bools(ends: vortex_array::a
 
 pub fn vortex_runend::decompress_bool::runend_decode_typed_bool(run_ends: impl core::iter::traits::iterator::Iterator<Item = usize>, values: &vortex_buffer::bit::buf::BitBuffer, values_validity: vortex_mask::Mask, values_nullability: vortex_array::dtype::nullability::Nullability, length: usize) -> vortex_array::array::ArrayRef
 
+pub struct vortex_runend::RunEnd
+
+impl vortex_runend::RunEnd
+
+pub const vortex_runend::RunEnd::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::take(array: &vortex_runend::RunEndArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::filter(array: &vortex_runend::RunEndArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::compute::is_constant::IsConstantKernel for vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::is_constant(&self, array: &Self::Array, opts: &vortex_array::compute::is_constant::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::is_sorted::IsSortedKernel for vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::is_sorted(&self, array: &vortex_runend::RunEndArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_runend::RunEnd::is_strict_sorted(&self, array: &vortex_runend::RunEndArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::min_max::MinMaxKernel for vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::min_max(&self, array: &vortex_runend::RunEndArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::min_max::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::compare(lhs: &vortex_runend::RunEndArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::cast(array: &vortex_runend::RunEndArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::kernel::FillNullReduce for vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::fill_null(array: &vortex_runend::RunEndArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_runend::RunEnd
+
+pub type vortex_runend::RunEnd::Array = vortex_runend::RunEndArray
+
+pub type vortex_runend::RunEnd::Metadata = vortex_array::metadata::ProstMetadata<vortex_runend::RunEndMetadata>
+
+pub type vortex_runend::RunEnd::OperationsVTable = vortex_runend::RunEnd
+
+pub type vortex_runend::RunEnd::ValidityVTable = vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::array_eq(array: &vortex_runend::RunEndArray, other: &vortex_runend::RunEndArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_runend::RunEnd::array_hash<H: core::hash::Hasher>(array: &vortex_runend::RunEndArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_runend::RunEnd::buffer(_array: &vortex_runend::RunEndArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_runend::RunEnd::buffer_name(_array: &vortex_runend::RunEndArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_runend::RunEnd::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_runend::RunEndArray>
+
+pub fn vortex_runend::RunEnd::child(array: &vortex_runend::RunEndArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_runend::RunEnd::child_name(_array: &vortex_runend::RunEndArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_runend::RunEnd::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_runend::RunEnd::dtype(array: &vortex_runend::RunEndArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_runend::RunEnd::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_runend::RunEnd::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_runend::RunEnd::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_runend::RunEnd::len(array: &vortex_runend::RunEndArray) -> usize
+
+pub fn vortex_runend::RunEnd::metadata(array: &vortex_runend::RunEndArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_runend::RunEnd::nbuffers(_array: &vortex_runend::RunEndArray) -> usize
+
+pub fn vortex_runend::RunEnd::nchildren(_array: &vortex_runend::RunEndArray) -> usize
+
+pub fn vortex_runend::RunEnd::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_runend::RunEnd::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_runend::RunEnd::stats(array: &vortex_runend::RunEndArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_runend::RunEnd::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_runend::RunEnd> for vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::scalar_at(array: &vortex_runend::RunEndArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::validity::ValidityVTable<vortex_runend::RunEnd> for vortex_runend::RunEnd
+
+pub fn vortex_runend::RunEnd::validity(array: &vortex_runend::RunEndArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
 pub struct vortex_runend::RunEndArray
 
 impl vortex_runend::RunEndArray
@@ -111,108 +213,6 @@ impl prost::message::Message for vortex_runend::RunEndMetadata
 pub fn vortex_runend::RunEndMetadata::clear(&mut self)
 
 pub fn vortex_runend::RunEndMetadata::encoded_len(&self) -> usize
-
-pub struct vortex_runend::RunEndVTable
-
-impl vortex_runend::RunEndVTable
-
-pub const vortex_runend::RunEndVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::take(array: &vortex_runend::RunEndArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::filter(array: &vortex_runend::RunEndArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::compute::is_constant::IsConstantKernel for vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::is_constant(&self, array: &Self::Array, opts: &vortex_array::compute::is_constant::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::is_sorted::IsSortedKernel for vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::is_sorted(&self, array: &vortex_runend::RunEndArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_runend::RunEndVTable::is_strict_sorted(&self, array: &vortex_runend::RunEndArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::min_max::MinMaxKernel for vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::min_max(&self, array: &vortex_runend::RunEndArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::min_max::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::compare(lhs: &vortex_runend::RunEndArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::cast(array: &vortex_runend::RunEndArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::kernel::FillNullReduce for vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::fill_null(array: &vortex_runend::RunEndArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_runend::RunEndVTable
-
-pub type vortex_runend::RunEndVTable::Array = vortex_runend::RunEndArray
-
-pub type vortex_runend::RunEndVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_runend::RunEndMetadata>
-
-pub type vortex_runend::RunEndVTable::OperationsVTable = vortex_runend::RunEndVTable
-
-pub type vortex_runend::RunEndVTable::ValidityVTable = vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::array_eq(array: &vortex_runend::RunEndArray, other: &vortex_runend::RunEndArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_runend::RunEndVTable::array_hash<H: core::hash::Hasher>(array: &vortex_runend::RunEndArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_runend::RunEndVTable::buffer(_array: &vortex_runend::RunEndArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_runend::RunEndVTable::buffer_name(_array: &vortex_runend::RunEndArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_runend::RunEndVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_runend::RunEndArray>
-
-pub fn vortex_runend::RunEndVTable::child(array: &vortex_runend::RunEndArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_runend::RunEndVTable::child_name(_array: &vortex_runend::RunEndArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_runend::RunEndVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_runend::RunEndVTable::dtype(array: &vortex_runend::RunEndArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_runend::RunEndVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_runend::RunEndVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_runend::RunEndVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_runend::RunEndVTable::len(array: &vortex_runend::RunEndArray) -> usize
-
-pub fn vortex_runend::RunEndVTable::metadata(array: &vortex_runend::RunEndArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_runend::RunEndVTable::nbuffers(_array: &vortex_runend::RunEndArray) -> usize
-
-pub fn vortex_runend::RunEndVTable::nchildren(_array: &vortex_runend::RunEndArray) -> usize
-
-pub fn vortex_runend::RunEndVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_runend::RunEndVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_runend::RunEndVTable::stats(array: &vortex_runend::RunEndArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_runend::RunEndVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_runend::RunEndVTable> for vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::scalar_at(array: &vortex_runend::RunEndArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::validity::ValidityVTable<vortex_runend::RunEndVTable> for vortex_runend::RunEndVTable
-
-pub fn vortex_runend::RunEndVTable::validity(array: &vortex_runend::RunEndArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub fn vortex_runend::initialize(session: &mut vortex_session::VortexSession)
 

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -15,7 +15,7 @@ use vortex_array::IntoArray;
 use vortex_array::Precision;
 use vortex_array::ProstMetadata;
 use vortex_array::SerializeMetadata;
-use vortex_array::arrays::PrimitiveVTable;
+use vortex_array::arrays::Primitive;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
@@ -58,7 +58,7 @@ pub struct RunEndMetadata {
     pub offset: u64,
 }
 
-impl VTable for RunEndVTable {
+impl VTable for RunEnd {
     type Array = RunEndArray;
 
     type Metadata = ProstMetadata<RunEndMetadata>;
@@ -223,9 +223,9 @@ pub struct RunEndArrayParts {
 }
 
 #[derive(Debug)]
-pub struct RunEndVTable;
+pub struct RunEnd;
 
-impl RunEndVTable {
+impl RunEnd {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.runend");
 }
 
@@ -407,7 +407,7 @@ impl RunEndArray {
 
     /// Run the array through run-end encoding.
     pub fn encode(array: ArrayRef) -> VortexResult<Self> {
-        if let Some(parray) = array.as_opt::<PrimitiveVTable>() {
+        if let Some(parray) = array.as_opt::<Primitive>() {
             let (ends, values) = runend_encode(parray);
             // SAFETY: runend_encode handles this
             unsafe {
@@ -459,7 +459,7 @@ impl RunEndArray {
     }
 }
 
-impl ValidityVTable<RunEndVTable> for RunEndVTable {
+impl ValidityVTable<RunEnd> for RunEnd {
     fn validity(array: &RunEndArray) -> VortexResult<Validity> {
         Ok(match array.values().validity()? {
             Validity::NonNullable | Validity::AllValid => Validity::AllValid,

--- a/encodings/runend/src/compute/cast.rs
+++ b/encodings/runend/src/compute/cast.rs
@@ -8,10 +8,10 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::RunEnd;
 use crate::RunEndArray;
-use crate::RunEndVTable;
 
-impl CastReduce for RunEndVTable {
+impl CastReduce for RunEnd {
     fn cast(array: &RunEndArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // Cast the values array to the target type
         let casted_values = array.values().cast(dtype.clone())?;

--- a/encodings/runend/src/compute/compare.rs
+++ b/encodings/runend/src/compute/compare.rs
@@ -14,11 +14,11 @@ use vortex_array::scalar_fn::fns::operators::CompareOperator;
 use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_error::VortexResult;
 
+use crate::RunEnd;
 use crate::RunEndArray;
-use crate::RunEndVTable;
 use crate::decompress_bool::runend_decode_bools;
 
-impl CompareKernel for RunEndVTable {
+impl CompareKernel for RunEnd {
     fn compare(
         lhs: &RunEndArray,
         rhs: &ArrayRef,

--- a/encodings/runend/src/compute/fill_null.rs
+++ b/encodings/runend/src/compute/fill_null.rs
@@ -8,11 +8,11 @@ use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::fns::fill_null::FillNullReduce;
 use vortex_error::VortexResult;
 
+use crate::RunEnd;
 use crate::RunEndArray;
 use crate::RunEndArrayParts;
-use crate::RunEndVTable;
 
-impl FillNullReduce for RunEndVTable {
+impl FillNullReduce for RunEnd {
     fn fill_null(array: &RunEndArray, fill_value: &Scalar) -> VortexResult<Option<ArrayRef>> {
         let RunEndArrayParts { values, ends } = array.clone().into_parts();
         let new_values = values.fill_null(fill_value.clone())?;

--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -19,13 +19,13 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::RunEnd;
 use crate::RunEndArray;
-use crate::RunEndVTable;
 use crate::compute::take::take_indices_unchecked;
 
 const FILTER_TAKE_THRESHOLD: f64 = 0.1;
 
-impl FilterKernel for RunEndVTable {
+impl FilterKernel for RunEnd {
     fn filter(
         array: &RunEndArray,
         mask: &Mask,

--- a/encodings/runend/src/compute/is_constant.rs
+++ b/encodings/runend/src/compute/is_constant.rs
@@ -10,9 +10,9 @@ use vortex_array::expr::stats::Stat;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 
-use crate::RunEndVTable;
+use crate::RunEnd;
 
-impl IsConstantKernel for RunEndVTable {
+impl IsConstantKernel for RunEnd {
     fn is_constant(
         &self,
         array: &Self::Array,
@@ -30,4 +30,4 @@ impl IsConstantKernel for RunEndVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(RunEndVTable).lift());
+register_kernel!(IsConstantKernelAdapter(RunEnd).lift());

--- a/encodings/runend/src/compute/is_sorted.rs
+++ b/encodings/runend/src/compute/is_sorted.rs
@@ -9,10 +9,10 @@ use vortex_array::compute::is_strict_sorted;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 
+use crate::RunEnd;
 use crate::RunEndArray;
-use crate::RunEndVTable;
 
-impl IsSortedKernel for RunEndVTable {
+impl IsSortedKernel for RunEnd {
     fn is_sorted(&self, array: &RunEndArray) -> VortexResult<Option<bool>> {
         is_sorted(array.values())
     }
@@ -22,4 +22,4 @@ impl IsSortedKernel for RunEndVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(RunEndVTable).lift());
+register_kernel!(IsSortedKernelAdapter(RunEnd).lift());

--- a/encodings/runend/src/compute/min_max.rs
+++ b/encodings/runend/src/compute/min_max.rs
@@ -8,13 +8,13 @@ use vortex_array::compute::min_max;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 
+use crate::RunEnd;
 use crate::RunEndArray;
-use crate::RunEndVTable;
 
-impl MinMaxKernel for RunEndVTable {
+impl MinMaxKernel for RunEnd {
     fn min_max(&self, array: &RunEndArray) -> VortexResult<Option<MinMaxResult>> {
         min_max(array.values())
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(RunEndVTable).lift());
+register_kernel!(MinMaxKernelAdapter(RunEnd).lift());

--- a/encodings/runend/src/compute/take.rs
+++ b/encodings/runend/src/compute/take.rs
@@ -20,10 +20,10 @@ use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
+use crate::RunEnd;
 use crate::RunEndArray;
-use crate::RunEndVTable;
 
-impl TakeExecute for RunEndVTable {
+impl TakeExecute for RunEnd {
     #[expect(
         clippy::cast_possible_truncation,
         reason = "index cast to usize inside macro"

--- a/encodings/runend/src/compute/take_from.rs
+++ b/encodings/runend/src/compute/take_from.rs
@@ -4,20 +4,20 @@
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Dict;
 use vortex_array::arrays::DictArray;
-use vortex_array::arrays::DictVTable;
 use vortex_array::dtype::DType;
 use vortex_array::kernel::ExecuteParentKernel;
 use vortex_error::VortexResult;
 
+use crate::RunEnd;
 use crate::RunEndArray;
-use crate::RunEndVTable;
 
 #[derive(Debug)]
-pub(crate) struct RunEndVTableTakeFrom;
+pub(crate) struct RunEndTakeFrom;
 
-impl ExecuteParentKernel<RunEndVTable> for RunEndVTableTakeFrom {
-    type Parent = DictVTable;
+impl ExecuteParentKernel<RunEnd> for RunEndTakeFrom {
+    type Parent = Dict;
 
     fn execute_parent(
         &self,
@@ -64,7 +64,7 @@ mod tests {
     use vortex_session::VortexSession;
 
     use crate::RunEndArray;
-    use crate::compute::take_from::RunEndVTableTakeFrom;
+    use crate::compute::take_from::RunEndTakeFrom;
 
     /// Build a DictArray whose codes are run-end encoded.
     ///
@@ -84,7 +84,7 @@ mod tests {
         let (codes, dict) = make_dict_with_runend_codes();
         let mut ctx = ExecutionCtx::new(VortexSession::empty());
 
-        let result = RunEndVTableTakeFrom
+        let result = RunEndTakeFrom
             .execute_parent(&codes, &dict, 0, &mut ctx)?
             .expect("kernel should return Some");
 
@@ -107,7 +107,7 @@ mod tests {
         };
         let mut ctx = ExecutionCtx::new(VortexSession::empty());
 
-        let result = RunEndVTableTakeFrom
+        let result = RunEndTakeFrom
             .execute_parent(&sliced_codes, &dict, 0, &mut ctx)?
             .expect("kernel should return Some");
 
@@ -130,7 +130,7 @@ mod tests {
         };
         let mut ctx = ExecutionCtx::new(VortexSession::empty());
 
-        let result = RunEndVTableTakeFrom
+        let result = RunEndTakeFrom
             .execute_parent(&sliced_codes, &dict, 0, &mut ctx)?
             .expect("kernel should return Some");
 
@@ -153,7 +153,7 @@ mod tests {
         };
         let mut ctx = ExecutionCtx::new(VortexSession::empty());
 
-        let result = RunEndVTableTakeFrom
+        let result = RunEndTakeFrom
             .execute_parent(&sliced_codes, &dict, 0, &mut ctx)?
             .expect("kernel should return Some");
 
@@ -167,7 +167,7 @@ mod tests {
         let (codes, dict) = make_dict_with_runend_codes();
         let mut ctx = ExecutionCtx::new(VortexSession::empty());
 
-        let result = RunEndVTableTakeFrom.execute_parent(&codes, &dict, 1, &mut ctx)?;
+        let result = RunEndTakeFrom.execute_parent(&codes, &dict, 1, &mut ctx)?;
         assert!(result.is_none());
         Ok(())
     }

--- a/encodings/runend/src/kernel.rs
+++ b/encodings/runend/src/kernel.rs
@@ -7,8 +7,8 @@ use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::Slice;
 use vortex_array::arrays::SliceArray;
-use vortex_array::arrays::SliceVTable;
 use vortex_array::arrays::dict::TakeExecuteAdaptor;
 use vortex_array::arrays::filter::FilterExecuteAdaptor;
 use vortex_array::kernel::ExecuteParentKernel;
@@ -16,16 +16,16 @@ use vortex_array::kernel::ParentKernelSet;
 use vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor;
 use vortex_error::VortexResult;
 
+use crate::RunEnd;
 use crate::RunEndArray;
-use crate::RunEndVTable;
-use crate::compute::take_from::RunEndVTableTakeFrom;
+use crate::compute::take_from::RunEndTakeFrom;
 
-pub(super) const PARENT_KERNELS: ParentKernelSet<RunEndVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&CompareExecuteAdaptor(RunEndVTable)),
+pub(super) const PARENT_KERNELS: ParentKernelSet<RunEnd> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&CompareExecuteAdaptor(RunEnd)),
     ParentKernelSet::lift(&RunEndSliceKernel),
-    ParentKernelSet::lift(&FilterExecuteAdaptor(RunEndVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(RunEndVTable)),
-    ParentKernelSet::lift(&RunEndVTableTakeFrom),
+    ParentKernelSet::lift(&FilterExecuteAdaptor(RunEnd)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(RunEnd)),
+    ParentKernelSet::lift(&RunEndTakeFrom),
 ]);
 
 /// Kernel to execute slicing on a RunEnd array.
@@ -35,8 +35,8 @@ pub(super) const PARENT_KERNELS: ParentKernelSet<RunEndVTable> = ParentKernelSet
 #[derive(Debug)]
 struct RunEndSliceKernel;
 
-impl ExecuteParentKernel<RunEndVTable> for RunEndSliceKernel {
-    type Parent = SliceVTable;
+impl ExecuteParentKernel<RunEnd> for RunEndSliceKernel {
+    type Parent = Slice;
 
     fn execute_parent(
         &self,

--- a/encodings/runend/src/lib.rs
+++ b/encodings/runend/src/lib.rs
@@ -31,7 +31,7 @@ use vortex_session::VortexSession;
 
 /// Initialize run-end encoding in the given session.
 pub fn initialize(session: &mut VortexSession) {
-    session.arrays().register(RunEndVTable::ID, RunEndVTable);
+    session.arrays().register(RunEnd::ID, RunEnd);
 }
 
 #[cfg(test)]

--- a/encodings/runend/src/ops.rs
+++ b/encodings/runend/src/ops.rs
@@ -10,10 +10,10 @@ use vortex_array::search_sorted::SearchSortedSide;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexResult;
 
+use crate::RunEnd;
 use crate::RunEndArray;
-use crate::RunEndVTable;
 
-impl OperationsVTable<RunEndVTable> for RunEndVTable {
+impl OperationsVTable<RunEnd> for RunEnd {
     fn scalar_at(array: &RunEndArray, index: usize) -> VortexResult<Scalar> {
         array.values().scalar_at(array.find_physical_index(index)?)
     }

--- a/encodings/runend/src/rules.rs
+++ b/encodings/runend/src/rules.rs
@@ -3,8 +3,8 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
-use vortex_array::arrays::ConstantVTable;
 use vortex_array::arrays::ScalarFnArray;
 use vortex_array::arrays::scalar_fn::AnyScalarFn;
 use vortex_array::dtype::DType;
@@ -14,16 +14,16 @@ use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 use vortex_array::scalar_fn::fns::fill_null::FillNullReduceAdaptor;
 use vortex_error::VortexResult;
 
+use crate::RunEnd;
 use crate::RunEndArray;
-use crate::RunEndVTable;
 
-pub(super) const RULES: ParentRuleSet<RunEndVTable> = ParentRuleSet::new(&[
+pub(super) const RULES: ParentRuleSet<RunEnd> = ParentRuleSet::new(&[
     // CastReduceAdaptor must come before RunEndScalarFnRule so that cast operations are executed
     // eagerly (surfacing out-of-range errors immediately) rather than being pushed lazily into
     // the values array by the generic scalar function push-down rule.
-    ParentRuleSet::lift(&CastReduceAdaptor(RunEndVTable)),
+    ParentRuleSet::lift(&CastReduceAdaptor(RunEnd)),
     ParentRuleSet::lift(&RunEndScalarFnRule),
-    ParentRuleSet::lift(&FillNullReduceAdaptor(RunEndVTable)),
+    ParentRuleSet::lift(&FillNullReduceAdaptor(RunEnd)),
 ]);
 
 /// A rule to push down scalar functions through run-end encoding into the values array.
@@ -32,7 +32,7 @@ pub(super) const RULES: ParentRuleSet<RunEndVTable> = ParentRuleSet::new(&[
 #[derive(Debug)]
 pub(crate) struct RunEndScalarFnRule;
 
-impl ArrayParentReduceRule<RunEndVTable> for RunEndScalarFnRule {
+impl ArrayParentReduceRule<RunEnd> for RunEndScalarFnRule {
     type Parent = AnyScalarFn;
 
     fn reduce_parent(
@@ -47,7 +47,7 @@ impl ArrayParentReduceRule<RunEndVTable> for RunEndScalarFnRule {
                 continue;
             }
 
-            if !child.is::<ConstantVTable>() {
+            if !child.is::<Constant>() {
                 // We can only push down if all other children are constants
                 return Ok(None);
             }
@@ -69,7 +69,7 @@ impl ArrayParentReduceRule<RunEndVTable> for RunEndScalarFnRule {
 
             // Replace other children with their constant scalar value with length adjusted
             // to the length of the run end values.
-            let constant = child.as_::<ConstantVTable>();
+            let constant = child.as_::<Constant>();
             *child = ConstantArray::new(constant.scalar().clone(), values_len).into_array();
         }
 

--- a/encodings/sequence/public-api.lock
+++ b/encodings/sequence/public-api.lock
@@ -1,5 +1,107 @@
 pub mod vortex_sequence
 
+pub struct vortex_sequence::Sequence
+
+impl vortex_sequence::Sequence
+
+pub const vortex_sequence::Sequence::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::take(array: &vortex_sequence::SequenceArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::filter(array: &vortex_sequence::SequenceArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::compute::is_sorted::IsSortedKernel for vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::is_sorted(&self, array: &vortex_sequence::SequenceArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_sequence::Sequence::is_strict_sorted(&self, array: &vortex_sequence::SequenceArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::min_max::MinMaxKernel for vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::min_max(&self, array: &vortex_sequence::SequenceArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::min_max::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::compare(lhs: &vortex_sequence::SequenceArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::cast(array: &vortex_sequence::SequenceArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::list_contains::kernel::ListContainsElementReduce for vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::list_contains(list: &vortex_array::array::ArrayRef, element: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_sequence::Sequence
+
+pub type vortex_sequence::Sequence::Array = vortex_sequence::SequenceArray
+
+pub type vortex_sequence::Sequence::Metadata = vortex_sequence::array::SequenceMetadata
+
+pub type vortex_sequence::Sequence::OperationsVTable = vortex_sequence::Sequence
+
+pub type vortex_sequence::Sequence::ValidityVTable = vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::array_eq(array: &vortex_sequence::SequenceArray, other: &vortex_sequence::SequenceArray, _precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_sequence::Sequence::array_hash<H: core::hash::Hasher>(array: &vortex_sequence::SequenceArray, state: &mut H, _precision: vortex_array::hash::Precision)
+
+pub fn vortex_sequence::Sequence::buffer(_array: &vortex_sequence::SequenceArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_sequence::Sequence::buffer_name(_array: &vortex_sequence::SequenceArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_sequence::Sequence::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_sequence::SequenceArray>
+
+pub fn vortex_sequence::Sequence::child(_array: &vortex_sequence::SequenceArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_sequence::Sequence::child_name(_array: &vortex_sequence::SequenceArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_sequence::Sequence::deserialize(bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_sequence::Sequence::dtype(array: &vortex_sequence::SequenceArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_sequence::Sequence::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_sequence::Sequence::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_sequence::Sequence::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_sequence::Sequence::len(array: &vortex_sequence::SequenceArray) -> usize
+
+pub fn vortex_sequence::Sequence::metadata(array: &vortex_sequence::SequenceArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_sequence::Sequence::nbuffers(_array: &vortex_sequence::SequenceArray) -> usize
+
+pub fn vortex_sequence::Sequence::nchildren(_array: &vortex_sequence::SequenceArray) -> usize
+
+pub fn vortex_sequence::Sequence::reduce_parent(array: &vortex_sequence::SequenceArray, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_sequence::Sequence::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_sequence::Sequence::stats(array: &vortex_sequence::SequenceArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_sequence::Sequence::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_sequence::Sequence> for vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::scalar_at(array: &vortex_sequence::SequenceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::validity::ValidityVTable<vortex_sequence::Sequence> for vortex_sequence::Sequence
+
+pub fn vortex_sequence::Sequence::validity(_array: &vortex_sequence::SequenceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
 pub struct vortex_sequence::SequenceArray
 
 impl vortex_sequence::SequenceArray
@@ -59,107 +161,5 @@ pub vortex_sequence::SequenceArrayParts::multiplier: vortex_array::scalar::typed
 pub vortex_sequence::SequenceArrayParts::nullability: vortex_array::dtype::nullability::Nullability
 
 pub vortex_sequence::SequenceArrayParts::ptype: vortex_array::dtype::ptype::PType
-
-pub struct vortex_sequence::SequenceVTable
-
-impl vortex_sequence::SequenceVTable
-
-pub const vortex_sequence::SequenceVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::take(array: &vortex_sequence::SequenceArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::filter(array: &vortex_sequence::SequenceArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::compute::is_sorted::IsSortedKernel for vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::is_sorted(&self, array: &vortex_sequence::SequenceArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_sequence::SequenceVTable::is_strict_sorted(&self, array: &vortex_sequence::SequenceArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::min_max::MinMaxKernel for vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::min_max(&self, array: &vortex_sequence::SequenceArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::min_max::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::compare(lhs: &vortex_sequence::SequenceArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::cast(array: &vortex_sequence::SequenceArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::list_contains::kernel::ListContainsElementReduce for vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::list_contains(list: &vortex_array::array::ArrayRef, element: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_sequence::SequenceVTable
-
-pub type vortex_sequence::SequenceVTable::Array = vortex_sequence::SequenceArray
-
-pub type vortex_sequence::SequenceVTable::Metadata = vortex_sequence::array::SequenceMetadata
-
-pub type vortex_sequence::SequenceVTable::OperationsVTable = vortex_sequence::SequenceVTable
-
-pub type vortex_sequence::SequenceVTable::ValidityVTable = vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::array_eq(array: &vortex_sequence::SequenceArray, other: &vortex_sequence::SequenceArray, _precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_sequence::SequenceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_sequence::SequenceArray, state: &mut H, _precision: vortex_array::hash::Precision)
-
-pub fn vortex_sequence::SequenceVTable::buffer(_array: &vortex_sequence::SequenceArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_sequence::SequenceVTable::buffer_name(_array: &vortex_sequence::SequenceArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_sequence::SequenceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_sequence::SequenceArray>
-
-pub fn vortex_sequence::SequenceVTable::child(_array: &vortex_sequence::SequenceArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_sequence::SequenceVTable::child_name(_array: &vortex_sequence::SequenceArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_sequence::SequenceVTable::deserialize(bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_sequence::SequenceVTable::dtype(array: &vortex_sequence::SequenceArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_sequence::SequenceVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_sequence::SequenceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_sequence::SequenceVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_sequence::SequenceVTable::len(array: &vortex_sequence::SequenceArray) -> usize
-
-pub fn vortex_sequence::SequenceVTable::metadata(array: &vortex_sequence::SequenceArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_sequence::SequenceVTable::nbuffers(_array: &vortex_sequence::SequenceArray) -> usize
-
-pub fn vortex_sequence::SequenceVTable::nchildren(_array: &vortex_sequence::SequenceArray) -> usize
-
-pub fn vortex_sequence::SequenceVTable::reduce_parent(array: &vortex_sequence::SequenceArray, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_sequence::SequenceVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_sequence::SequenceVTable::stats(array: &vortex_sequence::SequenceArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_sequence::SequenceVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_sequence::SequenceVTable> for vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::scalar_at(array: &vortex_sequence::SequenceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::validity::ValidityVTable<vortex_sequence::SequenceVTable> for vortex_sequence::SequenceVTable
-
-pub fn vortex_sequence::SequenceVTable::validity(_array: &vortex_sequence::SequenceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub fn vortex_sequence::sequence_encode(primitive_array: &vortex_array::arrays::primitive::array::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -235,7 +235,7 @@ impl SequenceArray {
     }
 }
 
-impl VTable for SequenceVTable {
+impl VTable for Sequence {
     type Array = SequenceArray;
 
     type Metadata = SequenceMetadata;
@@ -403,7 +403,7 @@ impl VTable for SequenceVTable {
     }
 }
 
-impl OperationsVTable<SequenceVTable> for SequenceVTable {
+impl OperationsVTable<Sequence> for Sequence {
     fn scalar_at(array: &SequenceArray, index: usize) -> VortexResult<Scalar> {
         Scalar::try_new(
             array.dtype().clone(),
@@ -412,16 +412,16 @@ impl OperationsVTable<SequenceVTable> for SequenceVTable {
     }
 }
 
-impl ValidityVTable<SequenceVTable> for SequenceVTable {
+impl ValidityVTable<Sequence> for Sequence {
     fn validity(_array: &SequenceArray) -> VortexResult<Validity> {
         Ok(Validity::AllValid)
     }
 }
 
 #[derive(Debug)]
-pub struct SequenceVTable;
+pub struct Sequence;
 
-impl SequenceVTable {
+impl Sequence {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.sequence");
 }
 

--- a/encodings/sequence/src/compute/cast.rs
+++ b/encodings/sequence/src/compute/cast.rs
@@ -11,10 +11,10 @@ use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
+use crate::Sequence;
 use crate::SequenceArray;
-use crate::SequenceVTable;
 
-impl CastReduce for SequenceVTable {
+impl CastReduce for Sequence {
     fn cast(array: &SequenceArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // SequenceArray represents arithmetic sequences (base + i * multiplier) which
         // only makes sense for integer types. Floating-point sequences would accumulate

--- a/encodings/sequence/src/compute/compare.rs
+++ b/encodings/sequence/src/compute/compare.rs
@@ -21,9 +21,9 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
 use crate::SequenceArray;
-use crate::array::SequenceVTable;
+use crate::array::Sequence;
 
-impl CompareKernel for SequenceVTable {
+impl CompareKernel for Sequence {
     fn compare(
         lhs: &SequenceArray,
         rhs: &ArrayRef,

--- a/encodings/sequence/src/compute/filter.rs
+++ b/encodings/sequence/src/compute/filter.rs
@@ -14,10 +14,10 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::Sequence;
 use crate::SequenceArray;
-use crate::SequenceVTable;
 
-impl FilterKernel for SequenceVTable {
+impl FilterKernel for Sequence {
     fn filter(
         array: &SequenceArray,
         mask: &Mask,

--- a/encodings/sequence/src/compute/is_sorted.rs
+++ b/encodings/sequence/src/compute/is_sorted.rs
@@ -8,10 +8,10 @@ use vortex_array::match_each_native_ptype;
 use vortex_array::register_kernel;
 use vortex_error::VortexResult;
 
+use crate::Sequence;
 use crate::SequenceArray;
-use crate::SequenceVTable;
 
-impl IsSortedKernel for SequenceVTable {
+impl IsSortedKernel for Sequence {
     fn is_sorted(&self, array: &SequenceArray) -> VortexResult<Option<bool>> {
         let m = array.multiplier();
         match_each_native_ptype!(m.ptype(), |P| {
@@ -27,4 +27,4 @@ impl IsSortedKernel for SequenceVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(SequenceVTable).lift());
+register_kernel!(IsSortedKernelAdapter(Sequence).lift());

--- a/encodings/sequence/src/compute/list_contains.rs
+++ b/encodings/sequence/src/compute/list_contains.rs
@@ -9,10 +9,10 @@ use vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduce;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
-use crate::array::SequenceVTable;
+use crate::array::Sequence;
 use crate::compute::compare::find_intersection_scalar;
 
-impl ListContainsElementReduce for SequenceVTable {
+impl ListContainsElementReduce for Sequence {
     fn list_contains(list: &ArrayRef, element: &Self::Array) -> VortexResult<Option<ArrayRef>> {
         let Some(list_scalar) = list.as_constant() else {
             return Ok(None);

--- a/encodings/sequence/src/compute/min_max.rs
+++ b/encodings/sequence/src/compute/min_max.rs
@@ -10,9 +10,9 @@ use vortex_array::scalar::Scalar;
 use vortex_error::VortexResult;
 
 use crate::SequenceArray;
-use crate::array::SequenceVTable;
+use crate::array::Sequence;
 
-impl MinMaxKernel for SequenceVTable {
+impl MinMaxKernel for Sequence {
     fn min_max(&self, array: &SequenceArray) -> VortexResult<Option<MinMaxResult>> {
         let base = array.base();
         let last = array.last();
@@ -28,4 +28,4 @@ impl MinMaxKernel for SequenceVTable {
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(SequenceVTable).lift());
+register_kernel!(MinMaxKernelAdapter(Sequence).lift());

--- a/encodings/sequence/src/compute/slice.rs
+++ b/encodings/sequence/src/compute/slice.rs
@@ -8,10 +8,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::slice::SliceReduce;
 use vortex_error::VortexResult;
 
+use crate::Sequence;
 use crate::SequenceArray;
-use crate::SequenceVTable;
 
-impl SliceReduce for SequenceVTable {
+impl SliceReduce for Sequence {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         // SAFETY: this is a slice of an already-validated `SequenceArray`, so this is still valid.
         Ok(Some(

--- a/encodings/sequence/src/compute/take.rs
+++ b/encodings/sequence/src/compute/take.rs
@@ -24,8 +24,8 @@ use vortex_error::vortex_panic;
 use vortex_mask::AllOr;
 use vortex_mask::Mask;
 
+use crate::Sequence;
 use crate::SequenceArray;
-use crate::SequenceVTable;
 
 fn take_inner<T: IntegerPType, S: NativePType>(
     mul: S,
@@ -72,7 +72,7 @@ fn take_inner<T: IntegerPType, S: NativePType>(
     }
 }
 
-impl TakeExecute for SequenceVTable {
+impl TakeExecute for Sequence {
     fn take(
         array: &SequenceArray,
         indices: &ArrayRef,

--- a/encodings/sequence/src/kernel.rs
+++ b/encodings/sequence/src/kernel.rs
@@ -6,10 +6,10 @@ use vortex_array::arrays::filter::FilterExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 use vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor;
 
-use crate::SequenceVTable;
+use crate::Sequence;
 
-pub(crate) const PARENT_KERNELS: ParentKernelSet<SequenceVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&CompareExecuteAdaptor(SequenceVTable)),
-    ParentKernelSet::lift(&FilterExecuteAdaptor(SequenceVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(SequenceVTable)),
+pub(crate) const PARENT_KERNELS: ParentKernelSet<Sequence> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&CompareExecuteAdaptor(Sequence)),
+    ParentKernelSet::lift(&FilterExecuteAdaptor(Sequence)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(Sequence)),
 ]);

--- a/encodings/sequence/src/lib.rs
+++ b/encodings/sequence/src/lib.rs
@@ -9,11 +9,11 @@ mod rules;
 
 /// Represents the equation A\[i\] = a * i + b.
 /// This can be used for compression, fast comparisons and also for row ids.
-pub use array::SequenceArray;
-pub use array::SequenceArrayParts;
+pub use array::Sequence;
 /// Represents the equation A\[i\] = a * i + b.
 /// This can be used for compression, fast comparisons and also for row ids.
-pub use array::SequenceVTable;
+pub use array::SequenceArray;
+pub use array::SequenceArrayParts;
 pub use compress::sequence_encode;
 
 // TODO(joe): hook up to the compressor

--- a/encodings/sequence/src/rules.rs
+++ b/encodings/sequence/src/rules.rs
@@ -6,10 +6,10 @@ use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 use vortex_array::scalar_fn::fns::list_contains::ListContainsElementReduceAdaptor;
 
-use crate::SequenceVTable;
+use crate::Sequence;
 
-pub(crate) static RULES: ParentRuleSet<SequenceVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&CastReduceAdaptor(SequenceVTable)),
-    ParentRuleSet::lift(&ListContainsElementReduceAdaptor(SequenceVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(SequenceVTable)),
+pub(crate) static RULES: ParentRuleSet<Sequence> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(Sequence)),
+    ParentRuleSet::lift(&ListContainsElementReduceAdaptor(Sequence)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(Sequence)),
 ]);

--- a/encodings/sparse/public-api.lock
+++ b/encodings/sparse/public-api.lock
@@ -20,6 +20,94 @@ pub fn vortex_sparse::ProstPatchesMetadata::clear(&mut self)
 
 pub fn vortex_sparse::ProstPatchesMetadata::encoded_len(&self) -> usize
 
+pub struct vortex_sparse::Sparse
+
+impl vortex_sparse::Sparse
+
+pub const vortex_sparse::Sparse::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_sparse::Sparse
+
+pub fn vortex_sparse::Sparse::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_sparse::Sparse
+
+pub fn vortex_sparse::Sparse::take(array: &vortex_sparse::SparseArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_sparse::Sparse
+
+pub fn vortex_sparse::Sparse::filter(array: &vortex_sparse::SparseArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceKernel for vortex_sparse::Sparse
+
+pub fn vortex_sparse::Sparse::slice(array: &vortex_sparse::SparseArray, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_sparse::Sparse
+
+pub fn vortex_sparse::Sparse::cast(array: &vortex_sparse::SparseArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::not::kernel::NotReduce for vortex_sparse::Sparse
+
+pub fn vortex_sparse::Sparse::invert(array: &vortex_sparse::SparseArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_sparse::Sparse
+
+pub type vortex_sparse::Sparse::Array = vortex_sparse::SparseArray
+
+pub type vortex_sparse::Sparse::Metadata = vortex_sparse::SparseMetadata
+
+pub type vortex_sparse::Sparse::OperationsVTable = vortex_sparse::Sparse
+
+pub type vortex_sparse::Sparse::ValidityVTable = vortex_sparse::Sparse
+
+pub fn vortex_sparse::Sparse::array_eq(array: &vortex_sparse::SparseArray, other: &vortex_sparse::SparseArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_sparse::Sparse::array_hash<H: core::hash::Hasher>(array: &vortex_sparse::SparseArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_sparse::Sparse::buffer(array: &vortex_sparse::SparseArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_sparse::Sparse::buffer_name(_array: &vortex_sparse::SparseArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_sparse::Sparse::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_sparse::SparseArray>
+
+pub fn vortex_sparse::Sparse::child(array: &vortex_sparse::SparseArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_sparse::Sparse::child_name(_array: &vortex_sparse::SparseArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_sparse::Sparse::deserialize(bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_sparse::Sparse::dtype(array: &vortex_sparse::SparseArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_sparse::Sparse::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_sparse::Sparse::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_sparse::Sparse::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_sparse::Sparse::len(array: &vortex_sparse::SparseArray) -> usize
+
+pub fn vortex_sparse::Sparse::metadata(array: &vortex_sparse::SparseArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_sparse::Sparse::nbuffers(_array: &vortex_sparse::SparseArray) -> usize
+
+pub fn vortex_sparse::Sparse::nchildren(array: &vortex_sparse::SparseArray) -> usize
+
+pub fn vortex_sparse::Sparse::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_sparse::Sparse::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_sparse::Sparse::stats(array: &vortex_sparse::SparseArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_sparse::Sparse::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_sparse::Sparse> for vortex_sparse::Sparse
+
+pub fn vortex_sparse::Sparse::scalar_at(array: &vortex_sparse::SparseArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::validity::ValidityVTable<vortex_sparse::Sparse> for vortex_sparse::Sparse
+
+pub fn vortex_sparse::Sparse::validity(array: &vortex_sparse::SparseArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
 pub struct vortex_sparse::SparseArray
 
 impl vortex_sparse::SparseArray
@@ -71,91 +159,3 @@ pub struct vortex_sparse::SparseMetadata
 impl core::fmt::Debug for vortex_sparse::SparseMetadata
 
 pub fn vortex_sparse::SparseMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-pub struct vortex_sparse::SparseVTable
-
-impl vortex_sparse::SparseVTable
-
-pub const vortex_sparse::SparseVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_sparse::SparseVTable
-
-pub fn vortex_sparse::SparseVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_sparse::SparseVTable
-
-pub fn vortex_sparse::SparseVTable::take(array: &vortex_sparse::SparseArray, indices: &vortex_array::array::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_sparse::SparseVTable
-
-pub fn vortex_sparse::SparseVTable::filter(array: &vortex_sparse::SparseArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceKernel for vortex_sparse::SparseVTable
-
-pub fn vortex_sparse::SparseVTable::slice(array: &vortex_sparse::SparseArray, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_sparse::SparseVTable
-
-pub fn vortex_sparse::SparseVTable::cast(array: &vortex_sparse::SparseArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::not::kernel::NotReduce for vortex_sparse::SparseVTable
-
-pub fn vortex_sparse::SparseVTable::invert(array: &vortex_sparse::SparseArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_sparse::SparseVTable
-
-pub type vortex_sparse::SparseVTable::Array = vortex_sparse::SparseArray
-
-pub type vortex_sparse::SparseVTable::Metadata = vortex_sparse::SparseMetadata
-
-pub type vortex_sparse::SparseVTable::OperationsVTable = vortex_sparse::SparseVTable
-
-pub type vortex_sparse::SparseVTable::ValidityVTable = vortex_sparse::SparseVTable
-
-pub fn vortex_sparse::SparseVTable::array_eq(array: &vortex_sparse::SparseArray, other: &vortex_sparse::SparseArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_sparse::SparseVTable::array_hash<H: core::hash::Hasher>(array: &vortex_sparse::SparseArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_sparse::SparseVTable::buffer(array: &vortex_sparse::SparseArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_sparse::SparseVTable::buffer_name(_array: &vortex_sparse::SparseArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_sparse::SparseVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_sparse::SparseArray>
-
-pub fn vortex_sparse::SparseVTable::child(array: &vortex_sparse::SparseArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_sparse::SparseVTable::child_name(_array: &vortex_sparse::SparseArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_sparse::SparseVTable::deserialize(bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_sparse::SparseVTable::dtype(array: &vortex_sparse::SparseArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_sparse::SparseVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_sparse::SparseVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_sparse::SparseVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_sparse::SparseVTable::len(array: &vortex_sparse::SparseArray) -> usize
-
-pub fn vortex_sparse::SparseVTable::metadata(array: &vortex_sparse::SparseArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_sparse::SparseVTable::nbuffers(_array: &vortex_sparse::SparseArray) -> usize
-
-pub fn vortex_sparse::SparseVTable::nchildren(array: &vortex_sparse::SparseArray) -> usize
-
-pub fn vortex_sparse::SparseVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_sparse::SparseVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_sparse::SparseVTable::stats(array: &vortex_sparse::SparseArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_sparse::SparseVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_sparse::SparseVTable> for vortex_sparse::SparseVTable
-
-pub fn vortex_sparse::SparseVTable::scalar_at(array: &vortex_sparse::SparseArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::validity::ValidityVTable<vortex_sparse::SparseVTable> for vortex_sparse::SparseVTable
-
-pub fn vortex_sparse::SparseVTable::validity(array: &vortex_sparse::SparseArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>

--- a/encodings/sparse/src/compute/cast.rs
+++ b/encodings/sparse/src/compute/cast.rs
@@ -8,10 +8,10 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::Sparse;
 use crate::SparseArray;
-use crate::SparseVTable;
 
-impl CastReduce for SparseVTable {
+impl CastReduce for Sparse {
     fn cast(array: &SparseArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // Cast both the patches values and the fill value
         let casted_fill = array.fill_scalar().cast(dtype)?;

--- a/encodings/sparse/src/compute/filter.rs
+++ b/encodings/sparse/src/compute/filter.rs
@@ -9,10 +9,10 @@ use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
 use crate::ConstantArray;
+use crate::Sparse;
 use crate::SparseArray;
-use crate::SparseVTable;
 
-impl FilterKernel for SparseVTable {
+impl FilterKernel for Sparse {
     fn filter(
         array: &SparseArray,
         mask: &Mask,

--- a/encodings/sparse/src/compute/take.rs
+++ b/encodings/sparse/src/compute/take.rs
@@ -9,10 +9,10 @@ use vortex_array::arrays::dict::TakeExecute;
 use vortex_error::VortexResult;
 
 use crate::ConstantArray;
+use crate::Sparse;
 use crate::SparseArray;
-use crate::SparseVTable;
 
-impl TakeExecute for SparseVTable {
+impl TakeExecute for Sparse {
     fn take(
         array: &SparseArray,
         indices: &ArrayRef,

--- a/encodings/sparse/src/kernel.rs
+++ b/encodings/sparse/src/kernel.rs
@@ -6,10 +6,10 @@ use vortex_array::arrays::filter::FilterExecuteAdaptor;
 use vortex_array::arrays::slice::SliceExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 
-use crate::SparseVTable;
+use crate::Sparse;
 
-pub(crate) static PARENT_KERNELS: ParentKernelSet<SparseVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&FilterExecuteAdaptor(SparseVTable)),
-    ParentKernelSet::lift(&SliceExecuteAdaptor(SparseVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(SparseVTable)),
+pub(crate) static PARENT_KERNELS: ParentKernelSet<Sparse> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&FilterExecuteAdaptor(Sparse)),
+    ParentKernelSet::lift(&SliceExecuteAdaptor(Sparse)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(Sparse)),
 ]);

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -73,7 +73,7 @@ pub struct ProstPatchesMetadata {
     patches: PatchesMetadata,
 }
 
-impl VTable for SparseVTable {
+impl VTable for Sparse {
     type Array = SparseArray;
 
     type Metadata = SparseMetadata;
@@ -269,9 +269,9 @@ pub struct SparseArray {
 }
 
 #[derive(Debug)]
-pub struct SparseVTable;
+pub struct Sparse;
 
-impl SparseVTable {
+impl Sparse {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.sparse");
 }
 
@@ -465,7 +465,7 @@ impl SparseArray {
     }
 }
 
-impl ValidityVTable<SparseVTable> for SparseVTable {
+impl ValidityVTable<Sparse> for Sparse {
     fn validity(array: &SparseArray) -> VortexResult<Validity> {
         let patches = unsafe {
             Patches::new_unchecked(

--- a/encodings/sparse/src/ops.rs
+++ b/encodings/sparse/src/ops.rs
@@ -5,10 +5,10 @@ use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexResult;
 
+use crate::Sparse;
 use crate::SparseArray;
-use crate::SparseVTable;
 
-impl OperationsVTable<SparseVTable> for SparseVTable {
+impl OperationsVTable<Sparse> for Sparse {
     fn scalar_at(array: &SparseArray, index: usize) -> VortexResult<Scalar> {
         Ok(array
             .patches()

--- a/encodings/sparse/src/rules.rs
+++ b/encodings/sparse/src/rules.rs
@@ -10,15 +10,15 @@ use vortex_array::scalar_fn::fns::not::NotReduce;
 use vortex_array::scalar_fn::fns::not::NotReduceAdaptor;
 use vortex_error::VortexResult;
 
+use crate::Sparse;
 use crate::SparseArray;
-use crate::SparseVTable;
 
-pub(crate) static RULES: ParentRuleSet<SparseVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&CastReduceAdaptor(SparseVTable)),
-    ParentRuleSet::lift(&NotReduceAdaptor(SparseVTable)),
+pub(crate) static RULES: ParentRuleSet<Sparse> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(Sparse)),
+    ParentRuleSet::lift(&NotReduceAdaptor(Sparse)),
 ]);
 
-impl NotReduce for SparseVTable {
+impl NotReduce for Sparse {
     fn invert(array: &SparseArray) -> VortexResult<Option<ArrayRef>> {
         let inverted_fill = array.fill_scalar().as_bool().invert().into_scalar();
         let inverted_patches = array.patches().clone().map_values(|values| values.not())?;

--- a/encodings/sparse/src/slice.rs
+++ b/encodings/sparse/src/slice.rs
@@ -10,10 +10,10 @@ use vortex_array::arrays::slice::SliceKernel;
 use vortex_error::VortexResult;
 
 use crate::ConstantArray;
+use crate::Sparse;
 use crate::SparseArray;
-use crate::SparseVTable;
 
-impl SliceKernel for SparseVTable {
+impl SliceKernel for Sparse {
     fn slice(
         array: &SparseArray,
         range: Range<usize>,

--- a/encodings/zigzag/public-api.lock
+++ b/encodings/zigzag/public-api.lock
@@ -1,5 +1,93 @@
 pub mod vortex_zigzag
 
+pub struct vortex_zigzag::ZigZag
+
+impl vortex_zigzag::ZigZag
+
+pub const vortex_zigzag::ZigZag::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_zigzag::ZigZag
+
+pub fn vortex_zigzag::ZigZag::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::take::TakeExecute for vortex_zigzag::ZigZag
+
+pub fn vortex_zigzag::ZigZag::take(array: &vortex_zigzag::ZigZagArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_zigzag::ZigZag
+
+pub fn vortex_zigzag::ZigZag::filter(array: &vortex_zigzag::ZigZagArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_zigzag::ZigZag
+
+pub fn vortex_zigzag::ZigZag::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_zigzag::ZigZag
+
+pub fn vortex_zigzag::ZigZag::cast(array: &vortex_zigzag::ZigZagArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_zigzag::ZigZag
+
+pub fn vortex_zigzag::ZigZag::mask(array: &vortex_zigzag::ZigZagArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_zigzag::ZigZag
+
+pub type vortex_zigzag::ZigZag::Array = vortex_zigzag::ZigZagArray
+
+pub type vortex_zigzag::ZigZag::Metadata = vortex_array::metadata::EmptyMetadata
+
+pub type vortex_zigzag::ZigZag::OperationsVTable = vortex_zigzag::ZigZag
+
+pub type vortex_zigzag::ZigZag::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
+
+pub fn vortex_zigzag::ZigZag::array_eq(array: &vortex_zigzag::ZigZagArray, other: &vortex_zigzag::ZigZagArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_zigzag::ZigZag::array_hash<H: core::hash::Hasher>(array: &vortex_zigzag::ZigZagArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_zigzag::ZigZag::buffer(_array: &vortex_zigzag::ZigZagArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_zigzag::ZigZag::buffer_name(_array: &vortex_zigzag::ZigZagArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_zigzag::ZigZag::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_zigzag::ZigZagArray>
+
+pub fn vortex_zigzag::ZigZag::child(array: &vortex_zigzag::ZigZagArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_zigzag::ZigZag::child_name(_array: &vortex_zigzag::ZigZagArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_zigzag::ZigZag::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_zigzag::ZigZag::dtype(array: &vortex_zigzag::ZigZagArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_zigzag::ZigZag::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_zigzag::ZigZag::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_zigzag::ZigZag::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_zigzag::ZigZag::len(array: &vortex_zigzag::ZigZagArray) -> usize
+
+pub fn vortex_zigzag::ZigZag::metadata(_array: &vortex_zigzag::ZigZagArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_zigzag::ZigZag::nbuffers(_array: &vortex_zigzag::ZigZagArray) -> usize
+
+pub fn vortex_zigzag::ZigZag::nchildren(_array: &vortex_zigzag::ZigZagArray) -> usize
+
+pub fn vortex_zigzag::ZigZag::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_zigzag::ZigZag::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_zigzag::ZigZag::stats(array: &vortex_zigzag::ZigZagArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_zigzag::ZigZag::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_zigzag::ZigZag> for vortex_zigzag::ZigZag
+
+pub fn vortex_zigzag::ZigZag::scalar_at(array: &vortex_zigzag::ZigZagArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::validity::ValidityChild<vortex_zigzag::ZigZag> for vortex_zigzag::ZigZag
+
+pub fn vortex_zigzag::ZigZag::validity_child(array: &vortex_zigzag::ZigZagArray) -> &vortex_array::array::ArrayRef
+
 pub struct vortex_zigzag::ZigZagArray
 
 impl vortex_zigzag::ZigZagArray
@@ -41,94 +129,6 @@ pub fn vortex_zigzag::ZigZagArray::deref(&self) -> &Self::Target
 impl vortex_array::array::IntoArray for vortex_zigzag::ZigZagArray
 
 pub fn vortex_zigzag::ZigZagArray::into_array(self) -> vortex_array::array::ArrayRef
-
-pub struct vortex_zigzag::ZigZagVTable
-
-impl vortex_zigzag::ZigZagVTable
-
-pub const vortex_zigzag::ZigZagVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_zigzag::ZigZagVTable
-
-pub fn vortex_zigzag::ZigZagVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::take::TakeExecute for vortex_zigzag::ZigZagVTable
-
-pub fn vortex_zigzag::ZigZagVTable::take(array: &vortex_zigzag::ZigZagArray, indices: &vortex_array::array::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_zigzag::ZigZagVTable
-
-pub fn vortex_zigzag::ZigZagVTable::filter(array: &vortex_zigzag::ZigZagArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_zigzag::ZigZagVTable
-
-pub fn vortex_zigzag::ZigZagVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_zigzag::ZigZagVTable
-
-pub fn vortex_zigzag::ZigZagVTable::cast(array: &vortex_zigzag::ZigZagArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::kernel::MaskReduce for vortex_zigzag::ZigZagVTable
-
-pub fn vortex_zigzag::ZigZagVTable::mask(array: &vortex_zigzag::ZigZagArray, mask: &vortex_array::array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_zigzag::ZigZagVTable
-
-pub type vortex_zigzag::ZigZagVTable::Array = vortex_zigzag::ZigZagArray
-
-pub type vortex_zigzag::ZigZagVTable::Metadata = vortex_array::metadata::EmptyMetadata
-
-pub type vortex_zigzag::ZigZagVTable::OperationsVTable = vortex_zigzag::ZigZagVTable
-
-pub type vortex_zigzag::ZigZagVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromChild
-
-pub fn vortex_zigzag::ZigZagVTable::array_eq(array: &vortex_zigzag::ZigZagArray, other: &vortex_zigzag::ZigZagArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_zigzag::ZigZagVTable::array_hash<H: core::hash::Hasher>(array: &vortex_zigzag::ZigZagArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_zigzag::ZigZagVTable::buffer(_array: &vortex_zigzag::ZigZagArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_zigzag::ZigZagVTable::buffer_name(_array: &vortex_zigzag::ZigZagArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_zigzag::ZigZagVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_zigzag::ZigZagArray>
-
-pub fn vortex_zigzag::ZigZagVTable::child(array: &vortex_zigzag::ZigZagArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_zigzag::ZigZagVTable::child_name(_array: &vortex_zigzag::ZigZagArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_zigzag::ZigZagVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_zigzag::ZigZagVTable::dtype(array: &vortex_zigzag::ZigZagArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_zigzag::ZigZagVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_zigzag::ZigZagVTable::execute_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_zigzag::ZigZagVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_zigzag::ZigZagVTable::len(array: &vortex_zigzag::ZigZagArray) -> usize
-
-pub fn vortex_zigzag::ZigZagVTable::metadata(_array: &vortex_zigzag::ZigZagArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_zigzag::ZigZagVTable::nbuffers(_array: &vortex_zigzag::ZigZagArray) -> usize
-
-pub fn vortex_zigzag::ZigZagVTable::nchildren(_array: &vortex_zigzag::ZigZagArray) -> usize
-
-pub fn vortex_zigzag::ZigZagVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_zigzag::ZigZagVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_zigzag::ZigZagVTable::stats(array: &vortex_zigzag::ZigZagArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_zigzag::ZigZagVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_zigzag::ZigZagVTable> for vortex_zigzag::ZigZagVTable
-
-pub fn vortex_zigzag::ZigZagVTable::scalar_at(array: &vortex_zigzag::ZigZagArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::validity::ValidityChild<vortex_zigzag::ZigZagVTable> for vortex_zigzag::ZigZagVTable
-
-pub fn vortex_zigzag::ZigZagVTable::validity_child(array: &vortex_zigzag::ZigZagArray) -> &vortex_array::array::ArrayRef
 
 pub fn vortex_zigzag::zigzag_decode(parray: vortex_array::arrays::primitive::array::PrimitiveArray) -> vortex_array::arrays::primitive::array::PrimitiveArray
 

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -41,7 +41,7 @@ use crate::zigzag_decode;
 
 vtable!(ZigZag);
 
-impl VTable for ZigZagVTable {
+impl VTable for ZigZag {
     type Array = ZigZagArray;
 
     type Metadata = EmptyMetadata;
@@ -181,9 +181,9 @@ pub struct ZigZagArray {
 }
 
 #[derive(Debug)]
-pub struct ZigZagVTable;
+pub struct ZigZag;
 
-impl ZigZagVTable {
+impl ZigZag {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.zigzag");
 }
 
@@ -217,7 +217,7 @@ impl ZigZagArray {
     }
 }
 
-impl OperationsVTable<ZigZagVTable> for ZigZagVTable {
+impl OperationsVTable<ZigZag> for ZigZag {
     fn scalar_at(array: &ZigZagArray, index: usize) -> VortexResult<Scalar> {
         let scalar = array.encoded().scalar_at(index)?;
         if scalar.is_null() {
@@ -238,7 +238,7 @@ impl OperationsVTable<ZigZagVTable> for ZigZagVTable {
     }
 }
 
-impl ValidityChild<ZigZagVTable> for ZigZagVTable {
+impl ValidityChild<ZigZag> for ZigZag {
     fn validity_child(array: &ZigZagArray) -> &ArrayRef {
         array.encoded()
     }
@@ -275,7 +275,7 @@ mod test {
         );
 
         let sliced = zigzag.slice(0..2).unwrap();
-        let sliced = sliced.as_::<ZigZagVTable>();
+        let sliced = sliced.as_::<ZigZag>();
         assert_eq!(
             sliced.scalar_at(sliced.len() - 1).unwrap(),
             Scalar::from(-5i32)

--- a/encodings/zigzag/src/compress.rs
+++ b/encodings/zigzag/src/compress.rs
@@ -76,12 +76,12 @@ mod test {
     use vortex_array::assert_arrays_eq;
 
     use super::*;
-    use crate::ZigZagVTable;
+    use crate::ZigZag;
 
     #[test]
     fn test_compress_i8() {
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i8..100)).unwrap();
-        assert!(compressed.is::<ZigZagVTable>());
+        assert!(compressed.is::<ZigZag>());
         assert_arrays_eq!(
             compressed.to_primitive(),
             PrimitiveArray::from_iter(-100_i8..100)
@@ -90,7 +90,7 @@ mod test {
     #[test]
     fn test_compress_i16() {
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i16..100)).unwrap();
-        assert!(compressed.is::<ZigZagVTable>());
+        assert!(compressed.is::<ZigZag>());
         assert_arrays_eq!(
             compressed.to_primitive(),
             PrimitiveArray::from_iter(-100_i16..100)
@@ -99,7 +99,7 @@ mod test {
     #[test]
     fn test_compress_i32() {
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i32..100)).unwrap();
-        assert!(compressed.is::<ZigZagVTable>());
+        assert!(compressed.is::<ZigZag>());
         assert_arrays_eq!(
             compressed.to_primitive(),
             PrimitiveArray::from_iter(-100_i32..100)
@@ -108,7 +108,7 @@ mod test {
     #[test]
     fn test_compress_i64() {
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i64..100)).unwrap();
-        assert!(compressed.is::<ZigZagVTable>());
+        assert!(compressed.is::<ZigZag>());
         assert_arrays_eq!(
             compressed.to_primitive(),
             PrimitiveArray::from_iter(-100_i64..100)

--- a/encodings/zigzag/src/compute/cast.rs
+++ b/encodings/zigzag/src/compute/cast.rs
@@ -8,10 +8,10 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::ZigZag;
 use crate::ZigZagArray;
-use crate::ZigZagVTable;
 
-impl CastReduce for ZigZagVTable {
+impl CastReduce for ZigZag {
     fn cast(array: &ZigZagArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !dtype.is_signed_int() {
             return Ok(None);

--- a/encodings/zigzag/src/compute/mod.rs
+++ b/encodings/zigzag/src/compute/mod.rs
@@ -16,17 +16,17 @@ use vortex_array::scalar_fn::fns::mask::MaskReduce;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::ZigZag;
 use crate::ZigZagArray;
-use crate::ZigZagVTable;
 
-impl FilterReduce for ZigZagVTable {
+impl FilterReduce for ZigZag {
     fn filter(array: &ZigZagArray, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
         let encoded = array.encoded().filter(mask.clone())?;
         Ok(Some(ZigZagArray::try_new(encoded)?.into_array()))
     }
 }
 
-impl TakeExecute for ZigZagVTable {
+impl TakeExecute for ZigZag {
     fn take(
         array: &ZigZagArray,
         indices: &ArrayRef,
@@ -37,7 +37,7 @@ impl TakeExecute for ZigZagVTable {
     }
 }
 
-impl MaskReduce for ZigZagVTable {
+impl MaskReduce for ZigZag {
     fn mask(array: &ZigZagArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let masked_encoded = MaskExpr.try_new_array(
             array.encoded().len(),

--- a/encodings/zigzag/src/kernel.rs
+++ b/encodings/zigzag/src/kernel.rs
@@ -4,7 +4,7 @@
 use vortex_array::arrays::dict::TakeExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 
-use crate::ZigZagVTable;
+use crate::ZigZag;
 
-pub(crate) const PARENT_KERNELS: ParentKernelSet<ZigZagVTable> =
-    ParentKernelSet::new(&[ParentKernelSet::lift(&TakeExecuteAdaptor(ZigZagVTable))]);
+pub(crate) const PARENT_KERNELS: ParentKernelSet<ZigZag> =
+    ParentKernelSet::new(&[ParentKernelSet::lift(&TakeExecuteAdaptor(ZigZag))]);

--- a/encodings/zigzag/src/rules.rs
+++ b/encodings/zigzag/src/rules.rs
@@ -7,11 +7,11 @@ use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 use vortex_array::scalar_fn::fns::mask::MaskReduceAdaptor;
 
-use crate::ZigZagVTable;
+use crate::ZigZag;
 
-pub(crate) static RULES: ParentRuleSet<ZigZagVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&CastReduceAdaptor(ZigZagVTable)),
-    ParentRuleSet::lift(&FilterReduceAdaptor(ZigZagVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(ZigZagVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(ZigZagVTable)),
+pub(crate) static RULES: ParentRuleSet<ZigZag> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(ZigZag)),
+    ParentRuleSet::lift(&FilterReduceAdaptor(ZigZag)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(ZigZag)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(ZigZag)),
 ]);

--- a/encodings/zigzag/src/slice.rs
+++ b/encodings/zigzag/src/slice.rs
@@ -8,10 +8,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::slice::SliceReduce;
 use vortex_error::VortexResult;
 
+use crate::ZigZag;
 use crate::ZigZagArray;
-use crate::ZigZagVTable;
 
-impl SliceReduce for ZigZagVTable {
+impl SliceReduce for ZigZag {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             ZigZagArray::new(array.encoded().slice(range)?).into_array(),

--- a/encodings/zstd/public-api.lock
+++ b/encodings/zstd/public-api.lock
@@ -1,5 +1,75 @@
 pub mod vortex_zstd
 
+pub struct vortex_zstd::Zstd
+
+impl vortex_zstd::Zstd
+
+pub const vortex_zstd::Zstd::ID: vortex_array::vtable::dyn_::ArrayId
+
+impl core::fmt::Debug for vortex_zstd::Zstd
+
+pub fn vortex_zstd::Zstd::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_zstd::Zstd
+
+pub fn vortex_zstd::Zstd::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_zstd::Zstd
+
+pub fn vortex_zstd::Zstd::cast(array: &vortex_zstd::ZstdArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+impl vortex_array::vtable::VTable for vortex_zstd::Zstd
+
+pub type vortex_zstd::Zstd::Array = vortex_zstd::ZstdArray
+
+pub type vortex_zstd::Zstd::Metadata = vortex_array::metadata::ProstMetadata<vortex_zstd::ZstdMetadata>
+
+pub type vortex_zstd::Zstd::OperationsVTable = vortex_zstd::Zstd
+
+pub type vortex_zstd::Zstd::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromValiditySliceHelper
+
+pub fn vortex_zstd::Zstd::array_eq(array: &vortex_zstd::ZstdArray, other: &vortex_zstd::ZstdArray, precision: vortex_array::hash::Precision) -> bool
+
+pub fn vortex_zstd::Zstd::array_hash<H: core::hash::Hasher>(array: &vortex_zstd::ZstdArray, state: &mut H, precision: vortex_array::hash::Precision)
+
+pub fn vortex_zstd::Zstd::buffer(array: &vortex_zstd::ZstdArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_zstd::Zstd::buffer_name(array: &vortex_zstd::ZstdArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_zstd::Zstd::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_zstd::ZstdArray>
+
+pub fn vortex_zstd::Zstd::child(array: &vortex_zstd::ZstdArray, idx: usize) -> vortex_array::array::ArrayRef
+
+pub fn vortex_zstd::Zstd::child_name(_array: &vortex_zstd::ZstdArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_zstd::Zstd::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_zstd::Zstd::dtype(array: &vortex_zstd::ZstdArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_zstd::Zstd::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
+
+pub fn vortex_zstd::Zstd::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
+
+pub fn vortex_zstd::Zstd::len(array: &vortex_zstd::ZstdArray) -> usize
+
+pub fn vortex_zstd::Zstd::metadata(array: &vortex_zstd::ZstdArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_zstd::Zstd::nbuffers(array: &vortex_zstd::ZstdArray) -> usize
+
+pub fn vortex_zstd::Zstd::nchildren(array: &vortex_zstd::ZstdArray) -> usize
+
+pub fn vortex_zstd::Zstd::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+
+pub fn vortex_zstd::Zstd::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_zstd::Zstd::stats(array: &vortex_zstd::ZstdArray) -> vortex_array::stats::array::StatsSetRef<'_>
+
+pub fn vortex_zstd::Zstd::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::operations::OperationsVTable<vortex_zstd::Zstd> for vortex_zstd::Zstd
+
+pub fn vortex_zstd::Zstd::scalar_at(array: &vortex_zstd::ZstdArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
 pub struct vortex_zstd::ZstdArray
 
 impl vortex_zstd::ZstdArray
@@ -153,75 +223,5 @@ impl prost::message::Message for vortex_zstd::ZstdMetadata
 pub fn vortex_zstd::ZstdMetadata::clear(&mut self)
 
 pub fn vortex_zstd::ZstdMetadata::encoded_len(&self) -> usize
-
-pub struct vortex_zstd::ZstdVTable
-
-impl vortex_zstd::ZstdVTable
-
-pub const vortex_zstd::ZstdVTable::ID: vortex_array::vtable::dyn_::ArrayId
-
-impl core::fmt::Debug for vortex_zstd::ZstdVTable
-
-pub fn vortex_zstd::ZstdVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_zstd::ZstdVTable
-
-pub fn vortex_zstd::ZstdVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_zstd::ZstdVTable
-
-pub fn vortex_zstd::ZstdVTable::cast(array: &vortex_zstd::ZstdArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-impl vortex_array::vtable::VTable for vortex_zstd::ZstdVTable
-
-pub type vortex_zstd::ZstdVTable::Array = vortex_zstd::ZstdArray
-
-pub type vortex_zstd::ZstdVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_zstd::ZstdMetadata>
-
-pub type vortex_zstd::ZstdVTable::OperationsVTable = vortex_zstd::ZstdVTable
-
-pub type vortex_zstd::ZstdVTable::ValidityVTable = vortex_array::vtable::validity::ValidityVTableFromValiditySliceHelper
-
-pub fn vortex_zstd::ZstdVTable::array_eq(array: &vortex_zstd::ZstdArray, other: &vortex_zstd::ZstdArray, precision: vortex_array::hash::Precision) -> bool
-
-pub fn vortex_zstd::ZstdVTable::array_hash<H: core::hash::Hasher>(array: &vortex_zstd::ZstdArray, state: &mut H, precision: vortex_array::hash::Precision)
-
-pub fn vortex_zstd::ZstdVTable::buffer(array: &vortex_zstd::ZstdArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_zstd::ZstdVTable::buffer_name(array: &vortex_zstd::ZstdArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_zstd::ZstdVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_zstd::ZstdArray>
-
-pub fn vortex_zstd::ZstdVTable::child(array: &vortex_zstd::ZstdArray, idx: usize) -> vortex_array::array::ArrayRef
-
-pub fn vortex_zstd::ZstdVTable::child_name(_array: &vortex_zstd::ZstdArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_zstd::ZstdVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_zstd::ZstdVTable::dtype(array: &vortex_zstd::ZstdArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_zstd::ZstdVTable::execute(array: &Self::Array, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::executor::ExecutionStep>
-
-pub fn vortex_zstd::ZstdVTable::id(_array: &Self::Array) -> vortex_array::vtable::dyn_::ArrayId
-
-pub fn vortex_zstd::ZstdVTable::len(array: &vortex_zstd::ZstdArray) -> usize
-
-pub fn vortex_zstd::ZstdVTable::metadata(array: &vortex_zstd::ZstdArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_zstd::ZstdVTable::nbuffers(array: &vortex_zstd::ZstdArray) -> usize
-
-pub fn vortex_zstd::ZstdVTable::nchildren(array: &vortex_zstd::ZstdArray) -> usize
-
-pub fn vortex_zstd::ZstdVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
-
-pub fn vortex_zstd::ZstdVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_zstd::ZstdVTable::stats(array: &vortex_zstd::ZstdArray) -> vortex_array::stats::array::StatsSetRef<'_>
-
-pub fn vortex_zstd::ZstdVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::operations::OperationsVTable<vortex_zstd::ZstdVTable> for vortex_zstd::ZstdVTable
-
-pub fn vortex_zstd::ZstdVTable::scalar_at(array: &vortex_zstd::ZstdArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub fn vortex_zstd::reconstruct_views(buffer: &vortex_buffer::ByteBuffer) -> vortex_buffer::buffer::Buffer<vortex_array::arrays::varbinview::view::BinaryView>

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -81,7 +81,7 @@ type ViewLen = u32;
 
 vtable!(Zstd);
 
-impl VTable for ZstdVTable {
+impl VTable for Zstd {
     type Array = ZstdArray;
 
     type Metadata = ProstMetadata<ZstdMetadata>;
@@ -289,9 +289,9 @@ impl VTable for ZstdVTable {
 }
 
 #[derive(Debug)]
-pub struct ZstdVTable;
+pub struct Zstd;
 
-impl ZstdVTable {
+impl Zstd {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.zstd");
 }
 
@@ -935,7 +935,7 @@ impl ValiditySliceHelper for ZstdArray {
     }
 }
 
-impl OperationsVTable<ZstdVTable> for ZstdVTable {
+impl OperationsVTable<Zstd> for Zstd {
     fn scalar_at(array: &ZstdArray, index: usize) -> VortexResult<Scalar> {
         array._slice(index, index + 1).decompress()?.scalar_at(0)
     }

--- a/encodings/zstd/src/compute/cast.rs
+++ b/encodings/zstd/src/compute/cast.rs
@@ -8,10 +8,10 @@ use vortex_array::dtype::Nullability;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
 use vortex_error::VortexResult;
 
+use crate::Zstd;
 use crate::ZstdArray;
-use crate::ZstdVTable;
 
-impl CastReduce for ZstdVTable {
+impl CastReduce for Zstd {
     fn cast(array: &ZstdArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !dtype.eq_ignore_nullability(array.dtype()) {
             // Type changes can't be handled in ZSTD, need to decode and tweak.

--- a/encodings/zstd/src/rules.rs
+++ b/encodings/zstd/src/rules.rs
@@ -5,9 +5,9 @@ use vortex_array::arrays::slice::SliceReduceAdaptor;
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 
-use crate::ZstdVTable;
+use crate::Zstd;
 
-pub(crate) static RULES: ParentRuleSet<ZstdVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&SliceReduceAdaptor(ZstdVTable)),
-    ParentRuleSet::lift(&CastReduceAdaptor(ZstdVTable)),
+pub(crate) static RULES: ParentRuleSet<Zstd> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&SliceReduceAdaptor(Zstd)),
+    ParentRuleSet::lift(&CastReduceAdaptor(Zstd)),
 ]);

--- a/encodings/zstd/src/slice.rs
+++ b/encodings/zstd/src/slice.rs
@@ -8,10 +8,10 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::slice::SliceReduce;
 use vortex_error::VortexResult;
 
+use crate::Zstd;
 use crate::ZstdArray;
-use crate::ZstdVTable;
 
-impl SliceReduce for ZstdVTable {
+impl SliceReduce for Zstd {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(slice_zstd(array, range)))
     }

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -38,9 +38,9 @@ use crate::ZstdBuffersMetadata;
 vtable!(ZstdBuffers);
 
 #[derive(Debug)]
-pub struct ZstdBuffersVTable;
+pub struct ZstdBuffers;
 
-impl ZstdBuffersVTable {
+impl ZstdBuffers {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.zstd_buffers");
 }
 
@@ -323,7 +323,7 @@ fn array_id_from_string(s: &str) -> ArrayId {
     ArrayId::new_arc(Arc::from(s))
 }
 
-impl VTable for ZstdBuffersVTable {
+impl VTable for ZstdBuffers {
     type Array = ZstdBuffersArray;
 
     type Metadata = ProstMetadata<ZstdBuffersMetadata>;
@@ -476,7 +476,7 @@ impl VTable for ZstdBuffersVTable {
     }
 }
 
-impl OperationsVTable<ZstdBuffersVTable> for ZstdBuffersVTable {
+impl OperationsVTable<ZstdBuffers> for ZstdBuffers {
     fn scalar_at(array: &ZstdBuffersArray, index: usize) -> VortexResult<Scalar> {
         // TODO(os): maybe we should not support scalar_at, it is really slow, and adding a cache
         // layer here is weird. Valid use of zstd buffers array would be by executing it first into
@@ -486,7 +486,7 @@ impl OperationsVTable<ZstdBuffersVTable> for ZstdBuffersVTable {
     }
 }
 
-impl ValidityVTable<ZstdBuffersVTable> for ZstdBuffersVTable {
+impl ValidityVTable<ZstdBuffers> for ZstdBuffers {
     fn validity(array: &ZstdBuffersArray) -> VortexResult<vortex_array::validity::Validity> {
         if !array.dtype.is_nullable() {
             return Ok(vortex_array::validity::Validity::NonNullable);

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -396,6 +396,122 @@ pub mod vortex_array::arrays
 
 pub mod vortex_array::arrays::bool
 
+pub struct vortex_array::arrays::bool::Bool
+
+impl vortex_array::arrays::Bool
+
+pub const vortex_array::arrays::Bool::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::is_constant(&self, array: &vortex_array::arrays::BoolArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::is_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::Bool::is_strict_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::min_max(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::sum(&self, array: &vortex_array::arrays::BoolArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Bool> for vortex_array::arrays::bool::BoolMaskedValidityRule
+
+pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::Masked
+
+pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::cast(array: &vortex_array::arrays::BoolArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::fill_null(array: &vortex_array::arrays::BoolArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::mask(array: &vortex_array::arrays::BoolArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Bool> for vortex_array::arrays::Bool
+
+pub fn vortex_array::arrays::Bool::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::Bool
+
+pub type vortex_array::arrays::Bool::Array = vortex_array::arrays::BoolArray
+
+pub type vortex_array::arrays::Bool::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::bool::vtable::BoolMetadata>
+
+pub type vortex_array::arrays::Bool::OperationsVTable = vortex_array::arrays::Bool
+
+pub type vortex_array::arrays::Bool::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::Bool::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::Bool::array_eq(array: &vortex_array::arrays::BoolArray, other: &vortex_array::arrays::BoolArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::Bool::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::BoolArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::Bool::buffer(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::Bool::buffer_name(_array: &vortex_array::arrays::BoolArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::Bool::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::BoolArray>
+
+pub fn vortex_array::arrays::Bool::child(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::Bool::child_name(_array: &vortex_array::arrays::BoolArray, _idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::Bool::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Bool::dtype(array: &vortex_array::arrays::BoolArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::Bool::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::Bool::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Bool::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Bool::len(array: &vortex_array::arrays::BoolArray) -> usize
+
+pub fn vortex_array::arrays::Bool::metadata(array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Bool::nbuffers(_array: &vortex_array::arrays::BoolArray) -> usize
+
+pub fn vortex_array::arrays::Bool::nchildren(array: &vortex_array::arrays::BoolArray) -> usize
+
+pub fn vortex_array::arrays::Bool::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Bool::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Bool::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Bool::stats(array: &vortex_array::arrays::BoolArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Bool::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
 pub struct vortex_array::arrays::bool::BoolArray
 
 impl vortex_array::arrays::BoolArray
@@ -500,129 +616,131 @@ impl core::fmt::Debug for vortex_array::arrays::bool::BoolMaskedValidityRule
 
 pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Bool> for vortex_array::arrays::bool::BoolMaskedValidityRule
 
-pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::bool::BoolVTable
-
-impl vortex_array::arrays::BoolVTable
-
-pub const vortex_array::arrays::BoolVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::is_constant(&self, array: &vortex_array::arrays::BoolArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::is_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::BoolVTable::is_strict_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::min_max(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::sum(&self, array: &vortex_array::arrays::BoolArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
-
-pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::Masked
 
 pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::cast(array: &vortex_array::arrays::BoolArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::fill_null(array: &vortex_array::arrays::BoolArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::mask(array: &vortex_array::arrays::BoolArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolVTable
-
-pub fn vortex_array::arrays::BoolVTable::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::BoolVTable
-
-pub type vortex_array::arrays::BoolVTable::Array = vortex_array::arrays::BoolArray
-
-pub type vortex_array::arrays::BoolVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::bool::vtable::BoolMetadata>
-
-pub type vortex_array::arrays::BoolVTable::OperationsVTable = vortex_array::arrays::BoolVTable
-
-pub type vortex_array::arrays::BoolVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::BoolVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::BoolVTable::array_eq(array: &vortex_array::arrays::BoolArray, other: &vortex_array::arrays::BoolArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::BoolVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::BoolArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::BoolVTable::buffer(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::BoolVTable::buffer_name(_array: &vortex_array::arrays::BoolArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::BoolVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::BoolArray>
-
-pub fn vortex_array::arrays::BoolVTable::child(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::BoolVTable::child_name(_array: &vortex_array::arrays::BoolArray, _idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::BoolVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::BoolVTable::dtype(array: &vortex_array::arrays::BoolArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::BoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::BoolVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::BoolVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::BoolVTable::len(array: &vortex_array::arrays::BoolArray) -> usize
-
-pub fn vortex_array::arrays::BoolVTable::metadata(array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::BoolVTable::nbuffers(_array: &vortex_array::arrays::BoolArray) -> usize
-
-pub fn vortex_array::arrays::BoolVTable::nchildren(array: &vortex_array::arrays::BoolArray) -> usize
-
-pub fn vortex_array::arrays::BoolVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::BoolVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::BoolVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::BoolVTable::stats(array: &vortex_array::arrays::BoolArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::BoolVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub mod vortex_array::arrays::chunked
+
+pub struct vortex_array::arrays::chunked::Chunked
+
+impl vortex_array::arrays::Chunked
+
+pub const vortex_array::arrays::Chunked::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::is_constant(&self, array: &vortex_array::arrays::ChunkedArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::is_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::Chunked::is_strict_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::min_max(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::sum(&self, array: &vortex_array::arrays::ChunkedArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::cast(array: &vortex_array::arrays::ChunkedArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::fill_null(array: &vortex_array::arrays::ChunkedArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskKernel for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::mask(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::Chunked
+
+pub type vortex_array::arrays::Chunked::Array = vortex_array::arrays::ChunkedArray
+
+pub type vortex_array::arrays::Chunked::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::Chunked::OperationsVTable = vortex_array::arrays::Chunked
+
+pub type vortex_array::arrays::Chunked::ValidityVTable = vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::append_to_builder(array: &vortex_array::arrays::ChunkedArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::Chunked::array_eq(array: &vortex_array::arrays::ChunkedArray, other: &vortex_array::arrays::ChunkedArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::Chunked::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ChunkedArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::Chunked::buffer(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::Chunked::buffer_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::Chunked::build(dtype: &vortex_array::dtype::DType, _len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ChunkedArray>
+
+pub fn vortex_array::arrays::Chunked::child(array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::Chunked::child_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::Chunked::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Chunked::dtype(array: &vortex_array::arrays::ChunkedArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::Chunked::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::Chunked::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Chunked::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Chunked::len(array: &vortex_array::arrays::ChunkedArray) -> usize
+
+pub fn vortex_array::arrays::Chunked::metadata(_array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Chunked::nbuffers(_array: &vortex_array::arrays::ChunkedArray) -> usize
+
+pub fn vortex_array::arrays::Chunked::nchildren(array: &vortex_array::arrays::ChunkedArray) -> usize
+
+pub fn vortex_array::arrays::Chunked::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Chunked::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Chunked::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Chunked::stats(array: &vortex_array::arrays::ChunkedArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Chunked::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::validity(array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::chunked::ChunkedArray
 
@@ -684,125 +802,119 @@ impl vortex_array::IntoArray for vortex_array::arrays::ChunkedArray
 
 pub fn vortex_array::arrays::ChunkedArray::into_array(self) -> vortex_array::ArrayRef
 
-pub struct vortex_array::arrays::chunked::ChunkedVTable
-
-impl vortex_array::arrays::ChunkedVTable
-
-pub const vortex_array::arrays::ChunkedVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::is_constant(&self, array: &vortex_array::arrays::ChunkedArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::is_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::ChunkedVTable::is_strict_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::min_max(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::sum(&self, array: &vortex_array::arrays::ChunkedArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::cast(array: &vortex_array::arrays::ChunkedArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::fill_null(array: &vortex_array::arrays::ChunkedArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::mask(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::ChunkedVTable
-
-pub type vortex_array::arrays::ChunkedVTable::Array = vortex_array::arrays::ChunkedArray
-
-pub type vortex_array::arrays::ChunkedVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::ChunkedVTable::OperationsVTable = vortex_array::arrays::ChunkedVTable
-
-pub type vortex_array::arrays::ChunkedVTable::ValidityVTable = vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::append_to_builder(array: &vortex_array::arrays::ChunkedArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ChunkedVTable::array_eq(array: &vortex_array::arrays::ChunkedArray, other: &vortex_array::arrays::ChunkedArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::ChunkedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ChunkedArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ChunkedVTable::buffer(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ChunkedVTable::buffer_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ChunkedVTable::build(dtype: &vortex_array::dtype::DType, _len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ChunkedArray>
-
-pub fn vortex_array::arrays::ChunkedVTable::child(array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ChunkedVTable::child_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ChunkedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ChunkedVTable::dtype(array: &vortex_array::arrays::ChunkedArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ChunkedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::ChunkedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ChunkedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ChunkedVTable::len(array: &vortex_array::arrays::ChunkedArray) -> usize
-
-pub fn vortex_array::arrays::ChunkedVTable::metadata(_array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ChunkedVTable::nbuffers(_array: &vortex_array::arrays::ChunkedArray) -> usize
-
-pub fn vortex_array::arrays::ChunkedVTable::nchildren(array: &vortex_array::arrays::ChunkedArray) -> usize
-
-pub fn vortex_array::arrays::ChunkedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ChunkedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ChunkedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ChunkedVTable::stats(array: &vortex_array::arrays::ChunkedArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ChunkedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::validity(array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
 pub mod vortex_array::arrays::constant
+
+pub struct vortex_array::arrays::constant::Constant
+
+impl vortex_array::arrays::Constant
+
+pub const vortex_array::arrays::Constant::ID: vortex_array::vtable::ArrayId
+
+impl vortex_array::arrays::Constant
+
+pub const vortex_array::arrays::Constant::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
+
+impl core::fmt::Debug for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::min_max(&self, array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::sum(&self, array: &vortex_array::arrays::ConstantArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::between(array: &vortex_array::arrays::ConstantArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::cast(array: &vortex_array::arrays::ConstantArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::fill_null(array: &vortex_array::arrays::ConstantArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::not::NotReduce for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::invert(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::Constant
+
+pub type vortex_array::arrays::Constant::Array = vortex_array::arrays::ConstantArray
+
+pub type vortex_array::arrays::Constant::Metadata = vortex_array::scalar::Scalar
+
+pub type vortex_array::arrays::Constant::OperationsVTable = vortex_array::arrays::Constant
+
+pub type vortex_array::arrays::Constant::ValidityVTable = vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::Constant::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::Constant::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ConstantArray, state: &mut H, _precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::Constant::buffer(array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::Constant::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::Constant::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
+
+pub fn vortex_array::arrays::Constant::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::Constant::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::Constant::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Constant::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::Constant::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::Constant::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Constant::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Constant::len(array: &vortex_array::arrays::ConstantArray) -> usize
+
+pub fn vortex_array::arrays::Constant::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Constant::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
+
+pub fn vortex_array::arrays::Constant::nchildren(_array: &vortex_array::arrays::ConstantArray) -> usize
+
+pub fn vortex_array::arrays::Constant::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Constant::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Constant::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Constant::stats(array: &vortex_array::arrays::ConstantArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Constant::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
+
+pub fn vortex_array::arrays::Constant::validity(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::constant::ConstantArray
 
@@ -843,118 +955,6 @@ pub fn vortex_array::arrays::ConstantArray::deref(&self) -> &Self::Target
 impl vortex_array::IntoArray for vortex_array::arrays::ConstantArray
 
 pub fn vortex_array::arrays::ConstantArray::into_array(self) -> vortex_array::ArrayRef
-
-pub struct vortex_array::arrays::constant::ConstantVTable
-
-impl vortex_array::arrays::ConstantVTable
-
-pub const vortex_array::arrays::ConstantVTable::ID: vortex_array::vtable::ArrayId
-
-impl vortex_array::arrays::ConstantVTable
-
-pub const vortex_array::arrays::ConstantVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
-
-impl core::fmt::Debug for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::min_max(&self, array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::sum(&self, array: &vortex_array::arrays::ConstantArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::between(array: &vortex_array::arrays::ConstantArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::cast(array: &vortex_array::arrays::ConstantArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::fill_null(array: &vortex_array::arrays::ConstantArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::not::NotReduce for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::invert(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::ConstantVTable
-
-pub type vortex_array::arrays::ConstantVTable::Array = vortex_array::arrays::ConstantArray
-
-pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::scalar::Scalar
-
-pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::arrays::ConstantVTable
-
-pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::ConstantVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ConstantArray, state: &mut H, _precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ConstantVTable::buffer(array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ConstantVTable::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ConstantVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
-
-pub fn vortex_array::arrays::ConstantVTable::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ConstantVTable::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ConstantVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::ConstantVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
-
-pub fn vortex_array::arrays::ConstantVTable::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
-
-pub fn vortex_array::arrays::ConstantVTable::nchildren(_array: &vortex_array::arrays::ConstantArray) -> usize
-
-pub fn vortex_array::arrays::ConstantVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ConstantVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ConstantVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ConstantVTable::stats(array: &vortex_array::arrays::ConstantArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ConstantVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
-
-pub fn vortex_array::arrays::ConstantVTable::validity(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub mod vortex_array::arrays::datetime
 
@@ -1019,6 +1019,122 @@ impl vortex_array::IntoArray for vortex_array::arrays::datetime::TemporalArray
 pub fn vortex_array::arrays::datetime::TemporalArray::into_array(self) -> vortex_array::ArrayRef
 
 pub mod vortex_array::arrays::decimal
+
+pub struct vortex_array::arrays::decimal::Decimal
+
+impl vortex_array::arrays::Decimal
+
+pub const vortex_array::arrays::Decimal::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::is_constant(&self, array: &vortex_array::arrays::DecimalArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::is_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::Decimal::is_strict_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::min_max(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::sum(&self, array: &vortex_array::arrays::DecimalArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Decimal> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
+
+pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::Masked
+
+pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::between(arr: &vortex_array::arrays::DecimalArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::cast(array: &vortex_array::arrays::DecimalArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::fill_null(array: &vortex_array::arrays::DecimalArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::mask(array: &vortex_array::arrays::DecimalArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Decimal> for vortex_array::arrays::Decimal
+
+pub fn vortex_array::arrays::Decimal::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::Decimal
+
+pub type vortex_array::arrays::Decimal::Array = vortex_array::arrays::DecimalArray
+
+pub type vortex_array::arrays::Decimal::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::decimal::vtable::DecimalMetadata>
+
+pub type vortex_array::arrays::Decimal::OperationsVTable = vortex_array::arrays::Decimal
+
+pub type vortex_array::arrays::Decimal::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::Decimal::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::Decimal::array_eq(array: &vortex_array::arrays::DecimalArray, other: &vortex_array::arrays::DecimalArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::Decimal::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DecimalArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::Decimal::buffer(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::Decimal::buffer_name(_array: &vortex_array::arrays::DecimalArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::Decimal::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DecimalArray>
+
+pub fn vortex_array::arrays::Decimal::child(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::Decimal::child_name(_array: &vortex_array::arrays::DecimalArray, _idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::Decimal::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Decimal::dtype(array: &vortex_array::arrays::DecimalArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::Decimal::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::Decimal::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Decimal::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Decimal::len(array: &vortex_array::arrays::DecimalArray) -> usize
+
+pub fn vortex_array::arrays::Decimal::metadata(array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Decimal::nbuffers(_array: &vortex_array::arrays::DecimalArray) -> usize
+
+pub fn vortex_array::arrays::Decimal::nchildren(array: &vortex_array::arrays::DecimalArray) -> usize
+
+pub fn vortex_array::arrays::Decimal::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Decimal::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Decimal::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Decimal::stats(array: &vortex_array::arrays::DecimalArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Decimal::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::decimal::DecimalArray
 
@@ -1116,127 +1232,11 @@ impl core::fmt::Debug for vortex_array::arrays::decimal::DecimalMaskedValidityRu
 
 pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Decimal> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
 
-pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::decimal::DecimalVTable
-
-impl vortex_array::arrays::DecimalVTable
-
-pub const vortex_array::arrays::DecimalVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::is_constant(&self, array: &vortex_array::arrays::DecimalArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::is_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::DecimalVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::min_max(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::sum(&self, array: &vortex_array::arrays::DecimalArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
-
-pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::Masked
 
 pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::between(arr: &vortex_array::arrays::DecimalArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::cast(array: &vortex_array::arrays::DecimalArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::fill_null(array: &vortex_array::arrays::DecimalArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::mask(array: &vortex_array::arrays::DecimalArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalVTable
-
-pub fn vortex_array::arrays::DecimalVTable::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::DecimalVTable
-
-pub type vortex_array::arrays::DecimalVTable::Array = vortex_array::arrays::DecimalArray
-
-pub type vortex_array::arrays::DecimalVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::decimal::vtable::DecimalMetadata>
-
-pub type vortex_array::arrays::DecimalVTable::OperationsVTable = vortex_array::arrays::DecimalVTable
-
-pub type vortex_array::arrays::DecimalVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::DecimalVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::DecimalVTable::array_eq(array: &vortex_array::arrays::DecimalArray, other: &vortex_array::arrays::DecimalArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::DecimalVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DecimalArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::DecimalVTable::buffer(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::DecimalVTable::buffer_name(_array: &vortex_array::arrays::DecimalArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::DecimalVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DecimalArray>
-
-pub fn vortex_array::arrays::DecimalVTable::child(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::DecimalVTable::child_name(_array: &vortex_array::arrays::DecimalArray, _idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::DecimalVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::DecimalVTable::dtype(array: &vortex_array::arrays::DecimalArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::DecimalVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::DecimalVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DecimalVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::DecimalVTable::len(array: &vortex_array::arrays::DecimalArray) -> usize
-
-pub fn vortex_array::arrays::DecimalVTable::metadata(array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::DecimalVTable::nbuffers(_array: &vortex_array::arrays::DecimalArray) -> usize
-
-pub fn vortex_array::arrays::DecimalVTable::nchildren(array: &vortex_array::arrays::DecimalArray) -> usize
-
-pub fn vortex_array::arrays::DecimalVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DecimalVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::DecimalVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::DecimalVTable::stats(array: &vortex_array::arrays::DecimalArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::DecimalVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::decimal::narrowed_decimal(decimal_array: vortex_array::arrays::DecimalArray) -> vortex_array::arrays::DecimalArray
 
@@ -1244,123 +1244,241 @@ pub mod vortex_array::arrays::dict
 
 pub mod vortex_array::arrays::dict::vtable
 
-pub struct vortex_array::arrays::dict::vtable::DictVTable
+pub struct vortex_array::arrays::dict::vtable::Dict
 
-impl vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::dict::Dict
 
-pub const vortex_array::arrays::dict::DictVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::dict::Dict::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::dict::DictVTable
+impl core::fmt::Debug for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::dict::Dict::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::dict::Dict::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::dict::Dict::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::dict::Dict::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::dict::Dict::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::dict::Dict
 
-pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
+pub type vortex_array::arrays::dict::Dict::Array = vortex_array::arrays::dict::DictArray
 
-pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
+pub type vortex_array::arrays::dict::Dict::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
 
-pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::dict::Dict::OperationsVTable = vortex_array::arrays::dict::Dict
 
-pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::dict::Dict::ValidityVTable = vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::dict::Dict::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::dict::Dict::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::dict::Dict::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::dict::Dict::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::dict::Dict::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+pub fn vortex_array::arrays::dict::Dict::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
 
-pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::dict::Dict::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::dict::Dict::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::dict::Dict::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::dict::Dict::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::dict::Dict::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::dict::Dict::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::dict::Dict::len(array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::dict::Dict::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::dict::Dict::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::dict::Dict::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::dict::Dict::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::dict::Dict::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::dict::Dict::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::dict::Dict::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
+pub struct vortex_array::arrays::dict::Dict
+
+impl vortex_array::arrays::dict::Dict
+
+pub const vortex_array::arrays::dict::Dict::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::dict::Dict::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::dict::Dict
+
+pub type vortex_array::arrays::dict::Dict::Array = vortex_array::arrays::dict::DictArray
+
+pub type vortex_array::arrays::dict::Dict::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
+
+pub type vortex_array::arrays::dict::Dict::OperationsVTable = vortex_array::arrays::dict::Dict
+
+pub type vortex_array::arrays::dict::Dict::ValidityVTable = vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::dict::Dict::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::dict::Dict::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::dict::Dict::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::dict::Dict::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::dict::Dict::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+
+pub fn vortex_array::arrays::dict::Dict::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::dict::Dict::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::dict::Dict::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::dict::Dict::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::dict::Dict::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::dict::Dict::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::Dict::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::dict::Dict::len(array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::Dict::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::dict::Dict::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::Dict::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
+
+pub fn vortex_array::arrays::dict::Dict::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::Dict::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::dict::Dict::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::dict::Dict::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::dict::Dict::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::dict::DictArray
 
@@ -1458,124 +1576,6 @@ pub fn vortex_array::arrays::dict::DictMetadata::clear(&mut self)
 
 pub fn vortex_array::arrays::dict::DictMetadata::encoded_len(&self) -> usize
 
-pub struct vortex_array::arrays::dict::DictVTable
-
-impl vortex_array::arrays::dict::DictVTable
-
-pub const vortex_array::arrays::dict::DictVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
-
-pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
-
-pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
-
-pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
-
-pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
-
-pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
-
-pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
 pub struct vortex_array::arrays::dict::TakeExecuteAdaptor<V>(pub V)
 
 impl<V: core::default::Default> core::default::Default for vortex_array::arrays::dict::TakeExecuteAdaptor<V>
@@ -1588,7 +1588,7 @@ pub fn vortex_array::arrays::dict::TakeExecuteAdaptor<V>::fmt(&self, f: &mut cor
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::dict::TakeExecuteAdaptor<V> where V: vortex_array::arrays::dict::TakeExecute
 
-pub type vortex_array::arrays::dict::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::dict::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::dict::Dict
 
 pub fn vortex_array::arrays::dict::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -1604,7 +1604,7 @@ pub fn vortex_array::arrays::dict::TakeReduceAdaptor<V>::fmt(&self, f: &mut core
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::dict::TakeReduceAdaptor<V> where V: vortex_array::arrays::dict::TakeReduce
 
-pub type vortex_array::arrays::dict::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::dict::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::dict::Dict
 
 pub fn vortex_array::arrays::dict::TakeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::dict::DictArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -1612,73 +1612,187 @@ pub trait vortex_array::arrays::dict::TakeExecute: vortex_array::vtable::VTable
 
 pub fn vortex_array::arrays::dict::TakeExecute::take(array: &Self::Array, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::BoolVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::DecimalVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ExtensionVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FixedSizeList::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ListVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::arrays::dict::TakeReduce: vortex_array::vtable::VTable
 
 pub fn vortex_array::arrays::dict::TakeReduce::take(array: &Self::Array, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListViewVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Masked::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::StructVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Struct::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::NullVTable::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::arrays::dict::take_canonical(values: vortex_array::Canonical, codes: &vortex_array::arrays::PrimitiveArray, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::Canonical>
 
 pub mod vortex_array::arrays::extension
+
+pub struct vortex_array::arrays::extension::Extension
+
+impl vortex_array::arrays::Extension
+
+pub const vortex_array::arrays::Extension::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::is_constant(&self, array: &vortex_array::arrays::ExtensionArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::is_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::Extension::is_strict_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::min_max(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::sum(&self, array: &vortex_array::arrays::ExtensionArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::cast(array: &vortex_array::arrays::ExtensionArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::mask(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::Extension
+
+pub type vortex_array::arrays::Extension::Array = vortex_array::arrays::ExtensionArray
+
+pub type vortex_array::arrays::Extension::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::Extension::OperationsVTable = vortex_array::arrays::Extension
+
+pub type vortex_array::arrays::Extension::ValidityVTable = vortex_array::vtable::ValidityVTableFromChild
+
+pub fn vortex_array::arrays::Extension::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::Extension::array_eq(array: &vortex_array::arrays::ExtensionArray, other: &vortex_array::arrays::ExtensionArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::Extension::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ExtensionArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::Extension::buffer(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::Extension::buffer_name(_array: &vortex_array::arrays::ExtensionArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::Extension::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ExtensionArray>
+
+pub fn vortex_array::arrays::Extension::child(array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::Extension::child_name(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::Extension::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Extension::dtype(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::Extension::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::Extension::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Extension::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Extension::len(array: &vortex_array::arrays::ExtensionArray) -> usize
+
+pub fn vortex_array::arrays::Extension::metadata(_array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Extension::nbuffers(_array: &vortex_array::arrays::ExtensionArray) -> usize
+
+pub fn vortex_array::arrays::Extension::nchildren(_array: &vortex_array::arrays::ExtensionArray) -> usize
+
+pub fn vortex_array::arrays::Extension::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Extension::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Extension::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Extension::stats(array: &vortex_array::arrays::ExtensionArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Extension::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityChild<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
+
+pub fn vortex_array::arrays::Extension::validity_child(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::ArrayRef
 
 pub struct vortex_array::arrays::extension::ExtensionArray
 
@@ -1742,121 +1856,79 @@ impl vortex_array::IntoArray for vortex_array::arrays::ExtensionArray
 
 pub fn vortex_array::arrays::ExtensionArray::into_array(self) -> vortex_array::ArrayRef
 
-pub struct vortex_array::arrays::extension::ExtensionVTable
-
-impl vortex_array::arrays::ExtensionVTable
-
-pub const vortex_array::arrays::ExtensionVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::is_constant(&self, array: &vortex_array::arrays::ExtensionArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::is_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::ExtensionVTable::is_strict_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::min_max(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::sum(&self, array: &vortex_array::arrays::ExtensionArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::cast(array: &vortex_array::arrays::ExtensionArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::mask(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::ExtensionVTable
-
-pub type vortex_array::arrays::ExtensionVTable::Array = vortex_array::arrays::ExtensionArray
-
-pub type vortex_array::arrays::ExtensionVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::ExtensionVTable::OperationsVTable = vortex_array::arrays::ExtensionVTable
-
-pub type vortex_array::arrays::ExtensionVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromChild
-
-pub fn vortex_array::arrays::ExtensionVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ExtensionVTable::array_eq(array: &vortex_array::arrays::ExtensionArray, other: &vortex_array::arrays::ExtensionArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::ExtensionVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ExtensionArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ExtensionVTable::buffer(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ExtensionVTable::buffer_name(_array: &vortex_array::arrays::ExtensionArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ExtensionVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ExtensionArray>
-
-pub fn vortex_array::arrays::ExtensionVTable::child(array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ExtensionVTable::child_name(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ExtensionVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ExtensionVTable::dtype(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ExtensionVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::ExtensionVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ExtensionVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ExtensionVTable::len(array: &vortex_array::arrays::ExtensionArray) -> usize
-
-pub fn vortex_array::arrays::ExtensionVTable::metadata(_array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ExtensionVTable::nbuffers(_array: &vortex_array::arrays::ExtensionArray) -> usize
-
-pub fn vortex_array::arrays::ExtensionVTable::nchildren(_array: &vortex_array::arrays::ExtensionArray) -> usize
-
-pub fn vortex_array::arrays::ExtensionVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ExtensionVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ExtensionVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ExtensionVTable::stats(array: &vortex_array::arrays::ExtensionArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ExtensionVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityChild<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::validity_child(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::ArrayRef
-
 pub mod vortex_array::arrays::filter
+
+pub struct vortex_array::arrays::filter::Filter
+
+impl vortex_array::arrays::Filter
+
+pub const vortex_array::arrays::Filter::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::Filter
+
+pub fn vortex_array::arrays::Filter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
+
+pub fn vortex_array::arrays::Filter::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::Filter
+
+pub type vortex_array::arrays::Filter::Array = vortex_array::arrays::FilterArray
+
+pub type vortex_array::arrays::Filter::Metadata = vortex_array::arrays::filter::vtable::FilterMetadata
+
+pub type vortex_array::arrays::Filter::OperationsVTable = vortex_array::arrays::Filter
+
+pub type vortex_array::arrays::Filter::ValidityVTable = vortex_array::arrays::Filter
+
+pub fn vortex_array::arrays::Filter::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::Filter::array_eq(array: &vortex_array::arrays::FilterArray, other: &vortex_array::arrays::FilterArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::Filter::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FilterArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::Filter::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::Filter::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::Filter::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::filter::vtable::FilterMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+
+pub fn vortex_array::arrays::Filter::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::Filter::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::Filter::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Filter::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::Filter::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::Filter::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Filter::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Filter::len(array: &vortex_array::arrays::FilterArray) -> usize
+
+pub fn vortex_array::arrays::Filter::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Filter::nbuffers(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::Filter::nchildren(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::Filter::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Filter::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Filter::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Filter::stats(array: &vortex_array::arrays::FilterArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Filter::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
+
+pub fn vortex_array::arrays::Filter::validity(array: &vortex_array::arrays::FilterArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::filter::FilterArray
 
@@ -1920,7 +1992,7 @@ pub fn vortex_array::arrays::filter::FilterExecuteAdaptor<V>::fmt(&self, f: &mut
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::filter::FilterExecuteAdaptor<V> where V: vortex_array::arrays::filter::FilterKernel
 
-pub type vortex_array::arrays::filter::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+pub type vortex_array::arrays::filter::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::Filter
 
 pub fn vortex_array::arrays::filter::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -1936,127 +2008,153 @@ pub fn vortex_array::arrays::filter::FilterReduceAdaptor<V>::fmt(&self, f: &mut 
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::filter::FilterReduceAdaptor<V> where V: vortex_array::arrays::filter::FilterReduce
 
-pub type vortex_array::arrays::filter::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+pub type vortex_array::arrays::filter::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::Filter
 
 pub fn vortex_array::arrays::filter::FilterReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::FilterArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::filter::FilterVTable
-
-impl vortex_array::arrays::FilterVTable
-
-pub const vortex_array::arrays::FilterVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::FilterVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::FilterVTable::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::FilterVTable
-
-pub type vortex_array::arrays::FilterVTable::Array = vortex_array::arrays::FilterArray
-
-pub type vortex_array::arrays::FilterVTable::Metadata = vortex_array::arrays::filter::vtable::FilterMetadata
-
-pub type vortex_array::arrays::FilterVTable::OperationsVTable = vortex_array::arrays::FilterVTable
-
-pub type vortex_array::arrays::FilterVTable::ValidityVTable = vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::FilterVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::FilterVTable::array_eq(array: &vortex_array::arrays::FilterArray, other: &vortex_array::arrays::FilterArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::FilterVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FilterArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::FilterVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::FilterVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::FilterVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::filter::vtable::FilterMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
-
-pub fn vortex_array::arrays::FilterVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::FilterVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::FilterVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::FilterVTable::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::FilterVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::FilterVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FilterVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::FilterVTable::len(array: &vortex_array::arrays::FilterArray) -> usize
-
-pub fn vortex_array::arrays::FilterVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::FilterVTable::nbuffers(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::FilterVTable::nchildren(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::FilterVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FilterVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FilterVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::FilterVTable::stats(array: &vortex_array::arrays::FilterArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::FilterVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
-
-pub fn vortex_array::arrays::FilterVTable::validity(array: &vortex_array::arrays::FilterArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub trait vortex_array::arrays::filter::FilterKernel: vortex_array::vtable::VTable
 
 pub fn vortex_array::arrays::filter::FilterKernel::filter(array: &Self::Array, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ListVTable
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::ListVTable::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBinVTable
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBinVTable::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::arrays::filter::FilterReduce: vortex_array::vtable::VTable
 
 pub fn vortex_array::arrays::filter::FilterReduce::filter(array: &Self::Array, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::BoolVTable::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ExtensionVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::MaskedVTable::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Masked::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::NullVTable::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::arrays::fixed_size_list
+
+pub struct vortex_array::arrays::fixed_size_list::FixedSizeList
+
+impl vortex_array::arrays::FixedSizeList
+
+pub const vortex_array::arrays::FixedSizeList::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::FixedSizeList
+
+pub fn vortex_array::arrays::FixedSizeList::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeList
+
+pub fn vortex_array::arrays::FixedSizeList::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeList
+
+pub fn vortex_array::arrays::FixedSizeList::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::FixedSizeList
+
+pub fn vortex_array::arrays::FixedSizeList::is_constant(&self, array: &vortex_array::arrays::FixedSizeListArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::FixedSizeList
+
+pub fn vortex_array::arrays::FixedSizeList::is_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::FixedSizeList::is_strict_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::FixedSizeList
+
+pub fn vortex_array::arrays::FixedSizeList::min_max(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::FixedSizeList
+
+pub fn vortex_array::arrays::FixedSizeList::cast(array: &vortex_array::arrays::FixedSizeListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::FixedSizeList
+
+pub fn vortex_array::arrays::FixedSizeList::mask(array: &vortex_array::arrays::FixedSizeListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FixedSizeList> for vortex_array::arrays::FixedSizeList
+
+pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::FixedSizeList
+
+pub type vortex_array::arrays::FixedSizeList::Array = vortex_array::arrays::FixedSizeListArray
+
+pub type vortex_array::arrays::FixedSizeList::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::FixedSizeList::OperationsVTable = vortex_array::arrays::FixedSizeList
+
+pub type vortex_array::arrays::FixedSizeList::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::FixedSizeList::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::FixedSizeList::array_eq(array: &vortex_array::arrays::FixedSizeListArray, other: &vortex_array::arrays::FixedSizeListArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::FixedSizeList::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FixedSizeListArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::FixedSizeList::buffer(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::FixedSizeList::buffer_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::FixedSizeList::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::FixedSizeListArray>
+
+pub fn vortex_array::arrays::FixedSizeList::child(array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::FixedSizeList::child_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::FixedSizeList::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::FixedSizeList::dtype(array: &vortex_array::arrays::FixedSizeListArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::FixedSizeList::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::FixedSizeList::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FixedSizeList::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::FixedSizeList::len(array: &vortex_array::arrays::FixedSizeListArray) -> usize
+
+pub fn vortex_array::arrays::FixedSizeList::metadata(_array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::FixedSizeList::nbuffers(_array: &vortex_array::arrays::FixedSizeListArray) -> usize
+
+pub fn vortex_array::arrays::FixedSizeList::nchildren(array: &vortex_array::arrays::FixedSizeListArray) -> usize
+
+pub fn vortex_array::arrays::FixedSizeList::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FixedSizeList::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FixedSizeList::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::FixedSizeList::stats(array: &vortex_array::arrays::FixedSizeListArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::FixedSizeList::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::fixed_size_list::FixedSizeListArray
 
@@ -2116,105 +2214,109 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::FixedSizeLis
 
 pub fn vortex_array::arrays::FixedSizeListArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::fixed_size_list::FixedSizeListVTable
-
-impl vortex_array::arrays::FixedSizeListVTable
-
-pub const vortex_array::arrays::FixedSizeListVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::is_constant(&self, array: &vortex_array::arrays::FixedSizeListArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::is_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::min_max(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::cast(array: &vortex_array::arrays::FixedSizeListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::mask(array: &vortex_array::arrays::FixedSizeListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FixedSizeListVTable> for vortex_array::arrays::FixedSizeListVTable
-
-pub fn vortex_array::arrays::FixedSizeListVTable::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::FixedSizeListVTable
-
-pub type vortex_array::arrays::FixedSizeListVTable::Array = vortex_array::arrays::FixedSizeListArray
-
-pub type vortex_array::arrays::FixedSizeListVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::FixedSizeListVTable::OperationsVTable = vortex_array::arrays::FixedSizeListVTable
-
-pub type vortex_array::arrays::FixedSizeListVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::FixedSizeListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::array_eq(array: &vortex_array::arrays::FixedSizeListArray, other: &vortex_array::arrays::FixedSizeListArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::FixedSizeListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FixedSizeListArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::FixedSizeListVTable::buffer(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::FixedSizeListVTable::buffer_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::FixedSizeListArray>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::child(array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::FixedSizeListVTable::child_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::FixedSizeListVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::dtype(array: &vortex_array::arrays::FixedSizeListArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::FixedSizeListVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::FixedSizeListVTable::len(array: &vortex_array::arrays::FixedSizeListArray) -> usize
-
-pub fn vortex_array::arrays::FixedSizeListVTable::metadata(_array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::nbuffers(_array: &vortex_array::arrays::FixedSizeListArray) -> usize
-
-pub fn vortex_array::arrays::FixedSizeListVTable::nchildren(array: &vortex_array::arrays::FixedSizeListArray) -> usize
-
-pub fn vortex_array::arrays::FixedSizeListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::stats(array: &vortex_array::arrays::FixedSizeListArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::FixedSizeListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
 pub mod vortex_array::arrays::list
+
+pub struct vortex_array::arrays::list::List
+
+impl vortex_array::arrays::List
+
+pub const vortex_array::arrays::List::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::List
+
+pub fn vortex_array::arrays::List::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::List
+
+pub fn vortex_array::arrays::List::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::List
+
+pub fn vortex_array::arrays::List::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::List
+
+pub fn vortex_array::arrays::List::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::List
+
+pub fn vortex_array::arrays::List::is_constant(&self, array: &vortex_array::arrays::ListArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::List
+
+pub fn vortex_array::arrays::List::is_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::List::is_strict_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::List
+
+pub fn vortex_array::arrays::List::min_max(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::List
+
+pub fn vortex_array::arrays::List::cast(array: &vortex_array::arrays::ListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::List
+
+pub fn vortex_array::arrays::List::mask(array: &vortex_array::arrays::ListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::List> for vortex_array::arrays::List
+
+pub fn vortex_array::arrays::List::scalar_at(array: &vortex_array::arrays::ListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::List
+
+pub type vortex_array::arrays::List::Array = vortex_array::arrays::ListArray
+
+pub type vortex_array::arrays::List::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::list::vtable::ListMetadata>
+
+pub type vortex_array::arrays::List::OperationsVTable = vortex_array::arrays::List
+
+pub type vortex_array::arrays::List::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::List::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::List::array_eq(array: &vortex_array::arrays::ListArray, other: &vortex_array::arrays::ListArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::List::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::List::buffer(_array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::List::buffer_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::List::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
+
+pub fn vortex_array::arrays::List::child(array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::List::child_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::List::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::List::dtype(array: &vortex_array::arrays::ListArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::List::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::List::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::List::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::List::len(array: &vortex_array::arrays::ListArray) -> usize
+
+pub fn vortex_array::arrays::List::metadata(array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::List::nbuffers(_array: &vortex_array::arrays::ListArray) -> usize
+
+pub fn vortex_array::arrays::List::nchildren(array: &vortex_array::arrays::ListArray) -> usize
+
+pub fn vortex_array::arrays::List::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::List::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::List::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::List::stats(array: &vortex_array::arrays::ListArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::List::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::list::ListArray
 
@@ -2288,108 +2390,6 @@ pub vortex_array::arrays::list::ListArrayParts::offsets: vortex_array::ArrayRef
 
 pub vortex_array::arrays::list::ListArrayParts::validity: vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::list::ListVTable
-
-impl vortex_array::arrays::ListVTable
-
-pub const vortex_array::arrays::ListVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::is_constant(&self, array: &vortex_array::arrays::ListArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::is_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::ListVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::min_max(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::cast(array: &vortex_array::arrays::ListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::mask(array: &vortex_array::arrays::ListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListVTable> for vortex_array::arrays::ListVTable
-
-pub fn vortex_array::arrays::ListVTable::scalar_at(array: &vortex_array::arrays::ListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::ListVTable
-
-pub type vortex_array::arrays::ListVTable::Array = vortex_array::arrays::ListArray
-
-pub type vortex_array::arrays::ListVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::list::vtable::ListMetadata>
-
-pub type vortex_array::arrays::ListVTable::OperationsVTable = vortex_array::arrays::ListVTable
-
-pub type vortex_array::arrays::ListVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::ListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ListVTable::array_eq(array: &vortex_array::arrays::ListArray, other: &vortex_array::arrays::ListArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::ListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ListVTable::buffer(_array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ListVTable::buffer_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ListVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
-
-pub fn vortex_array::arrays::ListVTable::child(array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ListVTable::child_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ListVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ListVTable::dtype(array: &vortex_array::arrays::ListArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ListVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::ListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ListVTable::len(array: &vortex_array::arrays::ListArray) -> usize
-
-pub fn vortex_array::arrays::ListVTable::metadata(array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ListVTable::nbuffers(_array: &vortex_array::arrays::ListArray) -> usize
-
-pub fn vortex_array::arrays::ListVTable::nchildren(array: &vortex_array::arrays::ListArray) -> usize
-
-pub fn vortex_array::arrays::ListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ListVTable::stats(array: &vortex_array::arrays::ListArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
 pub mod vortex_array::arrays::listview
 
 pub enum vortex_array::arrays::listview::ListViewRebuildMode
@@ -2401,6 +2401,104 @@ pub vortex_array::arrays::listview::ListViewRebuildMode::MakeZeroCopyToList
 pub vortex_array::arrays::listview::ListViewRebuildMode::OverlapCompression
 
 pub vortex_array::arrays::listview::ListViewRebuildMode::TrimElements
+
+pub struct vortex_array::arrays::listview::ListView
+
+impl vortex_array::arrays::ListView
+
+pub const vortex_array::arrays::ListView::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::ListView
+
+pub fn vortex_array::arrays::ListView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListView
+
+pub fn vortex_array::arrays::ListView::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListView
+
+pub fn vortex_array::arrays::ListView::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListView
+
+pub fn vortex_array::arrays::ListView::is_constant(&self, array: &vortex_array::arrays::ListViewArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListView
+
+pub fn vortex_array::arrays::ListView::is_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::ListView::is_strict_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListView
+
+pub fn vortex_array::arrays::ListView::min_max(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListView
+
+pub fn vortex_array::arrays::ListView::cast(array: &vortex_array::arrays::ListViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListView
+
+pub fn vortex_array::arrays::ListView::mask(array: &vortex_array::arrays::ListViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListView> for vortex_array::arrays::ListView
+
+pub fn vortex_array::arrays::ListView::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::ListView
+
+pub type vortex_array::arrays::ListView::Array = vortex_array::arrays::ListViewArray
+
+pub type vortex_array::arrays::ListView::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::listview::vtable::ListViewMetadata>
+
+pub type vortex_array::arrays::ListView::OperationsVTable = vortex_array::arrays::ListView
+
+pub type vortex_array::arrays::ListView::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::ListView::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::ListView::array_eq(array: &vortex_array::arrays::ListViewArray, other: &vortex_array::arrays::ListViewArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::ListView::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListViewArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::ListView::buffer(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::ListView::buffer_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::ListView::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
+
+pub fn vortex_array::arrays::ListView::child(array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::ListView::child_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::ListView::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ListView::dtype(array: &vortex_array::arrays::ListViewArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::ListView::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::ListView::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ListView::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::ListView::len(array: &vortex_array::arrays::ListViewArray) -> usize
+
+pub fn vortex_array::arrays::ListView::metadata(array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::ListView::nbuffers(_array: &vortex_array::arrays::ListViewArray) -> usize
+
+pub fn vortex_array::arrays::ListView::nchildren(array: &vortex_array::arrays::ListViewArray) -> usize
+
+pub fn vortex_array::arrays::ListView::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ListView::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::ListView::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::ListView::stats(array: &vortex_array::arrays::ListViewArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::ListView::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::listview::ListViewArray
 
@@ -2488,104 +2586,6 @@ pub vortex_array::arrays::listview::ListViewArrayParts::sizes: vortex_array::Arr
 
 pub vortex_array::arrays::listview::ListViewArrayParts::validity: vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::listview::ListViewVTable
-
-impl vortex_array::arrays::ListViewVTable
-
-pub const vortex_array::arrays::ListViewVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::is_constant(&self, array: &vortex_array::arrays::ListViewArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::is_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::ListViewVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::min_max(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::cast(array: &vortex_array::arrays::ListViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::mask(array: &vortex_array::arrays::ListViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListViewVTable> for vortex_array::arrays::ListViewVTable
-
-pub fn vortex_array::arrays::ListViewVTable::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::ListViewVTable
-
-pub type vortex_array::arrays::ListViewVTable::Array = vortex_array::arrays::ListViewArray
-
-pub type vortex_array::arrays::ListViewVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::listview::vtable::ListViewMetadata>
-
-pub type vortex_array::arrays::ListViewVTable::OperationsVTable = vortex_array::arrays::ListViewVTable
-
-pub type vortex_array::arrays::ListViewVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::ListViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::ListViewVTable::array_eq(array: &vortex_array::arrays::ListViewArray, other: &vortex_array::arrays::ListViewArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::ListViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListViewArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ListViewVTable::buffer(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ListViewVTable::buffer_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ListViewVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
-
-pub fn vortex_array::arrays::ListViewVTable::child(array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ListViewVTable::child_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ListViewVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ListViewVTable::dtype(array: &vortex_array::arrays::ListViewArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ListViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::ListViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListViewVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ListViewVTable::len(array: &vortex_array::arrays::ListViewArray) -> usize
-
-pub fn vortex_array::arrays::ListViewVTable::metadata(array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ListViewVTable::nbuffers(_array: &vortex_array::arrays::ListViewArray) -> usize
-
-pub fn vortex_array::arrays::ListViewVTable::nchildren(array: &vortex_array::arrays::ListViewArray) -> usize
-
-pub fn vortex_array::arrays::ListViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListViewVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ListViewVTable::stats(array: &vortex_array::arrays::ListViewArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ListViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
 pub fn vortex_array::arrays::listview::list_from_list_view(list_view: vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
 
 pub fn vortex_array::arrays::listview::list_view_from_list(list: vortex_array::arrays::ListArray, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
@@ -2593,6 +2593,90 @@ pub fn vortex_array::arrays::listview::list_view_from_list(list: vortex_array::a
 pub fn vortex_array::arrays::listview::recursive_list_from_list_view(array: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub mod vortex_array::arrays::masked
+
+pub struct vortex_array::arrays::masked::Masked
+
+impl vortex_array::arrays::Masked
+
+pub const vortex_array::arrays::Masked::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::Masked
+
+pub fn vortex_array::arrays::Masked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::Masked
+
+pub fn vortex_array::arrays::Masked::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Masked
+
+pub fn vortex_array::arrays::Masked::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Masked
+
+pub fn vortex_array::arrays::Masked::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Masked
+
+pub fn vortex_array::arrays::Masked::mask(array: &vortex_array::arrays::MaskedArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Masked> for vortex_array::arrays::Masked
+
+pub fn vortex_array::arrays::Masked::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::Masked
+
+pub type vortex_array::arrays::Masked::Array = vortex_array::arrays::MaskedArray
+
+pub type vortex_array::arrays::Masked::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::Masked::OperationsVTable = vortex_array::arrays::Masked
+
+pub type vortex_array::arrays::Masked::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::Masked::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::Masked::array_eq(array: &vortex_array::arrays::MaskedArray, other: &vortex_array::arrays::MaskedArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::Masked::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::MaskedArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::Masked::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::Masked::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::Masked::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::MaskedArray>
+
+pub fn vortex_array::arrays::Masked::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::Masked::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::Masked::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Masked::dtype(array: &vortex_array::arrays::MaskedArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::Masked::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::Masked::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Masked::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Masked::len(array: &vortex_array::arrays::MaskedArray) -> usize
+
+pub fn vortex_array::arrays::Masked::metadata(_array: &vortex_array::arrays::MaskedArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Masked::nbuffers(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::Masked::nchildren(array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::Masked::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Masked::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Masked::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Masked::stats(array: &vortex_array::arrays::MaskedArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Masked::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::masked::MaskedArray
 
@@ -2636,93 +2720,109 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::MaskedArray
 
 pub fn vortex_array::arrays::MaskedArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::masked::MaskedVTable
-
-impl vortex_array::arrays::MaskedVTable
-
-pub const vortex_array::arrays::MaskedVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::mask(array: &vortex_array::arrays::MaskedArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::MaskedVTable> for vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::MaskedVTable::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::MaskedVTable
-
-pub type vortex_array::arrays::MaskedVTable::Array = vortex_array::arrays::MaskedArray
-
-pub type vortex_array::arrays::MaskedVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::MaskedVTable::OperationsVTable = vortex_array::arrays::MaskedVTable
-
-pub type vortex_array::arrays::MaskedVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::MaskedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::MaskedVTable::array_eq(array: &vortex_array::arrays::MaskedArray, other: &vortex_array::arrays::MaskedArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::MaskedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::MaskedArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::MaskedVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::MaskedVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::MaskedVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::MaskedArray>
-
-pub fn vortex_array::arrays::MaskedVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::MaskedVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::MaskedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::MaskedVTable::dtype(array: &vortex_array::arrays::MaskedArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::MaskedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::MaskedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::MaskedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::MaskedVTable::len(array: &vortex_array::arrays::MaskedArray) -> usize
-
-pub fn vortex_array::arrays::MaskedVTable::metadata(_array: &vortex_array::arrays::MaskedArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::MaskedVTable::nbuffers(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::MaskedVTable::nchildren(array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::MaskedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::MaskedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::MaskedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::MaskedVTable::stats(array: &vortex_array::arrays::MaskedArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::MaskedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
 pub fn vortex_array::arrays::masked::mask_validity_canonical(canonical: vortex_array::Canonical, validity_mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::Canonical>
 
 pub mod vortex_array::arrays::null
+
+pub struct vortex_array::arrays::null::Null
+
+impl vortex_array::arrays::null::Null
+
+pub const vortex_array::arrays::null::Null::ID: vortex_array::vtable::ArrayId
+
+impl vortex_array::arrays::null::Null
+
+pub const vortex_array::arrays::null::Null::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
+
+impl core::fmt::Debug for vortex_array::arrays::null::Null
+
+pub fn vortex_array::arrays::null::Null::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::Null
+
+pub fn vortex_array::arrays::null::Null::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::Null
+
+pub fn vortex_array::arrays::null::Null::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::Null
+
+pub fn vortex_array::arrays::null::Null::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::Null
+
+pub fn vortex_array::arrays::null::Null::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::Null
+
+pub fn vortex_array::arrays::null::Null::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::Null
+
+pub fn vortex_array::arrays::null::Null::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
+
+pub fn vortex_array::arrays::null::Null::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::null::Null
+
+pub type vortex_array::arrays::null::Null::Array = vortex_array::arrays::null::NullArray
+
+pub type vortex_array::arrays::null::Null::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::null::Null::OperationsVTable = vortex_array::arrays::null::Null
+
+pub type vortex_array::arrays::null::Null::ValidityVTable = vortex_array::arrays::null::Null
+
+pub fn vortex_array::arrays::null::Null::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::null::Null::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::null::Null::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::null::Null::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::null::Null::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::null::Null::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
+
+pub fn vortex_array::arrays::null::Null::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::null::Null::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::null::Null::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::null::Null::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::null::Null::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::null::Null::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::null::Null::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::null::Null::len(array: &vortex_array::arrays::null::NullArray) -> usize
+
+pub fn vortex_array::arrays::null::Null::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::null::Null::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
+
+pub fn vortex_array::arrays::null::Null::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
+
+pub fn vortex_array::arrays::null::Null::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::null::Null::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::null::Null::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::null::Null::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::null::Null::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
+
+pub fn vortex_array::arrays::null::Null::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::null::NullArray
 
@@ -2763,106 +2863,6 @@ pub fn vortex_array::arrays::null::NullArray::execute(array: vortex_array::Array
 impl vortex_array::IntoArray for vortex_array::arrays::null::NullArray
 
 pub fn vortex_array::arrays::null::NullArray::into_array(self) -> vortex_array::ArrayRef
-
-pub struct vortex_array::arrays::null::NullVTable
-
-impl vortex_array::arrays::null::NullVTable
-
-pub const vortex_array::arrays::null::NullVTable::ID: vortex_array::vtable::ArrayId
-
-impl vortex_array::arrays::null::NullVTable
-
-pub const vortex_array::arrays::null::NullVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
-
-impl core::fmt::Debug for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::null::NullVTable
-
-pub type vortex_array::arrays::null::NullVTable::Array = vortex_array::arrays::null::NullArray
-
-pub type vortex_array::arrays::null::NullVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::null::NullVTable::OperationsVTable = vortex_array::arrays::null::NullVTable
-
-pub type vortex_array::arrays::null::NullVTable::ValidityVTable = vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::null::NullVTable::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::null::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::null::NullVTable::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::null::NullVTable::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::null::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
-
-pub fn vortex_array::arrays::null::NullVTable::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::null::NullVTable::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::null::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::null::NullVTable::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::null::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::null::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::null::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::null::NullVTable::len(array: &vortex_array::arrays::null::NullArray) -> usize
-
-pub fn vortex_array::arrays::null::NullVTable::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::null::NullVTable::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
-
-pub fn vortex_array::arrays::null::NullVTable::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
-
-pub fn vortex_array::arrays::null::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::null::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::null::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::null::NullVTable::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::null::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
-
-pub fn vortex_array::arrays::null::NullVTable::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub mod vortex_array::arrays::primitive
 
@@ -2931,6 +2931,126 @@ pub fn vortex_array::arrays::primitive::NativeValue<T>::eq(&self, other: &vortex
 impl<T: vortex_array::dtype::NativePType> core::cmp::PartialOrd for vortex_array::arrays::primitive::NativeValue<T>
 
 pub fn vortex_array::arrays::primitive::NativeValue<T>::partial_cmp(&self, other: &vortex_array::arrays::primitive::NativeValue<T>) -> core::option::Option<core::cmp::Ordering>
+
+pub struct vortex_array::arrays::primitive::Primitive
+
+impl vortex_array::arrays::Primitive
+
+pub const vortex_array::arrays::Primitive::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::is_constant(&self, array: &vortex_array::arrays::PrimitiveArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::is_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::Primitive::is_strict_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::min_max(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::compute::NaNCountKernel for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::nan_count(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<usize>
+
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Primitive> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
+
+pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::Masked
+
+pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::cast(array: &vortex_array::arrays::PrimitiveArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::fill_null(array: &vortex_array::arrays::PrimitiveArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::mask(array: &vortex_array::arrays::PrimitiveArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Primitive> for vortex_array::arrays::Primitive
+
+pub fn vortex_array::arrays::Primitive::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::Primitive
+
+pub type vortex_array::arrays::Primitive::Array = vortex_array::arrays::PrimitiveArray
+
+pub type vortex_array::arrays::Primitive::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::Primitive::OperationsVTable = vortex_array::arrays::Primitive
+
+pub type vortex_array::arrays::Primitive::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::Primitive::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::Primitive::array_eq(array: &vortex_array::arrays::PrimitiveArray, other: &vortex_array::arrays::PrimitiveArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::Primitive::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::PrimitiveArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::Primitive::buffer(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::Primitive::buffer_name(_array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::Primitive::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
+
+pub fn vortex_array::arrays::Primitive::child(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::Primitive::child_name(_array: &vortex_array::arrays::PrimitiveArray, _idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::Primitive::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Primitive::dtype(array: &vortex_array::arrays::PrimitiveArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::Primitive::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::Primitive::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Primitive::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Primitive::len(array: &vortex_array::arrays::PrimitiveArray) -> usize
+
+pub fn vortex_array::arrays::Primitive::metadata(_array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Primitive::nbuffers(_array: &vortex_array::arrays::PrimitiveArray) -> usize
+
+pub fn vortex_array::arrays::Primitive::nchildren(array: &vortex_array::arrays::PrimitiveArray) -> usize
+
+pub fn vortex_array::arrays::Primitive::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Primitive::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Primitive::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Primitive::stats(array: &vortex_array::arrays::PrimitiveArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Primitive::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::primitive::PrimitiveArray
 
@@ -3060,131 +3180,11 @@ impl core::fmt::Debug for vortex_array::arrays::primitive::PrimitiveMaskedValidi
 
 pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Primitive> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
 
-pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::primitive::PrimitiveVTable
-
-impl vortex_array::arrays::PrimitiveVTable
-
-pub const vortex_array::arrays::PrimitiveVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::is_constant(&self, array: &vortex_array::arrays::PrimitiveArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::is_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::is_strict_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::min_max(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::NaNCountKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::nan_count(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<usize>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
-
-pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::Masked
 
 pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::cast(array: &vortex_array::arrays::PrimitiveArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::fill_null(array: &vortex_array::arrays::PrimitiveArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::mask(array: &vortex_array::arrays::PrimitiveArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::PrimitiveVTable
-
-pub type vortex_array::arrays::PrimitiveVTable::Array = vortex_array::arrays::PrimitiveArray
-
-pub type vortex_array::arrays::PrimitiveVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::PrimitiveVTable::OperationsVTable = vortex_array::arrays::PrimitiveVTable
-
-pub type vortex_array::arrays::PrimitiveVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::PrimitiveVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::PrimitiveVTable::array_eq(array: &vortex_array::arrays::PrimitiveArray, other: &vortex_array::arrays::PrimitiveArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::PrimitiveVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::PrimitiveArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::PrimitiveVTable::buffer(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::PrimitiveVTable::buffer_name(_array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::PrimitiveVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
-
-pub fn vortex_array::arrays::PrimitiveVTable::child(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::PrimitiveVTable::child_name(_array: &vortex_array::arrays::PrimitiveArray, _idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::PrimitiveVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::PrimitiveVTable::dtype(array: &vortex_array::arrays::PrimitiveArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::PrimitiveVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::PrimitiveVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::PrimitiveVTable::len(array: &vortex_array::arrays::PrimitiveArray) -> usize
-
-pub fn vortex_array::arrays::PrimitiveVTable::metadata(_array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::PrimitiveVTable::nbuffers(_array: &vortex_array::arrays::PrimitiveArray) -> usize
-
-pub fn vortex_array::arrays::PrimitiveVTable::nchildren(array: &vortex_array::arrays::PrimitiveArray) -> usize
-
-pub fn vortex_array::arrays::PrimitiveVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::stats(array: &vortex_array::arrays::PrimitiveArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::PrimitiveVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub const vortex_array::arrays::primitive::IS_CONST_LANE_WIDTH: usize
 
@@ -3378,6 +3378,78 @@ pub fn V::try_new_array(&self, len: usize, options: Self::Options, children: imp
 
 pub mod vortex_array::arrays::shared
 
+pub struct vortex_array::arrays::shared::Shared
+
+impl vortex_array::arrays::Shared
+
+pub const vortex_array::arrays::Shared::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::Shared
+
+pub fn vortex_array::arrays::Shared::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
+
+pub fn vortex_array::arrays::Shared::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::Shared
+
+pub type vortex_array::arrays::Shared::Array = vortex_array::arrays::SharedArray
+
+pub type vortex_array::arrays::Shared::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::Shared::OperationsVTable = vortex_array::arrays::Shared
+
+pub type vortex_array::arrays::Shared::ValidityVTable = vortex_array::arrays::Shared
+
+pub fn vortex_array::arrays::Shared::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::Shared::array_eq(array: &vortex_array::arrays::SharedArray, other: &vortex_array::arrays::SharedArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::Shared::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SharedArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::Shared::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::Shared::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::Shared::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::SharedArray>
+
+pub fn vortex_array::arrays::Shared::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::Shared::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::Shared::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Shared::dtype(array: &vortex_array::arrays::SharedArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::Shared::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::Shared::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Shared::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Shared::len(array: &vortex_array::arrays::SharedArray) -> usize
+
+pub fn vortex_array::arrays::Shared::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Shared::nbuffers(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::Shared::nchildren(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::Shared::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Shared::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Shared::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Shared::stats(array: &vortex_array::arrays::SharedArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Shared::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
+
+pub fn vortex_array::arrays::Shared::validity(array: &vortex_array::arrays::SharedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
 pub struct vortex_array::arrays::shared::SharedArray
 
 impl vortex_array::arrays::SharedArray
@@ -3418,79 +3490,83 @@ impl vortex_array::IntoArray for vortex_array::arrays::SharedArray
 
 pub fn vortex_array::arrays::SharedArray::into_array(self) -> vortex_array::ArrayRef
 
-pub struct vortex_array::arrays::shared::SharedVTable
-
-impl vortex_array::arrays::SharedVTable
-
-pub const vortex_array::arrays::SharedVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::SharedVTable
-
-pub fn vortex_array::arrays::SharedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
-
-pub fn vortex_array::arrays::SharedVTable::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::SharedVTable
-
-pub type vortex_array::arrays::SharedVTable::Array = vortex_array::arrays::SharedArray
-
-pub type vortex_array::arrays::SharedVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::SharedVTable::OperationsVTable = vortex_array::arrays::SharedVTable
-
-pub type vortex_array::arrays::SharedVTable::ValidityVTable = vortex_array::arrays::SharedVTable
-
-pub fn vortex_array::arrays::SharedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::SharedVTable::array_eq(array: &vortex_array::arrays::SharedArray, other: &vortex_array::arrays::SharedArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::SharedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SharedArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::SharedVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::SharedVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::SharedVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::SharedArray>
-
-pub fn vortex_array::arrays::SharedVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::SharedVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::SharedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::SharedVTable::dtype(array: &vortex_array::arrays::SharedArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::SharedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::SharedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::SharedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::SharedVTable::len(array: &vortex_array::arrays::SharedArray) -> usize
-
-pub fn vortex_array::arrays::SharedVTable::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::SharedVTable::nbuffers(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::SharedVTable::nchildren(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::SharedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::SharedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::SharedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::SharedVTable::stats(array: &vortex_array::arrays::SharedArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::SharedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
-
-pub fn vortex_array::arrays::SharedVTable::validity(array: &vortex_array::arrays::SharedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
-
 pub mod vortex_array::arrays::slice
+
+pub struct vortex_array::arrays::slice::Slice
+
+impl vortex_array::arrays::slice::Slice
+
+pub const vortex_array::arrays::slice::Slice::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::slice::Slice
+
+pub fn vortex_array::arrays::slice::Slice::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::Slice
+
+pub fn vortex_array::arrays::slice::Slice::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
+
+pub fn vortex_array::arrays::slice::Slice::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::slice::Slice
+
+pub type vortex_array::arrays::slice::Slice::Array = vortex_array::arrays::slice::SliceArray
+
+pub type vortex_array::arrays::slice::Slice::Metadata = vortex_array::arrays::slice::SliceMetadata
+
+pub type vortex_array::arrays::slice::Slice::OperationsVTable = vortex_array::arrays::slice::Slice
+
+pub type vortex_array::arrays::slice::Slice::ValidityVTable = vortex_array::arrays::slice::Slice
+
+pub fn vortex_array::arrays::slice::Slice::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::slice::Slice::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::slice::Slice::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::slice::Slice::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::slice::Slice::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::slice::Slice::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+
+pub fn vortex_array::arrays::slice::Slice::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::slice::Slice::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::slice::Slice::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::slice::Slice::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::slice::Slice::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::slice::Slice::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::slice::Slice::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::slice::Slice::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
+
+pub fn vortex_array::arrays::slice::Slice::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::slice::Slice::nbuffers(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::slice::Slice::nchildren(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::slice::Slice::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::slice::Slice::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::slice::Slice::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::slice::Slice::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::slice::Slice::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
+
+pub fn vortex_array::arrays::slice::Slice::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::slice::SliceArray
 
@@ -3554,7 +3630,7 @@ pub fn vortex_array::arrays::slice::SliceExecuteAdaptor<V>::fmt(&self, f: &mut c
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::slice::SliceExecuteAdaptor<V> where V: vortex_array::arrays::slice::SliceKernel
 
-pub type vortex_array::arrays::slice::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
+pub type vortex_array::arrays::slice::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::slice::Slice
 
 pub fn vortex_array::arrays::slice::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -3576,163 +3652,183 @@ pub fn vortex_array::arrays::slice::SliceReduceAdaptor<V>::fmt(&self, f: &mut co
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::slice::SliceReduceAdaptor<V> where V: vortex_array::arrays::slice::SliceReduce
 
-pub type vortex_array::arrays::slice::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
+pub type vortex_array::arrays::slice::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::slice::Slice
 
 pub fn vortex_array::arrays::slice::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub struct vortex_array::arrays::slice::SliceVTable
-
-impl vortex_array::arrays::slice::SliceVTable
-
-pub const vortex_array::arrays::slice::SliceVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::slice::SliceVTable
-
-pub type vortex_array::arrays::slice::SliceVTable::Array = vortex_array::arrays::slice::SliceArray
-
-pub type vortex_array::arrays::slice::SliceVTable::Metadata = vortex_array::arrays::slice::SliceMetadata
-
-pub type vortex_array::arrays::slice::SliceVTable::OperationsVTable = vortex_array::arrays::slice::SliceVTable
-
-pub type vortex_array::arrays::slice::SliceVTable::ValidityVTable = vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::slice::SliceVTable::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::slice::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::slice::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::slice::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::slice::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
-
-pub fn vortex_array::arrays::slice::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::slice::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::slice::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::slice::SliceVTable::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::slice::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::slice::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::slice::SliceVTable::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
-
-pub fn vortex_array::arrays::slice::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::slice::SliceVTable::nbuffers(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::slice::SliceVTable::nchildren(_array: &Self::Array) -> usize
-
-pub fn vortex_array::arrays::slice::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::slice::SliceVTable::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::slice::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
-
-pub fn vortex_array::arrays::slice::SliceVTable::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub trait vortex_array::arrays::slice::SliceKernel: vortex_array::vtable::VTable
 
 pub fn vortex_array::arrays::slice::SliceKernel::slice(array: &Self::Array, range: core::ops::range::Range<usize>, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::arrays::slice::SliceReduce: vortex_array::vtable::VTable
 
 pub fn vortex_array::arrays::slice::SliceReduce::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::DecimalVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ExtensionVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FixedSizeList::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListViewVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Masked::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::StructVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Struct::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
 pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::SliceVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::slice::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::Slice::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::arrays::struct_
+
+pub struct vortex_array::arrays::struct_::Struct
+
+impl vortex_array::arrays::Struct
+
+pub const vortex_array::arrays::Struct::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::Struct
+
+pub fn vortex_array::arrays::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::Struct
+
+pub fn vortex_array::arrays::Struct::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Struct
+
+pub fn vortex_array::arrays::Struct::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Struct
+
+pub fn vortex_array::arrays::Struct::is_constant(&self, array: &vortex_array::arrays::StructArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Struct
+
+pub fn vortex_array::arrays::Struct::min_max(&self, _array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::Struct
+
+pub fn vortex_array::arrays::Struct::cast(array: &vortex_array::arrays::StructArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Struct
+
+pub fn vortex_array::arrays::Struct::mask(array: &vortex_array::arrays::StructArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::Struct
+
+pub fn vortex_array::arrays::Struct::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
+
+pub fn vortex_array::arrays::Struct::scalar_at(array: &vortex_array::arrays::StructArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::Struct
+
+pub type vortex_array::arrays::Struct::Array = vortex_array::arrays::StructArray
+
+pub type vortex_array::arrays::Struct::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::Struct::OperationsVTable = vortex_array::arrays::Struct
+
+pub type vortex_array::arrays::Struct::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::Struct::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::Struct::array_eq(array: &vortex_array::arrays::StructArray, other: &vortex_array::arrays::StructArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::Struct::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::StructArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::Struct::buffer(_array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::Struct::buffer_name(_array: &vortex_array::arrays::StructArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::Struct::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::StructArray>
+
+pub fn vortex_array::arrays::Struct::child(array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::Struct::child_name(array: &vortex_array::arrays::StructArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::Struct::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Struct::dtype(array: &vortex_array::arrays::StructArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::Struct::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::Struct::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Struct::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Struct::len(array: &vortex_array::arrays::StructArray) -> usize
+
+pub fn vortex_array::arrays::Struct::metadata(_array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Struct::nbuffers(_array: &vortex_array::arrays::StructArray) -> usize
+
+pub fn vortex_array::arrays::Struct::nchildren(array: &vortex_array::arrays::StructArray) -> usize
+
+pub fn vortex_array::arrays::Struct::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Struct::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Struct::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Struct::stats(array: &vortex_array::arrays::StructArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Struct::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::struct_::StructArray
 
@@ -3826,102 +3922,6 @@ pub vortex_array::arrays::struct_::StructArrayParts::struct_fields: vortex_array
 
 pub vortex_array::arrays::struct_::StructArrayParts::validity: vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::struct_::StructVTable
-
-impl vortex_array::arrays::StructVTable
-
-pub const vortex_array::arrays::StructVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::is_constant(&self, array: &vortex_array::arrays::StructArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::min_max(&self, _array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::cast(array: &vortex_array::arrays::StructArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::mask(array: &vortex_array::arrays::StructArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::scalar_at(array: &vortex_array::arrays::StructArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::StructVTable
-
-pub type vortex_array::arrays::StructVTable::Array = vortex_array::arrays::StructArray
-
-pub type vortex_array::arrays::StructVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::StructVTable::OperationsVTable = vortex_array::arrays::StructVTable
-
-pub type vortex_array::arrays::StructVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::StructVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::StructVTable::array_eq(array: &vortex_array::arrays::StructArray, other: &vortex_array::arrays::StructArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::StructVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::StructArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::StructVTable::buffer(_array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::StructVTable::buffer_name(_array: &vortex_array::arrays::StructArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::StructVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::StructArray>
-
-pub fn vortex_array::arrays::StructVTable::child(array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::StructVTable::child_name(array: &vortex_array::arrays::StructArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::StructVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::StructVTable::dtype(array: &vortex_array::arrays::StructArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::StructVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::StructVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::StructVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::StructVTable::len(array: &vortex_array::arrays::StructArray) -> usize
-
-pub fn vortex_array::arrays::StructVTable::metadata(_array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::StructVTable::nbuffers(_array: &vortex_array::arrays::StructArray) -> usize
-
-pub fn vortex_array::arrays::StructVTable::nchildren(array: &vortex_array::arrays::StructArray) -> usize
-
-pub fn vortex_array::arrays::StructVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::StructVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::StructVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::StructVTable::stats(array: &vortex_array::arrays::StructArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::StructVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
 pub mod vortex_array::arrays::varbin
 
 pub mod vortex_array::arrays::varbin::builder
@@ -3949,6 +3949,116 @@ pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::with_capacity(le
 impl<O: vortex_array::dtype::IntegerPType> core::default::Default for vortex_array::arrays::varbin::builder::VarBinBuilder<O>
 
 pub fn vortex_array::arrays::varbin::builder::VarBinBuilder<O>::default() -> Self
+
+pub struct vortex_array::arrays::varbin::VarBin
+
+impl vortex_array::arrays::VarBin
+
+pub const vortex_array::arrays::VarBin::ID: vortex_array::vtable::ArrayId
+
+impl vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::_slice(array: &vortex_array::arrays::VarBinArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+impl core::fmt::Debug for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::is_constant(&self, array: &vortex_array::arrays::VarBinArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::is_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::VarBin::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::min_max(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::cast(array: &vortex_array::arrays::VarBinArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::mask(array: &vortex_array::arrays::VarBinArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBin> for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::VarBin
+
+pub type vortex_array::arrays::VarBin::Array = vortex_array::arrays::VarBinArray
+
+pub type vortex_array::arrays::VarBin::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::varbin::vtable::VarBinMetadata>
+
+pub type vortex_array::arrays::VarBin::OperationsVTable = vortex_array::arrays::VarBin
+
+pub type vortex_array::arrays::VarBin::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::VarBin::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::VarBin::array_eq(array: &vortex_array::arrays::VarBinArray, other: &vortex_array::arrays::VarBinArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::VarBin::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::VarBin::buffer(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::VarBin::buffer_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::VarBin::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinArray>
+
+pub fn vortex_array::arrays::VarBin::child(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::VarBin::child_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::VarBin::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBin::dtype(array: &vortex_array::arrays::VarBinArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::VarBin::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::VarBin::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBin::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::VarBin::len(array: &vortex_array::arrays::VarBinArray) -> usize
+
+pub fn vortex_array::arrays::VarBin::metadata(array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBin::nbuffers(_array: &vortex_array::arrays::VarBinArray) -> usize
+
+pub fn vortex_array::arrays::VarBin::nchildren(array: &vortex_array::arrays::VarBinArray) -> usize
+
+pub fn vortex_array::arrays::VarBin::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBin::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBin::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::VarBin::stats(array: &vortex_array::arrays::VarBinArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::VarBin::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::varbin::VarBinArray
 
@@ -4077,116 +4187,6 @@ pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::colle
 impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a str>> for vortex_array::arrays::VarBinArray
 
 pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a str>>>(iter: T) -> Self
-
-pub struct vortex_array::arrays::varbin::VarBinVTable
-
-impl vortex_array::arrays::VarBinVTable
-
-pub const vortex_array::arrays::VarBinVTable::ID: vortex_array::vtable::ArrayId
-
-impl vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::_slice(array: &vortex_array::arrays::VarBinArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-impl core::fmt::Debug for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::is_constant(&self, array: &vortex_array::arrays::VarBinArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::VarBinVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::min_max(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::cast(array: &vortex_array::arrays::VarBinArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::mask(array: &vortex_array::arrays::VarBinArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinVTable> for vortex_array::arrays::VarBinVTable
-
-pub fn vortex_array::arrays::VarBinVTable::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinVTable
-
-pub type vortex_array::arrays::VarBinVTable::Array = vortex_array::arrays::VarBinArray
-
-pub type vortex_array::arrays::VarBinVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::varbin::vtable::VarBinMetadata>
-
-pub type vortex_array::arrays::VarBinVTable::OperationsVTable = vortex_array::arrays::VarBinVTable
-
-pub type vortex_array::arrays::VarBinVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::VarBinVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::VarBinVTable::array_eq(array: &vortex_array::arrays::VarBinArray, other: &vortex_array::arrays::VarBinArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::VarBinVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::VarBinVTable::buffer(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::VarBinVTable::buffer_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::VarBinVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinArray>
-
-pub fn vortex_array::arrays::VarBinVTable::child(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::VarBinVTable::child_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::VarBinVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::VarBinVTable::dtype(array: &vortex_array::arrays::VarBinArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::VarBinVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::VarBinVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::VarBinVTable::len(array: &vortex_array::arrays::VarBinArray) -> usize
-
-pub fn vortex_array::arrays::VarBinVTable::metadata(array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::VarBinVTable::nbuffers(_array: &vortex_array::arrays::VarBinArray) -> usize
-
-pub fn vortex_array::arrays::VarBinVTable::nchildren(array: &vortex_array::arrays::VarBinArray) -> usize
-
-pub fn vortex_array::arrays::VarBinVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::VarBinVTable::stats(array: &vortex_array::arrays::VarBinArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::VarBinVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub fn vortex_array::arrays::varbin::varbin_scalar(value: vortex_buffer::ByteBuffer, dtype: &vortex_array::dtype::DType) -> vortex_array::scalar::Scalar
 
@@ -4374,6 +4374,108 @@ pub fn vortex_array::arrays::varbinview::Ref::fmt(&self, f: &mut core::fmt::Form
 
 impl core::marker::Copy for vortex_array::arrays::varbinview::Ref
 
+pub struct vortex_array::arrays::varbinview::VarBinView
+
+impl vortex_array::arrays::VarBinView
+
+pub const vortex_array::arrays::VarBinView::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::VarBinView
+
+pub fn vortex_array::arrays::VarBinView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinView
+
+pub fn vortex_array::arrays::VarBinView::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinView
+
+pub fn vortex_array::arrays::VarBinView::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinView
+
+pub fn vortex_array::arrays::VarBinView::is_constant(&self, array: &vortex_array::arrays::VarBinViewArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinView
+
+pub fn vortex_array::arrays::VarBinView::is_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::VarBinView::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinView
+
+pub fn vortex_array::arrays::VarBinView::min_max(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinView
+
+pub fn vortex_array::arrays::VarBinView::cast(array: &vortex_array::arrays::VarBinViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinView
+
+pub fn vortex_array::arrays::VarBinView::mask(array: &vortex_array::arrays::VarBinViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinView
+
+pub fn vortex_array::arrays::VarBinView::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinView> for vortex_array::arrays::VarBinView
+
+pub fn vortex_array::arrays::VarBinView::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinView
+
+pub type vortex_array::arrays::VarBinView::Array = vortex_array::arrays::VarBinViewArray
+
+pub type vortex_array::arrays::VarBinView::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::VarBinView::OperationsVTable = vortex_array::arrays::VarBinView
+
+pub type vortex_array::arrays::VarBinView::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::VarBinView::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::VarBinView::array_eq(array: &vortex_array::arrays::VarBinViewArray, other: &vortex_array::arrays::VarBinViewArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::VarBinView::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinViewArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::VarBinView::buffer(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::VarBinView::buffer_name(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::VarBinView::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
+
+pub fn vortex_array::arrays::VarBinView::child(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::VarBinView::child_name(_array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::VarBinView::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBinView::dtype(array: &vortex_array::arrays::VarBinViewArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::VarBinView::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::VarBinView::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBinView::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::VarBinView::len(array: &vortex_array::arrays::VarBinViewArray) -> usize
+
+pub fn vortex_array::arrays::VarBinView::metadata(_array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBinView::nbuffers(array: &vortex_array::arrays::VarBinViewArray) -> usize
+
+pub fn vortex_array::arrays::VarBinView::nchildren(array: &vortex_array::arrays::VarBinViewArray) -> usize
+
+pub fn vortex_array::arrays::VarBinView::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBinView::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBinView::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::VarBinView::stats(array: &vortex_array::arrays::VarBinViewArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::VarBinView::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
 pub struct vortex_array::arrays::varbinview::VarBinViewArray
 
 impl vortex_array::arrays::VarBinViewArray
@@ -4494,107 +4596,121 @@ pub vortex_array::arrays::varbinview::VarBinViewArrayParts::validity: vortex_arr
 
 pub vortex_array::arrays::varbinview::VarBinViewArrayParts::views: vortex_array::buffer::BufferHandle
 
-pub struct vortex_array::arrays::varbinview::VarBinViewVTable
+pub struct vortex_array::arrays::Bool
 
-impl vortex_array::arrays::VarBinViewVTable
+impl vortex_array::arrays::Bool
 
-pub const vortex_array::arrays::VarBinViewVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::Bool::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::VarBinViewVTable
+impl core::fmt::Debug for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::Bool::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::is_constant(&self, array: &vortex_array::arrays::VarBinViewArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Bool::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Bool::is_constant(&self, array: &vortex_array::arrays::BoolArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::VarBinViewVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Bool
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinViewVTable
+pub fn vortex_array::arrays::Bool::is_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::VarBinViewVTable::min_max(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::Bool::is_strict_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::cast(array: &vortex_array::arrays::VarBinViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::min_max(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::mask(array: &vortex_array::arrays::VarBinViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::sum(&self, array: &vortex_array::arrays::BoolArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Bool> for vortex_array::arrays::bool::BoolMaskedValidityRule
 
-pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::Masked
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinViewVTable> for vortex_array::arrays::VarBinViewVTable
+pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinViewVTable::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Bool
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinViewVTable
+pub fn vortex_array::arrays::Bool::cast(array: &vortex_array::arrays::BoolArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub type vortex_array::arrays::VarBinViewVTable::Array = vortex_array::arrays::VarBinViewArray
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::Bool
 
-pub type vortex_array::arrays::VarBinViewVTable::Metadata = vortex_array::EmptyMetadata
+pub fn vortex_array::arrays::Bool::fill_null(array: &vortex_array::arrays::BoolArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub type vortex_array::arrays::VarBinViewVTable::OperationsVTable = vortex_array::arrays::VarBinViewVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Bool
 
-pub type vortex_array::arrays::VarBinViewVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub fn vortex_array::arrays::Bool::mask(array: &vortex_array::arrays::BoolArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Bool> for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::array_eq(array: &vortex_array::arrays::VarBinViewArray, other: &vortex_array::arrays::VarBinViewArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Bool::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::VarBinViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinViewArray, state: &mut H, precision: vortex_array::Precision)
+impl vortex_array::vtable::VTable for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::buffer(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub type vortex_array::arrays::Bool::Array = vortex_array::arrays::BoolArray
 
-pub fn vortex_array::arrays::VarBinViewVTable::buffer_name(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub type vortex_array::arrays::Bool::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::bool::vtable::BoolMetadata>
 
-pub fn vortex_array::arrays::VarBinViewVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
+pub type vortex_array::arrays::Bool::OperationsVTable = vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::child(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::ArrayRef
+pub type vortex_array::arrays::Bool::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::VarBinViewVTable::child_name(_array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Bool::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::VarBinViewVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Bool::array_eq(array: &vortex_array::arrays::BoolArray, other: &vortex_array::arrays::BoolArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::dtype(array: &vortex_array::arrays::VarBinViewArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Bool::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::BoolArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::VarBinViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Bool::buffer(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::VarBinViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::buffer_name(_array: &vortex_array::arrays::BoolArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::VarBinViewVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Bool::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::BoolArray>
 
-pub fn vortex_array::arrays::VarBinViewVTable::len(array: &vortex_array::arrays::VarBinViewArray) -> usize
+pub fn vortex_array::arrays::Bool::child(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::VarBinViewVTable::metadata(_array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Bool::child_name(_array: &vortex_array::arrays::BoolArray, _idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::VarBinViewVTable::nbuffers(array: &vortex_array::arrays::VarBinViewArray) -> usize
+pub fn vortex_array::arrays::Bool::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::VarBinViewVTable::nchildren(array: &vortex_array::arrays::VarBinViewArray) -> usize
+pub fn vortex_array::arrays::Bool::dtype(array: &vortex_array::arrays::BoolArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::VarBinViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::VarBinViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinViewVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Bool::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::VarBinViewVTable::stats(array: &vortex_array::arrays::VarBinViewArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Bool::len(array: &vortex_array::arrays::BoolArray) -> usize
 
-pub fn vortex_array::arrays::VarBinViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Bool::metadata(array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Bool::nbuffers(_array: &vortex_array::arrays::BoolArray) -> usize
+
+pub fn vortex_array::arrays::Bool::nchildren(array: &vortex_array::arrays::BoolArray) -> usize
+
+pub fn vortex_array::arrays::Bool::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Bool::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Bool::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Bool::stats(array: &vortex_array::arrays::BoolArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Bool::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::BoolArray
 
@@ -4680,121 +4796,123 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::BoolArray
 
 pub fn vortex_array::arrays::BoolArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::BoolVTable
+pub struct vortex_array::arrays::Chunked
 
-impl vortex_array::arrays::BoolVTable
+impl vortex_array::arrays::Chunked
 
-pub const vortex_array::arrays::BoolVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::Chunked::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::BoolVTable
+impl core::fmt::Debug for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::BoolVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::Chunked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::BoolVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::BoolVTable::take(array: &vortex_array::arrays::BoolArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::BoolVTable::filter(array: &vortex_array::arrays::BoolArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::BoolVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::BoolVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::BoolVTable::is_constant(&self, array: &vortex_array::arrays::BoolArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Chunked::is_constant(&self, array: &vortex_array::arrays::ChunkedArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::BoolVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::BoolVTable::is_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Chunked::is_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::BoolVTable::is_strict_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Chunked::is_strict_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::BoolVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::BoolVTable::min_max(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::Chunked::min_max(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::BoolVTable
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::BoolVTable::sum(&self, array: &vortex_array::arrays::BoolArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Chunked::sum(&self, array: &vortex_array::arrays::ChunkedArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Chunked
 
-pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub fn vortex_array::arrays::Chunked::cast(array: &vortex_array::arrays::ChunkedArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::Chunked
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::Chunked::fill_null(array: &vortex_array::arrays::ChunkedArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::cast(array: &vortex_array::arrays::BoolArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::scalar_fn::fns::mask::MaskKernel for vortex_array::arrays::Chunked
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::Chunked::mask(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::fill_null(array: &vortex_array::arrays::BoolArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::Chunked
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::Chunked::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::mask(array: &vortex_array::arrays::BoolArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolVTable
+pub fn vortex_array::arrays::Chunked::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::BoolVTable::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+impl vortex_array::vtable::VTable for vortex_array::arrays::Chunked
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::BoolVTable
+pub type vortex_array::arrays::Chunked::Array = vortex_array::arrays::ChunkedArray
 
-pub type vortex_array::arrays::BoolVTable::Array = vortex_array::arrays::BoolArray
+pub type vortex_array::arrays::Chunked::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::BoolVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::bool::vtable::BoolMetadata>
+pub type vortex_array::arrays::Chunked::OperationsVTable = vortex_array::arrays::Chunked
 
-pub type vortex_array::arrays::BoolVTable::OperationsVTable = vortex_array::arrays::BoolVTable
+pub type vortex_array::arrays::Chunked::ValidityVTable = vortex_array::arrays::Chunked
 
-pub type vortex_array::arrays::BoolVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub fn vortex_array::arrays::Chunked::append_to_builder(array: &vortex_array::arrays::ChunkedArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::BoolVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Chunked::array_eq(array: &vortex_array::arrays::ChunkedArray, other: &vortex_array::arrays::ChunkedArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::BoolVTable::array_eq(array: &vortex_array::arrays::BoolArray, other: &vortex_array::arrays::BoolArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Chunked::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ChunkedArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::BoolVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::BoolArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Chunked::buffer(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::BoolVTable::buffer(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Chunked::buffer_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::BoolVTable::buffer_name(_array: &vortex_array::arrays::BoolArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Chunked::build(dtype: &vortex_array::dtype::DType, _len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ChunkedArray>
 
-pub fn vortex_array::arrays::BoolVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::BoolArray>
+pub fn vortex_array::arrays::Chunked::child(array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::BoolVTable::child(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Chunked::child_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::BoolVTable::child_name(_array: &vortex_array::arrays::BoolArray, _idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Chunked::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::BoolVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Chunked::dtype(array: &vortex_array::arrays::ChunkedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::BoolVTable::dtype(array: &vortex_array::arrays::BoolArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Chunked::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::BoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Chunked::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::BoolVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Chunked::len(array: &vortex_array::arrays::ChunkedArray) -> usize
 
-pub fn vortex_array::arrays::BoolVTable::len(array: &vortex_array::arrays::BoolArray) -> usize
+pub fn vortex_array::arrays::Chunked::metadata(_array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::BoolVTable::metadata(array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Chunked::nbuffers(_array: &vortex_array::arrays::ChunkedArray) -> usize
 
-pub fn vortex_array::arrays::BoolVTable::nbuffers(_array: &vortex_array::arrays::BoolArray) -> usize
+pub fn vortex_array::arrays::Chunked::nchildren(array: &vortex_array::arrays::ChunkedArray) -> usize
 
-pub fn vortex_array::arrays::BoolVTable::nchildren(array: &vortex_array::arrays::BoolArray) -> usize
+pub fn vortex_array::arrays::Chunked::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::BoolVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Chunked::stats(array: &vortex_array::arrays::ChunkedArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::BoolVTable::stats(array: &vortex_array::arrays::BoolArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Chunked::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::BoolVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
+
+pub fn vortex_array::arrays::Chunked::validity(array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::ChunkedArray
 
@@ -4856,123 +4974,117 @@ impl vortex_array::IntoArray for vortex_array::arrays::ChunkedArray
 
 pub fn vortex_array::arrays::ChunkedArray::into_array(self) -> vortex_array::ArrayRef
 
-pub struct vortex_array::arrays::ChunkedVTable
+pub struct vortex_array::arrays::Constant
 
-impl vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::Constant
 
-pub const vortex_array::arrays::ChunkedVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::Constant::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ChunkedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub const vortex_array::arrays::Constant::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ChunkedVTable
+impl core::fmt::Debug for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ChunkedVTable::take(array: &vortex_array::arrays::ChunkedArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ChunkedVTable::filter(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_mask::Mask, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ChunkedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ChunkedVTable::is_constant(&self, array: &vortex_array::arrays::ChunkedArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Constant::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ChunkedVTable::is_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Constant::min_max(&self, array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-pub fn vortex_array::arrays::ChunkedVTable::is_strict_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Constant
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ChunkedVTable
+pub fn vortex_array::arrays::Constant::sum(&self, array: &vortex_array::arrays::ConstantArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::ChunkedVTable::min_max(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::Constant
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ChunkedVTable
+pub fn vortex_array::arrays::Constant::between(array: &vortex_array::arrays::ConstantArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ChunkedVTable::sum(&self, array: &vortex_array::arrays::ChunkedArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Constant
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ChunkedVTable
+pub fn vortex_array::arrays::Constant::cast(array: &vortex_array::arrays::ConstantArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ChunkedVTable::cast(array: &vortex_array::arrays::ChunkedArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::Constant
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::ChunkedVTable
+pub fn vortex_array::arrays::Constant::fill_null(array: &vortex_array::arrays::ConstantArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ChunkedVTable::fill_null(array: &vortex_array::arrays::ChunkedArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::scalar_fn::fns::not::NotReduce for vortex_array::arrays::Constant
 
-impl vortex_array::scalar_fn::fns::mask::MaskKernel for vortex_array::arrays::ChunkedVTable
+pub fn vortex_array::arrays::Constant::invert(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ChunkedVTable::mask(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
 
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::ChunkedVTable
+pub fn vortex_array::arrays::Constant::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::vtable::VTable for vortex_array::arrays::Constant
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
+pub type vortex_array::arrays::Constant::Array = vortex_array::arrays::ConstantArray
 
-pub fn vortex_array::arrays::ChunkedVTable::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub type vortex_array::arrays::Constant::Metadata = vortex_array::scalar::Scalar
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ChunkedVTable
+pub type vortex_array::arrays::Constant::OperationsVTable = vortex_array::arrays::Constant
 
-pub type vortex_array::arrays::ChunkedVTable::Array = vortex_array::arrays::ChunkedArray
+pub type vortex_array::arrays::Constant::ValidityVTable = vortex_array::arrays::Constant
 
-pub type vortex_array::arrays::ChunkedVTable::Metadata = vortex_array::EmptyMetadata
+pub fn vortex_array::arrays::Constant::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub type vortex_array::arrays::ChunkedVTable::OperationsVTable = vortex_array::arrays::ChunkedVTable
+pub fn vortex_array::arrays::Constant::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 
-pub type vortex_array::arrays::ChunkedVTable::ValidityVTable = vortex_array::arrays::ChunkedVTable
+pub fn vortex_array::arrays::Constant::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ConstantArray, state: &mut H, _precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::ChunkedVTable::append_to_builder(array: &vortex_array::arrays::ChunkedArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Constant::buffer(array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::ChunkedVTable::array_eq(array: &vortex_array::arrays::ChunkedArray, other: &vortex_array::arrays::ChunkedArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Constant::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ChunkedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ChunkedArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Constant::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
 
-pub fn vortex_array::arrays::ChunkedVTable::buffer(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Constant::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ChunkedVTable::buffer_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Constant::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ChunkedVTable::build(dtype: &vortex_array::dtype::DType, _len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ChunkedArray>
+pub fn vortex_array::arrays::Constant::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ChunkedVTable::child(array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Constant::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ChunkedVTable::child_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Constant::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::ChunkedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Constant::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ChunkedVTable::dtype(array: &vortex_array::arrays::ChunkedArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Constant::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::ChunkedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Constant::len(array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ChunkedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ChunkedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Constant::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ChunkedVTable::len(array: &vortex_array::arrays::ChunkedArray) -> usize
+pub fn vortex_array::arrays::Constant::nchildren(_array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ChunkedVTable::metadata(_array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Constant::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ChunkedVTable::nbuffers(_array: &vortex_array::arrays::ChunkedArray) -> usize
+pub fn vortex_array::arrays::Constant::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ChunkedVTable::nchildren(array: &vortex_array::arrays::ChunkedArray) -> usize
+pub fn vortex_array::arrays::Constant::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::ChunkedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::stats(array: &vortex_array::arrays::ConstantArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::ChunkedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::ChunkedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ChunkedVTable::stats(array: &vortex_array::arrays::ChunkedArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ChunkedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
-
-pub fn vortex_array::arrays::ChunkedVTable::validity(array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::Constant::validity(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::ConstantArray
 
@@ -5014,117 +5126,121 @@ impl vortex_array::IntoArray for vortex_array::arrays::ConstantArray
 
 pub fn vortex_array::arrays::ConstantArray::into_array(self) -> vortex_array::ArrayRef
 
-pub struct vortex_array::arrays::ConstantVTable
+pub struct vortex_array::arrays::Decimal
 
-impl vortex_array::arrays::ConstantVTable
+impl vortex_array::arrays::Decimal
 
-pub const vortex_array::arrays::ConstantVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::Decimal::ID: vortex_array::vtable::ArrayId
 
-impl vortex_array::arrays::ConstantVTable
+impl core::fmt::Debug for vortex_array::arrays::Decimal
 
-pub const vortex_array::arrays::ConstantVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
+pub fn vortex_array::arrays::Decimal::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl core::fmt::Debug for vortex_array::arrays::ConstantVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::ConstantVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::Decimal::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::ConstantVTable::take(array: &vortex_array::arrays::ConstantArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::ConstantVTable::filter(array: &vortex_array::arrays::ConstantArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::is_constant(&self, array: &vortex_array::arrays::DecimalArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::ConstantVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::is_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ConstantVTable
+pub fn vortex_array::arrays::Decimal::is_strict_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::ConstantVTable::min_max(&self, array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Decimal
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ConstantVTable
+pub fn vortex_array::arrays::Decimal::min_max(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-pub fn vortex_array::arrays::ConstantVTable::sum(&self, array: &vortex_array::arrays::ConstantArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Decimal
 
-impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::ConstantVTable
+pub fn vortex_array::arrays::Decimal::sum(&self, array: &vortex_array::arrays::DecimalArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::ConstantVTable::between(array: &vortex_array::arrays::ConstantArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Decimal> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ConstantVTable
+pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::ConstantVTable::cast(array: &vortex_array::arrays::ConstantArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::ConstantVTable::fill_null(array: &vortex_array::arrays::ConstantArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::between(arr: &vortex_array::arrays::DecimalArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::not::NotReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::ConstantVTable::invert(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::cast(array: &vortex_array::arrays::DecimalArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::ConstantVTable::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Decimal::fill_null(array: &vortex_array::arrays::DecimalArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ConstantVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Decimal
 
-pub type vortex_array::arrays::ConstantVTable::Array = vortex_array::arrays::ConstantArray
+pub fn vortex_array::arrays::Decimal::mask(array: &vortex_array::arrays::DecimalArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::scalar::Scalar
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Decimal> for vortex_array::arrays::Decimal
 
-pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::arrays::ConstantVTable
+pub fn vortex_array::arrays::Decimal::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub type vortex_array::arrays::Decimal::Array = vortex_array::arrays::DecimalArray
 
-pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
+pub type vortex_array::arrays::Decimal::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::decimal::vtable::DecimalMetadata>
 
-pub fn vortex_array::arrays::ConstantVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ConstantArray, state: &mut H, _precision: vortex_array::Precision)
+pub type vortex_array::arrays::Decimal::OperationsVTable = vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::ConstantVTable::buffer(array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub type vortex_array::arrays::Decimal::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::ConstantVTable::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Decimal::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::ConstantVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
+pub fn vortex_array::arrays::Decimal::array_eq(array: &vortex_array::arrays::DecimalArray, other: &vortex_array::arrays::DecimalArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::ConstantVTable::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Decimal::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DecimalArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::ConstantVTable::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Decimal::buffer(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Decimal::buffer_name(_array: &vortex_array::arrays::DecimalArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Decimal::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DecimalArray>
 
-pub fn vortex_array::arrays::ConstantVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Decimal::child(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ConstantVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::child_name(_array: &vortex_array::arrays::DecimalArray, _idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Decimal::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
+pub fn vortex_array::arrays::Decimal::dtype(array: &vortex_array::arrays::DecimalArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ConstantVTable::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Decimal::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
+pub fn vortex_array::arrays::Decimal::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ConstantVTable::nchildren(_array: &vortex_array::arrays::ConstantArray) -> usize
+pub fn vortex_array::arrays::Decimal::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::ConstantVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::len(array: &vortex_array::arrays::DecimalArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::metadata(array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ConstantVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Decimal::nbuffers(_array: &vortex_array::arrays::DecimalArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::stats(array: &vortex_array::arrays::ConstantArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Decimal::nchildren(array: &vortex_array::arrays::DecimalArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Decimal::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
+pub fn vortex_array::arrays::Decimal::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ConstantVTable::validity(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::Decimal::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Decimal::stats(array: &vortex_array::arrays::DecimalArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Decimal::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::DecimalArray
 
@@ -5202,121 +5318,123 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::DecimalArray
 
 pub fn vortex_array::arrays::DecimalArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::DecimalVTable
+pub struct vortex_array::arrays::Dict
 
-impl vortex_array::arrays::DecimalVTable
+impl vortex_array::arrays::dict::Dict
 
-pub const vortex_array::arrays::DecimalVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::dict::Dict::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::DecimalVTable
+impl core::fmt::Debug for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::DecimalVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::dict::Dict::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::DecimalVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::DecimalVTable::take(array: &vortex_array::arrays::DecimalArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::DecimalVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::DecimalVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DecimalVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::DecimalVTable::is_constant(&self, array: &vortex_array::arrays::DecimalArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::dict::Dict::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DecimalVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::DecimalVTable::is_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::dict::Dict::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::DecimalVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::Dict
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DecimalVTable
+pub fn vortex_array::arrays::dict::Dict::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::DecimalVTable::min_max(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::dict::Dict::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::DecimalVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::DecimalVTable::sum(&self, array: &vortex_array::arrays::DecimalArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::Dict
 
-pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::Dict
 
-impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::DecimalVTable
+pub fn vortex_array::arrays::dict::Dict::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DecimalVTable::between(arr: &vortex_array::arrays::DecimalArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::Dict
 
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::DecimalVTable
+pub fn vortex_array::arrays::dict::Dict::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DecimalVTable::cast(array: &vortex_array::arrays::DecimalArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::Dict
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::DecimalVTable
+pub fn vortex_array::arrays::dict::Dict::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DecimalVTable::fill_null(array: &vortex_array::arrays::DecimalArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::Dict
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DecimalVTable
+pub fn vortex_array::arrays::dict::Dict::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DecimalVTable::mask(array: &vortex_array::arrays::DecimalArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalVTable
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::DecimalVTable::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+impl vortex_array::vtable::VTable for vortex_array::arrays::dict::Dict
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::DecimalVTable
+pub type vortex_array::arrays::dict::Dict::Array = vortex_array::arrays::dict::DictArray
 
-pub type vortex_array::arrays::DecimalVTable::Array = vortex_array::arrays::DecimalArray
+pub type vortex_array::arrays::dict::Dict::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
 
-pub type vortex_array::arrays::DecimalVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::decimal::vtable::DecimalMetadata>
+pub type vortex_array::arrays::dict::Dict::OperationsVTable = vortex_array::arrays::dict::Dict
 
-pub type vortex_array::arrays::DecimalVTable::OperationsVTable = vortex_array::arrays::DecimalVTable
+pub type vortex_array::arrays::dict::Dict::ValidityVTable = vortex_array::arrays::dict::Dict
 
-pub type vortex_array::arrays::DecimalVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub fn vortex_array::arrays::dict::Dict::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::DecimalVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::dict::Dict::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::DecimalVTable::array_eq(array: &vortex_array::arrays::DecimalArray, other: &vortex_array::arrays::DecimalArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::dict::Dict::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::DecimalVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DecimalArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::dict::Dict::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::DecimalVTable::buffer(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::dict::Dict::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::DecimalVTable::buffer_name(_array: &vortex_array::arrays::DecimalArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::dict::Dict::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
 
-pub fn vortex_array::arrays::DecimalVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DecimalArray>
+pub fn vortex_array::arrays::dict::Dict::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::DecimalVTable::child(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::dict::Dict::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::DecimalVTable::child_name(_array: &vortex_array::arrays::DecimalArray, _idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::dict::Dict::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::DecimalVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::dict::Dict::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::DecimalVTable::dtype(array: &vortex_array::arrays::DecimalArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::dict::Dict::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::DecimalVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::dict::Dict::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DecimalVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::DecimalVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::dict::Dict::len(array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::DecimalVTable::len(array: &vortex_array::arrays::DecimalArray) -> usize
+pub fn vortex_array::arrays::dict::Dict::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::DecimalVTable::metadata(array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::dict::Dict::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::DecimalVTable::nbuffers(_array: &vortex_array::arrays::DecimalArray) -> usize
+pub fn vortex_array::arrays::dict::Dict::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::DecimalVTable::nchildren(array: &vortex_array::arrays::DecimalArray) -> usize
+pub fn vortex_array::arrays::dict::Dict::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DecimalVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DecimalVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::DecimalVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::dict::Dict::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::DecimalVTable::stats(array: &vortex_array::arrays::DecimalArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::dict::Dict::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::DecimalVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
+
+pub fn vortex_array::arrays::dict::Dict::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::DictArray
 
@@ -5376,123 +5494,119 @@ impl<K: arrow_array::types::ArrowDictionaryKeyType> vortex_array::arrow::FromArr
 
 pub fn vortex_array::arrays::dict::DictArray::from_arrow(array: &arrow_array::array::dictionary_array::DictionaryArray<K>, nullable: bool) -> vortex_error::VortexResult<Self>
 
-pub struct vortex_array::arrays::DictVTable
+pub struct vortex_array::arrays::Extension
 
-impl vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::Extension
 
-pub const vortex_array::arrays::dict::DictVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::Extension::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::dict::DictVTable
+impl core::fmt::Debug for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::Extension::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::take(array: &vortex_array::arrays::dict::DictArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::filter(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Extension::is_constant(&self, array: &vortex_array::arrays::ExtensionArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Extension::is_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Extension::is_strict_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::Extension::min_max(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::sum(&self, array: &vortex_array::arrays::ExtensionArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::cast(array: &vortex_array::arrays::ExtensionArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::mask(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub type vortex_array::arrays::Extension::Array = vortex_array::arrays::ExtensionArray
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::Extension::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
+pub type vortex_array::arrays::Extension::OperationsVTable = vortex_array::arrays::Extension
 
-pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
+pub type vortex_array::arrays::Extension::ValidityVTable = vortex_array::vtable::ValidityVTableFromChild
 
-pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
+pub fn vortex_array::arrays::Extension::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
+pub fn vortex_array::arrays::Extension::array_eq(array: &vortex_array::arrays::ExtensionArray, other: &vortex_array::arrays::ExtensionArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Extension::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ExtensionArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Extension::buffer(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Extension::buffer_name(_array: &vortex_array::arrays::ExtensionArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Extension::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ExtensionArray>
 
-pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Extension::child(array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+pub fn vortex_array::arrays::Extension::child_name(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Extension::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Extension::dtype(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Extension::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Extension::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Extension::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::len(array: &vortex_array::arrays::ExtensionArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Extension::metadata(_array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::Extension::nbuffers(_array: &vortex_array::arrays::ExtensionArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Extension::nchildren(_array: &vortex_array::arrays::ExtensionArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::Extension::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::Extension::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::stats(array: &vortex_array::arrays::ExtensionArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Extension::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
+impl vortex_array::vtable::ValidityChild<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
-
-pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::Extension::validity_child(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::ArrayRef
 
 pub struct vortex_array::arrays::ExtensionArray
 
@@ -5556,119 +5670,77 @@ impl vortex_array::IntoArray for vortex_array::arrays::ExtensionArray
 
 pub fn vortex_array::arrays::ExtensionArray::into_array(self) -> vortex_array::ArrayRef
 
-pub struct vortex_array::arrays::ExtensionVTable
+pub struct vortex_array::arrays::Filter
 
-impl vortex_array::arrays::ExtensionVTable
+impl vortex_array::arrays::Filter
 
-pub const vortex_array::arrays::ExtensionVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::Filter::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::ExtensionVTable
+impl core::fmt::Debug for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::ExtensionVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::Filter::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ExtensionVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::ExtensionVTable::take(array: &vortex_array::arrays::ExtensionArray, indices: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Filter::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::ExtensionVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::ExtensionVTable::filter(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub type vortex_array::arrays::Filter::Array = vortex_array::arrays::FilterArray
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ExtensionVTable
+pub type vortex_array::arrays::Filter::Metadata = vortex_array::arrays::filter::vtable::FilterMetadata
 
-pub fn vortex_array::arrays::ExtensionVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub type vortex_array::arrays::Filter::OperationsVTable = vortex_array::arrays::Filter
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ExtensionVTable
+pub type vortex_array::arrays::Filter::ValidityVTable = vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::ExtensionVTable::is_constant(&self, array: &vortex_array::arrays::ExtensionArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Filter::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ExtensionVTable
+pub fn vortex_array::arrays::Filter::array_eq(array: &vortex_array::arrays::FilterArray, other: &vortex_array::arrays::FilterArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::ExtensionVTable::is_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Filter::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FilterArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::ExtensionVTable::is_strict_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Filter::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ExtensionVTable
+pub fn vortex_array::arrays::Filter::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ExtensionVTable::min_max(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::Filter::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::filter::vtable::FilterMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ExtensionVTable
+pub fn vortex_array::arrays::Filter::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ExtensionVTable::sum(&self, array: &vortex_array::arrays::ExtensionArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Filter::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
 
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::ExtensionVTable
+pub fn vortex_array::arrays::Filter::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ExtensionVTable::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Filter::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ExtensionVTable
+pub fn vortex_array::arrays::Filter::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::ExtensionVTable::cast(array: &vortex_array::arrays::ExtensionArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Filter::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ExtensionVTable
+pub fn vortex_array::arrays::Filter::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::ExtensionVTable::mask(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Filter::len(array: &vortex_array::arrays::FilterArray) -> usize
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
+pub fn vortex_array::arrays::Filter::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ExtensionVTable::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Filter::nbuffers(_array: &Self::Array) -> usize
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ExtensionVTable
+pub fn vortex_array::arrays::Filter::nchildren(_array: &Self::Array) -> usize
 
-pub type vortex_array::arrays::ExtensionVTable::Array = vortex_array::arrays::ExtensionArray
+pub fn vortex_array::arrays::Filter::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub type vortex_array::arrays::ExtensionVTable::Metadata = vortex_array::EmptyMetadata
+pub fn vortex_array::arrays::Filter::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub type vortex_array::arrays::ExtensionVTable::OperationsVTable = vortex_array::arrays::ExtensionVTable
+pub fn vortex_array::arrays::Filter::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub type vortex_array::arrays::ExtensionVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromChild
+pub fn vortex_array::arrays::Filter::stats(array: &vortex_array::arrays::FilterArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::ExtensionVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Filter::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::ExtensionVTable::array_eq(array: &vortex_array::arrays::ExtensionArray, other: &vortex_array::arrays::ExtensionArray, precision: vortex_array::Precision) -> bool
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::ExtensionVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ExtensionArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::ExtensionVTable::buffer(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::ExtensionVTable::buffer_name(_array: &vortex_array::arrays::ExtensionArray, _idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::ExtensionVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ExtensionArray>
-
-pub fn vortex_array::arrays::ExtensionVTable::child(array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::ExtensionVTable::child_name(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::ExtensionVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ExtensionVTable::dtype(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::ExtensionVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::ExtensionVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ExtensionVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::ExtensionVTable::len(array: &vortex_array::arrays::ExtensionArray) -> usize
-
-pub fn vortex_array::arrays::ExtensionVTable::metadata(_array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ExtensionVTable::nbuffers(_array: &vortex_array::arrays::ExtensionArray) -> usize
-
-pub fn vortex_array::arrays::ExtensionVTable::nchildren(_array: &vortex_array::arrays::ExtensionArray) -> usize
-
-pub fn vortex_array::arrays::ExtensionVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ExtensionVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ExtensionVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ExtensionVTable::stats(array: &vortex_array::arrays::ExtensionArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ExtensionVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
-impl vortex_array::vtable::ValidityChild<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
-
-pub fn vortex_array::arrays::ExtensionVTable::validity_child(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::Filter::validity(array: &vortex_array::arrays::FilterArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::FilterArray
 
@@ -5714,77 +5786,103 @@ impl vortex_array::IntoArray for vortex_array::arrays::FilterArray
 
 pub fn vortex_array::arrays::FilterArray::into_array(self) -> vortex_array::ArrayRef
 
-pub struct vortex_array::arrays::FilterVTable
+pub struct vortex_array::arrays::FixedSizeList
 
-impl vortex_array::arrays::FilterVTable
+impl vortex_array::arrays::FixedSizeList
 
-pub const vortex_array::arrays::FilterVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::FixedSizeList::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::FilterVTable
+impl core::fmt::Debug for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FilterVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::FixedSizeList::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FilterVTable::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::FixedSizeList::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::FilterVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeList
 
-pub type vortex_array::arrays::FilterVTable::Array = vortex_array::arrays::FilterArray
+pub fn vortex_array::arrays::FixedSizeList::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub type vortex_array::arrays::FilterVTable::Metadata = vortex_array::arrays::filter::vtable::FilterMetadata
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::FixedSizeList
 
-pub type vortex_array::arrays::FilterVTable::OperationsVTable = vortex_array::arrays::FilterVTable
+pub fn vortex_array::arrays::FixedSizeList::is_constant(&self, array: &vortex_array::arrays::FixedSizeListArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub type vortex_array::arrays::FilterVTable::ValidityVTable = vortex_array::arrays::FilterVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FilterVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::FixedSizeList::is_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::FilterVTable::array_eq(array: &vortex_array::arrays::FilterArray, other: &vortex_array::arrays::FilterArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::FixedSizeList::is_strict_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::FilterVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FilterArray, state: &mut H, precision: vortex_array::Precision)
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FilterVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::FixedSizeList::min_max(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-pub fn vortex_array::arrays::FilterVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FilterVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::filter::vtable::FilterMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+pub fn vortex_array::arrays::FixedSizeList::cast(array: &vortex_array::arrays::FixedSizeListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::FilterVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FilterVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::FixedSizeList::mask(array: &vortex_array::arrays::FixedSizeListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::FilterVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FixedSizeList> for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FilterVTable::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::FilterVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+impl vortex_array::vtable::VTable for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FilterVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub type vortex_array::arrays::FixedSizeList::Array = vortex_array::arrays::FixedSizeListArray
 
-pub fn vortex_array::arrays::FilterVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub type vortex_array::arrays::FixedSizeList::Metadata = vortex_array::EmptyMetadata
 
-pub fn vortex_array::arrays::FilterVTable::len(array: &vortex_array::arrays::FilterArray) -> usize
+pub type vortex_array::arrays::FixedSizeList::OperationsVTable = vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FilterVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+pub type vortex_array::arrays::FixedSizeList::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::FilterVTable::nbuffers(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::FixedSizeList::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::FilterVTable::nchildren(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::FixedSizeList::array_eq(array: &vortex_array::arrays::FixedSizeListArray, other: &vortex_array::arrays::FixedSizeListArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::FilterVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FixedSizeList::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FixedSizeListArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::FilterVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FixedSizeList::buffer(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::FilterVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::FixedSizeList::buffer_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::FilterVTable::stats(array: &vortex_array::arrays::FilterArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::FixedSizeList::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::FixedSizeListArray>
 
-pub fn vortex_array::arrays::FilterVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::FixedSizeList::child(array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::ArrayRef
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
+pub fn vortex_array::arrays::FixedSizeList::child_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::FilterVTable::validity(array: &vortex_array::arrays::FilterArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::FixedSizeList::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::FixedSizeList::dtype(array: &vortex_array::arrays::FixedSizeListArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::FixedSizeList::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::FixedSizeList::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FixedSizeList::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::FixedSizeList::len(array: &vortex_array::arrays::FixedSizeListArray) -> usize
+
+pub fn vortex_array::arrays::FixedSizeList::metadata(_array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::FixedSizeList::nbuffers(_array: &vortex_array::arrays::FixedSizeListArray) -> usize
+
+pub fn vortex_array::arrays::FixedSizeList::nchildren(array: &vortex_array::arrays::FixedSizeListArray) -> usize
+
+pub fn vortex_array::arrays::FixedSizeList::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FixedSizeList::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::FixedSizeList::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::FixedSizeList::stats(array: &vortex_array::arrays::FixedSizeListArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::FixedSizeList::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::FixedSizeListArray
 
@@ -5844,103 +5942,107 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::FixedSizeLis
 
 pub fn vortex_array::arrays::FixedSizeListArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::FixedSizeListVTable
+pub struct vortex_array::arrays::List
 
-impl vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::arrays::List
 
-pub const vortex_array::arrays::FixedSizeListVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::List::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::FixedSizeListVTable
+impl core::fmt::Debug for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::FixedSizeListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::List::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::FixedSizeListVTable::take(array: &vortex_array::arrays::FixedSizeListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::FixedSizeListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::FixedSizeListVTable::is_constant(&self, array: &vortex_array::arrays::FixedSizeListArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::List::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::FixedSizeListVTable::is_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::List::is_constant(&self, array: &vortex_array::arrays::ListArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::List
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::FixedSizeListVTable
+pub fn vortex_array::arrays::List::is_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::min_max(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::List::is_strict_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::FixedSizeListVTable::cast(array: &vortex_array::arrays::FixedSizeListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::min_max(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::FixedSizeListVTable::mask(array: &vortex_array::arrays::FixedSizeListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::cast(array: &vortex_array::arrays::ListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FixedSizeListVTable> for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::FixedSizeListVTable::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::List::mask(array: &vortex_array::arrays::ListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::List> for vortex_array::arrays::List
 
-pub type vortex_array::arrays::FixedSizeListVTable::Array = vortex_array::arrays::FixedSizeListArray
+pub fn vortex_array::arrays::List::scalar_at(array: &vortex_array::arrays::ListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub type vortex_array::arrays::FixedSizeListVTable::Metadata = vortex_array::EmptyMetadata
+impl vortex_array::vtable::VTable for vortex_array::arrays::List
 
-pub type vortex_array::arrays::FixedSizeListVTable::OperationsVTable = vortex_array::arrays::FixedSizeListVTable
+pub type vortex_array::arrays::List::Array = vortex_array::arrays::ListArray
 
-pub type vortex_array::arrays::FixedSizeListVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub type vortex_array::arrays::List::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::list::vtable::ListMetadata>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub type vortex_array::arrays::List::OperationsVTable = vortex_array::arrays::List
 
-pub fn vortex_array::arrays::FixedSizeListVTable::array_eq(array: &vortex_array::arrays::FixedSizeListArray, other: &vortex_array::arrays::FixedSizeListArray, precision: vortex_array::Precision) -> bool
+pub type vortex_array::arrays::List::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::FixedSizeListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FixedSizeListArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::List::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::buffer(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::List::array_eq(array: &vortex_array::arrays::ListArray, other: &vortex_array::arrays::ListArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::FixedSizeListVTable::buffer_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::List::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::FixedSizeListVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::FixedSizeListArray>
+pub fn vortex_array::arrays::List::buffer(_array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::FixedSizeListVTable::child(array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::List::buffer_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::child_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::List::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::List::child(array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::FixedSizeListVTable::dtype(array: &vortex_array::arrays::FixedSizeListArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::List::child_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::FixedSizeListVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::List::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::dtype(array: &vortex_array::arrays::ListArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::FixedSizeListVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::List::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::len(array: &vortex_array::arrays::FixedSizeListArray) -> usize
+pub fn vortex_array::arrays::List::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::metadata(_array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::List::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::FixedSizeListVTable::nbuffers(_array: &vortex_array::arrays::FixedSizeListArray) -> usize
+pub fn vortex_array::arrays::List::len(array: &vortex_array::arrays::ListArray) -> usize
 
-pub fn vortex_array::arrays::FixedSizeListVTable::nchildren(array: &vortex_array::arrays::FixedSizeListArray) -> usize
+pub fn vortex_array::arrays::List::metadata(array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::nbuffers(_array: &vortex_array::arrays::ListArray) -> usize
 
-pub fn vortex_array::arrays::FixedSizeListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::nchildren(array: &vortex_array::arrays::ListArray) -> usize
 
-pub fn vortex_array::arrays::FixedSizeListVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::List::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::stats(array: &vortex_array::arrays::FixedSizeListArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::List::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::List::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::List::stats(array: &vortex_array::arrays::ListArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::List::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::ListArray
 
@@ -6004,107 +6106,103 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::ListArray
 
 pub fn vortex_array::arrays::ListArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::ListVTable
+pub struct vortex_array::arrays::ListView
 
-impl vortex_array::arrays::ListVTable
+impl vortex_array::arrays::ListView
 
-pub const vortex_array::arrays::ListVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::ListView::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::ListVTable
+impl core::fmt::Debug for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::ListView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::ListVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListVTable::take(array: &vortex_array::arrays::ListArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::ListVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListVTable::filter(array: &vortex_array::arrays::ListArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::is_constant(&self, array: &vortex_array::arrays::ListViewArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListVTable::is_constant(&self, array: &vortex_array::arrays::ListArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::ListView::is_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListVTable
+pub fn vortex_array::arrays::ListView::is_strict_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::ListVTable::is_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::ListView::min_max(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListVTable::min_max(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::ListView::cast(array: &vortex_array::arrays::ListViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListVTable::cast(array: &vortex_array::arrays::ListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::mask(array: &vortex_array::arrays::ListViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListView> for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListVTable::mask(array: &vortex_array::arrays::ListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListVTable> for vortex_array::arrays::ListVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListVTable::scalar_at(array: &vortex_array::arrays::ListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub type vortex_array::arrays::ListView::Array = vortex_array::arrays::ListViewArray
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ListVTable
+pub type vortex_array::arrays::ListView::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::listview::vtable::ListViewMetadata>
 
-pub type vortex_array::arrays::ListVTable::Array = vortex_array::arrays::ListArray
+pub type vortex_array::arrays::ListView::OperationsVTable = vortex_array::arrays::ListView
 
-pub type vortex_array::arrays::ListVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::list::vtable::ListMetadata>
+pub type vortex_array::arrays::ListView::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub type vortex_array::arrays::ListVTable::OperationsVTable = vortex_array::arrays::ListVTable
+pub fn vortex_array::arrays::ListView::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub type vortex_array::arrays::ListVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub fn vortex_array::arrays::ListView::array_eq(array: &vortex_array::arrays::ListViewArray, other: &vortex_array::arrays::ListViewArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::ListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ListView::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListViewArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::ListVTable::array_eq(array: &vortex_array::arrays::ListArray, other: &vortex_array::arrays::ListArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::ListView::buffer(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::ListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::ListView::buffer_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ListVTable::buffer(_array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::ListView::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
 
-pub fn vortex_array::arrays::ListVTable::buffer_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::ListView::child(array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ListVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
+pub fn vortex_array::arrays::ListView::child_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ListVTable::child(array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::ListView::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ListVTable::child_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::ListView::dtype(array: &vortex_array::arrays::ListViewArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ListVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ListView::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::ListVTable::dtype(array: &vortex_array::arrays::ListArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::ListView::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::ListView::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::ListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::len(array: &vortex_array::arrays::ListViewArray) -> usize
 
-pub fn vortex_array::arrays::ListVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::ListView::metadata(array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ListVTable::len(array: &vortex_array::arrays::ListArray) -> usize
+pub fn vortex_array::arrays::ListView::nbuffers(_array: &vortex_array::arrays::ListViewArray) -> usize
 
-pub fn vortex_array::arrays::ListVTable::metadata(array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ListView::nchildren(array: &vortex_array::arrays::ListViewArray) -> usize
 
-pub fn vortex_array::arrays::ListVTable::nbuffers(_array: &vortex_array::arrays::ListArray) -> usize
+pub fn vortex_array::arrays::ListView::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListVTable::nchildren(array: &vortex_array::arrays::ListArray) -> usize
+pub fn vortex_array::arrays::ListView::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::ListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::stats(array: &vortex_array::arrays::ListViewArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::ListVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ListVTable::stats(array: &vortex_array::arrays::ListArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ListView::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::ListViewArray
 
@@ -6180,103 +6278,89 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::ListViewArra
 
 pub fn vortex_array::arrays::ListViewArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::ListViewVTable
+pub struct vortex_array::arrays::Masked
 
-impl vortex_array::arrays::ListViewVTable
+impl vortex_array::arrays::Masked
 
-pub const vortex_array::arrays::ListViewVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::Masked::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::ListViewVTable
+impl core::fmt::Debug for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::ListViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::Masked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::ListViewVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::ListViewVTable::take(array: &vortex_array::arrays::ListViewArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Masked::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::ListViewVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::ListViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Masked::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListViewVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::ListViewVTable::is_constant(&self, array: &vortex_array::arrays::ListViewArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Masked::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListViewVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::ListViewVTable::is_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Masked::mask(array: &vortex_array::arrays::MaskedArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListViewVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Masked> for vortex_array::arrays::Masked
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListViewVTable
+pub fn vortex_array::arrays::Masked::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::ListViewVTable::min_max(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+impl vortex_array::vtable::VTable for vortex_array::arrays::Masked
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListViewVTable
+pub type vortex_array::arrays::Masked::Array = vortex_array::arrays::MaskedArray
 
-pub fn vortex_array::arrays::ListViewVTable::cast(array: &vortex_array::arrays::ListViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub type vortex_array::arrays::Masked::Metadata = vortex_array::EmptyMetadata
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListViewVTable
+pub type vortex_array::arrays::Masked::OperationsVTable = vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::ListViewVTable::mask(array: &vortex_array::arrays::ListViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub type vortex_array::arrays::Masked::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListViewVTable> for vortex_array::arrays::ListViewVTable
+pub fn vortex_array::arrays::Masked::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::ListViewVTable::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Masked::array_eq(array: &vortex_array::arrays::MaskedArray, other: &vortex_array::arrays::MaskedArray, precision: vortex_array::Precision) -> bool
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ListViewVTable
+pub fn vortex_array::arrays::Masked::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::MaskedArray, state: &mut H, precision: vortex_array::Precision)
 
-pub type vortex_array::arrays::ListViewVTable::Array = vortex_array::arrays::ListViewArray
+pub fn vortex_array::arrays::Masked::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub type vortex_array::arrays::ListViewVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::listview::vtable::ListViewMetadata>
+pub fn vortex_array::arrays::Masked::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub type vortex_array::arrays::ListViewVTable::OperationsVTable = vortex_array::arrays::ListViewVTable
+pub fn vortex_array::arrays::Masked::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::MaskedArray>
 
-pub type vortex_array::arrays::ListViewVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub fn vortex_array::arrays::Masked::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ListViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Masked::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ListViewVTable::array_eq(array: &vortex_array::arrays::ListViewArray, other: &vortex_array::arrays::ListViewArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Masked::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ListViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListViewArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Masked::dtype(array: &vortex_array::arrays::MaskedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ListViewVTable::buffer(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Masked::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::ListViewVTable::buffer_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Masked::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListViewVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
+pub fn vortex_array::arrays::Masked::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::ListViewVTable::child(array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Masked::len(array: &vortex_array::arrays::MaskedArray) -> usize
 
-pub fn vortex_array::arrays::ListViewVTable::child_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Masked::metadata(_array: &vortex_array::arrays::MaskedArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ListViewVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Masked::nbuffers(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::ListViewVTable::dtype(array: &vortex_array::arrays::ListViewArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Masked::nchildren(array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::ListViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Masked::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Masked::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListViewVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Masked::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::ListViewVTable::len(array: &vortex_array::arrays::ListViewArray) -> usize
+pub fn vortex_array::arrays::Masked::stats(array: &vortex_array::arrays::MaskedArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::ListViewVTable::metadata(array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::ListViewVTable::nbuffers(_array: &vortex_array::arrays::ListViewArray) -> usize
-
-pub fn vortex_array::arrays::ListViewVTable::nchildren(array: &vortex_array::arrays::ListViewArray) -> usize
-
-pub fn vortex_array::arrays::ListViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::ListViewVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::ListViewVTable::stats(array: &vortex_array::arrays::ListViewArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::ListViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Masked::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::MaskedArray
 
@@ -6320,89 +6404,105 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::MaskedArray
 
 pub fn vortex_array::arrays::MaskedArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::MaskedVTable
+pub struct vortex_array::arrays::Null
 
-impl vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::null::Null
 
-pub const vortex_array::arrays::MaskedVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::null::Null::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::MaskedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub const vortex_array::arrays::null::Null::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::MaskedVTable
+impl core::fmt::Debug for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::MaskedVTable::take(array: &vortex_array::arrays::MaskedArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::MaskedVTable::filter(array: &vortex_array::arrays::MaskedArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::MaskedVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::MaskedVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::MaskedVTable::mask(array: &vortex_array::arrays::MaskedArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::MaskedVTable> for vortex_array::arrays::MaskedVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::MaskedVTable::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::null::Null::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::MaskedVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::Null
 
-pub type vortex_array::arrays::MaskedVTable::Array = vortex_array::arrays::MaskedArray
+pub fn vortex_array::arrays::null::Null::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub type vortex_array::arrays::MaskedVTable::Metadata = vortex_array::EmptyMetadata
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::Null
 
-pub type vortex_array::arrays::MaskedVTable::OperationsVTable = vortex_array::arrays::MaskedVTable
+pub fn vortex_array::arrays::null::Null::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub type vortex_array::arrays::MaskedVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::MaskedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::null::Null::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::MaskedVTable::array_eq(array: &vortex_array::arrays::MaskedArray, other: &vortex_array::arrays::MaskedArray, precision: vortex_array::Precision) -> bool
+impl vortex_array::vtable::VTable for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::MaskedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::MaskedArray, state: &mut H, precision: vortex_array::Precision)
+pub type vortex_array::arrays::null::Null::Array = vortex_array::arrays::null::NullArray
 
-pub fn vortex_array::arrays::MaskedVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+pub type vortex_array::arrays::null::Null::Metadata = vortex_array::EmptyMetadata
 
-pub fn vortex_array::arrays::MaskedVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+pub type vortex_array::arrays::null::Null::OperationsVTable = vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::MaskedVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::MaskedArray>
+pub type vortex_array::arrays::null::Null::ValidityVTable = vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::MaskedVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::null::Null::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::MaskedVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::null::Null::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::MaskedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::null::Null::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::MaskedVTable::dtype(array: &vortex_array::arrays::MaskedArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::null::Null::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::MaskedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::null::Null::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::MaskedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
 
-pub fn vortex_array::arrays::MaskedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::null::Null::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::MaskedVTable::len(array: &vortex_array::arrays::MaskedArray) -> usize
+pub fn vortex_array::arrays::null::Null::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::MaskedVTable::metadata(_array: &vortex_array::arrays::MaskedArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::null::Null::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::MaskedVTable::nbuffers(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::null::Null::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::MaskedVTable::nchildren(array: &Self::Array) -> usize
+pub fn vortex_array::arrays::null::Null::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::MaskedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::MaskedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::MaskedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::null::Null::len(array: &vortex_array::arrays::null::NullArray) -> usize
 
-pub fn vortex_array::arrays::MaskedVTable::stats(array: &vortex_array::arrays::MaskedArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::null::Null::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::MaskedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::null::Null::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
+
+pub fn vortex_array::arrays::null::Null::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
+
+pub fn vortex_array::arrays::null::Null::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::null::Null::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::null::Null::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::null::Null::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::null::Null::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
+
+pub fn vortex_array::arrays::null::Null::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::NullArray
 
@@ -6444,105 +6544,125 @@ impl vortex_array::IntoArray for vortex_array::arrays::null::NullArray
 
 pub fn vortex_array::arrays::null::NullArray::into_array(self) -> vortex_array::ArrayRef
 
-pub struct vortex_array::arrays::NullVTable
+pub struct vortex_array::arrays::Primitive
 
-impl vortex_array::arrays::null::NullVTable
+impl vortex_array::arrays::Primitive
 
-pub const vortex_array::arrays::null::NullVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::Primitive::ID: vortex_array::vtable::ArrayId
 
-impl vortex_array::arrays::null::NullVTable
+impl core::fmt::Debug for vortex_array::arrays::Primitive
 
-pub const vortex_array::arrays::null::NullVTable::TAKE_RULES: vortex_array::optimizer::rules::ParentRuleSet<Self>
+pub fn vortex_array::arrays::Primitive::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl core::fmt::Debug for vortex_array::arrays::null::NullVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::null::NullVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::Primitive::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::null::NullVTable::take(array: &vortex_array::arrays::null::NullArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::null::NullVTable::filter(_array: &vortex_array::arrays::null::NullArray, mask: &vortex_mask::Mask) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::is_constant(&self, array: &vortex_array::arrays::PrimitiveArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::null::NullVTable::slice(_array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::is_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::NullVTable
+pub fn vortex_array::arrays::Primitive::is_strict_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::null::NullVTable::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Primitive
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::NullVTable
+pub fn vortex_array::arrays::Primitive::min_max(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-pub fn vortex_array::arrays::null::NullVTable::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::compute::NaNCountKernel for vortex_array::arrays::Primitive
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::NullVTable
+pub fn vortex_array::arrays::Primitive::nan_count(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<usize>
 
-pub fn vortex_array::arrays::null::NullVTable::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Primitive
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
+pub fn vortex_array::arrays::Primitive::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::null::NullVTable::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Primitive> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::null::NullVTable
+pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::Masked
 
-pub type vortex_array::arrays::null::NullVTable::Array = vortex_array::arrays::null::NullArray
+pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub type vortex_array::arrays::null::NullVTable::Metadata = vortex_array::EmptyMetadata
+impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::Primitive
 
-pub type vortex_array::arrays::null::NullVTable::OperationsVTable = vortex_array::arrays::null::NullVTable
+pub fn vortex_array::arrays::Primitive::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub type vortex_array::arrays::null::NullVTable::ValidityVTable = vortex_array::arrays::null::NullVTable
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::null::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Primitive::cast(array: &vortex_array::arrays::PrimitiveArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::null::NullVTable::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::null::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Primitive::fill_null(array: &vortex_array::arrays::PrimitiveArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::null::NullVTable::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::null::NullVTable::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Primitive::mask(array: &vortex_array::arrays::PrimitiveArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::null::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Primitive> for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::null::NullVTable::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Primitive::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::null::NullVTable::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
+impl vortex_array::vtable::VTable for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::null::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub type vortex_array::arrays::Primitive::Array = vortex_array::arrays::PrimitiveArray
 
-pub fn vortex_array::arrays::null::NullVTable::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
+pub type vortex_array::arrays::Primitive::Metadata = vortex_array::EmptyMetadata
 
-pub fn vortex_array::arrays::null::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub type vortex_array::arrays::Primitive::OperationsVTable = vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::null::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub type vortex_array::arrays::Primitive::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::null::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Primitive::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::null::NullVTable::len(array: &vortex_array::arrays::null::NullArray) -> usize
+pub fn vortex_array::arrays::Primitive::array_eq(array: &vortex_array::arrays::PrimitiveArray, other: &vortex_array::arrays::PrimitiveArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::null::NullVTable::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Primitive::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::PrimitiveArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::null::NullVTable::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
+pub fn vortex_array::arrays::Primitive::buffer(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::null::NullVTable::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
+pub fn vortex_array::arrays::Primitive::buffer_name(_array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::null::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
 
-pub fn vortex_array::arrays::null::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::child(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::null::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Primitive::child_name(_array: &vortex_array::arrays::PrimitiveArray, _idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::null::NullVTable::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Primitive::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::null::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Primitive::dtype(array: &vortex_array::arrays::PrimitiveArray) -> &vortex_array::dtype::DType
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
+pub fn vortex_array::arrays::Primitive::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::null::NullVTable::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::Primitive::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Primitive::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Primitive::len(array: &vortex_array::arrays::PrimitiveArray) -> usize
+
+pub fn vortex_array::arrays::Primitive::metadata(_array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Primitive::nbuffers(_array: &vortex_array::arrays::PrimitiveArray) -> usize
+
+pub fn vortex_array::arrays::Primitive::nchildren(array: &vortex_array::arrays::PrimitiveArray) -> usize
+
+pub fn vortex_array::arrays::Primitive::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Primitive::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Primitive::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Primitive::stats(array: &vortex_array::arrays::PrimitiveArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Primitive::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::PrimitiveArray
 
@@ -6653,126 +6773,6 @@ pub fn vortex_array::arrays::PrimitiveArray::from_iter<I: core::iter::traits::co
 impl<T: vortex_array::dtype::NativePType> vortex_array::accessor::ArrayAccessor<T> for vortex_array::arrays::PrimitiveArray
 
 pub fn vortex_array::arrays::PrimitiveArray::with_iterator<F, R>(&self, f: F) -> R where F: for<'a> core::ops::function::FnOnce(&mut dyn core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a T>>) -> R
-
-pub struct vortex_array::arrays::PrimitiveVTable
-
-impl vortex_array::arrays::PrimitiveVTable
-
-pub const vortex_array::arrays::PrimitiveVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::take(array: &vortex_array::arrays::PrimitiveArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::is_constant(&self, array: &vortex_array::arrays::PrimitiveArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::is_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::is_strict_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::min_max(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::compute::NaNCountKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::nan_count(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<usize>
-
-impl vortex_array::compute::SumKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
-
-pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
-
-pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::cast(array: &vortex_array::arrays::PrimitiveArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::fill_null(array: &vortex_array::arrays::PrimitiveArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::mask(array: &vortex_array::arrays::PrimitiveArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveVTable
-
-pub fn vortex_array::arrays::PrimitiveVTable::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::PrimitiveVTable
-
-pub type vortex_array::arrays::PrimitiveVTable::Array = vortex_array::arrays::PrimitiveArray
-
-pub type vortex_array::arrays::PrimitiveVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::PrimitiveVTable::OperationsVTable = vortex_array::arrays::PrimitiveVTable
-
-pub type vortex_array::arrays::PrimitiveVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::PrimitiveVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::PrimitiveVTable::array_eq(array: &vortex_array::arrays::PrimitiveArray, other: &vortex_array::arrays::PrimitiveArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::PrimitiveVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::PrimitiveArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::PrimitiveVTable::buffer(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::PrimitiveVTable::buffer_name(_array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::PrimitiveVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
-
-pub fn vortex_array::arrays::PrimitiveVTable::child(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::PrimitiveVTable::child_name(_array: &vortex_array::arrays::PrimitiveArray, _idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::PrimitiveVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::PrimitiveVTable::dtype(array: &vortex_array::arrays::PrimitiveArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::PrimitiveVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::PrimitiveVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::PrimitiveVTable::len(array: &vortex_array::arrays::PrimitiveArray) -> usize
-
-pub fn vortex_array::arrays::PrimitiveVTable::metadata(_array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::PrimitiveVTable::nbuffers(_array: &vortex_array::arrays::PrimitiveArray) -> usize
-
-pub fn vortex_array::arrays::PrimitiveVTable::nchildren(array: &vortex_array::arrays::PrimitiveArray) -> usize
-
-pub fn vortex_array::arrays::PrimitiveVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::PrimitiveVTable::stats(array: &vortex_array::arrays::PrimitiveArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::PrimitiveVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::ScalarFnArray
 
@@ -6902,6 +6902,78 @@ impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::scalar_fn::Scala
 
 pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::validity(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
+pub struct vortex_array::arrays::Shared
+
+impl vortex_array::arrays::Shared
+
+pub const vortex_array::arrays::Shared::ID: vortex_array::vtable::ArrayId
+
+impl core::fmt::Debug for vortex_array::arrays::Shared
+
+pub fn vortex_array::arrays::Shared::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
+
+pub fn vortex_array::arrays::Shared::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::Shared
+
+pub type vortex_array::arrays::Shared::Array = vortex_array::arrays::SharedArray
+
+pub type vortex_array::arrays::Shared::Metadata = vortex_array::EmptyMetadata
+
+pub type vortex_array::arrays::Shared::OperationsVTable = vortex_array::arrays::Shared
+
+pub type vortex_array::arrays::Shared::ValidityVTable = vortex_array::arrays::Shared
+
+pub fn vortex_array::arrays::Shared::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::Shared::array_eq(array: &vortex_array::arrays::SharedArray, other: &vortex_array::arrays::SharedArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::Shared::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SharedArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::Shared::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::Shared::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::Shared::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::SharedArray>
+
+pub fn vortex_array::arrays::Shared::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::Shared::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::Shared::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Shared::dtype(array: &vortex_array::arrays::SharedArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::Shared::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::Shared::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Shared::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Shared::len(array: &vortex_array::arrays::SharedArray) -> usize
+
+pub fn vortex_array::arrays::Shared::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Shared::nbuffers(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::Shared::nchildren(_array: &Self::Array) -> usize
+
+pub fn vortex_array::arrays::Shared::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Shared::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Shared::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Shared::stats(array: &vortex_array::arrays::SharedArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Shared::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
+
+pub fn vortex_array::arrays::Shared::validity(array: &vortex_array::arrays::SharedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+
 pub struct vortex_array::arrays::SharedArray
 
 impl vortex_array::arrays::SharedArray
@@ -6942,77 +7014,81 @@ impl vortex_array::IntoArray for vortex_array::arrays::SharedArray
 
 pub fn vortex_array::arrays::SharedArray::into_array(self) -> vortex_array::ArrayRef
 
-pub struct vortex_array::arrays::SharedVTable
+pub struct vortex_array::arrays::Slice
 
-impl vortex_array::arrays::SharedVTable
+impl vortex_array::arrays::slice::Slice
 
-pub const vortex_array::arrays::SharedVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::slice::Slice::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::SharedVTable
+impl core::fmt::Debug for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::SharedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::slice::Slice::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::SharedVTable::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::slice::Slice::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::SharedVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
 
-pub type vortex_array::arrays::SharedVTable::Array = vortex_array::arrays::SharedArray
+pub fn vortex_array::arrays::slice::Slice::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub type vortex_array::arrays::SharedVTable::Metadata = vortex_array::EmptyMetadata
+impl vortex_array::vtable::VTable for vortex_array::arrays::slice::Slice
 
-pub type vortex_array::arrays::SharedVTable::OperationsVTable = vortex_array::arrays::SharedVTable
+pub type vortex_array::arrays::slice::Slice::Array = vortex_array::arrays::slice::SliceArray
 
-pub type vortex_array::arrays::SharedVTable::ValidityVTable = vortex_array::arrays::SharedVTable
+pub type vortex_array::arrays::slice::Slice::Metadata = vortex_array::arrays::slice::SliceMetadata
 
-pub fn vortex_array::arrays::SharedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub type vortex_array::arrays::slice::Slice::OperationsVTable = vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::SharedVTable::array_eq(array: &vortex_array::arrays::SharedArray, other: &vortex_array::arrays::SharedArray, precision: vortex_array::Precision) -> bool
+pub type vortex_array::arrays::slice::Slice::ValidityVTable = vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::SharedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SharedArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::slice::Slice::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::SharedVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::slice::Slice::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::SharedVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::slice::Slice::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::SharedVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::SharedArray>
+pub fn vortex_array::arrays::slice::Slice::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::SharedVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::slice::Slice::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::SharedVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::slice::Slice::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
 
-pub fn vortex_array::arrays::SharedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::slice::Slice::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::SharedVTable::dtype(array: &vortex_array::arrays::SharedArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::slice::Slice::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::SharedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::slice::Slice::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::SharedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::Slice::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::SharedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::slice::Slice::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::SharedVTable::len(array: &vortex_array::arrays::SharedArray) -> usize
+pub fn vortex_array::arrays::slice::Slice::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::SharedVTable::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::slice::Slice::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::SharedVTable::nbuffers(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::slice::Slice::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
 
-pub fn vortex_array::arrays::SharedVTable::nchildren(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::slice::Slice::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::SharedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::Slice::nbuffers(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::SharedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::Slice::nchildren(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::SharedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::slice::Slice::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::SharedVTable::stats(array: &vortex_array::arrays::SharedArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::slice::Slice::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::SharedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::slice::Slice::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
+pub fn vortex_array::arrays::slice::Slice::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::SharedVTable::validity(array: &vortex_array::arrays::SharedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::slice::Slice::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
+
+pub fn vortex_array::arrays::slice::Slice::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 pub struct vortex_array::arrays::SliceArray
 
@@ -7058,81 +7134,101 @@ impl vortex_array::IntoArray for vortex_array::arrays::slice::SliceArray
 
 pub fn vortex_array::arrays::slice::SliceArray::into_array(self) -> vortex_array::ArrayRef
 
-pub struct vortex_array::arrays::SliceVTable
+pub struct vortex_array::arrays::Struct
 
-impl vortex_array::arrays::slice::SliceVTable
+impl vortex_array::arrays::Struct
 
-pub const vortex_array::arrays::slice::SliceVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::Struct::ID: vortex_array::vtable::ArrayId
 
-impl core::fmt::Debug for vortex_array::arrays::slice::SliceVTable
+impl core::fmt::Debug for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::slice::SliceVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::slice::SliceVTable
+impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::slice::SliceVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Struct::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::slice::SliceVTable::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Struct::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::slice::SliceVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Struct
 
-pub type vortex_array::arrays::slice::SliceVTable::Array = vortex_array::arrays::slice::SliceArray
+pub fn vortex_array::arrays::Struct::is_constant(&self, array: &vortex_array::arrays::StructArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub type vortex_array::arrays::slice::SliceVTable::Metadata = vortex_array::arrays::slice::SliceMetadata
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Struct
 
-pub type vortex_array::arrays::slice::SliceVTable::OperationsVTable = vortex_array::arrays::slice::SliceVTable
+pub fn vortex_array::arrays::Struct::min_max(&self, _array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-pub type vortex_array::arrays::slice::SliceVTable::ValidityVTable = vortex_array::arrays::slice::SliceVTable
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::slice::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Struct::cast(array: &vortex_array::arrays::StructArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::slice::SliceVTable::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::slice::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Struct::mask(array: &vortex_array::arrays::StructArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::slice::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::slice::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Struct::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::slice::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::slice::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Struct::scalar_at(array: &vortex_array::arrays::StructArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-pub fn vortex_array::arrays::slice::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+impl vortex_array::vtable::VTable for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::slice::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub type vortex_array::arrays::Struct::Array = vortex_array::arrays::StructArray
 
-pub fn vortex_array::arrays::slice::SliceVTable::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
+pub type vortex_array::arrays::Struct::Metadata = vortex_array::EmptyMetadata
 
-pub fn vortex_array::arrays::slice::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub type vortex_array::arrays::Struct::OperationsVTable = vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::slice::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub type vortex_array::arrays::Struct::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::slice::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Struct::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::slice::SliceVTable::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
+pub fn vortex_array::arrays::Struct::array_eq(array: &vortex_array::arrays::StructArray, other: &vortex_array::arrays::StructArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::slice::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Struct::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::StructArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::slice::SliceVTable::nbuffers(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::Struct::buffer(_array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::slice::SliceVTable::nchildren(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::Struct::buffer_name(_array: &vortex_array::arrays::StructArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::slice::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Struct::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::StructArray>
 
-pub fn vortex_array::arrays::slice::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Struct::child(array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::slice::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Struct::child_name(array: &vortex_array::arrays::StructArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::slice::SliceVTable::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Struct::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::slice::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Struct::dtype(array: &vortex_array::arrays::StructArray) -> &vortex_array::dtype::DType
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
+pub fn vortex_array::arrays::Struct::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::slice::SliceVTable::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::Struct::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Struct::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::Struct::len(array: &vortex_array::arrays::StructArray) -> usize
+
+pub fn vortex_array::arrays::Struct::metadata(_array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::Struct::nbuffers(_array: &vortex_array::arrays::StructArray) -> usize
+
+pub fn vortex_array::arrays::Struct::nchildren(array: &vortex_array::arrays::StructArray) -> usize
+
+pub fn vortex_array::arrays::Struct::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Struct::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::Struct::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::Struct::stats(array: &vortex_array::arrays::StructArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::Struct::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::StructArray
 
@@ -7218,102 +7314,6 @@ impl vortex_array::vtable::ValidityHelper for vortex_array::arrays::StructArray
 
 pub fn vortex_array::arrays::StructArray::validity(&self) -> &vortex_array::validity::Validity
 
-pub struct vortex_array::arrays::StructVTable
-
-impl vortex_array::arrays::StructVTable
-
-pub const vortex_array::arrays::StructVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::take(array: &vortex_array::arrays::StructArray, indices: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::is_constant(&self, array: &vortex_array::arrays::StructArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::min_max(&self, _array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::cast(array: &vortex_array::arrays::StructArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::mask(array: &vortex_array::arrays::StructArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
-
-pub fn vortex_array::arrays::StructVTable::scalar_at(array: &vortex_array::arrays::StructArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::StructVTable
-
-pub type vortex_array::arrays::StructVTable::Array = vortex_array::arrays::StructArray
-
-pub type vortex_array::arrays::StructVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::StructVTable::OperationsVTable = vortex_array::arrays::StructVTable
-
-pub type vortex_array::arrays::StructVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::StructVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::StructVTable::array_eq(array: &vortex_array::arrays::StructArray, other: &vortex_array::arrays::StructArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::StructVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::StructArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::StructVTable::buffer(_array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::StructVTable::buffer_name(_array: &vortex_array::arrays::StructArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::StructVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::StructArray>
-
-pub fn vortex_array::arrays::StructVTable::child(array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::StructVTable::child_name(array: &vortex_array::arrays::StructArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::StructVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::StructVTable::dtype(array: &vortex_array::arrays::StructArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::StructVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::StructVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::StructVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::StructVTable::len(array: &vortex_array::arrays::StructArray) -> usize
-
-pub fn vortex_array::arrays::StructVTable::metadata(_array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::StructVTable::nbuffers(_array: &vortex_array::arrays::StructArray) -> usize
-
-pub fn vortex_array::arrays::StructVTable::nchildren(array: &vortex_array::arrays::StructArray) -> usize
-
-pub fn vortex_array::arrays::StructVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::StructVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::StructVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::StructVTable::stats(array: &vortex_array::arrays::StructArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::StructVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
-
 pub struct vortex_array::arrays::TemporalArray
 
 impl vortex_array::arrays::datetime::TemporalArray
@@ -7373,6 +7373,116 @@ pub fn vortex_array::arrays::datetime::TemporalArray::fmt(&self, f: &mut core::f
 impl vortex_array::IntoArray for vortex_array::arrays::datetime::TemporalArray
 
 pub fn vortex_array::arrays::datetime::TemporalArray::into_array(self) -> vortex_array::ArrayRef
+
+pub struct vortex_array::arrays::VarBin
+
+impl vortex_array::arrays::VarBin
+
+pub const vortex_array::arrays::VarBin::ID: vortex_array::vtable::ArrayId
+
+impl vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::_slice(array: &vortex_array::arrays::VarBinArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+impl core::fmt::Debug for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::is_constant(&self, array: &vortex_array::arrays::VarBinArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::is_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+pub fn vortex_array::arrays::VarBin::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::min_max(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::cast(array: &vortex_array::arrays::VarBinArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::mask(array: &vortex_array::arrays::VarBinArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBin> for vortex_array::arrays::VarBin
+
+pub fn vortex_array::arrays::VarBin::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+
+impl vortex_array::vtable::VTable for vortex_array::arrays::VarBin
+
+pub type vortex_array::arrays::VarBin::Array = vortex_array::arrays::VarBinArray
+
+pub type vortex_array::arrays::VarBin::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::varbin::vtable::VarBinMetadata>
+
+pub type vortex_array::arrays::VarBin::OperationsVTable = vortex_array::arrays::VarBin
+
+pub type vortex_array::arrays::VarBin::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+
+pub fn vortex_array::arrays::VarBin::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+
+pub fn vortex_array::arrays::VarBin::array_eq(array: &vortex_array::arrays::VarBinArray, other: &vortex_array::arrays::VarBinArray, precision: vortex_array::Precision) -> bool
+
+pub fn vortex_array::arrays::VarBin::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinArray, state: &mut H, precision: vortex_array::Precision)
+
+pub fn vortex_array::arrays::VarBin::buffer(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::buffer::BufferHandle
+
+pub fn vortex_array::arrays::VarBin::buffer_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> core::option::Option<alloc::string::String>
+
+pub fn vortex_array::arrays::VarBin::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinArray>
+
+pub fn vortex_array::arrays::VarBin::child(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::VarBin::child_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> alloc::string::String
+
+pub fn vortex_array::arrays::VarBin::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBin::dtype(array: &vortex_array::arrays::VarBinArray) -> &vortex_array::dtype::DType
+
+pub fn vortex_array::arrays::VarBin::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+
+pub fn vortex_array::arrays::VarBin::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBin::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+
+pub fn vortex_array::arrays::VarBin::len(array: &vortex_array::arrays::VarBinArray) -> usize
+
+pub fn vortex_array::arrays::VarBin::metadata(array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<Self::Metadata>
+
+pub fn vortex_array::arrays::VarBin::nbuffers(_array: &vortex_array::arrays::VarBinArray) -> usize
+
+pub fn vortex_array::arrays::VarBin::nchildren(array: &vortex_array::arrays::VarBinArray) -> usize
+
+pub fn vortex_array::arrays::VarBin::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBin::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub fn vortex_array::arrays::VarBin::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::arrays::VarBin::stats(array: &vortex_array::arrays::VarBinArray) -> vortex_array::stats::StatsSetRef<'_>
+
+pub fn vortex_array::arrays::VarBin::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::VarBinArray
 
@@ -7502,115 +7612,107 @@ impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a str>
 
 pub fn vortex_array::arrays::VarBinArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a str>>>(iter: T) -> Self
 
-pub struct vortex_array::arrays::VarBinVTable
+pub struct vortex_array::arrays::VarBinView
 
-impl vortex_array::arrays::VarBinVTable
+impl vortex_array::arrays::VarBinView
 
-pub const vortex_array::arrays::VarBinVTable::ID: vortex_array::vtable::ArrayId
+pub const vortex_array::arrays::VarBinView::ID: vortex_array::vtable::ArrayId
 
-impl vortex_array::arrays::VarBinVTable
+impl core::fmt::Debug for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinVTable::_slice(array: &vortex_array::arrays::VarBinArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::arrays::VarBinView::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
-impl core::fmt::Debug for vortex_array::arrays::VarBinVTable
+impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+pub fn vortex_array::arrays::VarBinView::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinVTable
+impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinVTable::take(array: &vortex_array::arrays::VarBinArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::arrays::filter::FilterKernel for vortex_array::arrays::VarBinVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinVTable::filter(array: &vortex_array::arrays::VarBinArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::is_constant(&self, array: &vortex_array::arrays::VarBinViewArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::is_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinVTable
+pub fn vortex_array::arrays::VarBinView::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::VarBinVTable::is_constant(&self, array: &vortex_array::arrays::VarBinArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinView
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinVTable
+pub fn vortex_array::arrays::VarBinView::min_max(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-pub fn vortex_array::arrays::VarBinVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::VarBinView::cast(array: &vortex_array::arrays::VarBinViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinVTable::min_max(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::VarBinView::mask(array: &vortex_array::arrays::VarBinViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBinVTable
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinVTable::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinView> for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinVTable::cast(array: &vortex_array::arrays::VarBinArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinVTable::mask(array: &vortex_array::arrays::VarBinArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub type vortex_array::arrays::VarBinView::Array = vortex_array::arrays::VarBinViewArray
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinVTable> for vortex_array::arrays::VarBinVTable
+pub type vortex_array::arrays::VarBinView::Metadata = vortex_array::EmptyMetadata
 
-pub fn vortex_array::arrays::VarBinVTable::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub type vortex_array::arrays::VarBinView::OperationsVTable = vortex_array::arrays::VarBinView
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinVTable
+pub type vortex_array::arrays::VarBinView::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub type vortex_array::arrays::VarBinVTable::Array = vortex_array::arrays::VarBinArray
+pub fn vortex_array::arrays::VarBinView::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub type vortex_array::arrays::VarBinVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::varbin::vtable::VarBinMetadata>
+pub fn vortex_array::arrays::VarBinView::array_eq(array: &vortex_array::arrays::VarBinViewArray, other: &vortex_array::arrays::VarBinViewArray, precision: vortex_array::Precision) -> bool
 
-pub type vortex_array::arrays::VarBinVTable::OperationsVTable = vortex_array::arrays::VarBinVTable
+pub fn vortex_array::arrays::VarBinView::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinViewArray, state: &mut H, precision: vortex_array::Precision)
 
-pub type vortex_array::arrays::VarBinVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub fn vortex_array::arrays::VarBinView::buffer(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::VarBinVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::VarBinView::buffer_name(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::VarBinVTable::array_eq(array: &vortex_array::arrays::VarBinArray, other: &vortex_array::arrays::VarBinArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::VarBinView::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
 
-pub fn vortex_array::arrays::VarBinVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::VarBinView::child(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::VarBinVTable::buffer(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::VarBinView::child_name(_array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::VarBinVTable::buffer_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::VarBinView::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::VarBinVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinArray>
+pub fn vortex_array::arrays::VarBinView::dtype(array: &vortex_array::arrays::VarBinViewArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::VarBinVTable::child(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::VarBinView::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::VarBinVTable::child_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::VarBinView::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::VarBinView::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::VarBinVTable::dtype(array: &vortex_array::arrays::VarBinArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::VarBinView::len(array: &vortex_array::arrays::VarBinViewArray) -> usize
 
-pub fn vortex_array::arrays::VarBinVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::VarBinView::metadata(_array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::VarBinVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::nbuffers(array: &vortex_array::arrays::VarBinViewArray) -> usize
 
-pub fn vortex_array::arrays::VarBinVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::VarBinView::nchildren(array: &vortex_array::arrays::VarBinViewArray) -> usize
 
-pub fn vortex_array::arrays::VarBinVTable::len(array: &vortex_array::arrays::VarBinArray) -> usize
+pub fn vortex_array::arrays::VarBinView::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinVTable::metadata(array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::VarBinView::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinVTable::nbuffers(_array: &vortex_array::arrays::VarBinArray) -> usize
+pub fn vortex_array::arrays::VarBinView::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::VarBinVTable::nchildren(array: &vortex_array::arrays::VarBinArray) -> usize
+pub fn vortex_array::arrays::VarBinView::stats(array: &vortex_array::arrays::VarBinViewArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::VarBinVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::VarBinVTable::stats(array: &vortex_array::arrays::VarBinArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::VarBinVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::VarBinView::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_array::arrays::VarBinViewArray
 
@@ -7721,108 +7823,6 @@ pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::c
 impl<'a> core::iter::traits::collect::FromIterator<core::option::Option<&'a str>> for vortex_array::arrays::VarBinViewArray
 
 pub fn vortex_array::arrays::VarBinViewArray::from_iter<T: core::iter::traits::collect::IntoIterator<Item = core::option::Option<&'a str>>>(iter: T) -> Self
-
-pub struct vortex_array::arrays::VarBinViewVTable
-
-impl vortex_array::arrays::VarBinViewVTable
-
-pub const vortex_array::arrays::VarBinViewVTable::ID: vortex_array::vtable::ArrayId
-
-impl core::fmt::Debug for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_array::arrays::dict::TakeExecute for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::take(array: &vortex_array::arrays::VarBinViewArray, indices: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::arrays::slice::SliceReduce for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::slice(array: &Self::Array, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::is_constant(&self, array: &vortex_array::arrays::VarBinViewArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-pub fn vortex_array::arrays::VarBinViewVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
-
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::min_max(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
-
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::cast(array: &vortex_array::arrays::VarBinViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::mask(array: &vortex_array::arrays::VarBinViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinViewVTable> for vortex_array::arrays::VarBinViewVTable
-
-pub fn vortex_array::arrays::VarBinViewVTable::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
-
-impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinViewVTable
-
-pub type vortex_array::arrays::VarBinViewVTable::Array = vortex_array::arrays::VarBinViewArray
-
-pub type vortex_array::arrays::VarBinViewVTable::Metadata = vortex_array::EmptyMetadata
-
-pub type vortex_array::arrays::VarBinViewVTable::OperationsVTable = vortex_array::arrays::VarBinViewVTable
-
-pub type vortex_array::arrays::VarBinViewVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
-
-pub fn vortex_array::arrays::VarBinViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::arrays::VarBinViewVTable::array_eq(array: &vortex_array::arrays::VarBinViewArray, other: &vortex_array::arrays::VarBinViewArray, precision: vortex_array::Precision) -> bool
-
-pub fn vortex_array::arrays::VarBinViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinViewArray, state: &mut H, precision: vortex_array::Precision)
-
-pub fn vortex_array::arrays::VarBinViewVTable::buffer(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
-
-pub fn vortex_array::arrays::VarBinViewVTable::buffer_name(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> core::option::Option<alloc::string::String>
-
-pub fn vortex_array::arrays::VarBinViewVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
-
-pub fn vortex_array::arrays::VarBinViewVTable::child(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::ArrayRef
-
-pub fn vortex_array::arrays::VarBinViewVTable::child_name(_array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> alloc::string::String
-
-pub fn vortex_array::arrays::VarBinViewVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::VarBinViewVTable::dtype(array: &vortex_array::arrays::VarBinViewArray) -> &vortex_array::dtype::DType
-
-pub fn vortex_array::arrays::VarBinViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
-
-pub fn vortex_array::arrays::VarBinViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinViewVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
-
-pub fn vortex_array::arrays::VarBinViewVTable::len(array: &vortex_array::arrays::VarBinViewArray) -> usize
-
-pub fn vortex_array::arrays::VarBinViewVTable::metadata(_array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<Self::Metadata>
-
-pub fn vortex_array::arrays::VarBinViewVTable::nbuffers(array: &vortex_array::arrays::VarBinViewArray) -> usize
-
-pub fn vortex_array::arrays::VarBinViewVTable::nchildren(array: &vortex_array::arrays::VarBinViewArray) -> usize
-
-pub fn vortex_array::arrays::VarBinViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
-
-pub fn vortex_array::arrays::VarBinViewVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
-
-pub fn vortex_array::arrays::VarBinViewVTable::stats(array: &vortex_array::arrays::VarBinViewArray) -> vortex_array::stats::StatsSetRef<'_>
-
-pub fn vortex_array::arrays::VarBinViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub mod vortex_array::arrow
 
@@ -9762,53 +9762,53 @@ pub trait vortex_array::compute::IsConstantKernel: vortex_array::vtable::VTable
 
 pub fn vortex_array::compute::IsConstantKernel::is_constant(&self, array: &Self::Array, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::BoolVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::BoolVTable::is_constant(&self, array: &vortex_array::arrays::BoolArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Bool::is_constant(&self, array: &vortex_array::arrays::BoolArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::is_constant(&self, array: &vortex_array::arrays::ChunkedArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Chunked::is_constant(&self, array: &vortex_array::arrays::ChunkedArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::DecimalVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::DecimalVTable::is_constant(&self, array: &vortex_array::arrays::DecimalArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Decimal::is_constant(&self, array: &vortex_array::arrays::DecimalArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ExtensionVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::is_constant(&self, array: &vortex_array::arrays::ExtensionArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Extension::is_constant(&self, array: &vortex_array::arrays::ExtensionArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeListVTable::is_constant(&self, array: &vortex_array::arrays::FixedSizeListArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::FixedSizeList::is_constant(&self, array: &vortex_array::arrays::FixedSizeListArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::ListVTable::is_constant(&self, array: &vortex_array::arrays::ListArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::List::is_constant(&self, array: &vortex_array::arrays::ListArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListViewVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListViewVTable::is_constant(&self, array: &vortex_array::arrays::ListViewArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::ListView::is_constant(&self, array: &vortex_array::arrays::ListViewArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::is_constant(&self, array: &vortex_array::arrays::PrimitiveArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Primitive::is_constant(&self, array: &vortex_array::arrays::PrimitiveArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::StructVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::StructVTable::is_constant(&self, array: &vortex_array::arrays::StructArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Struct::is_constant(&self, array: &vortex_array::arrays::StructArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBinVTable::is_constant(&self, array: &vortex_array::arrays::VarBinArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::VarBin::is_constant(&self, array: &vortex_array::arrays::VarBinArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinViewVTable::is_constant(&self, array: &vortex_array::arrays::VarBinViewArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::VarBinView::is_constant(&self, array: &vortex_array::arrays::VarBinViewArray, _opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::IsConstantKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::dict::Dict::is_constant(&self, array: &vortex_array::arrays::dict::DictArray, opts: &vortex_array::compute::IsConstantOpts) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 pub trait vortex_array::compute::IsSortedIteratorExt where <Self as core::iter::traits::iterator::Iterator>::Item: core::cmp::PartialOrd: core::iter::traits::iterator::Iterator
 
@@ -9824,71 +9824,71 @@ pub fn vortex_array::compute::IsSortedKernel::is_sorted(&self, array: &Self::Arr
 
 pub fn vortex_array::compute::IsSortedKernel::is_strict_sorted(&self, array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::BoolVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::BoolVTable::is_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Bool::is_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::BoolVTable::is_strict_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Bool::is_strict_sorted(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::is_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Chunked::is_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::ChunkedVTable::is_strict_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Chunked::is_strict_sorted(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::DecimalVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::DecimalVTable::is_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Decimal::is_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::DecimalVTable::is_strict_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Decimal::is_strict_sorted(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ExtensionVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::is_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Extension::is_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::ExtensionVTable::is_strict_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Extension::is_strict_sorted(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeListVTable::is_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::FixedSizeList::is_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::FixedSizeList::is_strict_sorted(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::ListVTable::is_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::List::is_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::ListVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::List::is_strict_sorted(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListViewVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListViewVTable::is_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::ListView::is_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::ListViewVTable::is_strict_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::ListView::is_strict_sorted(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::is_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Primitive::is_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::PrimitiveVTable::is_strict_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::Primitive::is_strict_sorted(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBinVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::VarBin::is_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::VarBinVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::VarBin::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinViewVTable::is_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::VarBinView::is_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::VarBinViewVTable::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::VarBinView::is_strict_sorted(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::IsSortedKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::dict::Dict::is_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
-pub fn vortex_array::arrays::dict::DictVTable::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
+pub fn vortex_array::arrays::dict::Dict::is_strict_sorted(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<bool>>
 
 pub trait vortex_array::compute::Kernel: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug
 
@@ -9918,69 +9918,69 @@ pub trait vortex_array::compute::MinMaxKernel: vortex_array::vtable::VTable
 
 pub fn vortex_array::compute::MinMaxKernel::min_max(&self, array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::BoolVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::BoolVTable::min_max(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::Bool::min_max(&self, array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::min_max(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::Chunked::min_max(&self, array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ConstantVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::min_max(&self, array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::Constant::min_max(&self, array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::DecimalVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::DecimalVTable::min_max(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::Decimal::min_max(&self, array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ExtensionVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::min_max(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::Extension::min_max(&self, array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeListVTable::min_max(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::FixedSizeList::min_max(&self, _array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::ListVTable::min_max(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::List::min_max(&self, _array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListViewVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListViewVTable::min_max(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::ListView::min_max(&self, _array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::min_max(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::Primitive::min_max(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::StructVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::StructVTable::min_max(&self, _array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::Struct::min_max(&self, _array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBinVTable::min_max(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::VarBin::min_max(&self, array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinViewVTable::min_max(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::VarBinView::min_max(&self, array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::dict::Dict::min_max(&self, array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
-impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::NullVTable
+impl vortex_array::compute::MinMaxKernel for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::NullVTable::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
+pub fn vortex_array::arrays::null::Null::min_max(&self, _array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::compute::MinMaxResult>>
 
 pub trait vortex_array::compute::NaNCountKernel: vortex_array::vtable::VTable
 
 pub fn vortex_array::compute::NaNCountKernel::nan_count(&self, array: &Self::Array) -> vortex_error::VortexResult<usize>
 
-impl vortex_array::compute::NaNCountKernel for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::compute::NaNCountKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::nan_count(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<usize>
+pub fn vortex_array::arrays::Primitive::nan_count(&self, array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<usize>
 
 pub trait vortex_array::compute::Options: 'static
 
@@ -10002,29 +10002,29 @@ pub trait vortex_array::compute::SumKernel: vortex_array::vtable::VTable
 
 pub fn vortex_array::compute::SumKernel::sum(&self, array: &Self::Array, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::BoolVTable
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::BoolVTable::sum(&self, array: &vortex_array::arrays::BoolArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Bool::sum(&self, array: &vortex_array::arrays::BoolArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::sum(&self, array: &vortex_array::arrays::ChunkedArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Chunked::sum(&self, array: &vortex_array::arrays::ChunkedArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ConstantVTable
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::sum(&self, array: &vortex_array::arrays::ConstantArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Constant::sum(&self, array: &vortex_array::arrays::ConstantArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::DecimalVTable
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::DecimalVTable::sum(&self, array: &vortex_array::arrays::DecimalArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Decimal::sum(&self, array: &vortex_array::arrays::DecimalArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::ExtensionVTable
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::sum(&self, array: &vortex_array::arrays::ExtensionArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Extension::sum(&self, array: &vortex_array::arrays::ExtensionArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::compute::SumKernel for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::compute::SumKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Primitive::sum(&self, array: &vortex_array::arrays::PrimitiveArray, accumulator: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub fn vortex_array::compute::is_constant(array: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<bool>>
 
@@ -14474,19 +14474,19 @@ pub fn vortex_array::kernel::ExecuteParentKernel::execute_parent(&self, array: &
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::dict::TakeExecuteAdaptor<V> where V: vortex_array::arrays::dict::TakeExecute
 
-pub type vortex_array::arrays::dict::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::dict::TakeExecuteAdaptor<V>::Parent = vortex_array::arrays::dict::Dict
 
 pub fn vortex_array::arrays::dict::TakeExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::filter::FilterExecuteAdaptor<V> where V: vortex_array::arrays::filter::FilterKernel
 
-pub type vortex_array::arrays::filter::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+pub type vortex_array::arrays::filter::FilterExecuteAdaptor<V>::Parent = vortex_array::arrays::Filter
 
 pub fn vortex_array::arrays::filter::FilterExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::arrays::slice::SliceExecuteAdaptor<V> where V: vortex_array::arrays::slice::SliceKernel
 
-pub type vortex_array::arrays::slice::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
+pub type vortex_array::arrays::slice::SliceExecuteAdaptor<V>::Parent = vortex_array::arrays::slice::Slice
 
 pub fn vortex_array::arrays::slice::SliceExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -14670,39 +14670,39 @@ pub type vortex_array::optimizer::rules::ArrayParentReduceRule::Parent: vortex_a
 
 pub fn vortex_array::optimizer::rules::ArrayParentReduceRule::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::BoolVTable> for vortex_array::arrays::bool::BoolMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Bool> for vortex_array::arrays::bool::BoolMaskedValidityRule
 
-pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::bool::BoolMaskedValidityRule::Parent = vortex_array::arrays::Masked
 
 pub fn vortex_array::arrays::bool::BoolMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::BoolArray, parent: &vortex_array::arrays::MaskedArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Decimal> for vortex_array::arrays::decimal::DecimalMaskedValidityRule
 
-pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::decimal::DecimalMaskedValidityRule::Parent = vortex_array::arrays::Masked
 
 pub fn vortex_array::arrays::decimal::DecimalMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::DecimalArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
+impl vortex_array::optimizer::rules::ArrayParentReduceRule<vortex_array::arrays::Primitive> for vortex_array::arrays::primitive::PrimitiveMaskedValidityRule
 
-pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::Parent = vortex_array::arrays::Masked
 
 pub fn vortex_array::arrays::primitive::PrimitiveMaskedValidityRule::reduce_parent(&self, array: &vortex_array::arrays::PrimitiveArray, parent: &vortex_array::arrays::MaskedArray, _child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::dict::TakeReduceAdaptor<V> where V: vortex_array::arrays::dict::TakeReduce
 
-pub type vortex_array::arrays::dict::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::dict::TakeReduceAdaptor<V>::Parent = vortex_array::arrays::dict::Dict
 
 pub fn vortex_array::arrays::dict::TakeReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::dict::DictArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::filter::FilterReduceAdaptor<V> where V: vortex_array::arrays::filter::FilterReduce
 
-pub type vortex_array::arrays::filter::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::FilterVTable
+pub type vortex_array::arrays::filter::FilterReduceAdaptor<V>::Parent = vortex_array::arrays::Filter
 
 pub fn vortex_array::arrays::filter::FilterReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: &vortex_array::arrays::FilterArray, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl<V> vortex_array::optimizer::rules::ArrayParentReduceRule<V> for vortex_array::arrays::slice::SliceReduceAdaptor<V> where V: vortex_array::arrays::slice::SliceReduce
 
-pub type vortex_array::arrays::slice::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::slice::SliceVTable
+pub type vortex_array::arrays::slice::SliceReduceAdaptor<V>::Parent = vortex_array::arrays::slice::Slice
 
 pub fn vortex_array::arrays::slice::SliceReduceAdaptor<V>::reduce_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: <Self::Parent as vortex_array::matcher::Matcher>::Match, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
@@ -16926,21 +16926,21 @@ pub trait vortex_array::scalar_fn::fns::between::BetweenKernel: vortex_array::vt
 
 pub fn vortex_array::scalar_fn::fns::between::BetweenKernel::between(array: &Self::Array, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::DecimalVTable
+impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::DecimalVTable::between(arr: &vortex_array::arrays::DecimalArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::between(arr: &vortex_array::arrays::DecimalArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::scalar_fn::fns::between::BetweenKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::between(arr: &vortex_array::arrays::PrimitiveArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::between::BetweenReduce: vortex_array::vtable::VTable
 
 pub fn vortex_array::scalar_fn::fns::between::BetweenReduce::between(array: &Self::Array, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::scalar_fn::fns::between::BetweenReduce for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::between(array: &vortex_array::arrays::ConstantArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::between(array: &vortex_array::arrays::ConstantArray, lower: &vortex_array::ArrayRef, upper: &vortex_array::ArrayRef, options: &vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::binary
 
@@ -17006,17 +17006,17 @@ pub trait vortex_array::scalar_fn::fns::binary::CompareKernel: vortex_array::vta
 
 pub fn vortex_array::scalar_fn::fns::binary::CompareKernel::compare(lhs: &Self::Array, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::ExtensionVTable
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBinVTable
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBinVTable::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::scalar_fn::fns::binary::and_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -17186,65 +17186,65 @@ pub trait vortex_array::scalar_fn::fns::cast::CastKernel: vortex_array::vtable::
 
 pub fn vortex_array::scalar_fn::fns::cast::CastKernel::cast(array: &Self::Array, dtype: &vortex_array::dtype::DType, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::DecimalVTable
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::DecimalVTable::cast(array: &vortex_array::arrays::DecimalArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::cast(array: &vortex_array::arrays::DecimalArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::cast(array: &vortex_array::arrays::PrimitiveArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::cast(array: &vortex_array::arrays::PrimitiveArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::StructVTable
+impl vortex_array::scalar_fn::fns::cast::CastKernel for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::StructVTable::cast(array: &vortex_array::arrays::StructArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Struct::cast(array: &vortex_array::arrays::StructArray, dtype: &vortex_array::dtype::DType, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::cast::CastReduce: vortex_array::vtable::VTable
 
 pub fn vortex_array::scalar_fn::fns::cast::CastReduce::cast(array: &Self::Array, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::BoolVTable::cast(array: &vortex_array::arrays::BoolArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::cast(array: &vortex_array::arrays::BoolArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ChunkedVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::cast(array: &vortex_array::arrays::ChunkedArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::cast(array: &vortex_array::arrays::ChunkedArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::cast(array: &vortex_array::arrays::ConstantArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::cast(array: &vortex_array::arrays::ConstantArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ExtensionVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::cast(array: &vortex_array::arrays::ExtensionArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::cast(array: &vortex_array::arrays::ExtensionArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeListVTable::cast(array: &vortex_array::arrays::FixedSizeListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FixedSizeList::cast(array: &vortex_array::arrays::FixedSizeListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::ListVTable::cast(array: &vortex_array::arrays::ListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::cast(array: &vortex_array::arrays::ListArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListViewVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListViewVTable::cast(array: &vortex_array::arrays::ListViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::cast(array: &vortex_array::arrays::ListViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBinVTable::cast(array: &vortex_array::arrays::VarBinArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::cast(array: &vortex_array::arrays::VarBinArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinViewVTable::cast(array: &vortex_array::arrays::VarBinViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::cast(array: &vortex_array::arrays::VarBinViewArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::cast(array: &vortex_array::arrays::dict::DictArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::NullVTable::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::dynamic
 
@@ -17406,33 +17406,33 @@ pub trait vortex_array::scalar_fn::fns::fill_null::FillNullKernel: vortex_array:
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNullKernel::fill_null(array: &Self::Array, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::BoolVTable
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::BoolVTable::fill_null(array: &vortex_array::arrays::BoolArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::fill_null(array: &vortex_array::arrays::BoolArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::DecimalVTable
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::DecimalVTable::fill_null(array: &vortex_array::arrays::DecimalArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::fill_null(array: &vortex_array::arrays::DecimalArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::fill_null(array: &vortex_array::arrays::PrimitiveArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::fill_null(array: &vortex_array::arrays::PrimitiveArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::fill_null::FillNullKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::fill_null(array: &vortex_array::arrays::dict::DictArray, fill_value: &vortex_array::scalar::Scalar, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::fill_null::FillNullReduce: vortex_array::vtable::VTable
 
 pub fn vortex_array::scalar_fn::fns::fill_null::FillNullReduce::fill_null(array: &Self::Array, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::ChunkedVTable
+impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::fill_null(array: &vortex_array::arrays::ChunkedArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::fill_null(array: &vortex_array::arrays::ChunkedArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::scalar_fn::fns::fill_null::FillNullReduce for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::fill_null(array: &vortex_array::arrays::ConstantArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::fill_null(array: &vortex_array::arrays::ConstantArray, fill_value: &vortex_array::scalar::Scalar) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::get_item
 
@@ -17642,9 +17642,9 @@ pub trait vortex_array::scalar_fn::fns::like::LikeReduce: vortex_array::vtable::
 
 pub fn vortex_array::scalar_fn::fns::like::LikeReduce::like(array: &Self::Array, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::like::LikeReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::like(array: &vortex_array::arrays::dict::DictArray, pattern: &vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::list_contains
 
@@ -17854,65 +17854,65 @@ pub trait vortex_array::scalar_fn::fns::mask::MaskKernel: vortex_array::vtable::
 
 pub fn vortex_array::scalar_fn::fns::mask::MaskKernel::mask(array: &Self::Array, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::scalar_fn::fns::mask::MaskKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::mask(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::mask(array: &vortex_array::arrays::ChunkedArray, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::mask::MaskReduce: vortex_array::vtable::VTable
 
 pub fn vortex_array::scalar_fn::fns::mask::MaskReduce::mask(array: &Self::Array, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::BoolVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::BoolVTable::mask(array: &vortex_array::arrays::BoolArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::mask(array: &vortex_array::arrays::BoolArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::DecimalVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::DecimalVTable::mask(array: &vortex_array::arrays::DecimalArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::mask(array: &vortex_array::arrays::DecimalArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ExtensionVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::mask(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::mask(array: &vortex_array::arrays::ExtensionArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeListVTable::mask(array: &vortex_array::arrays::FixedSizeListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FixedSizeList::mask(array: &vortex_array::arrays::FixedSizeListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::ListVTable::mask(array: &vortex_array::arrays::ListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::mask(array: &vortex_array::arrays::ListArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListViewVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListViewVTable::mask(array: &vortex_array::arrays::ListViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::mask(array: &vortex_array::arrays::ListViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::MaskedVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::MaskedVTable::mask(array: &vortex_array::arrays::MaskedArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Masked::mask(array: &vortex_array::arrays::MaskedArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::mask(array: &vortex_array::arrays::PrimitiveArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::mask(array: &vortex_array::arrays::PrimitiveArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::StructVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::StructVTable::mask(array: &vortex_array::arrays::StructArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Struct::mask(array: &vortex_array::arrays::StructArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBinVTable::mask(array: &vortex_array::arrays::VarBinArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::mask(array: &vortex_array::arrays::VarBinArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinViewVTable::mask(array: &vortex_array::arrays::VarBinViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::mask(array: &vortex_array::arrays::VarBinViewArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::DictVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::mask(array: &vortex_array::arrays::dict::DictArray, mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::NullVTable
+impl vortex_array::scalar_fn::fns::mask::MaskReduce for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::NullVTable::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::mask(array: &vortex_array::arrays::null::NullArray, _mask: &vortex_array::ArrayRef) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::merge
 
@@ -18078,9 +18078,9 @@ pub trait vortex_array::scalar_fn::fns::not::NotReduce: vortex_array::vtable::VT
 
 pub fn vortex_array::scalar_fn::fns::not::NotReduce::invert(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::not::NotReduce for vortex_array::arrays::ConstantVTable
+impl vortex_array::scalar_fn::fns::not::NotReduce for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::invert(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::invert(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub mod vortex_array::scalar_fn::fns::operators
 
@@ -18530,17 +18530,17 @@ pub trait vortex_array::scalar_fn::fns::zip::ZipKernel: vortex_array::vtable::VT
 
 pub fn vortex_array::scalar_fn::fns::zip::ZipKernel::zip(array: &Self::Array, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::ChunkedVTable
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::zip(if_true: &vortex_array::arrays::ChunkedArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::StructVTable
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::StructVTable::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Struct::zip(if_true: &vortex_array::arrays::StructArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::scalar_fn::fns::zip::ZipKernel for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinViewVTable::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::zip(if_true: &vortex_array::arrays::VarBinViewArray, if_false: &vortex_array::ArrayRef, mask: &vortex_array::ArrayRef, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub trait vortex_array::scalar_fn::fns::zip::ZipReduce: vortex_array::vtable::VTable
 
@@ -20334,81 +20334,81 @@ pub trait vortex_array::vtable::OperationsVTable<V: vortex_array::vtable::VTable
 
 pub fn vortex_array::vtable::OperationsVTable::scalar_at(array: &<V as vortex_array::vtable::VTable>::Array, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::BoolVTable> for vortex_array::arrays::BoolVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Bool> for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::BoolVTable::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Bool::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Chunked::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Constant::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::DecimalVTable> for vortex_array::arrays::DecimalVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Decimal> for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::DecimalVTable::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Decimal::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Extension::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::FilterVTable::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Filter::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FixedSizeListVTable> for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FixedSizeList> for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeListVTable::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListVTable> for vortex_array::arrays::ListVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::List> for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::ListVTable::scalar_at(array: &vortex_array::arrays::ListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::List::scalar_at(array: &vortex_array::arrays::ListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListViewVTable> for vortex_array::arrays::ListViewVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListView> for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListViewVTable::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::ListView::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::MaskedVTable> for vortex_array::arrays::MaskedVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Masked> for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::MaskedVTable::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Masked::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::PrimitiveVTable> for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Primitive> for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::PrimitiveVTable::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Primitive::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
 
-pub fn vortex_array::arrays::SharedVTable::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Shared::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::StructVTable> for vortex_array::arrays::StructVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::StructVTable::scalar_at(array: &vortex_array::arrays::StructArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Struct::scalar_at(array: &vortex_array::arrays::StructArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinVTable> for vortex_array::arrays::VarBinVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBin> for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBinVTable::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBin::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinViewVTable> for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinView> for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinViewVTable::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBinView::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::NullVTable::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::null::Null::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
 pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
+impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::slice::SliceVTable::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::slice::Slice::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::vtable::OperationsVTable<V> for vortex_array::vtable::NotSupported
 
@@ -20468,923 +20468,923 @@ pub fn vortex_array::vtable::VTable::stats(array: &Self::Array) -> vortex_array:
 
 pub fn vortex_array::vtable::VTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::BoolVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Bool
 
-pub type vortex_array::arrays::BoolVTable::Array = vortex_array::arrays::BoolArray
+pub type vortex_array::arrays::Bool::Array = vortex_array::arrays::BoolArray
 
-pub type vortex_array::arrays::BoolVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::bool::vtable::BoolMetadata>
+pub type vortex_array::arrays::Bool::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::bool::vtable::BoolMetadata>
 
-pub type vortex_array::arrays::BoolVTable::OperationsVTable = vortex_array::arrays::BoolVTable
+pub type vortex_array::arrays::Bool::OperationsVTable = vortex_array::arrays::Bool
 
-pub type vortex_array::arrays::BoolVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub type vortex_array::arrays::Bool::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::BoolVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Bool::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::BoolVTable::array_eq(array: &vortex_array::arrays::BoolArray, other: &vortex_array::arrays::BoolArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Bool::array_eq(array: &vortex_array::arrays::BoolArray, other: &vortex_array::arrays::BoolArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::BoolVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::BoolArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Bool::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::BoolArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::BoolVTable::buffer(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Bool::buffer(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::BoolVTable::buffer_name(_array: &vortex_array::arrays::BoolArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Bool::buffer_name(_array: &vortex_array::arrays::BoolArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::BoolVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::BoolArray>
+pub fn vortex_array::arrays::Bool::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::BoolArray>
 
-pub fn vortex_array::arrays::BoolVTable::child(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Bool::child(array: &vortex_array::arrays::BoolArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::BoolVTable::child_name(_array: &vortex_array::arrays::BoolArray, _idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Bool::child_name(_array: &vortex_array::arrays::BoolArray, _idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::BoolVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Bool::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::BoolVTable::dtype(array: &vortex_array::arrays::BoolArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Bool::dtype(array: &vortex_array::arrays::BoolArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::BoolVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Bool::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::BoolVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Bool::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::BoolVTable::len(array: &vortex_array::arrays::BoolArray) -> usize
+pub fn vortex_array::arrays::Bool::len(array: &vortex_array::arrays::BoolArray) -> usize
 
-pub fn vortex_array::arrays::BoolVTable::metadata(array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Bool::metadata(array: &vortex_array::arrays::BoolArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::BoolVTable::nbuffers(_array: &vortex_array::arrays::BoolArray) -> usize
+pub fn vortex_array::arrays::Bool::nbuffers(_array: &vortex_array::arrays::BoolArray) -> usize
 
-pub fn vortex_array::arrays::BoolVTable::nchildren(array: &vortex_array::arrays::BoolArray) -> usize
+pub fn vortex_array::arrays::Bool::nchildren(array: &vortex_array::arrays::BoolArray) -> usize
 
-pub fn vortex_array::arrays::BoolVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Bool::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::BoolVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Bool::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::BoolVTable::stats(array: &vortex_array::arrays::BoolArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Bool::stats(array: &vortex_array::arrays::BoolArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::BoolVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Bool::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ChunkedVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Chunked
 
-pub type vortex_array::arrays::ChunkedVTable::Array = vortex_array::arrays::ChunkedArray
+pub type vortex_array::arrays::Chunked::Array = vortex_array::arrays::ChunkedArray
 
-pub type vortex_array::arrays::ChunkedVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::Chunked::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::ChunkedVTable::OperationsVTable = vortex_array::arrays::ChunkedVTable
+pub type vortex_array::arrays::Chunked::OperationsVTable = vortex_array::arrays::Chunked
 
-pub type vortex_array::arrays::ChunkedVTable::ValidityVTable = vortex_array::arrays::ChunkedVTable
+pub type vortex_array::arrays::Chunked::ValidityVTable = vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::append_to_builder(array: &vortex_array::arrays::ChunkedArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Chunked::append_to_builder(array: &vortex_array::arrays::ChunkedArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::ChunkedVTable::array_eq(array: &vortex_array::arrays::ChunkedArray, other: &vortex_array::arrays::ChunkedArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Chunked::array_eq(array: &vortex_array::arrays::ChunkedArray, other: &vortex_array::arrays::ChunkedArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::ChunkedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ChunkedArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Chunked::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ChunkedArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::ChunkedVTable::buffer(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Chunked::buffer(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::ChunkedVTable::buffer_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Chunked::buffer_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ChunkedVTable::build(dtype: &vortex_array::dtype::DType, _len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ChunkedArray>
+pub fn vortex_array::arrays::Chunked::build(dtype: &vortex_array::dtype::DType, _len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ChunkedArray>
 
-pub fn vortex_array::arrays::ChunkedVTable::child(array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Chunked::child(array: &vortex_array::arrays::ChunkedArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ChunkedVTable::child_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Chunked::child_name(_array: &vortex_array::arrays::ChunkedArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ChunkedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Chunked::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ChunkedVTable::dtype(array: &vortex_array::arrays::ChunkedArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Chunked::dtype(array: &vortex_array::arrays::ChunkedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ChunkedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Chunked::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::ChunkedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ChunkedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Chunked::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::ChunkedVTable::len(array: &vortex_array::arrays::ChunkedArray) -> usize
+pub fn vortex_array::arrays::Chunked::len(array: &vortex_array::arrays::ChunkedArray) -> usize
 
-pub fn vortex_array::arrays::ChunkedVTable::metadata(_array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Chunked::metadata(_array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ChunkedVTable::nbuffers(_array: &vortex_array::arrays::ChunkedArray) -> usize
+pub fn vortex_array::arrays::Chunked::nbuffers(_array: &vortex_array::arrays::ChunkedArray) -> usize
 
-pub fn vortex_array::arrays::ChunkedVTable::nchildren(array: &vortex_array::arrays::ChunkedArray) -> usize
+pub fn vortex_array::arrays::Chunked::nchildren(array: &vortex_array::arrays::ChunkedArray) -> usize
 
-pub fn vortex_array::arrays::ChunkedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ChunkedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Chunked::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ChunkedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Chunked::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::ChunkedVTable::stats(array: &vortex_array::arrays::ChunkedArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Chunked::stats(array: &vortex_array::arrays::ChunkedArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::ChunkedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Chunked::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ConstantVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Constant
 
-pub type vortex_array::arrays::ConstantVTable::Array = vortex_array::arrays::ConstantArray
+pub type vortex_array::arrays::Constant::Array = vortex_array::arrays::ConstantArray
 
-pub type vortex_array::arrays::ConstantVTable::Metadata = vortex_array::scalar::Scalar
+pub type vortex_array::arrays::Constant::Metadata = vortex_array::scalar::Scalar
 
-pub type vortex_array::arrays::ConstantVTable::OperationsVTable = vortex_array::arrays::ConstantVTable
+pub type vortex_array::arrays::Constant::OperationsVTable = vortex_array::arrays::Constant
 
-pub type vortex_array::arrays::ConstantVTable::ValidityVTable = vortex_array::arrays::ConstantVTable
+pub type vortex_array::arrays::Constant::ValidityVTable = vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Constant::append_to_builder(array: &vortex_array::arrays::ConstantArray, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::ConstantVTable::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Constant::array_eq(array: &vortex_array::arrays::ConstantArray, other: &vortex_array::arrays::ConstantArray, _precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::ConstantVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ConstantArray, state: &mut H, _precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Constant::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ConstantArray, state: &mut H, _precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::ConstantVTable::buffer(array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Constant::buffer(array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::ConstantVTable::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Constant::buffer_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ConstantVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
+pub fn vortex_array::arrays::Constant::build(_dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ConstantArray>
 
-pub fn vortex_array::arrays::ConstantVTable::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Constant::child(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ConstantVTable::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Constant::child_name(_array: &vortex_array::arrays::ConstantArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ConstantVTable::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Constant::deserialize(_bytes: &[u8], dtype: &vortex_array::dtype::DType, _len: usize, buffers: &[vortex_array::buffer::BufferHandle], session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ConstantVTable::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Constant::dtype(array: &vortex_array::arrays::ConstantArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ConstantVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Constant::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::ConstantVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ConstantVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Constant::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::ConstantVTable::len(array: &vortex_array::arrays::ConstantArray) -> usize
+pub fn vortex_array::arrays::Constant::len(array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Constant::metadata(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ConstantVTable::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
+pub fn vortex_array::arrays::Constant::nbuffers(_array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::nchildren(_array: &vortex_array::arrays::ConstantArray) -> usize
+pub fn vortex_array::arrays::Constant::nchildren(_array: &vortex_array::arrays::ConstantArray) -> usize
 
-pub fn vortex_array::arrays::ConstantVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ConstantVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Constant::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ConstantVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Constant::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::ConstantVTable::stats(array: &vortex_array::arrays::ConstantArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Constant::stats(array: &vortex_array::arrays::ConstantArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::ConstantVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Constant::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::DecimalVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Decimal
 
-pub type vortex_array::arrays::DecimalVTable::Array = vortex_array::arrays::DecimalArray
+pub type vortex_array::arrays::Decimal::Array = vortex_array::arrays::DecimalArray
 
-pub type vortex_array::arrays::DecimalVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::decimal::vtable::DecimalMetadata>
+pub type vortex_array::arrays::Decimal::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::decimal::vtable::DecimalMetadata>
 
-pub type vortex_array::arrays::DecimalVTable::OperationsVTable = vortex_array::arrays::DecimalVTable
+pub type vortex_array::arrays::Decimal::OperationsVTable = vortex_array::arrays::Decimal
 
-pub type vortex_array::arrays::DecimalVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub type vortex_array::arrays::Decimal::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::DecimalVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Decimal::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::DecimalVTable::array_eq(array: &vortex_array::arrays::DecimalArray, other: &vortex_array::arrays::DecimalArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Decimal::array_eq(array: &vortex_array::arrays::DecimalArray, other: &vortex_array::arrays::DecimalArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::DecimalVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DecimalArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Decimal::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::DecimalArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::DecimalVTable::buffer(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Decimal::buffer(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::DecimalVTable::buffer_name(_array: &vortex_array::arrays::DecimalArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Decimal::buffer_name(_array: &vortex_array::arrays::DecimalArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::DecimalVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DecimalArray>
+pub fn vortex_array::arrays::Decimal::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::DecimalArray>
 
-pub fn vortex_array::arrays::DecimalVTable::child(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Decimal::child(array: &vortex_array::arrays::DecimalArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::DecimalVTable::child_name(_array: &vortex_array::arrays::DecimalArray, _idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Decimal::child_name(_array: &vortex_array::arrays::DecimalArray, _idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::DecimalVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Decimal::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::DecimalVTable::dtype(array: &vortex_array::arrays::DecimalArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Decimal::dtype(array: &vortex_array::arrays::DecimalArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::DecimalVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Decimal::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::DecimalVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DecimalVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Decimal::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::DecimalVTable::len(array: &vortex_array::arrays::DecimalArray) -> usize
+pub fn vortex_array::arrays::Decimal::len(array: &vortex_array::arrays::DecimalArray) -> usize
 
-pub fn vortex_array::arrays::DecimalVTable::metadata(array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Decimal::metadata(array: &vortex_array::arrays::DecimalArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::DecimalVTable::nbuffers(_array: &vortex_array::arrays::DecimalArray) -> usize
+pub fn vortex_array::arrays::Decimal::nbuffers(_array: &vortex_array::arrays::DecimalArray) -> usize
 
-pub fn vortex_array::arrays::DecimalVTable::nchildren(array: &vortex_array::arrays::DecimalArray) -> usize
+pub fn vortex_array::arrays::Decimal::nchildren(array: &vortex_array::arrays::DecimalArray) -> usize
 
-pub fn vortex_array::arrays::DecimalVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DecimalVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Decimal::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::DecimalVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Decimal::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::DecimalVTable::stats(array: &vortex_array::arrays::DecimalArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Decimal::stats(array: &vortex_array::arrays::DecimalArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::DecimalVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Decimal::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ExtensionVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Extension
 
-pub type vortex_array::arrays::ExtensionVTable::Array = vortex_array::arrays::ExtensionArray
+pub type vortex_array::arrays::Extension::Array = vortex_array::arrays::ExtensionArray
 
-pub type vortex_array::arrays::ExtensionVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::Extension::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::ExtensionVTable::OperationsVTable = vortex_array::arrays::ExtensionVTable
+pub type vortex_array::arrays::Extension::OperationsVTable = vortex_array::arrays::Extension
 
-pub type vortex_array::arrays::ExtensionVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromChild
+pub type vortex_array::arrays::Extension::ValidityVTable = vortex_array::vtable::ValidityVTableFromChild
 
-pub fn vortex_array::arrays::ExtensionVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Extension::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::ExtensionVTable::array_eq(array: &vortex_array::arrays::ExtensionArray, other: &vortex_array::arrays::ExtensionArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Extension::array_eq(array: &vortex_array::arrays::ExtensionArray, other: &vortex_array::arrays::ExtensionArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::ExtensionVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ExtensionArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Extension::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ExtensionArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::ExtensionVTable::buffer(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Extension::buffer(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::ExtensionVTable::buffer_name(_array: &vortex_array::arrays::ExtensionArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Extension::buffer_name(_array: &vortex_array::arrays::ExtensionArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ExtensionVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ExtensionArray>
+pub fn vortex_array::arrays::Extension::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ExtensionArray>
 
-pub fn vortex_array::arrays::ExtensionVTable::child(array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Extension::child(array: &vortex_array::arrays::ExtensionArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ExtensionVTable::child_name(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Extension::child_name(_array: &vortex_array::arrays::ExtensionArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ExtensionVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Extension::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ExtensionVTable::dtype(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Extension::dtype(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ExtensionVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Extension::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::ExtensionVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ExtensionVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Extension::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::ExtensionVTable::len(array: &vortex_array::arrays::ExtensionArray) -> usize
+pub fn vortex_array::arrays::Extension::len(array: &vortex_array::arrays::ExtensionArray) -> usize
 
-pub fn vortex_array::arrays::ExtensionVTable::metadata(_array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Extension::metadata(_array: &vortex_array::arrays::ExtensionArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ExtensionVTable::nbuffers(_array: &vortex_array::arrays::ExtensionArray) -> usize
+pub fn vortex_array::arrays::Extension::nbuffers(_array: &vortex_array::arrays::ExtensionArray) -> usize
 
-pub fn vortex_array::arrays::ExtensionVTable::nchildren(_array: &vortex_array::arrays::ExtensionArray) -> usize
+pub fn vortex_array::arrays::Extension::nchildren(_array: &vortex_array::arrays::ExtensionArray) -> usize
 
-pub fn vortex_array::arrays::ExtensionVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ExtensionVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ExtensionVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Extension::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::ExtensionVTable::stats(array: &vortex_array::arrays::ExtensionArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Extension::stats(array: &vortex_array::arrays::ExtensionArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::ExtensionVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Extension::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::FilterVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Filter
 
-pub type vortex_array::arrays::FilterVTable::Array = vortex_array::arrays::FilterArray
+pub type vortex_array::arrays::Filter::Array = vortex_array::arrays::FilterArray
 
-pub type vortex_array::arrays::FilterVTable::Metadata = vortex_array::arrays::filter::vtable::FilterMetadata
+pub type vortex_array::arrays::Filter::Metadata = vortex_array::arrays::filter::vtable::FilterMetadata
 
-pub type vortex_array::arrays::FilterVTable::OperationsVTable = vortex_array::arrays::FilterVTable
+pub type vortex_array::arrays::Filter::OperationsVTable = vortex_array::arrays::Filter
 
-pub type vortex_array::arrays::FilterVTable::ValidityVTable = vortex_array::arrays::FilterVTable
+pub type vortex_array::arrays::Filter::ValidityVTable = vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::FilterVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Filter::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::FilterVTable::array_eq(array: &vortex_array::arrays::FilterArray, other: &vortex_array::arrays::FilterArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Filter::array_eq(array: &vortex_array::arrays::FilterArray, other: &vortex_array::arrays::FilterArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::FilterVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FilterArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Filter::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FilterArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::FilterVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Filter::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::FilterVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Filter::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::FilterVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::filter::vtable::FilterMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+pub fn vortex_array::arrays::Filter::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::filter::vtable::FilterMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
 
-pub fn vortex_array::arrays::FilterVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Filter::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::FilterVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Filter::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::FilterVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Filter::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::FilterVTable::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Filter::dtype(array: &vortex_array::arrays::FilterArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::FilterVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Filter::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::FilterVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Filter::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::FilterVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Filter::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::FilterVTable::len(array: &vortex_array::arrays::FilterArray) -> usize
+pub fn vortex_array::arrays::Filter::len(array: &vortex_array::arrays::FilterArray) -> usize
 
-pub fn vortex_array::arrays::FilterVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Filter::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::FilterVTable::nbuffers(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::Filter::nbuffers(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::FilterVTable::nchildren(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::Filter::nchildren(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::FilterVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Filter::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::FilterVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Filter::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::FilterVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Filter::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::FilterVTable::stats(array: &vortex_array::arrays::FilterArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Filter::stats(array: &vortex_array::arrays::FilterArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::FilterVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Filter::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::FixedSizeListVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::FixedSizeList
 
-pub type vortex_array::arrays::FixedSizeListVTable::Array = vortex_array::arrays::FixedSizeListArray
+pub type vortex_array::arrays::FixedSizeList::Array = vortex_array::arrays::FixedSizeListArray
 
-pub type vortex_array::arrays::FixedSizeListVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::FixedSizeList::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::FixedSizeListVTable::OperationsVTable = vortex_array::arrays::FixedSizeListVTable
+pub type vortex_array::arrays::FixedSizeList::OperationsVTable = vortex_array::arrays::FixedSizeList
 
-pub type vortex_array::arrays::FixedSizeListVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub type vortex_array::arrays::FixedSizeList::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::FixedSizeListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::FixedSizeList::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::array_eq(array: &vortex_array::arrays::FixedSizeListArray, other: &vortex_array::arrays::FixedSizeListArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::FixedSizeList::array_eq(array: &vortex_array::arrays::FixedSizeListArray, other: &vortex_array::arrays::FixedSizeListArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::FixedSizeListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FixedSizeListArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::FixedSizeList::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::FixedSizeListArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::FixedSizeListVTable::buffer(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::FixedSizeList::buffer(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::FixedSizeListVTable::buffer_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::FixedSizeList::buffer_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::FixedSizeListArray>
+pub fn vortex_array::arrays::FixedSizeList::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::FixedSizeListArray>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::child(array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::FixedSizeList::child(array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::FixedSizeListVTable::child_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::FixedSizeList::child_name(_array: &vortex_array::arrays::FixedSizeListArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::FixedSizeListVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::FixedSizeList::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::dtype(array: &vortex_array::arrays::FixedSizeListArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::FixedSizeList::dtype(array: &vortex_array::arrays::FixedSizeListArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::FixedSizeListVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::FixedSizeList::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FixedSizeList::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::FixedSizeList::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::FixedSizeListVTable::len(array: &vortex_array::arrays::FixedSizeListArray) -> usize
+pub fn vortex_array::arrays::FixedSizeList::len(array: &vortex_array::arrays::FixedSizeListArray) -> usize
 
-pub fn vortex_array::arrays::FixedSizeListVTable::metadata(_array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::FixedSizeList::metadata(_array: &vortex_array::arrays::FixedSizeListArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::nbuffers(_array: &vortex_array::arrays::FixedSizeListArray) -> usize
+pub fn vortex_array::arrays::FixedSizeList::nbuffers(_array: &vortex_array::arrays::FixedSizeListArray) -> usize
 
-pub fn vortex_array::arrays::FixedSizeListVTable::nchildren(array: &vortex_array::arrays::FixedSizeListArray) -> usize
+pub fn vortex_array::arrays::FixedSizeList::nchildren(array: &vortex_array::arrays::FixedSizeListArray) -> usize
 
-pub fn vortex_array::arrays::FixedSizeListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FixedSizeList::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::FixedSizeList::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::FixedSizeList::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::stats(array: &vortex_array::arrays::FixedSizeListArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::FixedSizeList::stats(array: &vortex_array::arrays::FixedSizeListArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::FixedSizeListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::FixedSizeList::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ListVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::List
 
-pub type vortex_array::arrays::ListVTable::Array = vortex_array::arrays::ListArray
+pub type vortex_array::arrays::List::Array = vortex_array::arrays::ListArray
 
-pub type vortex_array::arrays::ListVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::list::vtable::ListMetadata>
+pub type vortex_array::arrays::List::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::list::vtable::ListMetadata>
 
-pub type vortex_array::arrays::ListVTable::OperationsVTable = vortex_array::arrays::ListVTable
+pub type vortex_array::arrays::List::OperationsVTable = vortex_array::arrays::List
 
-pub type vortex_array::arrays::ListVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub type vortex_array::arrays::List::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::ListVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::List::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::ListVTable::array_eq(array: &vortex_array::arrays::ListArray, other: &vortex_array::arrays::ListArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::List::array_eq(array: &vortex_array::arrays::ListArray, other: &vortex_array::arrays::ListArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::ListVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::List::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::ListVTable::buffer(_array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::List::buffer(_array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::ListVTable::buffer_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::List::buffer_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ListVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
+pub fn vortex_array::arrays::List::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListArray>
 
-pub fn vortex_array::arrays::ListVTable::child(array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::List::child(array: &vortex_array::arrays::ListArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ListVTable::child_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::List::child_name(_array: &vortex_array::arrays::ListArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ListVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::List::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ListVTable::dtype(array: &vortex_array::arrays::ListArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::List::dtype(array: &vortex_array::arrays::ListArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ListVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::List::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::ListVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::List::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::ListVTable::len(array: &vortex_array::arrays::ListArray) -> usize
+pub fn vortex_array::arrays::List::len(array: &vortex_array::arrays::ListArray) -> usize
 
-pub fn vortex_array::arrays::ListVTable::metadata(array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::List::metadata(array: &vortex_array::arrays::ListArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ListVTable::nbuffers(_array: &vortex_array::arrays::ListArray) -> usize
+pub fn vortex_array::arrays::List::nbuffers(_array: &vortex_array::arrays::ListArray) -> usize
 
-pub fn vortex_array::arrays::ListVTable::nchildren(array: &vortex_array::arrays::ListArray) -> usize
+pub fn vortex_array::arrays::List::nchildren(array: &vortex_array::arrays::ListArray) -> usize
 
-pub fn vortex_array::arrays::ListVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::List::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::List::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::ListVTable::stats(array: &vortex_array::arrays::ListArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::List::stats(array: &vortex_array::arrays::ListArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::ListVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::List::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::ListViewVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::ListView
 
-pub type vortex_array::arrays::ListViewVTable::Array = vortex_array::arrays::ListViewArray
+pub type vortex_array::arrays::ListView::Array = vortex_array::arrays::ListViewArray
 
-pub type vortex_array::arrays::ListViewVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::listview::vtable::ListViewMetadata>
+pub type vortex_array::arrays::ListView::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::listview::vtable::ListViewMetadata>
 
-pub type vortex_array::arrays::ListViewVTable::OperationsVTable = vortex_array::arrays::ListViewVTable
+pub type vortex_array::arrays::ListView::OperationsVTable = vortex_array::arrays::ListView
 
-pub type vortex_array::arrays::ListViewVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub type vortex_array::arrays::ListView::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::ListViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ListView::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::ListViewVTable::array_eq(array: &vortex_array::arrays::ListViewArray, other: &vortex_array::arrays::ListViewArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::ListView::array_eq(array: &vortex_array::arrays::ListViewArray, other: &vortex_array::arrays::ListViewArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::ListViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListViewArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::ListView::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::ListViewArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::ListViewVTable::buffer(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::ListView::buffer(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::ListViewVTable::buffer_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::ListView::buffer_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::ListViewVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
+pub fn vortex_array::arrays::ListView::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::ListViewArray>
 
-pub fn vortex_array::arrays::ListViewVTable::child(array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::ListView::child(array: &vortex_array::arrays::ListViewArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::ListViewVTable::child_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::ListView::child_name(_array: &vortex_array::arrays::ListViewArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::ListViewVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ListView::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ListViewVTable::dtype(array: &vortex_array::arrays::ListViewArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::ListView::dtype(array: &vortex_array::arrays::ListViewArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::ListViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::ListView::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::ListViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListViewVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::ListView::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::ListViewVTable::len(array: &vortex_array::arrays::ListViewArray) -> usize
+pub fn vortex_array::arrays::ListView::len(array: &vortex_array::arrays::ListViewArray) -> usize
 
-pub fn vortex_array::arrays::ListViewVTable::metadata(array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::ListView::metadata(array: &vortex_array::arrays::ListViewArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::ListViewVTable::nbuffers(_array: &vortex_array::arrays::ListViewArray) -> usize
+pub fn vortex_array::arrays::ListView::nbuffers(_array: &vortex_array::arrays::ListViewArray) -> usize
 
-pub fn vortex_array::arrays::ListViewVTable::nchildren(array: &vortex_array::arrays::ListViewArray) -> usize
+pub fn vortex_array::arrays::ListView::nchildren(array: &vortex_array::arrays::ListViewArray) -> usize
 
-pub fn vortex_array::arrays::ListViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::ListView::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::ListViewVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::ListView::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::ListViewVTable::stats(array: &vortex_array::arrays::ListViewArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::ListView::stats(array: &vortex_array::arrays::ListViewArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::ListViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::ListView::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::MaskedVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Masked
 
-pub type vortex_array::arrays::MaskedVTable::Array = vortex_array::arrays::MaskedArray
+pub type vortex_array::arrays::Masked::Array = vortex_array::arrays::MaskedArray
 
-pub type vortex_array::arrays::MaskedVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::Masked::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::MaskedVTable::OperationsVTable = vortex_array::arrays::MaskedVTable
+pub type vortex_array::arrays::Masked::OperationsVTable = vortex_array::arrays::Masked
 
-pub type vortex_array::arrays::MaskedVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub type vortex_array::arrays::Masked::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::MaskedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Masked::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::MaskedVTable::array_eq(array: &vortex_array::arrays::MaskedArray, other: &vortex_array::arrays::MaskedArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Masked::array_eq(array: &vortex_array::arrays::MaskedArray, other: &vortex_array::arrays::MaskedArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::MaskedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::MaskedArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Masked::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::MaskedArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::MaskedVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Masked::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::MaskedVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Masked::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::MaskedVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::MaskedArray>
+pub fn vortex_array::arrays::Masked::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::MaskedArray>
 
-pub fn vortex_array::arrays::MaskedVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Masked::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::MaskedVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Masked::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::MaskedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Masked::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::MaskedVTable::dtype(array: &vortex_array::arrays::MaskedArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Masked::dtype(array: &vortex_array::arrays::MaskedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::MaskedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Masked::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::MaskedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Masked::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::MaskedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Masked::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::MaskedVTable::len(array: &vortex_array::arrays::MaskedArray) -> usize
+pub fn vortex_array::arrays::Masked::len(array: &vortex_array::arrays::MaskedArray) -> usize
 
-pub fn vortex_array::arrays::MaskedVTable::metadata(_array: &vortex_array::arrays::MaskedArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Masked::metadata(_array: &vortex_array::arrays::MaskedArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::MaskedVTable::nbuffers(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::Masked::nbuffers(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::MaskedVTable::nchildren(array: &Self::Array) -> usize
+pub fn vortex_array::arrays::Masked::nchildren(array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::MaskedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Masked::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::MaskedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Masked::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::MaskedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Masked::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::MaskedVTable::stats(array: &vortex_array::arrays::MaskedArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Masked::stats(array: &vortex_array::arrays::MaskedArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::MaskedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Masked::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::PrimitiveVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Primitive
 
-pub type vortex_array::arrays::PrimitiveVTable::Array = vortex_array::arrays::PrimitiveArray
+pub type vortex_array::arrays::Primitive::Array = vortex_array::arrays::PrimitiveArray
 
-pub type vortex_array::arrays::PrimitiveVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::Primitive::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::PrimitiveVTable::OperationsVTable = vortex_array::arrays::PrimitiveVTable
+pub type vortex_array::arrays::Primitive::OperationsVTable = vortex_array::arrays::Primitive
 
-pub type vortex_array::arrays::PrimitiveVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub type vortex_array::arrays::Primitive::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::PrimitiveVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Primitive::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::PrimitiveVTable::array_eq(array: &vortex_array::arrays::PrimitiveArray, other: &vortex_array::arrays::PrimitiveArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Primitive::array_eq(array: &vortex_array::arrays::PrimitiveArray, other: &vortex_array::arrays::PrimitiveArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::PrimitiveVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::PrimitiveArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Primitive::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::PrimitiveArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::PrimitiveVTable::buffer(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Primitive::buffer(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::PrimitiveVTable::buffer_name(_array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Primitive::buffer_name(_array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::PrimitiveVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
+pub fn vortex_array::arrays::Primitive::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::PrimitiveArray>
 
-pub fn vortex_array::arrays::PrimitiveVTable::child(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Primitive::child(array: &vortex_array::arrays::PrimitiveArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::PrimitiveVTable::child_name(_array: &vortex_array::arrays::PrimitiveArray, _idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Primitive::child_name(_array: &vortex_array::arrays::PrimitiveArray, _idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::PrimitiveVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Primitive::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::PrimitiveVTable::dtype(array: &vortex_array::arrays::PrimitiveArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Primitive::dtype(array: &vortex_array::arrays::PrimitiveArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::PrimitiveVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Primitive::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::PrimitiveVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::PrimitiveVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Primitive::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::PrimitiveVTable::len(array: &vortex_array::arrays::PrimitiveArray) -> usize
+pub fn vortex_array::arrays::Primitive::len(array: &vortex_array::arrays::PrimitiveArray) -> usize
 
-pub fn vortex_array::arrays::PrimitiveVTable::metadata(_array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Primitive::metadata(_array: &vortex_array::arrays::PrimitiveArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::PrimitiveVTable::nbuffers(_array: &vortex_array::arrays::PrimitiveArray) -> usize
+pub fn vortex_array::arrays::Primitive::nbuffers(_array: &vortex_array::arrays::PrimitiveArray) -> usize
 
-pub fn vortex_array::arrays::PrimitiveVTable::nchildren(array: &vortex_array::arrays::PrimitiveArray) -> usize
+pub fn vortex_array::arrays::Primitive::nchildren(array: &vortex_array::arrays::PrimitiveArray) -> usize
 
-pub fn vortex_array::arrays::PrimitiveVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::PrimitiveVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Primitive::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::PrimitiveVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Primitive::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::PrimitiveVTable::stats(array: &vortex_array::arrays::PrimitiveArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Primitive::stats(array: &vortex_array::arrays::PrimitiveArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::PrimitiveVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Primitive::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::SharedVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Shared
 
-pub type vortex_array::arrays::SharedVTable::Array = vortex_array::arrays::SharedArray
+pub type vortex_array::arrays::Shared::Array = vortex_array::arrays::SharedArray
 
-pub type vortex_array::arrays::SharedVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::Shared::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::SharedVTable::OperationsVTable = vortex_array::arrays::SharedVTable
+pub type vortex_array::arrays::Shared::OperationsVTable = vortex_array::arrays::Shared
 
-pub type vortex_array::arrays::SharedVTable::ValidityVTable = vortex_array::arrays::SharedVTable
+pub type vortex_array::arrays::Shared::ValidityVTable = vortex_array::arrays::Shared
 
-pub fn vortex_array::arrays::SharedVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Shared::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::SharedVTable::array_eq(array: &vortex_array::arrays::SharedArray, other: &vortex_array::arrays::SharedArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Shared::array_eq(array: &vortex_array::arrays::SharedArray, other: &vortex_array::arrays::SharedArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::SharedVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SharedArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Shared::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::SharedArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::SharedVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Shared::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::SharedVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Shared::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::SharedVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::SharedArray>
+pub fn vortex_array::arrays::Shared::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::SharedArray>
 
-pub fn vortex_array::arrays::SharedVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Shared::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::SharedVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Shared::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::SharedVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Shared::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::SharedVTable::dtype(array: &vortex_array::arrays::SharedArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Shared::dtype(array: &vortex_array::arrays::SharedArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::SharedVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Shared::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::SharedVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Shared::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::SharedVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Shared::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::SharedVTable::len(array: &vortex_array::arrays::SharedArray) -> usize
+pub fn vortex_array::arrays::Shared::len(array: &vortex_array::arrays::SharedArray) -> usize
 
-pub fn vortex_array::arrays::SharedVTable::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Shared::metadata(_array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::SharedVTable::nbuffers(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::Shared::nbuffers(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::SharedVTable::nchildren(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::Shared::nchildren(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::SharedVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Shared::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::SharedVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Shared::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::SharedVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Shared::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::SharedVTable::stats(array: &vortex_array::arrays::SharedArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Shared::stats(array: &vortex_array::arrays::SharedArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::SharedVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Shared::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::StructVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::Struct
 
-pub type vortex_array::arrays::StructVTable::Array = vortex_array::arrays::StructArray
+pub type vortex_array::arrays::Struct::Array = vortex_array::arrays::StructArray
 
-pub type vortex_array::arrays::StructVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::Struct::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::StructVTable::OperationsVTable = vortex_array::arrays::StructVTable
+pub type vortex_array::arrays::Struct::OperationsVTable = vortex_array::arrays::Struct
 
-pub type vortex_array::arrays::StructVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub type vortex_array::arrays::Struct::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::StructVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Struct::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::StructVTable::array_eq(array: &vortex_array::arrays::StructArray, other: &vortex_array::arrays::StructArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::Struct::array_eq(array: &vortex_array::arrays::StructArray, other: &vortex_array::arrays::StructArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::StructVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::StructArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::Struct::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::StructArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::StructVTable::buffer(_array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::Struct::buffer(_array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::StructVTable::buffer_name(_array: &vortex_array::arrays::StructArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::Struct::buffer_name(_array: &vortex_array::arrays::StructArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::StructVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::StructArray>
+pub fn vortex_array::arrays::Struct::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::StructArray>
 
-pub fn vortex_array::arrays::StructVTable::child(array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::Struct::child(array: &vortex_array::arrays::StructArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::StructVTable::child_name(array: &vortex_array::arrays::StructArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::Struct::child_name(array: &vortex_array::arrays::StructArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::StructVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Struct::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::StructVTable::dtype(array: &vortex_array::arrays::StructArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::Struct::dtype(array: &vortex_array::arrays::StructArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::StructVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::Struct::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::StructVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Struct::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::StructVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::Struct::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::StructVTable::len(array: &vortex_array::arrays::StructArray) -> usize
+pub fn vortex_array::arrays::Struct::len(array: &vortex_array::arrays::StructArray) -> usize
 
-pub fn vortex_array::arrays::StructVTable::metadata(_array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::Struct::metadata(_array: &vortex_array::arrays::StructArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::StructVTable::nbuffers(_array: &vortex_array::arrays::StructArray) -> usize
+pub fn vortex_array::arrays::Struct::nbuffers(_array: &vortex_array::arrays::StructArray) -> usize
 
-pub fn vortex_array::arrays::StructVTable::nchildren(array: &vortex_array::arrays::StructArray) -> usize
+pub fn vortex_array::arrays::Struct::nchildren(array: &vortex_array::arrays::StructArray) -> usize
 
-pub fn vortex_array::arrays::StructVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Struct::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::StructVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Struct::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::StructVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::Struct::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::StructVTable::stats(array: &vortex_array::arrays::StructArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::Struct::stats(array: &vortex_array::arrays::StructArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::StructVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Struct::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::VarBin
 
-pub type vortex_array::arrays::VarBinVTable::Array = vortex_array::arrays::VarBinArray
+pub type vortex_array::arrays::VarBin::Array = vortex_array::arrays::VarBinArray
 
-pub type vortex_array::arrays::VarBinVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::varbin::vtable::VarBinMetadata>
+pub type vortex_array::arrays::VarBin::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::varbin::vtable::VarBinMetadata>
 
-pub type vortex_array::arrays::VarBinVTable::OperationsVTable = vortex_array::arrays::VarBinVTable
+pub type vortex_array::arrays::VarBin::OperationsVTable = vortex_array::arrays::VarBin
 
-pub type vortex_array::arrays::VarBinVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub type vortex_array::arrays::VarBin::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::VarBinVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::VarBin::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::VarBinVTable::array_eq(array: &vortex_array::arrays::VarBinArray, other: &vortex_array::arrays::VarBinArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::VarBin::array_eq(array: &vortex_array::arrays::VarBinArray, other: &vortex_array::arrays::VarBinArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::VarBinVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::VarBin::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::VarBinVTable::buffer(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::VarBin::buffer(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::VarBinVTable::buffer_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::VarBin::buffer_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::VarBinVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinArray>
+pub fn vortex_array::arrays::VarBin::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinArray>
 
-pub fn vortex_array::arrays::VarBinVTable::child(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::VarBin::child(array: &vortex_array::arrays::VarBinArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::VarBinVTable::child_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::VarBin::child_name(_array: &vortex_array::arrays::VarBinArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::VarBinVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::VarBin::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::VarBinVTable::dtype(array: &vortex_array::arrays::VarBinArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::VarBin::dtype(array: &vortex_array::arrays::VarBinArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::VarBinVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::VarBin::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::VarBinVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::VarBin::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::VarBinVTable::len(array: &vortex_array::arrays::VarBinArray) -> usize
+pub fn vortex_array::arrays::VarBin::len(array: &vortex_array::arrays::VarBinArray) -> usize
 
-pub fn vortex_array::arrays::VarBinVTable::metadata(array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::VarBin::metadata(array: &vortex_array::arrays::VarBinArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::VarBinVTable::nbuffers(_array: &vortex_array::arrays::VarBinArray) -> usize
+pub fn vortex_array::arrays::VarBin::nbuffers(_array: &vortex_array::arrays::VarBinArray) -> usize
 
-pub fn vortex_array::arrays::VarBinVTable::nchildren(array: &vortex_array::arrays::VarBinArray) -> usize
+pub fn vortex_array::arrays::VarBin::nchildren(array: &vortex_array::arrays::VarBinArray) -> usize
 
-pub fn vortex_array::arrays::VarBinVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::VarBin::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::VarBinVTable::stats(array: &vortex_array::arrays::VarBinArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::VarBin::stats(array: &vortex_array::arrays::VarBinArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::VarBinVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::VarBin::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinViewVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinView
 
-pub type vortex_array::arrays::VarBinViewVTable::Array = vortex_array::arrays::VarBinViewArray
+pub type vortex_array::arrays::VarBinView::Array = vortex_array::arrays::VarBinViewArray
 
-pub type vortex_array::arrays::VarBinViewVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::VarBinView::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::VarBinViewVTable::OperationsVTable = vortex_array::arrays::VarBinViewVTable
+pub type vortex_array::arrays::VarBinView::OperationsVTable = vortex_array::arrays::VarBinView
 
-pub type vortex_array::arrays::VarBinViewVTable::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
+pub type vortex_array::arrays::VarBinView::ValidityVTable = vortex_array::vtable::ValidityVTableFromValidityHelper
 
-pub fn vortex_array::arrays::VarBinViewVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::VarBinView::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::VarBinViewVTable::array_eq(array: &vortex_array::arrays::VarBinViewArray, other: &vortex_array::arrays::VarBinViewArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::VarBinView::array_eq(array: &vortex_array::arrays::VarBinViewArray, other: &vortex_array::arrays::VarBinViewArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::VarBinViewVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinViewArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::VarBinView::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::VarBinViewArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::VarBinViewVTable::buffer(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::VarBinView::buffer(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::VarBinViewVTable::buffer_name(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::VarBinView::buffer_name(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::VarBinViewVTable::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
+pub fn vortex_array::arrays::VarBinView::build(dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::VarBinViewArray>
 
-pub fn vortex_array::arrays::VarBinViewVTable::child(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::VarBinView::child(array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::VarBinViewVTable::child_name(_array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::VarBinView::child_name(_array: &vortex_array::arrays::VarBinViewArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::VarBinViewVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::VarBinView::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::VarBinViewVTable::dtype(array: &vortex_array::arrays::VarBinViewArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::VarBinView::dtype(array: &vortex_array::arrays::VarBinViewArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::VarBinViewVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::VarBinView::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::VarBinViewVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinViewVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::VarBinView::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::VarBinViewVTable::len(array: &vortex_array::arrays::VarBinViewArray) -> usize
+pub fn vortex_array::arrays::VarBinView::len(array: &vortex_array::arrays::VarBinViewArray) -> usize
 
-pub fn vortex_array::arrays::VarBinViewVTable::metadata(_array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::VarBinView::metadata(_array: &vortex_array::arrays::VarBinViewArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::VarBinViewVTable::nbuffers(array: &vortex_array::arrays::VarBinViewArray) -> usize
+pub fn vortex_array::arrays::VarBinView::nbuffers(array: &vortex_array::arrays::VarBinViewArray) -> usize
 
-pub fn vortex_array::arrays::VarBinViewVTable::nchildren(array: &vortex_array::arrays::VarBinViewArray) -> usize
+pub fn vortex_array::arrays::VarBinView::nchildren(array: &vortex_array::arrays::VarBinViewArray) -> usize
 
-pub fn vortex_array::arrays::VarBinViewVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinViewVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBinView::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::VarBinViewVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::VarBinView::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::VarBinViewVTable::stats(array: &vortex_array::arrays::VarBinViewArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::VarBinView::stats(array: &vortex_array::arrays::VarBinViewArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::VarBinViewVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::VarBinView::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::dict::Dict
 
-pub type vortex_array::arrays::dict::DictVTable::Array = vortex_array::arrays::dict::DictArray
+pub type vortex_array::arrays::dict::Dict::Array = vortex_array::arrays::dict::DictArray
 
-pub type vortex_array::arrays::dict::DictVTable::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
+pub type vortex_array::arrays::dict::Dict::Metadata = vortex_array::ProstMetadata<vortex_array::arrays::dict::DictMetadata>
 
-pub type vortex_array::arrays::dict::DictVTable::OperationsVTable = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::dict::Dict::OperationsVTable = vortex_array::arrays::dict::Dict
 
-pub type vortex_array::arrays::dict::DictVTable::ValidityVTable = vortex_array::arrays::dict::DictVTable
+pub type vortex_array::arrays::dict::Dict::ValidityVTable = vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::dict::Dict::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::dict::DictVTable::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::dict::Dict::array_eq(array: &vortex_array::arrays::dict::DictArray, other: &vortex_array::arrays::dict::DictArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::dict::DictVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::dict::Dict::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::dict::DictArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::dict::DictVTable::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::dict::Dict::buffer(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::dict::DictVTable::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::dict::Dict::buffer_name(_array: &vortex_array::arrays::dict::DictArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::dict::DictVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
+pub fn vortex_array::arrays::dict::Dict::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::dict::DictArray>
 
-pub fn vortex_array::arrays::dict::DictVTable::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::dict::Dict::child(array: &vortex_array::arrays::dict::DictArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::dict::DictVTable::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::dict::Dict::child_name(_array: &vortex_array::arrays::dict::DictArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::dict::DictVTable::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::dict::Dict::deserialize(bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::dict::DictVTable::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::dict::Dict::dtype(array: &vortex_array::arrays::dict::DictArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::dict::DictVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::dict::Dict::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::dict::DictVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::dict::Dict::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::dict::DictVTable::len(array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::dict::Dict::len(array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::dict::Dict::metadata(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::dict::DictVTable::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::dict::Dict::nbuffers(_array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
+pub fn vortex_array::arrays::dict::Dict::nchildren(_array: &vortex_array::arrays::dict::DictArray) -> usize
 
-pub fn vortex_array::arrays::dict::DictVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::dict::DictVTable::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::dict::Dict::serialize(metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::dict::DictVTable::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::dict::Dict::stats(array: &vortex_array::arrays::dict::DictArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::dict::DictVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::dict::Dict::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::null::NullVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::null::Null
 
-pub type vortex_array::arrays::null::NullVTable::Array = vortex_array::arrays::null::NullArray
+pub type vortex_array::arrays::null::Null::Array = vortex_array::arrays::null::NullArray
 
-pub type vortex_array::arrays::null::NullVTable::Metadata = vortex_array::EmptyMetadata
+pub type vortex_array::arrays::null::Null::Metadata = vortex_array::EmptyMetadata
 
-pub type vortex_array::arrays::null::NullVTable::OperationsVTable = vortex_array::arrays::null::NullVTable
+pub type vortex_array::arrays::null::Null::OperationsVTable = vortex_array::arrays::null::Null
 
-pub type vortex_array::arrays::null::NullVTable::ValidityVTable = vortex_array::arrays::null::NullVTable
+pub type vortex_array::arrays::null::Null::ValidityVTable = vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::NullVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::null::Null::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::null::NullVTable::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::null::Null::array_eq(array: &vortex_array::arrays::null::NullArray, other: &vortex_array::arrays::null::NullArray, _precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::null::NullVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
+pub fn vortex_array::arrays::null::Null::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::null::NullArray, state: &mut H, _precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::null::NullVTable::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::null::Null::buffer(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::null::NullVTable::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::null::Null::buffer_name(_array: &vortex_array::arrays::null::NullArray, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::null::NullVTable::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
+pub fn vortex_array::arrays::null::Null::build(_dtype: &vortex_array::dtype::DType, len: usize, _metadata: &Self::Metadata, _buffers: &[vortex_array::buffer::BufferHandle], _children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<vortex_array::arrays::null::NullArray>
 
-pub fn vortex_array::arrays::null::NullVTable::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::null::Null::child(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::null::NullVTable::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::null::Null::child_name(_array: &vortex_array::arrays::null::NullArray, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::null::NullVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::null::Null::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::null::NullVTable::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::null::Null::dtype(_array: &vortex_array::arrays::null::NullArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::null::NullVTable::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::null::Null::execute(array: &Self::Array, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::null::NullVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::null::NullVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::null::Null::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::null::NullVTable::len(array: &vortex_array::arrays::null::NullArray) -> usize
+pub fn vortex_array::arrays::null::Null::len(array: &vortex_array::arrays::null::NullArray) -> usize
 
-pub fn vortex_array::arrays::null::NullVTable::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::null::Null::metadata(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::null::NullVTable::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
+pub fn vortex_array::arrays::null::Null::nbuffers(_array: &vortex_array::arrays::null::NullArray) -> usize
 
-pub fn vortex_array::arrays::null::NullVTable::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
+pub fn vortex_array::arrays::null::Null::nchildren(_array: &vortex_array::arrays::null::NullArray) -> usize
 
-pub fn vortex_array::arrays::null::NullVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::null::NullVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::null::Null::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::null::NullVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::null::Null::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::null::NullVTable::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::null::Null::stats(array: &vortex_array::arrays::null::NullArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::null::NullVTable::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::null::Null::with_children(_array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
@@ -21440,67 +21440,67 @@ pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::stats(array: &vortex_arr
 
 pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_array::vtable::VTable for vortex_array::arrays::slice::SliceVTable
+impl vortex_array::vtable::VTable for vortex_array::arrays::slice::Slice
 
-pub type vortex_array::arrays::slice::SliceVTable::Array = vortex_array::arrays::slice::SliceArray
+pub type vortex_array::arrays::slice::Slice::Array = vortex_array::arrays::slice::SliceArray
 
-pub type vortex_array::arrays::slice::SliceVTable::Metadata = vortex_array::arrays::slice::SliceMetadata
+pub type vortex_array::arrays::slice::Slice::Metadata = vortex_array::arrays::slice::SliceMetadata
 
-pub type vortex_array::arrays::slice::SliceVTable::OperationsVTable = vortex_array::arrays::slice::SliceVTable
+pub type vortex_array::arrays::slice::Slice::OperationsVTable = vortex_array::arrays::slice::Slice
 
-pub type vortex_array::arrays::slice::SliceVTable::ValidityVTable = vortex_array::arrays::slice::SliceVTable
+pub type vortex_array::arrays::slice::Slice::ValidityVTable = vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::slice::SliceVTable::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::slice::Slice::append_to_builder(array: &Self::Array, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::arrays::slice::SliceVTable::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
+pub fn vortex_array::arrays::slice::Slice::array_eq(array: &vortex_array::arrays::slice::SliceArray, other: &vortex_array::arrays::slice::SliceArray, precision: vortex_array::Precision) -> bool
 
-pub fn vortex_array::arrays::slice::SliceVTable::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
+pub fn vortex_array::arrays::slice::Slice::array_hash<H: core::hash::Hasher>(array: &vortex_array::arrays::slice::SliceArray, state: &mut H, precision: vortex_array::Precision)
 
-pub fn vortex_array::arrays::slice::SliceVTable::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
+pub fn vortex_array::arrays::slice::Slice::buffer(_array: &Self::Array, _idx: usize) -> vortex_array::buffer::BufferHandle
 
-pub fn vortex_array::arrays::slice::SliceVTable::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
+pub fn vortex_array::arrays::slice::Slice::buffer_name(_array: &Self::Array, _idx: usize) -> core::option::Option<alloc::string::String>
 
-pub fn vortex_array::arrays::slice::SliceVTable::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
+pub fn vortex_array::arrays::slice::Slice::build(dtype: &vortex_array::dtype::DType, len: usize, metadata: &vortex_array::arrays::slice::SliceMetadata, _buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren) -> vortex_error::VortexResult<Self::Array>
 
-pub fn vortex_array::arrays::slice::SliceVTable::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
+pub fn vortex_array::arrays::slice::Slice::child(array: &Self::Array, idx: usize) -> vortex_array::ArrayRef
 
-pub fn vortex_array::arrays::slice::SliceVTable::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
+pub fn vortex_array::arrays::slice::Slice::child_name(_array: &Self::Array, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::slice::SliceVTable::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::slice::Slice::deserialize(_bytes: &[u8], _dtype: &vortex_array::dtype::DType, _len: usize, _buffers: &[vortex_array::buffer::BufferHandle], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::slice::SliceVTable::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
+pub fn vortex_array::arrays::slice::Slice::dtype(array: &vortex_array::arrays::slice::SliceArray) -> &vortex_array::dtype::DType
 
-pub fn vortex_array::arrays::slice::SliceVTable::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
+pub fn vortex_array::arrays::slice::Slice::execute(array: &Self::Array, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ExecutionStep>
 
-pub fn vortex_array::arrays::slice::SliceVTable::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::Slice::execute_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::slice::SliceVTable::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
+pub fn vortex_array::arrays::slice::Slice::id(_array: &Self::Array) -> vortex_array::vtable::ArrayId
 
-pub fn vortex_array::arrays::slice::SliceVTable::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
+pub fn vortex_array::arrays::slice::Slice::len(array: &vortex_array::arrays::slice::SliceArray) -> usize
 
-pub fn vortex_array::arrays::slice::SliceVTable::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
+pub fn vortex_array::arrays::slice::Slice::metadata(array: &Self::Array) -> vortex_error::VortexResult<Self::Metadata>
 
-pub fn vortex_array::arrays::slice::SliceVTable::nbuffers(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::slice::Slice::nbuffers(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::slice::SliceVTable::nchildren(_array: &Self::Array) -> usize
+pub fn vortex_array::arrays::slice::Slice::nchildren(_array: &Self::Array) -> usize
 
-pub fn vortex_array::arrays::slice::SliceVTable::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::Slice::reduce(array: &Self::Array) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::slice::SliceVTable::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::slice::Slice::reduce_parent(array: &Self::Array, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::arrays::slice::SliceVTable::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+pub fn vortex_array::arrays::slice::Slice::serialize(_metadata: Self::Metadata) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
-pub fn vortex_array::arrays::slice::SliceVTable::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
+pub fn vortex_array::arrays::slice::Slice::stats(array: &vortex_array::arrays::slice::SliceArray) -> vortex_array::stats::StatsSetRef<'_>
 
-pub fn vortex_array::arrays::slice::SliceVTable::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::slice::Slice::with_children(array: &mut Self::Array, children: alloc::vec::Vec<vortex_array::ArrayRef>) -> vortex_error::VortexResult<()>
 
 pub trait vortex_array::vtable::ValidityChild<V: vortex_array::vtable::VTable>
 
 pub fn vortex_array::vtable::ValidityChild::validity_child(array: &<V as vortex_array::vtable::VTable>::Array) -> &vortex_array::ArrayRef
 
-impl vortex_array::vtable::ValidityChild<vortex_array::arrays::ExtensionVTable> for vortex_array::arrays::ExtensionVTable
+impl vortex_array::vtable::ValidityChild<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::ExtensionVTable::validity_child(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::ArrayRef
+pub fn vortex_array::arrays::Extension::validity_child(array: &vortex_array::arrays::ExtensionArray) -> &vortex_array::ArrayRef
 
 pub trait vortex_array::vtable::ValidityChildSliceHelper
 
@@ -21562,37 +21562,37 @@ pub trait vortex_array::vtable::ValidityVTable<V: vortex_array::vtable::VTable>
 
 pub fn vortex_array::vtable::ValidityVTable::validity(array: &<V as vortex_array::vtable::VTable>::Array) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ChunkedVTable> for vortex_array::arrays::ChunkedVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::ChunkedVTable::validity(array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::Chunked::validity(array: &vortex_array::arrays::ChunkedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::ConstantVTable> for vortex_array::arrays::ConstantVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::ConstantVTable::validity(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::Constant::validity(array: &vortex_array::arrays::ConstantArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::FilterVTable> for vortex_array::arrays::FilterVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::FilterVTable::validity(array: &vortex_array::arrays::FilterArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::Filter::validity(array: &vortex_array::arrays::FilterArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::SharedVTable> for vortex_array::arrays::SharedVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
 
-pub fn vortex_array::arrays::SharedVTable::validity(array: &vortex_array::arrays::SharedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::Shared::validity(array: &vortex_array::arrays::SharedArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::DictVTable> for vortex_array::arrays::dict::DictVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::DictVTable::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::dict::Dict::validity(array: &vortex_array::arrays::dict::DictArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::NullVTable> for vortex_array::arrays::null::NullVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::NullVTable::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::null::Null::validity(_array: &vortex_array::arrays::null::NullArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
 pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::validity(array: &vortex_array::arrays::scalar_fn::ScalarFnArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
-impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::SliceVTable> for vortex_array::arrays::slice::SliceVTable
+impl vortex_array::vtable::ValidityVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::slice::SliceVTable::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
+pub fn vortex_array::arrays::slice::Slice::validity(array: &vortex_array::arrays::slice::SliceArray) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::vtable::ValidityVTable<V> for vortex_array::vtable::ValidityVTableFromChildSliceHelper where <V as vortex_array::vtable::VTable>::Array: vortex_array::vtable::ValidityChildSliceHelper
 

--- a/vortex-array/src/aggregate_fn/session.rs
+++ b/vortex-array/src/aggregate_fn/session.rs
@@ -14,7 +14,7 @@ use crate::aggregate_fn::AggregateFnPluginRef;
 use crate::aggregate_fn::AggregateFnVTable;
 use crate::aggregate_fn::kernels::DynAggregateKernel;
 use crate::aggregate_fn::kernels::DynGroupedAggregateKernel;
-use crate::arrays::ChunkedVTable;
+use crate::arrays::Chunked;
 use crate::arrays::chunked::compute::aggregate::ChunkedArrayAggregate;
 use crate::vtable::ArrayId;
 
@@ -41,7 +41,7 @@ impl Default for AggregateFnSession {
         };
 
         // Register the built-in aggregate kernels.
-        this.register_aggregate_kernel(ChunkedVTable::ID, None, &ChunkedArrayAggregate);
+        this.register_aggregate_kernel(Chunked::ID, None, &ChunkedArrayAggregate);
 
         this
     }

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -31,16 +31,16 @@ use crate::ExecutionCtx;
 use crate::LEGACY_SESSION;
 use crate::ToCanonical;
 use crate::VortexSessionExecute;
-use crate::arrays::BoolVTable;
-use crate::arrays::ConstantVTable;
+use crate::arrays::Bool;
+use crate::arrays::Constant;
 use crate::arrays::DictArray;
 use crate::arrays::FilterArray;
-use crate::arrays::NullVTable;
-use crate::arrays::PrimitiveVTable;
+use crate::arrays::Null;
+use crate::arrays::Primitive;
 use crate::arrays::ScalarFnVTable;
 use crate::arrays::SliceArray;
-use crate::arrays::VarBinVTable;
-use crate::arrays::VarBinViewVTable;
+use crate::arrays::VarBin;
+use crate::arrays::VarBinView;
 use crate::buffer::BufferHandle;
 use crate::builders::ArrayBuilder;
 use crate::compute;
@@ -326,7 +326,7 @@ impl dyn DynArray + '_ {
     }
 
     pub fn as_constant(&self) -> Option<Scalar> {
-        self.as_opt::<ConstantVTable>().map(|a| a.scalar().clone())
+        self.as_opt::<Constant>().map(|a| a.scalar().clone())
     }
 
     /// Total size of the array in bytes, including all children and buffers.
@@ -342,11 +342,11 @@ impl dyn DynArray + '_ {
 
     /// Returns whether this array is an arrow encoding.
     pub fn is_arrow(&self) -> bool {
-        self.is::<NullVTable>()
-            || self.is::<BoolVTable>()
-            || self.is::<PrimitiveVTable>()
-            || self.is::<VarBinVTable>()
-            || self.is::<VarBinViewVTable>()
+        self.is::<Null>()
+            || self.is::<Bool>()
+            || self.is::<Primitive>()
+            || self.is::<VarBin>()
+            || self.is::<VarBinView>()
     }
 
     /// Whether the array is of a canonical encoding.
@@ -492,7 +492,7 @@ impl<V: VTable> DynArray for ArrayAdapter<V> {
             .optimize()?;
 
         // Propagate some stats from the original array to the sliced array.
-        if !sliced.is::<ConstantVTable>() {
+        if !sliced.is::<Constant>() {
             self.statistics().with_iter(|iter| {
                 sliced.statistics().inherit(iter.filter(|(stat, value)| {
                     matches!(

--- a/vortex-array/src/arrays/bool/compute/cast.rs
+++ b/vortex-array/src/arrays/bool/compute/cast.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::IntoArray;
 use crate::array::ArrayRef;
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
 use crate::dtype::DType;
 use crate::scalar_fn::fns::cast::CastReduce;
 use crate::vtable::ValidityHelper;
 
-impl CastReduce for BoolVTable {
+impl CastReduce for Bool {
     fn cast(array: &BoolArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !matches!(dtype, DType::Bool(_)) {
             return Ok(None);

--- a/vortex-array/src/arrays/bool/compute/fill_null.rs
+++ b/vortex-array/src/arrays/bool/compute/fill_null.rs
@@ -7,14 +7,14 @@ use vortex_error::vortex_err;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::fill_null::FillNullKernel;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl FillNullKernel for BoolVTable {
+impl FillNullKernel for Bool {
     fn fill_null(
         array: &BoolArray,
         fill_value: &Scalar,

--- a/vortex-array/src/arrays/bool/compute/filter.rs
+++ b/vortex-array/src/arrays/bool/compute/filter.rs
@@ -11,15 +11,15 @@ use vortex_mask::MaskIter;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
 use crate::arrays::filter::FilterReduce;
 use crate::vtable::ValidityHelper;
 
 /// If the filter density is above 80%, we use slices to filter the array instead of indices.
 const FILTER_SLICES_DENSITY_THRESHOLD: f64 = 0.8;
 
-impl FilterReduce for BoolVTable {
+impl FilterReduce for Bool {
     fn filter(array: &BoolArray, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
         let validity = array.validity().filter(mask)?;
 

--- a/vortex-array/src/arrays/bool/compute/is_constant.rs
+++ b/vortex-array/src/arrays/bool/compute/is_constant.rs
@@ -3,14 +3,14 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
 use crate::compute::IsConstantOpts;
 use crate::register_kernel;
 
-impl IsConstantKernel for BoolVTable {
+impl IsConstantKernel for Bool {
     fn is_constant(&self, array: &BoolArray, opts: &IsConstantOpts) -> VortexResult<Option<bool>> {
         // If the array is small, then it is a constant time operation.
         if opts.is_negligible_cost() && array.len() > 64 {
@@ -22,7 +22,7 @@ impl IsConstantKernel for BoolVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(BoolVTable).lift());
+register_kernel!(IsConstantKernelAdapter(Bool).lift());
 
 #[cfg(test)]
 mod tests {

--- a/vortex-array/src/arrays/bool/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/bool/compute/is_sorted.rs
@@ -4,14 +4,14 @@
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
 use crate::compute::IsSortedIteratorExt;
 use crate::compute::IsSortedKernel;
 use crate::compute::IsSortedKernelAdapter;
 use crate::register_kernel;
 
-impl IsSortedKernel for BoolVTable {
+impl IsSortedKernel for Bool {
     fn is_sorted(&self, array: &BoolArray) -> VortexResult<Option<bool>> {
         match array.validity_mask()? {
             Mask::AllFalse(_) => Ok(Some(true)),
@@ -51,4 +51,4 @@ impl IsSortedKernel for BoolVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(BoolVTable).lift());
+register_kernel!(IsSortedKernelAdapter(Bool).lift());

--- a/vortex-array/src/arrays/bool/compute/mask.rs
+++ b/vortex-array/src/arrays/bool/compute/mask.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl MaskReduce for BoolVTable {
+impl MaskReduce for Bool {
     fn mask(array: &BoolArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             BoolArray::new(

--- a/vortex-array/src/arrays/bool/compute/min_max.rs
+++ b/vortex-array/src/arrays/bool/compute/min_max.rs
@@ -7,8 +7,8 @@ use Nullability::NonNullable;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
@@ -16,7 +16,7 @@ use crate::dtype::Nullability;
 use crate::register_kernel;
 use crate::scalar::Scalar;
 
-impl MinMaxKernel for BoolVTable {
+impl MinMaxKernel for Bool {
     fn min_max(&self, array: &BoolArray) -> VortexResult<Option<MinMaxResult>> {
         let mask = array.validity_mask()?;
         let true_non_null = match &mask {
@@ -72,7 +72,7 @@ impl MinMaxKernel for BoolVTable {
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(BoolVTable).lift());
+register_kernel!(MinMaxKernelAdapter(Bool).lift());
 
 #[cfg(test)]
 mod tests {

--- a/vortex-array/src/arrays/bool/compute/rules.rs
+++ b/vortex-array/src/arrays/bool/compute/rules.rs
@@ -5,10 +5,10 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
+use crate::arrays::Masked;
 use crate::arrays::MaskedArray;
-use crate::arrays::MaskedVTable;
 use crate::arrays::filter::FilterReduceAdaptor;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ArrayParentReduceRule;
@@ -17,12 +17,12 @@ use crate::scalar_fn::fns::cast::CastReduceAdaptor;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 use crate::vtable::ValidityHelper;
 
-pub(crate) const RULES: ParentRuleSet<BoolVTable> = ParentRuleSet::new(&[
+pub(crate) const RULES: ParentRuleSet<Bool> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&BoolMaskedValidityRule),
-    ParentRuleSet::lift(&CastReduceAdaptor(BoolVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(BoolVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(BoolVTable)),
-    ParentRuleSet::lift(&FilterReduceAdaptor(BoolVTable)),
+    ParentRuleSet::lift(&CastReduceAdaptor(Bool)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(Bool)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(Bool)),
+    ParentRuleSet::lift(&FilterReduceAdaptor(Bool)),
 ]);
 
 /// Rule to push down validity masking from MaskedArray parent into BoolArray child.
@@ -32,8 +32,8 @@ pub(crate) const RULES: ParentRuleSet<BoolVTable> = ParentRuleSet::new(&[
 #[derive(Default, Debug)]
 pub struct BoolMaskedValidityRule;
 
-impl ArrayParentReduceRule<BoolVTable> for BoolMaskedValidityRule {
-    type Parent = MaskedVTable;
+impl ArrayParentReduceRule<Bool> for BoolMaskedValidityRule {
+    type Parent = Masked;
 
     fn reduce_parent(
         &self,

--- a/vortex-array/src/arrays/bool/compute/slice.rs
+++ b/vortex-array/src/arrays/bool/compute/slice.rs
@@ -7,12 +7,12 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
 use crate::arrays::slice::SliceReduce;
 use crate::vtable::ValidityHelper;
 
-impl SliceReduce for BoolVTable {
+impl SliceReduce for Bool {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             BoolArray::new(

--- a/vortex-array/src/arrays/bool/compute/sum.rs
+++ b/vortex-array/src/arrays/bool/compute/sum.rs
@@ -7,15 +7,15 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::AllOr;
 
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
 use crate::compute::SumKernel;
 use crate::compute::SumKernelAdapter;
 use crate::dtype::Nullability;
 use crate::register_kernel;
 use crate::scalar::Scalar;
 
-impl SumKernel for BoolVTable {
+impl SumKernel for Bool {
     fn sum(&self, array: &BoolArray, accumulator: &Scalar) -> VortexResult<Scalar> {
         let true_count: Option<u64> = match array.validity_mask()?.bit_buffer() {
             AllOr::All => {
@@ -43,4 +43,4 @@ impl SumKernel for BoolVTable {
     }
 }
 
-register_kernel!(SumKernelAdapter(BoolVTable).lift());
+register_kernel!(SumKernelAdapter(Bool).lift());

--- a/vortex-array/src/arrays/bool/compute/take.rs
+++ b/vortex-array/src/arrays/bool/compute/take.rs
@@ -11,8 +11,8 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
 use crate::arrays::ConstantArray;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::dict::TakeExecute;
@@ -22,7 +22,7 @@ use crate::match_each_integer_ptype;
 use crate::scalar::Scalar;
 use crate::vtable::ValidityHelper;
 
-impl TakeExecute for BoolVTable {
+impl TakeExecute for Bool {
     fn take(
         array: &BoolArray,
         indices: &ArrayRef,

--- a/vortex-array/src/arrays/bool/mod.rs
+++ b/vortex-array/src/arrays/bool/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod compute;
 
 mod vtable;
 pub use compute::rules::BoolMaskedValidityRule;
-pub use vtable::BoolVTable;
+pub use vtable::Bool;
 
 #[cfg(feature = "_test-harness")]
 mod test_harness;

--- a/vortex-array/src/arrays/bool/vtable/kernel.rs
+++ b/vortex-array/src/arrays/bool/vtable/kernel.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::BoolVTable;
+use crate::arrays::Bool;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::kernel::ParentKernelSet;
 use crate::scalar_fn::fns::fill_null::FillNullExecuteAdaptor;
 
-pub(super) const PARENT_KERNELS: ParentKernelSet<BoolVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&FillNullExecuteAdaptor(BoolVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(BoolVTable)),
+pub(super) const PARENT_KERNELS: ParentKernelSet<Bool> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&FillNullExecuteAdaptor(Bool)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(Bool)),
 ]);

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -49,7 +49,7 @@ pub struct BoolMetadata {
     pub offset: u32,
 }
 
-impl VTable for BoolVTable {
+impl VTable for Bool {
     type Array = BoolArray;
 
     type Metadata = ProstMetadata<BoolMetadata>;
@@ -208,8 +208,8 @@ impl VTable for BoolVTable {
 }
 
 #[derive(Debug)]
-pub struct BoolVTable;
+pub struct Bool;
 
-impl BoolVTable {
+impl Bool {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.bool");
 }

--- a/vortex-array/src/arrays/bool/vtable/operations.rs
+++ b/vortex-array/src/arrays/bool/vtable/operations.rs
@@ -3,12 +3,12 @@
 
 use vortex_error::VortexResult;
 
-use crate::arrays::BoolVTable;
+use crate::arrays::Bool;
 use crate::arrays::bool::vtable::BoolArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<BoolVTable> for BoolVTable {
+impl OperationsVTable<Bool> for Bool {
     fn scalar_at(array: &BoolArray, index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::bool(
             array.to_bit_buffer().value(index),

--- a/vortex-array/src/arrays/chunked/compute/aggregate.rs
+++ b/vortex-array/src/arrays/chunked/compute/aggregate.rs
@@ -7,7 +7,7 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::aggregate_fn::AggregateFnRef;
 use crate::aggregate_fn::kernels::DynAggregateKernel;
-use crate::arrays::ChunkedVTable;
+use crate::arrays::Chunked;
 use crate::scalar::Scalar;
 
 #[derive(Debug)]
@@ -20,7 +20,7 @@ impl DynAggregateKernel for ChunkedArrayAggregate {
         batch: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<Scalar>> {
-        let Some(chunked) = batch.as_opt::<ChunkedVTable>() else {
+        let Some(chunked) = batch.as_opt::<Chunked>() else {
             return Ok(None);
         };
 

--- a/vortex-array/src/arrays/chunked/compute/cast.rs
+++ b/vortex-array/src/arrays/chunked/compute/cast.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::scalar_fn::fns::cast::CastReduce;
 
-impl CastReduce for ChunkedVTable {
+impl CastReduce for Chunked {
     fn cast(array: &ChunkedArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         let mut cast_chunks = Vec::new();
         for chunk in array.chunks() {

--- a/vortex-array/src/arrays/chunked/compute/fill_null.rs
+++ b/vortex-array/src/arrays/chunked/compute/fill_null.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::builtins::ArrayBuiltins;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::fill_null::FillNullReduce;
 
-impl FillNullReduce for ChunkedVTable {
+impl FillNullReduce for Chunked {
     fn fill_null(array: &ChunkedArray, fill_value: &Scalar) -> VortexResult<Option<ArrayRef>> {
         let new_chunks = array
             .chunks()

--- a/vortex-array/src/arrays/chunked/compute/filter.rs
+++ b/vortex-array/src/arrays/chunked/compute/filter.rs
@@ -11,8 +11,8 @@ use crate::ArrayRef;
 use crate::DynArray;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::filter::FilterKernel;
 use crate::search_sorted::SearchSorted;
@@ -22,7 +22,7 @@ use crate::validity::Validity;
 // This is modeled after the constant with the equivalent name in arrow-rs.
 pub(crate) const FILTER_SLICES_SELECTIVITY_THRESHOLD: f64 = 0.8;
 
-impl FilterKernel for ChunkedVTable {
+impl FilterKernel for Chunked {
     fn filter(
         array: &ChunkedArray,
         mask: &Mask,

--- a/vortex-array/src/arrays/chunked/compute/is_constant.rs
+++ b/vortex-array/src/arrays/chunked/compute/is_constant.rs
@@ -5,15 +5,15 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::DynArray;
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
 use crate::compute::IsConstantOpts;
 use crate::compute::is_constant_opts;
 use crate::register_kernel;
 
-impl IsConstantKernel for ChunkedVTable {
+impl IsConstantKernel for Chunked {
     fn is_constant(
         &self,
         array: &ChunkedArray,
@@ -51,7 +51,7 @@ impl IsConstantKernel for ChunkedVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(ChunkedVTable).lift());
+register_kernel!(IsConstantKernelAdapter(Chunked).lift());
 
 #[cfg(test)]
 mod tests {

--- a/vortex-array/src/arrays/chunked/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/chunked/compute/is_sorted.rs
@@ -5,15 +5,15 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::DynArray;
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::compute::IsSortedKernel;
 use crate::compute::IsSortedKernelAdapter;
 use crate::compute::is_sorted;
 use crate::compute::is_strict_sorted;
 use crate::register_kernel;
 
-impl IsSortedKernel for ChunkedVTable {
+impl IsSortedKernel for Chunked {
     fn is_sorted(&self, array: &ChunkedArray) -> VortexResult<Option<bool>> {
         is_sorted_impl(array, false, is_sorted)
     }
@@ -23,7 +23,7 @@ impl IsSortedKernel for ChunkedVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(ChunkedVTable).lift());
+register_kernel!(IsSortedKernelAdapter(Chunked).lift());
 
 fn is_sorted_impl(
     array: &ChunkedArray,

--- a/vortex-array/src/arrays/chunked/compute/kernel.rs
+++ b/vortex-array/src/arrays/chunked/compute/kernel.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::ChunkedVTable;
+use crate::arrays::Chunked;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::arrays::filter::FilterExecuteAdaptor;
 use crate::arrays::slice::SliceExecuteAdaptor;
@@ -9,10 +9,10 @@ use crate::kernel::ParentKernelSet;
 use crate::scalar_fn::fns::mask::MaskExecuteAdaptor;
 use crate::scalar_fn::fns::zip::ZipExecuteAdaptor;
 
-pub(crate) static PARENT_KERNELS: ParentKernelSet<ChunkedVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&FilterExecuteAdaptor(ChunkedVTable)),
-    ParentKernelSet::lift(&MaskExecuteAdaptor(ChunkedVTable)),
-    ParentKernelSet::lift(&SliceExecuteAdaptor(ChunkedVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(ChunkedVTable)),
-    ParentKernelSet::lift(&ZipExecuteAdaptor(ChunkedVTable)),
+pub(crate) static PARENT_KERNELS: ParentKernelSet<Chunked> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&FilterExecuteAdaptor(Chunked)),
+    ParentKernelSet::lift(&MaskExecuteAdaptor(Chunked)),
+    ParentKernelSet::lift(&SliceExecuteAdaptor(Chunked)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(Chunked)),
+    ParentKernelSet::lift(&ZipExecuteAdaptor(Chunked)),
 ]);

--- a/vortex-array/src/arrays/chunked/compute/mask.rs
+++ b/vortex-array/src/arrays/chunked/compute/mask.rs
@@ -6,14 +6,14 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::fns::mask::Mask as MaskExpr;
 use crate::scalar_fn::fns::mask::MaskKernel;
 
-impl MaskKernel for ChunkedVTable {
+impl MaskKernel for Chunked {
     fn mask(
         array: &ChunkedArray,
         mask: &ArrayRef,

--- a/vortex-array/src/arrays/chunked/compute/min_max.rs
+++ b/vortex-array/src/arrays/chunked/compute/min_max.rs
@@ -4,8 +4,8 @@
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
@@ -15,7 +15,7 @@ use crate::partial_ord::partial_min;
 use crate::register_kernel;
 use crate::scalar::Scalar;
 
-impl MinMaxKernel for ChunkedVTable {
+impl MinMaxKernel for Chunked {
     fn min_max(&self, array: &ChunkedArray) -> VortexResult<Option<MinMaxResult>> {
         let mut min_max_all_null = true;
         let res = array
@@ -69,4 +69,4 @@ impl MinMaxKernel for ChunkedVTable {
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(ChunkedVTable).lift());
+register_kernel!(MinMaxKernelAdapter(Chunked).lift());

--- a/vortex-array/src/arrays/chunked/compute/rules.rs
+++ b/vortex-array/src/arrays/chunked/compute/rules.rs
@@ -6,10 +6,10 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::arrays::ScalarFnArray;
 use crate::arrays::scalar_fn::AnyScalarFn;
 use crate::optimizer::ArrayOptimizer;
@@ -18,17 +18,17 @@ use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::cast::CastReduceAdaptor;
 use crate::scalar_fn::fns::fill_null::FillNullReduceAdaptor;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<ChunkedVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&CastReduceAdaptor(ChunkedVTable)),
+pub(crate) const PARENT_RULES: ParentRuleSet<Chunked> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(Chunked)),
     ParentRuleSet::lift(&ChunkedUnaryScalarFnPushDownRule),
     ParentRuleSet::lift(&ChunkedConstantScalarFnPushDownRule),
-    ParentRuleSet::lift(&FillNullReduceAdaptor(ChunkedVTable)),
+    ParentRuleSet::lift(&FillNullReduceAdaptor(Chunked)),
 ]);
 
 /// Push down any unary scalar function through chunked arrays.
 #[derive(Debug)]
 struct ChunkedUnaryScalarFnPushDownRule;
-impl ArrayParentReduceRule<ChunkedVTable> for ChunkedUnaryScalarFnPushDownRule {
+impl ArrayParentReduceRule<Chunked> for ChunkedUnaryScalarFnPushDownRule {
     type Parent = AnyScalarFn;
 
     fn reduce_parent(
@@ -64,7 +64,7 @@ impl ArrayParentReduceRule<ChunkedVTable> for ChunkedUnaryScalarFnPushDownRule {
 /// Push down non-unary scalar functions through chunked arrays where other siblings are constant.
 #[derive(Debug)]
 struct ChunkedConstantScalarFnPushDownRule;
-impl ArrayParentReduceRule<ChunkedVTable> for ChunkedConstantScalarFnPushDownRule {
+impl ArrayParentReduceRule<Chunked> for ChunkedConstantScalarFnPushDownRule {
     type Parent = AnyScalarFn;
 
     fn reduce_parent(
@@ -77,7 +77,7 @@ impl ArrayParentReduceRule<ChunkedVTable> for ChunkedConstantScalarFnPushDownRul
             if idx == child_idx {
                 continue;
             }
-            if !child.is::<ConstantVTable>() {
+            if !child.is::<Constant>() {
                 return Ok(None);
             }
         }
@@ -95,7 +95,7 @@ impl ArrayParentReduceRule<ChunkedVTable> for ChunkedConstantScalarFnPushDownRul
                             chunk.clone()
                         } else {
                             ConstantArray::new(
-                                child.as_::<ConstantVTable>().scalar().clone(),
+                                child.as_::<Constant>().scalar().clone(),
                                 chunk.len(),
                             )
                             .into_array()

--- a/vortex-array/src/arrays/chunked/compute/slice.rs
+++ b/vortex-array/src/arrays/chunked/compute/slice.rs
@@ -9,11 +9,11 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::arrays::slice::SliceKernel;
 
-impl SliceKernel for ChunkedVTable {
+impl SliceKernel for Chunked {
     fn slice(
         array: &Self::Array,
         range: Range<usize>,

--- a/vortex-array/src/arrays/chunked/compute/sum.rs
+++ b/vortex-array/src/arrays/chunked/compute/sum.rs
@@ -3,15 +3,15 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::compute::SumKernel;
 use crate::compute::SumKernelAdapter;
 use crate::compute::sum_with_accumulator;
 use crate::register_kernel;
 use crate::scalar::Scalar;
 
-impl SumKernel for ChunkedVTable {
+impl SumKernel for Chunked {
     fn sum(&self, array: &ChunkedArray, accumulator: &Scalar) -> VortexResult<Scalar> {
         array
             .chunks
@@ -22,7 +22,7 @@ impl SumKernel for ChunkedVTable {
     }
 }
 
-register_kernel!(SumKernelAdapter(ChunkedVTable).lift());
+register_kernel!(SumKernelAdapter(Chunked).lift());
 
 #[cfg(test)]
 mod tests {

--- a/vortex-array/src/arrays/chunked/compute/take.rs
+++ b/vortex-array/src/arrays/chunked/compute/take.rs
@@ -9,8 +9,8 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::dict::TakeExecute;
 use crate::builtins::ArrayBuiltins;
@@ -99,7 +99,7 @@ fn take_chunked(
     flat.take(PrimitiveArray::new(final_take.freeze(), take_validity).into_array())
 }
 
-impl TakeExecute for ChunkedVTable {
+impl TakeExecute for Chunked {
     fn take(
         array: &ChunkedArray,
         indices: &ArrayRef,

--- a/vortex-array/src/arrays/chunked/compute/zip.rs
+++ b/vortex-array/src/arrays/chunked/compute/zip.rs
@@ -6,22 +6,22 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::builtins::ArrayBuiltins;
 use crate::scalar_fn::fns::zip::ZipKernel;
 
 // Push down the zip call to the chunks. Without this rule
 // the default implementation canonicalises the chunked array
 // then zips once.
-impl ZipKernel for ChunkedVTable {
+impl ZipKernel for Chunked {
     fn zip(
         if_true: &ChunkedArray,
         if_false: &ArrayRef,
         mask: &ArrayRef,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let Some(if_false) = if_false.as_opt::<ChunkedVTable>() else {
+        let Some(if_false) = if_false.as_opt::<Chunked>() else {
             return Ok(None);
         };
         let dtype = if_true
@@ -80,8 +80,8 @@ mod tests {
     use crate::LEGACY_SESSION;
     use crate::ToCanonical;
     use crate::VortexSessionExecute;
+    use crate::arrays::Chunked;
     use crate::arrays::ChunkedArray;
-    use crate::arrays::ChunkedVTable;
     use crate::builtins::ArrayBuiltins;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
@@ -121,7 +121,7 @@ mod tests {
             .execute::<ArrayRef>(&mut LEGACY_SESSION.create_execution_ctx())
             .unwrap();
         let zipped = zipped
-            .as_opt::<ChunkedVTable>()
+            .as_opt::<Chunked>()
             .expect("zip should keep chunked encoding");
 
         assert_eq!(zipped.nchunks(), 4);

--- a/vortex-array/src/arrays/chunked/mod.rs
+++ b/vortex-array/src/arrays/chunked/mod.rs
@@ -7,7 +7,7 @@ pub use array::ChunkedArray;
 pub(crate) mod compute;
 
 mod vtable;
-pub use vtable::ChunkedVTable;
+pub use vtable::Chunked;
 
 #[cfg(test)]
 mod tests;

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -43,13 +43,13 @@ mod validity;
 vtable!(Chunked);
 
 #[derive(Debug)]
-pub struct ChunkedVTable;
+pub struct Chunked;
 
-impl ChunkedVTable {
+impl Chunked {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.chunked");
 }
 
-impl VTable for ChunkedVTable {
+impl VTable for Chunked {
     type Array = ChunkedArray;
 
     type Metadata = EmptyMetadata;

--- a/vortex-array/src/arrays/chunked/vtable/operations.rs
+++ b/vortex-array/src/arrays/chunked/vtable/operations.rs
@@ -4,12 +4,12 @@
 use vortex_error::VortexResult;
 
 use crate::DynArray;
-use crate::arrays::ChunkedVTable;
+use crate::arrays::Chunked;
 use crate::arrays::chunked::vtable::ChunkedArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<ChunkedVTable> for ChunkedVTable {
+impl OperationsVTable<Chunked> for Chunked {
     fn scalar_at(array: &ChunkedArray, index: usize) -> VortexResult<Scalar> {
         let (chunk_index, chunk_offset) = array.find_chunk_idx(index)?;
         array.chunk(chunk_index).scalar_at(chunk_offset)

--- a/vortex-array/src/arrays/chunked/vtable/validity.rs
+++ b/vortex-array/src/arrays/chunked/vtable/validity.rs
@@ -6,14 +6,14 @@ use vortex_error::VortexResult;
 
 use crate::DynArray;
 use crate::IntoArray;
-use crate::arrays::ChunkedVTable;
+use crate::arrays::Chunked;
 use crate::arrays::chunked::vtable::ChunkedArray;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::validity::Validity;
 use crate::vtable::ValidityVTable;
 
-impl ValidityVTable<ChunkedVTable> for ChunkedVTable {
+impl ValidityVTable<Chunked> for Chunked {
     fn validity(array: &ChunkedArray) -> VortexResult<Validity> {
         let validities: Vec<Validity> =
             array.chunks().iter().map(|c| c.validity()).try_collect()?;

--- a/vortex-array/src/arrays/constant/compute/between.rs
+++ b/vortex-array/src/arrays/constant/compute/between.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::between::BetweenOptions;
 use crate::scalar_fn::fns::between::BetweenReduce;
 
-impl BetweenReduce for ConstantVTable {
+impl BetweenReduce for Constant {
     fn between(
         array: &ConstantArray,
         lower: &ArrayRef,

--- a/vortex-array/src/arrays/constant/compute/cast.rs
+++ b/vortex-array/src/arrays/constant/compute/cast.rs
@@ -5,12 +5,12 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::dtype::DType;
 use crate::scalar_fn::fns::cast::CastReduce;
 
-impl CastReduce for ConstantVTable {
+impl CastReduce for Constant {
     fn cast(array: &ConstantArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         match array.scalar().cast(dtype) {
             Ok(scalar) => Ok(Some(ConstantArray::new(scalar, array.len()).into_array())),

--- a/vortex-array/src/arrays/constant/compute/fill_null.rs
+++ b/vortex-array/src/arrays/constant/compute/fill_null.rs
@@ -4,13 +4,13 @@
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::fill_null::FillNullReduce;
 use crate::scalar_fn::fns::fill_null::fill_null_constant;
 
-impl FillNullReduce for ConstantVTable {
+impl FillNullReduce for Constant {
     fn fill_null(array: &ConstantArray, fill_value: &Scalar) -> VortexResult<Option<ArrayRef>> {
         fill_null_constant(array, fill_value).map(Some)
     }

--- a/vortex-array/src/arrays/constant/compute/filter.rs
+++ b/vortex-array/src/arrays/constant/compute/filter.rs
@@ -6,11 +6,11 @@ use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::arrays::filter::FilterReduce;
 
-impl FilterReduce for ConstantVTable {
+impl FilterReduce for Constant {
     fn filter(array: &ConstantArray, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             ConstantArray::new(array.scalar().clone(), mask.true_count()).into_array(),

--- a/vortex-array/src/arrays/constant/compute/min_max.rs
+++ b/vortex-array/src/arrays/constant/compute/min_max.rs
@@ -3,14 +3,14 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
 use crate::register_kernel;
 
-impl MinMaxKernel for ConstantVTable {
+impl MinMaxKernel for Constant {
     fn min_max(&self, array: &ConstantArray) -> VortexResult<Option<MinMaxResult>> {
         let scalar = array.scalar();
         if scalar.is_null() || scalar.as_primitive_opt().is_some_and(|p| p.is_nan()) {
@@ -24,7 +24,7 @@ impl MinMaxKernel for ConstantVTable {
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(ConstantVTable).lift());
+register_kernel!(MinMaxKernelAdapter(Constant).lift());
 
 #[cfg(test)]
 mod test {

--- a/vortex-array/src/arrays/constant/compute/not.rs
+++ b/vortex-array/src/arrays/constant/compute/not.rs
@@ -5,12 +5,12 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::not::NotReduce;
 
-impl NotReduce for ConstantVTable {
+impl NotReduce for Constant {
     fn invert(array: &ConstantArray) -> VortexResult<Option<ArrayRef>> {
         let value = match array.scalar().as_bool().value() {
             Some(b) => Scalar::bool(!b, array.dtype().nullability()),

--- a/vortex-array/src/arrays/constant/compute/rules.rs
+++ b/vortex-array/src/arrays/constant/compute/rules.rs
@@ -5,10 +5,10 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
+use crate::arrays::Filter;
 use crate::arrays::FilterArray;
-use crate::arrays::FilterVTable;
 use crate::arrays::dict::TakeReduceAdaptor;
 use crate::arrays::filter::FilterReduceAdaptor;
 use crate::arrays::slice::SliceReduceAdaptor;
@@ -19,22 +19,22 @@ use crate::scalar_fn::fns::cast::CastReduceAdaptor;
 use crate::scalar_fn::fns::fill_null::FillNullReduceAdaptor;
 use crate::scalar_fn::fns::not::NotReduceAdaptor;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<ConstantVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&BetweenReduceAdaptor(ConstantVTable)),
-    ParentRuleSet::lift(&CastReduceAdaptor(ConstantVTable)),
+pub(crate) const PARENT_RULES: ParentRuleSet<Constant> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&BetweenReduceAdaptor(Constant)),
+    ParentRuleSet::lift(&CastReduceAdaptor(Constant)),
     ParentRuleSet::lift(&ConstantFilterRule),
-    ParentRuleSet::lift(&FillNullReduceAdaptor(ConstantVTable)),
-    ParentRuleSet::lift(&FilterReduceAdaptor(ConstantVTable)),
-    ParentRuleSet::lift(&NotReduceAdaptor(ConstantVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(ConstantVTable)),
-    ParentRuleSet::lift(&TakeReduceAdaptor(ConstantVTable)),
+    ParentRuleSet::lift(&FillNullReduceAdaptor(Constant)),
+    ParentRuleSet::lift(&FilterReduceAdaptor(Constant)),
+    ParentRuleSet::lift(&NotReduceAdaptor(Constant)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(Constant)),
+    ParentRuleSet::lift(&TakeReduceAdaptor(Constant)),
 ]);
 
 #[derive(Debug)]
 struct ConstantFilterRule;
 
-impl ArrayParentReduceRule<ConstantVTable> for ConstantFilterRule {
-    type Parent = FilterVTable;
+impl ArrayParentReduceRule<Constant> for ConstantFilterRule {
+    type Parent = Filter;
 
     fn reduce_parent(
         &self,

--- a/vortex-array/src/arrays/constant/compute/slice.rs
+++ b/vortex-array/src/arrays/constant/compute/slice.rs
@@ -7,11 +7,11 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::arrays::slice::SliceReduce;
 
-impl SliceReduce for ConstantVTable {
+impl SliceReduce for Constant {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             ConstantArray::new(array.scalar.clone(), range.len()).into_array(),

--- a/vortex-array/src/arrays/constant/compute/sum.rs
+++ b/vortex-array/src/arrays/constant/compute/sum.rs
@@ -9,8 +9,8 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::compute::SumKernel;
 use crate::compute::SumKernelAdapter;
 use crate::dtype::DType;
@@ -27,7 +27,7 @@ use crate::scalar::PrimitiveScalar;
 use crate::scalar::Scalar;
 use crate::scalar::ScalarValue;
 
-impl SumKernel for ConstantVTable {
+impl SumKernel for Constant {
     fn sum(&self, array: &ConstantArray, accumulator: &Scalar) -> VortexResult<Scalar> {
         // Compute the expected dtype of the sum.
         let sum_dtype = Stat::Sum
@@ -165,7 +165,7 @@ fn sum_float(
     Ok(Some(initial + v * len_f64))
 }
 
-register_kernel!(SumKernelAdapter(ConstantVTable).lift());
+register_kernel!(SumKernelAdapter(Constant).lift());
 
 #[cfg(test)]
 mod tests {

--- a/vortex-array/src/arrays/constant/compute/take.rs
+++ b/vortex-array/src/arrays/constant/compute/take.rs
@@ -7,8 +7,8 @@ use vortex_mask::AllOr;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::arrays::MaskedArray;
 use crate::arrays::dict::TakeReduce;
 use crate::arrays::dict::TakeReduceAdaptor;
@@ -16,7 +16,7 @@ use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar::Scalar;
 use crate::validity::Validity;
 
-impl TakeReduce for ConstantVTable {
+impl TakeReduce for Constant {
     fn take(array: &ConstantArray, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let result = match indices.validity_mask()?.bit_buffer() {
             AllOr::All => {
@@ -52,7 +52,7 @@ impl TakeReduce for ConstantVTable {
     }
 }
 
-impl ConstantVTable {
+impl Constant {
     pub const TAKE_RULES: ParentRuleSet<Self> =
         ParentRuleSet::new(&[ParentRuleSet::lift(&TakeReduceAdaptor::<Self>(Self))]);
 }

--- a/vortex-array/src/arrays/constant/mod.rs
+++ b/vortex-array/src/arrays/constant/mod.rs
@@ -13,4 +13,4 @@ pub(crate) mod compute;
 
 mod vtable;
 
-pub use vtable::ConstantVTable;
+pub use vtable::Constant;

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -45,13 +45,13 @@ mod validity;
 vtable!(Constant);
 
 #[derive(Debug)]
-pub struct ConstantVTable;
+pub struct Constant;
 
-impl ConstantVTable {
+impl Constant {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.constant");
 }
 
-impl VTable for ConstantVTable {
+impl VTable for Constant {
     type Array = ConstantArray;
 
     type Metadata = Scalar;

--- a/vortex-array/src/arrays/constant/vtable/operations.rs
+++ b/vortex-array/src/arrays/constant/vtable/operations.rs
@@ -3,12 +3,12 @@
 
 use vortex_error::VortexResult;
 
-use crate::arrays::ConstantVTable;
+use crate::arrays::Constant;
 use crate::arrays::constant::vtable::ConstantArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<ConstantVTable> for ConstantVTable {
+impl OperationsVTable<Constant> for Constant {
     fn scalar_at(array: &ConstantArray, _index: usize) -> VortexResult<Scalar> {
         Ok(array.scalar.clone())
     }

--- a/vortex-array/src/arrays/constant/vtable/validity.rs
+++ b/vortex-array/src/arrays/constant/vtable/validity.rs
@@ -3,12 +3,12 @@
 
 use vortex_error::VortexResult;
 
-use crate::arrays::ConstantVTable;
+use crate::arrays::Constant;
 use crate::arrays::constant::vtable::ConstantArray;
 use crate::validity::Validity;
 use crate::vtable::ValidityVTable;
 
-impl ValidityVTable<ConstantVTable> for ConstantVTable {
+impl ValidityVTable<Constant> for Constant {
     fn validity(array: &ConstantArray) -> VortexResult<Validity> {
         debug_assert!(array.dtype().is_nullable());
         Ok(if array.scalar().is_null() {

--- a/vortex-array/src/arrays/datetime/mod.rs
+++ b/vortex-array/src/arrays/datetime/mod.rs
@@ -13,8 +13,8 @@ use vortex_error::vortex_err;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::dtype::DType;
 use crate::dtype::extension::ExtDTypeRef;
 use crate::extension::datetime::AnyTemporal;
@@ -178,7 +178,7 @@ impl TryFrom<ArrayRef> for TemporalArray {
     /// `TemporalMetadata` variants, an error is returned.
     fn try_from(value: ArrayRef) -> Result<Self, Self::Error> {
         let ext = value
-            .as_opt::<ExtensionVTable>()
+            .as_opt::<Extension>()
             .ok_or_else(|| vortex_err!("array must be an ExtensionArray"))?;
         if !ext.ext_dtype().is::<AnyTemporal>() {
             vortex_bail!(

--- a/vortex-array/src/arrays/decimal/compute/between.rs
+++ b/vortex-array/src/arrays/decimal/compute/between.rs
@@ -9,8 +9,8 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
 use crate::dtype::NativeDecimalType;
 use crate::dtype::Nullability;
 use crate::match_each_decimal_value_type;
@@ -20,7 +20,7 @@ use crate::scalar_fn::fns::between::BetweenOptions;
 use crate::scalar_fn::fns::between::StrictComparison;
 use crate::vtable::ValidityHelper;
 
-impl BetweenKernel for DecimalVTable {
+impl BetweenKernel for Decimal {
     fn between(
         arr: &DecimalArray,
         lower: &ArrayRef,

--- a/vortex-array/src/arrays/decimal/compute/cast.rs
+++ b/vortex-array/src/arrays/decimal/compute/cast.rs
@@ -10,8 +10,8 @@ use vortex_error::vortex_panic;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
 use crate::dtype::DType;
 use crate::dtype::DecimalType;
 use crate::dtype::NativeDecimalType;
@@ -19,7 +19,7 @@ use crate::match_each_decimal_value_type;
 use crate::scalar_fn::fns::cast::CastKernel;
 use crate::vtable::ValidityHelper;
 
-impl CastKernel for DecimalVTable {
+impl CastKernel for Decimal {
     fn cast(
         array: &DecimalArray,
         dtype: &DType,

--- a/vortex-array/src/arrays/decimal/compute/fill_null.rs
+++ b/vortex-array/src/arrays/decimal/compute/fill_null.rs
@@ -13,8 +13,8 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
 use crate::dtype::NativeDecimalType;
 use crate::match_each_decimal_value_type;
 use crate::scalar::DecimalValue;
@@ -23,7 +23,7 @@ use crate::scalar_fn::fns::fill_null::FillNullKernel;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl FillNullKernel for DecimalVTable {
+impl FillNullKernel for Decimal {
     fn fill_null(
         array: &DecimalArray,
         fill_value: &Scalar,

--- a/vortex-array/src/arrays/decimal/compute/is_constant.rs
+++ b/vortex-array/src/arrays/decimal/compute/is_constant.rs
@@ -4,15 +4,15 @@
 use itertools::Itertools;
 use vortex_error::VortexResult;
 
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
 use crate::compute::IsConstantOpts;
 use crate::match_each_decimal_value_type;
 use crate::register_kernel;
 
-impl IsConstantKernel for DecimalVTable {
+impl IsConstantKernel for Decimal {
     fn is_constant(
         &self,
         array: &DecimalArray,
@@ -25,7 +25,7 @@ impl IsConstantKernel for DecimalVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(DecimalVTable).lift());
+register_kernel!(IsConstantKernelAdapter(Decimal).lift());
 
 #[cfg(test)]
 mod tests {

--- a/vortex-array/src/arrays/decimal/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/decimal/compute/is_sorted.rs
@@ -5,8 +5,8 @@ use itertools::Itertools;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
 use crate::compute::IsSortedIteratorExt;
 use crate::compute::IsSortedKernel;
 use crate::compute::IsSortedKernelAdapter;
@@ -14,7 +14,7 @@ use crate::dtype::NativeDecimalType;
 use crate::match_each_decimal_value_type;
 use crate::register_kernel;
 
-impl IsSortedKernel for DecimalVTable {
+impl IsSortedKernel for Decimal {
     fn is_sorted(&self, array: &DecimalArray) -> VortexResult<Option<bool>> {
         is_decimal_sorted(array, false)
     }
@@ -24,7 +24,7 @@ impl IsSortedKernel for DecimalVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(DecimalVTable).lift());
+register_kernel!(IsSortedKernelAdapter(Decimal).lift());
 
 fn is_decimal_sorted(array: &DecimalArray, strict: bool) -> VortexResult<Option<bool>> {
     match_each_decimal_value_type!(array.values_type, |S| {

--- a/vortex-array/src/arrays/decimal/compute/mask.rs
+++ b/vortex-array/src/arrays/decimal/compute/mask.rs
@@ -5,14 +5,14 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
 use crate::match_each_decimal_value_type;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl MaskReduce for DecimalVTable {
+impl MaskReduce for Decimal {
     fn mask(array: &DecimalArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(match_each_decimal_value_type!(
             array.values_type(),

--- a/vortex-array/src/arrays/decimal/compute/min_max.rs
+++ b/vortex-array/src/arrays/decimal/compute/min_max.rs
@@ -5,8 +5,8 @@ use itertools::Itertools;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
@@ -18,7 +18,7 @@ use crate::register_kernel;
 use crate::scalar::DecimalValue;
 use crate::scalar::Scalar;
 
-impl MinMaxKernel for DecimalVTable {
+impl MinMaxKernel for Decimal {
     fn min_max(&self, array: &DecimalArray) -> VortexResult<Option<MinMaxResult>> {
         match_each_decimal_value_type!(array.values_type(), |T| {
             compute_min_max_with_validity::<T>(array)
@@ -26,7 +26,7 @@ impl MinMaxKernel for DecimalVTable {
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(DecimalVTable).lift());
+register_kernel!(MinMaxKernelAdapter(Decimal).lift());
 
 #[inline]
 fn compute_min_max_with_validity<D>(array: &DecimalArray) -> VortexResult<Option<MinMaxResult>>

--- a/vortex-array/src/arrays/decimal/compute/rules.rs
+++ b/vortex-array/src/arrays/decimal/compute/rules.rs
@@ -7,10 +7,10 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
+use crate::arrays::Masked;
 use crate::arrays::MaskedArray;
-use crate::arrays::MaskedVTable;
 use crate::arrays::slice::SliceReduce;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::match_each_decimal_value_type;
@@ -19,10 +19,10 @@ use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 use crate::vtable::ValidityHelper;
 
-pub(crate) static RULES: ParentRuleSet<DecimalVTable> = ParentRuleSet::new(&[
+pub(crate) static RULES: ParentRuleSet<Decimal> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&DecimalMaskedValidityRule),
-    ParentRuleSet::lift(&MaskReduceAdaptor(DecimalVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(DecimalVTable)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(Decimal)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(Decimal)),
 ]);
 
 /// Rule to push down validity masking from MaskedArray parent into DecimalArray child.
@@ -32,8 +32,8 @@ pub(crate) static RULES: ParentRuleSet<DecimalVTable> = ParentRuleSet::new(&[
 #[derive(Default, Debug)]
 pub struct DecimalMaskedValidityRule;
 
-impl ArrayParentReduceRule<DecimalVTable> for DecimalMaskedValidityRule {
-    type Parent = MaskedVTable;
+impl ArrayParentReduceRule<Decimal> for DecimalMaskedValidityRule {
+    type Parent = Masked;
 
     fn reduce_parent(
         &self,
@@ -60,7 +60,7 @@ impl ArrayParentReduceRule<DecimalVTable> for DecimalMaskedValidityRule {
     }
 }
 
-impl SliceReduce for DecimalVTable {
+impl SliceReduce for Decimal {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let result = match_each_decimal_value_type!(array.values_type(), |D| {
             let sliced = array.buffer::<D>().slice(range.clone());

--- a/vortex-array/src/arrays/decimal/compute/sum.rs
+++ b/vortex-array/src/arrays/decimal/compute/sum.rs
@@ -12,8 +12,8 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_mask::Mask;
 
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
 use crate::compute::SumKernel;
 use crate::compute::SumKernelAdapter;
 use crate::dtype::DType;
@@ -26,7 +26,7 @@ use crate::register_kernel;
 use crate::scalar::DecimalValue;
 use crate::scalar::Scalar;
 
-impl SumKernel for DecimalVTable {
+impl SumKernel for Decimal {
     fn sum(&self, array: &DecimalArray, accumulator: &Scalar) -> VortexResult<Scalar> {
         let return_dtype = Stat::Sum
             .dtype(array.dtype())
@@ -126,7 +126,7 @@ where
     Some(sum)
 }
 
-register_kernel!(SumKernelAdapter(DecimalVTable).lift());
+register_kernel!(SumKernelAdapter(Decimal).lift());
 
 #[cfg(test)]
 mod tests {

--- a/vortex-array/src/arrays/decimal/compute/take.rs
+++ b/vortex-array/src/arrays/decimal/compute/take.rs
@@ -6,8 +6,8 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::dict::TakeExecute;
 use crate::dtype::IntegerPType;
@@ -17,7 +17,7 @@ use crate::match_each_decimal_value_type;
 use crate::match_each_integer_ptype;
 use crate::vtable::ValidityHelper;
 
-impl TakeExecute for DecimalVTable {
+impl TakeExecute for Decimal {
     fn take(
         array: &DecimalArray,
         indices: &ArrayRef,

--- a/vortex-array/src/arrays/decimal/mod.rs
+++ b/vortex-array/src/arrays/decimal/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod compute;
 
 mod vtable;
 pub use compute::rules::DecimalMaskedValidityRule;
-pub use vtable::DecimalVTable;
+pub use vtable::Decimal;
 
 mod utils;
 pub use utils::*;

--- a/vortex-array/src/arrays/decimal/vtable/kernel.rs
+++ b/vortex-array/src/arrays/decimal/vtable/kernel.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::DecimalVTable;
+use crate::arrays::Decimal;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::kernel::ParentKernelSet;
 use crate::scalar_fn::fns::between::BetweenExecuteAdaptor;
 use crate::scalar_fn::fns::cast::CastExecuteAdaptor;
 use crate::scalar_fn::fns::fill_null::FillNullExecuteAdaptor;
 
-pub(super) const PARENT_KERNELS: ParentKernelSet<DecimalVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&BetweenExecuteAdaptor(DecimalVTable)),
-    ParentKernelSet::lift(&CastExecuteAdaptor(DecimalVTable)),
-    ParentKernelSet::lift(&FillNullExecuteAdaptor(DecimalVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(DecimalVTable)),
+pub(super) const PARENT_KERNELS: ParentKernelSet<Decimal> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&BetweenExecuteAdaptor(Decimal)),
+    ParentKernelSet::lift(&CastExecuteAdaptor(Decimal)),
+    ParentKernelSet::lift(&FillNullExecuteAdaptor(Decimal)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(Decimal)),
 ]);

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -51,7 +51,7 @@ pub struct DecimalMetadata {
     pub(super) values_type: i32,
 }
 
-impl VTable for DecimalVTable {
+impl VTable for Decimal {
     type Array = DecimalArray;
 
     type Metadata = ProstMetadata<DecimalMetadata>;
@@ -230,9 +230,9 @@ impl VTable for DecimalVTable {
 }
 
 #[derive(Debug)]
-pub struct DecimalVTable;
+pub struct Decimal;
 
-impl DecimalVTable {
+impl Decimal {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.decimal");
 }
 
@@ -245,8 +245,8 @@ mod tests {
     use crate::ArrayContext;
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
+    use crate::arrays::Decimal;
     use crate::arrays::DecimalArray;
-    use crate::arrays::DecimalVTable;
     use crate::dtype::DecimalDType;
     use crate::serde::ArrayParts;
     use crate::serde::SerializeOptions;
@@ -278,6 +278,6 @@ mod tests {
         let decoded = parts
             .decode(&dtype, 5, &ReadContext::new(ctx.to_ids()), &LEGACY_SESSION)
             .unwrap();
-        assert!(decoded.is::<DecimalVTable>());
+        assert!(decoded.is::<Decimal>());
     }
 }

--- a/vortex-array/src/arrays/decimal/vtable/operations.rs
+++ b/vortex-array/src/arrays/decimal/vtable/operations.rs
@@ -3,14 +3,14 @@
 
 use vortex_error::VortexResult;
 
-use crate::arrays::DecimalVTable;
+use crate::arrays::Decimal;
 use crate::arrays::decimal::vtable::DecimalArray;
 use crate::match_each_decimal_value_type;
 use crate::scalar::DecimalValue;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<DecimalVTable> for DecimalVTable {
+impl OperationsVTable<Decimal> for Decimal {
     fn scalar_at(array: &DecimalArray, index: usize) -> VortexResult<Scalar> {
         Ok(match_each_decimal_value_type!(array.values_type(), |D| {
             Scalar::decimal(
@@ -28,8 +28,8 @@ mod tests {
 
     use crate::DynArray;
     use crate::IntoArray;
+    use crate::arrays::Decimal;
     use crate::arrays::DecimalArray;
-    use crate::arrays::DecimalVTable;
     use crate::dtype::DecimalDType;
     use crate::dtype::Nullability;
     use crate::scalar::DecimalValue;
@@ -48,7 +48,7 @@ mod tests {
         let sliced = array.slice(1..3).unwrap();
         assert_eq!(sliced.len(), 2);
 
-        let decimal = sliced.as_::<DecimalVTable>();
+        let decimal = sliced.as_::<Decimal>();
         assert_eq!(decimal.buffer::<i128>(), buffer![200i128, 300i128]);
     }
 

--- a/vortex-array/src/arrays/dict/compute/cast.rs
+++ b/vortex-array/src/arrays/dict/compute/cast.rs
@@ -3,8 +3,8 @@
 
 use vortex_error::VortexResult;
 
+use super::Dict;
 use super::DictArray;
-use super::DictVTable;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
@@ -12,7 +12,7 @@ use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::scalar_fn::fns::cast::CastReduce;
 
-impl CastReduce for DictVTable {
+impl CastReduce for Dict {
     fn cast(array: &DictArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // Can have un-reference null values making the cast of values fail without a possible mask.
         // TODO(joe): optimize this, could look at accessible values and fill_null not those?
@@ -52,7 +52,7 @@ mod tests {
 
     use crate::IntoArray;
     use crate::ToCanonical;
-    use crate::arrays::DictVTable;
+    use crate::arrays::Dict;
     use crate::arrays::PrimitiveArray;
     use crate::assert_arrays_eq;
     use crate::builders::dict::dict_encode;
@@ -121,7 +121,7 @@ mod tests {
         );
 
         // Check that codes and values are still NonNullable
-        let non_nullable_dict = non_nullable.as_::<DictVTable>();
+        let non_nullable_dict = non_nullable.as_::<Dict>();
         assert_eq!(
             non_nullable_dict.codes().dtype().nullability(),
             Nullability::NonNullable
@@ -141,7 +141,7 @@ mod tests {
         );
 
         // Check that both codes and values are now Nullable
-        let nullable_dict = nullable.as_::<DictVTable>();
+        let nullable_dict = nullable.as_::<Dict>();
         assert_eq!(
             nullable_dict.codes().dtype().nullability(),
             Nullability::NonNullable
@@ -161,7 +161,7 @@ mod tests {
         );
 
         // Check that both codes and values are NonNullable again
-        let back_dict = back_to_non_nullable.as_::<DictVTable>();
+        let back_dict = back_to_non_nullable.as_::<Dict>();
         assert_eq!(
             back_dict.codes().dtype().nullability(),
             Nullability::NonNullable

--- a/vortex-array/src/arrays/dict/compute/compare.rs
+++ b/vortex-array/src/arrays/dict/compute/compare.rs
@@ -3,8 +3,8 @@
 
 use vortex_error::VortexResult;
 
+use super::Dict;
 use super::DictArray;
-use super::DictVTable;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::DynArray;
@@ -16,7 +16,7 @@ use crate::scalar_fn::fns::binary::CompareKernel;
 use crate::scalar_fn::fns::operators::CompareOperator;
 use crate::scalar_fn::fns::operators::Operator;
 
-impl CompareKernel for DictVTable {
+impl CompareKernel for Dict {
     fn compare(
         lhs: &DictArray,
         rhs: &ArrayRef,

--- a/vortex-array/src/arrays/dict/compute/fill_null.rs
+++ b/vortex-array/src/arrays/dict/compute/fill_null.rs
@@ -3,8 +3,8 @@
 
 use vortex_error::VortexResult;
 
+use super::Dict;
 use super::DictArray;
-use super::DictVTable;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::DynArray;
@@ -19,7 +19,7 @@ use crate::scalar::ScalarValue;
 use crate::scalar_fn::fns::fill_null::FillNullKernel;
 use crate::scalar_fn::fns::operators::Operator;
 
-impl FillNullKernel for DictVTable {
+impl FillNullKernel for Dict {
     fn fill_null(
         array: &DictArray,
         fill_value: &Scalar,

--- a/vortex-array/src/arrays/dict/compute/is_constant.rs
+++ b/vortex-array/src/arrays/dict/compute/is_constant.rs
@@ -3,15 +3,15 @@
 
 use vortex_error::VortexResult;
 
+use super::Dict;
 use super::DictArray;
-use super::DictVTable;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
 use crate::compute::IsConstantOpts;
 use crate::compute::is_constant_opts;
 use crate::register_kernel;
 
-impl IsConstantKernel for DictVTable {
+impl IsConstantKernel for Dict {
     fn is_constant(&self, array: &DictArray, opts: &IsConstantOpts) -> VortexResult<Option<bool>> {
         if is_constant_opts(array.codes(), opts)? == Some(true) {
             return Ok(Some(true));
@@ -21,4 +21,4 @@ impl IsConstantKernel for DictVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(DictVTable).lift());
+register_kernel!(IsConstantKernelAdapter(Dict).lift());

--- a/vortex-array/src/arrays/dict/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/dict/compute/is_sorted.rs
@@ -3,15 +3,15 @@
 
 use vortex_error::VortexResult;
 
+use super::Dict;
 use super::DictArray;
-use super::DictVTable;
 use crate::compute::IsSortedKernel;
 use crate::compute::IsSortedKernelAdapter;
 use crate::compute::is_sorted;
 use crate::compute::is_strict_sorted;
 use crate::register_kernel;
 
-impl IsSortedKernel for DictVTable {
+impl IsSortedKernel for Dict {
     fn is_sorted(&self, array: &DictArray) -> VortexResult<Option<bool>> {
         if Some((true, true)) == is_sorted(array.values())?.zip(is_sorted(array.codes())?) {
             return Ok(Some(true));
@@ -29,4 +29,4 @@ impl IsSortedKernel for DictVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(DictVTable).lift());
+register_kernel!(IsSortedKernelAdapter(Dict).lift());

--- a/vortex-array/src/arrays/dict/compute/like.rs
+++ b/vortex-array/src/arrays/dict/compute/like.rs
@@ -3,8 +3,8 @@
 
 use vortex_error::VortexResult;
 
+use super::Dict;
 use super::DictArray;
-use super::DictVTable;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
@@ -15,7 +15,7 @@ use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::like::LikeOptions;
 use crate::scalar_fn::fns::like::LikeReduce;
 
-impl LikeReduce for DictVTable {
+impl LikeReduce for Dict {
     fn like(
         array: &DictArray,
         pattern: &ArrayRef,

--- a/vortex-array/src/arrays/dict/compute/mask.rs
+++ b/vortex-array/src/arrays/dict/compute/mask.rs
@@ -5,14 +5,14 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Dict;
 use crate::arrays::DictArray;
-use crate::arrays::DictVTable;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::fns::mask::Mask as MaskExpr;
 use crate::scalar_fn::fns::mask::MaskReduce;
 
-impl MaskReduce for DictVTable {
+impl MaskReduce for Dict {
     fn mask(array: &DictArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let masked_codes = MaskExpr.try_new_array(
             array.codes().len(),

--- a/vortex-array/src/arrays/dict/compute/min_max.rs
+++ b/vortex-array/src/arrays/dict/compute/min_max.rs
@@ -3,8 +3,8 @@
 
 use vortex_error::VortexResult;
 
+use super::Dict;
 use super::DictArray;
-use super::DictVTable;
 use crate::DynArray as _;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
@@ -16,7 +16,7 @@ use crate::compute::min_max;
 use crate::register_kernel;
 use crate::validity::Validity;
 
-impl MinMaxKernel for DictVTable {
+impl MinMaxKernel for Dict {
     fn min_max(&self, array: &DictArray) -> VortexResult<Option<MinMaxResult>> {
         let codes_validity = array.codes().validity_mask()?;
         if codes_validity.all_false() {
@@ -39,7 +39,7 @@ impl MinMaxKernel for DictVTable {
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(DictVTable).lift());
+register_kernel!(MinMaxKernelAdapter(Dict).lift());
 
 #[cfg(test)]
 mod tests {

--- a/vortex-array/src/arrays/dict/compute/mod.rs
+++ b/vortex-array/src/arrays/dict/compute/mod.rs
@@ -15,8 +15,8 @@ mod slice;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use super::Dict;
 use super::DictArray;
-use super::DictVTable;
 use super::TakeExecute;
 use crate::ArrayRef;
 use crate::DynArray;
@@ -24,7 +24,7 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::filter::FilterReduce;
 
-impl TakeExecute for DictVTable {
+impl TakeExecute for Dict {
     fn take(
         array: &DictArray,
         indices: &ArrayRef,
@@ -39,7 +39,7 @@ impl TakeExecute for DictVTable {
     }
 }
 
-impl FilterReduce for DictVTable {
+impl FilterReduce for Dict {
     fn filter(array: &DictArray, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
         let codes = array.codes().filter(mask.clone())?;
 

--- a/vortex-array/src/arrays/dict/compute/rules.rs
+++ b/vortex-array/src/arrays/dict/compute/rules.rs
@@ -8,10 +8,10 @@ use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
 use crate::Precision;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
+use crate::arrays::Dict;
 use crate::arrays::DictArray;
-use crate::arrays::DictVTable;
 use crate::arrays::ScalarFnArray;
 use crate::arrays::filter::FilterReduceAdaptor;
 use crate::arrays::scalar_fn::AnyScalarFn;
@@ -26,21 +26,21 @@ use crate::scalar_fn::fns::like::LikeReduceAdaptor;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 use crate::scalar_fn::fns::pack::Pack;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<DictVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&FilterReduceAdaptor(DictVTable)),
-    ParentRuleSet::lift(&CastReduceAdaptor(DictVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(DictVTable)),
-    ParentRuleSet::lift(&LikeReduceAdaptor(DictVTable)),
+pub(crate) const PARENT_RULES: ParentRuleSet<Dict> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&FilterReduceAdaptor(Dict)),
+    ParentRuleSet::lift(&CastReduceAdaptor(Dict)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(Dict)),
+    ParentRuleSet::lift(&LikeReduceAdaptor(Dict)),
     ParentRuleSet::lift(&DictionaryScalarFnValuesPushDownRule),
     ParentRuleSet::lift(&DictionaryScalarFnCodesPullUpRule),
-    ParentRuleSet::lift(&SliceReduceAdaptor(DictVTable)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(Dict)),
 ]);
 
 /// Push down a scalar function to run only over the values of a dictionary array.
 #[derive(Debug)]
 struct DictionaryScalarFnValuesPushDownRule;
 
-impl ArrayParentReduceRule<DictVTable> for DictionaryScalarFnValuesPushDownRule {
+impl ArrayParentReduceRule<Dict> for DictionaryScalarFnValuesPushDownRule {
     type Parent = AnyScalarFn;
 
     fn reduce_parent(
@@ -88,7 +88,7 @@ impl ArrayParentReduceRule<DictVTable> for DictionaryScalarFnValuesPushDownRule 
             .children()
             .iter()
             .enumerate()
-            .all(|(idx, c)| idx == child_idx || c.is::<ConstantVTable>())
+            .all(|(idx, c)| idx == child_idx || c.is::<Constant>())
         {
             return Ok(None);
         }
@@ -112,7 +112,7 @@ impl ArrayParentReduceRule<DictVTable> for DictionaryScalarFnValuesPushDownRule 
             if idx == child_idx {
                 new_children.push(array.values().clone());
             } else {
-                let scalar = child.as_::<ConstantVTable>().scalar().clone();
+                let scalar = child.as_::<Constant>().scalar().clone();
                 new_children.push(ConstantArray::new(scalar, values_len).into_array());
             }
         }
@@ -141,7 +141,7 @@ impl ArrayParentReduceRule<DictVTable> for DictionaryScalarFnValuesPushDownRule 
 #[derive(Debug)]
 struct DictionaryScalarFnCodesPullUpRule;
 
-impl ArrayParentReduceRule<DictVTable> for DictionaryScalarFnCodesPullUpRule {
+impl ArrayParentReduceRule<Dict> for DictionaryScalarFnCodesPullUpRule {
     type Parent = AnyScalarFn;
 
     fn reduce_parent(
@@ -159,7 +159,7 @@ impl ArrayParentReduceRule<DictVTable> for DictionaryScalarFnCodesPullUpRule {
         // This is a cheap first loop.
         if !parent.children().iter().enumerate().all(|(idx, c)| {
             idx == child_idx
-                || c.as_opt::<DictVTable>()
+                || c.as_opt::<Dict>()
                     .is_some_and(|c| c.values().len() == array.values().len())
         }) {
             return Ok(None);
@@ -169,7 +169,7 @@ impl ArrayParentReduceRule<DictVTable> for DictionaryScalarFnCodesPullUpRule {
         // We use the cheaper Precision::Ptr to avoid doing data comparisons.
         if !parent.children().iter().enumerate().all(|(idx, c)| {
             idx == child_idx
-                || c.as_opt::<DictVTable>()
+                || c.as_opt::<Dict>()
                     .is_some_and(|c| c.codes().array_eq(array.codes(), Precision::Value))
         }) {
             return Ok(None);
@@ -180,7 +180,7 @@ impl ArrayParentReduceRule<DictVTable> for DictionaryScalarFnCodesPullUpRule {
             if idx == child_idx {
                 new_children.push(array.values().clone());
             } else {
-                new_children.push(child.as_::<DictVTable>().values().clone());
+                new_children.push(child.as_::<Dict>().values().clone());
             }
         }
 

--- a/vortex-array/src/arrays/dict/compute/slice.rs
+++ b/vortex-array/src/arrays/dict/compute/slice.rs
@@ -7,18 +7,18 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
+use crate::arrays::Dict;
 use crate::arrays::DictArray;
-use crate::arrays::DictVTable;
 use crate::arrays::slice::SliceReduce;
 use crate::scalar::Scalar;
 
-impl SliceReduce for DictVTable {
+impl SliceReduce for Dict {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let sliced_code = array.codes().slice(range)?;
         // TODO(joe): if the range is size 1 replace with a constant array
-        if let Some(code) = sliced_code.as_opt::<ConstantVTable>() {
+        if let Some(code) = sliced_code.as_opt::<Constant>() {
             let code = code.scalar().as_primitive().as_::<usize>();
             return if let Some(code) = code {
                 let values = array.values().slice(code..code + 1)?;

--- a/vortex-array/src/arrays/dict/execute.rs
+++ b/vortex-array/src/arrays/dict/execute.rs
@@ -9,23 +9,23 @@ use vortex_error::VortexResult;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
+use crate::arrays::FixedSizeList;
 use crate::arrays::FixedSizeListArray;
-use crate::arrays::FixedSizeListVTable;
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::arrays::NullArray;
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::arrays::dict::TakeExecute;
 use crate::arrays::dict::TakeReduce;
 
@@ -65,9 +65,9 @@ fn take_bool(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<BoolArray> {
     Ok(
-        <BoolVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)?
+        <Bool as TakeExecute>::take(array, &codes.clone().into_array(), ctx)?
             .vortex_expect("take bool should not return None")
-            .as_::<BoolVTable>()
+            .as_::<Bool>()
             .clone(),
     )
 }
@@ -77,10 +77,10 @@ fn take_primitive(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> PrimitiveArray {
-    <PrimitiveVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
+    <Primitive as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
         .vortex_expect("take primitive array")
         .vortex_expect("take primitive should not return None")
-        .as_::<PrimitiveVTable>()
+        .as_::<Primitive>()
         .clone()
 }
 
@@ -89,10 +89,10 @@ fn take_decimal(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> DecimalArray {
-    <DecimalVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
+    <Decimal as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
         .vortex_expect("take decimal array")
         .vortex_expect("take decimal should not return None")
-        .as_::<DecimalVTable>()
+        .as_::<Decimal>()
         .clone()
 }
 
@@ -101,18 +101,18 @@ fn take_varbinview(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> VarBinViewArray {
-    <VarBinViewVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
+    <VarBinView as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
         .vortex_expect("take varbinview array")
         .vortex_expect("take varbinview should not return None")
-        .as_::<VarBinViewVTable>()
+        .as_::<VarBinView>()
         .clone()
 }
 
 fn take_listview(array: &ListViewArray, codes: &PrimitiveArray) -> ListViewArray {
-    <ListViewVTable as TakeReduce>::take(array, &codes.clone().into_array())
+    <ListView as TakeReduce>::take(array, &codes.clone().into_array())
         .vortex_expect("take listview array")
         .vortex_expect("take listview should not return None")
-        .as_::<ListViewVTable>()
+        .as_::<ListView>()
         .clone()
 }
 
@@ -121,18 +121,18 @@ fn take_fixed_size_list(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> FixedSizeListArray {
-    <FixedSizeListVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
+    <FixedSizeList as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
         .vortex_expect("take fixed size list array")
         .vortex_expect("take fixed size list should not return None")
-        .as_::<FixedSizeListVTable>()
+        .as_::<FixedSizeList>()
         .clone()
 }
 
 fn take_struct(array: &StructArray, codes: &PrimitiveArray) -> StructArray {
-    <StructVTable as TakeReduce>::take(array, &codes.clone().into_array())
+    <Struct as TakeReduce>::take(array, &codes.clone().into_array())
         .vortex_expect("take struct array")
         .vortex_expect("take struct should not return None")
-        .as_::<StructVTable>()
+        .as_::<Struct>()
         .clone()
 }
 
@@ -141,9 +141,9 @@ fn take_extension(
     codes: &PrimitiveArray,
     ctx: &mut ExecutionCtx,
 ) -> ExtensionArray {
-    <ExtensionVTable as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
+    <Extension as TakeExecute>::take(array, &codes.clone().into_array(), ctx)
         .vortex_expect("take extension storage")
         .vortex_expect("take extension should not return None")
-        .as_::<ExtensionVTable>()
+        .as_::<Extension>()
         .clone()
 }

--- a/vortex-array/src/arrays/dict/take.rs
+++ b/vortex-array/src/arrays/dict/take.rs
@@ -3,8 +3,8 @@
 
 use vortex_error::VortexResult;
 
+use super::Dict;
 use super::DictArray;
-use super::DictVTable;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::DynArray;
@@ -83,7 +83,7 @@ impl<V> ArrayParentReduceRule<V> for TakeReduceAdaptor<V>
 where
     V: TakeReduce,
 {
-    type Parent = DictVTable;
+    type Parent = Dict;
 
     fn reduce_parent(
         &self,
@@ -113,7 +113,7 @@ impl<V> ExecuteParentKernel<V> for TakeExecuteAdaptor<V>
 where
     V: TakeExecute,
 {
-    type Parent = DictVTable;
+    type Parent = Dict;
 
     fn execute_parent(
         &self,

--- a/vortex-array/src/arrays/dict/vtable/kernel.rs
+++ b/vortex-array/src/arrays/dict/vtable/kernel.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::DictVTable;
+use crate::arrays::Dict;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::kernel::ParentKernelSet;
 use crate::scalar_fn::fns::binary::CompareExecuteAdaptor;
 use crate::scalar_fn::fns::fill_null::FillNullExecuteAdaptor;
 
-pub(super) const PARENT_KERNELS: ParentKernelSet<DictVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&CompareExecuteAdaptor(DictVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(DictVTable)),
-    ParentKernelSet::lift(&FillNullExecuteAdaptor(DictVTable)),
+pub(super) const PARENT_KERNELS: ParentKernelSet<Dict> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&CompareExecuteAdaptor(Dict)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(Dict)),
+    ParentKernelSet::lift(&FillNullExecuteAdaptor(Dict)),
 ]);

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -45,13 +45,13 @@ mod validity;
 vtable!(Dict);
 
 #[derive(Debug)]
-pub struct DictVTable;
+pub struct Dict;
 
-impl DictVTable {
+impl Dict {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.dict");
 }
 
-impl VTable for DictVTable {
+impl VTable for Dict {
     type Array = DictArray;
 
     type Metadata = ProstMetadata<DictMetadata>;

--- a/vortex-array/src/arrays/dict/vtable/operations.rs
+++ b/vortex-array/src/arrays/dict/vtable/operations.rs
@@ -4,13 +4,13 @@
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
-use super::DictVTable;
+use super::Dict;
 use crate::DynArray;
 use crate::arrays::DictArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<DictVTable> for DictVTable {
+impl OperationsVTable<Dict> for Dict {
     fn scalar_at(array: &DictArray, index: usize) -> VortexResult<Scalar> {
         let Some(dict_index) = array
             .codes()

--- a/vortex-array/src/arrays/dict/vtable/validity.rs
+++ b/vortex-array/src/arrays/dict/vtable/validity.rs
@@ -3,7 +3,7 @@
 
 use vortex_error::VortexResult;
 
-use super::DictVTable;
+use super::Dict;
 use crate::DynArray;
 use crate::IntoArray;
 use crate::arrays::DictArray;
@@ -13,7 +13,7 @@ use crate::scalar::Scalar;
 use crate::validity::Validity;
 use crate::vtable::ValidityVTable;
 
-impl ValidityVTable<DictVTable> for DictVTable {
+impl ValidityVTable<Dict> for Dict {
     fn validity(array: &DictArray) -> VortexResult<Validity> {
         Ok(
             match (array.codes().validity()?, array.values().validity()?) {

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -3,13 +3,13 @@
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::scalar_fn::fns::cast::CastReduce;
 
-impl CastReduce for ExtensionVTable {
+impl CastReduce for Extension {
     fn cast(array: &ExtensionArray, dtype: &DType) -> vortex_error::VortexResult<Option<ArrayRef>> {
         if !array.dtype().eq_ignore_nullability(dtype) {
             return Ok(None);

--- a/vortex-array/src/arrays/extension/compute/compare.rs
+++ b/vortex-array/src/arrays/extension/compute/compare.rs
@@ -8,14 +8,14 @@ use crate::DynArray;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::builtins::ArrayBuiltins;
 use crate::scalar_fn::fns::binary::CompareKernel;
 use crate::scalar_fn::fns::operators::CompareOperator;
 use crate::scalar_fn::fns::operators::Operator;
 
-impl CompareKernel for ExtensionVTable {
+impl CompareKernel for Extension {
     fn compare(
         lhs: &ExtensionArray,
         rhs: &ArrayRef,
@@ -36,7 +36,7 @@ impl CompareKernel for ExtensionVTable {
         }
 
         // If the RHS is an extension array matching ours, we can extract the storage.
-        if let Some(rhs_ext) = rhs.as_opt::<ExtensionVTable>() {
+        if let Some(rhs_ext) = rhs.as_opt::<Extension>() {
             return lhs
                 .storage_array()
                 .to_array()

--- a/vortex-array/src/arrays/extension/compute/filter.rs
+++ b/vortex-array/src/arrays/extension/compute/filter.rs
@@ -6,11 +6,11 @@ use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::arrays::filter::FilterReduce;
 
-impl FilterReduce for ExtensionVTable {
+impl FilterReduce for Extension {
     fn filter(array: &ExtensionArray, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             ExtensionArray::new(

--- a/vortex-array/src/arrays/extension/compute/is_constant.rs
+++ b/vortex-array/src/arrays/extension/compute/is_constant.rs
@@ -3,15 +3,15 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
 use crate::compute::IsConstantOpts;
 use crate::compute::{self};
 use crate::register_kernel;
 
-impl IsConstantKernel for ExtensionVTable {
+impl IsConstantKernel for Extension {
     fn is_constant(
         &self,
         array: &ExtensionArray,
@@ -21,4 +21,4 @@ impl IsConstantKernel for ExtensionVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(ExtensionVTable).lift());
+register_kernel!(IsConstantKernelAdapter(Extension).lift());

--- a/vortex-array/src/arrays/extension/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/extension/compute/is_sorted.rs
@@ -3,14 +3,14 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::compute::IsSortedKernel;
 use crate::compute::IsSortedKernelAdapter;
 use crate::compute::{self};
 use crate::register_kernel;
 
-impl IsSortedKernel for ExtensionVTable {
+impl IsSortedKernel for Extension {
     fn is_sorted(&self, array: &ExtensionArray) -> VortexResult<Option<bool>> {
         compute::is_sorted(array.storage_array())
     }
@@ -20,4 +20,4 @@ impl IsSortedKernel for ExtensionVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(ExtensionVTable).lift());
+register_kernel!(IsSortedKernelAdapter(Extension).lift());

--- a/vortex-array/src/arrays/extension/compute/mask.rs
+++ b/vortex-array/src/arrays/extension/compute/mask.rs
@@ -5,14 +5,14 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::fns::mask::Mask as MaskExpr;
 use crate::scalar_fn::fns::mask::MaskReduce;
 
-impl MaskReduce for ExtensionVTable {
+impl MaskReduce for Extension {
     fn mask(array: &ExtensionArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let masked_storage = MaskExpr.try_new_array(
             array.storage_array().len(),

--- a/vortex-array/src/arrays/extension/compute/min_max.rs
+++ b/vortex-array/src/arrays/extension/compute/min_max.rs
@@ -3,8 +3,8 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
@@ -13,7 +13,7 @@ use crate::dtype::Nullability;
 use crate::register_kernel;
 use crate::scalar::Scalar;
 
-impl MinMaxKernel for ExtensionVTable {
+impl MinMaxKernel for Extension {
     fn min_max(&self, array: &ExtensionArray) -> VortexResult<Option<MinMaxResult>> {
         let non_nullable_ext_dtype = array.ext_dtype().with_nullability(Nullability::NonNullable);
         Ok(
@@ -27,4 +27,4 @@ impl MinMaxKernel for ExtensionVTable {
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(ExtensionVTable).lift());
+register_kernel!(MinMaxKernelAdapter(Extension).lift());

--- a/vortex-array/src/arrays/extension/compute/rules.rs
+++ b/vortex-array/src/arrays/extension/compute/rules.rs
@@ -5,10 +5,10 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
+use crate::arrays::Filter;
 use crate::arrays::FilterArray;
-use crate::arrays::FilterVTable;
 use crate::arrays::filter::FilterReduceAdaptor;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ArrayParentReduceRule;
@@ -16,20 +16,20 @@ use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::cast::CastReduceAdaptor;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<ExtensionVTable> = ParentRuleSet::new(&[
+pub(crate) const PARENT_RULES: ParentRuleSet<Extension> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&ExtensionFilterPushDownRule),
-    ParentRuleSet::lift(&CastReduceAdaptor(ExtensionVTable)),
-    ParentRuleSet::lift(&FilterReduceAdaptor(ExtensionVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(ExtensionVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(ExtensionVTable)),
+    ParentRuleSet::lift(&CastReduceAdaptor(Extension)),
+    ParentRuleSet::lift(&FilterReduceAdaptor(Extension)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(Extension)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(Extension)),
 ]);
 
 /// Push filter operations into the storage array of an extension array.
 #[derive(Debug)]
 struct ExtensionFilterPushDownRule;
 
-impl ArrayParentReduceRule<ExtensionVTable> for ExtensionFilterPushDownRule {
-    type Parent = FilterVTable;
+impl ArrayParentReduceRule<Extension> for ExtensionFilterPushDownRule {
+    type Parent = Filter;
 
     fn reduce_parent(
         &self,
@@ -58,8 +58,8 @@ mod tests {
     use crate::IntoArray;
     use crate::ToCanonical;
     use crate::arrays::ConstantArray;
+    use crate::arrays::Extension;
     use crate::arrays::ExtensionArray;
-    use crate::arrays::ExtensionVTable;
     use crate::arrays::FilterArray;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::scalar_fn::ScalarFnArrayExt;
@@ -132,12 +132,12 @@ mod tests {
 
         // The result should be an ExtensionArray, not a FilterArray
         assert!(
-            optimized.as_opt::<ExtensionVTable>().is_some(),
+            optimized.as_opt::<Extension>().is_some(),
             "Expected ExtensionArray after optimization, got {}",
             optimized.encoding_id()
         );
 
-        let ext_result = optimized.as_::<ExtensionVTable>();
+        let ext_result = optimized.as_::<Extension>();
         assert_eq!(ext_result.len(), 3);
         assert_eq!(ext_result.ext_dtype(), &ext_dtype);
 
@@ -163,8 +163,8 @@ mod tests {
 
         let optimized = filter_array.optimize().unwrap();
 
-        assert!(optimized.as_opt::<ExtensionVTable>().is_some());
-        let ext_result = optimized.as_::<ExtensionVTable>();
+        assert!(optimized.as_opt::<Extension>().is_some());
+        let ext_result = optimized.as_::<Extension>();
         assert_eq!(ext_result.len(), 3);
 
         // Check values: should be [Some(1), None, None]
@@ -228,9 +228,7 @@ mod tests {
         // The first child should still be an ExtensionArray (no pushdown happened)
         let scalar_fn = optimized.as_opt::<crate::arrays::ScalarFnVTable>().unwrap();
         assert!(
-            scalar_fn.children()[0]
-                .as_opt::<ExtensionVTable>()
-                .is_some(),
+            scalar_fn.children()[0].as_opt::<Extension>().is_some(),
             "Expected first child to remain ExtensionArray when ext types differ"
         );
     }
@@ -255,9 +253,7 @@ mod tests {
         // No pushdown should happen because sibling is not a constant
         let scalar_fn = optimized.as_opt::<crate::arrays::ScalarFnVTable>().unwrap();
         assert!(
-            scalar_fn.children()[0]
-                .as_opt::<ExtensionVTable>()
-                .is_some(),
+            scalar_fn.children()[0].as_opt::<Extension>().is_some(),
             "Expected first child to remain ExtensionArray when sibling is not constant"
         );
     }
@@ -280,9 +276,7 @@ mod tests {
         // No pushdown should happen because constant is not an extension scalar
         let scalar_fn = optimized.as_opt::<crate::arrays::ScalarFnVTable>().unwrap();
         assert!(
-            scalar_fn.children()[0]
-                .as_opt::<ExtensionVTable>()
-                .is_some(),
+            scalar_fn.children()[0].as_opt::<Extension>().is_some(),
             "Expected first child to remain ExtensionArray when constant is not extension"
         );
     }

--- a/vortex-array/src/arrays/extension/compute/slice.rs
+++ b/vortex-array/src/arrays/extension/compute/slice.rs
@@ -7,11 +7,11 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::arrays::slice::SliceReduce;
 
-impl SliceReduce for ExtensionVTable {
+impl SliceReduce for Extension {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             ExtensionArray::new(

--- a/vortex-array/src/arrays/extension/compute/sum.rs
+++ b/vortex-array/src/arrays/extension/compute/sum.rs
@@ -3,18 +3,18 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::compute::SumKernel;
 use crate::compute::SumKernelAdapter;
 use crate::compute::{self};
 use crate::register_kernel;
 use crate::scalar::Scalar;
 
-impl SumKernel for ExtensionVTable {
+impl SumKernel for Extension {
     fn sum(&self, array: &ExtensionArray, accumulator: &Scalar) -> VortexResult<Scalar> {
         compute::sum_with_accumulator(array.storage_array(), accumulator)
     }
 }
 
-register_kernel!(SumKernelAdapter(ExtensionVTable).lift());
+register_kernel!(SumKernelAdapter(Extension).lift());

--- a/vortex-array/src/arrays/extension/compute/take.rs
+++ b/vortex-array/src/arrays/extension/compute/take.rs
@@ -7,11 +7,11 @@ use crate::ArrayRef;
 use crate::DynArray;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::arrays::dict::TakeExecute;
 
-impl TakeExecute for ExtensionVTable {
+impl TakeExecute for Extension {
     fn take(
         array: &ExtensionArray,
         indices: &ArrayRef,

--- a/vortex-array/src/arrays/extension/mod.rs
+++ b/vortex-array/src/arrays/extension/mod.rs
@@ -7,4 +7,4 @@ pub use array::ExtensionArray;
 pub(crate) mod compute;
 
 mod vtable;
-pub use vtable::ExtensionVTable;
+pub use vtable::Extension;

--- a/vortex-array/src/arrays/extension/vtable/kernel.rs
+++ b/vortex-array/src/arrays/extension/vtable/kernel.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::ExtensionVTable;
+use crate::arrays::Extension;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::kernel::ParentKernelSet;
 use crate::scalar_fn::fns::binary::CompareExecuteAdaptor;
 
-pub(super) const PARENT_KERNELS: ParentKernelSet<ExtensionVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&CompareExecuteAdaptor(ExtensionVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(ExtensionVTable)),
+pub(super) const PARENT_KERNELS: ParentKernelSet<Extension> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&CompareExecuteAdaptor(Extension)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(Extension)),
 ]);

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -36,7 +36,7 @@ use crate::vtable::ValidityVTableFromChild;
 
 vtable!(Extension);
 
-impl VTable for ExtensionVTable {
+impl VTable for Extension {
     type Array = ExtensionArray;
 
     type Metadata = EmptyMetadata;
@@ -176,8 +176,8 @@ impl VTable for ExtensionVTable {
 }
 
 #[derive(Debug)]
-pub struct ExtensionVTable;
+pub struct Extension;
 
-impl ExtensionVTable {
+impl Extension {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.ext");
 }

--- a/vortex-array/src/arrays/extension/vtable/operations.rs
+++ b/vortex-array/src/arrays/extension/vtable/operations.rs
@@ -4,12 +4,12 @@
 use vortex_error::VortexResult;
 
 use crate::DynArray;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<ExtensionVTable> for ExtensionVTable {
+impl OperationsVTable<Extension> for Extension {
     fn scalar_at(array: &ExtensionArray, index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::extension_ref(
             array.ext_dtype().clone(),

--- a/vortex-array/src/arrays/extension/vtable/validity.rs
+++ b/vortex-array/src/arrays/extension/vtable/validity.rs
@@ -2,11 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use crate::ArrayRef;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
 use crate::vtable::ValidityChild;
 
-impl ValidityChild<ExtensionVTable> for ExtensionVTable {
+impl ValidityChild<Extension> for Extension {
     fn validity_child(array: &ExtensionArray) -> &ArrayRef {
         &array.storage_array
     }

--- a/vortex-array/src/arrays/filter/execute/varbinview.rs
+++ b/vortex-array/src/arrays/filter/execute/varbinview.rs
@@ -11,8 +11,8 @@ use vortex_mask::MaskValues;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::arrays::filter::execute::values_to_mask;
 use crate::arrow::FromArrowArray;
 use crate::arrow::IntoArrowArray;
@@ -21,7 +21,7 @@ pub fn filter_varbinview(array: &VarBinViewArray, mask: &Arc<MaskValues>) -> Var
     // Delegate to the Arrow implementation of filter over `VarBinView`.
     arrow_filter_fn(&array.clone().into_array(), &values_to_mask(mask))
         .vortex_expect("VarBinViewArray is Arrow-compatible and supports arrow_filter_fn")
-        .as_::<VarBinViewVTable>()
+        .as_::<VarBinView>()
         .clone()
 }
 

--- a/vortex-array/src/arrays/filter/kernel.rs
+++ b/vortex-array/src/arrays/filter/kernel.rs
@@ -8,8 +8,8 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Filter;
 use crate::arrays::FilterArray;
-use crate::arrays::FilterVTable;
 use crate::kernel::ExecuteParentKernel;
 use crate::matcher::Matcher;
 use crate::optimizer::rules::ArrayParentReduceRule;
@@ -77,7 +77,7 @@ impl<V> ArrayParentReduceRule<V> for FilterReduceAdaptor<V>
 where
     V: FilterReduce,
 {
-    type Parent = FilterVTable;
+    type Parent = Filter;
 
     fn reduce_parent(
         &self,
@@ -100,7 +100,7 @@ impl<V> ExecuteParentKernel<V> for FilterExecuteAdaptor<V>
 where
     V: FilterKernel,
 {
-    type Parent = FilterVTable;
+    type Parent = Filter;
 
     fn execute_parent(
         &self,

--- a/vortex-array/src/arrays/filter/mod.rs
+++ b/vortex-array/src/arrays/filter/mod.rs
@@ -16,4 +16,4 @@ pub use kernel::FilterReduceAdaptor;
 mod rules;
 
 mod vtable;
-pub use vtable::FilterVTable;
+pub use vtable::Filter;

--- a/vortex-array/src/arrays/filter/rules.rs
+++ b/vortex-array/src/arrays/filter/rules.rs
@@ -8,20 +8,20 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Filter;
 use crate::arrays::FilterArray;
-use crate::arrays::FilterVTable;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
 use crate::arrays::struct_::StructArrayParts;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::optimizer::rules::ArrayReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::optimizer::rules::ReduceRuleSet;
 
-pub(super) const PARENT_RULES: ParentRuleSet<FilterVTable> =
+pub(super) const PARENT_RULES: ParentRuleSet<Filter> =
     ParentRuleSet::new(&[ParentRuleSet::lift(&FilterFilterRule)]);
 
-pub(super) const RULES: ReduceRuleSet<FilterVTable> =
+pub(super) const RULES: ReduceRuleSet<Filter> =
     ReduceRuleSet::new(&[&TrivialFilterRule, &FilterStructRule]);
 
 /// A simple redecution rule that simplifies a [`FilterArray`] whose child is also a
@@ -29,8 +29,8 @@ pub(super) const RULES: ReduceRuleSet<FilterVTable> =
 #[derive(Debug)]
 struct FilterFilterRule;
 
-impl ArrayParentReduceRule<FilterVTable> for FilterFilterRule {
-    type Parent = FilterVTable;
+impl ArrayParentReduceRule<Filter> for FilterFilterRule {
+    type Parent = Filter;
 
     fn reduce_parent(
         &self,
@@ -48,7 +48,7 @@ impl ArrayParentReduceRule<FilterVTable> for FilterFilterRule {
 #[derive(Debug)]
 struct TrivialFilterRule;
 
-impl ArrayReduceRule<FilterVTable> for TrivialFilterRule {
+impl ArrayReduceRule<Filter> for TrivialFilterRule {
     fn reduce(&self, array: &FilterArray) -> VortexResult<Option<ArrayRef>> {
         match array.filter_mask() {
             Mask::AllTrue(_) => Ok(Some(array.child.clone())),
@@ -62,10 +62,10 @@ impl ArrayReduceRule<FilterVTable> for TrivialFilterRule {
 #[derive(Debug)]
 struct FilterStructRule;
 
-impl ArrayReduceRule<FilterVTable> for FilterStructRule {
+impl ArrayReduceRule<Filter> for FilterStructRule {
     fn reduce(&self, array: &FilterArray) -> VortexResult<Option<ArrayRef>> {
         let mask = array.filter_mask();
-        let Some(struct_array) = array.child().as_opt::<StructVTable>() else {
+        let Some(struct_array) = array.child().as_opt::<Struct>() else {
             return Ok(None);
         };
 

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -41,13 +41,13 @@ use crate::vtable::ValidityVTable;
 vtable!(Filter);
 
 #[derive(Debug)]
-pub struct FilterVTable;
+pub struct Filter;
 
-impl FilterVTable {
+impl Filter {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.filter");
 }
 
-impl VTable for FilterVTable {
+impl VTable for Filter {
     type Array = FilterArray;
     type Metadata = FilterMetadata;
     type OperationsVTable = Self;
@@ -182,14 +182,14 @@ impl VTable for FilterVTable {
         RULES.evaluate(array)
     }
 }
-impl OperationsVTable<FilterVTable> for FilterVTable {
+impl OperationsVTable<Filter> for Filter {
     fn scalar_at(array: &FilterArray, index: usize) -> VortexResult<Scalar> {
         let rank_idx = array.mask.rank(index);
         array.child.scalar_at(rank_idx)
     }
 }
 
-impl ValidityVTable<FilterVTable> for FilterVTable {
+impl ValidityVTable<Filter> for Filter {
     fn validity(array: &FilterArray) -> VortexResult<Validity> {
         array.child.validity()?.filter(&array.mask)
     }

--- a/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/cast.rs
@@ -5,8 +5,8 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::FixedSizeList;
 use crate::arrays::FixedSizeListArray;
-use crate::arrays::FixedSizeListVTable;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::scalar_fn::fns::cast::CastReduce;
@@ -16,7 +16,7 @@ use crate::vtable::ValidityHelper;
 ///
 /// Recursively casts the inner elements array to the target element type while preserving the list
 /// structure.
-impl CastReduce for FixedSizeListVTable {
+impl CastReduce for FixedSizeList {
     fn cast(array: &FixedSizeListArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         let Some(target_element_type) = dtype.as_fixed_size_list_element_opt() else {
             return Ok(None);

--- a/vortex-array/src/arrays/fixed_size_list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/is_constant.rs
@@ -3,8 +3,8 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::FixedSizeList;
 use crate::arrays::FixedSizeListArray;
-use crate::arrays::FixedSizeListVTable;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
 use crate::compute::IsConstantOpts;
@@ -13,7 +13,7 @@ use crate::register_kernel;
 /// IsConstant implementation for [`FixedSizeListArray`].
 ///
 /// Compares each list scalar against the first to determine if all lists are identical.
-impl IsConstantKernel for FixedSizeListVTable {
+impl IsConstantKernel for FixedSizeList {
     fn is_constant(
         &self,
         array: &FixedSizeListArray,
@@ -41,4 +41,4 @@ impl IsConstantKernel for FixedSizeListVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(FixedSizeListVTable).lift());
+register_kernel!(IsConstantKernelAdapter(FixedSizeList).lift());

--- a/vortex-array/src/arrays/fixed_size_list/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/is_sorted.rs
@@ -3,14 +3,14 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::FixedSizeList;
 use crate::arrays::FixedSizeListArray;
-use crate::arrays::FixedSizeListVTable;
 use crate::compute::IsSortedKernel;
 use crate::compute::IsSortedKernelAdapter;
 use crate::register_kernel;
 
 /// IsSorted implementation for [`FixedSizeListArray`].
-impl IsSortedKernel for FixedSizeListVTable {
+impl IsSortedKernel for FixedSizeList {
     fn is_sorted(&self, _array: &FixedSizeListArray) -> VortexResult<Option<bool>> {
         // This would require comparing lists lexicographically.
         Ok(None)
@@ -22,4 +22,4 @@ impl IsSortedKernel for FixedSizeListVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(FixedSizeListVTable).lift());
+register_kernel!(IsSortedKernelAdapter(FixedSizeList).lift());

--- a/vortex-array/src/arrays/fixed_size_list/compute/mask.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/mask.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::FixedSizeList;
 use crate::arrays::FixedSizeListArray;
-use crate::arrays::FixedSizeListVTable;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl MaskReduce for FixedSizeListVTable {
+impl MaskReduce for FixedSizeList {
     fn mask(array: &FixedSizeListArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         // SAFETY: masking the validity does not affect the invariants
         Ok(Some(

--- a/vortex-array/src/arrays/fixed_size_list/compute/min_max.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/min_max.rs
@@ -3,19 +3,19 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::FixedSizeList;
 use crate::arrays::FixedSizeListArray;
-use crate::arrays::FixedSizeListVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
 use crate::register_kernel;
 
 /// MinMax implementation for [`FixedSizeListArray`].
-impl MinMaxKernel for FixedSizeListVTable {
+impl MinMaxKernel for FixedSizeList {
     fn min_max(&self, _array: &FixedSizeListArray) -> VortexResult<Option<MinMaxResult>> {
         // This would require finding the lexicographically minimum and maximum lists.
         Ok(None)
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(FixedSizeListVTable).lift());
+register_kernel!(MinMaxKernelAdapter(FixedSizeList).lift());

--- a/vortex-array/src/arrays/fixed_size_list/compute/rules.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/rules.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::FixedSizeListVTable;
+use crate::arrays::FixedSizeList;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::cast::CastReduceAdaptor;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<FixedSizeListVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&CastReduceAdaptor(FixedSizeListVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(FixedSizeListVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(FixedSizeListVTable)),
+pub(crate) const PARENT_RULES: ParentRuleSet<FixedSizeList> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(FixedSizeList)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(FixedSizeList)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(FixedSizeList)),
 ]);

--- a/vortex-array/src/arrays/fixed_size_list/compute/slice.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/slice.rs
@@ -7,12 +7,12 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::FixedSizeList;
 use crate::arrays::FixedSizeListArray;
-use crate::arrays::FixedSizeListVTable;
 use crate::arrays::slice::SliceReduce;
 use crate::vtable::ValidityHelper;
 
-impl SliceReduce for FixedSizeListVTable {
+impl SliceReduce for FixedSizeList {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let new_len = range.len();
         let list_size = array.list_size() as usize;

--- a/vortex-array/src/arrays/fixed_size_list/compute/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/compute/take.rs
@@ -10,8 +10,8 @@ use vortex_error::vortex_panic;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::FixedSizeList;
 use crate::arrays::FixedSizeListArray;
-use crate::arrays::FixedSizeListVTable;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::dict::TakeExecute;
 use crate::dtype::IntegerPType;
@@ -25,7 +25,7 @@ use crate::vtable::ValidityHelper;
 /// Unlike `ListView`, `FixedSizeListArray` must rebuild the elements array because it requires
 /// that elements start at offset 0 and be perfectly packed without gaps. We expand list indices
 /// into element indices and push them down to the child elements array.
-impl TakeExecute for FixedSizeListVTable {
+impl TakeExecute for FixedSizeList {
     fn take(
         array: &FixedSizeListArray,
         indices: &ArrayRef,

--- a/vortex-array/src/arrays/fixed_size_list/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/mod.rs
@@ -7,7 +7,7 @@ pub use array::FixedSizeListArray;
 pub(crate) mod compute;
 
 mod vtable;
-pub use vtable::FixedSizeListVTable;
+pub use vtable::FixedSizeList;
 
 #[cfg(test)]
 mod tests;

--- a/vortex-array/src/arrays/fixed_size_list/vtable/kernel.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/kernel.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::FixedSizeListVTable;
+use crate::arrays::FixedSizeList;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::kernel::ParentKernelSet;
 
-impl FixedSizeListVTable {
-    pub(crate) const PARENT_KERNELS: ParentKernelSet<FixedSizeListVTable> =
-        ParentKernelSet::new(&[ParentKernelSet::lift(&TakeExecuteAdaptor(
-            FixedSizeListVTable,
-        ))]);
+impl FixedSizeList {
+    pub(crate) const PARENT_KERNELS: ParentKernelSet<FixedSizeList> =
+        ParentKernelSet::new(&[ParentKernelSet::lift(&TakeExecuteAdaptor(FixedSizeList))]);
 }

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -37,13 +37,13 @@ mod validity;
 vtable!(FixedSizeList);
 
 #[derive(Debug)]
-pub struct FixedSizeListVTable;
+pub struct FixedSizeList;
 
-impl FixedSizeListVTable {
+impl FixedSizeList {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.fixed_size_list");
 }
 
-impl VTable for FixedSizeListVTable {
+impl VTable for FixedSizeList {
     type Array = FixedSizeListArray;
 
     type Metadata = EmptyMetadata;
@@ -169,7 +169,7 @@ impl VTable for FixedSizeListVTable {
     ) -> VortexResult<FixedSizeListArray> {
         vortex_ensure!(
             buffers.is_empty(),
-            "`FixedSizeListVTable::build` expects no buffers"
+            "`FixedSizeList::build` expects no buffers"
         );
 
         let DType::FixedSizeList(element_dtype, list_size, _) = &dtype else {
@@ -178,7 +178,7 @@ impl VTable for FixedSizeListVTable {
 
         let validity = {
             if children.len() > 2 {
-                vortex_bail!("`FixedSizeListVTable::build` method expected 1 or 2 children")
+                vortex_bail!("`FixedSizeList::build` method expected 1 or 2 children")
             }
 
             if children.len() == 2 {

--- a/vortex-array/src/arrays/fixed_size_list/vtable/operations.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/operations.rs
@@ -3,12 +3,12 @@
 
 use vortex_error::VortexResult;
 
-use crate::arrays::FixedSizeListVTable;
+use crate::arrays::FixedSizeList;
 use crate::arrays::fixed_size_list::vtable::FixedSizeListArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<FixedSizeListVTable> for FixedSizeListVTable {
+impl OperationsVTable<FixedSizeList> for FixedSizeList {
     fn scalar_at(array: &FixedSizeListArray, index: usize) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
         let list = array.fixed_size_list_elements_at(index)?;

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -14,8 +14,8 @@ use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
-use crate::arrays::ListVTable;
-use crate::arrays::PrimitiveVTable;
+use crate::arrays::List;
+use crate::arrays::Primitive;
 use crate::builtins::ArrayBuiltins;
 use crate::compute::min_max;
 use crate::dtype::DType;
@@ -258,7 +258,7 @@ impl ListArray {
             self.len()
         );
 
-        if let Some(p) = self.offsets().as_opt::<PrimitiveVTable>() {
+        if let Some(p) = self.offsets().as_opt::<Primitive>() {
             Ok(match_each_native_ptype!(p.ptype(), |P| {
                 p.as_slice::<P>()[index].as_()
             }))
@@ -317,7 +317,7 @@ impl ListArray {
         let mut elements = self.sliced_elements()?;
         if recurse && elements.is_canonical() {
             elements = elements.to_canonical()?.compact()?.into_array();
-        } else if recurse && let Some(child_list_array) = elements.as_opt::<ListVTable>() {
+        } else if recurse && let Some(child_list_array) = elements.as_opt::<List>() {
             elements = child_list_array.reset_offsets(recurse)?.into_array();
         }
 

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -5,14 +5,14 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::List;
 use crate::arrays::ListArray;
-use crate::arrays::ListVTable;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::scalar_fn::fns::cast::CastReduce;
 use crate::vtable::ValidityHelper;
 
-impl CastReduce for ListVTable {
+impl CastReduce for List {
     fn cast(array: &ListArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         let Some(target_element_type) = dtype.as_list_element_opt() else {
             return Ok(None);

--- a/vortex-array/src/arrays/list/compute/filter.rs
+++ b/vortex-array/src/arrays/list/compute/filter.rs
@@ -17,8 +17,8 @@ use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::List;
 use crate::arrays::ListArray;
-use crate::arrays::ListVTable;
 use crate::arrays::filter::FilterKernel;
 use crate::dtype::IntegerPType;
 use crate::match_each_integer_ptype;
@@ -92,7 +92,7 @@ fn process_element_range(
     }
 }
 
-impl FilterKernel for ListVTable {
+impl FilterKernel for List {
     fn filter(
         array: &ListArray,
         mask: &Mask,

--- a/vortex-array/src/arrays/list/compute/is_constant.rs
+++ b/vortex-array/src/arrays/list/compute/is_constant.rs
@@ -3,8 +3,8 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::List;
 use crate::arrays::ListArray;
-use crate::arrays::ListVTable;
 use crate::builtins::ArrayBuiltins;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
@@ -15,7 +15,7 @@ use crate::scalar_fn::fns::operators::Operator;
 
 const SMALL_ARRAY_THRESHOLD: usize = 64;
 
-impl IsConstantKernel for ListVTable {
+impl IsConstantKernel for List {
     fn is_constant(&self, array: &ListArray, opts: &IsConstantOpts) -> VortexResult<Option<bool>> {
         // At this point, we're guaranteed:
         // - Array has at least 2 elements
@@ -71,7 +71,7 @@ impl IsConstantKernel for ListVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(ListVTable).lift());
+register_kernel!(IsConstantKernelAdapter(List).lift());
 
 #[cfg(test)]
 mod tests {

--- a/vortex-array/src/arrays/list/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/list/compute/is_sorted.rs
@@ -3,13 +3,13 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::List;
 use crate::arrays::ListArray;
-use crate::arrays::ListVTable;
 use crate::compute::IsSortedKernel;
 use crate::compute::IsSortedKernelAdapter;
 use crate::register_kernel;
 
-impl IsSortedKernel for ListVTable {
+impl IsSortedKernel for List {
     fn is_sorted(&self, _array: &ListArray) -> VortexResult<Option<bool>> {
         // This would require comparing lists lexicographically.
         Ok(None)
@@ -21,4 +21,4 @@ impl IsSortedKernel for ListVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(ListVTable).lift());
+register_kernel!(IsSortedKernelAdapter(List).lift());

--- a/vortex-array/src/arrays/list/compute/kernels.rs
+++ b/vortex-array/src/arrays/list/compute/kernels.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::ListVTable;
+use crate::arrays::List;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::arrays::filter::FilterExecuteAdaptor;
 use crate::kernel::ParentKernelSet;
 
-pub(crate) const PARENT_KERNELS: ParentKernelSet<ListVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&FilterExecuteAdaptor(ListVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(ListVTable)),
+pub(crate) const PARENT_KERNELS: ParentKernelSet<List> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&FilterExecuteAdaptor(List)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(List)),
 ]);

--- a/vortex-array/src/arrays/list/compute/mask.rs
+++ b/vortex-array/src/arrays/list/compute/mask.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::List;
 use crate::arrays::ListArray;
-use crate::arrays::ListVTable;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl MaskReduce for ListVTable {
+impl MaskReduce for List {
     fn mask(array: &ListArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         ListArray::try_new(
             array.elements().clone(),

--- a/vortex-array/src/arrays/list/compute/min_max.rs
+++ b/vortex-array/src/arrays/list/compute/min_max.rs
@@ -3,18 +3,18 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::List;
 use crate::arrays::ListArray;
-use crate::arrays::ListVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
 use crate::register_kernel;
 
-impl MinMaxKernel for ListVTable {
+impl MinMaxKernel for List {
     fn min_max(&self, _array: &ListArray) -> VortexResult<Option<MinMaxResult>> {
         // This would require finding the lexicographically minimum and maximum lists.
         Ok(None)
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(ListVTable).lift());
+register_kernel!(MinMaxKernelAdapter(List).lift());

--- a/vortex-array/src/arrays/list/compute/rules.rs
+++ b/vortex-array/src/arrays/list/compute/rules.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::ListVTable;
+use crate::arrays::List;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::cast::CastReduceAdaptor;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<ListVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&CastReduceAdaptor(ListVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(ListVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(ListVTable)),
+pub(crate) const PARENT_RULES: ParentRuleSet<List> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(List)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(List)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(List)),
 ]);

--- a/vortex-array/src/arrays/list/compute/slice.rs
+++ b/vortex-array/src/arrays/list/compute/slice.rs
@@ -7,12 +7,12 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::List;
 use crate::arrays::ListArray;
-use crate::arrays::ListVTable;
 use crate::arrays::slice::SliceReduce;
 use crate::vtable::ValidityHelper;
 
-impl SliceReduce for ListVTable {
+impl SliceReduce for List {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             ListArray::new(

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -7,8 +7,8 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::List;
 use crate::arrays::ListArray;
-use crate::arrays::ListVTable;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::dict::TakeExecute;
 use crate::builders::ArrayBuilder;
@@ -23,7 +23,7 @@ use crate::vtable::ValidityHelper;
 // TODO(connor)[ListView]: Re-revert to the version where we simply convert to a `ListView` and call
 // the `ListView::take` compute function once `ListView` is more stable.
 
-impl TakeExecute for ListVTable {
+impl TakeExecute for List {
     /// Take implementation for [`ListArray`].
     ///
     /// Unlike `ListView`, `ListArray` must rebuild the elements array to maintain its invariant

--- a/vortex-array/src/arrays/list/mod.rs
+++ b/vortex-array/src/arrays/list/mod.rs
@@ -8,7 +8,7 @@ pub use array::ListArrayParts;
 pub(crate) mod compute;
 
 mod vtable;
-pub use vtable::ListVTable;
+pub use vtable::List;
 
 #[cfg(feature = "_test-harness")]
 mod test_harness;

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -15,7 +15,7 @@ use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::FilterArray;
-use crate::arrays::ListVTable;
+use crate::arrays::List;
 use crate::arrays::PrimitiveArray;
 use crate::assert_arrays_eq;
 use crate::builders::ArrayBuilder;
@@ -430,7 +430,7 @@ fn test_offset_to_0() {
     assert_eq!(list.len(), 2);
 
     // For a sliced ListArray, we need to check it's still a ListArray
-    let list_array = list.as_::<ListVTable>();
+    let list_array = list.as_::<List>();
 
     // Check the offsets array has correct length (n+1 for n lists)
     assert_eq!(list_array.offsets().len(), 3);
@@ -592,7 +592,7 @@ fn test_list_of_lists() {
 
     // Access the first list of lists and verify its contents.
     let first_outer = list_of_lists.list_elements_at(0).unwrap();
-    let first_outer_list = first_outer.as_::<ListVTable>();
+    let first_outer_list = first_outer.as_::<List>();
     assert_eq!(first_outer_list.len(), 2);
 
     // Check first inner list [1, 2].
@@ -605,7 +605,7 @@ fn test_list_of_lists() {
 
     // Check the second list of lists [[4, 5, 6]].
     let second_outer = list_of_lists.list_elements_at(1).unwrap();
-    let second_outer_list = second_outer.as_::<ListVTable>();
+    let second_outer_list = second_outer.as_::<List>();
     assert_eq!(second_outer_list.len(), 1);
 
     let inner = second_outer_list.list_elements_at(0).unwrap();
@@ -618,7 +618,7 @@ fn test_list_of_lists() {
 
     // Check the fourth list of lists [[7]].
     let fourth_outer = list_of_lists.list_elements_at(3).unwrap();
-    let fourth_outer_list = fourth_outer.as_::<ListVTable>();
+    let fourth_outer_list = fourth_outer.as_::<List>();
     assert_eq!(fourth_outer_list.len(), 1);
 
     let inner = fourth_outer_list.list_elements_at(0).unwrap();
@@ -632,12 +632,12 @@ fn test_list_of_lists() {
 
     // Test slicing.
     let sliced = list_of_lists.slice(1..3).unwrap();
-    let sliced_list = sliced.as_::<ListVTable>();
+    let sliced_list = sliced.as_::<List>();
     assert_eq!(sliced_list.len(), 2);
 
     // First element of slice should be [[4, 5, 6]].
     let first_sliced = sliced_list.list_elements_at(0).unwrap();
-    let first_sliced_list = first_sliced.as_::<ListVTable>();
+    let first_sliced_list = first_sliced.as_::<List>();
     assert_eq!(first_sliced_list.len(), 1);
 
     // Second element of slice should be empty [].
@@ -679,14 +679,14 @@ fn test_list_of_lists_nullable_outer() {
 
     // Third element should be [[4, 5, 6]].
     let third = list_of_lists.list_elements_at(2).unwrap();
-    let third_list = third.as_::<ListVTable>();
+    let third_list = third.as_::<List>();
     assert_eq!(third_list.len(), 1);
     let inner = third_list.list_elements_at(0).unwrap();
     assert_eq!(inner.len(), 3);
 
     // Fourth element should be [[7]].
     let fourth = list_of_lists.list_elements_at(3).unwrap();
-    let fourth_list = fourth.as_::<ListVTable>();
+    let fourth_list = fourth.as_::<List>();
     assert_eq!(fourth_list.len(), 1);
 }
 
@@ -723,7 +723,7 @@ fn test_list_of_lists_nullable_inner() {
 
     // First outer list should have 3 inner lists with the second being null.
     let first_outer = list_of_lists.list_elements_at(0).unwrap();
-    let first_list = first_outer.as_::<ListVTable>();
+    let first_list = first_outer.as_::<List>();
     assert_eq!(first_list.len(), 3);
 
     // Check that second inner list is null.
@@ -758,7 +758,7 @@ fn test_list_of_lists_both_nullable() {
     let first_outer = list_of_lists.scalar_at(0).unwrap();
     assert!(!first_outer.is_null());
     let first_outer_array = list_of_lists.list_elements_at(0).unwrap();
-    let first_list = first_outer_array.as_::<ListVTable>();
+    let first_list = first_outer_array.as_::<List>();
     assert_eq!(first_list.len(), 2);
 
     // First inner list should be [1, 2].
@@ -775,14 +775,14 @@ fn test_list_of_lists_both_nullable() {
 
     // Third outer list should have [3].
     let third_outer = list_of_lists.list_elements_at(2).unwrap();
-    let third_list = third_outer.as_::<ListVTable>();
+    let third_list = third_outer.as_::<List>();
     assert_eq!(third_list.len(), 1);
     let inner = third_list.list_elements_at(0).unwrap();
     assert_arrays_eq!(inner, PrimitiveArray::from_iter([3]));
 
     // Fourth outer list should have a null inner list.
     let fourth_outer = list_of_lists.list_elements_at(3).unwrap();
-    let fourth_list = fourth_outer.as_::<ListVTable>();
+    let fourth_list = fourth_outer.as_::<List>();
     assert_eq!(fourth_list.len(), 1);
     let inner = fourth_list.scalar_at(0).unwrap();
     assert!(inner.is_null());
@@ -890,7 +890,7 @@ fn test_recursive_compact_list_of_lists() {
     let original = create_list_of_lists_nullable(nested_data);
     // Slice to remove prefix - creates wasted space since offsets no longer reference early elements
     let sliced = original.slice(1..3).unwrap();
-    let sliced_list = sliced.as_::<ListVTable>();
+    let sliced_list = sliced.as_::<List>();
 
     // Test non-recursive compaction: only resets outer list offsets
     let non_recursive = sliced_list.reset_offsets(false).unwrap();
@@ -901,8 +901,8 @@ fn test_recursive_compact_list_of_lists() {
     assert_eq!(recursive.len(), 2);
 
     // Check the flattened elements - this shows the actual compaction difference
-    let non_recursive_flat_elements = non_recursive.elements().as_::<ListVTable>().elements();
-    let recursive_flat_elements = recursive.elements().as_::<ListVTable>().elements();
+    let non_recursive_flat_elements = non_recursive.elements().as_::<List>().elements();
+    let recursive_flat_elements = recursive.elements().as_::<List>().elements();
 
     // Non-recursive should still have all original elements [1,2,3,4,5,6,7,8,9,10,11,12]
     assert_eq!(non_recursive_flat_elements.len(), 12);

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -50,7 +50,7 @@ pub struct ListMetadata {
     offset_ptype: i32,
 }
 
-impl VTable for ListVTable {
+impl VTable for List {
     type Array = ListArray;
 
     type Metadata = ProstMetadata<ListMetadata>;
@@ -228,8 +228,8 @@ impl VTable for ListVTable {
 }
 
 #[derive(Debug)]
-pub struct ListVTable;
+pub struct List;
 
-impl ListVTable {
+impl List {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.list");
 }

--- a/vortex-array/src/arrays/list/vtable/operations.rs
+++ b/vortex-array/src/arrays/list/vtable/operations.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 
 use vortex_error::VortexResult;
 
-use crate::arrays::ListVTable;
+use crate::arrays::List;
 use crate::arrays::list::vtable::ListArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<ListVTable> for ListVTable {
+impl OperationsVTable<List> for List {
     fn scalar_at(array: &ListArray, index: usize) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
         let elems = array.list_elements_at(index)?;

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -13,8 +13,8 @@ use vortex_error::vortex_err;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::ToCanonical;
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::arrays::bool;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
@@ -366,7 +366,7 @@ impl ListViewArray {
 
         // Fast path for `PrimitiveArray`.
         self.offsets
-            .as_opt::<PrimitiveVTable>()
+            .as_opt::<Primitive>()
             .map(|p| match_each_integer_ptype!(p.ptype(), |P| { p.as_slice::<P>()[index].as_() }))
             .unwrap_or_else(|| {
                 // Slow path: use `scalar_at` if we can't downcast directly to `PrimitiveArray`.
@@ -394,7 +394,7 @@ impl ListViewArray {
 
         // Fast path for `PrimitiveArray`.
         self.sizes
-            .as_opt::<PrimitiveVTable>()
+            .as_opt::<Primitive>()
             .map(|p| match_each_integer_ptype!(p.ptype(), |P| { p.as_slice::<P>()[index].as_() }))
             .unwrap_or_else(|| {
                 // Slow path: use `scalar_at` if we can't downcast directly to `PrimitiveArray`.

--- a/vortex-array/src/arrays/listview/compute/cast.rs
+++ b/vortex-array/src/arrays/listview/compute/cast.rs
@@ -5,14 +5,14 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::scalar_fn::fns::cast::CastReduce;
 use crate::vtable::ValidityHelper;
 
-impl CastReduce for ListViewVTable {
+impl CastReduce for ListView {
     fn cast(array: &ListViewArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         // Check if we're casting to a `List` type.
         let Some(target_element_type) = dtype.as_list_element_opt() else {

--- a/vortex-array/src/arrays/listview/compute/is_constant.rs
+++ b/vortex-array/src/arrays/listview/compute/is_constant.rs
@@ -3,15 +3,15 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
 use crate::compute::IsConstantOpts;
 use crate::compute::is_constant_opts;
 use crate::register_kernel;
 
-impl IsConstantKernel for ListViewVTable {
+impl IsConstantKernel for ListView {
     fn is_constant(
         &self,
         array: &ListViewArray,
@@ -49,4 +49,4 @@ impl IsConstantKernel for ListViewVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(ListViewVTable).lift());
+register_kernel!(IsConstantKernelAdapter(ListView).lift());

--- a/vortex-array/src/arrays/listview/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/listview/compute/is_sorted.rs
@@ -3,13 +3,13 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::compute::IsSortedKernel;
 use crate::compute::IsSortedKernelAdapter;
 use crate::register_kernel;
 
-impl IsSortedKernel for ListViewVTable {
+impl IsSortedKernel for ListView {
     fn is_sorted(&self, _array: &ListViewArray) -> VortexResult<Option<bool>> {
         // This would require comparing lists lexicographically.
         Ok(None)
@@ -21,4 +21,4 @@ impl IsSortedKernel for ListViewVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(ListViewVTable).lift());
+register_kernel!(IsSortedKernelAdapter(ListView).lift());

--- a/vortex-array/src/arrays/listview/compute/mask.rs
+++ b/vortex-array/src/arrays/listview/compute/mask.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl MaskReduce for ListViewVTable {
+impl MaskReduce for ListView {
     fn mask(array: &ListViewArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         // SAFETY: masking the validity does not affect the invariants
         Ok(Some(

--- a/vortex-array/src/arrays/listview/compute/min_max.rs
+++ b/vortex-array/src/arrays/listview/compute/min_max.rs
@@ -3,18 +3,18 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
 use crate::register_kernel;
 
-impl MinMaxKernel for ListViewVTable {
+impl MinMaxKernel for ListView {
     fn min_max(&self, _array: &ListViewArray) -> VortexResult<Option<MinMaxResult>> {
         // This would require finding the lexicographically minimum and maximum lists.
         Ok(None)
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(ListViewVTable).lift());
+register_kernel!(MinMaxKernelAdapter(ListView).lift());

--- a/vortex-array/src/arrays/listview/compute/rules.rs
+++ b/vortex-array/src/arrays/listview/compute/rules.rs
@@ -6,10 +6,10 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Filter;
 use crate::arrays::FilterArray;
-use crate::arrays::FilterVTable;
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::arrays::dict::TakeReduceAdaptor;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ArrayParentReduceRule;
@@ -18,19 +18,19 @@ use crate::scalar_fn::fns::cast::CastReduceAdaptor;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 use crate::vtable::ValidityHelper;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<ListViewVTable> = ParentRuleSet::new(&[
+pub(crate) const PARENT_RULES: ParentRuleSet<ListView> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&ListViewFilterPushDown),
-    ParentRuleSet::lift(&CastReduceAdaptor(ListViewVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(ListViewVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(ListViewVTable)),
-    ParentRuleSet::lift(&TakeReduceAdaptor(ListViewVTable)),
+    ParentRuleSet::lift(&CastReduceAdaptor(ListView)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(ListView)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(ListView)),
+    ParentRuleSet::lift(&TakeReduceAdaptor(ListView)),
 ]);
 
 #[derive(Debug)]
 struct ListViewFilterPushDown;
 
-impl ArrayParentReduceRule<ListViewVTable> for ListViewFilterPushDown {
-    type Parent = FilterVTable;
+impl ArrayParentReduceRule<ListView> for ListViewFilterPushDown {
+    type Parent = Filter;
 
     fn reduce_parent(
         &self,

--- a/vortex-array/src/arrays/listview/compute/slice.rs
+++ b/vortex-array/src/arrays/listview/compute/slice.rs
@@ -7,11 +7,11 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::arrays::slice::SliceReduce;
 
-impl SliceReduce for ListViewVTable {
+impl SliceReduce for ListView {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             unsafe {

--- a/vortex-array/src/arrays/listview/compute/take.rs
+++ b/vortex-array/src/arrays/listview/compute/take.rs
@@ -7,8 +7,8 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::arrays::dict::TakeReduce;
 use crate::arrays::listview::ListViewRebuildMode;
 use crate::builtins::ArrayBuiltins;
@@ -41,7 +41,7 @@ const REBUILD_DENSITY_THRESHOLD: f64 = 0.1;
 ///
 /// The trade-off is that we may keep unreferenced elements in memory, but this is acceptable since
 /// we're optimizing for read performance and the data isn't being copied.
-impl TakeReduce for ListViewVTable {
+impl TakeReduce for ListView {
     fn take(array: &ListViewArray, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let elements = array.elements();
         let offsets = array.offsets();

--- a/vortex-array/src/arrays/listview/mod.rs
+++ b/vortex-array/src/arrays/listview/mod.rs
@@ -8,7 +8,7 @@ pub use array::ListViewArrayParts;
 pub(crate) mod compute;
 
 mod vtable;
-pub use vtable::ListViewVTable;
+pub use vtable::ListView;
 
 mod conversion;
 pub use conversion::list_from_list_view;

--- a/vortex-array/src/arrays/listview/tests/nested.rs
+++ b/vortex-array/src/arrays/listview/tests/nested.rs
@@ -5,8 +5,8 @@ use vortex_buffer::buffer;
 
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::StructArray;
 use crate::dtype::DType;
@@ -61,7 +61,7 @@ fn test_listview_of_listview_with_overlapping() {
 
     // Verify the outer structure.
     let first_outer = outer_listview.list_elements_at(0).unwrap();
-    let first_outer_lv = first_outer.as_::<ListViewVTable>();
+    let first_outer_lv = first_outer.as_::<ListView>();
     assert_eq!(first_outer_lv.len(), 3);
 
     // Verify overlapping data is preserved correctly.
@@ -112,7 +112,7 @@ fn test_listview_of_listview_with_overlapping() {
     // Test slicing the outer ListView.
     let sliced = outer_listview.slice(1..2).unwrap();
     assert_eq!(sliced.len(), 1);
-    let sliced_lv = sliced.as_::<ListViewVTable>();
+    let sliced_lv = sliced.as_::<ListView>();
     let inner_after_slice = sliced_lv.list_elements_at(0).unwrap();
     assert_eq!(inner_after_slice.len(), 3);
 }
@@ -164,12 +164,12 @@ fn test_deeply_nested_out_of_order() {
 
     // Navigate through the scrambled structure.
     let top0 = level3.list_elements_at(0).unwrap();
-    let top0_lv = top0.as_::<ListViewVTable>();
+    let top0_lv = top0.as_::<ListView>();
     assert_eq!(top0_lv.len(), 2);
 
     // Due to out-of-order at level3, top0 actually contains level2[2] and level2[3].
     let mid0 = top0_lv.list_elements_at(0).unwrap();
-    let mid0_lv = mid0.as_::<ListViewVTable>();
+    let mid0_lv = mid0.as_::<ListView>();
     assert_eq!(mid0_lv.len(), 2);
 
     // Verify data integrity through the scrambled offsets.
@@ -229,7 +229,7 @@ fn test_mixed_offset_size_types() {
     // Test slicing with mixed types.
     let sliced = outer_listview.slice(1..3).unwrap();
     assert_eq!(sliced.len(), 2);
-    let sliced_lv = sliced.as_::<ListViewVTable>();
+    let sliced_lv = sliced.as_::<ListView>();
 
     // Verify the sliced data maintains correct offsets despite type differences.
     let sliced_first = sliced_lv.list_elements_at(0).unwrap();
@@ -280,7 +280,7 @@ fn test_listview_zero_and_overlapping() {
 
     // Test first outer list with mixed empty/non-empty.
     let first_outer = outer_listview.list_elements_at(0).unwrap();
-    let first_outer_lv = first_outer.as_::<ListViewVTable>();
+    let first_outer_lv = first_outer.as_::<ListView>();
 
     let inner0 = first_outer_lv.list_elements_at(0).unwrap();
     assert_eq!(inner0.len(), 0); // Empty
@@ -302,7 +302,7 @@ fn test_listview_zero_and_overlapping() {
 
     // Test second outer list with overlapping data.
     let second_outer = outer_listview.list_elements_at(1).unwrap();
-    let second_outer_lv = second_outer.as_::<ListViewVTable>();
+    let second_outer_lv = second_outer.as_::<ListView>();
 
     let inner3 = second_outer_lv.list_elements_at(0).unwrap();
     assert_eq!(inner3.len(), 3); // [2, 3, 4]

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -15,8 +15,8 @@ use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::BoolArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::arrays::PrimitiveArray;
 use crate::assert_arrays_eq;
 use crate::builtins::ArrayBuiltins;
@@ -43,7 +43,7 @@ fn test_slice_comprehensive() {
 
     // Test basic slice [1..3] - middle portion.
     let sliced = listview.slice(1..3).unwrap();
-    let sliced_list = sliced.as_::<ListViewVTable>();
+    let sliced_list = sliced.as_::<ListView>();
     assert_eq!(sliced_list.len(), 2, "Wrong slice length");
     assert_eq!(sliced_list.offset_at(0), 3, "Wrong offset for list[1]");
     assert_eq!(sliced_list.size_at(0), 2, "Wrong size for list[1]");
@@ -52,7 +52,7 @@ fn test_slice_comprehensive() {
 
     // Test full array slice [0..4].
     let full = listview.slice(0..4).unwrap();
-    let full_list = full.as_::<ListViewVTable>();
+    let full_list = full.as_::<ListView>();
     assert_eq!(full_list.len(), 4, "Full slice should preserve length");
     for i in 0..4 {
         // Compare the sliced elements
@@ -66,7 +66,7 @@ fn test_slice_comprehensive() {
 
     // Test single element slice [2..3].
     let single = listview.slice(2..3).unwrap();
-    let single_list = single.as_::<ListViewVTable>();
+    let single_list = single.as_::<ListView>();
     assert_eq!(single_list.len(), 1, "Single element slice failed");
     assert_eq!(single_list.offset_at(0), 5, "Wrong offset for single slice");
     assert_eq!(single_list.size_at(0), 3, "Wrong size for single slice");
@@ -84,7 +84,7 @@ fn test_slice_out_of_order() {
 
     // Slice [1..4] should maintain the out-of-order offsets.
     let sliced = listview.slice(1..4).unwrap();
-    let sliced_list = sliced.as_::<ListViewVTable>();
+    let sliced_list = sliced.as_::<ListView>();
 
     assert_eq!(
         sliced_list.len(),
@@ -143,7 +143,7 @@ fn test_slice_with_nulls() {
 
     // Slice [1..3] should preserve nulls.
     let sliced = listview.slice(1..3).unwrap();
-    let sliced_list = sliced.as_::<ListViewVTable>();
+    let sliced_list = sliced.as_::<ListView>();
 
     assert_eq!(sliced_list.len(), 2);
     assert!(sliced_list.is_invalid(0).unwrap()); // Original index 1 was null.

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -40,9 +40,9 @@ mod validity;
 vtable!(ListView);
 
 #[derive(Debug)]
-pub struct ListViewVTable;
+pub struct ListView;
 
-impl ListViewVTable {
+impl ListView {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.listview");
 }
 
@@ -56,7 +56,7 @@ pub struct ListViewMetadata {
     size_ptype: i32,
 }
 
-impl VTable for ListViewVTable {
+impl VTable for ListView {
     type Array = ListViewArray;
 
     type Metadata = ProstMetadata<ListViewMetadata>;

--- a/vortex-array/src/arrays/listview/vtable/operations.rs
+++ b/vortex-array/src/arrays/listview/vtable/operations.rs
@@ -5,12 +5,12 @@ use std::sync::Arc;
 
 use vortex_error::VortexResult;
 
-use crate::arrays::ListViewVTable;
+use crate::arrays::ListView;
 use crate::arrays::listview::vtable::ListViewArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<ListViewVTable> for ListViewVTable {
+impl OperationsVTable<ListView> for ListView {
     fn scalar_at(array: &ListViewArray, index: usize) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
         let list = array.list_elements_at(index)?;

--- a/vortex-array/src/arrays/masked/compute/filter.rs
+++ b/vortex-array/src/arrays/masked/compute/filter.rs
@@ -6,12 +6,12 @@ use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Masked;
 use crate::arrays::MaskedArray;
-use crate::arrays::MaskedVTable;
 use crate::arrays::filter::FilterReduce;
 use crate::vtable::ValidityHelper;
 
-impl FilterReduce for MaskedVTable {
+impl FilterReduce for Masked {
     fn filter(array: &MaskedArray, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
         // Filter the validity to get the new validity
         let filtered_validity = array.validity().filter(mask)?;

--- a/vortex-array/src/arrays/masked/compute/mask.rs
+++ b/vortex-array/src/arrays/masked/compute/mask.rs
@@ -4,8 +4,8 @@
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::arrays::Masked;
 use crate::arrays::MaskedArray;
-use crate::arrays::MaskedVTable;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::fns::mask::Mask as MaskExpr;
@@ -13,7 +13,7 @@ use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl MaskReduce for MaskedVTable {
+impl MaskReduce for Masked {
     fn mask(array: &MaskedArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         // AND the existing validity mask with the new mask and push into child.
         let combined_mask = array

--- a/vortex-array/src/arrays/masked/compute/rules.rs
+++ b/vortex-array/src/arrays/masked/compute/rules.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::MaskedVTable;
+use crate::arrays::Masked;
 use crate::arrays::dict::TakeReduceAdaptor;
 use crate::arrays::filter::FilterReduceAdaptor;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<MaskedVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&FilterReduceAdaptor(MaskedVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(MaskedVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(MaskedVTable)),
-    ParentRuleSet::lift(&TakeReduceAdaptor(MaskedVTable)),
+pub(crate) const PARENT_RULES: ParentRuleSet<Masked> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&FilterReduceAdaptor(Masked)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(Masked)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(Masked)),
+    ParentRuleSet::lift(&TakeReduceAdaptor(Masked)),
 ]);

--- a/vortex-array/src/arrays/masked/compute/slice.rs
+++ b/vortex-array/src/arrays/masked/compute/slice.rs
@@ -7,12 +7,12 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Masked;
 use crate::arrays::MaskedArray;
-use crate::arrays::MaskedVTable;
 use crate::arrays::slice::SliceReduce;
 use crate::stats::ArrayStats;
 
-impl SliceReduce for MaskedVTable {
+impl SliceReduce for Masked {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let child = array.child.slice(range.clone())?;
         let validity = array.validity.slice(range)?;

--- a/vortex-array/src/arrays/masked/compute/take.rs
+++ b/vortex-array/src/arrays/masked/compute/take.rs
@@ -6,14 +6,14 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Masked;
 use crate::arrays::MaskedArray;
-use crate::arrays::MaskedVTable;
 use crate::arrays::dict::TakeReduce;
 use crate::builtins::ArrayBuiltins;
 use crate::scalar::Scalar;
 use crate::vtable::ValidityHelper;
 
-impl TakeReduce for MaskedVTable {
+impl TakeReduce for Masked {
     fn take(array: &MaskedArray, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let taken_child = if !indices.all_valid()? {
             // This is safe because we'll mask out these positions in the validity.

--- a/vortex-array/src/arrays/masked/mod.rs
+++ b/vortex-array/src/arrays/masked/mod.rs
@@ -10,7 +10,7 @@ mod execute;
 pub use execute::mask_validity_canonical;
 
 mod vtable;
-pub use vtable::MaskedVTable;
+pub use vtable::Masked;
 
 #[cfg(test)]
 mod tests;

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -41,13 +41,13 @@ use crate::vtable::validity_to_child;
 vtable!(Masked);
 
 #[derive(Debug)]
-pub struct MaskedVTable;
+pub struct Masked;
 
-impl MaskedVTable {
+impl Masked {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.masked");
 }
 
-impl VTable for MaskedVTable {
+impl VTable for Masked {
     type Array = MaskedArray;
 
     type Metadata = EmptyMetadata;
@@ -227,8 +227,8 @@ mod tests {
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
+    use crate::arrays::Masked;
     use crate::arrays::MaskedArray;
-    use crate::arrays::MaskedVTable;
     use crate::arrays::PrimitiveArray;
     use crate::dtype::Nullability;
     use crate::serde::ArrayParts;
@@ -282,7 +282,7 @@ mod tests {
             )
             .unwrap();
 
-        assert!(decoded.is::<MaskedVTable>());
+        assert!(decoded.is::<Masked>());
         assert_eq!(
             array.as_ref().display_values().to_string(),
             decoded.display_values().to_string()

--- a/vortex-array/src/arrays/masked/vtable/operations.rs
+++ b/vortex-array/src/arrays/masked/vtable/operations.rs
@@ -4,12 +4,12 @@
 use vortex_error::VortexResult;
 
 use crate::DynArray;
+use crate::arrays::Masked;
 use crate::arrays::MaskedArray;
-use crate::arrays::MaskedVTable;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<MaskedVTable> for MaskedVTable {
+impl OperationsVTable<Masked> for Masked {
     fn scalar_at(array: &MaskedArray, index: usize) -> VortexResult<Scalar> {
         // Invalid indices are handled by the entrypoint function.
         Ok(array.child.scalar_at(index)?.into_nullable())

--- a/vortex-array/src/arrays/mod.rs
+++ b/vortex-array/src/arrays/mod.rs
@@ -16,83 +16,83 @@ mod validation_tests;
 pub mod dict_test;
 
 pub mod bool;
+pub use bool::Bool;
 pub use bool::BoolArray;
-pub use bool::BoolVTable;
 
 pub mod chunked;
+pub use chunked::Chunked;
 pub use chunked::ChunkedArray;
-pub use chunked::ChunkedVTable;
 
 pub mod constant;
+pub use constant::Constant;
 pub use constant::ConstantArray;
-pub use constant::ConstantVTable;
 
 pub mod datetime;
 pub use datetime::TemporalArray;
 
 pub mod decimal;
+pub use decimal::Decimal;
 pub use decimal::DecimalArray;
-pub use decimal::DecimalVTable;
 
 pub mod dict;
+pub use dict::Dict;
 pub use dict::DictArray;
-pub use dict::DictVTable;
 
 pub mod extension;
+pub use extension::Extension;
 pub use extension::ExtensionArray;
-pub use extension::ExtensionVTable;
 
 pub mod filter;
+pub use filter::Filter;
 pub use filter::FilterArray;
-pub use filter::FilterVTable;
 
 pub mod fixed_size_list;
+pub use fixed_size_list::FixedSizeList;
 pub use fixed_size_list::FixedSizeListArray;
-pub use fixed_size_list::FixedSizeListVTable;
 
 pub mod list;
+pub use list::List;
 pub use list::ListArray;
-pub use list::ListVTable;
 
 pub mod listview;
+pub use listview::ListView;
 pub use listview::ListViewArray;
-pub use listview::ListViewVTable;
 
 pub mod masked;
+pub use masked::Masked;
 pub use masked::MaskedArray;
-pub use masked::MaskedVTable;
 
 pub mod null;
+pub use null::Null;
 pub use null::NullArray;
-pub use null::NullVTable;
 
 pub mod primitive;
+pub use primitive::Primitive;
 pub use primitive::PrimitiveArray;
-pub use primitive::PrimitiveVTable;
 
 pub mod scalar_fn;
 pub use scalar_fn::ScalarFnArray;
 pub use scalar_fn::ScalarFnVTable;
 
 pub mod shared;
+pub use shared::Shared;
 pub use shared::SharedArray;
-pub use shared::SharedVTable;
 
 pub mod slice;
+pub use slice::Slice;
 pub use slice::SliceArray;
-pub use slice::SliceVTable;
 
 pub mod struct_;
+pub use struct_::Struct;
 pub use struct_::StructArray;
-pub use struct_::StructVTable;
 
 pub mod varbin;
+pub use varbin::VarBin;
 pub use varbin::VarBinArray;
-pub use varbin::VarBinVTable;
 
 pub mod varbinview;
+pub use varbinview::VarBinView;
 pub use varbinview::VarBinViewArray;
-pub use varbinview::VarBinViewVTable;
 
 #[cfg(feature = "arbitrary")]
 pub mod arbitrary;

--- a/vortex-array/src/arrays/null/compute/cast.rs
+++ b/vortex-array/src/arrays/null/compute/cast.rs
@@ -7,13 +7,13 @@ use vortex_error::vortex_bail;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::Null;
 use crate::arrays::NullArray;
-use crate::arrays::NullVTable;
 use crate::dtype::DType;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::cast::CastReduce;
 
-impl CastReduce for NullVTable {
+impl CastReduce for Null {
     fn cast(array: &NullArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !dtype.is_nullable() {
             vortex_bail!("Cannot cast Null to {}", dtype);

--- a/vortex-array/src/arrays/null/compute/filter.rs
+++ b/vortex-array/src/arrays/null/compute/filter.rs
@@ -6,11 +6,11 @@ use vortex_mask::Mask;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Null;
 use crate::arrays::NullArray;
-use crate::arrays::NullVTable;
 use crate::arrays::filter::FilterReduce;
 
-impl FilterReduce for NullVTable {
+impl FilterReduce for Null {
     fn filter(_array: &NullArray, mask: &Mask) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(NullArray::new(mask.true_count()).into_array()))
     }

--- a/vortex-array/src/arrays/null/compute/mask.rs
+++ b/vortex-array/src/arrays/null/compute/mask.rs
@@ -5,11 +5,11 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Null;
 use crate::arrays::NullArray;
-use crate::arrays::NullVTable;
 use crate::scalar_fn::fns::mask::MaskReduce;
 
-impl MaskReduce for NullVTable {
+impl MaskReduce for Null {
     fn mask(array: &NullArray, _mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         // Null array is already all nulls, masking has no effect.
         Ok(Some(array.clone().into_array()))

--- a/vortex-array/src/arrays/null/compute/min_max.rs
+++ b/vortex-array/src/arrays/null/compute/min_max.rs
@@ -3,17 +3,17 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::Null;
 use crate::arrays::NullArray;
-use crate::arrays::NullVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
 use crate::register_kernel;
 
-impl MinMaxKernel for NullVTable {
+impl MinMaxKernel for Null {
     fn min_max(&self, _array: &NullArray) -> VortexResult<Option<MinMaxResult>> {
         Ok(None)
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(NullVTable).lift());
+register_kernel!(MinMaxKernelAdapter(Null).lift());

--- a/vortex-array/src/arrays/null/compute/rules.rs
+++ b/vortex-array/src/arrays/null/compute/rules.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::NullVTable;
+use crate::arrays::Null;
 use crate::arrays::dict::TakeReduceAdaptor;
 use crate::arrays::filter::FilterReduceAdaptor;
 use crate::arrays::slice::SliceReduceAdaptor;
@@ -9,10 +9,10 @@ use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::cast::CastReduceAdaptor;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<NullVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&FilterReduceAdaptor(NullVTable)),
-    ParentRuleSet::lift(&CastReduceAdaptor(NullVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(NullVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(NullVTable)),
-    ParentRuleSet::lift(&TakeReduceAdaptor(NullVTable)),
+pub(crate) const PARENT_RULES: ParentRuleSet<Null> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&FilterReduceAdaptor(Null)),
+    ParentRuleSet::lift(&CastReduceAdaptor(Null)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(Null)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(Null)),
+    ParentRuleSet::lift(&TakeReduceAdaptor(Null)),
 ]);

--- a/vortex-array/src/arrays/null/compute/slice.rs
+++ b/vortex-array/src/arrays/null/compute/slice.rs
@@ -7,11 +7,11 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Null;
 use crate::arrays::NullArray;
-use crate::arrays::NullVTable;
 use crate::arrays::slice::SliceReduce;
 
-impl SliceReduce for NullVTable {
+impl SliceReduce for Null {
     fn slice(_array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(NullArray::new(range.len()).into_array()))
     }

--- a/vortex-array/src/arrays/null/compute/take.rs
+++ b/vortex-array/src/arrays/null/compute/take.rs
@@ -7,14 +7,14 @@ use vortex_error::vortex_bail;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::ToCanonical;
+use crate::arrays::Null;
 use crate::arrays::NullArray;
-use crate::arrays::NullVTable;
 use crate::arrays::dict::TakeReduce;
 use crate::arrays::dict::TakeReduceAdaptor;
 use crate::match_each_integer_ptype;
 use crate::optimizer::rules::ParentRuleSet;
 
-impl TakeReduce for NullVTable {
+impl TakeReduce for Null {
     #[allow(clippy::cast_possible_truncation)]
     fn take(array: &NullArray, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         let indices = indices.to_primitive();
@@ -32,7 +32,7 @@ impl TakeReduce for NullVTable {
     }
 }
 
-impl NullVTable {
+impl Null {
     pub const TAKE_RULES: ParentRuleSet<Self> =
         ParentRuleSet::new(&[ParentRuleSet::lift(&TakeReduceAdaptor::<Self>(Self))]);
 }

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -32,7 +32,7 @@ pub(crate) mod compute;
 
 vtable!(Null);
 
-impl VTable for NullVTable {
+impl VTable for Null {
     type Array = NullArray;
 
     type Metadata = EmptyMetadata;
@@ -171,9 +171,9 @@ pub struct NullArray {
 }
 
 #[derive(Debug)]
-pub struct NullVTable;
+pub struct Null;
 
-impl NullVTable {
+impl Null {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.null");
 }
 
@@ -185,13 +185,13 @@ impl NullArray {
         }
     }
 }
-impl OperationsVTable<NullVTable> for NullVTable {
+impl OperationsVTable<Null> for Null {
     fn scalar_at(_array: &NullArray, _index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::null(DType::Null))
     }
 }
 
-impl ValidityVTable<NullVTable> for NullVTable {
+impl ValidityVTable<Null> for Null {
     fn validity(_array: &NullArray) -> VortexResult<Validity> {
         Ok(Validity::AllInvalid)
     }

--- a/vortex-array/src/arrays/primitive/compute/between.rs
+++ b/vortex-array/src/arrays/primitive/compute/between.rs
@@ -8,8 +8,8 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::dtype::NativePType;
 use crate::dtype::Nullability;
 use crate::match_each_native_ptype;
@@ -18,7 +18,7 @@ use crate::scalar_fn::fns::between::BetweenOptions;
 use crate::scalar_fn::fns::between::StrictComparison;
 use crate::vtable::ValidityHelper;
 
-impl BetweenKernel for PrimitiveVTable {
+impl BetweenKernel for Primitive {
     fn between(
         arr: &PrimitiveArray,
         lower: &ArrayRef,

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -11,15 +11,15 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::dtype::DType;
 use crate::dtype::NativePType;
 use crate::match_each_native_ptype;
 use crate::scalar_fn::fns::cast::CastKernel;
 use crate::vtable::ValidityHelper;
 
-impl CastKernel for PrimitiveVTable {
+impl CastKernel for Primitive {
     fn cast(
         array: &PrimitiveArray,
         dtype: &DType,

--- a/vortex-array/src/arrays/primitive/compute/fill_null.rs
+++ b/vortex-array/src/arrays/primitive/compute/fill_null.rs
@@ -10,15 +10,15 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::match_each_native_ptype;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::fill_null::FillNullKernel;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl FillNullKernel for PrimitiveVTable {
+impl FillNullKernel for Primitive {
     fn fill_null(
         array: &PrimitiveArray,
         fill_value: &Scalar,

--- a/vortex-array/src/arrays/primitive/compute/is_constant.rs
+++ b/vortex-array/src/arrays/primitive/compute/is_constant.rs
@@ -3,8 +3,8 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
 use crate::compute::IsConstantOpts;
@@ -21,7 +21,7 @@ cfg_if::cfg_if! {
     }
 }
 
-impl IsConstantKernel for PrimitiveVTable {
+impl IsConstantKernel for Primitive {
     fn is_constant(
         &self,
         array: &PrimitiveArray,
@@ -41,7 +41,7 @@ impl IsConstantKernel for PrimitiveVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(PrimitiveVTable).lift());
+register_kernel!(IsConstantKernelAdapter(Primitive).lift());
 
 /// Assumes any floating point has been cast into its bit representation for which != and !is_eq are the same
 /// Assumes there's at least 1 value in the slice, which is an invariant of the entry level function.

--- a/vortex-array/src/arrays/primitive/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/primitive/compute/is_sorted.rs
@@ -5,8 +5,8 @@ use itertools::Itertools;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::compute::IsSortedIteratorExt;
 use crate::compute::IsSortedKernel;
 use crate::compute::IsSortedKernelAdapter;
@@ -14,7 +14,7 @@ use crate::dtype::NativePType;
 use crate::match_each_native_ptype;
 use crate::register_kernel;
 
-impl IsSortedKernel for PrimitiveVTable {
+impl IsSortedKernel for Primitive {
     fn is_sorted(&self, array: &PrimitiveArray) -> VortexResult<Option<bool>> {
         match_each_native_ptype!(array.ptype(), |P| {
             compute_is_sorted::<P>(array, false).map(Some)
@@ -28,7 +28,7 @@ impl IsSortedKernel for PrimitiveVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(PrimitiveVTable).lift());
+register_kernel!(IsSortedKernelAdapter(Primitive).lift());
 
 #[derive(Copy, Clone)]
 struct ComparablePrimitive<T: NativePType>(T);

--- a/vortex-array/src/arrays/primitive/compute/mask.rs
+++ b/vortex-array/src/arrays/primitive/compute/mask.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl MaskReduce for PrimitiveVTable {
+impl MaskReduce for Primitive {
     fn mask(array: &PrimitiveArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         // SAFETY: validity and data buffer still have same length
         Ok(Some(unsafe {

--- a/vortex-array/src/arrays/primitive/compute/min_max.rs
+++ b/vortex-array/src/arrays/primitive/compute/min_max.rs
@@ -5,8 +5,8 @@ use itertools::Itertools;
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
@@ -17,7 +17,7 @@ use crate::register_kernel;
 use crate::scalar::PValue;
 use crate::scalar::Scalar;
 
-impl MinMaxKernel for PrimitiveVTable {
+impl MinMaxKernel for Primitive {
     fn min_max(&self, array: &PrimitiveArray) -> VortexResult<Option<MinMaxResult>> {
         match_each_native_ptype!(array.ptype(), |T| {
             compute_min_max_with_validity::<T>(array)
@@ -25,7 +25,7 @@ impl MinMaxKernel for PrimitiveVTable {
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(PrimitiveVTable).lift());
+register_kernel!(MinMaxKernelAdapter(Primitive).lift());
 
 #[inline]
 fn compute_min_max_with_validity<T>(array: &PrimitiveArray) -> VortexResult<Option<MinMaxResult>>

--- a/vortex-array/src/arrays/primitive/compute/nan_count.rs
+++ b/vortex-array/src/arrays/primitive/compute/nan_count.rs
@@ -4,15 +4,15 @@
 use vortex_error::VortexResult;
 use vortex_mask::Mask;
 
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::compute::NaNCountKernel;
 use crate::compute::NaNCountKernelAdapter;
 use crate::dtype::NativePType;
 use crate::match_each_float_ptype;
 use crate::register_kernel;
 
-impl NaNCountKernel for PrimitiveVTable {
+impl NaNCountKernel for Primitive {
     fn nan_count(&self, array: &PrimitiveArray) -> VortexResult<usize> {
         Ok(match_each_float_ptype!(array.ptype(), |F| {
             compute_nan_count_with_validity(array.as_slice::<F>(), array.validity_mask()?)
@@ -20,7 +20,7 @@ impl NaNCountKernel for PrimitiveVTable {
     }
 }
 
-register_kernel!(NaNCountKernelAdapter(PrimitiveVTable).lift());
+register_kernel!(NaNCountKernelAdapter(Primitive).lift());
 
 #[inline]
 fn compute_nan_count_with_validity<T: NativePType>(values: &[T], validity: Mask) -> usize {

--- a/vortex-array/src/arrays/primitive/compute/rules.rs
+++ b/vortex-array/src/arrays/primitive/compute/rules.rs
@@ -5,20 +5,20 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Masked;
 use crate::arrays::MaskedArray;
-use crate::arrays::MaskedVTable;
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ArrayParentReduceRule;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 use crate::vtable::ValidityHelper;
 
-pub(crate) const RULES: ParentRuleSet<PrimitiveVTable> = ParentRuleSet::new(&[
+pub(crate) const RULES: ParentRuleSet<Primitive> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&PrimitiveMaskedValidityRule),
-    ParentRuleSet::lift(&MaskReduceAdaptor(PrimitiveVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(PrimitiveVTable)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(Primitive)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(Primitive)),
 ]);
 
 /// Rule to push down validity masking from MaskedArray parent into PrimitiveArray child.
@@ -28,8 +28,8 @@ pub(crate) const RULES: ParentRuleSet<PrimitiveVTable> = ParentRuleSet::new(&[
 #[derive(Default, Debug)]
 pub struct PrimitiveMaskedValidityRule;
 
-impl ArrayParentReduceRule<PrimitiveVTable> for PrimitiveMaskedValidityRule {
-    type Parent = MaskedVTable;
+impl ArrayParentReduceRule<Primitive> for PrimitiveMaskedValidityRule {
+    type Parent = Masked;
 
     fn reduce_parent(
         &self,

--- a/vortex-array/src/arrays/primitive/compute/slice.rs
+++ b/vortex-array/src/arrays/primitive/compute/slice.rs
@@ -7,14 +7,14 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::arrays::slice::SliceReduce;
 use crate::dtype::NativePType;
 use crate::match_each_native_ptype;
 use crate::vtable::ValidityHelper;
 
-impl SliceReduce for PrimitiveVTable {
+impl SliceReduce for Primitive {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let result = match_each_native_ptype!(array.ptype(), |T| {
             PrimitiveArray::from_buffer_handle(

--- a/vortex-array/src/arrays/primitive/compute/sum.rs
+++ b/vortex-array/src/arrays/primitive/compute/sum.rs
@@ -10,8 +10,8 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_mask::AllOr;
 
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::compute::SumKernel;
 use crate::compute::SumKernelAdapter;
 use crate::dtype::NativePType;
@@ -20,7 +20,7 @@ use crate::match_each_native_ptype;
 use crate::register_kernel;
 use crate::scalar::Scalar;
 
-impl SumKernel for PrimitiveVTable {
+impl SumKernel for Primitive {
     fn sum(&self, array: &PrimitiveArray, accumulator: &Scalar) -> VortexResult<Scalar> {
         let array_sum_scalar = match array.validity_mask()?.bit_buffer() {
             AllOr::All => {
@@ -90,7 +90,7 @@ impl SumKernel for PrimitiveVTable {
     }
 }
 
-register_kernel!(SumKernelAdapter(PrimitiveVTable).lift());
+register_kernel!(SumKernelAdapter(Primitive).lift());
 
 fn sum_integer<T: NativePType + ToPrimitive, R: NativePType + CheckedAdd>(
     values: &[T],

--- a/vortex-array/src/arrays/primitive/compute/take/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/mod.rs
@@ -17,8 +17,8 @@ use vortex_error::vortex_bail;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
 use crate::arrays::dict::TakeExecute;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
@@ -80,7 +80,7 @@ impl TakeImpl for TakeKernelScalar {
     }
 }
 
-impl TakeExecute for PrimitiveVTable {
+impl TakeExecute for Primitive {
     fn take(
         array: &PrimitiveArray,
         indices: &ArrayRef,

--- a/vortex-array/src/arrays/primitive/mod.rs
+++ b/vortex-array/src/arrays/primitive/mod.rs
@@ -13,7 +13,7 @@ pub use compute::compute_is_constant;
 
 mod vtable;
 pub use compute::rules::PrimitiveMaskedValidityRule;
-pub use vtable::PrimitiveVTable;
+pub use vtable::Primitive;
 
 mod native_value;
 pub use native_value::NativeValue;

--- a/vortex-array/src/arrays/primitive/vtable/kernel.rs
+++ b/vortex-array/src/arrays/primitive/vtable/kernel.rs
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::PrimitiveVTable;
+use crate::arrays::Primitive;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::kernel::ParentKernelSet;
 use crate::scalar_fn::fns::between::BetweenExecuteAdaptor;
 use crate::scalar_fn::fns::cast::CastExecuteAdaptor;
 use crate::scalar_fn::fns::fill_null::FillNullExecuteAdaptor;
 
-pub(super) const PARENT_KERNELS: ParentKernelSet<PrimitiveVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&BetweenExecuteAdaptor(PrimitiveVTable)),
-    ParentKernelSet::lift(&CastExecuteAdaptor(PrimitiveVTable)),
-    ParentKernelSet::lift(&FillNullExecuteAdaptor(PrimitiveVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(PrimitiveVTable)),
+pub(super) const PARENT_KERNELS: ParentKernelSet<Primitive> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&BetweenExecuteAdaptor(Primitive)),
+    ParentKernelSet::lift(&CastExecuteAdaptor(Primitive)),
+    ParentKernelSet::lift(&FillNullExecuteAdaptor(Primitive)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(Primitive)),
 ]);

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -43,7 +43,7 @@ use crate::vtable::ArrayId;
 
 vtable!(Primitive);
 
-impl VTable for PrimitiveVTable {
+impl VTable for Primitive {
     type Array = PrimitiveArray;
 
     type Metadata = EmptyMetadata;
@@ -222,8 +222,8 @@ impl VTable for PrimitiveVTable {
 }
 
 #[derive(Debug)]
-pub struct PrimitiveVTable;
+pub struct Primitive;
 
-impl PrimitiveVTable {
+impl Primitive {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.primitive");
 }

--- a/vortex-array/src/arrays/primitive/vtable/operations.rs
+++ b/vortex-array/src/arrays/primitive/vtable/operations.rs
@@ -3,13 +3,13 @@
 
 use vortex_error::VortexResult;
 
-use crate::arrays::PrimitiveVTable;
+use crate::arrays::Primitive;
 use crate::arrays::primitive::vtable::PrimitiveArray;
 use crate::match_each_native_ptype;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<PrimitiveVTable> for PrimitiveVTable {
+impl OperationsVTable<Primitive> for Primitive {
     fn scalar_at(array: &PrimitiveArray, index: usize) -> VortexResult<Scalar> {
         Ok(match_each_native_ptype!(array.ptype(), |T| {
             Scalar::primitive(array.as_slice::<T>()[index], array.dtype().nullability())

--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -12,10 +12,10 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
+use crate::arrays::Filter;
 use crate::arrays::FilterArray;
-use crate::arrays::FilterVTable;
 use crate::arrays::ScalarFnArray;
 use crate::arrays::ScalarFnVTable;
 use crate::arrays::StructArray;
@@ -73,7 +73,7 @@ impl ArrayReduceRule<ScalarFnVTable> for ScalarFnPackToStructRule {
 struct ScalarFnConstantRule;
 impl ArrayReduceRule<ScalarFnVTable> for ScalarFnConstantRule {
     fn reduce(&self, array: &ScalarFnArray) -> VortexResult<Option<ArrayRef>> {
-        if !array.children.iter().all(|c| c.is::<ConstantVTable>()) {
+        if !array.children.iter().all(|c| c.is::<Constant>()) {
             return Ok(None);
         }
         if array.is_empty() {
@@ -183,7 +183,7 @@ impl ReduceCtx for ArrayReduceCtx {
 struct ScalarFnUnaryFilterPushDownRule;
 
 impl ArrayParentReduceRule<ScalarFnVTable> for ScalarFnUnaryFilterPushDownRule {
-    type Parent = FilterVTable;
+    type Parent = Filter;
 
     fn reduce_parent(
         &self,
@@ -196,14 +196,14 @@ impl ArrayParentReduceRule<ScalarFnVTable> for ScalarFnUnaryFilterPushDownRule {
         if child
             .children
             .iter()
-            .filter(|c| !c.is::<ConstantVTable>())
+            .filter(|c| !c.is::<Constant>())
             .count()
             == 1
         {
             let new_children: Vec<_> = child
                 .children
                 .iter()
-                .map(|c| match c.as_opt::<ConstantVTable>() {
+                .map(|c| match c.as_opt::<Constant>() {
                     Some(array) => {
                         Ok(ConstantArray::new(array.scalar().clone(), parent.len()).into_array())
                     }

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -45,7 +45,7 @@ use crate::vtable;
 use crate::vtable::ArrayId;
 use crate::vtable::VTable;
 
-vtable!(ScalarFn);
+vtable!(ScalarFn, ScalarFnVTable);
 
 #[derive(Clone, Debug)]
 pub struct ScalarFnVTable;

--- a/vortex-array/src/arrays/shared/mod.rs
+++ b/vortex-array/src/arrays/shared/mod.rs
@@ -5,7 +5,7 @@ mod array;
 mod vtable;
 
 pub use array::SharedArray;
-pub use vtable::SharedVTable;
+pub use vtable::Shared;
 
 #[cfg(test)]
 mod tests;

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -33,13 +33,13 @@ vtable!(Shared);
 // TODO(ngates): consider hooking Shared into the iterative execution model. Cache either the
 //  most executed, or after each iteration, and return a shared cache for each execution.
 #[derive(Debug)]
-pub struct SharedVTable;
+pub struct Shared;
 
-impl SharedVTable {
+impl Shared {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.shared");
 }
 
-impl VTable for SharedVTable {
+impl VTable for Shared {
     type Array = SharedArray;
     type Metadata = EmptyMetadata;
     type OperationsVTable = Self;
@@ -151,13 +151,13 @@ impl VTable for SharedVTable {
             .map(ExecutionStep::Done)
     }
 }
-impl OperationsVTable<SharedVTable> for SharedVTable {
+impl OperationsVTable<Shared> for Shared {
     fn scalar_at(array: &SharedArray, index: usize) -> VortexResult<Scalar> {
         array.current_array_ref().scalar_at(index)
     }
 }
 
-impl ValidityVTable<SharedVTable> for SharedVTable {
+impl ValidityVTable<Shared> for Shared {
     fn validity(array: &SharedArray) -> VortexResult<Validity> {
         array.current_array_ref().validity()
     }

--- a/vortex-array/src/arrays/slice/mod.rs
+++ b/vortex-array/src/arrays/slice/mod.rs
@@ -71,7 +71,7 @@ impl<V> ArrayParentReduceRule<V> for SliceReduceAdaptor<V>
 where
     V: SliceReduce,
 {
-    type Parent = SliceVTable;
+    type Parent = Slice;
 
     fn reduce_parent(
         &self,
@@ -94,7 +94,7 @@ impl<V> ExecuteParentKernel<V> for SliceExecuteAdaptor<V>
 where
     V: SliceKernel,
 {
-    type Parent = SliceVTable;
+    type Parent = Slice;
 
     fn execute_parent(
         &self,

--- a/vortex-array/src/arrays/slice/rules.rs
+++ b/vortex-array/src/arrays/slice/rules.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::SliceVTable;
+use crate::arrays::Slice;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ParentRuleSet;
 
-pub(super) const PARENT_RULES: ParentRuleSet<SliceVTable> =
-    ParentRuleSet::new(&[ParentRuleSet::lift(&SliceReduceAdaptor(SliceVTable))]);
+pub(super) const PARENT_RULES: ParentRuleSet<Slice> =
+    ParentRuleSet::new(&[ParentRuleSet::lift(&SliceReduceAdaptor(Slice))]);

--- a/vortex-array/src/arrays/slice/slice_.rs
+++ b/vortex-array/src/arrays/slice/slice_.rs
@@ -7,11 +7,11 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Slice;
 use crate::arrays::SliceArray;
-use crate::arrays::SliceVTable;
 use crate::arrays::slice::SliceReduce;
 
-impl SliceReduce for SliceVTable {
+impl SliceReduce for Slice {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let inner_range = array.slice_range();
 

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -40,19 +40,19 @@ use crate::vtable::ValidityVTable;
 vtable!(Slice);
 
 #[derive(Debug)]
-pub struct SliceVTable;
+pub struct Slice;
 
-impl SliceVTable {
+impl Slice {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.slice");
 }
 
-impl VTable for SliceVTable {
+impl VTable for Slice {
     type Array = SliceArray;
     type Metadata = SliceMetadata;
     type OperationsVTable = Self;
     type ValidityVTable = Self;
     fn id(_array: &Self::Array) -> ArrayId {
-        SliceVTable::ID
+        Slice::ID
     }
 
     fn len(array: &SliceArray) -> usize {
@@ -182,13 +182,13 @@ impl VTable for SliceVTable {
         PARENT_RULES.evaluate(array, parent, child_idx)
     }
 }
-impl OperationsVTable<SliceVTable> for SliceVTable {
+impl OperationsVTable<Slice> for Slice {
     fn scalar_at(array: &SliceArray, index: usize) -> VortexResult<Scalar> {
         array.child.scalar_at(array.range.start + index)
     }
 }
 
-impl ValidityVTable<SliceVTable> for SliceVTable {
+impl ValidityVTable<Slice> for Slice {
     fn validity(array: &SliceArray) -> VortexResult<Validity> {
         array.child.validity()?.slice(array.range.clone())
     }

--- a/vortex-array/src/arrays/struct_/compute/cast.rs
+++ b/vortex-array/src/arrays/struct_/compute/cast.rs
@@ -9,15 +9,15 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::cast::CastKernel;
 use crate::vtable::ValidityHelper;
 
-impl CastKernel for StructVTable {
+impl CastKernel for Struct {
     fn cast(
         array: &StructArray,
         dtype: &DType,

--- a/vortex-array/src/arrays/struct_/compute/is_constant.rs
+++ b/vortex-array/src/arrays/struct_/compute/is_constant.rs
@@ -3,15 +3,15 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
 use crate::compute::IsConstantOpts;
 use crate::compute::{self};
 use crate::register_kernel;
 
-impl IsConstantKernel for StructVTable {
+impl IsConstantKernel for Struct {
     fn is_constant(
         &self,
         array: &StructArray,
@@ -35,4 +35,4 @@ impl IsConstantKernel for StructVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(StructVTable).lift());
+register_kernel!(IsConstantKernelAdapter(Struct).lift());

--- a/vortex-array/src/arrays/struct_/compute/mask.rs
+++ b/vortex-array/src/arrays/struct_/compute/mask.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl MaskReduce for StructVTable {
+impl MaskReduce for Struct {
     fn mask(array: &StructArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         StructArray::try_new_with_dtype(
             array.unmasked_fields().clone(),

--- a/vortex-array/src/arrays/struct_/compute/min_max.rs
+++ b/vortex-array/src/arrays/struct_/compute/min_max.rs
@@ -3,18 +3,18 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
 use crate::register_kernel;
 
-impl MinMaxKernel for StructVTable {
+impl MinMaxKernel for Struct {
     fn min_max(&self, _array: &StructArray) -> VortexResult<Option<MinMaxResult>> {
         // TODO(joe): Implement struct min max
         Ok(None)
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(StructVTable).lift());
+register_kernel!(MinMaxKernelAdapter(Struct).lift());

--- a/vortex-array/src/arrays/struct_/compute/rules.rs
+++ b/vortex-array/src/arrays/struct_/compute/rules.rs
@@ -8,8 +8,8 @@ use vortex_error::vortex_err;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
 use crate::arrays::dict::TakeReduceAdaptor;
 use crate::arrays::scalar_fn::ExactScalarFn;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
@@ -26,12 +26,12 @@ use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<StructVTable> = ParentRuleSet::new(&[
+pub(crate) const PARENT_RULES: ParentRuleSet<Struct> = ParentRuleSet::new(&[
     ParentRuleSet::lift(&StructCastPushDownRule),
     ParentRuleSet::lift(&StructGetItemRule),
-    ParentRuleSet::lift(&MaskReduceAdaptor(StructVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(StructVTable)),
-    ParentRuleSet::lift(&TakeReduceAdaptor(StructVTable)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(Struct)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(Struct)),
+    ParentRuleSet::lift(&TakeReduceAdaptor(Struct)),
 ]);
 
 /// Rule to push down cast into struct fields.
@@ -42,7 +42,7 @@ pub(crate) const PARENT_RULES: ParentRuleSet<StructVTable> = ParentRuleSet::new(
 /// at the end of the struct, filled with null values.
 #[derive(Debug)]
 struct StructCastPushDownRule;
-impl ArrayParentReduceRule<StructVTable> for StructCastPushDownRule {
+impl ArrayParentReduceRule<Struct> for StructCastPushDownRule {
     type Parent = ExactScalarFn<Cast>;
 
     fn reduce_parent(
@@ -96,7 +96,7 @@ impl ArrayParentReduceRule<StructVTable> for StructCastPushDownRule {
 /// Rule to flatten get_item from struct by field name
 #[derive(Debug)]
 pub(crate) struct StructGetItemRule;
-impl ArrayParentReduceRule<StructVTable> for StructGetItemRule {
+impl ArrayParentReduceRule<Struct> for StructGetItemRule {
     type Parent = ExactScalarFn<GetItem>;
 
     fn reduce_parent(

--- a/vortex-array/src/arrays/struct_/compute/slice.rs
+++ b/vortex-array/src/arrays/struct_/compute/slice.rs
@@ -8,12 +8,12 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
 use crate::arrays::slice::SliceReduce;
 use crate::vtable::ValidityHelper;
 
-impl SliceReduce for StructVTable {
+impl SliceReduce for Struct {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let fields: Vec<_> = array
             .unmasked_fields()

--- a/vortex-array/src/arrays/struct_/compute/take.rs
+++ b/vortex-array/src/arrays/struct_/compute/take.rs
@@ -6,15 +6,15 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
 use crate::arrays::dict::TakeReduce;
 use crate::builtins::ArrayBuiltins;
 use crate::scalar::Scalar;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl TakeReduce for StructVTable {
+impl TakeReduce for Struct {
     fn take(array: &StructArray, indices: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         // If the struct array is empty then the indices must be all null, otherwise it will access
         // an out of bounds element.

--- a/vortex-array/src/arrays/struct_/compute/zip.rs
+++ b/vortex-array/src/arrays/struct_/compute/zip.rs
@@ -10,21 +10,21 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
 use crate::builtins::ArrayBuiltins;
 use crate::scalar_fn::fns::zip::ZipKernel;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl ZipKernel for StructVTable {
+impl ZipKernel for Struct {
     fn zip(
         if_true: &StructArray,
         if_false: &ArrayRef,
         mask: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let Some(if_false) = if_false.as_opt::<StructVTable>() else {
+        let Some(if_false) = if_false.as_opt::<Struct>() else {
             return Ok(None);
         };
         assert_eq!(

--- a/vortex-array/src/arrays/struct_/mod.rs
+++ b/vortex-array/src/arrays/struct_/mod.rs
@@ -7,7 +7,7 @@ pub use array::StructArrayParts;
 pub(crate) mod compute;
 
 mod vtable;
-pub use vtable::StructVTable;
+pub use vtable::Struct;
 
 #[cfg(test)]
 mod tests;

--- a/vortex-array/src/arrays/struct_/vtable/kernel.rs
+++ b/vortex-array/src/arrays/struct_/vtable/kernel.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::StructVTable;
+use crate::arrays::Struct;
 use crate::kernel::ParentKernelSet;
 use crate::scalar_fn::fns::cast::CastExecuteAdaptor;
 use crate::scalar_fn::fns::zip::ZipExecuteAdaptor;
 
-pub(super) const PARENT_KERNELS: ParentKernelSet<StructVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&CastExecuteAdaptor(StructVTable)),
-    ParentKernelSet::lift(&ZipExecuteAdaptor(StructVTable)),
+pub(super) const PARENT_KERNELS: ParentKernelSet<Struct> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&CastExecuteAdaptor(Struct)),
+    ParentKernelSet::lift(&ZipExecuteAdaptor(Struct)),
 ]);

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -41,7 +41,7 @@ use crate::vtable::ArrayId;
 
 vtable!(Struct);
 
-impl VTable for StructVTable {
+impl VTable for Struct {
     type Array = StructArray;
 
     type Metadata = EmptyMetadata;
@@ -230,8 +230,8 @@ impl VTable for StructVTable {
 }
 
 #[derive(Debug)]
-pub struct StructVTable;
+pub struct Struct;
 
-impl StructVTable {
+impl Struct {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.struct");
 }

--- a/vortex-array/src/arrays/struct_/vtable/operations.rs
+++ b/vortex-array/src/arrays/struct_/vtable/operations.rs
@@ -4,12 +4,12 @@
 use vortex_error::VortexResult;
 
 use crate::DynArray;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<StructVTable> for StructVTable {
+impl OperationsVTable<Struct> for Struct {
     fn scalar_at(array: &StructArray, index: usize) -> VortexResult<Scalar> {
         let field_scalars: VortexResult<Vec<Scalar>> = array
             .unmasked_fields()

--- a/vortex-array/src/arrays/varbin/compute/cast.rs
+++ b/vortex-array/src/arrays/varbin/compute/cast.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
-use crate::arrays::VarBinVTable;
 use crate::dtype::DType;
 use crate::scalar_fn::fns::cast::CastReduce;
 use crate::vtable::ValidityHelper;
 
-impl CastReduce for VarBinVTable {
+impl CastReduce for VarBin {
     fn cast(array: &VarBinArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !array.dtype().eq_ignore_nullability(dtype) {
             return Ok(None);

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -16,8 +16,8 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
-use crate::arrays::VarBinVTable;
 use crate::arrays::VarBinViewArray;
 use crate::arrow::Datum;
 use crate::arrow::from_arrow_array_with_len;
@@ -31,7 +31,7 @@ use crate::scalar_fn::fns::operators::Operator;
 use crate::vtable::ValidityHelper;
 
 // This implementation exists so we can have custom translation of RHS to arrow that's not the same as IntoCanonical
-impl CompareKernel for VarBinVTable {
+impl CompareKernel for VarBin {
     fn compare(
         lhs: &VarBinArray,
         rhs: &ArrayRef,
@@ -115,7 +115,7 @@ impl CompareKernel for VarBinVTable {
             .map_err(|err| vortex_err!("Failed to compare VarBin array: {}", err))?;
 
             Ok(Some(from_arrow_array_with_len(&array, len, nullable)?))
-        } else if !rhs.is::<VarBinVTable>() {
+        } else if !rhs.is::<VarBin>() {
             // NOTE: If the rhs is not a VarBin array it will be canonicalized to a VarBinView
             // Arrow doesn't support comparing VarBin to VarBinView arrays, so we convert ourselves
             // to VarBinView and re-invoke.

--- a/vortex-array/src/arrays/varbin/compute/filter.rs
+++ b/vortex-array/src/arrays/varbin/compute/filter.rs
@@ -15,8 +15,8 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
-use crate::arrays::VarBinVTable;
 use crate::arrays::filter::FilterKernel;
 use crate::arrays::varbin::builder::VarBinBuilder;
 use crate::dtype::DType;
@@ -25,7 +25,7 @@ use crate::match_each_integer_ptype;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl FilterKernel for VarBinVTable {
+impl FilterKernel for VarBin {
     fn filter(
         array: &VarBinArray,
         mask: &Mask,

--- a/vortex-array/src/arrays/varbin/compute/is_constant.rs
+++ b/vortex-array/src/arrays/varbin/compute/is_constant.rs
@@ -4,14 +4,14 @@
 use vortex_error::VortexResult;
 
 use crate::accessor::ArrayAccessor;
+use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
-use crate::arrays::VarBinVTable;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
 use crate::compute::IsConstantOpts;
 use crate::register_kernel;
 
-impl IsConstantKernel for VarBinVTable {
+impl IsConstantKernel for VarBin {
     fn is_constant(
         &self,
         array: &VarBinArray,
@@ -24,7 +24,7 @@ impl IsConstantKernel for VarBinVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(VarBinVTable).lift());
+register_kernel!(IsConstantKernelAdapter(VarBin).lift());
 
 pub(super) fn compute_is_constant(iter: &mut dyn Iterator<Item = Option<&[u8]>>) -> bool {
     let Some(first_value) = iter.next() else {

--- a/vortex-array/src/arrays/varbin/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/varbin/compute/is_sorted.rs
@@ -4,14 +4,14 @@
 use vortex_error::VortexResult;
 
 use crate::accessor::ArrayAccessor;
+use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
-use crate::arrays::VarBinVTable;
 use crate::compute::IsSortedIteratorExt;
 use crate::compute::IsSortedKernel;
 use crate::compute::IsSortedKernelAdapter;
 use crate::register_kernel;
 
-impl IsSortedKernel for VarBinVTable {
+impl IsSortedKernel for VarBin {
     fn is_sorted(&self, array: &VarBinArray) -> VortexResult<Option<bool>> {
         Ok(Some(
             array.with_iterator(|bytes_iter| bytes_iter.is_sorted()),
@@ -25,4 +25,4 @@ impl IsSortedKernel for VarBinVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(VarBinVTable).lift());
+register_kernel!(IsSortedKernelAdapter(VarBin).lift());

--- a/vortex-array/src/arrays/varbin/compute/mask.rs
+++ b/vortex-array/src/arrays/varbin/compute/mask.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
-use crate::arrays::VarBinVTable;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl MaskReduce for VarBinVTable {
+impl MaskReduce for VarBin {
     fn mask(array: &VarBinArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             VarBinArray::try_new(

--- a/vortex-array/src/arrays/varbin/compute/min_max.rs
+++ b/vortex-array/src/arrays/varbin/compute/min_max.rs
@@ -6,8 +6,8 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
 
 use crate::accessor::ArrayAccessor;
+use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
-use crate::arrays::VarBinVTable;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
@@ -16,13 +16,13 @@ use crate::dtype::Nullability::NonNullable;
 use crate::register_kernel;
 use crate::scalar::Scalar;
 
-impl MinMaxKernel for VarBinVTable {
+impl MinMaxKernel for VarBin {
     fn min_max(&self, array: &VarBinArray) -> VortexResult<Option<MinMaxResult>> {
         Ok(varbin_compute_min_max(array, array.dtype()))
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(VarBinVTable).lift());
+register_kernel!(MinMaxKernelAdapter(VarBin).lift());
 
 /// Compute the min and max of VarBin like array.
 pub(crate) fn varbin_compute_min_max<T: ArrayAccessor<[u8]>>(

--- a/vortex-array/src/arrays/varbin/compute/rules.rs
+++ b/vortex-array/src/arrays/varbin/compute/rules.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::VarBinVTable;
+use crate::arrays::VarBin;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::cast::CastReduceAdaptor;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<VarBinVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&CastReduceAdaptor(VarBinVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(VarBinVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(VarBinVTable)),
+pub(crate) const PARENT_RULES: ParentRuleSet<VarBin> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(VarBin)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(VarBin)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(VarBin)),
 ]);

--- a/vortex-array/src/arrays/varbin/compute/slice.rs
+++ b/vortex-array/src/arrays/varbin/compute/slice.rs
@@ -7,17 +7,17 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
-use crate::arrays::VarBinVTable;
 use crate::arrays::slice::SliceReduce;
 
-impl SliceReduce for VarBinVTable {
+impl SliceReduce for VarBin {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
-        VarBinVTable::_slice(array, range).map(Some)
+        VarBin::_slice(array, range).map(Some)
     }
 }
 
-impl VarBinVTable {
+impl VarBin {
     pub fn _slice(array: &VarBinArray, range: Range<usize>) -> VortexResult<ArrayRef> {
         Ok(unsafe {
             VarBinArray::new_unchecked_from_handle(

--- a/vortex-array/src/arrays/varbin/compute/take.rs
+++ b/vortex-array/src/arrays/varbin/compute/take.rs
@@ -12,8 +12,8 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
-use crate::arrays::VarBinVTable;
 use crate::arrays::dict::TakeExecute;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
@@ -21,7 +21,7 @@ use crate::executor::ExecutionCtx;
 use crate::match_each_integer_ptype;
 use crate::validity::Validity;
 
-impl TakeExecute for VarBinVTable {
+impl TakeExecute for VarBin {
     fn take(
         array: &VarBinArray,
         indices: &ArrayRef,

--- a/vortex-array/src/arrays/varbin/mod.rs
+++ b/vortex-array/src/arrays/varbin/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod compute;
 pub(crate) use compute::varbin_compute_min_max;
 
 mod vtable;
-pub use vtable::VarBinVTable;
+pub use vtable::VarBin;
 
 pub mod builder;
 

--- a/vortex-array/src/arrays/varbin/vtable/kernel.rs
+++ b/vortex-array/src/arrays/varbin/vtable/kernel.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::VarBinVTable;
+use crate::arrays::VarBin;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::arrays::filter::FilterExecuteAdaptor;
 use crate::kernel::ParentKernelSet;
 use crate::scalar_fn::fns::binary::CompareExecuteAdaptor;
 
-pub(super) const PARENT_KERNELS: ParentKernelSet<VarBinVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&CompareExecuteAdaptor(VarBinVTable)),
-    ParentKernelSet::lift(&FilterExecuteAdaptor(VarBinVTable)),
-    ParentKernelSet::lift(&TakeExecuteAdaptor(VarBinVTable)),
+pub(super) const PARENT_KERNELS: ParentKernelSet<VarBin> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&CompareExecuteAdaptor(VarBin)),
+    ParentKernelSet::lift(&FilterExecuteAdaptor(VarBin)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(VarBin)),
 ]);

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -51,7 +51,7 @@ pub struct VarBinMetadata {
     pub(crate) offsets_ptype: i32,
 }
 
-impl VTable for VarBinVTable {
+impl VTable for VarBin {
     type Array = VarBinArray;
 
     type Metadata = ProstMetadata<VarBinMetadata>;
@@ -227,8 +227,8 @@ impl VTable for VarBinVTable {
 }
 
 #[derive(Debug)]
-pub struct VarBinVTable;
+pub struct VarBin;
 
-impl VarBinVTable {
+impl VarBin {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.varbin");
 }

--- a/vortex-array/src/arrays/varbin/vtable/operations.rs
+++ b/vortex-array/src/arrays/varbin/vtable/operations.rs
@@ -3,13 +3,13 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
-use crate::arrays::VarBinVTable;
 use crate::arrays::varbin::varbin_scalar;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<VarBinVTable> for VarBinVTable {
+impl OperationsVTable<VarBin> for VarBin {
     fn scalar_at(array: &VarBinArray, index: usize) -> VortexResult<Scalar> {
         Ok(varbin_scalar(array.bytes_at(index), array.dtype()))
     }

--- a/vortex-array/src/arrays/varbinview/compute/cast.rs
+++ b/vortex-array/src/arrays/varbinview/compute/cast.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::dtype::DType;
 use crate::scalar_fn::fns::cast::CastReduce;
 use crate::vtable::ValidityHelper;
 
-impl CastReduce for VarBinViewVTable {
+impl CastReduce for VarBinView {
     fn cast(array: &VarBinViewArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
         if !array.dtype().eq_ignore_nullability(dtype) {
             return Ok(None);

--- a/vortex-array/src/arrays/varbinview/compute/is_constant.rs
+++ b/vortex-array/src/arrays/varbinview/compute/is_constant.rs
@@ -4,15 +4,15 @@
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::arrays::varbinview::Ref;
 use crate::compute::IsConstantKernel;
 use crate::compute::IsConstantKernelAdapter;
 use crate::compute::IsConstantOpts;
 use crate::register_kernel;
 
-impl IsConstantKernel for VarBinViewVTable {
+impl IsConstantKernel for VarBinView {
     fn is_constant(
         &self,
         array: &VarBinViewArray,
@@ -60,4 +60,4 @@ impl IsConstantKernel for VarBinViewVTable {
     }
 }
 
-register_kernel!(IsConstantKernelAdapter(VarBinViewVTable).lift());
+register_kernel!(IsConstantKernelAdapter(VarBinView).lift());

--- a/vortex-array/src/arrays/varbinview/compute/is_sorted.rs
+++ b/vortex-array/src/arrays/varbinview/compute/is_sorted.rs
@@ -4,14 +4,14 @@
 use vortex_error::VortexResult;
 
 use crate::accessor::ArrayAccessor;
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::compute::IsSortedIteratorExt;
 use crate::compute::IsSortedKernel;
 use crate::compute::IsSortedKernelAdapter;
 use crate::register_kernel;
 
-impl IsSortedKernel for VarBinViewVTable {
+impl IsSortedKernel for VarBinView {
     fn is_sorted(&self, array: &VarBinViewArray) -> VortexResult<Option<bool>> {
         Ok(Some(
             array.with_iterator(|bytes_iter| bytes_iter.is_sorted()),
@@ -25,4 +25,4 @@ impl IsSortedKernel for VarBinViewVTable {
     }
 }
 
-register_kernel!(IsSortedKernelAdapter(VarBinViewVTable).lift());
+register_kernel!(IsSortedKernelAdapter(VarBinView).lift());

--- a/vortex-array/src/arrays/varbinview/compute/mask.rs
+++ b/vortex-array/src/arrays/varbinview/compute/mask.rs
@@ -5,13 +5,13 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::scalar_fn::fns::mask::MaskReduce;
 use crate::validity::Validity;
 use crate::vtable::ValidityHelper;
 
-impl MaskReduce for VarBinViewVTable {
+impl MaskReduce for VarBinView {
     fn mask(array: &VarBinViewArray, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         // SAFETY: masking the validity does not affect the invariants
         unsafe {

--- a/vortex-array/src/arrays/varbinview/compute/min_max.rs
+++ b/vortex-array/src/arrays/varbinview/compute/min_max.rs
@@ -3,18 +3,18 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::arrays::varbin::varbin_compute_min_max;
 use crate::compute::MinMaxKernel;
 use crate::compute::MinMaxKernelAdapter;
 use crate::compute::MinMaxResult;
 use crate::register_kernel;
 
-impl MinMaxKernel for VarBinViewVTable {
+impl MinMaxKernel for VarBinView {
     fn min_max(&self, array: &VarBinViewArray) -> VortexResult<Option<MinMaxResult>> {
         Ok(varbin_compute_min_max(array, array.dtype()))
     }
 }
 
-register_kernel!(MinMaxKernelAdapter(VarBinViewVTable).lift());
+register_kernel!(MinMaxKernelAdapter(VarBinView).lift());

--- a/vortex-array/src/arrays/varbinview/compute/rules.rs
+++ b/vortex-array/src/arrays/varbinview/compute/rules.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
-use crate::arrays::VarBinViewVTable;
+use crate::arrays::VarBinView;
 use crate::arrays::slice::SliceReduceAdaptor;
 use crate::optimizer::rules::ParentRuleSet;
 use crate::scalar_fn::fns::cast::CastReduceAdaptor;
 use crate::scalar_fn::fns::mask::MaskReduceAdaptor;
 
-pub(crate) const PARENT_RULES: ParentRuleSet<VarBinViewVTable> = ParentRuleSet::new(&[
-    ParentRuleSet::lift(&CastReduceAdaptor(VarBinViewVTable)),
-    ParentRuleSet::lift(&MaskReduceAdaptor(VarBinViewVTable)),
-    ParentRuleSet::lift(&SliceReduceAdaptor(VarBinViewVTable)),
+pub(crate) const PARENT_RULES: ParentRuleSet<VarBinView> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(VarBinView)),
+    ParentRuleSet::lift(&MaskReduceAdaptor(VarBinView)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(VarBinView)),
 ]);

--- a/vortex-array/src/arrays/varbinview/compute/slice.rs
+++ b/vortex-array/src/arrays/varbinview/compute/slice.rs
@@ -8,12 +8,12 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::arrays::slice::SliceReduce;
 use crate::arrays::varbinview::BinaryView;
 
-impl SliceReduce for VarBinViewVTable {
+impl SliceReduce for VarBinView {
     fn slice(array: &Self::Array, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             VarBinViewArray::new_handle(

--- a/vortex-array/src/arrays/varbinview/compute/take.rs
+++ b/vortex-array/src/arrays/varbinview/compute/take.rs
@@ -12,8 +12,8 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::arrays::PrimitiveArray;
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::arrays::dict::TakeExecute;
 use crate::arrays::varbinview::BinaryView;
 use crate::buffer::BufferHandle;
@@ -21,7 +21,7 @@ use crate::executor::ExecutionCtx;
 use crate::match_each_integer_ptype;
 use crate::vtable::ValidityHelper;
 
-impl TakeExecute for VarBinViewVTable {
+impl TakeExecute for VarBinView {
     /// Take involves creating a new array that references the old array, just with the given set of views.
     fn take(
         array: &VarBinViewArray,

--- a/vortex-array/src/arrays/varbinview/compute/zip.rs
+++ b/vortex-array/src/arrays/varbinview/compute/zip.rs
@@ -12,8 +12,8 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::arrays::varbinview::BinaryView;
 use crate::builders::DeduplicatedBuffers;
 use crate::builders::LazyBitBufferBuilder;
@@ -21,14 +21,14 @@ use crate::scalar_fn::fns::zip::ZipKernel;
 
 // A dedicated VarBinView zip kernel that builds the result directly by adjusting views and validity,
 // instead of routing through the generic builder (which would redo buffer lookups per mask slice).
-impl ZipKernel for VarBinViewVTable {
+impl ZipKernel for VarBinView {
     fn zip(
         if_true: &VarBinViewArray,
         if_false: &ArrayRef,
         mask: &ArrayRef,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let Some(if_false) = if_false.as_opt::<VarBinViewVTable>() else {
+        let Some(if_false) = if_false.as_opt::<VarBinView>() else {
             return Ok(None);
         };
 

--- a/vortex-array/src/arrays/varbinview/mod.rs
+++ b/vortex-array/src/arrays/varbinview/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod compact;
 pub(crate) mod compute;
 
 mod vtable;
-pub use vtable::VarBinViewVTable;
+pub use vtable::VarBinView;
 
 pub mod build_views;
 

--- a/vortex-array/src/arrays/varbinview/vtable/kernel.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/kernel.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use crate::arrays::VarBinViewVTable;
+use crate::arrays::VarBinView;
 use crate::arrays::dict::TakeExecuteAdaptor;
 use crate::kernel::ParentKernelSet;
 use crate::scalar_fn::fns::zip::ZipExecuteAdaptor;
 
-pub(super) const PARENT_KERNELS: ParentKernelSet<VarBinViewVTable> = ParentKernelSet::new(&[
-    ParentKernelSet::lift(&TakeExecuteAdaptor(VarBinViewVTable)),
-    ParentKernelSet::lift(&ZipExecuteAdaptor(VarBinViewVTable)),
+pub(super) const PARENT_KERNELS: ParentKernelSet<VarBinView> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&TakeExecuteAdaptor(VarBinView)),
+    ParentKernelSet::lift(&ZipExecuteAdaptor(VarBinView)),
 ]);

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -42,13 +42,13 @@ mod validity;
 vtable!(VarBinView);
 
 #[derive(Debug)]
-pub struct VarBinViewVTable;
+pub struct VarBinView;
 
-impl VarBinViewVTable {
+impl VarBinView {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.varbinview");
 }
 
-impl VTable for VarBinViewVTable {
+impl VTable for VarBinView {
     type Array = VarBinViewArray;
 
     type Metadata = EmptyMetadata;

--- a/vortex-array/src/arrays/varbinview/vtable/operations.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/operations.rs
@@ -3,13 +3,13 @@
 
 use vortex_error::VortexResult;
 
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::arrays::varbin::varbin_scalar;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
-impl OperationsVTable<VarBinViewVTable> for VarBinViewVTable {
+impl OperationsVTable<VarBinView> for VarBinView {
     fn scalar_at(array: &VarBinViewArray, index: usize) -> VortexResult<Scalar> {
         Ok(varbin_scalar(array.bytes_at(index), array.dtype()))
     }

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -680,14 +680,14 @@ mod tests {
 
     use crate::ArrayRef;
     use crate::IntoArray;
-    use crate::arrays::DecimalVTable;
-    use crate::arrays::FixedSizeListVTable;
-    use crate::arrays::ListVTable;
-    use crate::arrays::ListViewVTable;
-    use crate::arrays::PrimitiveVTable;
-    use crate::arrays::StructVTable;
-    use crate::arrays::VarBinVTable;
-    use crate::arrays::VarBinViewVTable;
+    use crate::arrays::Decimal;
+    use crate::arrays::FixedSizeList;
+    use crate::arrays::List;
+    use crate::arrays::ListView;
+    use crate::arrays::Primitive;
+    use crate::arrays::Struct;
+    use crate::arrays::VarBin;
+    use crate::arrays::VarBinView;
     use crate::arrow::FromArrowArray as _;
     use crate::arrow::convert::TemporalArray;
     use crate::dtype::DType;
@@ -709,10 +709,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be PrimitiveArray with I8 ptype
-        let primitive_array = vortex_array.as_::<PrimitiveVTable>();
+        let primitive_array = vortex_array.as_::<Primitive>();
         assert_eq!(primitive_array.ptype(), PType::I8);
 
-        let primitive_array_non_null = vortex_array_non_null.as_::<PrimitiveVTable>();
+        let primitive_array_non_null = vortex_array_non_null.as_::<Primitive>();
         assert_eq!(primitive_array_non_null.ptype(), PType::I8);
     }
 
@@ -728,10 +728,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be PrimitiveArray with I16 ptype
-        let primitive_array = vortex_array.as_::<PrimitiveVTable>();
+        let primitive_array = vortex_array.as_::<Primitive>();
         assert_eq!(primitive_array.ptype(), PType::I16);
 
-        let primitive_array_non_null = vortex_array_non_null.as_::<PrimitiveVTable>();
+        let primitive_array_non_null = vortex_array_non_null.as_::<Primitive>();
         assert_eq!(primitive_array_non_null.ptype(), PType::I16);
     }
 
@@ -747,10 +747,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be PrimitiveArray with I32 ptype
-        let primitive_array = vortex_array.as_::<PrimitiveVTable>();
+        let primitive_array = vortex_array.as_::<Primitive>();
         assert_eq!(primitive_array.ptype(), PType::I32);
 
-        let primitive_array_non_null = vortex_array_non_null.as_::<PrimitiveVTable>();
+        let primitive_array_non_null = vortex_array_non_null.as_::<Primitive>();
         assert_eq!(primitive_array_non_null.ptype(), PType::I32);
     }
 
@@ -766,10 +766,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be PrimitiveArray with I64 ptype
-        let primitive_array = vortex_array.as_::<PrimitiveVTable>();
+        let primitive_array = vortex_array.as_::<Primitive>();
         assert_eq!(primitive_array.ptype(), PType::I64);
 
-        let primitive_array_non_null = vortex_array_non_null.as_::<PrimitiveVTable>();
+        let primitive_array_non_null = vortex_array_non_null.as_::<Primitive>();
         assert_eq!(primitive_array_non_null.ptype(), PType::I64);
     }
 
@@ -785,10 +785,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be PrimitiveArray with U8 ptype
-        let primitive_array = vortex_array.as_::<PrimitiveVTable>();
+        let primitive_array = vortex_array.as_::<Primitive>();
         assert_eq!(primitive_array.ptype(), PType::U8);
 
-        let primitive_array_non_null = vortex_array_non_null.as_::<PrimitiveVTable>();
+        let primitive_array_non_null = vortex_array_non_null.as_::<Primitive>();
         assert_eq!(primitive_array_non_null.ptype(), PType::U8);
     }
 
@@ -804,10 +804,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be PrimitiveArray with U16 ptype
-        let primitive_array = vortex_array.as_::<PrimitiveVTable>();
+        let primitive_array = vortex_array.as_::<Primitive>();
         assert_eq!(primitive_array.ptype(), PType::U16);
 
-        let primitive_array_non_null = vortex_array_non_null.as_::<PrimitiveVTable>();
+        let primitive_array_non_null = vortex_array_non_null.as_::<Primitive>();
         assert_eq!(primitive_array_non_null.ptype(), PType::U16);
     }
 
@@ -823,10 +823,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be PrimitiveArray with U32 ptype
-        let primitive_array = vortex_array.as_::<PrimitiveVTable>();
+        let primitive_array = vortex_array.as_::<Primitive>();
         assert_eq!(primitive_array.ptype(), PType::U32);
 
-        let primitive_array_non_null = vortex_array_non_null.as_::<PrimitiveVTable>();
+        let primitive_array_non_null = vortex_array_non_null.as_::<Primitive>();
         assert_eq!(primitive_array_non_null.ptype(), PType::U32);
     }
 
@@ -842,10 +842,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be PrimitiveArray with U64 ptype
-        let primitive_array = vortex_array.as_::<PrimitiveVTable>();
+        let primitive_array = vortex_array.as_::<Primitive>();
         assert_eq!(primitive_array.ptype(), PType::U64);
 
-        let primitive_array_non_null = vortex_array_non_null.as_::<PrimitiveVTable>();
+        let primitive_array_non_null = vortex_array_non_null.as_::<Primitive>();
         assert_eq!(primitive_array_non_null.ptype(), PType::U64);
     }
 
@@ -871,10 +871,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 2);
 
         // Verify metadata - should be PrimitiveArray with F16 ptype
-        let primitive_array = vortex_array.as_::<PrimitiveVTable>();
+        let primitive_array = vortex_array.as_::<Primitive>();
         assert_eq!(primitive_array.ptype(), PType::F16);
 
-        let primitive_array_non_null = vortex_array_non_null.as_::<PrimitiveVTable>();
+        let primitive_array_non_null = vortex_array_non_null.as_::<Primitive>();
         assert_eq!(primitive_array_non_null.ptype(), PType::F16);
     }
 
@@ -890,10 +890,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be PrimitiveArray with F32 ptype
-        let primitive_array = vortex_array.as_::<PrimitiveVTable>();
+        let primitive_array = vortex_array.as_::<Primitive>();
         assert_eq!(primitive_array.ptype(), PType::F32);
 
-        let primitive_array_non_null = vortex_array_non_null.as_::<PrimitiveVTable>();
+        let primitive_array_non_null = vortex_array_non_null.as_::<Primitive>();
         assert_eq!(primitive_array_non_null.ptype(), PType::F32);
     }
 
@@ -909,10 +909,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be PrimitiveArray with F64 ptype
-        let primitive_array = vortex_array.as_::<PrimitiveVTable>();
+        let primitive_array = vortex_array.as_::<Primitive>();
         assert_eq!(primitive_array.ptype(), PType::F64);
 
-        let primitive_array_non_null = vortex_array_non_null.as_::<PrimitiveVTable>();
+        let primitive_array_non_null = vortex_array_non_null.as_::<Primitive>();
         assert_eq!(primitive_array_non_null.ptype(), PType::F64);
     }
 
@@ -942,11 +942,11 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 3);
 
         // Verify metadata - should be DecimalArray with correct precision and scale
-        let decimal_vortex_array = vortex_array.as_::<DecimalVTable>();
+        let decimal_vortex_array = vortex_array.as_::<Decimal>();
         assert_eq!(decimal_vortex_array.decimal_dtype().precision(), 10);
         assert_eq!(decimal_vortex_array.decimal_dtype().scale(), 2);
 
-        let decimal_vortex_array_non_null = vortex_array_non_null.as_::<DecimalVTable>();
+        let decimal_vortex_array_non_null = vortex_array_non_null.as_::<Decimal>();
         assert_eq!(
             decimal_vortex_array_non_null.decimal_dtype().precision(),
             10
@@ -979,11 +979,11 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 3);
 
         // Verify metadata - should be DecimalArray with correct precision and scale
-        let decimal_vortex_array = vortex_array.as_::<DecimalVTable>();
+        let decimal_vortex_array = vortex_array.as_::<Decimal>();
         assert_eq!(decimal_vortex_array.decimal_dtype().precision(), 38);
         assert_eq!(decimal_vortex_array.decimal_dtype().scale(), 10);
 
-        let decimal_vortex_array_non_null = vortex_array_non_null.as_::<DecimalVTable>();
+        let decimal_vortex_array_non_null = vortex_array_non_null.as_::<Decimal>();
         assert_eq!(
             decimal_vortex_array_non_null.decimal_dtype().precision(),
             38
@@ -1209,10 +1209,10 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be VarBinArray with Utf8 dtype
-        let varbin_array = vortex_array.as_::<VarBinVTable>();
+        let varbin_array = vortex_array.as_::<VarBin>();
         assert_eq!(varbin_array.dtype(), &DType::Utf8(true.into()));
 
-        let varbin_array_non_null = vortex_array_non_null.as_::<VarBinVTable>();
+        let varbin_array_non_null = vortex_array_non_null.as_::<VarBin>();
         assert_eq!(varbin_array_non_null.dtype(), &DType::Utf8(false.into()));
     }
 
@@ -1295,14 +1295,14 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be VarBinViewArray with correct buffer count and dtype
-        let varbin_view_array = vortex_array.as_::<VarBinViewVTable>();
+        let varbin_view_array = vortex_array.as_::<VarBinView>();
         assert_eq!(
             varbin_view_array.buffers().len(),
             arrow_array.data_buffers().len()
         );
         assert_eq!(varbin_view_array.dtype(), &DType::Utf8(true.into()));
 
-        let varbin_view_array_non_null = vortex_array_non_null.as_::<VarBinViewVTable>();
+        let varbin_view_array_non_null = vortex_array_non_null.as_::<VarBinView>();
         assert_eq!(
             varbin_view_array_non_null.buffers().len(),
             arrow_array_non_null.data_buffers().len()
@@ -1335,14 +1335,14 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 4);
 
         // Verify metadata - should be VarBinViewArray with correct buffer count and dtype
-        let varbin_view_array = vortex_array.as_::<VarBinViewVTable>();
+        let varbin_view_array = vortex_array.as_::<VarBinView>();
         assert_eq!(
             varbin_view_array.buffers().len(),
             arrow_array.data_buffers().len()
         );
         assert_eq!(varbin_view_array.dtype(), &DType::Binary(true.into()));
 
-        let varbin_view_array_non_null = vortex_array_non_null.as_::<VarBinViewVTable>();
+        let varbin_view_array_non_null = vortex_array_non_null.as_::<VarBinView>();
         assert_eq!(
             varbin_view_array_non_null.buffers().len(),
             arrow_array_non_null.data_buffers().len()
@@ -1388,7 +1388,7 @@ mod tests {
         assert_eq!(vortex_array.len(), 3);
 
         // Verify metadata - should be StructArray with correct field names
-        let struct_vortex_array = vortex_array.as_::<StructVTable>();
+        let struct_vortex_array = vortex_array.as_::<Struct>();
         assert_eq!(struct_vortex_array.names().len(), 2);
         assert_eq!(struct_vortex_array.names()[0], "field1");
         assert_eq!(struct_vortex_array.names()[1], "field2");
@@ -1409,7 +1409,7 @@ mod tests {
         assert_eq!(vortex_nullable_array.len(), 3);
 
         // Verify metadata for nullable struct
-        let struct_vortex_nullable_array = vortex_nullable_array.as_::<StructVTable>();
+        let struct_vortex_nullable_array = vortex_nullable_array.as_::<Struct>();
         assert_eq!(struct_vortex_nullable_array.names().len(), 2);
         assert_eq!(struct_vortex_nullable_array.names()[0], "field1");
         assert_eq!(struct_vortex_nullable_array.names()[1], "field2");
@@ -1428,8 +1428,8 @@ mod tests {
         assert_eq!(vortex_array.len(), 3);
 
         // Verify metadata - should be ListArray with correct offsets
-        let list_vortex_array = vortex_array.as_::<ListVTable>();
-        let offsets_array = list_vortex_array.offsets().as_::<PrimitiveVTable>();
+        let list_vortex_array = vortex_array.as_::<List>();
+        let offsets_array = list_vortex_array.offsets().as_::<Primitive>();
         assert_eq!(offsets_array.len(), 4); // n+1 offsets for n lists
         assert_eq!(offsets_array.ptype(), PType::I32);
 
@@ -1443,10 +1443,8 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 2);
 
         // Verify metadata for non-nullable list
-        let list_vortex_array_non_null = vortex_array_non_null.as_::<ListVTable>();
-        let offsets_array_non_null = list_vortex_array_non_null
-            .offsets()
-            .as_::<PrimitiveVTable>();
+        let list_vortex_array_non_null = vortex_array_non_null.as_::<List>();
+        let offsets_array_non_null = list_vortex_array_non_null.offsets().as_::<Primitive>();
         assert_eq!(offsets_array_non_null.len(), 3); // n+1 offsets for n lists
         assert_eq!(offsets_array_non_null.ptype(), PType::I32);
     }
@@ -1463,8 +1461,8 @@ mod tests {
         assert_eq!(vortex_array.len(), 3);
 
         // Verify metadata - should be ListArray with correct offsets (I64 for large lists)
-        let list_vortex_array = vortex_array.as_::<ListVTable>();
-        let offsets_array = list_vortex_array.offsets().as_::<PrimitiveVTable>();
+        let list_vortex_array = vortex_array.as_::<List>();
+        let offsets_array = list_vortex_array.offsets().as_::<Primitive>();
         assert_eq!(offsets_array.len(), 4); // n+1 offsets for n lists
         assert_eq!(offsets_array.ptype(), PType::I64); // Large lists use I64 offsets
 
@@ -1478,10 +1476,8 @@ mod tests {
         assert_eq!(vortex_array_non_null.len(), 2);
 
         // Verify metadata for non-nullable large list
-        let list_vortex_array_non_null = vortex_array_non_null.as_::<ListVTable>();
-        let offsets_array_non_null = list_vortex_array_non_null
-            .offsets()
-            .as_::<PrimitiveVTable>();
+        let list_vortex_array_non_null = vortex_array_non_null.as_::<List>();
+        let offsets_array_non_null = list_vortex_array_non_null.offsets().as_::<Primitive>();
         assert_eq!(offsets_array_non_null.len(), 3); // n+1 offsets for n lists
         assert_eq!(offsets_array_non_null.ptype(), PType::I64); // Large lists use I64 offsets
     }
@@ -1513,7 +1509,7 @@ mod tests {
         assert_eq!(vortex_array.len(), 4);
 
         // Verify metadata - should be FixedSizeListArray with correct list size
-        let fsl_vortex_array = vortex_array.as_::<FixedSizeListVTable>();
+        let fsl_vortex_array = vortex_array.as_::<FixedSizeList>();
         assert_eq!(fsl_vortex_array.list_size(), 3);
         assert_eq!(fsl_vortex_array.elements().len(), 12); // 4 lists * 3 elements
 
@@ -1546,7 +1542,7 @@ mod tests {
         assert_eq!(vortex_array_nullable.len(), 3);
 
         // Verify metadata for nullable array
-        let fsl_vortex_array_nullable = vortex_array_nullable.as_::<FixedSizeListVTable>();
+        let fsl_vortex_array_nullable = vortex_array_nullable.as_::<FixedSizeList>();
         assert_eq!(fsl_vortex_array_nullable.list_size(), 3);
         assert_eq!(fsl_vortex_array_nullable.elements().len(), 9); // 3 lists * 3 elements
     }
@@ -1585,9 +1581,9 @@ mod tests {
         assert_eq!(vortex_array.len(), 4);
 
         // Verify metadata - should be ListViewArray with correct offsets and sizes
-        let list_view_vortex_array = vortex_array.as_::<ListViewVTable>();
-        let offsets_array = list_view_vortex_array.offsets().as_::<PrimitiveVTable>();
-        let sizes_array = list_view_vortex_array.sizes().as_::<PrimitiveVTable>();
+        let list_view_vortex_array = vortex_array.as_::<ListView>();
+        let offsets_array = list_view_vortex_array.offsets().as_::<Primitive>();
+        let sizes_array = list_view_vortex_array.sizes().as_::<Primitive>();
 
         assert_eq!(offsets_array.len(), 4);
         assert_eq!(offsets_array.ptype(), PType::I32);
@@ -1627,13 +1623,9 @@ mod tests {
         assert_eq!(large_vortex_array.len(), 4);
 
         // Verify metadata for large ListView
-        let large_list_view_vortex_array = large_vortex_array.as_::<ListViewVTable>();
-        let large_offsets_array = large_list_view_vortex_array
-            .offsets()
-            .as_::<PrimitiveVTable>();
-        let large_sizes_array = large_list_view_vortex_array
-            .sizes()
-            .as_::<PrimitiveVTable>();
+        let large_list_view_vortex_array = large_vortex_array.as_::<ListView>();
+        let large_offsets_array = large_list_view_vortex_array.offsets().as_::<Primitive>();
+        let large_sizes_array = large_list_view_vortex_array.sizes().as_::<Primitive>();
 
         assert_eq!(large_offsets_array.len(), 4);
         assert_eq!(large_offsets_array.ptype(), PType::I64); // Large ListView uses I64 offsets

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -12,8 +12,8 @@ use vortex_error::vortex_panic;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::arrow::FromArrowArray;
 use crate::arrow::IntoArrowArray;
 
@@ -27,7 +27,7 @@ pub struct Datum {
 impl Datum {
     /// Create a new [`Datum`] from an [`ArrayRef`], which can then be passed to Arrow compute.
     pub fn try_new(array: &ArrayRef) -> VortexResult<Self> {
-        if array.is::<ConstantVTable>() {
+        if array.is::<Constant>() {
             Ok(Self {
                 array: array.slice(0..1)?.into_arrow_preferred()?,
                 is_scalar: true,
@@ -53,7 +53,7 @@ impl Datum {
         array: &ArrayRef,
         target_datatype: &DataType,
     ) -> VortexResult<Self> {
-        if array.is::<ConstantVTable>() {
+        if array.is::<Constant>() {
             Ok(Self {
                 array: array.slice(0..1)?.into_arrow(target_datatype)?,
                 is_scalar: true,

--- a/vortex-array/src/arrow/executor/byte.rs
+++ b/vortex-array/src/arrow/executor/byte.rs
@@ -14,8 +14,8 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
+use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
-use crate::arrays::VarBinVTable;
 use crate::arrays::VarBinViewArray;
 use crate::arrow::byte_view::execute_varbinview_to_arrow;
 use crate::arrow::executor::validity::to_arrow_null_buffer;
@@ -34,7 +34,7 @@ where
     T::Offset: NativePType,
 {
     // If the Vortex array is already in VarBin format, we can directly convert it.
-    if let Some(array) = array.as_opt::<VarBinVTable>() {
+    if let Some(array) = array.as_opt::<VarBin>() {
         return varbin_to_byte_array::<T>(array, ctx);
     }
 

--- a/vortex-array/src/arrow/executor/dictionary.rs
+++ b/vortex-array/src/arrow/executor/dictionary.rs
@@ -17,10 +17,10 @@ use vortex_error::vortex_bail;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
+use crate::arrays::Dict;
 use crate::arrays::DictArray;
-use crate::arrays::DictVTable;
 use crate::arrays::dict::DictArrayParts;
 use crate::arrow::ArrowArrayExecutor;
 
@@ -30,11 +30,11 @@ pub(super) fn to_arrow_dictionary(
     values_type: &DataType,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
-    let array = match array.try_into::<DictVTable>() {
+    let array = match array.try_into::<Dict>() {
         Ok(dict) => return dict_to_dict(dict, codes_type, values_type, ctx),
         Err(array) => array,
     };
-    let array = match array.try_into::<ConstantVTable>() {
+    let array = match array.try_into::<Constant>() {
         Ok(constant) => return constant_to_dict(constant, codes_type, values_type, ctx),
         Err(array) => array,
     };

--- a/vortex-array/src/arrow/executor/fixed_size_list.rs
+++ b/vortex-array/src/arrow/executor/fixed_size_list.rs
@@ -9,8 +9,8 @@ use vortex_error::vortex_ensure;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::arrays::FixedSizeList;
 use crate::arrays::FixedSizeListArray;
-use crate::arrays::FixedSizeListVTable;
 use crate::arrow::ArrowArrayExecutor;
 use crate::arrow::executor::validity::to_arrow_null_buffer;
 use crate::vtable::ValidityHelper;
@@ -22,7 +22,7 @@ pub(super) fn to_arrow_fixed_list(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<arrow_array::ArrayRef> {
     // Check for Vortex FixedSizeListArray and convert directly.
-    if let Some(array) = array.as_opt::<FixedSizeListVTable>() {
+    if let Some(array) = array.as_opt::<FixedSizeList>() {
         return list_to_list(array, elements_field, list_size, ctx);
     }
 

--- a/vortex-array/src/arrow/executor/list.rs
+++ b/vortex-array/src/arrow/executor/list.rs
@@ -17,10 +17,10 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::DynArray;
 use crate::ExecutionCtx;
+use crate::arrays::List;
 use crate::arrays::ListArray;
-use crate::arrays::ListVTable;
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::arrays::listview::ListViewArrayParts;
 use crate::arrays::listview::ListViewRebuildMode;
 use crate::arrow::ArrowArrayExecutor;
@@ -38,12 +38,12 @@ pub(super) fn to_arrow_list<O: OffsetSizeTrait + NativePType>(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
     // If the Vortex array is already in List format, we can directly convert it.
-    if let Some(array) = array.as_opt::<ListVTable>() {
+    if let Some(array) = array.as_opt::<List>() {
         return list_to_list::<O>(array, elements_field, ctx);
     }
 
     // If the Vortex array is a ListViewArray, rebuild to ZCTL if needed and convert.
-    let array = match array.try_into::<ListViewVTable>() {
+    let array = match array.try_into::<ListView>() {
         Ok(array) => {
             let zctl = if array.is_zero_copy_to_list() {
                 array

--- a/vortex-array/src/arrow/executor/list_view.rs
+++ b/vortex-array/src/arrow/executor/list_view.rs
@@ -11,8 +11,8 @@ use vortex_error::vortex_ensure;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::listview::ListViewArrayParts;
 use crate::arrow::ArrowArrayExecutor;
@@ -28,7 +28,7 @@ pub(super) fn to_arrow_list_view<O: OffsetSizeTrait + IntegerPType>(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<arrow_array::ArrayRef> {
     // Check for Vortex ListViewArray and convert directly.
-    let array = match array.try_into::<ListViewVTable>() {
+    let array = match array.try_into::<ListView>() {
         Ok(array) => return list_view_to_list_view::<O>(array, elements_field, ctx),
         Err(array) => array,
     };

--- a/vortex-array/src/arrow/executor/mod.rs
+++ b/vortex-array/src/arrow/executor/mod.rs
@@ -31,8 +31,8 @@ use vortex_error::vortex_ensure;
 
 use crate::ArrayRef;
 use crate::DynArray;
-use crate::arrays::ListVTable;
-use crate::arrays::VarBinVTable;
+use crate::arrays::List;
+use crate::arrays::VarBin;
 use crate::arrow::executor::bool::to_arrow_bool;
 use crate::arrow::executor::byte::to_arrow_byte_array;
 use crate::arrow::executor::byte_view::to_arrow_byte_view;
@@ -193,7 +193,7 @@ impl ArrowArrayExecutor for ArrayRef {
 /// - `ListArray`: Uses `List` instead of `ListView`
 fn preferred_arrow_type(array: &ArrayRef) -> VortexResult<DataType> {
     // VarBinArray: use offset-based Binary/Utf8 instead of View types
-    if let Some(varbin) = array.as_opt::<VarBinVTable>() {
+    if let Some(varbin) = array.as_opt::<VarBin>() {
         let offsets_ptype = PType::try_from(varbin.offsets().dtype())?;
         let use_large = matches!(offsets_ptype, PType::I64 | PType::U64);
 
@@ -207,7 +207,7 @@ fn preferred_arrow_type(array: &ArrayRef) -> VortexResult<DataType> {
     }
 
     // ListArray: use List with appropriate offset size
-    if let Some(list) = array.as_opt::<ListVTable>() {
+    if let Some(list) = array.as_opt::<List>() {
         let offsets_ptype = PType::try_from(list.offsets().dtype())?;
         let use_large = matches!(offsets_ptype, PType::I64 | PType::U64);
         // Recursively get the preferred type for elements

--- a/vortex-array/src/arrow/executor/run_end.rs
+++ b/vortex-array/src/arrow/executor/run_end.rs
@@ -23,8 +23,8 @@ use crate::DynArray;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::array::ArrayVisitor;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::arrow::ArrowArrayExecutor;
 
 /// The encoding ID used by `vortex-runend`. We match on this string to avoid a crate dependency.
@@ -48,7 +48,7 @@ pub(super) fn to_arrow_run_end(
     values_type: &Field,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrowArrayRef> {
-    let array = match array.try_into::<ConstantVTable>() {
+    let array = match array.try_into::<Constant>() {
         Ok(constant) => {
             return constant_to_run_end(constant, ends_type, values_type, ctx);
         }

--- a/vortex-array/src/arrow/executor/struct_.rs
+++ b/vortex-array/src/arrow/executor/struct_.rs
@@ -16,10 +16,10 @@ use crate::ArrayRef;
 use crate::DynArray;
 use crate::ExecutionCtx;
 use crate::IntoArray;
-use crate::arrays::ChunkedVTable;
+use crate::arrays::Chunked;
 use crate::arrays::ScalarFnVTable;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
 use crate::arrays::struct_::StructArrayParts;
 use crate::arrow::ArrowArrayExecutor;
 use crate::arrow::executor::validity::to_arrow_null_buffer;
@@ -38,7 +38,7 @@ pub(super) fn to_arrow_struct(
     let len = array.len();
 
     // If the array is chunked, then we invert the chunk-of-struct to struct-of-chunk.
-    let array = match array.try_into::<ChunkedVTable>() {
+    let array = match array.try_into::<Chunked>() {
         Ok(array) => {
             // NOTE(ngates): this currently uses the old into_canonical code path, but we should
             //  just call directly into the swizzle-chunks function.
@@ -47,8 +47,8 @@ pub(super) fn to_arrow_struct(
         Err(array) => array,
     };
 
-    // Attempt to short-circuit if the array is already a StructVTable:
-    let array = match array.try_into::<StructVTable>() {
+    // Attempt to short-circuit if the array is already a Struct:
+    let array = match array.try_into::<Struct>() {
         Ok(array) => {
             let len = array.len();
             let StructArrayParts {

--- a/vortex-array/src/builders/dict/bytes.rs
+++ b/vortex-array/src/builders/dict/bytes.rs
@@ -22,9 +22,9 @@ use crate::DynArray;
 use crate::IntoArray;
 use crate::accessor::ArrayAccessor;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::VarBinVTable;
+use crate::arrays::VarBin;
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::arrays::varbinview::build_views::BinaryView;
 use crate::canonical::ToCanonical;
 use crate::dtype::DType;
@@ -168,9 +168,9 @@ impl<Code: UnsignedPType> DictEncoder for BytesDictBuilder<Code> {
         );
 
         let len = array.len();
-        if let Some(varbinview) = array.as_opt::<VarBinViewVTable>() {
+        if let Some(varbinview) = array.as_opt::<VarBinView>() {
             self.encode_bytes(varbinview, len)
-        } else if let Some(varbin) = array.as_opt::<VarBinVTable>() {
+        } else if let Some(varbin) = array.as_opt::<VarBin>() {
             self.encode_bytes(varbin, len)
         } else {
             // NOTE(aduffy): it is very rare that this path would be taken, only e.g.

--- a/vortex-array/src/builders/dict/mod.rs
+++ b/vortex-array/src/builders/dict/mod.rs
@@ -12,9 +12,9 @@ use crate::DynArray;
 use crate::IntoArray;
 use crate::ToCanonical;
 use crate::arrays::DictArray;
-use crate::arrays::PrimitiveVTable;
-use crate::arrays::VarBinVTable;
-use crate::arrays::VarBinViewVTable;
+use crate::arrays::Primitive;
+use crate::arrays::VarBin;
+use crate::arrays::VarBinView;
 use crate::dtype::PType;
 use crate::match_each_native_ptype;
 
@@ -44,13 +44,13 @@ pub trait DictEncoder: Send {
 }
 
 pub fn dict_encoder(array: &ArrayRef, constraints: &DictConstraints) -> Box<dyn DictEncoder> {
-    let dict_builder: Box<dyn DictEncoder> = if let Some(pa) = array.as_opt::<PrimitiveVTable>() {
+    let dict_builder: Box<dyn DictEncoder> = if let Some(pa) = array.as_opt::<Primitive>() {
         match_each_native_ptype!(pa.ptype(), |P| {
             primitive_dict_builder::<P>(pa.dtype().nullability(), constraints)
         })
-    } else if let Some(vbv) = array.as_opt::<VarBinViewVTable>() {
+    } else if let Some(vbv) = array.as_opt::<VarBinView>() {
         bytes_dict_builder(vbv.dtype().clone(), constraints)
-    } else if let Some(vb) = array.as_opt::<VarBinVTable>() {
+    } else if let Some(vb) = array.as_opt::<VarBin>() {
         bytes_dict_builder(vb.dtype().clone(), constraints)
     } else {
         vortex_panic!("Can only encode primitive or varbin/view arrays")

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -17,24 +17,24 @@ use crate::DynArray;
 use crate::Executable;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
+use crate::arrays::Decimal;
 use crate::arrays::DecimalArray;
-use crate::arrays::DecimalVTable;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
-use crate::arrays::ExtensionVTable;
+use crate::arrays::FixedSizeList;
 use crate::arrays::FixedSizeListArray;
-use crate::arrays::FixedSizeListVTable;
+use crate::arrays::ListView;
 use crate::arrays::ListViewArray;
-use crate::arrays::ListViewVTable;
+use crate::arrays::Null;
 use crate::arrays::NullArray;
-use crate::arrays::NullVTable;
+use crate::arrays::Primitive;
 use crate::arrays::PrimitiveArray;
-use crate::arrays::PrimitiveVTable;
+use crate::arrays::Struct;
 use crate::arrays::StructArray;
-use crate::arrays::StructVTable;
+use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
-use crate::arrays::VarBinViewVTable;
 use crate::arrays::bool::BoolArrayParts;
 use crate::arrays::decimal::DecimalArrayParts;
 use crate::arrays::listview::ListViewArrayParts;
@@ -793,7 +793,7 @@ impl<T: NativePType> Executable for Buffer<T> {
 /// This will panic if the array's dtype is not primitive.
 impl Executable for PrimitiveArray {
     fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        match array.try_into::<PrimitiveVTable>() {
+        match array.try_into::<Primitive>() {
             Ok(primitive) => Ok(primitive),
             Err(array) => Ok(Canonical::execute(array, ctx)?.into_primitive()),
         }
@@ -805,7 +805,7 @@ impl Executable for PrimitiveArray {
 /// This will panic if the array's dtype is not bool.
 impl Executable for BoolArray {
     fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        match array.try_into::<BoolVTable>() {
+        match array.try_into::<Bool>() {
             Ok(bool_array) => Ok(bool_array),
             Err(array) => Ok(Canonical::execute(array, ctx)?.into_bool()),
         }
@@ -831,7 +831,7 @@ impl Executable for BitBuffer {
 /// This will panic if the array's dtype is not null.
 impl Executable for NullArray {
     fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        match array.try_into::<NullVTable>() {
+        match array.try_into::<Null>() {
             Ok(null_array) => Ok(null_array),
             Err(array) => Ok(Canonical::execute(array, ctx)?.into_null()),
         }
@@ -843,7 +843,7 @@ impl Executable for NullArray {
 /// This will panic if the array's dtype is not utf8 or binary.
 impl Executable for VarBinViewArray {
     fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        match array.try_into::<VarBinViewVTable>() {
+        match array.try_into::<VarBinView>() {
             Ok(varbinview) => Ok(varbinview),
             Err(array) => Ok(Canonical::execute(array, ctx)?.into_varbinview()),
         }
@@ -855,7 +855,7 @@ impl Executable for VarBinViewArray {
 /// This will panic if the array's dtype is not an extension type.
 impl Executable for ExtensionArray {
     fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        match array.try_into::<ExtensionVTable>() {
+        match array.try_into::<Extension>() {
             Ok(ext_array) => Ok(ext_array),
             Err(array) => Ok(Canonical::execute(array, ctx)?.into_extension()),
         }
@@ -867,7 +867,7 @@ impl Executable for ExtensionArray {
 /// This will panic if the array's dtype is not decimal.
 impl Executable for DecimalArray {
     fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        match array.try_into::<DecimalVTable>() {
+        match array.try_into::<Decimal>() {
             Ok(decimal) => Ok(decimal),
             Err(array) => Ok(Canonical::execute(array, ctx)?.into_decimal()),
         }
@@ -879,7 +879,7 @@ impl Executable for DecimalArray {
 /// This will panic if the array's dtype is not list.
 impl Executable for ListViewArray {
     fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        match array.try_into::<ListViewVTable>() {
+        match array.try_into::<ListView>() {
             Ok(list) => Ok(list),
             Err(array) => Ok(Canonical::execute(array, ctx)?.into_listview()),
         }
@@ -891,7 +891,7 @@ impl Executable for ListViewArray {
 /// This will panic if the array's dtype is not fixed size list.
 impl Executable for FixedSizeListArray {
     fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        match array.try_into::<FixedSizeListVTable>() {
+        match array.try_into::<FixedSizeList>() {
             Ok(fsl) => Ok(fsl),
             Err(array) => Ok(Canonical::execute(array, ctx)?.into_fixed_size_list()),
         }
@@ -903,7 +903,7 @@ impl Executable for FixedSizeListArray {
 /// This will panic if the array's dtype is not struct.
 impl Executable for StructArray {
     fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
-        match array.try_into::<StructVTable>() {
+        match array.try_into::<Struct>() {
             Ok(struct_array) => Ok(struct_array),
             Err(array) => Ok(Canonical::execute(array, ctx)?.into_struct()),
         }
@@ -962,38 +962,36 @@ impl Matcher for AnyCanonical {
     type Match<'a> = CanonicalView<'a>;
 
     fn matches(array: &dyn DynArray) -> bool {
-        array.is::<NullVTable>()
-            || array.is::<BoolVTable>()
-            || array.is::<PrimitiveVTable>()
-            || array.is::<DecimalVTable>()
-            || array.is::<StructVTable>()
-            || array.is::<ListViewVTable>()
-            || array.is::<FixedSizeListVTable>()
-            || array.is::<VarBinViewVTable>()
-            || array.is::<ExtensionVTable>()
+        array.is::<Null>()
+            || array.is::<Bool>()
+            || array.is::<Primitive>()
+            || array.is::<Decimal>()
+            || array.is::<Struct>()
+            || array.is::<ListView>()
+            || array.is::<FixedSizeList>()
+            || array.is::<VarBinView>()
+            || array.is::<Extension>()
     }
 
     fn try_match<'a>(array: &'a dyn DynArray) -> Option<Self::Match<'a>> {
-        if let Some(a) = array.as_opt::<NullVTable>() {
+        if let Some(a) = array.as_opt::<Null>() {
             Some(CanonicalView::Null(a))
-        } else if let Some(a) = array.as_opt::<BoolVTable>() {
+        } else if let Some(a) = array.as_opt::<Bool>() {
             Some(CanonicalView::Bool(a))
-        } else if let Some(a) = array.as_opt::<PrimitiveVTable>() {
+        } else if let Some(a) = array.as_opt::<Primitive>() {
             Some(CanonicalView::Primitive(a))
-        } else if let Some(a) = array.as_opt::<DecimalVTable>() {
+        } else if let Some(a) = array.as_opt::<Decimal>() {
             Some(CanonicalView::Decimal(a))
-        } else if let Some(a) = array.as_opt::<StructVTable>() {
+        } else if let Some(a) = array.as_opt::<Struct>() {
             Some(CanonicalView::Struct(a))
-        } else if let Some(a) = array.as_opt::<ListViewVTable>() {
+        } else if let Some(a) = array.as_opt::<ListView>() {
             Some(CanonicalView::List(a))
-        } else if let Some(a) = array.as_opt::<FixedSizeListVTable>() {
+        } else if let Some(a) = array.as_opt::<FixedSizeList>() {
             Some(CanonicalView::FixedSizeList(a))
-        } else if let Some(a) = array.as_opt::<VarBinViewVTable>() {
+        } else if let Some(a) = array.as_opt::<VarBinView>() {
             Some(CanonicalView::VarBinView(a))
         } else {
-            array
-                .as_opt::<ExtensionVTable>()
-                .map(CanonicalView::Extension)
+            array.as_opt::<Extension>().map(CanonicalView::Extension)
         }
     }
 }

--- a/vortex-array/src/columnar.rs
+++ b/vortex-array/src/columnar.rs
@@ -12,8 +12,8 @@ use crate::DynArray;
 use crate::Executable;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::dtype::DType;
 use crate::matcher::Matcher;
 use crate::scalar::Scalar;
@@ -71,7 +71,7 @@ impl IntoArray for Columnar {
 impl Executable for Columnar {
     fn execute(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         let result = array.execute_until::<AnyColumnar>(ctx)?;
-        if let Some(constant) = result.as_opt::<ConstantVTable>() {
+        if let Some(constant) = result.as_opt::<Constant>() {
             Ok(Columnar::Constant(constant.clone()))
         } else {
             Ok(Columnar::Canonical(
@@ -103,7 +103,7 @@ impl Matcher for AnyColumnar {
     type Match<'a> = ColumnarView<'a>;
 
     fn try_match<'a>(array: &'a dyn DynArray) -> Option<Self::Match<'a>> {
-        if let Some(constant) = array.as_opt::<ConstantVTable>() {
+        if let Some(constant) = array.as_opt::<Constant>() {
             Some(ColumnarView::Constant(constant))
         } else {
             array.as_opt::<AnyCanonical>().map(ColumnarView::Canonical)

--- a/vortex-array/src/compute/is_constant.rs
+++ b/vortex-array/src/compute/is_constant.rs
@@ -13,8 +13,8 @@ use vortex_error::vortex_err;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray as _;
-use crate::arrays::ConstantVTable;
-use crate::arrays::NullVTable;
+use crate::arrays::Constant;
+use crate::arrays::Null;
 use crate::compute::ComputeFn;
 use crate::compute::ComputeFnVTable;
 use crate::compute::InvocationArgs;
@@ -142,7 +142,7 @@ fn is_constant_impl(
     }
 
     // Constant and null arrays are always constant
-    if array.is::<ConstantVTable>() || array.is::<NullVTable>() {
+    if array.is::<Constant>() || array.is::<Null>() {
         return Ok(Some(true));
     }
 

--- a/vortex-array/src/compute/is_sorted.rs
+++ b/vortex-array/src/compute/is_sorted.rs
@@ -13,8 +13,8 @@ use vortex_error::vortex_err;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray as _;
-use crate::arrays::ConstantVTable;
-use crate::arrays::NullVTable;
+use crate::arrays::Constant;
+use crate::arrays::Null;
 use crate::compute::ComputeFn;
 use crate::compute::ComputeFnVTable;
 use crate::compute::InvocationArgs;
@@ -257,7 +257,7 @@ fn is_sorted_impl(
     }
 
     // Constant and null arrays are always sorted, but not strict sorted.
-    if array.is::<ConstantVTable>() || array.is::<NullVTable>() {
+    if array.is::<Constant>() || array.is::<Null>() {
         return Ok(Some(!strict));
     }
 

--- a/vortex-array/src/compute/min_max.rs
+++ b/vortex-array/src/compute/min_max.rs
@@ -11,7 +11,7 @@ use vortex_error::vortex_bail;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray as _;
-use crate::arrays::ConstantVTable;
+use crate::arrays::Constant;
 use crate::compute::ComputeFn;
 use crate::compute::ComputeFnVTable;
 use crate::compute::InvocationArgs;
@@ -157,8 +157,8 @@ fn min_max_impl(
         return Ok(None);
     }
 
-    if let Some(array) = array.as_opt::<ConstantVTable>() {
-        return ConstantVTable.min_max(array);
+    if let Some(array) = array.as_opt::<Constant>() {
+        return Constant.min_max(array);
     }
 
     let min = array

--- a/vortex-array/src/display/tree.rs
+++ b/vortex-array/src/display/tree.rs
@@ -11,7 +11,7 @@ use vortex_error::VortexExpect as _;
 use crate::ArrayRef;
 use crate::ArrayVisitor;
 use crate::DynArray;
-use crate::arrays::ChunkedVTable;
+use crate::arrays::Chunked;
 use crate::display::DisplayOptions;
 use crate::expr::stats::Stat;
 use crate::expr::stats::StatsProvider;
@@ -164,7 +164,7 @@ impl<'a, 'b: 'a> TreeFormatter<'a, 'b> {
                 .flatten()
                 .unwrap_or(nbytes);
 
-            self.ancestor_sizes.push(if array.is::<ChunkedVTable>() {
+            self.ancestor_sizes.push(if array.is::<Chunked>() {
                 // Treat each chunk as a new root
                 None
             } else {

--- a/vortex-array/src/iter.rs
+++ b/vortex-array/src/iter.rs
@@ -11,8 +11,8 @@ use vortex_error::VortexResult;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Chunked;
 use crate::arrays::ChunkedArray;
-use crate::arrays::ChunkedVTable;
 use crate::dtype::DType;
 use crate::stream::ArrayStream;
 use crate::stream::ArrayStreamAdapter;
@@ -96,7 +96,7 @@ impl dyn DynArray + '_ {
     /// Create an [`ArrayIterator`] over the array.
     pub fn to_array_iterator(&self) -> impl ArrayIterator + 'static {
         let dtype = self.dtype().clone();
-        let iter = if let Some(chunked) = self.as_opt::<ChunkedVTable>() {
+        let iter = if let Some(chunked) = self.as_opt::<Chunked>() {
             ArrayChunkIterator::Chunked(Arc::new(chunked.clone()), 0)
         } else {
             ArrayChunkIterator::Single(Some(self.to_array()))

--- a/vortex-array/src/mask.rs
+++ b/vortex-array/src/mask.rs
@@ -13,7 +13,7 @@ use crate::Executable;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
-use crate::arrays::ConstantVTable;
+use crate::arrays::Constant;
 use crate::columnar::Columnar;
 use crate::dtype::DType;
 
@@ -23,7 +23,7 @@ impl Executable for Mask {
             vortex_bail!("Mask array must have boolean dtype, not {}", array.dtype());
         }
 
-        if let Some(constant) = array.as_opt::<ConstantVTable>() {
+        if let Some(constant) = array.as_opt::<Constant>() {
             let mask_value = constant.scalar().as_bool().value().unwrap_or(false);
             return Ok(Mask::new(array.len(), mask_value));
         }

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -20,8 +20,8 @@ use crate::DynArray;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::ConstantArray;
-use crate::arrays::DecimalVTable;
-use crate::arrays::PrimitiveVTable;
+use crate::arrays::Decimal;
+use crate::arrays::Primitive;
 use crate::builtins::ArrayBuiltins;
 use crate::compute::Options;
 use crate::dtype::DType;
@@ -151,15 +151,14 @@ fn between_canonical(
     }
 
     // Try type-specific kernels
-    if let Some(prim) = arr.as_opt::<PrimitiveVTable>()
+    if let Some(prim) = arr.as_opt::<Primitive>()
         && let Some(result) =
-            <PrimitiveVTable as BetweenKernel>::between(prim, lower, upper, options, ctx)?
+            <Primitive as BetweenKernel>::between(prim, lower, upper, options, ctx)?
     {
         return Ok(result);
     }
-    if let Some(dec) = arr.as_opt::<DecimalVTable>()
-        && let Some(result) =
-            <DecimalVTable as BetweenKernel>::between(dec, lower, upper, options, ctx)?
+    if let Some(dec) = arr.as_opt::<Decimal>()
+        && let Some(result) = <Decimal as BetweenKernel>::between(dec, lower, upper, options, ctx)?
     {
         return Ok(result);
     }

--- a/vortex-array/src/scalar_fn/fns/binary/boolean.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/boolean.rs
@@ -9,8 +9,8 @@ use vortex_error::vortex_err;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::arrow::FromArrowArray;
 use crate::arrow::IntoArrowArray;
 use crate::builtins::ArrayBuiltins;
@@ -67,10 +67,7 @@ fn constant_boolean(
     rhs: &ArrayRef,
     op: Operator,
 ) -> VortexResult<Option<ArrayRef>> {
-    let (Some(lhs), Some(rhs)) = (
-        lhs.as_opt::<ConstantVTable>(),
-        rhs.as_opt::<ConstantVTable>(),
-    ) else {
+    let (Some(lhs), Some(rhs)) = (lhs.as_opt::<Constant>(), rhs.as_opt::<Constant>()) else {
         return Ok(None);
     };
 

--- a/vortex-array/src/scalar_fn/fns/binary/compare.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare.rs
@@ -14,8 +14,8 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::arrays::ScalarFnVTable;
 use crate::arrays::scalar_fn::ExactScalarFn;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
@@ -129,10 +129,8 @@ pub(crate) fn execute_compare(
     }
 
     // Constant-constant fast path
-    if let (Some(lhs_const), Some(rhs_const)) = (
-        lhs.as_opt::<ConstantVTable>(),
-        rhs.as_opt::<ConstantVTable>(),
-    ) {
+    if let (Some(lhs_const), Some(rhs_const)) = (lhs.as_opt::<Constant>(), rhs.as_opt::<Constant>())
+    {
         let result = scalar_cmp(lhs_const.scalar(), rhs_const.scalar(), op);
         return Ok(ConstantArray::new(result, lhs.len()).into_array());
     }

--- a/vortex-array/src/scalar_fn/fns/binary/numeric.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric.rs
@@ -5,8 +5,8 @@ use vortex_error::VortexResult;
 
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::arrow::Datum;
 use crate::arrow::from_arrow_array_with_len;
 use crate::scalar::NumericOperator;
@@ -53,10 +53,7 @@ fn constant_numeric(
     rhs: &ArrayRef,
     op: NumericOperator,
 ) -> VortexResult<Option<ArrayRef>> {
-    let (Some(lhs), Some(rhs)) = (
-        lhs.as_opt::<ConstantVTable>(),
-        rhs.as_opt::<ConstantVTable>(),
-    ) else {
+    let (Some(lhs), Some(rhs)) = (lhs.as_opt::<Constant>(), rhs.as_opt::<Constant>()) else {
         return Ok(None);
     };
 

--- a/vortex-array/src/scalar_fn/fns/cast/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/cast/mod.rs
@@ -18,17 +18,17 @@ use crate::ArrayRef;
 use crate::CanonicalView;
 use crate::ColumnarView;
 use crate::ExecutionCtx;
-use crate::arrays::BoolVTable;
+use crate::arrays::Bool;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
-use crate::arrays::DecimalVTable;
-use crate::arrays::ExtensionVTable;
-use crate::arrays::FixedSizeListVTable;
-use crate::arrays::ListViewVTable;
-use crate::arrays::NullVTable;
-use crate::arrays::PrimitiveVTable;
-use crate::arrays::StructVTable;
-use crate::arrays::VarBinViewVTable;
+use crate::arrays::Decimal;
+use crate::arrays::Extension;
+use crate::arrays::FixedSizeList;
+use crate::arrays::ListView;
+use crate::arrays::Null;
+use crate::arrays::Primitive;
+use crate::arrays::Struct;
+use crate::arrays::VarBinView;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::expr::StatsCatalog;
@@ -205,21 +205,21 @@ fn cast_canonical(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
     match canonical {
-        CanonicalView::Null(a) => <NullVTable as CastReduce>::cast(a, dtype),
-        CanonicalView::Bool(a) => <BoolVTable as CastReduce>::cast(a, dtype),
-        CanonicalView::Primitive(a) => <PrimitiveVTable as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::Decimal(a) => <DecimalVTable as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::VarBinView(a) => <VarBinViewVTable as CastReduce>::cast(a, dtype),
-        CanonicalView::List(a) => <ListViewVTable as CastReduce>::cast(a, dtype),
-        CanonicalView::FixedSizeList(a) => <FixedSizeListVTable as CastReduce>::cast(a, dtype),
-        CanonicalView::Struct(a) => <StructVTable as CastKernel>::cast(a, dtype, ctx),
-        CanonicalView::Extension(a) => <ExtensionVTable as CastReduce>::cast(a, dtype),
+        CanonicalView::Null(a) => <Null as CastReduce>::cast(a, dtype),
+        CanonicalView::Bool(a) => <Bool as CastReduce>::cast(a, dtype),
+        CanonicalView::Primitive(a) => <Primitive as CastKernel>::cast(a, dtype, ctx),
+        CanonicalView::Decimal(a) => <Decimal as CastKernel>::cast(a, dtype, ctx),
+        CanonicalView::VarBinView(a) => <VarBinView as CastReduce>::cast(a, dtype),
+        CanonicalView::List(a) => <ListView as CastReduce>::cast(a, dtype),
+        CanonicalView::FixedSizeList(a) => <FixedSizeList as CastReduce>::cast(a, dtype),
+        CanonicalView::Struct(a) => <Struct as CastKernel>::cast(a, dtype, ctx),
+        CanonicalView::Extension(a) => <Extension as CastReduce>::cast(a, dtype),
     }
 }
 
 /// Cast a constant array by dispatching to its [`CastReduce`] implementation.
 fn cast_constant(array: &ConstantArray, dtype: &DType) -> VortexResult<Option<ArrayRef>> {
-    <ConstantVTable as CastReduce>::cast(array, dtype)
+    <Constant as CastReduce>::cast(array, dtype)
 }
 
 #[cfg(test)]

--- a/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/fill_null/mod.rs
@@ -17,9 +17,9 @@ use crate::ArrayRef;
 use crate::CanonicalView;
 use crate::ColumnarView;
 use crate::ExecutionCtx;
-use crate::arrays::BoolVTable;
-use crate::arrays::DecimalVTable;
-use crate::arrays::PrimitiveVTable;
+use crate::arrays::Bool;
+use crate::arrays::Decimal;
+use crate::arrays::Primitive;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::expr::Expression;
@@ -166,16 +166,14 @@ fn fill_null_canonical(
         return result.execute::<ArrayRef>(ctx);
     }
     match canonical {
-        CanonicalView::Bool(a) => <BoolVTable as FillNullKernel>::fill_null(a, fill_value, ctx)?
+        CanonicalView::Bool(a) => <Bool as FillNullKernel>::fill_null(a, fill_value, ctx)?
             .ok_or_else(|| vortex_err!("FillNullKernel for BoolArray returned None")),
         CanonicalView::Primitive(a) => {
-            <PrimitiveVTable as FillNullKernel>::fill_null(a, fill_value, ctx)?
+            <Primitive as FillNullKernel>::fill_null(a, fill_value, ctx)?
                 .ok_or_else(|| vortex_err!("FillNullKernel for PrimitiveArray returned None"))
         }
-        CanonicalView::Decimal(a) => {
-            <DecimalVTable as FillNullKernel>::fill_null(a, fill_value, ctx)?
-                .ok_or_else(|| vortex_err!("FillNullKernel for DecimalArray returned None"))
-        }
+        CanonicalView::Decimal(a) => <Decimal as FillNullKernel>::fill_null(a, fill_value, ctx)?
+            .ok_or_else(|| vortex_err!("FillNullKernel for DecimalArray returned None")),
         other => vortex_bail!(
             "No FillNullKernel for canonical array {}",
             other.as_ref().encoding_id()

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -22,8 +22,8 @@ use crate::DynArray;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::scalar_fn::ScalarFnArrayExt;
@@ -278,7 +278,7 @@ fn list_contains_scalar(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     // If the list array is constant, we perform a single comparison.
-    if array.len() > 1 && array.is::<ConstantVTable>() {
+    if array.len() > 1 && array.is::<Constant>() {
         let contains = list_contains_scalar(&array.slice(0..1)?, value, nullability, ctx)?;
         return Ok(ConstantArray::new(contains.scalar_at(0)?, array.len()).into_array());
     }
@@ -455,8 +455,8 @@ mod tests {
     use crate::ArrayRef;
     use crate::DynArray;
     use crate::IntoArray;
+    use crate::arrays::List;
     use crate::arrays::ListArray;
-    use crate::arrays::ListVTable;
     use crate::arrays::VarBinArray;
     use crate::assert_arrays_eq;
     use crate::canonical::ToCanonical;
@@ -480,8 +480,8 @@ mod tests {
     use crate::expr::stats::Stat;
     use crate::scalar::Scalar;
     use crate::scalar_fn::fns::list_contains::BoolArray;
+    use crate::scalar_fn::fns::list_contains::Constant;
     use crate::scalar_fn::fns::list_contains::ConstantArray;
-    use crate::scalar_fn::fns::list_contains::ConstantVTable;
     use crate::scalar_fn::fns::list_contains::ListViewArray;
     use crate::scalar_fn::fns::list_contains::PrimitiveArray;
     use crate::validity::Validity;
@@ -694,7 +694,7 @@ mod tests {
     fn nonnull_strings(values: Vec<Vec<&str>>) -> ArrayRef {
         ListArray::from_iter_slow::<u64, _>(values, Arc::new(DType::Utf8(Nullability::NonNullable)))
             .unwrap()
-            .as_::<ListVTable>()
+            .as_::<List>()
             .to_listview()
             .into_array()
     }
@@ -800,7 +800,7 @@ mod tests {
 
         let expr = list_contains(root(), lit(2i32));
         let contains = list_array.apply(&expr).unwrap();
-        assert!(contains.is::<ConstantVTable>(), "Expected constant result");
+        assert!(contains.is::<Constant>(), "Expected constant result");
         let expected = BoolArray::from_iter([true, true]);
         assert_arrays_eq!(contains, expected);
     }
@@ -818,7 +818,7 @@ mod tests {
 
         let expr = list_contains(root(), lit(2i32));
         let contains = list_array.apply(&expr).unwrap();
-        assert!(contains.is::<ConstantVTable>(), "Expected constant result");
+        assert!(contains.is::<Constant>(), "Expected constant result");
 
         let expected = BoolArray::new(
             [false, false, false, false, false].into_iter().collect(),

--- a/vortex-array/src/scalar_fn/fns/mask/kernel.rs
+++ b/vortex-array/src/scalar_fn/fns/mask/kernel.rs
@@ -6,7 +6,7 @@ use vortex_error::vortex_err;
 
 use crate::ArrayRef;
 use crate::ExecutionCtx;
-use crate::arrays::BoolVTable;
+use crate::arrays::Bool;
 use crate::arrays::scalar_fn::ExactScalarFn;
 use crate::arrays::scalar_fn::ScalarFnArrayView;
 use crate::kernel::ExecuteParentKernel;
@@ -74,7 +74,7 @@ where
         let mask_child = parent
             .nth_child(1)
             .ok_or_else(|| vortex_err!("Mask expression must have 2 children"))?;
-        if mask_child.as_opt::<BoolVTable>().is_none() {
+        if mask_child.as_opt::<Bool>().is_none() {
             return Ok(None);
         };
         <V as MaskReduce>::mask(array, &mask_child)

--- a/vortex-array/src/scalar_fn/fns/mask/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/mask/mod.rs
@@ -15,8 +15,8 @@ use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::BoolArray;
+use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
-use crate::arrays::ConstantVTable;
 use crate::arrays::masked::mask_validity_canonical;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
@@ -153,7 +153,7 @@ impl ScalarFnVTable for Mask {
 fn execute_constant(input: &ArrayRef, mask_array: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
     let len = input.len();
 
-    if let Some(constant_mask) = mask_array.as_opt::<ConstantVTable>() {
+    if let Some(constant_mask) = mask_array.as_opt::<Constant>() {
         let mask_value = constant_mask.scalar().as_bool().value().unwrap_or(false);
         return if mask_value {
             input.cast(input.dtype().as_nullable()).map(Some)
@@ -164,7 +164,7 @@ fn execute_constant(input: &ArrayRef, mask_array: &ArrayRef) -> VortexResult<Opt
         };
     }
 
-    if let Some(constant_input) = input.as_opt::<ConstantVTable>()
+    if let Some(constant_input) = input.as_opt::<Constant>()
         && constant_input.scalar().is_null()
     {
         return Ok(Some(

--- a/vortex-array/src/scalar_fn/fns/not/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/not/mod.rs
@@ -14,8 +14,8 @@ use crate::ArrayRef;
 use crate::DynArray;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::arrays::Bool;
 use crate::arrays::BoolArray;
-use crate::arrays::BoolVTable;
 use crate::arrays::ConstantArray;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
@@ -102,7 +102,7 @@ impl ScalarFnVTable for Not {
         }
 
         // For boolean array
-        if let Some(bool) = child.as_opt::<BoolVTable>() {
+        if let Some(bool) = child.as_opt::<Bool>() {
             return Ok(BoolArray::new(!bool.to_bit_buffer(), bool.validity()?).into_array());
         }
 

--- a/vortex-array/src/scalar_fn/fns/zip/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/zip/mod.rs
@@ -233,8 +233,8 @@ mod tests {
     use crate::VortexSessionExecute;
     use crate::arrays::ConstantArray;
     use crate::arrays::PrimitiveArray;
+    use crate::arrays::Struct;
     use crate::arrays::StructArray;
-    use crate::arrays::StructVTable;
     use crate::arrays::VarBinViewArray;
     use crate::arrow::IntoArrowArray;
     use crate::assert_arrays_eq;
@@ -346,7 +346,7 @@ mod tests {
         let wrapped_result = mask_array
             .zip(wrapped1, wrapped2)?
             .execute::<ArrayRef>(&mut LEGACY_SESSION.create_execution_ctx())?;
-        assert!(wrapped_result.is::<StructVTable>());
+        assert!(wrapped_result.is::<Struct>());
 
         Ok(())
     }

--- a/vortex-array/src/session/mod.rs
+++ b/vortex-array/src/session/mod.rs
@@ -5,20 +5,20 @@ use vortex_session::Ref;
 use vortex_session::SessionExt;
 use vortex_session::registry::Registry;
 
-use crate::arrays::BoolVTable;
-use crate::arrays::ChunkedVTable;
-use crate::arrays::ConstantVTable;
-use crate::arrays::DecimalVTable;
-use crate::arrays::ExtensionVTable;
-use crate::arrays::FixedSizeListVTable;
-use crate::arrays::ListVTable;
-use crate::arrays::ListViewVTable;
-use crate::arrays::MaskedVTable;
-use crate::arrays::NullVTable;
-use crate::arrays::PrimitiveVTable;
-use crate::arrays::StructVTable;
-use crate::arrays::VarBinVTable;
-use crate::arrays::VarBinViewVTable;
+use crate::arrays::Bool;
+use crate::arrays::Chunked;
+use crate::arrays::Constant;
+use crate::arrays::Decimal;
+use crate::arrays::Extension;
+use crate::arrays::FixedSizeList;
+use crate::arrays::List;
+use crate::arrays::ListView;
+use crate::arrays::Masked;
+use crate::arrays::Null;
+use crate::arrays::Primitive;
+use crate::arrays::Struct;
+use crate::arrays::VarBin;
+use crate::arrays::VarBinView;
 use crate::vtable::ArrayId;
 use crate::vtable::DynVTable;
 
@@ -46,22 +46,22 @@ impl Default for ArraySession {
         let encodings = ArrayRegistry::default();
 
         // Register the canonical encodings.
-        encodings.register(NullVTable::ID, NullVTable);
-        encodings.register(BoolVTable::ID, BoolVTable);
-        encodings.register(PrimitiveVTable::ID, PrimitiveVTable);
-        encodings.register(DecimalVTable::ID, DecimalVTable);
-        encodings.register(VarBinViewVTable::ID, VarBinViewVTable);
-        encodings.register(ListViewVTable::ID, ListViewVTable);
-        encodings.register(FixedSizeListVTable::ID, FixedSizeListVTable);
-        encodings.register(StructVTable::ID, StructVTable);
-        encodings.register(ExtensionVTable::ID, ExtensionVTable);
+        encodings.register(Null::ID, Null);
+        encodings.register(Bool::ID, Bool);
+        encodings.register(Primitive::ID, Primitive);
+        encodings.register(Decimal::ID, Decimal);
+        encodings.register(VarBinView::ID, VarBinView);
+        encodings.register(ListView::ID, ListView);
+        encodings.register(FixedSizeList::ID, FixedSizeList);
+        encodings.register(Struct::ID, Struct);
+        encodings.register(Extension::ID, Extension);
 
         // Register the utility encodings.
-        encodings.register(ChunkedVTable::ID, ChunkedVTable);
-        encodings.register(ConstantVTable::ID, ConstantVTable);
-        encodings.register(MaskedVTable::ID, MaskedVTable);
-        encodings.register(ListVTable::ID, ListVTable);
-        encodings.register(VarBinVTable::ID, VarBinVTable);
+        encodings.register(Chunked::ID, Chunked);
+        encodings.register(Constant::ID, Constant);
+        encodings.register(Masked::ID, Masked);
+        encodings.register(List::ID, List);
+        encodings.register(VarBin::ID, VarBin);
 
         Self {
             registry: encodings,

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -304,38 +304,41 @@ pub fn patches_child_name(idx: usize) -> &'static str {
 #[macro_export]
 macro_rules! vtable {
     ($V:ident) => {
+        $crate::vtable!($V, $V);
+    };
+    ($Base:ident, $VT:ident) => {
         $crate::aliases::paste::paste! {
-            impl AsRef<dyn $crate::DynArray> for [<$V Array>] {
+            impl AsRef<dyn $crate::DynArray> for [<$Base Array>] {
                 fn as_ref(&self) -> &dyn $crate::DynArray {
                     // We can unsafe cast ourselves to an ArrayAdapter.
-                    unsafe { &*(self as *const [<$V Array>] as *const $crate::ArrayAdapter<[<$V VTable>]>) }
+                    unsafe { &*(self as *const [<$Base Array>] as *const $crate::ArrayAdapter<$VT>) }
                 }
             }
 
-            impl std::ops::Deref for [<$V Array>] {
+            impl std::ops::Deref for [<$Base Array>] {
                 type Target = dyn $crate::DynArray;
 
                 fn deref(&self) -> &Self::Target {
                     // We can unsafe cast ourselves to an ArrayAdapter.
-                    unsafe { &*(self as *const [<$V Array>] as *const $crate::ArrayAdapter<[<$V VTable>]>) }
+                    unsafe { &*(self as *const [<$Base Array>] as *const $crate::ArrayAdapter<$VT>) }
                 }
             }
 
-            impl $crate::IntoArray for [<$V Array>] {
+            impl $crate::IntoArray for [<$Base Array>] {
                 fn into_array(self) -> $crate::ArrayRef {
                     // We can unsafe transmute ourselves to an ArrayAdapter.
-                    std::sync::Arc::new(unsafe { std::mem::transmute::<[<$V Array>], $crate::ArrayAdapter::<[<$V VTable>]>>(self) })
+                    std::sync::Arc::new(unsafe { std::mem::transmute::<[<$Base Array>], $crate::ArrayAdapter::<$VT>>(self) })
                 }
             }
 
-            impl From<[<$V Array>]> for $crate::ArrayRef {
-                fn from(value: [<$V Array>]) -> $crate::ArrayRef {
+            impl From<[<$Base Array>]> for $crate::ArrayRef {
+                fn from(value: [<$Base Array>]) -> $crate::ArrayRef {
                     use $crate::IntoArray;
                     value.into_array()
                 }
             }
 
-            impl [<$V Array>] {
+            impl [<$Base Array>] {
                 #[deprecated(note = "use `.into_array()` (owned) or `.clone().into_array()` (ref) to make clones explicit")]
                 pub fn to_array(&self) -> $crate::ArrayRef {
                     use $crate::IntoArray;

--- a/vortex-bench/src/datasets/struct_list_of_ints.rs
+++ b/vortex-bench/src/datasets/struct_list_of_ints.rs
@@ -115,7 +115,7 @@ impl Dataset for StructListOfInts {
             let array = self.to_vortex_array().await?;
 
             // Convert to Arrow RecordBatches and write to parquet
-            let chunked = array.as_::<vortex::array::arrays::ChunkedVTable>();
+            let chunked = array.as_::<vortex::array::arrays::Chunked>();
             let chunks = chunked.chunks();
 
             let file = File::create(&temp_path)?;

--- a/vortex-btrblocks/public-api.lock
+++ b/vortex-btrblocks/public-api.lock
@@ -268,7 +268,7 @@ pub fn vortex_btrblocks::IntegerStats::fmt(&self, f: &mut core::fmt::Formatter<'
 
 impl vortex_btrblocks::CompressorStats for vortex_btrblocks::IntegerStats
 
-pub type vortex_btrblocks::IntegerStats::ArrayVTable = vortex_array::arrays::primitive::vtable::PrimitiveVTable
+pub type vortex_btrblocks::IntegerStats::ArrayVTable = vortex_array::arrays::primitive::vtable::Primitive
 
 pub fn vortex_btrblocks::IntegerStats::generate(input: &<Self::ArrayVTable as vortex_array::vtable::VTable>::Array) -> Self
 
@@ -316,7 +316,7 @@ pub fn vortex_btrblocks::CompressorStats::source(&self) -> &<Self::ArrayVTable a
 
 impl vortex_btrblocks::CompressorStats for vortex_btrblocks::IntegerStats
 
-pub type vortex_btrblocks::IntegerStats::ArrayVTable = vortex_array::arrays::primitive::vtable::PrimitiveVTable
+pub type vortex_btrblocks::IntegerStats::ArrayVTable = vortex_array::arrays::primitive::vtable::Primitive
 
 pub fn vortex_btrblocks::IntegerStats::generate(input: &<Self::ArrayVTable as vortex_array::vtable::VTable>::Array) -> Self
 

--- a/vortex-btrblocks/src/canonical_compressor.rs
+++ b/vortex-btrblocks/src/canonical_compressor.rs
@@ -327,9 +327,9 @@ mod tests {
     use rstest::rstest;
     use vortex_array::DynArray;
     use vortex_array::IntoArray;
-    use vortex_array::arrays::ListVTable;
+    use vortex_array::arrays::List;
+    use vortex_array::arrays::ListView;
     use vortex_array::arrays::ListViewArray;
-    use vortex_array::arrays::ListViewVTable;
     use vortex_array::assert_arrays_eq;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
@@ -365,9 +365,9 @@ mod tests {
         let array_ref = input.clone().into_array();
         let result = BtrBlocksCompressor::default().compress(&array_ref)?;
         if expect_list {
-            assert!(result.as_opt::<ListVTable>().is_some());
+            assert!(result.as_opt::<List>().is_some());
         } else {
-            assert!(result.as_opt::<ListViewVTable>().is_some());
+            assert!(result.as_opt::<ListView>().is_some());
         }
         assert_arrays_eq!(result, input);
         Ok(())

--- a/vortex-btrblocks/src/compressor/float/mod.rs
+++ b/vortex-btrblocks/src/compressor/float/mod.rs
@@ -8,8 +8,8 @@ use std::hash::Hash;
 use std::hash::Hasher;
 
 use enum_iterator::Sequence;
+use vortex_alp::ALP;
 use vortex_alp::ALPArray;
-use vortex_alp::ALPVTable;
 use vortex_alp::RDEncoder;
 use vortex_alp::alp_encode;
 use vortex_array::ArrayRef;
@@ -19,7 +19,7 @@ use vortex_array::ToCanonical;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::MaskedArray;
-use vortex_array::arrays::PrimitiveVTable;
+use vortex_array::arrays::Primitive;
 use vortex_array::arrays::dict::DictArrayParts;
 use vortex_array::dtype::PType;
 use vortex_array::scalar::Scalar;
@@ -27,8 +27,8 @@ use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityHelper;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
+use vortex_sparse::Sparse;
 use vortex_sparse::SparseArray;
-use vortex_sparse::SparseVTable;
 
 use self::dictionary::dictionary_encode;
 pub use self::stats::FloatStats;
@@ -89,7 +89,7 @@ pub struct FloatCompressor<'a> {
 }
 
 impl<'a> Compressor for FloatCompressor<'a> {
-    type ArrayVTable = PrimitiveVTable;
+    type ArrayVTable = Primitive;
     type SchemeType = dyn FloatScheme;
     type StatsType = FloatStats;
 
@@ -321,7 +321,7 @@ impl Scheme for ALPScheme {
         excludes: &[FloatCode],
     ) -> VortexResult<ArrayRef> {
         let alp_encoded = alp_encode(&stats.source().to_primitive(), None)?;
-        let alp = alp_encoded.as_::<ALPVTable>();
+        let alp = alp_encoded.as_::<ALP>();
         let alp_ints = alp.encoded().to_primitive();
 
         // Compress the ALP ints.
@@ -503,7 +503,7 @@ impl Scheme for NullDominated {
         // We pass None as we only run this pathway for NULL-dominated float arrays
         let sparse_encoded = SparseArray::encode(&stats.src.clone().into_array(), None)?;
 
-        if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {
+        if let Some(sparse) = sparse_encoded.as_opt::<Sparse>() {
             // Compress the values
             let new_excludes = [IntSparseScheme.code()];
 
@@ -673,9 +673,9 @@ mod tests {
 #[cfg(test)]
 mod scheme_selection_tests {
 
-    use vortex_alp::ALPVTable;
-    use vortex_array::arrays::ConstantVTable;
-    use vortex_array::arrays::DictVTable;
+    use vortex_alp::ALP;
+    use vortex_array::arrays::Constant;
+    use vortex_array::arrays::Dict;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::builders::ArrayBuilder;
     use vortex_array::builders::PrimitiveBuilder;
@@ -696,7 +696,7 @@ mod scheme_selection_tests {
         let compressed =
             btr.float_compressor()
                 .compress(&btr, &array, CompressorContext::default(), &[])?;
-        assert!(compressed.is::<ConstantVTable>());
+        assert!(compressed.is::<Constant>());
         Ok(())
     }
 
@@ -708,7 +708,7 @@ mod scheme_selection_tests {
         let compressed =
             btr.float_compressor()
                 .compress(&btr, &array, CompressorContext::default(), &[])?;
-        assert!(compressed.is::<ALPVTable>());
+        assert!(compressed.is::<ALP>());
         Ok(())
     }
 
@@ -723,7 +723,7 @@ mod scheme_selection_tests {
         let compressed =
             btr.float_compressor()
                 .compress(&btr, &array, CompressorContext::default(), &[])?;
-        assert!(compressed.is::<DictVTable>());
+        assert!(compressed.is::<Dict>());
         Ok(())
     }
 

--- a/vortex-btrblocks/src/compressor/float/stats.rs
+++ b/vortex-btrblocks/src/compressor/float/stats.rs
@@ -8,8 +8,8 @@ use num_traits::Float;
 use rustc_hash::FxBuildHasher;
 use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
+use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::PrimitiveVTable;
 use vortex_array::arrays::primitive::NativeValue;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::PType;
@@ -81,7 +81,7 @@ impl FloatStats {
 }
 
 impl CompressorStats for FloatStats {
-    type ArrayVTable = PrimitiveVTable;
+    type ArrayVTable = Primitive;
 
     fn generate_opts(input: &PrimitiveArray, opts: GenerateStatsOptions) -> Self {
         Self::generate_opts_fallible(input, opts)

--- a/vortex-btrblocks/src/compressor/integer/mod.rs
+++ b/vortex-btrblocks/src/compressor/integer/mod.rs
@@ -16,8 +16,8 @@ use vortex_array::ToCanonical;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::MaskedArray;
+use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::PrimitiveVTable;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityHelper;
@@ -32,8 +32,8 @@ use vortex_fastlanes::bitpack_compress::find_best_bit_width;
 use vortex_runend::RunEndArray;
 use vortex_runend::compress::runend_encode;
 use vortex_sequence::sequence_encode;
+use vortex_sparse::Sparse;
 use vortex_sparse::SparseArray;
-use vortex_sparse::SparseVTable;
 use vortex_zigzag::ZigZagArray;
 use vortex_zigzag::zigzag_encode;
 
@@ -74,7 +74,7 @@ pub struct IntCompressor<'a> {
 }
 
 impl<'a> Compressor for IntCompressor<'a> {
-    type ArrayVTable = PrimitiveVTable;
+    type ArrayVTable = Primitive;
     type SchemeType = dyn IntegerScheme;
     type StatsType = IntegerStats;
 
@@ -609,7 +609,7 @@ impl Scheme for SparseScheme {
             )),
         )?;
 
-        if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {
+        if let Some(sparse) = sparse_encoded.as_opt::<Sparse>() {
             // Compress the values
             let mut new_excludes = vec![SparseScheme.code(), IntCode::Dict];
             new_excludes.extend_from_slice(excludes);
@@ -892,7 +892,7 @@ mod tests {
     use vortex_array::DynArray;
     use vortex_array::IntoArray;
     use vortex_array::ToCanonical;
-    use vortex_array::arrays::DictVTable;
+    use vortex_array::arrays::Dict;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::validity::Validity;
@@ -901,8 +901,8 @@ mod tests {
     use vortex_buffer::BufferMut;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
-    use vortex_sequence::SequenceVTable;
-    use vortex_sparse::SparseVTable;
+    use vortex_sequence::Sequence;
+    use vortex_sparse::Sparse;
 
     use super::IntegerStats;
     use super::RLE_INTEGER_SCHEME;
@@ -957,7 +957,7 @@ mod tests {
             CompressorContext::default(),
             &[],
         )?;
-        assert!(compressed.is::<DictVTable>());
+        assert!(compressed.is::<Dict>());
         Ok(())
     }
 
@@ -974,7 +974,7 @@ mod tests {
             CompressorContext::default(),
             &[],
         )?;
-        assert!(compressed.is::<SparseVTable>());
+        assert!(compressed.is::<Sparse>());
         let decoded = compressed.clone();
         let expected =
             PrimitiveArray::new(buffer![189u8, 189, 189, 0, 0], array.validity().clone())
@@ -998,7 +998,7 @@ mod tests {
             CompressorContext::default(),
             &[],
         )?;
-        assert!(compressed.is::<SparseVTable>());
+        assert!(compressed.is::<Sparse>());
         let decoded = compressed.clone();
         let expected = PrimitiveArray::new(
             buffer![0u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 46],
@@ -1020,7 +1020,7 @@ mod tests {
             CompressorContext::default(),
             &[],
         )?;
-        assert!(compressed.is::<SequenceVTable>());
+        assert!(compressed.is::<Sequence>());
         let decoded = compressed;
         let expected = PrimitiveArray::from_option_iter(values.into_iter().map(Some)).into_array();
         assert_arrays_eq!(decoded.as_ref(), expected.as_ref());
@@ -1074,18 +1074,18 @@ mod tests {
 mod scheme_selection_tests {
     use std::iter;
 
-    use vortex_array::arrays::ConstantVTable;
-    use vortex_array::arrays::DictVTable;
+    use vortex_array::arrays::Constant;
+    use vortex_array::arrays::Dict;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
     use vortex_error::VortexResult;
-    use vortex_fastlanes::BitPackedVTable;
-    use vortex_fastlanes::FoRVTable;
-    use vortex_fastlanes::RLEVTable;
-    use vortex_runend::RunEndVTable;
-    use vortex_sequence::SequenceVTable;
-    use vortex_sparse::SparseVTable;
+    use vortex_fastlanes::BitPacked;
+    use vortex_fastlanes::FoR;
+    use vortex_fastlanes::RLE;
+    use vortex_runend::RunEnd;
+    use vortex_sequence::Sequence;
+    use vortex_sparse::Sparse;
 
     use crate::BtrBlocksCompressor;
     use crate::CompressorContext;
@@ -1099,7 +1099,7 @@ mod scheme_selection_tests {
         let compressed =
             btr.integer_compressor()
                 .compress(&btr, &array, CompressorContext::default(), &[])?;
-        assert!(compressed.is::<ConstantVTable>());
+        assert!(compressed.is::<Constant>());
         Ok(())
     }
 
@@ -1111,7 +1111,7 @@ mod scheme_selection_tests {
         let compressed =
             btr.integer_compressor()
                 .compress(&btr, &array, CompressorContext::default(), &[])?;
-        assert!(compressed.is::<FoRVTable>());
+        assert!(compressed.is::<FoR>());
         Ok(())
     }
 
@@ -1123,7 +1123,7 @@ mod scheme_selection_tests {
         let compressed =
             btr.integer_compressor()
                 .compress(&btr, &array, CompressorContext::default(), &[])?;
-        assert!(compressed.is::<BitPackedVTable>());
+        assert!(compressed.is::<BitPacked>());
         Ok(())
     }
 
@@ -1142,7 +1142,7 @@ mod scheme_selection_tests {
         let compressed =
             btr.integer_compressor()
                 .compress(&btr, &array, CompressorContext::default(), &[])?;
-        assert!(compressed.is::<SparseVTable>());
+        assert!(compressed.is::<Sparse>());
         Ok(())
     }
 
@@ -1172,7 +1172,7 @@ mod scheme_selection_tests {
         let compressed =
             btr.integer_compressor()
                 .compress(&btr, &array, CompressorContext::default(), &[])?;
-        assert!(compressed.is::<DictVTable>());
+        assert!(compressed.is::<Dict>());
         Ok(())
     }
 
@@ -1187,7 +1187,7 @@ mod scheme_selection_tests {
         let compressed =
             btr.integer_compressor()
                 .compress(&btr, &array, CompressorContext::default(), &[])?;
-        assert!(compressed.is::<RunEndVTable>());
+        assert!(compressed.is::<RunEnd>());
         Ok(())
     }
 
@@ -1199,7 +1199,7 @@ mod scheme_selection_tests {
         let compressed =
             btr.integer_compressor()
                 .compress(&btr, &array, CompressorContext::default(), &[])?;
-        assert!(compressed.is::<SequenceVTable>());
+        assert!(compressed.is::<Sequence>());
         Ok(())
     }
 
@@ -1214,7 +1214,7 @@ mod scheme_selection_tests {
         let compressed =
             btr.integer_compressor()
                 .compress(&btr, &array, CompressorContext::default(), &[])?;
-        assert!(compressed.is::<RLEVTable>());
+        assert!(compressed.is::<RLE>());
         Ok(())
     }
 }

--- a/vortex-btrblocks/src/compressor/integer/stats.rs
+++ b/vortex-btrblocks/src/compressor/integer/stats.rs
@@ -7,8 +7,8 @@ use num_traits::PrimInt;
 use rustc_hash::FxBuildHasher;
 use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
+use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
-use vortex_array::arrays::PrimitiveVTable;
 use vortex_array::arrays::primitive::NativeValue;
 use vortex_array::dtype::IntegerPType;
 use vortex_array::expr::stats::Stat;
@@ -175,7 +175,7 @@ impl IntegerStats {
 }
 
 impl CompressorStats for IntegerStats {
-    type ArrayVTable = PrimitiveVTable;
+    type ArrayVTable = Primitive;
 
     fn generate_opts(input: &PrimitiveArray, opts: GenerateStatsOptions) -> Self {
         Self::generate_opts_fallible(input, opts)

--- a/vortex-btrblocks/src/compressor/string.rs
+++ b/vortex-btrblocks/src/compressor/string.rs
@@ -13,8 +13,8 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::MaskedArray;
 use vortex_array::arrays::VarBinArray;
+use vortex_array::arrays::VarBinView;
 use vortex_array::arrays::VarBinViewArray;
-use vortex_array::arrays::VarBinViewVTable;
 use vortex_array::builders::dict::dict_encode;
 use vortex_array::compute::is_constant;
 use vortex_array::scalar::Scalar;
@@ -26,8 +26,8 @@ use vortex_error::vortex_err;
 use vortex_fsst::FSSTArray;
 use vortex_fsst::fsst_compress;
 use vortex_fsst::fsst_train_compressor;
+use vortex_sparse::Sparse;
 use vortex_sparse::SparseArray;
-use vortex_sparse::SparseVTable;
 use vortex_utils::aliases::hash_set::HashSet;
 
 use super::integer::DictScheme as IntDictScheme;
@@ -99,7 +99,7 @@ impl StringStats {
 }
 
 impl CompressorStats for StringStats {
-    type ArrayVTable = VarBinViewVTable;
+    type ArrayVTable = VarBinView;
 
     fn generate_opts(input: &VarBinViewArray, opts: GenerateStatsOptions) -> Self {
         Self::generate_opts_fallible(input, opts)
@@ -139,7 +139,7 @@ pub struct StringCompressor<'a> {
 }
 
 impl<'a> Compressor for StringCompressor<'a> {
-    type ArrayVTable = VarBinViewVTable;
+    type ArrayVTable = VarBinView;
     type SchemeType = dyn StringScheme;
     type StatsType = StringStats;
 
@@ -498,7 +498,7 @@ impl Scheme for NullDominated {
         // We pass None as we only run this pathway for NULL-dominated string arrays
         let sparse_encoded = SparseArray::encode(&stats.src.clone().into_array(), None)?;
 
-        if let Some(sparse) = sparse_encoded.as_opt::<SparseVTable>() {
+        if let Some(sparse) = sparse_encoded.as_opt::<Sparse>() {
             // Compress the indices only (not the values for strings)
             let new_excludes = vec![IntSparseScheme.code(), IntCode::Dict];
 
@@ -633,13 +633,13 @@ mod tests {
 #[cfg(test)]
 mod scheme_selection_tests {
     use vortex_array::IntoArray;
-    use vortex_array::arrays::ConstantVTable;
-    use vortex_array::arrays::DictVTable;
+    use vortex_array::arrays::Constant;
+    use vortex_array::arrays::Dict;
     use vortex_array::arrays::VarBinViewArray;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
     use vortex_error::VortexResult;
-    use vortex_fsst::FSSTVTable;
+    use vortex_fsst::FSST;
 
     use crate::BtrBlocksCompressor;
 
@@ -649,7 +649,7 @@ mod scheme_selection_tests {
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
         let array_ref = array.into_array();
         let compressed = BtrBlocksCompressor::default().compress(&array_ref)?;
-        assert!(compressed.is::<ConstantVTable>());
+        assert!(compressed.is::<Constant>());
         Ok(())
     }
 
@@ -663,7 +663,7 @@ mod scheme_selection_tests {
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
         let array_ref = array.into_array();
         let compressed = BtrBlocksCompressor::default().compress(&array_ref)?;
-        assert!(compressed.is::<DictVTable>());
+        assert!(compressed.is::<Dict>());
         Ok(())
     }
 
@@ -678,7 +678,7 @@ mod scheme_selection_tests {
         let array = VarBinViewArray::from_iter(strings, DType::Utf8(Nullability::NonNullable));
         let array_ref = array.into_array();
         let compressed = BtrBlocksCompressor::default().compress(&array_ref)?;
-        assert!(compressed.is::<FSSTVTable>());
+        assert!(compressed.is::<FSST>());
         Ok(())
     }
 }

--- a/vortex-cuda/gpu-scan-cli/src/main.rs
+++ b/vortex-cuda/gpu-scan-cli/src/main.rs
@@ -19,7 +19,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use vortex::VortexSessionDefault;
 use vortex::array::ToCanonical;
-use vortex::array::arrays::DictVTable;
+use vortex::array::arrays::Dict;
 use vortex::buffer::ByteBufferMut;
 use vortex::error::VortexResult;
 use vortex::file::OpenOptionsSessionExt;
@@ -184,7 +184,7 @@ async fn cmd_scan(path: PathBuf, gpu_file: bool, json_output: bool) -> VortexRes
             .zip(record.struct_fields().names().iter())
         {
             let field_name = field_name.to_string();
-            if field.is::<DictVTable>() {
+            if field.is::<Dict>() {
                 continue;
             }
 

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -11,22 +11,22 @@ use futures::executor::block_on;
 use vortex::array::ArrayRef;
 use vortex::array::DynArray;
 use vortex::array::ExecutionCtx;
-use vortex::array::arrays::DictVTable;
-use vortex::array::arrays::PrimitiveVTable;
-use vortex::array::arrays::SliceVTable;
+use vortex::array::arrays::Dict;
+use vortex::array::arrays::Primitive;
+use vortex::array::arrays::Slice;
 use vortex::array::arrays::primitive::PrimitiveArrayParts;
 use vortex::array::buffer::BufferHandle;
 use vortex::array::session::ArraySession;
 use vortex::dtype::PType;
+use vortex::encodings::alp::ALP;
 use vortex::encodings::alp::ALPFloat;
-use vortex::encodings::alp::ALPVTable;
+use vortex::encodings::fastlanes::BitPacked;
 use vortex::encodings::fastlanes::BitPackedArrayParts;
-use vortex::encodings::fastlanes::BitPackedVTable;
+use vortex::encodings::fastlanes::FoR;
 use vortex::encodings::fastlanes::FoRArray;
-use vortex::encodings::fastlanes::FoRVTable;
+use vortex::encodings::runend::RunEnd;
 use vortex::encodings::runend::RunEndArrayParts;
-use vortex::encodings::runend::RunEndVTable;
-use vortex::encodings::zigzag::ZigZagVTable;
+use vortex::encodings::zigzag::ZigZag;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
 use vortex::error::vortex_err;
@@ -142,21 +142,21 @@ impl PlanBuilderState<'_> {
     fn walk(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
         let id = array.encoding_id();
 
-        if id == BitPackedVTable::ID {
+        if id == BitPacked::ID {
             self.walk_bitpacked(array)
-        } else if id == FoRVTable::ID {
+        } else if id == FoR::ID {
             self.walk_for(array)
-        } else if id == ZigZagVTable::ID {
+        } else if id == ZigZag::ID {
             self.walk_zigzag(array)
-        } else if id == ALPVTable::ID {
+        } else if id == ALP::ID {
             self.walk_alp(array)
-        } else if id == DictVTable::ID {
+        } else if id == Dict::ID {
             self.walk_dict(array)
-        } else if id == RunEndVTable::ID {
+        } else if id == RunEnd::ID {
             self.walk_runend(array)
-        } else if id == PrimitiveVTable::ID {
+        } else if id == Primitive::ID {
             self.walk_primitive(array)
-        } else if id == SliceVTable::ID {
+        } else if id == Slice::ID {
             self.walk_slice(array)
         } else {
             vortex_bail!(
@@ -171,7 +171,7 @@ impl PlanBuilderState<'_> {
     /// When the plan builder encounters a `SliceArray`, it resolves the slice
     /// by invoking the child's `reduce_parent`, `execute_parent`.
     fn walk_slice(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
-        let slice_arr = array.as_::<SliceVTable>();
+        let slice_arr = array.as_::<Slice>();
         let child = slice_arr.child().clone();
 
         // reduce_parent: (for types with SliceReduceAdaptor, like FoR/ZigZag)
@@ -213,7 +213,7 @@ impl PlanBuilderState<'_> {
     /// as it cannot be expressed as pointer arithmetic on the device pointer.
     fn walk_bitpacked(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
         let bp = array
-            .try_into::<BitPackedVTable>()
+            .try_into::<BitPacked>()
             .map_err(|_| vortex_err!("Expected BitPackedArray"))?;
         let BitPackedArrayParts {
             offset,
@@ -240,7 +240,7 @@ impl PlanBuilderState<'_> {
     /// FoRArray → recurse into encoded child, add FoR scalar op.
     fn walk_for(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
         let for_arr = array
-            .try_into::<FoRVTable>()
+            .try_into::<FoR>()
             .map_err(|_| vortex_err!("Expected FoRArray"))?;
         let ref_u64 = extract_for_reference(&for_arr)?;
         let encoded = for_arr.encoded().clone();
@@ -253,7 +253,7 @@ impl PlanBuilderState<'_> {
     /// ZigZagArray → recurse into encoded child, add ZigZag scalar op.
     fn walk_zigzag(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
         let zz = array
-            .try_into::<ZigZagVTable>()
+            .try_into::<ZigZag>()
             .map_err(|_| vortex_err!("Expected ZigZagArray"))?;
         let encoded = zz.encoded().clone();
 
@@ -265,7 +265,7 @@ impl PlanBuilderState<'_> {
     /// ALPArray → recurse into encoded child, add ALP scalar op (f32 only).
     fn walk_alp(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
         let alp = array
-            .try_into::<ALPVTable>()
+            .try_into::<ALP>()
             .map_err(|_| vortex_err!("Expected ALPArray"))?;
 
         if alp.patches().is_some() {
@@ -293,7 +293,7 @@ impl PlanBuilderState<'_> {
     /// DictArray → add input stage for values, recurse into codes, add DICT scalar op.
     fn walk_dict(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
         let dict = array
-            .try_into::<DictVTable>()
+            .try_into::<Dict>()
             .map_err(|_| vortex_err!("Expected DictArray"))?;
         let values = dict.values().clone();
         let codes = dict.codes().clone();
@@ -308,7 +308,7 @@ impl PlanBuilderState<'_> {
     /// RunEndArray → add input stages for ends and values, RUNEND source op.
     fn walk_runend(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
         let re = array
-            .try_into::<RunEndVTable>()
+            .try_into::<RunEnd>()
             .map_err(|_| vortex_err!("Expected RunEndArray"))?;
         let offset = re.offset() as u64;
         let RunEndArrayParts { ends, values } = re.into_parts();

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -20,8 +20,8 @@ use vortex::array::Canonical;
 use vortex::array::DynArray;
 use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
+use vortex::array::arrays::Struct;
 use vortex::array::arrays::StructArray;
-use vortex::array::arrays::StructVTable;
 use vortex::array::arrays::struct_::StructArrayParts;
 use vortex::array::buffer::BufferHandle;
 use vortex::dtype::PType;
@@ -337,14 +337,14 @@ pub trait CudaArrayExt: DynArray {
 impl CudaArrayExt for ArrayRef {
     #[allow(clippy::unwrap_in_result, clippy::unwrap_used)]
     async fn execute_cuda(self, ctx: &mut CudaExecutionCtx) -> VortexResult<Canonical> {
-        if self.encoding_id() == StructVTable::ID {
+        if self.encoding_id() == Struct::ID {
             let len = self.len();
             let StructArrayParts {
                 fields,
                 struct_fields,
                 validity,
                 ..
-            } = self.try_into::<StructVTable>().unwrap().into_parts();
+            } = self.try_into::<Struct>().unwrap().into_parts();
 
             let mut cuda_fields = Vec::with_capacity(fields.len());
             for field in fields.iter() {

--- a/vortex-cuda/src/kernel/arrays/constant.rs
+++ b/vortex-cuda/src/kernel/arrays/constant.rs
@@ -10,8 +10,8 @@ use cudarc::driver::PushKernelArg;
 use tracing::instrument;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
+use vortex::array::arrays::Constant;
 use vortex::array::arrays::ConstantArray;
-use vortex::array::arrays::ConstantVTable;
 use vortex::array::arrays::DecimalArray;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::buffer::BufferHandle;
@@ -40,7 +40,7 @@ pub(crate) struct ConstantNumericExecutor;
 
 impl ConstantNumericExecutor {
     fn try_specialize(array: ArrayRef) -> Option<ConstantArray> {
-        array.try_into::<ConstantVTable>().ok()
+        array.try_into::<Constant>().ok()
     }
 }
 

--- a/vortex-cuda/src/kernel/arrays/dict.rs
+++ b/vortex-cuda/src/kernel/arrays/dict.rs
@@ -11,8 +11,8 @@ use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::IntoArray;
 use vortex::array::arrays::DecimalArray;
+use vortex::array::arrays::Dict;
 use vortex::array::arrays::DictArray;
-use vortex::array::arrays::DictVTable;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::VarBinViewArray;
 use vortex::array::arrays::decimal::DecimalArrayParts;
@@ -49,7 +49,7 @@ impl CudaExecute for DictExecutor {
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<Canonical> {
         let dict_array = array
-            .try_into::<DictVTable>()
+            .try_into::<Dict>()
             .ok()
             .vortex_expect("Array is not a Dict array");
 

--- a/vortex-cuda/src/kernel/arrays/shared.rs
+++ b/vortex-cuda/src/kernel/arrays/shared.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use tracing::instrument;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
-use vortex::array::arrays::SharedVTable;
+use vortex::array::arrays::Shared;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 
@@ -26,7 +26,7 @@ impl CudaExecute for SharedExecutor {
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<Canonical> {
         let shared = array
-            .try_into::<SharedVTable>()
+            .try_into::<Shared>()
             .ok()
             .vortex_expect("Array is not a Shared array");
 

--- a/vortex-cuda/src/kernel/encodings/alp.rs
+++ b/vortex-cuda/src/kernel/encodings/alp.rs
@@ -16,9 +16,9 @@ use vortex::array::arrays::primitive::PrimitiveArrayParts;
 use vortex::array::buffer::BufferHandle;
 use vortex::array::match_each_unsigned_integer_ptype;
 use vortex::dtype::NativePType;
+use vortex::encodings::alp::ALP;
 use vortex::encodings::alp::ALPArray;
 use vortex::encodings::alp::ALPFloat;
-use vortex::encodings::alp::ALPVTable;
 use vortex::encodings::alp::match_each_alp_float_ptype;
 use vortex::error::VortexResult;
 use vortex::error::vortex_ensure;
@@ -44,7 +44,7 @@ impl CudaExecute for ALPExecutor {
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<Canonical> {
         let array = array
-            .try_into::<ALPVTable>()
+            .try_into::<ALP>()
             .map_err(|_| vortex_err!("Expected ALPArray"))?;
 
         match_each_alp_float_ptype!(array.ptype(), |A| { decode_alp::<A>(array, ctx).await })

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -16,10 +16,10 @@ use vortex::array::buffer::BufferHandle;
 use vortex::array::buffer::DeviceBufferExt;
 use vortex::array::match_each_integer_ptype;
 use vortex::dtype::NativePType;
+use vortex::encodings::fastlanes::BitPacked;
 use vortex::encodings::fastlanes::BitPackedArray;
 use vortex::encodings::fastlanes::BitPackedArrayParts;
-use vortex::encodings::fastlanes::BitPackedVTable;
-use vortex::encodings::fastlanes::unpack_iter::BitPacked;
+use vortex::encodings::fastlanes::unpack_iter::BitPacked as BitPackedUnpack;
 use vortex::error::VortexResult;
 use vortex::error::vortex_ensure;
 use vortex::error::vortex_err;
@@ -37,7 +37,7 @@ pub(crate) struct BitPackedExecutor;
 
 impl BitPackedExecutor {
     fn try_specialize(array: ArrayRef) -> Option<BitPackedArray> {
-        array.try_into::<BitPackedVTable>().ok()
+        array.try_into::<BitPacked>().ok()
     }
 }
 
@@ -93,7 +93,7 @@ pub(crate) async fn decode_bitpacked<A>(
     ctx: &mut CudaExecutionCtx,
 ) -> VortexResult<Canonical>
 where
-    A: BitPacked + NativePType + DeviceRepr + Send + Sync + 'static,
+    A: BitPackedUnpack + NativePType + DeviceRepr + Send + Sync + 'static,
     A::Physical: DeviceRepr + Send + Sync + 'static,
 {
     let BitPackedArrayParts {
@@ -522,13 +522,9 @@ mod tests {
             .vortex_expect("operation should succeed in test");
         let slice_ref = bitpacked_array.clone().into_array().slice(67..3969)?;
         let mut exec_ctx = ExecutionCtx::new(VortexSession::empty().with::<ArraySession>());
-        let sliced_array = <BitPackedVTable as VTable>::execute_parent(
-            &bitpacked_array,
-            &slice_ref,
-            0,
-            &mut exec_ctx,
-        )?
-        .expect("expected slice kernel to execute");
+        let sliced_array =
+            <BitPacked as VTable>::execute_parent(&bitpacked_array, &slice_ref, 0, &mut exec_ctx)?
+                .expect("expected slice kernel to execute");
         let cpu_result = sliced_array.to_canonical()?;
         let gpu_result = block_on(async {
             BitPackedExecutor

--- a/vortex-cuda/src/kernel/encodings/date_time_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/date_time_parts.rs
@@ -21,7 +21,7 @@ use vortex::dtype::DType;
 use vortex::dtype::NativePType;
 use vortex::dtype::Nullability;
 use vortex::dtype::PType;
-use vortex::encodings::datetime_parts::DateTimePartsVTable;
+use vortex::encodings::datetime_parts::DateTimeParts;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
 use vortex::error::vortex_err;
@@ -51,7 +51,7 @@ impl CudaExecute for DateTimePartsExecutor {
     ) -> VortexResult<Canonical> {
         let output_len = array.len();
         let array = array
-            .try_into::<DateTimePartsVTable>()
+            .try_into::<DateTimeParts>()
             .map_err(|_| vortex_err!("Expected DateTimePartsArray"))?;
 
         // Extract the temporal metadata from the dtype

--- a/vortex-cuda/src/kernel/encodings/decimal_byte_parts.rs
+++ b/vortex-cuda/src/kernel/encodings/decimal_byte_parts.rs
@@ -9,8 +9,8 @@ use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::arrays::DecimalArray;
 use vortex::array::arrays::primitive::PrimitiveArrayParts;
+use vortex::encodings::decimal_byte_parts::DecimalByteParts;
 use vortex::encodings::decimal_byte_parts::DecimalBytePartsArrayParts;
-use vortex::encodings::decimal_byte_parts::DecimalBytePartsVTable;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
 
@@ -30,7 +30,7 @@ impl CudaExecute for DecimalBytePartsExecutor {
         array: ArrayRef,
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<Canonical> {
-        let Ok(array) = array.try_into::<DecimalBytePartsVTable>() else {
+        let Ok(array) = array.try_into::<DecimalByteParts>() else {
             vortex_bail!("cannot downcast to DecimalBytePartsArray")
         };
 

--- a/vortex-cuda/src/kernel/encodings/for_.rs
+++ b/vortex-cuda/src/kernel/encodings/for_.rs
@@ -11,14 +11,14 @@ use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::DynArray;
 use vortex::array::arrays::PrimitiveArray;
-use vortex::array::arrays::SliceVTable;
+use vortex::array::arrays::Slice;
 use vortex::array::arrays::primitive::PrimitiveArrayParts;
 use vortex::array::match_each_integer_ptype;
 use vortex::array::match_each_native_simd_ptype;
 use vortex::dtype::NativePType;
-use vortex::encodings::fastlanes::BitPackedVTable;
+use vortex::encodings::fastlanes::BitPacked;
+use vortex::encodings::fastlanes::FoR;
 use vortex::encodings::fastlanes::FoRArray;
-use vortex::encodings::fastlanes::FoRVTable;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_ensure;
@@ -36,7 +36,7 @@ pub(crate) struct FoRExecutor;
 
 impl FoRExecutor {
     fn try_specialize(array: ArrayRef) -> Option<FoRArray> {
-        array.try_into::<FoRVTable>().ok()
+        array.try_into::<FoR>().ok()
     }
 }
 
@@ -51,7 +51,7 @@ impl CudaExecute for FoRExecutor {
         let array = Self::try_specialize(array).ok_or_else(|| vortex_err!("Expected FoRArray"))?;
 
         // Fuse FOR + BP => FFOR
-        if let Some(bitpacked) = array.encoded().as_opt::<BitPackedVTable>() {
+        if let Some(bitpacked) = array.encoded().as_opt::<BitPacked>() {
             match_each_integer_ptype!(bitpacked.ptype(), |P| {
                 let reference: P = array.reference_scalar().try_into()?;
                 return decode_bitpacked(bitpacked.clone(), reference, ctx).await;
@@ -59,8 +59,8 @@ impl CudaExecute for FoRExecutor {
         }
 
         // Fuse FOR + SLICE + BP => SLICE + FFOR
-        if let Some(slice_array) = array.encoded().as_opt::<SliceVTable>()
-            && let Some(bitpacked) = slice_array.child().as_opt::<BitPackedVTable>()
+        if let Some(slice_array) = array.encoded().as_opt::<Slice>()
+            && let Some(bitpacked) = slice_array.child().as_opt::<BitPacked>()
         {
             let slice_range = slice_array.slice_range().clone();
             let unpacked = match_each_integer_ptype!(bitpacked.ptype(), |P| {

--- a/vortex-cuda/src/kernel/encodings/runend.rs
+++ b/vortex-cuda/src/kernel/encodings/runend.rs
@@ -18,9 +18,9 @@ use vortex::array::match_each_unsigned_integer_ptype;
 use vortex::array::validity::Validity;
 use vortex::dtype::NativePType;
 use vortex::dtype::PType;
+use vortex::encodings::runend::RunEnd;
 use vortex::encodings::runend::RunEndArray;
 use vortex::encodings::runend::RunEndArrayParts;
-use vortex::encodings::runend::RunEndVTable;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
 use vortex::error::vortex_ensure;
@@ -39,7 +39,7 @@ pub(crate) struct RunEndExecutor;
 
 impl RunEndExecutor {
     fn try_specialize(array: ArrayRef) -> Option<RunEndArray> {
-        array.try_into::<RunEndVTable>().ok()
+        array.try_into::<RunEnd>().ok()
     }
 }
 

--- a/vortex-cuda/src/kernel/encodings/sequence.rs
+++ b/vortex-cuda/src/kernel/encodings/sequence.rs
@@ -14,8 +14,8 @@ use vortex::array::buffer::BufferHandle;
 use vortex::array::match_each_native_ptype;
 use vortex::dtype::NativePType;
 use vortex::dtype::Nullability;
+use vortex::encodings::sequence::Sequence;
 use vortex::encodings::sequence::SequenceArrayParts;
-use vortex::encodings::sequence::SequenceVTable;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
 
@@ -36,7 +36,7 @@ impl CudaExecute for SequenceExecutor {
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<Canonical> {
         let array = array
-            .try_into::<SequenceVTable>()
+            .try_into::<Sequence>()
             .map_err(|_| vortex_err!("SequenceExecutor can only accept SequenceArray"))?;
 
         let SequenceArrayParts {

--- a/vortex-cuda/src/kernel/encodings/zigzag.rs
+++ b/vortex-cuda/src/kernel/encodings/zigzag.rs
@@ -14,8 +14,8 @@ use vortex::array::arrays::primitive::PrimitiveArrayParts;
 use vortex::array::match_each_unsigned_integer_ptype;
 use vortex::dtype::NativePType;
 use vortex::dtype::PType;
+use vortex::encodings::zigzag::ZigZag;
 use vortex::encodings::zigzag::ZigZagArray;
-use vortex::encodings::zigzag::ZigZagVTable;
 use vortex::error::VortexResult;
 use vortex::error::vortex_ensure;
 use vortex::error::vortex_err;
@@ -31,7 +31,7 @@ pub(crate) struct ZigZagExecutor;
 
 impl ZigZagExecutor {
     fn try_specialize(array: ArrayRef) -> Option<ZigZagArray> {
-        array.try_into::<ZigZagVTable>().ok()
+        array.try_into::<ZigZag>().ok()
     }
 }
 

--- a/vortex-cuda/src/kernel/encodings/zstd.rs
+++ b/vortex-cuda/src/kernel/encodings/zstd.rs
@@ -23,10 +23,10 @@ use vortex::buffer::Alignment;
 use vortex::buffer::Buffer;
 use vortex::buffer::ByteBuffer;
 use vortex::dtype::DType;
+use vortex::encodings::zstd::Zstd;
 use vortex::encodings::zstd::ZstdArray;
 use vortex::encodings::zstd::ZstdArrayParts;
 use vortex::encodings::zstd::ZstdMetadata;
-use vortex::encodings::zstd::ZstdVTable;
 use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
@@ -184,7 +184,7 @@ pub(crate) struct ZstdExecutor;
 
 impl ZstdExecutor {
     fn try_specialize(array: ArrayRef) -> Option<ZstdArray> {
-        array.as_opt::<ZstdVTable>().cloned()
+        array.as_opt::<Zstd>().cloned()
     }
 }
 

--- a/vortex-cuda/src/kernel/encodings/zstd_buffers.rs
+++ b/vortex-cuda/src/kernel/encodings/zstd_buffers.rs
@@ -16,8 +16,8 @@ use vortex::array::buffer::BufferHandle;
 use vortex::array::buffer::DeviceBuffer;
 use vortex::buffer::Alignment;
 use vortex::buffer::Buffer;
+use vortex::encodings::zstd::ZstdBuffers;
 use vortex::encodings::zstd::ZstdBuffersArray;
-use vortex::encodings::zstd::ZstdBuffersVTable;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
 use vortex_nvcomp::sys;
@@ -41,7 +41,7 @@ impl CudaExecute for ZstdBuffersExecutor {
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<Canonical> {
         let zstd_buffers = array
-            .try_into::<ZstdBuffersVTable>()
+            .try_into::<ZstdBuffers>()
             .map_err(|_| vortex_err!("expected zstd buffers array"))?;
         decode_zstd_buffers(zstd_buffers, ctx).await
     }

--- a/vortex-cuda/src/kernel/filter/mod.rs
+++ b/vortex-cuda/src/kernel/filter/mod.rs
@@ -18,7 +18,7 @@ use cudarc::driver::DeviceRepr;
 use tracing::instrument;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
-use vortex::array::arrays::FilterVTable;
+use vortex::array::arrays::Filter;
 use vortex::array::arrays::filter::FilterArrayParts;
 use vortex::array::buffer::BufferHandle;
 use vortex::array::match_each_decimal_value_type;
@@ -50,7 +50,7 @@ impl CudaExecute for FilterExecutor {
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<Canonical> {
         let filter_array = array
-            .try_into::<FilterVTable>()
+            .try_into::<Filter>()
             .map_err(|_| vortex_err!("Expected FilterArray"))?;
 
         let FilterArrayParts { child, mask } = filter_array.into_parts();

--- a/vortex-cuda/src/kernel/slice/mod.rs
+++ b/vortex-cuda/src/kernel/slice/mod.rs
@@ -6,7 +6,7 @@ use tracing::instrument;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::DynArray;
-use vortex::array::arrays::SliceVTable;
+use vortex::array::arrays::Slice;
 use vortex::array::arrays::slice::SliceArrayParts;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
@@ -26,7 +26,7 @@ impl CudaExecute for SliceExecutor {
         array: ArrayRef,
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<Canonical> {
-        let slice_array = array.try_into::<SliceVTable>().map_err(|array| {
+        let slice_array = array.try_into::<Slice>().map_err(|array| {
             vortex_err!(
                 "SliceExecutor requires input of SliceArray, was {}",
                 array.encoding_id()

--- a/vortex-cuda/src/layout.rs
+++ b/vortex-cuda/src/layout.rs
@@ -22,7 +22,7 @@ use vortex::array::DynArray;
 use vortex::array::MaskFuture;
 use vortex::array::ProstMetadata;
 use vortex::array::VortexSessionExecute;
-use vortex::array::arrays::ConstantVTable;
+use vortex::array::arrays::Constant;
 use vortex::array::expr::Expression;
 use vortex::array::expr::stats::Precision;
 use vortex::array::expr::stats::Stat;
@@ -123,7 +123,7 @@ impl CudaFlatLayout {
     }
 }
 
-impl VTable for CudaFlatVTable {
+impl VTable for CudaFlat {
     type Layout = CudaFlatLayout;
     type Encoding = CudaFlatLayoutEncoding;
     type Metadata = ProstMetadata<CudaFlatLayoutMetadata>;
@@ -552,7 +552,7 @@ fn extract_constant_buffers(chunk: &ArrayRef) -> Vec<InlinedBuffer> {
     let mut buffer_idx = 0u32;
     for array in chunk.depth_first_traversal() {
         let n = array.nbuffers();
-        if array.encoding_id() == ConstantVTable::ID {
+        if array.encoding_id() == Constant::ID {
             for buf in array.buffers() {
                 result.push(InlinedBuffer {
                     buffer_index: buffer_idx,

--- a/vortex-cuda/src/lib.rs
+++ b/vortex-cuda/src/lib.rs
@@ -58,22 +58,22 @@ pub use session::CudaSession;
 pub use session::CudaSessionExt;
 pub use stream::VortexCudaStream;
 pub use stream_pool::VortexCudaStreamPool;
-use vortex::array::arrays::ConstantVTable;
-use vortex::array::arrays::DictVTable;
-use vortex::array::arrays::FilterVTable;
-use vortex::array::arrays::SharedVTable;
-use vortex::array::arrays::SliceVTable;
-use vortex::encodings::alp::ALPVTable;
-use vortex::encodings::datetime_parts::DateTimePartsVTable;
-use vortex::encodings::decimal_byte_parts::DecimalBytePartsVTable;
-use vortex::encodings::fastlanes::BitPackedVTable;
-use vortex::encodings::fastlanes::FoRVTable;
-use vortex::encodings::runend::RunEndVTable;
-use vortex::encodings::sequence::SequenceVTable;
-use vortex::encodings::zigzag::ZigZagVTable;
+use vortex::array::arrays::Constant;
+use vortex::array::arrays::Dict;
+use vortex::array::arrays::Filter;
+use vortex::array::arrays::Shared;
+use vortex::array::arrays::Slice;
+use vortex::encodings::alp::ALP;
+use vortex::encodings::datetime_parts::DateTimeParts;
+use vortex::encodings::decimal_byte_parts::DecimalByteParts;
+use vortex::encodings::fastlanes::BitPacked;
+use vortex::encodings::fastlanes::FoR;
+use vortex::encodings::runend::RunEnd;
+use vortex::encodings::sequence::Sequence;
+use vortex::encodings::zigzag::ZigZag;
+use vortex::encodings::zstd::Zstd;
 #[cfg(feature = "unstable_encodings")]
-use vortex::encodings::zstd::ZstdBuffersVTable;
-use vortex::encodings::zstd::ZstdVTable;
+use vortex::encodings::zstd::ZstdBuffers;
 #[cfg(test)]
 use vortex_cuda_macros::test;
 pub use vortex_nvcomp as nvcomp;
@@ -92,22 +92,22 @@ pub fn cuda_available() -> bool {
 /// Registers CUDA kernels.
 pub fn initialize_cuda(session: &CudaSession) {
     info!("Registering CUDA kernels");
-    session.register_kernel(ALPVTable::ID, &ALPExecutor);
-    session.register_kernel(BitPackedVTable::ID, &BitPackedExecutor);
-    session.register_kernel(ConstantVTable::ID, &ConstantNumericExecutor);
-    session.register_kernel(DateTimePartsVTable::ID, &DateTimePartsExecutor);
-    session.register_kernel(DecimalBytePartsVTable::ID, &DecimalBytePartsExecutor);
-    session.register_kernel(DictVTable::ID, &DictExecutor);
-    session.register_kernel(SharedVTable::ID, &SharedExecutor);
-    session.register_kernel(FoRVTable::ID, &FoRExecutor);
-    session.register_kernel(RunEndVTable::ID, &RunEndExecutor);
-    session.register_kernel(SequenceVTable::ID, &SequenceExecutor);
-    session.register_kernel(ZigZagVTable::ID, &ZigZagExecutor);
-    session.register_kernel(ZstdVTable::ID, &ZstdExecutor);
+    session.register_kernel(ALP::ID, &ALPExecutor);
+    session.register_kernel(BitPacked::ID, &BitPackedExecutor);
+    session.register_kernel(Constant::ID, &ConstantNumericExecutor);
+    session.register_kernel(DateTimeParts::ID, &DateTimePartsExecutor);
+    session.register_kernel(DecimalByteParts::ID, &DecimalBytePartsExecutor);
+    session.register_kernel(Dict::ID, &DictExecutor);
+    session.register_kernel(Shared::ID, &SharedExecutor);
+    session.register_kernel(FoR::ID, &FoRExecutor);
+    session.register_kernel(RunEnd::ID, &RunEndExecutor);
+    session.register_kernel(Sequence::ID, &SequenceExecutor);
+    session.register_kernel(ZigZag::ID, &ZigZagExecutor);
+    session.register_kernel(Zstd::ID, &ZstdExecutor);
     #[cfg(feature = "unstable_encodings")]
-    session.register_kernel(ZstdBuffersVTable::ID, &ZstdBuffersExecutor);
+    session.register_kernel(ZstdBuffers::ID, &ZstdBuffersExecutor);
 
     // Operation kernels
-    session.register_kernel(FilterVTable::ID, &FilterExecutor);
-    session.register_kernel(SliceVTable::ID, &SliceExecutor);
+    session.register_kernel(Filter::ID, &FilterExecutor);
+    session.register_kernel(Slice::ID, &SliceExecutor);
 }

--- a/vortex-duckdb/src/datasource.rs
+++ b/vortex-duckdb/src/datasource.rs
@@ -22,8 +22,8 @@ use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::ScalarFnVTable;
+use vortex::array::arrays::Struct;
 use vortex::array::arrays::StructArray;
-use vortex::array::arrays::StructVTable;
 use vortex::array::optimizer::ArrayOptimizer;
 use vortex::dtype::DType;
 use vortex::dtype::FieldNames;
@@ -329,7 +329,7 @@ impl<T: DataSourceTableFunction> TableFunction for T {
                 let (array_result, conversion_cache) = result?;
                 let array_result = array_result.optimize_recursive()?;
 
-                let array_result = if let Some(array) = array_result.as_opt::<StructVTable>() {
+                let array_result = if let Some(array) = array_result.as_opt::<Struct>() {
                     array.clone()
                 } else if let Some(array) = array_result.as_opt::<ScalarFnVTable>()
                     && let Some(pack_options) = array.scalar_fn().as_opt::<Pack>()

--- a/vortex-duckdb/src/exporter/dict.rs
+++ b/vortex-duckdb/src/exporter/dict.rs
@@ -8,8 +8,8 @@ use num_traits::AsPrimitive;
 use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
+use vortex::array::arrays::Constant;
 use vortex::array::arrays::ConstantArray;
-use vortex::array::arrays::ConstantVTable;
 use vortex::array::arrays::DictArray;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::match_each_integer_ptype;
@@ -44,7 +44,7 @@ pub(crate) fn new_exporter_with_flatten(
     // Grab the cache dictionary values.
     let values = array.values();
     let values_type: LogicalType = values.dtype().try_into()?;
-    if let Some(constant) = values.as_opt::<ConstantVTable>() {
+    if let Some(constant) = values.as_opt::<Constant>() {
         return constant::new_exporter_with_mask(
             ConstantArray::new(constant.scalar().clone(), array.codes().len()),
             array.codes().validity_mask()?,

--- a/vortex-duckdb/src/exporter/mod.rs
+++ b/vortex-duckdb/src/exporter/mod.rs
@@ -26,14 +26,14 @@ pub use decimal::precision_to_duckdb_storage_size;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
-use vortex::array::arrays::ConstantVTable;
-use vortex::array::arrays::DictVTable;
-use vortex::array::arrays::ListVTable;
+use vortex::array::arrays::Constant;
+use vortex::array::arrays::Dict;
+use vortex::array::arrays::List;
 use vortex::array::arrays::StructArray;
 use vortex::array::arrays::TemporalArray;
 use vortex::array::vtable::ValidityHelper;
-use vortex::encodings::runend::RunEndVTable;
-use vortex::encodings::sequence::SequenceVTable;
+use vortex::encodings::runend::RunEnd;
+use vortex::encodings::sequence::Sequence;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
 
@@ -140,25 +140,25 @@ fn new_array_exporter_with_flatten(
     ctx: &mut ExecutionCtx,
     flatten: bool,
 ) -> VortexResult<Box<dyn ColumnExporter>> {
-    let array = match array.try_into::<ConstantVTable>() {
+    let array = match array.try_into::<Constant>() {
         Ok(array) => return constant::new_exporter(array),
         Err(array) => array,
     };
 
-    if let Some(array) = array.as_opt::<SequenceVTable>() {
+    if let Some(array) = array.as_opt::<Sequence>() {
         return sequence::new_exporter(array);
     }
 
-    let array = match array.try_into::<RunEndVTable>() {
+    let array = match array.try_into::<RunEnd>() {
         Ok(array) => return run_end::new_exporter(array, cache, ctx),
         Err(array) => array,
     };
 
-    if let Some(array) = array.as_opt::<DictVTable>() {
+    if let Some(array) = array.as_opt::<Dict>() {
         return dict::new_exporter_with_flatten(array, cache, ctx, flatten);
     }
 
-    let array = match array.try_into::<ListVTable>() {
+    let array = match array.try_into::<List>() {
         Ok(array) => return list::new_exporter(array, cache, ctx),
         Err(array) => array,
     };

--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -233,6 +233,8 @@ typedef struct DType DType;
  */
 typedef struct Nullability Nullability;
 
+typedef struct Primitive Primitive;
+
 /**
  * Base type for all Vortex arrays.
  *

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -109,23 +109,23 @@ pub use footer::*;
 pub use forever_constant::*;
 pub use open::*;
 pub use strategy::*;
-use vortex_alp::ALPRDVTable;
-use vortex_alp::ALPVTable;
-use vortex_array::arrays::DictVTable;
+use vortex_alp::ALP;
+use vortex_alp::ALPRD;
+use vortex_array::arrays::Dict;
 use vortex_array::session::ArraySessionExt;
-use vortex_bytebool::ByteBoolVTable;
-use vortex_datetime_parts::DateTimePartsVTable;
-use vortex_decimal_byte_parts::DecimalBytePartsVTable;
-use vortex_fastlanes::BitPackedVTable;
-use vortex_fastlanes::DeltaVTable;
-use vortex_fastlanes::FoRVTable;
-use vortex_fastlanes::RLEVTable;
-use vortex_fsst::FSSTVTable;
-use vortex_pco::PcoVTable;
-use vortex_sequence::SequenceVTable;
+use vortex_bytebool::ByteBool;
+use vortex_datetime_parts::DateTimeParts;
+use vortex_decimal_byte_parts::DecimalByteParts;
+use vortex_fastlanes::BitPacked;
+use vortex_fastlanes::Delta;
+use vortex_fastlanes::FoR;
+use vortex_fastlanes::RLE;
+use vortex_fsst::FSST;
+use vortex_pco::Pco;
+use vortex_sequence::Sequence;
 use vortex_session::VortexSession;
-use vortex_sparse::SparseVTable;
-use vortex_zigzag::ZigZagVTable;
+use vortex_sparse::Sparse;
+use vortex_zigzag::ZigZag;
 pub use writer::*;
 
 /// The current version of the Vortex file format
@@ -167,28 +167,25 @@ mod forever_constant {
 pub fn register_default_encodings(session: &mut VortexSession) {
     {
         let arrays = session.arrays();
-        arrays.register(ALPVTable::ID, ALPVTable);
-        arrays.register(ALPRDVTable::ID, ALPRDVTable);
-        arrays.register(BitPackedVTable::ID, BitPackedVTable);
-        arrays.register(ByteBoolVTable::ID, ByteBoolVTable);
-        arrays.register(DateTimePartsVTable::ID, DateTimePartsVTable);
-        arrays.register(DecimalBytePartsVTable::ID, DecimalBytePartsVTable);
-        arrays.register(DeltaVTable::ID, DeltaVTable);
-        arrays.register(DictVTable::ID, DictVTable);
-        arrays.register(FSSTVTable::ID, FSSTVTable);
-        arrays.register(FoRVTable::ID, FoRVTable);
-        arrays.register(PcoVTable::ID, PcoVTable);
-        arrays.register(RLEVTable::ID, RLEVTable);
-        arrays.register(SequenceVTable::ID, SequenceVTable);
-        arrays.register(SparseVTable::ID, SparseVTable);
-        arrays.register(ZigZagVTable::ID, ZigZagVTable);
+        arrays.register(ALP::ID, ALP);
+        arrays.register(ALPRD::ID, ALPRD);
+        arrays.register(BitPacked::ID, BitPacked);
+        arrays.register(ByteBool::ID, ByteBool);
+        arrays.register(DateTimeParts::ID, DateTimeParts);
+        arrays.register(DecimalByteParts::ID, DecimalByteParts);
+        arrays.register(Delta::ID, Delta);
+        arrays.register(Dict::ID, Dict);
+        arrays.register(FSST::ID, FSST);
+        arrays.register(FoR::ID, FoR);
+        arrays.register(Pco::ID, Pco);
+        arrays.register(RLE::ID, RLE);
+        arrays.register(Sequence::ID, Sequence);
+        arrays.register(Sparse::ID, Sparse);
+        arrays.register(ZigZag::ID, ZigZag);
         #[cfg(feature = "zstd")]
-        arrays.register(vortex_zstd::ZstdVTable::ID, vortex_zstd::ZstdVTable);
+        arrays.register(vortex_zstd::Zstd::ID, vortex_zstd::Zstd);
         #[cfg(all(feature = "zstd", feature = "unstable_encodings"))]
-        arrays.register(
-            vortex_zstd::ZstdBuffersVTable::ID,
-            vortex_zstd::ZstdBuffersVTable,
-        );
+        arrays.register(vortex_zstd::ZstdBuffers::ID, vortex_zstd::ZstdBuffers);
     }
 
     // Eventually all encodings crates should expose an initialize function. For now it's only

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -6,25 +6,25 @@
 use std::sync::Arc;
 use std::sync::LazyLock;
 
+use vortex_alp::ALP;
 // Compressed encodings from encoding crates
 // Canonical array encodings from vortex-array
-use vortex_alp::ALPRDVTable;
-use vortex_alp::ALPVTable;
-use vortex_array::arrays::BoolVTable;
-use vortex_array::arrays::ChunkedVTable;
-use vortex_array::arrays::ConstantVTable;
-use vortex_array::arrays::DecimalVTable;
-use vortex_array::arrays::DictVTable;
-use vortex_array::arrays::ExtensionVTable;
-use vortex_array::arrays::FixedSizeListVTable;
-use vortex_array::arrays::ListVTable;
-use vortex_array::arrays::ListViewVTable;
-use vortex_array::arrays::MaskedVTable;
-use vortex_array::arrays::NullVTable;
-use vortex_array::arrays::PrimitiveVTable;
-use vortex_array::arrays::StructVTable;
-use vortex_array::arrays::VarBinVTable;
-use vortex_array::arrays::VarBinViewVTable;
+use vortex_alp::ALPRD;
+use vortex_array::arrays::Bool;
+use vortex_array::arrays::Chunked;
+use vortex_array::arrays::Constant;
+use vortex_array::arrays::Decimal;
+use vortex_array::arrays::Dict;
+use vortex_array::arrays::Extension;
+use vortex_array::arrays::FixedSizeList;
+use vortex_array::arrays::List;
+use vortex_array::arrays::ListView;
+use vortex_array::arrays::Masked;
+use vortex_array::arrays::Null;
+use vortex_array::arrays::Primitive;
+use vortex_array::arrays::Struct;
+use vortex_array::arrays::VarBin;
+use vortex_array::arrays::VarBinView;
 use vortex_array::dtype::FieldPath;
 use vortex_array::session::ArrayRegistry;
 #[cfg(feature = "zstd")]
@@ -35,14 +35,14 @@ use vortex_btrblocks::FloatCode;
 use vortex_btrblocks::IntCode;
 #[cfg(feature = "zstd")]
 use vortex_btrblocks::StringCode;
-use vortex_bytebool::ByteBoolVTable;
-use vortex_datetime_parts::DateTimePartsVTable;
-use vortex_decimal_byte_parts::DecimalBytePartsVTable;
-use vortex_fastlanes::BitPackedVTable;
-use vortex_fastlanes::DeltaVTable;
-use vortex_fastlanes::FoRVTable;
-use vortex_fastlanes::RLEVTable;
-use vortex_fsst::FSSTVTable;
+use vortex_bytebool::ByteBool;
+use vortex_datetime_parts::DateTimeParts;
+use vortex_decimal_byte_parts::DecimalByteParts;
+use vortex_fastlanes::BitPacked;
+use vortex_fastlanes::Delta;
+use vortex_fastlanes::FoR;
+use vortex_fastlanes::RLE;
+use vortex_fsst::FSST;
 use vortex_layout::LayoutStrategy;
 use vortex_layout::layouts::buffered::BufferedStrategy;
 use vortex_layout::layouts::chunked::writer::ChunkedLayoutStrategy;
@@ -56,16 +56,16 @@ use vortex_layout::layouts::repartition::RepartitionWriterOptions;
 use vortex_layout::layouts::table::TableStrategy;
 use vortex_layout::layouts::zoned::writer::ZonedLayoutOptions;
 use vortex_layout::layouts::zoned::writer::ZonedStrategy;
-use vortex_pco::PcoVTable;
-use vortex_runend::RunEndVTable;
-use vortex_sequence::SequenceVTable;
-use vortex_sparse::SparseVTable;
+use vortex_pco::Pco;
+use vortex_runend::RunEnd;
+use vortex_sequence::Sequence;
+use vortex_sparse::Sparse;
 use vortex_utils::aliases::hash_map::HashMap;
-use vortex_zigzag::ZigZagVTable;
-#[cfg(all(feature = "zstd", feature = "unstable_encodings"))]
-use vortex_zstd::ZstdBuffersVTable;
+use vortex_zigzag::ZigZag;
 #[cfg(feature = "zstd")]
-use vortex_zstd::ZstdVTable;
+use vortex_zstd::Zstd;
+#[cfg(all(feature = "zstd", feature = "unstable_encodings"))]
+use vortex_zstd::ZstdBuffers;
 
 const ONE_MEG: u64 = 1 << 20;
 
@@ -77,43 +77,43 @@ pub static ALLOWED_ENCODINGS: LazyLock<ArrayRegistry> = LazyLock::new(|| {
     let registry = ArrayRegistry::default();
 
     // Canonical encodings from vortex-array
-    registry.register(NullVTable::ID, NullVTable);
-    registry.register(BoolVTable::ID, BoolVTable);
-    registry.register(PrimitiveVTable::ID, PrimitiveVTable);
-    registry.register(DecimalVTable::ID, DecimalVTable);
-    registry.register(VarBinVTable::ID, VarBinVTable);
-    registry.register(VarBinViewVTable::ID, VarBinViewVTable);
-    registry.register(ListVTable::ID, ListVTable);
-    registry.register(ListViewVTable::ID, ListViewVTable);
-    registry.register(FixedSizeListVTable::ID, FixedSizeListVTable);
-    registry.register(StructVTable::ID, StructVTable);
-    registry.register(ExtensionVTable::ID, ExtensionVTable);
-    registry.register(ChunkedVTable::ID, ChunkedVTable);
-    registry.register(ConstantVTable::ID, ConstantVTable);
-    registry.register(MaskedVTable::ID, MaskedVTable);
-    registry.register(DictVTable::ID, DictVTable);
+    registry.register(Null::ID, Null);
+    registry.register(Bool::ID, Bool);
+    registry.register(Primitive::ID, Primitive);
+    registry.register(Decimal::ID, Decimal);
+    registry.register(VarBin::ID, VarBin);
+    registry.register(VarBinView::ID, VarBinView);
+    registry.register(List::ID, List);
+    registry.register(ListView::ID, ListView);
+    registry.register(FixedSizeList::ID, FixedSizeList);
+    registry.register(Struct::ID, Struct);
+    registry.register(Extension::ID, Extension);
+    registry.register(Chunked::ID, Chunked);
+    registry.register(Constant::ID, Constant);
+    registry.register(Masked::ID, Masked);
+    registry.register(Dict::ID, Dict);
 
     // Compressed encodings from encoding crates
-    registry.register(ALPVTable::ID, ALPVTable);
-    registry.register(ALPRDVTable::ID, ALPRDVTable);
-    registry.register(BitPackedVTable::ID, BitPackedVTable);
-    registry.register(ByteBoolVTable::ID, ByteBoolVTable);
-    registry.register(DateTimePartsVTable::ID, DateTimePartsVTable);
-    registry.register(DecimalBytePartsVTable::ID, DecimalBytePartsVTable);
-    registry.register(DeltaVTable::ID, DeltaVTable);
-    registry.register(FoRVTable::ID, FoRVTable);
-    registry.register(FSSTVTable::ID, FSSTVTable);
-    registry.register(PcoVTable::ID, PcoVTable);
-    registry.register(RLEVTable::ID, RLEVTable);
-    registry.register(RunEndVTable::ID, RunEndVTable);
-    registry.register(SequenceVTable::ID, SequenceVTable);
-    registry.register(SparseVTable::ID, SparseVTable);
-    registry.register(ZigZagVTable::ID, ZigZagVTable);
+    registry.register(ALP::ID, ALP);
+    registry.register(ALPRD::ID, ALPRD);
+    registry.register(BitPacked::ID, BitPacked);
+    registry.register(ByteBool::ID, ByteBool);
+    registry.register(DateTimeParts::ID, DateTimeParts);
+    registry.register(DecimalByteParts::ID, DecimalByteParts);
+    registry.register(Delta::ID, Delta);
+    registry.register(FoR::ID, FoR);
+    registry.register(FSST::ID, FSST);
+    registry.register(Pco::ID, Pco);
+    registry.register(RLE::ID, RLE);
+    registry.register(RunEnd::ID, RunEnd);
+    registry.register(Sequence::ID, Sequence);
+    registry.register(Sparse::ID, Sparse);
+    registry.register(ZigZag::ID, ZigZag);
 
     #[cfg(feature = "zstd")]
-    registry.register(ZstdVTable::ID, ZstdVTable);
+    registry.register(Zstd::ID, Zstd);
     #[cfg(all(feature = "zstd", feature = "unstable_encodings"))]
-    registry.register(ZstdBuffersVTable::ID, ZstdBuffersVTable);
+    registry.register(ZstdBuffers::ID, ZstdBuffers);
 
     registry
 });

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -18,7 +18,7 @@ use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::DecimalArray;
-use vortex_array::arrays::DictVTable;
+use vortex_array::arrays::Dict;
 use vortex_array::arrays::ListArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::StructArray;
@@ -1320,10 +1320,10 @@ async fn test_array_stream_no_double_dict_encode() -> VortexResult<()> {
     let read_array = file.scan()?.into_array_stream()?.read_all().await?;
 
     let dict = read_array
-        .as_opt::<DictVTable>()
+        .as_opt::<Dict>()
         .expect("expected root to be dictionary");
     assert!(
-        !dict.codes().is::<DictVTable>(),
+        !dict.codes().is::<Dict>(),
         "dictionary codes should not be dictionary encoded"
     );
     Ok(())

--- a/vortex-layout/public-api.lock
+++ b/vortex-layout/public-api.lock
@@ -60,6 +60,44 @@ pub fn vortex_layout::layouts::chunked::writer::ChunkedLayoutStrategy::buffered_
 
 pub fn vortex_layout::layouts::chunked::writer::ChunkedLayoutStrategy::write_stream<'life0, 'async_trait>(&'life0 self, ctx: vortex_array::ArrayContext, segment_sink: vortex_layout::segments::SegmentSinkRef, stream: vortex_layout::sequence::SendableSequentialStream, eof: vortex_layout::sequence::SequencePointer, handle: vortex_io::runtime::handle::Handle) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_layout::LayoutRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 
+pub struct vortex_layout::layouts::chunked::Chunked
+
+impl core::fmt::Debug for vortex_layout::layouts::chunked::Chunked
+
+pub fn vortex_layout::layouts::chunked::Chunked::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_layout::VTable for vortex_layout::layouts::chunked::Chunked
+
+pub type vortex_layout::layouts::chunked::Chunked::Encoding = vortex_layout::layouts::chunked::ChunkedLayoutEncoding
+
+pub type vortex_layout::layouts::chunked::Chunked::Layout = vortex_layout::layouts::chunked::ChunkedLayout
+
+pub type vortex_layout::layouts::chunked::Chunked::Metadata = vortex_array::metadata::EmptyMetadata
+
+pub fn vortex_layout::layouts::chunked::Chunked::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+
+pub fn vortex_layout::layouts::chunked::Chunked::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+
+pub fn vortex_layout::layouts::chunked::Chunked::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+
+pub fn vortex_layout::layouts::chunked::Chunked::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+
+pub fn vortex_layout::layouts::chunked::Chunked::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+
+pub fn vortex_layout::layouts::chunked::Chunked::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+
+pub fn vortex_layout::layouts::chunked::Chunked::metadata(_layout: &Self::Layout) -> Self::Metadata
+
+pub fn vortex_layout::layouts::chunked::Chunked::nchildren(layout: &Self::Layout) -> usize
+
+pub fn vortex_layout::layouts::chunked::Chunked::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+
+pub fn vortex_layout::layouts::chunked::Chunked::row_count(layout: &Self::Layout) -> u64
+
+pub fn vortex_layout::layouts::chunked::Chunked::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+
+pub fn vortex_layout::layouts::chunked::Chunked::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+
 pub struct vortex_layout::layouts::chunked::ChunkedLayout
 
 impl vortex_layout::layouts::chunked::ChunkedLayout
@@ -109,44 +147,6 @@ impl core::ops::deref::Deref for vortex_layout::layouts::chunked::ChunkedLayoutE
 pub type vortex_layout::layouts::chunked::ChunkedLayoutEncoding::Target = dyn vortex_layout::LayoutEncoding
 
 pub fn vortex_layout::layouts::chunked::ChunkedLayoutEncoding::deref(&self) -> &Self::Target
-
-pub struct vortex_layout::layouts::chunked::ChunkedVTable
-
-impl core::fmt::Debug for vortex_layout::layouts::chunked::ChunkedVTable
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_layout::VTable for vortex_layout::layouts::chunked::ChunkedVTable
-
-pub type vortex_layout::layouts::chunked::ChunkedVTable::Encoding = vortex_layout::layouts::chunked::ChunkedLayoutEncoding
-
-pub type vortex_layout::layouts::chunked::ChunkedVTable::Layout = vortex_layout::layouts::chunked::ChunkedLayout
-
-pub type vortex_layout::layouts::chunked::ChunkedVTable::Metadata = vortex_array::metadata::EmptyMetadata
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::metadata(_layout: &Self::Layout) -> Self::Metadata
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::nchildren(layout: &Self::Layout) -> usize
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::row_count(layout: &Self::Layout) -> u64
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
-
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
 pub mod vortex_layout::layouts::collect
 
@@ -278,6 +278,44 @@ pub fn vortex_layout::layouts::dict::writer::DictStrategy::write_stream<'life0, 
 
 pub fn vortex_layout::layouts::dict::writer::dict_layout_supported(dtype: &vortex_array::dtype::DType) -> bool
 
+pub struct vortex_layout::layouts::dict::Dict
+
+impl core::fmt::Debug for vortex_layout::layouts::dict::Dict
+
+pub fn vortex_layout::layouts::dict::Dict::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_layout::VTable for vortex_layout::layouts::dict::Dict
+
+pub type vortex_layout::layouts::dict::Dict::Encoding = vortex_layout::layouts::dict::DictLayoutEncoding
+
+pub type vortex_layout::layouts::dict::Dict::Layout = vortex_layout::layouts::dict::DictLayout
+
+pub type vortex_layout::layouts::dict::Dict::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::dict::DictLayoutMetadata>
+
+pub fn vortex_layout::layouts::dict::Dict::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+
+pub fn vortex_layout::layouts::dict::Dict::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+
+pub fn vortex_layout::layouts::dict::Dict::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+
+pub fn vortex_layout::layouts::dict::Dict::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+
+pub fn vortex_layout::layouts::dict::Dict::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+
+pub fn vortex_layout::layouts::dict::Dict::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+
+pub fn vortex_layout::layouts::dict::Dict::metadata(layout: &Self::Layout) -> Self::Metadata
+
+pub fn vortex_layout::layouts::dict::Dict::nchildren(_layout: &Self::Layout) -> usize
+
+pub fn vortex_layout::layouts::dict::Dict::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+
+pub fn vortex_layout::layouts::dict::Dict::row_count(layout: &Self::Layout) -> u64
+
+pub fn vortex_layout::layouts::dict::Dict::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+
+pub fn vortex_layout::layouts::dict::Dict::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+
 pub struct vortex_layout::layouts::dict::DictLayout
 
 impl vortex_layout::layouts::dict::DictLayout
@@ -358,44 +396,6 @@ pub fn vortex_layout::layouts::dict::DictLayoutMetadata::clear(&mut self)
 
 pub fn vortex_layout::layouts::dict::DictLayoutMetadata::encoded_len(&self) -> usize
 
-pub struct vortex_layout::layouts::dict::DictVTable
-
-impl core::fmt::Debug for vortex_layout::layouts::dict::DictVTable
-
-pub fn vortex_layout::layouts::dict::DictVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_layout::VTable for vortex_layout::layouts::dict::DictVTable
-
-pub type vortex_layout::layouts::dict::DictVTable::Encoding = vortex_layout::layouts::dict::DictLayoutEncoding
-
-pub type vortex_layout::layouts::dict::DictVTable::Layout = vortex_layout::layouts::dict::DictLayout
-
-pub type vortex_layout::layouts::dict::DictVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::dict::DictLayoutMetadata>
-
-pub fn vortex_layout::layouts::dict::DictVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
-
-pub fn vortex_layout::layouts::dict::DictVTable::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
-
-pub fn vortex_layout::layouts::dict::DictVTable::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
-
-pub fn vortex_layout::layouts::dict::DictVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
-
-pub fn vortex_layout::layouts::dict::DictVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
-
-pub fn vortex_layout::layouts::dict::DictVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
-
-pub fn vortex_layout::layouts::dict::DictVTable::metadata(layout: &Self::Layout) -> Self::Metadata
-
-pub fn vortex_layout::layouts::dict::DictVTable::nchildren(_layout: &Self::Layout) -> usize
-
-pub fn vortex_layout::layouts::dict::DictVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
-
-pub fn vortex_layout::layouts::dict::DictVTable::row_count(layout: &Self::Layout) -> u64
-
-pub fn vortex_layout::layouts::dict::DictVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
-
-pub fn vortex_layout::layouts::dict::DictVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
-
 pub mod vortex_layout::layouts::file_stats
 
 pub struct vortex_layout::layouts::file_stats::FileStatsAccumulator
@@ -443,6 +443,44 @@ impl vortex_layout::LayoutStrategy for vortex_layout::layouts::flat::writer::Fla
 pub fn vortex_layout::layouts::flat::writer::FlatLayoutStrategy::buffered_bytes(&self) -> u64
 
 pub fn vortex_layout::layouts::flat::writer::FlatLayoutStrategy::write_stream<'life0, 'async_trait>(&'life0 self, ctx: vortex_array::ArrayContext, segment_sink: vortex_layout::segments::SegmentSinkRef, stream: vortex_layout::sequence::SendableSequentialStream, _eof: vortex_layout::sequence::SequencePointer, _handle: vortex_io::runtime::handle::Handle) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_layout::LayoutRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
+
+pub struct vortex_layout::layouts::flat::Flat
+
+impl core::fmt::Debug for vortex_layout::layouts::flat::Flat
+
+pub fn vortex_layout::layouts::flat::Flat::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_layout::VTable for vortex_layout::layouts::flat::Flat
+
+pub type vortex_layout::layouts::flat::Flat::Encoding = vortex_layout::layouts::flat::FlatLayoutEncoding
+
+pub type vortex_layout::layouts::flat::Flat::Layout = vortex_layout::layouts::flat::FlatLayout
+
+pub type vortex_layout::layouts::flat::Flat::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::flat::FlatLayoutMetadata>
+
+pub fn vortex_layout::layouts::flat::Flat::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, _children: &dyn vortex_layout::LayoutChildren, ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+
+pub fn vortex_layout::layouts::flat::Flat::child(_layout: &Self::Layout, _idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+
+pub fn vortex_layout::layouts::flat::Flat::child_type(_layout: &Self::Layout, _idx: usize) -> vortex_layout::LayoutChildType
+
+pub fn vortex_layout::layouts::flat::Flat::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+
+pub fn vortex_layout::layouts::flat::Flat::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+
+pub fn vortex_layout::layouts::flat::Flat::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+
+pub fn vortex_layout::layouts::flat::Flat::metadata(layout: &Self::Layout) -> Self::Metadata
+
+pub fn vortex_layout::layouts::flat::Flat::nchildren(_layout: &Self::Layout) -> usize
+
+pub fn vortex_layout::layouts::flat::Flat::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+
+pub fn vortex_layout::layouts::flat::Flat::row_count(layout: &Self::Layout) -> u64
+
+pub fn vortex_layout::layouts::flat::Flat::segment_ids(layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+
+pub fn vortex_layout::layouts::flat::Flat::with_children(_layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
 pub struct vortex_layout::layouts::flat::FlatLayout
 
@@ -521,44 +559,6 @@ impl prost::message::Message for vortex_layout::layouts::flat::FlatLayoutMetadat
 pub fn vortex_layout::layouts::flat::FlatLayoutMetadata::clear(&mut self)
 
 pub fn vortex_layout::layouts::flat::FlatLayoutMetadata::encoded_len(&self) -> usize
-
-pub struct vortex_layout::layouts::flat::FlatVTable
-
-impl core::fmt::Debug for vortex_layout::layouts::flat::FlatVTable
-
-pub fn vortex_layout::layouts::flat::FlatVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_layout::VTable for vortex_layout::layouts::flat::FlatVTable
-
-pub type vortex_layout::layouts::flat::FlatVTable::Encoding = vortex_layout::layouts::flat::FlatLayoutEncoding
-
-pub type vortex_layout::layouts::flat::FlatVTable::Layout = vortex_layout::layouts::flat::FlatLayout
-
-pub type vortex_layout::layouts::flat::FlatVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::flat::FlatLayoutMetadata>
-
-pub fn vortex_layout::layouts::flat::FlatVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, _children: &dyn vortex_layout::LayoutChildren, ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
-
-pub fn vortex_layout::layouts::flat::FlatVTable::child(_layout: &Self::Layout, _idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
-
-pub fn vortex_layout::layouts::flat::FlatVTable::child_type(_layout: &Self::Layout, _idx: usize) -> vortex_layout::LayoutChildType
-
-pub fn vortex_layout::layouts::flat::FlatVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
-
-pub fn vortex_layout::layouts::flat::FlatVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
-
-pub fn vortex_layout::layouts::flat::FlatVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
-
-pub fn vortex_layout::layouts::flat::FlatVTable::metadata(layout: &Self::Layout) -> Self::Metadata
-
-pub fn vortex_layout::layouts::flat::FlatVTable::nchildren(_layout: &Self::Layout) -> usize
-
-pub fn vortex_layout::layouts::flat::FlatVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
-
-pub fn vortex_layout::layouts::flat::FlatVTable::row_count(layout: &Self::Layout) -> u64
-
-pub fn vortex_layout::layouts::flat::FlatVTable::segment_ids(layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
-
-pub fn vortex_layout::layouts::flat::FlatVTable::with_children(_layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
 pub mod vortex_layout::layouts::repartition
 
@@ -660,6 +660,44 @@ pub fn vortex_layout::layouts::struct_::writer::StructStrategy::buffered_bytes(&
 
 pub fn vortex_layout::layouts::struct_::writer::StructStrategy::write_stream<'life0, 'async_trait>(&'life0 self, ctx: vortex_array::ArrayContext, segment_sink: vortex_layout::segments::SegmentSinkRef, stream: vortex_layout::sequence::SendableSequentialStream, eof: vortex_layout::sequence::SequencePointer, handle: vortex_io::runtime::handle::Handle) -> core::pin::Pin<alloc::boxed::Box<(dyn core::future::future::Future<Output = vortex_error::VortexResult<vortex_layout::LayoutRef>> + core::marker::Send + 'async_trait)>> where Self: 'async_trait, 'life0: 'async_trait
 
+pub struct vortex_layout::layouts::struct_::Struct
+
+impl core::fmt::Debug for vortex_layout::layouts::struct_::Struct
+
+pub fn vortex_layout::layouts::struct_::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_layout::VTable for vortex_layout::layouts::struct_::Struct
+
+pub type vortex_layout::layouts::struct_::Struct::Encoding = vortex_layout::layouts::struct_::StructLayoutEncoding
+
+pub type vortex_layout::layouts::struct_::Struct::Layout = vortex_layout::layouts::struct_::StructLayout
+
+pub type vortex_layout::layouts::struct_::Struct::Metadata = vortex_array::metadata::EmptyMetadata
+
+pub fn vortex_layout::layouts::struct_::Struct::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+
+pub fn vortex_layout::layouts::struct_::Struct::child(layout: &Self::Layout, index: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+
+pub fn vortex_layout::layouts::struct_::Struct::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+
+pub fn vortex_layout::layouts::struct_::Struct::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+
+pub fn vortex_layout::layouts::struct_::Struct::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+
+pub fn vortex_layout::layouts::struct_::Struct::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+
+pub fn vortex_layout::layouts::struct_::Struct::metadata(_layout: &Self::Layout) -> Self::Metadata
+
+pub fn vortex_layout::layouts::struct_::Struct::nchildren(layout: &Self::Layout) -> usize
+
+pub fn vortex_layout::layouts::struct_::Struct::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+
+pub fn vortex_layout::layouts::struct_::Struct::row_count(layout: &Self::Layout) -> u64
+
+pub fn vortex_layout::layouts::struct_::Struct::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+
+pub fn vortex_layout::layouts::struct_::Struct::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+
 pub struct vortex_layout::layouts::struct_::StructLayout
 
 impl vortex_layout::layouts::struct_::StructLayout
@@ -715,44 +753,6 @@ impl core::ops::deref::Deref for vortex_layout::layouts::struct_::StructLayoutEn
 pub type vortex_layout::layouts::struct_::StructLayoutEncoding::Target = dyn vortex_layout::LayoutEncoding
 
 pub fn vortex_layout::layouts::struct_::StructLayoutEncoding::deref(&self) -> &Self::Target
-
-pub struct vortex_layout::layouts::struct_::StructVTable
-
-impl core::fmt::Debug for vortex_layout::layouts::struct_::StructVTable
-
-pub fn vortex_layout::layouts::struct_::StructVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_layout::VTable for vortex_layout::layouts::struct_::StructVTable
-
-pub type vortex_layout::layouts::struct_::StructVTable::Encoding = vortex_layout::layouts::struct_::StructLayoutEncoding
-
-pub type vortex_layout::layouts::struct_::StructVTable::Layout = vortex_layout::layouts::struct_::StructLayout
-
-pub type vortex_layout::layouts::struct_::StructVTable::Metadata = vortex_array::metadata::EmptyMetadata
-
-pub fn vortex_layout::layouts::struct_::StructVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
-
-pub fn vortex_layout::layouts::struct_::StructVTable::child(layout: &Self::Layout, index: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
-
-pub fn vortex_layout::layouts::struct_::StructVTable::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
-
-pub fn vortex_layout::layouts::struct_::StructVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
-
-pub fn vortex_layout::layouts::struct_::StructVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
-
-pub fn vortex_layout::layouts::struct_::StructVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
-
-pub fn vortex_layout::layouts::struct_::StructVTable::metadata(_layout: &Self::Layout) -> Self::Metadata
-
-pub fn vortex_layout::layouts::struct_::StructVTable::nchildren(layout: &Self::Layout) -> usize
-
-pub fn vortex_layout::layouts::struct_::StructVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
-
-pub fn vortex_layout::layouts::struct_::StructVTable::row_count(layout: &Self::Layout) -> u64
-
-pub fn vortex_layout::layouts::struct_::StructVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
-
-pub fn vortex_layout::layouts::struct_::StructVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
 pub mod vortex_layout::layouts::table
 
@@ -844,6 +844,44 @@ impl core::clone::Clone for vortex_layout::layouts::zoned::zone_map::ZoneMap
 
 pub fn vortex_layout::layouts::zoned::zone_map::ZoneMap::clone(&self) -> vortex_layout::layouts::zoned::zone_map::ZoneMap
 
+pub struct vortex_layout::layouts::zoned::Zoned
+
+impl core::fmt::Debug for vortex_layout::layouts::zoned::Zoned
+
+pub fn vortex_layout::layouts::zoned::Zoned::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl vortex_layout::VTable for vortex_layout::layouts::zoned::Zoned
+
+pub type vortex_layout::layouts::zoned::Zoned::Encoding = vortex_layout::layouts::zoned::ZonedLayoutEncoding
+
+pub type vortex_layout::layouts::zoned::Zoned::Layout = vortex_layout::layouts::zoned::ZonedLayout
+
+pub type vortex_layout::layouts::zoned::Zoned::Metadata = vortex_layout::layouts::zoned::ZonedMetadata
+
+pub fn vortex_layout::layouts::zoned::Zoned::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &vortex_layout::layouts::zoned::ZonedMetadata, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+
+pub fn vortex_layout::layouts::zoned::Zoned::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+
+pub fn vortex_layout::layouts::zoned::Zoned::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+
+pub fn vortex_layout::layouts::zoned::Zoned::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+
+pub fn vortex_layout::layouts::zoned::Zoned::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+
+pub fn vortex_layout::layouts::zoned::Zoned::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+
+pub fn vortex_layout::layouts::zoned::Zoned::metadata(layout: &Self::Layout) -> Self::Metadata
+
+pub fn vortex_layout::layouts::zoned::Zoned::nchildren(_layout: &Self::Layout) -> usize
+
+pub fn vortex_layout::layouts::zoned::Zoned::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+
+pub fn vortex_layout::layouts::zoned::Zoned::row_count(layout: &Self::Layout) -> u64
+
+pub fn vortex_layout::layouts::zoned::Zoned::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+
+pub fn vortex_layout::layouts::zoned::Zoned::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+
 pub struct vortex_layout::layouts::zoned::ZonedLayout
 
 impl vortex_layout::layouts::zoned::ZonedLayout
@@ -923,44 +961,6 @@ pub fn vortex_layout::layouts::zoned::ZonedMetadata::deserialize(metadata: &[u8]
 impl vortex_array::metadata::SerializeMetadata for vortex_layout::layouts::zoned::ZonedMetadata
 
 pub fn vortex_layout::layouts::zoned::ZonedMetadata::serialize(self) -> alloc::vec::Vec<u8>
-
-pub struct vortex_layout::layouts::zoned::ZonedVTable
-
-impl core::fmt::Debug for vortex_layout::layouts::zoned::ZonedVTable
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
-
-impl vortex_layout::VTable for vortex_layout::layouts::zoned::ZonedVTable
-
-pub type vortex_layout::layouts::zoned::ZonedVTable::Encoding = vortex_layout::layouts::zoned::ZonedLayoutEncoding
-
-pub type vortex_layout::layouts::zoned::ZonedVTable::Layout = vortex_layout::layouts::zoned::ZonedLayout
-
-pub type vortex_layout::layouts::zoned::ZonedVTable::Metadata = vortex_layout::layouts::zoned::ZonedMetadata
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &vortex_layout::layouts::zoned::ZonedMetadata, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::metadata(layout: &Self::Layout) -> Self::Metadata
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::nchildren(_layout: &Self::Layout) -> usize
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::row_count(layout: &Self::Layout) -> u64
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
-
-pub fn vortex_layout::layouts::zoned::ZonedVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
 pub const vortex_layout::layouts::zoned::MAX_IS_TRUNCATED: &str
 
@@ -1290,165 +1290,165 @@ pub fn vortex_layout::vtable::VTable::segment_ids(layout: &Self::Layout) -> allo
 
 pub fn vortex_layout::vtable::VTable::with_children(_layout: &mut Self::Layout, _children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_layout::VTable for vortex_layout::layouts::chunked::ChunkedVTable
+impl vortex_layout::VTable for vortex_layout::layouts::chunked::Chunked
 
-pub type vortex_layout::layouts::chunked::ChunkedVTable::Encoding = vortex_layout::layouts::chunked::ChunkedLayoutEncoding
+pub type vortex_layout::layouts::chunked::Chunked::Encoding = vortex_layout::layouts::chunked::ChunkedLayoutEncoding
 
-pub type vortex_layout::layouts::chunked::ChunkedVTable::Layout = vortex_layout::layouts::chunked::ChunkedLayout
+pub type vortex_layout::layouts::chunked::Chunked::Layout = vortex_layout::layouts::chunked::ChunkedLayout
 
-pub type vortex_layout::layouts::chunked::ChunkedVTable::Metadata = vortex_array::metadata::EmptyMetadata
+pub type vortex_layout::layouts::chunked::Chunked::Metadata = vortex_array::metadata::EmptyMetadata
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+pub fn vortex_layout::layouts::chunked::Chunked::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+pub fn vortex_layout::layouts::chunked::Chunked::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+pub fn vortex_layout::layouts::chunked::Chunked::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+pub fn vortex_layout::layouts::chunked::Chunked::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+pub fn vortex_layout::layouts::chunked::Chunked::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+pub fn vortex_layout::layouts::chunked::Chunked::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::metadata(_layout: &Self::Layout) -> Self::Metadata
+pub fn vortex_layout::layouts::chunked::Chunked::metadata(_layout: &Self::Layout) -> Self::Metadata
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::nchildren(layout: &Self::Layout) -> usize
+pub fn vortex_layout::layouts::chunked::Chunked::nchildren(layout: &Self::Layout) -> usize
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+pub fn vortex_layout::layouts::chunked::Chunked::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::row_count(layout: &Self::Layout) -> u64
+pub fn vortex_layout::layouts::chunked::Chunked::row_count(layout: &Self::Layout) -> u64
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+pub fn vortex_layout::layouts::chunked::Chunked::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::chunked::Chunked::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_layout::VTable for vortex_layout::layouts::dict::DictVTable
+impl vortex_layout::VTable for vortex_layout::layouts::dict::Dict
 
-pub type vortex_layout::layouts::dict::DictVTable::Encoding = vortex_layout::layouts::dict::DictLayoutEncoding
+pub type vortex_layout::layouts::dict::Dict::Encoding = vortex_layout::layouts::dict::DictLayoutEncoding
 
-pub type vortex_layout::layouts::dict::DictVTable::Layout = vortex_layout::layouts::dict::DictLayout
+pub type vortex_layout::layouts::dict::Dict::Layout = vortex_layout::layouts::dict::DictLayout
 
-pub type vortex_layout::layouts::dict::DictVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::dict::DictLayoutMetadata>
+pub type vortex_layout::layouts::dict::Dict::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::dict::DictLayoutMetadata>
 
-pub fn vortex_layout::layouts::dict::DictVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+pub fn vortex_layout::layouts::dict::Dict::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
 
-pub fn vortex_layout::layouts::dict::DictVTable::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+pub fn vortex_layout::layouts::dict::Dict::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
-pub fn vortex_layout::layouts::dict::DictVTable::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+pub fn vortex_layout::layouts::dict::Dict::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
 
-pub fn vortex_layout::layouts::dict::DictVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+pub fn vortex_layout::layouts::dict::Dict::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
 
-pub fn vortex_layout::layouts::dict::DictVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+pub fn vortex_layout::layouts::dict::Dict::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
 
-pub fn vortex_layout::layouts::dict::DictVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+pub fn vortex_layout::layouts::dict::Dict::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
 
-pub fn vortex_layout::layouts::dict::DictVTable::metadata(layout: &Self::Layout) -> Self::Metadata
+pub fn vortex_layout::layouts::dict::Dict::metadata(layout: &Self::Layout) -> Self::Metadata
 
-pub fn vortex_layout::layouts::dict::DictVTable::nchildren(_layout: &Self::Layout) -> usize
+pub fn vortex_layout::layouts::dict::Dict::nchildren(_layout: &Self::Layout) -> usize
 
-pub fn vortex_layout::layouts::dict::DictVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+pub fn vortex_layout::layouts::dict::Dict::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
 
-pub fn vortex_layout::layouts::dict::DictVTable::row_count(layout: &Self::Layout) -> u64
+pub fn vortex_layout::layouts::dict::Dict::row_count(layout: &Self::Layout) -> u64
 
-pub fn vortex_layout::layouts::dict::DictVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+pub fn vortex_layout::layouts::dict::Dict::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
 
-pub fn vortex_layout::layouts::dict::DictVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::dict::Dict::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_layout::VTable for vortex_layout::layouts::flat::FlatVTable
+impl vortex_layout::VTable for vortex_layout::layouts::flat::Flat
 
-pub type vortex_layout::layouts::flat::FlatVTable::Encoding = vortex_layout::layouts::flat::FlatLayoutEncoding
+pub type vortex_layout::layouts::flat::Flat::Encoding = vortex_layout::layouts::flat::FlatLayoutEncoding
 
-pub type vortex_layout::layouts::flat::FlatVTable::Layout = vortex_layout::layouts::flat::FlatLayout
+pub type vortex_layout::layouts::flat::Flat::Layout = vortex_layout::layouts::flat::FlatLayout
 
-pub type vortex_layout::layouts::flat::FlatVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::flat::FlatLayoutMetadata>
+pub type vortex_layout::layouts::flat::Flat::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::flat::FlatLayoutMetadata>
 
-pub fn vortex_layout::layouts::flat::FlatVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, _children: &dyn vortex_layout::LayoutChildren, ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+pub fn vortex_layout::layouts::flat::Flat::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, _children: &dyn vortex_layout::LayoutChildren, ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
 
-pub fn vortex_layout::layouts::flat::FlatVTable::child(_layout: &Self::Layout, _idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+pub fn vortex_layout::layouts::flat::Flat::child(_layout: &Self::Layout, _idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
-pub fn vortex_layout::layouts::flat::FlatVTable::child_type(_layout: &Self::Layout, _idx: usize) -> vortex_layout::LayoutChildType
+pub fn vortex_layout::layouts::flat::Flat::child_type(_layout: &Self::Layout, _idx: usize) -> vortex_layout::LayoutChildType
 
-pub fn vortex_layout::layouts::flat::FlatVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+pub fn vortex_layout::layouts::flat::Flat::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
 
-pub fn vortex_layout::layouts::flat::FlatVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+pub fn vortex_layout::layouts::flat::Flat::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
 
-pub fn vortex_layout::layouts::flat::FlatVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+pub fn vortex_layout::layouts::flat::Flat::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
 
-pub fn vortex_layout::layouts::flat::FlatVTable::metadata(layout: &Self::Layout) -> Self::Metadata
+pub fn vortex_layout::layouts::flat::Flat::metadata(layout: &Self::Layout) -> Self::Metadata
 
-pub fn vortex_layout::layouts::flat::FlatVTable::nchildren(_layout: &Self::Layout) -> usize
+pub fn vortex_layout::layouts::flat::Flat::nchildren(_layout: &Self::Layout) -> usize
 
-pub fn vortex_layout::layouts::flat::FlatVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+pub fn vortex_layout::layouts::flat::Flat::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
 
-pub fn vortex_layout::layouts::flat::FlatVTable::row_count(layout: &Self::Layout) -> u64
+pub fn vortex_layout::layouts::flat::Flat::row_count(layout: &Self::Layout) -> u64
 
-pub fn vortex_layout::layouts::flat::FlatVTable::segment_ids(layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+pub fn vortex_layout::layouts::flat::Flat::segment_ids(layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
 
-pub fn vortex_layout::layouts::flat::FlatVTable::with_children(_layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::flat::Flat::with_children(_layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_layout::VTable for vortex_layout::layouts::struct_::StructVTable
+impl vortex_layout::VTable for vortex_layout::layouts::struct_::Struct
 
-pub type vortex_layout::layouts::struct_::StructVTable::Encoding = vortex_layout::layouts::struct_::StructLayoutEncoding
+pub type vortex_layout::layouts::struct_::Struct::Encoding = vortex_layout::layouts::struct_::StructLayoutEncoding
 
-pub type vortex_layout::layouts::struct_::StructVTable::Layout = vortex_layout::layouts::struct_::StructLayout
+pub type vortex_layout::layouts::struct_::Struct::Layout = vortex_layout::layouts::struct_::StructLayout
 
-pub type vortex_layout::layouts::struct_::StructVTable::Metadata = vortex_array::metadata::EmptyMetadata
+pub type vortex_layout::layouts::struct_::Struct::Metadata = vortex_array::metadata::EmptyMetadata
 
-pub fn vortex_layout::layouts::struct_::StructVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+pub fn vortex_layout::layouts::struct_::Struct::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
 
-pub fn vortex_layout::layouts::struct_::StructVTable::child(layout: &Self::Layout, index: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+pub fn vortex_layout::layouts::struct_::Struct::child(layout: &Self::Layout, index: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
-pub fn vortex_layout::layouts::struct_::StructVTable::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+pub fn vortex_layout::layouts::struct_::Struct::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
 
-pub fn vortex_layout::layouts::struct_::StructVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+pub fn vortex_layout::layouts::struct_::Struct::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
 
-pub fn vortex_layout::layouts::struct_::StructVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+pub fn vortex_layout::layouts::struct_::Struct::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
 
-pub fn vortex_layout::layouts::struct_::StructVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+pub fn vortex_layout::layouts::struct_::Struct::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
 
-pub fn vortex_layout::layouts::struct_::StructVTable::metadata(_layout: &Self::Layout) -> Self::Metadata
+pub fn vortex_layout::layouts::struct_::Struct::metadata(_layout: &Self::Layout) -> Self::Metadata
 
-pub fn vortex_layout::layouts::struct_::StructVTable::nchildren(layout: &Self::Layout) -> usize
+pub fn vortex_layout::layouts::struct_::Struct::nchildren(layout: &Self::Layout) -> usize
 
-pub fn vortex_layout::layouts::struct_::StructVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+pub fn vortex_layout::layouts::struct_::Struct::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
 
-pub fn vortex_layout::layouts::struct_::StructVTable::row_count(layout: &Self::Layout) -> u64
+pub fn vortex_layout::layouts::struct_::Struct::row_count(layout: &Self::Layout) -> u64
 
-pub fn vortex_layout::layouts::struct_::StructVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+pub fn vortex_layout::layouts::struct_::Struct::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
 
-pub fn vortex_layout::layouts::struct_::StructVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::struct_::Struct::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_layout::VTable for vortex_layout::layouts::zoned::ZonedVTable
+impl vortex_layout::VTable for vortex_layout::layouts::zoned::Zoned
 
-pub type vortex_layout::layouts::zoned::ZonedVTable::Encoding = vortex_layout::layouts::zoned::ZonedLayoutEncoding
+pub type vortex_layout::layouts::zoned::Zoned::Encoding = vortex_layout::layouts::zoned::ZonedLayoutEncoding
 
-pub type vortex_layout::layouts::zoned::ZonedVTable::Layout = vortex_layout::layouts::zoned::ZonedLayout
+pub type vortex_layout::layouts::zoned::Zoned::Layout = vortex_layout::layouts::zoned::ZonedLayout
 
-pub type vortex_layout::layouts::zoned::ZonedVTable::Metadata = vortex_layout::layouts::zoned::ZonedMetadata
+pub type vortex_layout::layouts::zoned::Zoned::Metadata = vortex_layout::layouts::zoned::ZonedMetadata
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &vortex_layout::layouts::zoned::ZonedMetadata, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+pub fn vortex_layout::layouts::zoned::Zoned::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &vortex_layout::layouts::zoned::ZonedMetadata, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+pub fn vortex_layout::layouts::zoned::Zoned::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+pub fn vortex_layout::layouts::zoned::Zoned::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+pub fn vortex_layout::layouts::zoned::Zoned::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+pub fn vortex_layout::layouts::zoned::Zoned::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+pub fn vortex_layout::layouts::zoned::Zoned::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::metadata(layout: &Self::Layout) -> Self::Metadata
+pub fn vortex_layout::layouts::zoned::Zoned::metadata(layout: &Self::Layout) -> Self::Metadata
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::nchildren(_layout: &Self::Layout) -> usize
+pub fn vortex_layout::layouts::zoned::Zoned::nchildren(_layout: &Self::Layout) -> usize
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+pub fn vortex_layout::layouts::zoned::Zoned::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::row_count(layout: &Self::Layout) -> u64
+pub fn vortex_layout::layouts::zoned::Zoned::row_count(layout: &Self::Layout) -> u64
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+pub fn vortex_layout::layouts::zoned::Zoned::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::zoned::Zoned::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
 pub macro vortex_layout::vtable!
 
@@ -1794,165 +1794,165 @@ pub fn vortex_layout::VTable::segment_ids(layout: &Self::Layout) -> alloc::vec::
 
 pub fn vortex_layout::VTable::with_children(_layout: &mut Self::Layout, _children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_layout::VTable for vortex_layout::layouts::chunked::ChunkedVTable
+impl vortex_layout::VTable for vortex_layout::layouts::chunked::Chunked
 
-pub type vortex_layout::layouts::chunked::ChunkedVTable::Encoding = vortex_layout::layouts::chunked::ChunkedLayoutEncoding
+pub type vortex_layout::layouts::chunked::Chunked::Encoding = vortex_layout::layouts::chunked::ChunkedLayoutEncoding
 
-pub type vortex_layout::layouts::chunked::ChunkedVTable::Layout = vortex_layout::layouts::chunked::ChunkedLayout
+pub type vortex_layout::layouts::chunked::Chunked::Layout = vortex_layout::layouts::chunked::ChunkedLayout
 
-pub type vortex_layout::layouts::chunked::ChunkedVTable::Metadata = vortex_array::metadata::EmptyMetadata
+pub type vortex_layout::layouts::chunked::Chunked::Metadata = vortex_array::metadata::EmptyMetadata
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+pub fn vortex_layout::layouts::chunked::Chunked::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+pub fn vortex_layout::layouts::chunked::Chunked::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+pub fn vortex_layout::layouts::chunked::Chunked::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+pub fn vortex_layout::layouts::chunked::Chunked::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+pub fn vortex_layout::layouts::chunked::Chunked::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+pub fn vortex_layout::layouts::chunked::Chunked::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::metadata(_layout: &Self::Layout) -> Self::Metadata
+pub fn vortex_layout::layouts::chunked::Chunked::metadata(_layout: &Self::Layout) -> Self::Metadata
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::nchildren(layout: &Self::Layout) -> usize
+pub fn vortex_layout::layouts::chunked::Chunked::nchildren(layout: &Self::Layout) -> usize
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+pub fn vortex_layout::layouts::chunked::Chunked::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::row_count(layout: &Self::Layout) -> u64
+pub fn vortex_layout::layouts::chunked::Chunked::row_count(layout: &Self::Layout) -> u64
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+pub fn vortex_layout::layouts::chunked::Chunked::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
 
-pub fn vortex_layout::layouts::chunked::ChunkedVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::chunked::Chunked::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_layout::VTable for vortex_layout::layouts::dict::DictVTable
+impl vortex_layout::VTable for vortex_layout::layouts::dict::Dict
 
-pub type vortex_layout::layouts::dict::DictVTable::Encoding = vortex_layout::layouts::dict::DictLayoutEncoding
+pub type vortex_layout::layouts::dict::Dict::Encoding = vortex_layout::layouts::dict::DictLayoutEncoding
 
-pub type vortex_layout::layouts::dict::DictVTable::Layout = vortex_layout::layouts::dict::DictLayout
+pub type vortex_layout::layouts::dict::Dict::Layout = vortex_layout::layouts::dict::DictLayout
 
-pub type vortex_layout::layouts::dict::DictVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::dict::DictLayoutMetadata>
+pub type vortex_layout::layouts::dict::Dict::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::dict::DictLayoutMetadata>
 
-pub fn vortex_layout::layouts::dict::DictVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+pub fn vortex_layout::layouts::dict::Dict::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
 
-pub fn vortex_layout::layouts::dict::DictVTable::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+pub fn vortex_layout::layouts::dict::Dict::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
-pub fn vortex_layout::layouts::dict::DictVTable::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+pub fn vortex_layout::layouts::dict::Dict::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
 
-pub fn vortex_layout::layouts::dict::DictVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+pub fn vortex_layout::layouts::dict::Dict::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
 
-pub fn vortex_layout::layouts::dict::DictVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+pub fn vortex_layout::layouts::dict::Dict::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
 
-pub fn vortex_layout::layouts::dict::DictVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+pub fn vortex_layout::layouts::dict::Dict::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
 
-pub fn vortex_layout::layouts::dict::DictVTable::metadata(layout: &Self::Layout) -> Self::Metadata
+pub fn vortex_layout::layouts::dict::Dict::metadata(layout: &Self::Layout) -> Self::Metadata
 
-pub fn vortex_layout::layouts::dict::DictVTable::nchildren(_layout: &Self::Layout) -> usize
+pub fn vortex_layout::layouts::dict::Dict::nchildren(_layout: &Self::Layout) -> usize
 
-pub fn vortex_layout::layouts::dict::DictVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+pub fn vortex_layout::layouts::dict::Dict::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
 
-pub fn vortex_layout::layouts::dict::DictVTable::row_count(layout: &Self::Layout) -> u64
+pub fn vortex_layout::layouts::dict::Dict::row_count(layout: &Self::Layout) -> u64
 
-pub fn vortex_layout::layouts::dict::DictVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+pub fn vortex_layout::layouts::dict::Dict::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
 
-pub fn vortex_layout::layouts::dict::DictVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::dict::Dict::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_layout::VTable for vortex_layout::layouts::flat::FlatVTable
+impl vortex_layout::VTable for vortex_layout::layouts::flat::Flat
 
-pub type vortex_layout::layouts::flat::FlatVTable::Encoding = vortex_layout::layouts::flat::FlatLayoutEncoding
+pub type vortex_layout::layouts::flat::Flat::Encoding = vortex_layout::layouts::flat::FlatLayoutEncoding
 
-pub type vortex_layout::layouts::flat::FlatVTable::Layout = vortex_layout::layouts::flat::FlatLayout
+pub type vortex_layout::layouts::flat::Flat::Layout = vortex_layout::layouts::flat::FlatLayout
 
-pub type vortex_layout::layouts::flat::FlatVTable::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::flat::FlatLayoutMetadata>
+pub type vortex_layout::layouts::flat::Flat::Metadata = vortex_array::metadata::ProstMetadata<vortex_layout::layouts::flat::FlatLayoutMetadata>
 
-pub fn vortex_layout::layouts::flat::FlatVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, _children: &dyn vortex_layout::LayoutChildren, ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+pub fn vortex_layout::layouts::flat::Flat::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, _children: &dyn vortex_layout::LayoutChildren, ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
 
-pub fn vortex_layout::layouts::flat::FlatVTable::child(_layout: &Self::Layout, _idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+pub fn vortex_layout::layouts::flat::Flat::child(_layout: &Self::Layout, _idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
-pub fn vortex_layout::layouts::flat::FlatVTable::child_type(_layout: &Self::Layout, _idx: usize) -> vortex_layout::LayoutChildType
+pub fn vortex_layout::layouts::flat::Flat::child_type(_layout: &Self::Layout, _idx: usize) -> vortex_layout::LayoutChildType
 
-pub fn vortex_layout::layouts::flat::FlatVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+pub fn vortex_layout::layouts::flat::Flat::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
 
-pub fn vortex_layout::layouts::flat::FlatVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+pub fn vortex_layout::layouts::flat::Flat::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
 
-pub fn vortex_layout::layouts::flat::FlatVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+pub fn vortex_layout::layouts::flat::Flat::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
 
-pub fn vortex_layout::layouts::flat::FlatVTable::metadata(layout: &Self::Layout) -> Self::Metadata
+pub fn vortex_layout::layouts::flat::Flat::metadata(layout: &Self::Layout) -> Self::Metadata
 
-pub fn vortex_layout::layouts::flat::FlatVTable::nchildren(_layout: &Self::Layout) -> usize
+pub fn vortex_layout::layouts::flat::Flat::nchildren(_layout: &Self::Layout) -> usize
 
-pub fn vortex_layout::layouts::flat::FlatVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+pub fn vortex_layout::layouts::flat::Flat::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
 
-pub fn vortex_layout::layouts::flat::FlatVTable::row_count(layout: &Self::Layout) -> u64
+pub fn vortex_layout::layouts::flat::Flat::row_count(layout: &Self::Layout) -> u64
 
-pub fn vortex_layout::layouts::flat::FlatVTable::segment_ids(layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+pub fn vortex_layout::layouts::flat::Flat::segment_ids(layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
 
-pub fn vortex_layout::layouts::flat::FlatVTable::with_children(_layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::flat::Flat::with_children(_layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_layout::VTable for vortex_layout::layouts::struct_::StructVTable
+impl vortex_layout::VTable for vortex_layout::layouts::struct_::Struct
 
-pub type vortex_layout::layouts::struct_::StructVTable::Encoding = vortex_layout::layouts::struct_::StructLayoutEncoding
+pub type vortex_layout::layouts::struct_::Struct::Encoding = vortex_layout::layouts::struct_::StructLayoutEncoding
 
-pub type vortex_layout::layouts::struct_::StructVTable::Layout = vortex_layout::layouts::struct_::StructLayout
+pub type vortex_layout::layouts::struct_::Struct::Layout = vortex_layout::layouts::struct_::StructLayout
 
-pub type vortex_layout::layouts::struct_::StructVTable::Metadata = vortex_array::metadata::EmptyMetadata
+pub type vortex_layout::layouts::struct_::Struct::Metadata = vortex_array::metadata::EmptyMetadata
 
-pub fn vortex_layout::layouts::struct_::StructVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+pub fn vortex_layout::layouts::struct_::Struct::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, row_count: u64, _metadata: &<Self::Metadata as vortex_array::metadata::DeserializeMetadata>::Output, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
 
-pub fn vortex_layout::layouts::struct_::StructVTable::child(layout: &Self::Layout, index: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+pub fn vortex_layout::layouts::struct_::Struct::child(layout: &Self::Layout, index: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
-pub fn vortex_layout::layouts::struct_::StructVTable::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+pub fn vortex_layout::layouts::struct_::Struct::child_type(layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
 
-pub fn vortex_layout::layouts::struct_::StructVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+pub fn vortex_layout::layouts::struct_::Struct::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
 
-pub fn vortex_layout::layouts::struct_::StructVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+pub fn vortex_layout::layouts::struct_::Struct::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
 
-pub fn vortex_layout::layouts::struct_::StructVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+pub fn vortex_layout::layouts::struct_::Struct::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
 
-pub fn vortex_layout::layouts::struct_::StructVTable::metadata(_layout: &Self::Layout) -> Self::Metadata
+pub fn vortex_layout::layouts::struct_::Struct::metadata(_layout: &Self::Layout) -> Self::Metadata
 
-pub fn vortex_layout::layouts::struct_::StructVTable::nchildren(layout: &Self::Layout) -> usize
+pub fn vortex_layout::layouts::struct_::Struct::nchildren(layout: &Self::Layout) -> usize
 
-pub fn vortex_layout::layouts::struct_::StructVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+pub fn vortex_layout::layouts::struct_::Struct::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
 
-pub fn vortex_layout::layouts::struct_::StructVTable::row_count(layout: &Self::Layout) -> u64
+pub fn vortex_layout::layouts::struct_::Struct::row_count(layout: &Self::Layout) -> u64
 
-pub fn vortex_layout::layouts::struct_::StructVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+pub fn vortex_layout::layouts::struct_::Struct::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
 
-pub fn vortex_layout::layouts::struct_::StructVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::struct_::Struct::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
-impl vortex_layout::VTable for vortex_layout::layouts::zoned::ZonedVTable
+impl vortex_layout::VTable for vortex_layout::layouts::zoned::Zoned
 
-pub type vortex_layout::layouts::zoned::ZonedVTable::Encoding = vortex_layout::layouts::zoned::ZonedLayoutEncoding
+pub type vortex_layout::layouts::zoned::Zoned::Encoding = vortex_layout::layouts::zoned::ZonedLayoutEncoding
 
-pub type vortex_layout::layouts::zoned::ZonedVTable::Layout = vortex_layout::layouts::zoned::ZonedLayout
+pub type vortex_layout::layouts::zoned::Zoned::Layout = vortex_layout::layouts::zoned::ZonedLayout
 
-pub type vortex_layout::layouts::zoned::ZonedVTable::Metadata = vortex_layout::layouts::zoned::ZonedMetadata
+pub type vortex_layout::layouts::zoned::Zoned::Metadata = vortex_layout::layouts::zoned::ZonedMetadata
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &vortex_layout::layouts::zoned::ZonedMetadata, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
+pub fn vortex_layout::layouts::zoned::Zoned::build(_encoding: &Self::Encoding, dtype: &vortex_array::dtype::DType, _row_count: u64, metadata: &vortex_layout::layouts::zoned::ZonedMetadata, _segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, _ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<Self::Layout>
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
+pub fn vortex_layout::layouts::zoned::Zoned::child(layout: &Self::Layout, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
+pub fn vortex_layout::layouts::zoned::Zoned::child_type(_layout: &Self::Layout, idx: usize) -> vortex_layout::LayoutChildType
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
+pub fn vortex_layout::layouts::zoned::Zoned::dtype(layout: &Self::Layout) -> &vortex_array::dtype::DType
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
+pub fn vortex_layout::layouts::zoned::Zoned::encoding(_layout: &Self::Layout) -> vortex_layout::LayoutEncodingRef
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
+pub fn vortex_layout::layouts::zoned::Zoned::id(_encoding: &Self::Encoding) -> vortex_layout::LayoutId
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::metadata(layout: &Self::Layout) -> Self::Metadata
+pub fn vortex_layout::layouts::zoned::Zoned::metadata(layout: &Self::Layout) -> Self::Metadata
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::nchildren(_layout: &Self::Layout) -> usize
+pub fn vortex_layout::layouts::zoned::Zoned::nchildren(_layout: &Self::Layout) -> usize
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
+pub fn vortex_layout::layouts::zoned::Zoned::new_reader(layout: &Self::Layout, name: alloc::sync::Arc<str>, segment_source: alloc::sync::Arc<dyn vortex_layout::segments::SegmentSource>, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<vortex_layout::LayoutReaderRef>
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::row_count(layout: &Self::Layout) -> u64
+pub fn vortex_layout::layouts::zoned::Zoned::row_count(layout: &Self::Layout) -> u64
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
+pub fn vortex_layout::layouts::zoned::Zoned::segment_ids(_layout: &Self::Layout) -> alloc::vec::Vec<vortex_layout::segments::SegmentId>
 
-pub fn vortex_layout::layouts::zoned::ZonedVTable::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::zoned::Zoned::with_children(layout: &mut Self::Layout, children: alloc::vec::Vec<vortex_layout::LayoutRef>) -> vortex_error::VortexResult<()>
 
 pub fn vortex_layout::layout_from_flatbuffer(flatbuffer: vortex_flatbuffers::FlatBuffer, dtype: &vortex_array::dtype::DType, layout_ctx: &vortex_session::registry::ReadContext, ctx: &vortex_session::registry::ReadContext, layouts: &vortex_layout::session::LayoutRegistry) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 

--- a/vortex-layout/src/display.rs
+++ b/vortex-layout/src/display.rs
@@ -10,8 +10,8 @@ use vortex_error::VortexResult;
 use vortex_utils::aliases::hash_map::HashMap;
 
 use crate::LayoutRef;
+use crate::layouts::flat::Flat;
 use crate::layouts::flat::FlatLayout;
-use crate::layouts::flat::FlatVTable;
 use crate::segments::SegmentId;
 use crate::segments::SegmentSource;
 
@@ -55,7 +55,7 @@ fn collect_segments_to_fetch(
     segment_ids: &mut Vec<SegmentId>,
 ) -> VortexResult<()> {
     // For FlatLayout, only add if there's no inline array_tree
-    if let Some(flat_layout) = layout.as_opt::<FlatVTable>() {
+    if let Some(flat_layout) = layout.as_opt::<Flat>() {
         if flat_layout.array_tree().is_none() {
             segment_ids.push(flat_layout.segment_id());
         }
@@ -147,7 +147,7 @@ impl DisplayLayoutTree {
         }
 
         // For FlatLayout, show buffer info
-        if let Some(flat_layout) = layout.as_opt::<FlatVTable>() {
+        if let Some(flat_layout) = layout.as_opt::<Flat>() {
             node_parts.push(format_flat_layout_buffers(
                 flat_layout,
                 self.segment_buffer_sizes.as_ref(),
@@ -235,7 +235,7 @@ mod tests {
     use crate::IntoLayout;
     use crate::OwnedLayoutChildren;
     use crate::layouts::chunked::ChunkedLayout;
-    use crate::layouts::flat::FlatVTable;
+    use crate::layouts::flat::Flat;
     use crate::layouts::flat::writer::FlatLayoutStrategy;
     use crate::layouts::struct_::StructLayout;
     use crate::segments::TestSegments;
@@ -415,7 +415,7 @@ vortex.chunked, dtype: i32, children: 2, rows: 10
                 .unwrap()
         });
 
-        let flat_layout = layout.as_::<FlatVTable>();
+        let flat_layout = layout.as_::<Flat>();
 
         let array_tree = flat_layout
             .array_tree()

--- a/vortex-layout/src/layouts/chunked/mod.rs
+++ b/vortex-layout/src/layouts/chunked/mod.rs
@@ -28,7 +28,7 @@ use crate::vtable;
 
 vtable!(Chunked);
 
-impl VTable for ChunkedVTable {
+impl VTable for Chunked {
     type Layout = ChunkedLayout;
     type Encoding = ChunkedLayoutEncoding;
     type Metadata = EmptyMetadata;

--- a/vortex-layout/src/layouts/dict/mod.rs
+++ b/vortex-layout/src/layouts/dict/mod.rs
@@ -34,7 +34,7 @@ use crate::vtable;
 
 vtable!(Dict);
 
-impl VTable for DictVTable {
+impl VTable for Dict {
     type Layout = DictLayout;
     type Encoding = DictLayoutEncoding;
     type Metadata = ProstMetadata<DictLayoutMetadata>;
@@ -116,7 +116,7 @@ impl VTable for DictVTable {
             .map(Nullability::from)
             // The old behaviour (without `is_nullable_codes` metadata) used the nullability
             // of the values (and whole array).
-            // see [`SerdeVTable<DictVTable>::build`].
+            // see [`SerdeVTable<Dict>::build`].
             .unwrap_or_else(|| dtype.nullability());
         let codes = children.child(1, &DType::Primitive(metadata.codes_ptype(), codes_nullable))?;
         Ok(unsafe {

--- a/vortex-layout/src/layouts/dict/writer.rs
+++ b/vortex-layout/src/layouts/dict/writer.rs
@@ -21,7 +21,7 @@ use futures::try_join;
 use vortex_array::ArrayContext;
 use vortex_array::ArrayRef;
 use vortex_array::DynArray;
-use vortex_array::arrays::DictVTable;
+use vortex_array::arrays::Dict;
 use vortex_array::builders::dict::DictConstraints;
 use vortex_array::builders::dict::DictEncoder;
 use vortex_array::builders::dict::dict_encoder;
@@ -152,7 +152,7 @@ impl LayoutStrategy for DictStrategy {
             None => true, // empty stream
             Some(chunk) => {
                 let compressed = BtrBlocksCompressor::default().compress(&chunk)?;
-                !compressed.is::<DictVTable>()
+                !compressed.is::<Dict>()
             }
         };
         if should_fallback {

--- a/vortex-layout/src/layouts/flat/mod.rs
+++ b/vortex-layout/src/layouts/flat/mod.rs
@@ -37,7 +37,7 @@ pub(super) fn flat_layout_inline_array_node() -> bool {
 
 vtable!(Flat);
 
-impl VTable for FlatVTable {
+impl VTable for Flat {
     type Layout = FlatLayout;
     type Encoding = FlatLayoutEncoding;
     type Metadata = ProstMetadata<FlatLayoutMetadata>;

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -202,10 +202,10 @@ mod tests {
     use vortex_array::MaskFuture;
     use vortex_array::ToCanonical;
     use vortex_array::arrays::BoolArray;
+    use vortex_array::arrays::Dict;
     use vortex_array::arrays::DictArray;
-    use vortex_array::arrays::DictVTable;
+    use vortex_array::arrays::Primitive;
     use vortex_array::arrays::PrimitiveArray;
-    use vortex_array::arrays::PrimitiveVTable;
     use vortex_array::arrays::StructArray;
     use vortex_array::builders::ArrayBuilder;
     use vortex_array::builders::VarBinViewBuilder;
@@ -426,7 +426,7 @@ mod tests {
                 let (ptr, eof) = SequenceId::root().split();
                 // Only allow primitive encodings - filter arrays should fail.
                 let allowed = ArrayRegistry::default();
-                allowed.register(PrimitiveVTable::ID, PrimitiveVTable);
+                allowed.register(Primitive::ID, Primitive);
                 let layout = FlatLayoutStrategy::default()
                     .with_allow_encodings(allowed)
                     .write_stream(
@@ -467,8 +467,8 @@ mod tests {
                 let (ptr, eof) = SequenceId::root().split();
                 // Only allow primitive encodings - filter arrays should fail.
                 let allowed = ArrayRegistry::default();
-                allowed.register(PrimitiveVTable::ID, PrimitiveVTable);
-                allowed.register(DictVTable::ID, DictVTable);
+                allowed.register(Primitive::ID, Primitive);
+                allowed.register(Dict::ID, Dict);
                 let layout = FlatLayoutStrategy::default()
                     .with_allow_encodings(allowed)
                     .write_stream(

--- a/vortex-layout/src/layouts/struct_/mod.rs
+++ b/vortex-layout/src/layouts/struct_/mod.rs
@@ -37,7 +37,7 @@ use crate::vtable;
 
 vtable!(Struct);
 
-impl VTable for StructVTable {
+impl VTable for Struct {
     type Layout = StructLayout;
     type Encoding = StructLayoutEncoding;
     type Metadata = EmptyMetadata;

--- a/vortex-layout/src/layouts/zoned/mod.rs
+++ b/vortex-layout/src/layouts/zoned/mod.rs
@@ -40,7 +40,7 @@ use crate::vtable;
 
 vtable!(Zoned);
 
-impl VTable for ZonedVTable {
+impl VTable for Zoned {
     type Layout = ZonedLayout;
     type Encoding = ZonedLayoutEncoding;
     type Metadata = ZonedMetadata;

--- a/vortex-layout/src/vtable.rs
+++ b/vortex-layout/src/vtable.rs
@@ -90,14 +90,14 @@ macro_rules! vtable {
     ($V:ident) => {
         $crate::aliases::paste::paste! {
             #[derive(Debug)]
-            pub struct [<$V VTable>];
+            pub struct $V;
 
             impl AsRef<dyn $crate::Layout> for [<$V Layout>] {
                 fn as_ref(&self) -> &dyn $crate::Layout {
                     // SAFETY: LayoutAdapter is #[repr(transparent)] over the Layout type,
                     // which guarantees identical memory layout. This cast is safe because
                     // we're only changing the type metadata, not the actual data.
-                    unsafe { &*(self as *const [<$V Layout>] as *const $crate::LayoutAdapter<[<$V VTable>]>) }
+                    unsafe { &*(self as *const [<$V Layout>] as *const $crate::LayoutAdapter<$V>) }
                 }
             }
 
@@ -108,7 +108,7 @@ macro_rules! vtable {
                     // SAFETY: LayoutAdapter is #[repr(transparent)] over the Layout type,
                     // which guarantees identical memory layout. This cast is safe because
                     // we're only changing the type metadata, not the actual data.
-                    unsafe { &*(self as *const [<$V Layout>] as *const $crate::LayoutAdapter<[<$V VTable>]>) }
+                    unsafe { &*(self as *const [<$V Layout>] as *const $crate::LayoutAdapter<$V>) }
                 }
             }
 
@@ -117,7 +117,7 @@ macro_rules! vtable {
                     // SAFETY: LayoutAdapter is #[repr(transparent)] over the Layout type,
                     // guaranteeing identical memory layout and alignment. The transmute is safe
                     // because both types have the same size and representation.
-                    std::sync::Arc::new(unsafe { std::mem::transmute::<[<$V Layout>], $crate::LayoutAdapter::<[<$V VTable>]>>(self) })
+                    std::sync::Arc::new(unsafe { std::mem::transmute::<[<$V Layout>], $crate::LayoutAdapter::<$V>>(self) })
                 }
             }
 
@@ -133,7 +133,7 @@ macro_rules! vtable {
                     // SAFETY: LayoutEncodingAdapter is #[repr(transparent)] over the LayoutEncoding type,
                     // which guarantees identical memory layout. This cast is safe because
                     // we're only changing the type metadata, not the actual data.
-                    unsafe { &*(self as *const [<$V LayoutEncoding>] as *const $crate::LayoutEncodingAdapter<[<$V VTable>]>) }
+                    unsafe { &*(self as *const [<$V LayoutEncoding>] as *const $crate::LayoutEncodingAdapter<$V>) }
                 }
             }
 
@@ -144,7 +144,7 @@ macro_rules! vtable {
                     // SAFETY: LayoutEncodingAdapter is #[repr(transparent)] over the LayoutEncoding type,
                     // which guarantees identical memory layout. This cast is safe because
                     // we're only changing the type metadata, not the actual data.
-                    unsafe { &*(self as *const [<$V LayoutEncoding>] as *const $crate::LayoutEncodingAdapter<[<$V VTable>]>) }
+                    unsafe { &*(self as *const [<$V LayoutEncoding>] as *const $crate::LayoutEncodingAdapter<$V>) }
                 }
             }
         }

--- a/vortex-python/src/arrays/builtins/chunked.rs
+++ b/vortex-python/src/arrays/builtins/chunked.rs
@@ -4,7 +4,7 @@
 use pyo3::PyRef;
 use pyo3::pyclass;
 use pyo3::pymethods;
-use vortex::array::arrays::ChunkedVTable;
+use vortex::array::arrays::Chunked;
 
 use crate::arrays::PyArrayRef;
 use crate::arrays::native::AsArrayRef;
@@ -16,7 +16,7 @@ use crate::arrays::native::PyNativeArray;
 pub(crate) struct PyChunkedArray;
 
 impl EncodingSubclass for PyChunkedArray {
-    type VTable = ChunkedVTable;
+    type VTable = Chunked;
 }
 
 #[pymethods]

--- a/vortex-python/src/arrays/builtins/constant.rs
+++ b/vortex-python/src/arrays/builtins/constant.rs
@@ -6,7 +6,7 @@ use pyo3::PyRef;
 use pyo3::PyResult;
 use pyo3::pyclass;
 use pyo3::pymethods;
-use vortex::array::arrays::ConstantVTable;
+use vortex::array::arrays::Constant;
 
 use crate::arrays::native::AsArrayRef;
 use crate::arrays::native::EncodingSubclass;
@@ -18,7 +18,7 @@ use crate::scalar::PyScalar;
 pub(crate) struct PyConstantArray;
 
 impl EncodingSubclass for PyConstantArray {
-    type VTable = ConstantVTable;
+    type VTable = Constant;
 }
 
 #[pymethods]

--- a/vortex-python/src/arrays/builtins/decimal.rs
+++ b/vortex-python/src/arrays/builtins/decimal.rs
@@ -4,7 +4,7 @@
 use pyo3::PyRef;
 use pyo3::pyclass;
 use pyo3::pymethods;
-use vortex::array::arrays::DecimalVTable;
+use vortex::array::arrays::Decimal;
 
 use crate::arrays::native::AsArrayRef;
 use crate::arrays::native::EncodingSubclass;
@@ -15,7 +15,7 @@ use crate::arrays::native::PyNativeArray;
 pub(crate) struct PyDecimalArray;
 
 impl EncodingSubclass for PyDecimalArray {
-    type VTable = DecimalVTable;
+    type VTable = Decimal;
 }
 
 #[pymethods]

--- a/vortex-python/src/arrays/builtins/mod.rs
+++ b/vortex-python/src/arrays/builtins/mod.rs
@@ -13,14 +13,14 @@ pub(crate) use decimal::*;
 pub(crate) use primitive::*;
 use pyo3::prelude::*;
 pub(crate) use struct_::*;
-use vortex::array::arrays::BoolVTable;
-use vortex::array::arrays::ExtensionVTable;
-use vortex::array::arrays::FixedSizeListVTable;
-use vortex::array::arrays::ListVTable;
-use vortex::array::arrays::NullVTable;
-use vortex::array::arrays::VarBinVTable;
-use vortex::array::arrays::VarBinViewVTable;
-use vortex::encodings::bytebool::ByteBoolVTable;
+use vortex::array::arrays::Bool;
+use vortex::array::arrays::Extension;
+use vortex::array::arrays::FixedSizeList;
+use vortex::array::arrays::List;
+use vortex::array::arrays::Null;
+use vortex::array::arrays::VarBin;
+use vortex::array::arrays::VarBinView;
+use vortex::encodings::bytebool::ByteBool;
 
 use crate::arrays::native::EncodingSubclass;
 use crate::arrays::native::PyNativeArray;
@@ -30,7 +30,7 @@ use crate::arrays::native::PyNativeArray;
 pub(crate) struct PyNullArray;
 
 impl EncodingSubclass for PyNullArray {
-    type VTable = NullVTable;
+    type VTable = Null;
 }
 
 /// Concrete class for arrays with `vortex.bool` encoding.
@@ -38,7 +38,7 @@ impl EncodingSubclass for PyNullArray {
 pub(crate) struct PyBoolArray;
 
 impl EncodingSubclass for PyBoolArray {
-    type VTable = BoolVTable;
+    type VTable = Bool;
 }
 
 /// Concrete class for arrays with `vortex.bytebool` encoding.
@@ -46,7 +46,7 @@ impl EncodingSubclass for PyBoolArray {
 pub(crate) struct PyByteBoolArray;
 
 impl EncodingSubclass for PyByteBoolArray {
-    type VTable = ByteBoolVTable;
+    type VTable = ByteBool;
 }
 
 /// Concrete class for arrays with `vortex.varbin` encoding.
@@ -54,7 +54,7 @@ impl EncodingSubclass for PyByteBoolArray {
 pub(crate) struct PyVarBinArray;
 
 impl EncodingSubclass for PyVarBinArray {
-    type VTable = VarBinVTable;
+    type VTable = VarBin;
 }
 
 /// Concrete class for arrays with `vortex.varbinview` encoding.
@@ -62,7 +62,7 @@ impl EncodingSubclass for PyVarBinArray {
 pub(crate) struct PyVarBinViewArray;
 
 impl EncodingSubclass for PyVarBinViewArray {
-    type VTable = VarBinViewVTable;
+    type VTable = VarBinView;
 }
 
 /// Concrete class for arrays with `vortex.list` encoding.
@@ -70,7 +70,7 @@ impl EncodingSubclass for PyVarBinViewArray {
 pub(crate) struct PyListArray;
 
 impl EncodingSubclass for PyListArray {
-    type VTable = ListVTable;
+    type VTable = List;
 }
 
 /// Concrete class for arrays with `vortex.fixed_size_list` encoding.
@@ -78,7 +78,7 @@ impl EncodingSubclass for PyListArray {
 pub(crate) struct PyFixedSizeListArray;
 
 impl EncodingSubclass for PyFixedSizeListArray {
-    type VTable = FixedSizeListVTable;
+    type VTable = FixedSizeList;
 }
 
 /// Concrete class for arrays with `vortex.ext` encoding.
@@ -86,5 +86,5 @@ impl EncodingSubclass for PyFixedSizeListArray {
 pub(crate) struct PyExtensionArray;
 
 impl EncodingSubclass for PyExtensionArray {
-    type VTable = ExtensionVTable;
+    type VTable = Extension;
 }

--- a/vortex-python/src/arrays/builtins/primitive.rs
+++ b/vortex-python/src/arrays/builtins/primitive.rs
@@ -4,7 +4,7 @@
 use pyo3::PyRef;
 use pyo3::pyclass;
 use pyo3::pymethods;
-use vortex::array::arrays::PrimitiveVTable;
+use vortex::array::arrays::Primitive;
 
 use crate::arrays::native::AsArrayRef;
 use crate::arrays::native::EncodingSubclass;
@@ -16,7 +16,7 @@ use crate::dtype::PyPType;
 pub(crate) struct PyPrimitiveArray;
 
 impl EncodingSubclass for PyPrimitiveArray {
-    type VTable = PrimitiveVTable;
+    type VTable = Primitive;
 }
 
 #[pymethods]

--- a/vortex-python/src/arrays/builtins/struct_.rs
+++ b/vortex-python/src/arrays/builtins/struct_.rs
@@ -6,7 +6,7 @@ use pyo3::PyRef;
 use pyo3::PyResult;
 use pyo3::pyclass;
 use pyo3::pymethods;
-use vortex::array::arrays::StructVTable;
+use vortex::array::arrays::Struct;
 
 use crate::arrays::PyArrayRef;
 use crate::arrays::native::AsArrayRef;
@@ -19,7 +19,7 @@ use crate::error::PyVortexResult;
 pub(crate) struct PyStructArray;
 
 impl EncodingSubclass for PyStructArray {
-    type VTable = StructVTable;
+    type VTable = Struct;
 }
 
 #[pymethods]

--- a/vortex-python/src/arrays/compressed.rs
+++ b/vortex-python/src/arrays/compressed.rs
@@ -4,15 +4,15 @@
 use pyo3::prelude::*;
 use vortex::array::IntoArray;
 use vortex::array::ToCanonical;
-use vortex::array::arrays::DictVTable;
-use vortex::encodings::alp::ALPRDVTable;
-use vortex::encodings::alp::ALPVTable;
-use vortex::encodings::datetime_parts::DateTimePartsVTable;
-use vortex::encodings::fsst::FSSTVTable;
-use vortex::encodings::runend::RunEndVTable;
-use vortex::encodings::sequence::SequenceVTable;
-use vortex::encodings::sparse::SparseVTable;
-use vortex::encodings::zigzag::ZigZagVTable;
+use vortex::array::arrays::Dict;
+use vortex::encodings::alp::ALP;
+use vortex::encodings::alp::ALPRD;
+use vortex::encodings::datetime_parts::DateTimeParts;
+use vortex::encodings::fsst::FSST;
+use vortex::encodings::runend::RunEnd;
+use vortex::encodings::sequence::Sequence;
+use vortex::encodings::sparse::Sparse;
+use vortex::encodings::zigzag::ZigZag;
 use vortex::encodings::zigzag::zigzag_encode;
 
 use crate::PyVortex;
@@ -26,7 +26,7 @@ use crate::error::PyVortexResult;
 pub(crate) struct PyAlpArray;
 
 impl EncodingSubclass for PyAlpArray {
-    type VTable = ALPVTable;
+    type VTable = ALP;
 }
 
 /// Concrete class for arrays with `vortex.alprd` encoding.
@@ -34,7 +34,7 @@ impl EncodingSubclass for PyAlpArray {
 pub(crate) struct PyAlpRdArray;
 
 impl EncodingSubclass for PyAlpRdArray {
-    type VTable = ALPRDVTable;
+    type VTable = ALPRD;
 }
 
 /// Concrete class for arrays with `vortex.datetimeparts` encoding.
@@ -42,7 +42,7 @@ impl EncodingSubclass for PyAlpRdArray {
 pub(crate) struct PyDateTimePartsArray;
 
 impl EncodingSubclass for PyDateTimePartsArray {
-    type VTable = DateTimePartsVTable;
+    type VTable = DateTimeParts;
 }
 
 /// Concrete class for arrays with `vortex.dict` encoding.
@@ -50,7 +50,7 @@ impl EncodingSubclass for PyDateTimePartsArray {
 pub(crate) struct PyDictArray;
 
 impl EncodingSubclass for PyDictArray {
-    type VTable = DictVTable;
+    type VTable = Dict;
 }
 
 /// Concrete class for arrays with `vortex.fsst` encoding.
@@ -58,7 +58,7 @@ impl EncodingSubclass for PyDictArray {
 pub(crate) struct PyFsstArray;
 
 impl EncodingSubclass for PyFsstArray {
-    type VTable = FSSTVTable;
+    type VTable = FSST;
 }
 
 /// Concrete class for arrays with `vortex.runend` encoding.
@@ -66,7 +66,7 @@ impl EncodingSubclass for PyFsstArray {
 pub(crate) struct PyRunEndArray;
 
 impl EncodingSubclass for PyRunEndArray {
-    type VTable = RunEndVTable;
+    type VTable = RunEnd;
 }
 
 /// Concrete class for arrays with `vortex.sparse` encoding.
@@ -74,7 +74,7 @@ impl EncodingSubclass for PyRunEndArray {
 pub(crate) struct PySparseArray;
 
 impl EncodingSubclass for PySparseArray {
-    type VTable = SparseVTable;
+    type VTable = Sparse;
 }
 
 /// Concrete class for arrays with `vortex.zigzag` encoding.
@@ -82,7 +82,7 @@ impl EncodingSubclass for PySparseArray {
 pub(crate) struct PyZigZagArray;
 
 impl EncodingSubclass for PyZigZagArray {
-    type VTable = ZigZagVTable;
+    type VTable = ZigZag;
 }
 
 #[pymethods]
@@ -100,5 +100,5 @@ impl PyZigZagArray {
 pub(crate) struct PySequenceArray;
 
 impl EncodingSubclass for PySequenceArray {
-    type VTable = SequenceVTable;
+    type VTable = Sequence;
 }

--- a/vortex-python/src/arrays/fastlanes.rs
+++ b/vortex-python/src/arrays/fastlanes.rs
@@ -2,9 +2,9 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use pyo3::prelude::*;
-use vortex::encodings::fastlanes::BitPackedVTable;
-use vortex::encodings::fastlanes::DeltaVTable;
-use vortex::encodings::fastlanes::FoRVTable;
+use vortex::encodings::fastlanes::BitPacked;
+use vortex::encodings::fastlanes::Delta;
+use vortex::encodings::fastlanes::FoR;
 
 use crate::arrays::native::AsArrayRef;
 use crate::arrays::native::EncodingSubclass;
@@ -15,7 +15,7 @@ use crate::arrays::native::PyNativeArray;
 pub(crate) struct PyFastLanesBitPackedArray;
 
 impl EncodingSubclass for PyFastLanesBitPackedArray {
-    type VTable = BitPackedVTable;
+    type VTable = BitPacked;
 }
 
 #[pymethods]
@@ -32,7 +32,7 @@ impl PyFastLanesBitPackedArray {
 pub(crate) struct PyFastLanesDeltaArray;
 
 impl EncodingSubclass for PyFastLanesDeltaArray {
-    type VTable = DeltaVTable;
+    type VTable = Delta;
 }
 
 /// Concrete class for arrays with `fastlanes.for` encoding.
@@ -40,5 +40,5 @@ impl EncodingSubclass for PyFastLanesDeltaArray {
 pub(crate) struct PyFastLanesFoRArray;
 
 impl EncodingSubclass for PyFastLanesFoRArray {
-    type VTable = FoRVTable;
+    type VTable = FoR;
 }

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -25,7 +25,7 @@ use vortex::array::ArrayRef;
 use vortex::array::DynArray;
 use vortex::array::IntoArray;
 use vortex::array::ToCanonical;
-use vortex::array::arrays::ChunkedVTable;
+use vortex::array::arrays::Chunked;
 use vortex::array::arrow::IntoArrowArray;
 use vortex::array::builtins::ArrayBuiltins;
 use vortex::array::match_each_integer_ptype;
@@ -324,7 +324,7 @@ impl PyArray {
         let array = PyArrayRef::extract(self_.as_any().as_borrowed())?.into_inner();
         let py = self_.py();
 
-        if let Some(chunked_array) = array.as_opt::<ChunkedVTable>() {
+        if let Some(chunked_array) = array.as_opt::<Chunked>() {
             // We figure out a single Arrow Data Type to convert all chunks into, otherwise
             // the preferred type of each chunk may be different.
             let arrow_dtype = chunked_array.dtype().to_arrow_dtype()?;

--- a/vortex-python/src/arrays/native.rs
+++ b/vortex-python/src/arrays/native.rs
@@ -8,32 +8,32 @@ use pyo3::prelude::*;
 use vortex::array::ArrayAdapter;
 use vortex::array::ArrayRef;
 use vortex::array::DynArray;
-use vortex::array::arrays::BoolVTable;
-use vortex::array::arrays::ChunkedVTable;
-use vortex::array::arrays::ConstantVTable;
-use vortex::array::arrays::DecimalVTable;
-use vortex::array::arrays::DictVTable;
-use vortex::array::arrays::ExtensionVTable;
-use vortex::array::arrays::FixedSizeListVTable;
-use vortex::array::arrays::ListVTable;
-use vortex::array::arrays::NullVTable;
-use vortex::array::arrays::PrimitiveVTable;
-use vortex::array::arrays::StructVTable;
-use vortex::array::arrays::VarBinVTable;
-use vortex::array::arrays::VarBinViewVTable;
+use vortex::array::arrays::Bool;
+use vortex::array::arrays::Chunked;
+use vortex::array::arrays::Constant;
+use vortex::array::arrays::Decimal;
+use vortex::array::arrays::Dict;
+use vortex::array::arrays::Extension;
+use vortex::array::arrays::FixedSizeList;
+use vortex::array::arrays::List;
+use vortex::array::arrays::Null;
+use vortex::array::arrays::Primitive;
+use vortex::array::arrays::Struct;
+use vortex::array::arrays::VarBin;
+use vortex::array::arrays::VarBinView;
 use vortex::array::vtable::VTable;
-use vortex::encodings::alp::ALPRDVTable;
-use vortex::encodings::alp::ALPVTable;
-use vortex::encodings::bytebool::ByteBoolVTable;
-use vortex::encodings::datetime_parts::DateTimePartsVTable;
-use vortex::encodings::fastlanes::BitPackedVTable;
-use vortex::encodings::fastlanes::DeltaVTable;
-use vortex::encodings::fastlanes::FoRVTable;
-use vortex::encodings::fsst::FSSTVTable;
-use vortex::encodings::runend::RunEndVTable;
-use vortex::encodings::sequence::SequenceVTable;
-use vortex::encodings::sparse::SparseVTable;
-use vortex::encodings::zigzag::ZigZagVTable;
+use vortex::encodings::alp::ALP;
+use vortex::encodings::alp::ALPRD;
+use vortex::encodings::bytebool::ByteBool;
+use vortex::encodings::datetime_parts::DateTimeParts;
+use vortex::encodings::fastlanes::BitPacked;
+use vortex::encodings::fastlanes::Delta;
+use vortex::encodings::fastlanes::FoR;
+use vortex::encodings::fsst::FSST;
+use vortex::encodings::runend::RunEnd;
+use vortex::encodings::sequence::Sequence;
+use vortex::encodings::sparse::Sparse;
+use vortex::encodings::zigzag::ZigZag;
 use vortex::error::VortexExpect;
 
 use crate::arrays::PyArray;
@@ -79,103 +79,103 @@ impl PyNativeArray {
     /// Initialize a [`PyArray`] from a Vortex [`ArrayRef`], ensuring we return the correct typed
     /// subclass array.
     pub fn init(py: Python, array: ArrayRef) -> PyResult<Bound<PyNativeArray>> {
-        if array.is::<NullVTable>() {
+        if array.is::<Null>() {
             return Self::with_subclass(py, array, PyNullArray);
         }
 
-        if array.is::<BoolVTable>() {
+        if array.is::<Bool>() {
             return Self::with_subclass(py, array, PyBoolArray);
         }
 
-        if array.is::<PrimitiveVTable>() {
+        if array.is::<Primitive>() {
             return Self::with_subclass(py, array, PyPrimitiveArray);
         }
 
-        if array.is::<VarBinVTable>() {
+        if array.is::<VarBin>() {
             return Self::with_subclass(py, array, PyVarBinArray);
         }
 
-        if array.is::<VarBinViewVTable>() {
+        if array.is::<VarBinView>() {
             return Self::with_subclass(py, array, PyVarBinViewArray);
         }
 
-        if array.is::<StructVTable>() {
+        if array.is::<Struct>() {
             return Self::with_subclass(py, array, PyStructArray);
         }
 
-        if array.is::<ListVTable>() {
+        if array.is::<List>() {
             return Self::with_subclass(py, array, PyListArray);
         }
 
-        if array.is::<FixedSizeListVTable>() {
+        if array.is::<FixedSizeList>() {
             return Self::with_subclass(py, array, PyFixedSizeListArray);
         }
 
-        if array.is::<ExtensionVTable>() {
+        if array.is::<Extension>() {
             return Self::with_subclass(py, array, PyExtensionArray);
         }
 
-        if array.is::<ChunkedVTable>() {
+        if array.is::<Chunked>() {
             return Self::with_subclass(py, array, PyChunkedArray);
         }
 
-        if array.is::<ConstantVTable>() {
+        if array.is::<Constant>() {
             return Self::with_subclass(py, array, PyConstantArray);
         }
 
-        if array.is::<ByteBoolVTable>() {
+        if array.is::<ByteBool>() {
             return Self::with_subclass(py, array, PyByteBoolArray);
         }
 
-        if array.is::<SparseVTable>() {
+        if array.is::<Sparse>() {
             return Self::with_subclass(py, array, PySparseArray);
         }
 
-        if array.is::<ALPVTable>() {
+        if array.is::<ALP>() {
             return Self::with_subclass(py, array, PyAlpArray);
         }
 
-        if array.is::<ALPRDVTable>() {
+        if array.is::<ALPRD>() {
             return Self::with_subclass(py, array, PyAlpRdArray);
         }
 
-        if array.is::<DateTimePartsVTable>() {
+        if array.is::<DateTimeParts>() {
             return Self::with_subclass(py, array, PyDateTimePartsArray);
         }
 
-        if array.is::<DictVTable>() {
+        if array.is::<Dict>() {
             return Self::with_subclass(py, array, PyDictArray);
         }
 
-        if array.is::<FSSTVTable>() {
+        if array.is::<FSST>() {
             return Self::with_subclass(py, array, PyFsstArray);
         }
 
-        if array.is::<RunEndVTable>() {
+        if array.is::<RunEnd>() {
             return Self::with_subclass(py, array, PyRunEndArray);
         }
 
-        if array.is::<ZigZagVTable>() {
+        if array.is::<ZigZag>() {
             return Self::with_subclass(py, array, PyZigZagArray);
         }
 
-        if array.is::<BitPackedVTable>() {
+        if array.is::<BitPacked>() {
             return Self::with_subclass(py, array, PyFastLanesBitPackedArray);
         }
 
-        if array.is::<DeltaVTable>() {
+        if array.is::<Delta>() {
             return Self::with_subclass(py, array, PyFastLanesDeltaArray);
         }
 
-        if array.is::<FoRVTable>() {
+        if array.is::<FoR>() {
             return Self::with_subclass(py, array, PyFastLanesFoRArray);
         }
 
-        if array.is::<DecimalVTable>() {
+        if array.is::<Decimal>() {
             return Self::with_subclass(py, array, PyDecimalArray);
         }
 
-        if array.is::<SequenceVTable>() {
+        if array.is::<Sequence>() {
             return Self::with_subclass(py, array, PySequenceArray);
         }
 

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -4,7 +4,6 @@
 use std::hash::Hash;
 use std::sync::Arc;
 
-use pyo3::Python;
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
@@ -37,9 +36,9 @@ vtable!(Python);
 
 /// Wrapper struct encapsulating a Python encoding.
 #[derive(Debug)]
-pub struct PythonVTable;
+pub struct Python;
 
-impl VTable for PythonVTable {
+impl VTable for Python {
     type Array = PythonArray;
 
     type Metadata = RawMetadata;
@@ -101,7 +100,7 @@ impl VTable for PythonVTable {
     }
 
     fn metadata(array: &PythonArray) -> VortexResult<Self::Metadata> {
-        Python::attach(|py| {
+        pyo3::Python::attach(|py| {
             let obj = array.object.bind(py);
             if !obj
                 .hasattr(intern!(py, "metadata"))
@@ -161,13 +160,13 @@ impl VTable for PythonVTable {
     }
 }
 
-impl OperationsVTable<PythonVTable> for PythonVTable {
+impl OperationsVTable<Python> for Python {
     fn scalar_at(_array: &PythonArray, _index: usize) -> VortexResult<Scalar> {
         todo!()
     }
 }
 
-impl ValidityVTable<PythonVTable> for PythonVTable {
+impl ValidityVTable<Python> for Python {
     fn validity(_array: &PythonArray) -> VortexResult<Validity> {
         todo!()
     }

--- a/vortex-python/src/registry.rs
+++ b/vortex-python/src/registry.rs
@@ -3,12 +3,11 @@
 
 use pyo3::Bound;
 use pyo3::PyResult;
-use pyo3::Python;
 use pyo3::prelude::*;
 use vortex::array::session::ArraySessionExt;
 
 use crate::SESSION;
-use crate::arrays::py::PythonVTable;
+use crate::arrays::py::Python as PythonVTable;
 use crate::arrays::py::id_from_obj;
 use crate::error::PyVortexResult;
 use crate::install_module;

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -11,9 +11,9 @@ use vortex::array::ArrayRef;
 use vortex::array::DynArray;
 use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
+use vortex::array::arrays::Constant;
 use vortex::array::arrays::ConstantArray;
-use vortex::array::arrays::ConstantVTable;
-use vortex::array::arrays::ExtensionVTable;
+use vortex::array::arrays::Extension;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::match_each_float_ptype;
 use vortex::dtype::DType;
@@ -197,7 +197,7 @@ impl ScalarFnVTable for CosineSimilarity {
 /// Extracts the storage array from an extension array without canonicalizing.
 fn extension_storage(array: &ArrayRef) -> VortexResult<ArrayRef> {
     let ext = array
-        .as_opt::<ExtensionVTable>()
+        .as_opt::<Extension>()
         .ok_or_else(|| vortex_err!("cosine_similarity input must be an extension array"))?;
     Ok(ext.storage_array().clone())
 }
@@ -211,7 +211,7 @@ fn extract_flat_elements(
     storage: &ArrayRef,
     list_size: usize,
 ) -> VortexResult<(PrimitiveArray, usize)> {
-    if let Some(constant) = storage.as_opt::<ConstantVTable>() {
+    if let Some(constant) = storage.as_opt::<Constant>() {
         // Rewrite the array as a length 1 array so when we canonicalize, we do not duplicate a
         // huge amount of data.
         let single = ConstantArray::new(constant.scalar().clone(), 1).into_array();

--- a/vortex-tui/src/browse/app.rs
+++ b/vortex-tui/src/browse/app.rs
@@ -15,8 +15,8 @@ use vortex::file::SegmentSpec;
 use vortex::file::VortexFile;
 use vortex::layout::LayoutRef;
 use vortex::layout::VTable;
-use vortex::layout::layouts::flat::FlatVTable;
-use vortex::layout::layouts::zoned::ZonedVTable;
+use vortex::layout::layouts::flat::Flat;
+use vortex::layout::layouts::zoned::Zoned;
 use vortex::layout::segments::SegmentId;
 use vortex::layout::segments::SegmentSource;
 use vortex::session::VortexSession;
@@ -116,10 +116,10 @@ impl LayoutCursor {
     ///
     /// # Panics
     ///
-    /// Panics if the current layout is not a [`FlatVTable`] layout.
+    /// Panics if the current layout is not a [`Flat`] layout.
     pub fn flat_layout_metadata_info(&self) -> String {
-        let flat_layout = self.layout.as_::<FlatVTable>();
-        let metadata = FlatVTable::metadata(flat_layout);
+        let flat_layout = self.layout.as_::<Flat>();
+        let metadata = Flat::metadata(flat_layout);
 
         match metadata.0.array_encoding_tree.as_ref() {
             Some(tree) => {
@@ -151,10 +151,10 @@ impl LayoutCursor {
 
     /// Returns `true` if the cursor is currently pointing at a statistics table.
     ///
-    /// A statistics table is the second child of a [`ZonedVTable`] layout.
+    /// A statistics table is the second child of a [`Zoned`] layout.
     pub fn is_stats_table(&self) -> bool {
         let parent = self.parent();
-        parent.layout().is::<ZonedVTable>() && self.path.last().copied().unwrap_or_default() == 1
+        parent.layout().is::<Zoned>() && self.path.last().copied().unwrap_or_default() == 1
     }
 
     /// Get the data type of the current layout.
@@ -340,7 +340,7 @@ impl AppState {
     ///
     /// This resets the list selection to the first item and clears any scroll offset.
     /// The caller is responsible for awaiting `load_flat_data()` afterward if the
-    /// new layout is a [`FlatVTable`].
+    /// new layout is a [`Flat`].
     pub fn reset_layout_view_state(&mut self) {
         self.layouts_list_state = ListState::default().with_selected(Some(0));
         self.tree_scroll_offset = 0;
@@ -376,7 +376,7 @@ impl AppState {
         self.cached_flat_array = Some(array);
 
         // Load the flatbuffer size.
-        let segment_id = layout.as_::<FlatVTable>().segment_id();
+        let segment_id = layout.as_::<Flat>().segment_id();
         let segment = self
             .cursor
             .segment_source

--- a/vortex-tui/src/browse/mod.rs
+++ b/vortex-tui/src/browse/mod.rs
@@ -9,7 +9,7 @@ use app::Tab;
 use input::InputEvent;
 use input::InputKeyCode;
 use vortex::error::VortexExpect;
-use vortex::layout::layouts::flat::FlatVTable;
+use vortex::layout::layouts::flat::Flat;
 
 pub mod app;
 pub(crate) mod input;
@@ -36,7 +36,7 @@ pub(crate) enum HandleResult {
 /// Navigate the layout list up by the given amount.
 fn navigate_layout_up(app: &mut AppState, amount: usize) {
     let amount_u16 = amount.try_into().unwrap_or(u16::MAX);
-    if app.cursor.layout().is::<FlatVTable>() {
+    if app.cursor.layout().is::<Flat>() {
         app.tree_scroll_offset = app.tree_scroll_offset.saturating_sub(amount_u16);
     } else {
         app.layouts_list_state.scroll_up_by(amount_u16);
@@ -46,7 +46,7 @@ fn navigate_layout_up(app: &mut AppState, amount: usize) {
 /// Navigate the layout list down by the given amount.
 fn navigate_layout_down(app: &mut AppState, amount: usize) {
     let amount_u16 = amount.try_into().unwrap_or(u16::MAX);
-    if app.cursor.layout().is::<FlatVTable>() {
+    if app.cursor.layout().is::<Flat>() {
         app.tree_scroll_offset = app.tree_scroll_offset.saturating_add(amount_u16);
     } else {
         app.layouts_list_state.scroll_down_by(amount_u16);
@@ -361,7 +361,7 @@ mod native {
 
     async fn run(mut terminal: DefaultTerminal, mut app: AppState) -> VortexResult<()> {
         // Eagerly load data if the initial layout is flat.
-        if app.cursor.layout().is::<FlatVTable>() {
+        if app.cursor.layout().is::<Flat>() {
             app.load_flat_data().await;
         }
 
@@ -413,7 +413,7 @@ mod native {
                 }
 
                 // After handling, load flat data if we navigated to a FlatLayout.
-                if app.cursor.layout().is::<FlatVTable>() && app.cached_flat_array.is_none() {
+                if app.cursor.layout().is::<Flat>() && app.cached_flat_array.is_none() {
                     app.load_flat_data().await;
                 }
 

--- a/vortex-tui/src/browse/ui/layouts.rs
+++ b/vortex-tui/src/browse/ui/layouts.rs
@@ -30,8 +30,8 @@ use vortex::array::ArrayRef;
 use vortex::array::DynArray;
 use vortex::array::ToCanonical;
 use vortex::error::VortexExpect;
-use vortex::layout::layouts::flat::FlatVTable;
-use vortex::layout::layouts::zoned::ZonedVTable;
+use vortex::layout::layouts::flat::Flat;
+use vortex::layout::layouts::zoned::Zoned;
 
 use crate::browse::app::AppState;
 
@@ -44,7 +44,7 @@ pub fn render_layouts(app_state: &mut AppState, area: Rect, buf: &mut Buffer) {
     render_layout_header(app_state, header_area, buf);
 
     // Render the list view if the layout has children
-    if app_state.cursor.layout().is::<FlatVTable>() {
+    if app_state.cursor.layout().is::<Flat>() {
         render_array(
             app_state,
             detail_area,
@@ -73,7 +73,7 @@ fn render_layout_header(app: &AppState, area: Rect, buf: &mut Buffer) {
         Text::from(format!("Segment data size: {size}")).bold(),
     ];
 
-    if cursor.layout().is::<FlatVTable>() {
+    if cursor.layout().is::<Flat>() {
         if let Some(fb_size) = app.cached_flatbuffer_size {
             rows.push(Text::from(format!(
                 "FlatBuffer Size: {}",
@@ -86,7 +86,7 @@ fn render_layout_header(app: &AppState, area: Rect, buf: &mut Buffer) {
         rows.push(Text::from(metadata_info));
     }
 
-    if let Some(layout) = cursor.layout().as_opt::<ZonedVTable>() {
+    if let Some(layout) = cursor.layout().as_opt::<Zoned>() {
         // Push any zone stats.
         let mut line = String::new();
         line.push_str("Statistics: ");

--- a/vortex-tui/src/wasm.rs
+++ b/vortex-tui/src/wasm.rs
@@ -17,7 +17,7 @@ use vortex::array::MaskFuture;
 use vortex::array::serde::ArrayParts;
 use vortex::error::VortexExpect;
 use vortex::expr::root;
-use vortex::layout::layouts::flat::FlatVTable;
+use vortex::layout::layouts::flat::Flat;
 use vortex::layout::segments::SegmentSource;
 use vortex::session::VortexSession;
 use wasm_bindgen::prelude::*;
@@ -41,7 +41,7 @@ pub fn init() {
 /// since the single-threaded event loop can't process spawned tasks while busy-waiting.
 fn maybe_load_flat_data(app: &Rc<RefCell<AppState>>) {
     let borrowed = app.borrow();
-    if !borrowed.cursor.layout().is::<FlatVTable>() {
+    if !borrowed.cursor.layout().is::<Flat>() {
         return;
     }
     if borrowed.cached_flat_array.is_some() {
@@ -97,7 +97,7 @@ async fn load_flatbuffer_size(
     layout: &vortex::layout::LayoutRef,
     segment_source: &Arc<dyn SegmentSource>,
 ) -> usize {
-    let segment_id = layout.as_::<FlatVTable>().segment_id();
+    let segment_id = layout.as_::<Flat>().segment_id();
     let segment = segment_source
         .request(segment_id)
         .await


### PR DESCRIPTION
We are about to move more functions onto the VTable struct. To make this API nicer for users we're renaming FooVTable to Foo. Since users don't really interact with these structs at the moment, it should have a relatively small blast radius.

That said, anyone who has code like this should update it

```diff
- if let Some(foo) = array.as_opt::<FooVTable>() { ... }
+ if let Some(foo) = array.as_opt::<Foo>() { ... }
```