### PR TITLE
Add support for nulls and unsigned integers through Arrow Datasets

### DIFF
--- a/vortex-python/python/vortex/substrait.py
+++ b/vortex-python/python/vortex/substrait.py
@@ -14,26 +14,39 @@ if TYPE_CHECKING:
         SimpleExtensionDeclaration,
         SimpleExtensionURI,  # pyright: ignore[reportDeprecated]
     )
-    from substrait.type_pb2 import NamedStruct
+    from substrait.type_pb2 import NamedStruct, Type
 else:
     try:
         # substrait >= 0.27
         from substrait.algebra_pb2 import Expression, FunctionArgument
         from substrait.extended_expression_pb2 import ExpressionReference, ExtendedExpression
         from substrait.extensions.extensions_pb2 import SimpleExtensionDeclaration, SimpleExtensionURI
-        from substrait.type_pb2 import NamedStruct
+        from substrait.type_pb2 import NamedStruct, Type
     except ImportError:
         # substrait < 0.27
         from substrait.gen.proto.algebra_pb2 import Expression, FunctionArgument
         from substrait.gen.proto.extended_expression_pb2 import ExpressionReference, ExtendedExpression
         from substrait.gen.proto.extensions.extensions_pb2 import SimpleExtensionDeclaration, SimpleExtensionURI
-        from substrait.gen.proto.type_pb2 import NamedStruct
+        from substrait.gen.proto.type_pb2 import NamedStruct, Type
 
 from ._lib import dtype as _dtype  # pyright: ignore[reportMissingModuleSource]
 from ._lib import expr as _expr  # pyright: ignore[reportMissingModuleSource]
 
+ExtensionTypes = dict[int, str]
+TypeVariations = dict[int, str]
+IntWidth = Literal[8, 16, 32, 64]
+
 
 def literal(substrait_object: Expression.Literal) -> _expr.Expr:
+    return _literal(substrait_object, extension_types={}, type_variations={})
+
+
+def _literal(
+    substrait_object: Expression.Literal,
+    *,
+    extension_types: ExtensionTypes,
+    type_variations: TypeVariations,
+) -> _expr.Expr:
     # https://github.com/substrait-io/substrait/blob/main/proto/substrait/algebra.proto#L890
     match substrait_object.WhichOneof("literal_type"):
         case "boolean":
@@ -78,6 +91,16 @@ def literal(substrait_object: Expression.Literal) -> _expr.Expr:
         case "precision_time":
             unit = _precision_to_unit("precision_time", substrait_object.precision_time.precision)
             return _expr.literal(_dtype.time(unit=unit, nullable=False), substrait_object.precision_time.value)
+        case "null":
+            return _expr.literal(
+                _type_to_dtype(
+                    substrait_object.null,
+                    force_nullable=True,
+                    extension_types=extension_types,
+                    type_variations=type_variations,
+                ),
+                None,
+            )
         case "interval_year_to_month":
             raise NotImplementedError
         case "interval_day_to_second":
@@ -100,9 +123,6 @@ def literal(substrait_object: Expression.Literal) -> _expr.Expr:
             raise NotImplementedError
         case "uuid":
             raise NotImplementedError
-        case "null":
-            # substrait_object.null is a Type which needs to be converted
-            raise NotImplementedError
         case "list":
             raise NotImplementedError
         case "empty_list":
@@ -115,6 +135,231 @@ def literal(substrait_object: Expression.Literal) -> _expr.Expr:
             raise NotImplementedError
         case literal_type:
             raise ValueError(f"unknown literal_type {literal_type}")
+
+
+def _type_to_dtype(
+    substrait_type: Type,
+    *,
+    force_nullable: bool = False,
+    extension_types: ExtensionTypes | None = None,
+    type_variations: TypeVariations | None = None,
+) -> _dtype.DType:
+    extension_types = extension_types or {}
+    type_variations = type_variations or {}
+
+    match substrait_type.WhichOneof("kind"):
+        case "bool":
+            return _dtype.bool_(nullable=_nullability(substrait_type.bool.nullability, force_nullable=force_nullable))
+        case "i8":
+            return _integer_dtype(
+                8,
+                substrait_type.i8.type_variation_reference,
+                substrait_type.i8.nullability,
+                force_nullable=force_nullable,
+                type_variations=type_variations,
+            )
+        case "i16":
+            return _integer_dtype(
+                16,
+                substrait_type.i16.type_variation_reference,
+                substrait_type.i16.nullability,
+                force_nullable=force_nullable,
+                type_variations=type_variations,
+            )
+        case "i32":
+            return _integer_dtype(
+                32,
+                substrait_type.i32.type_variation_reference,
+                substrait_type.i32.nullability,
+                force_nullable=force_nullable,
+                type_variations=type_variations,
+            )
+        case "i64":
+            return _integer_dtype(
+                64,
+                substrait_type.i64.type_variation_reference,
+                substrait_type.i64.nullability,
+                force_nullable=force_nullable,
+                type_variations=type_variations,
+            )
+        case "fp32":
+            return _dtype.float_(
+                32,
+                nullable=_nullability(substrait_type.fp32.nullability, force_nullable=force_nullable),
+            )
+        case "fp64":
+            return _dtype.float_(
+                64,
+                nullable=_nullability(substrait_type.fp64.nullability, force_nullable=force_nullable),
+            )
+        case "string":
+            return _dtype.utf8(nullable=_nullability(substrait_type.string.nullability, force_nullable=force_nullable))
+        case "binary":
+            return _dtype.binary(
+                nullable=_nullability(substrait_type.binary.nullability, force_nullable=force_nullable)
+            )
+        case "decimal":
+            return _dtype.decimal(
+                precision=substrait_type.decimal.precision,
+                scale=substrait_type.decimal.scale,
+                nullable=_nullability(substrait_type.decimal.nullability, force_nullable=force_nullable),
+            )
+        case "date":
+            return _dtype.date(
+                unit="days",
+                nullable=_nullability(substrait_type.date.nullability, force_nullable=force_nullable),
+            )
+        case "time":
+            return _dtype.time(
+                unit="us",
+                nullable=_nullability(substrait_type.time.nullability, force_nullable=force_nullable),
+            )
+        case "precision_time":
+            return _dtype.time(
+                unit=_precision_to_unit("precision_time", substrait_type.precision_time.precision),
+                nullable=_nullability(
+                    substrait_type.precision_time.nullability,
+                    force_nullable=force_nullable,
+                ),
+            )
+        case "timestamp":
+            return _dtype.timestamp(
+                unit="us",
+                nullable=_nullability(substrait_type.timestamp.nullability, force_nullable=force_nullable),
+            )
+        case "precision_timestamp":
+            return _dtype.timestamp(
+                unit=_precision_to_unit("precision_timestamp", substrait_type.precision_timestamp.precision),
+                nullable=_nullability(
+                    substrait_type.precision_timestamp.nullability,
+                    force_nullable=force_nullable,
+                ),
+            )
+        case "timestamp_tz":
+            return _dtype.timestamp(
+                unit="us",
+                tz="UTC",
+                nullable=_nullability(
+                    substrait_type.timestamp_tz.nullability,
+                    force_nullable=force_nullable,
+                ),
+            )
+        case "precision_timestamp_tz":
+            return _dtype.timestamp(
+                unit=_precision_to_unit(
+                    "precision_timestamp_tz",
+                    substrait_type.precision_timestamp_tz.precision,
+                ),
+                tz="UTC",
+                nullable=_nullability(
+                    substrait_type.precision_timestamp_tz.nullability,
+                    force_nullable=force_nullable,
+                ),
+            )
+        case "list":
+            return _dtype.list_(
+                _type_to_dtype(
+                    substrait_type.list.type,
+                    extension_types=extension_types,
+                    type_variations=type_variations,
+                ),
+                nullable=_nullability(substrait_type.list.nullability, force_nullable=force_nullable),
+            )
+        case "user_defined":
+            return _user_defined_dtype(
+                substrait_type.user_defined.type_reference,
+                substrait_type.user_defined.type_variation_reference,
+                substrait_type.user_defined.nullability,
+                force_nullable=force_nullable,
+                extension_types=extension_types,
+                type_variations=type_variations,
+            )
+        case "struct":
+            raise NotImplementedError("Substrait null struct literals are not supported because field names are absent")
+        case "map":
+            raise NotImplementedError("Substrait map types are not supported")
+        case kind:
+            raise NotImplementedError(f"Substrait type {kind} is not supported")
+
+
+def _integer_dtype(
+    width: IntWidth,
+    type_variation_reference: int,
+    nullability: int,
+    *,
+    force_nullable: bool,
+    type_variations: TypeVariations,
+) -> _dtype.DType:
+    nullable = _nullability(nullability, force_nullable=force_nullable)
+    if _is_unsigned_integer_name(type_variations.get(type_variation_reference), width):
+        return _dtype.uint(width, nullable=nullable)
+    return _dtype.int_(width, nullable=nullable)
+
+
+def _user_defined_dtype(
+    type_reference: int,
+    type_variation_reference: int,
+    nullability: int,
+    *,
+    force_nullable: bool,
+    extension_types: ExtensionTypes,
+    type_variations: TypeVariations,
+) -> _dtype.DType:
+    nullable = _nullability(nullability, force_nullable=force_nullable)
+
+    # PyArrow's `to_substrait()` currently encodes unsigned integers as Arrow-defined
+    # user-defined types named `u8`/`u16`/`u32`/`u64`, even though core Substrait does not
+    # define unsigned simple types:
+    # https://github.com/apache/arrow/blob/main/format/substrait/extension_types.yaml
+    extension_name = extension_types.get(type_reference)
+    match extension_name:
+        case "u8":
+            return _dtype.uint(8, nullable=nullable)
+        case "u16":
+            return _dtype.uint(16, nullable=nullable)
+        case "u32":
+            return _dtype.uint(32, nullable=nullable)
+        case "u64":
+            return _dtype.uint(64, nullable=nullable)
+        case _:
+            pass
+
+    variation_name = type_variations.get(type_variation_reference)
+    match variation_name:
+        case "u8":
+            return _dtype.uint(8, nullable=nullable)
+        case "u16":
+            return _dtype.uint(16, nullable=nullable)
+        case "u32":
+            return _dtype.uint(32, nullable=nullable)
+        case "u64":
+            return _dtype.uint(64, nullable=nullable)
+        case _:
+            pass
+
+    raise NotImplementedError(f"Substrait user-defined type {extension_name or type_reference} is not supported")
+
+
+def _is_unsigned_integer_name(name: str | None, width: IntWidth | None = None) -> bool:
+    if name is None:
+        return False
+
+    normalized = name.strip().lower().replace("-", "_").replace(" ", "_")
+    if width is not None and normalized in {f"u{width}", f"uint{width}", f"unsigned_{width}"}:
+        return True
+    return normalized.startswith("unsigned")
+
+
+def _nullability(nullability: int, *, force_nullable: bool = False) -> bool:
+    if force_nullable:
+        return True
+    match nullability:
+        case 1:
+            return True
+        case 2:
+            return False
+        case other:
+            raise ValueError(f"Unknown Substrait nullability {other}")
 
 
 def _precision_to_unit(type_: str, p: int) -> Literal["s", "ms", "us", "ns"]:
@@ -170,16 +415,35 @@ def struct_field(substrait_object: Expression.ReferenceSegment.StructField) -> l
 
 
 def scalar_function(
-    substrait_object: Expression.ScalarFunction, functions: list[Callable[..., _expr.Expr]], schema: NamedStruct
+    substrait_object: Expression.ScalarFunction,
+    functions: list[Callable[..., _expr.Expr]],
+    schema: NamedStruct,
+    *,
+    extension_types: ExtensionTypes,
+    type_variations: TypeVariations,
 ) -> _expr.Expr:
     # https://github.com/substrait-io/substrait/blob/main/proto/substrait/extensions/extensions.proto#L57
     function = functions[substrait_object.function_reference]
-    arguments = [function_argument(argument, functions, schema) for argument in substrait_object.arguments]
+    arguments = [
+        function_argument(
+            argument,
+            functions,
+            schema,
+            extension_types=extension_types,
+            type_variations=type_variations,
+        )
+        for argument in substrait_object.arguments
+    ]
     return function(*arguments)
 
 
 def function_argument(
-    substrait_object: FunctionArgument, functions: list[Callable[..., _expr.Expr]], schema: NamedStruct
+    substrait_object: FunctionArgument,
+    functions: list[Callable[..., _expr.Expr]],
+    schema: NamedStruct,
+    *,
+    extension_types: ExtensionTypes,
+    type_variations: TypeVariations,
 ) -> _expr.Expr:
     # https://github.com/substrait-io/substrait/blob/main/proto/substrait/algebra.proto#L832
     match substrait_object.WhichOneof("arg_type"):
@@ -188,7 +452,13 @@ def function_argument(
         case "type":
             raise NotImplementedError
         case "value":
-            return expression(substrait_object.value, functions, schema)
+            return expression(
+                substrait_object.value,
+                functions,
+                schema,
+                extension_types=extension_types,
+                type_variations=type_variations,
+            )
         case arg_type:
             raise ValueError(f"unknown arg_type {arg_type}")
 
@@ -255,16 +525,31 @@ def _is_not_null(e: _expr.Expr) -> _expr.Expr:
 
 
 def expression(
-    substrait_object: Expression, functions: list[Callable[..., _expr.Expr]], schema: NamedStruct
+    substrait_object: Expression,
+    functions: list[Callable[..., _expr.Expr]],
+    schema: NamedStruct,
+    *,
+    extension_types: ExtensionTypes,
+    type_variations: TypeVariations,
 ) -> _expr.Expr:
     # https://github.com/substrait-io/substrait/blob/main/proto/substrait/algebra.proto#L857
     match substrait_object.WhichOneof("rex_type"):
         case "literal":
-            return literal(substrait_object.literal)
+            return _literal(
+                substrait_object.literal,
+                extension_types=extension_types,
+                type_variations=type_variations,
+            )
         case "selection":
             return field_reference(substrait_object.selection, schema)
         case "scalar_function":
-            return scalar_function(substrait_object.scalar_function, functions, schema)
+            return scalar_function(
+                substrait_object.scalar_function,
+                functions,
+                schema,
+                extension_types=extension_types,
+                type_variations=type_variations,
+            )
         case "window_function":
             raise NotImplementedError
         case "if_then":
@@ -280,12 +565,23 @@ def expression(
 
 
 def expression_reference(
-    substrait_object: ExpressionReference, functions: list[Callable[..., _expr.Expr]], schema: NamedStruct
+    substrait_object: ExpressionReference,
+    functions: list[Callable[..., _expr.Expr]],
+    schema: NamedStruct,
+    *,
+    extension_types: ExtensionTypes,
+    type_variations: TypeVariations,
 ) -> _expr.Expr:
     # https://github.com/substrait-io/substrait/blob/main/proto/substrait/extended__expression.proto#L16
     match substrait_object.WhichOneof("expr_type"):
         case "expression":
-            return expression(substrait_object.expression, functions, schema)
+            return expression(
+                substrait_object.expression,
+                functions,
+                schema,
+                extension_types=extension_types,
+                type_variations=type_variations,
+            )
         case _:
             raise ValueError("unknown expr_type: {}")
 
@@ -293,6 +589,8 @@ def expression_reference(
 def extended_expression(substrait_object: ExtendedExpression) -> list[_expr.Expr]:
     # https://github.com/substrait-io/substrait/blob/main/proto/substrait/extended__expression.proto#L27
     functions: list[Callable[..., _expr.Expr]] = []
+    extension_types: ExtensionTypes = {}
+    type_variations: TypeVariations = {}
 
     substrait_schema = substrait_object.base_schema
     extension_uris = substrait_object.extension_uris
@@ -302,9 +600,29 @@ def extended_expression(substrait_object: ExtendedExpression) -> list[_expr.Expr
     for extension in extensions:
         # https://github.com/substrait-io/substrait/blob/main/proto/substrait/extensions/extensions.proto#L25
         match extension.WhichOneof("mapping_type"):
+            case "extension_type":
+                extension_types[extension.extension_type.type_anchor] = extension.extension_type.name
+                # Arrow can declare extension-backed types like `null` in the schema even when the
+                # expression only references functions. Those declarations do not participate in
+                # function_reference indexing.
+                continue
+            case "extension_type_variation":
+                type_variations[extension.extension_type_variation.type_variation_anchor] = (
+                    extension.extension_type_variation.name
+                )
+                continue
             case "extension_function":
                 functions.append(extension_function(extension.extension_function, extension_uris))
             case mapping_type:
                 raise ValueError(f"unsupported extension mapping_type {mapping_type}")
 
-    return [expression_reference(expression, functions, substrait_schema) for expression in expressions]
+    return [
+        expression_reference(
+            expression,
+            functions,
+            substrait_schema,
+            extension_types=extension_types,
+            type_variations=type_variations,
+        )
+        for expression in expressions
+    ]

--- a/vortex-python/test/test_dataset.py
+++ b/vortex-python/test/test_dataset.py
@@ -3,6 +3,7 @@
 
 import math
 import os
+from pathlib import Path
 
 import duckdb
 import polars
@@ -126,6 +127,25 @@ def test_filter(ds: vx.dataset.VortexDataset):
 
     tbl = ds.to_table(filter=((pc.field("index") / 2) < 10))
     assert len(tbl) == 20
+
+
+def test_filter_with_nested_null_dtype(tmp_path: Path):
+    path = tmp_path / "test.vortex"
+
+    batch = pa.RecordBatch.from_pylist(
+        [
+            {"a": 0, "b": {"x": None}},
+            {"a": 1, "b": {"x": None}},
+        ]
+    )
+
+    arr = vx.array(batch.to_struct_array())
+    vx.io.write(vx.ArrayIterator.from_iter(arr.dtype, iter([arr])), str(path))
+
+    dataset = vx.open(str(path)).to_dataset()
+    actual = dataset.to_table(filter=pc.field("a") == 0)
+
+    assert actual.to_pylist() == [{"a": 0, "b": {"x": None}}]
 
 
 def test_duckdb(ds: vx.dataset.VortexDataset):

--- a/vortex-python/test/test_expression.py
+++ b/vortex-python/test/test_expression.py
@@ -3,10 +3,36 @@
 
 # Tests the _schema_for_substrait workaround in vortex/arrow/expression.py
 
+from typing import TYPE_CHECKING, Literal, TypeAlias
+
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 from vortex.arrow.expression import _schema_for_substrait, arrow_to_vortex  # pyright: ignore[reportPrivateUsage]
+
+import vortex as vx
+import vortex.expr as ve
+from vortex import substrait as vx_substrait
+
+if TYPE_CHECKING:
+    from substrait.algebra_pb2 import Expression
+    from substrait.type_pb2 import Type
+else:
+    try:
+        from substrait.algebra_pb2 import Expression
+        from substrait.type_pb2 import Type
+    except ImportError:
+        from substrait.gen.proto.algebra_pb2 import Expression
+        from substrait.gen.proto.type_pb2 import Type
+
+UIntWidth: TypeAlias = Literal[8, 16, 32, 64]
+UnsignedNullCase: TypeAlias = tuple[pa.DataType, UIntWidth]
+UNSIGNED_NULL_CASES: list[UnsignedNullCase] = [
+    (pa.uint8(), 8),
+    (pa.uint16(), 16),
+    (pa.uint32(), 32),
+    (pa.uint64(), 64),
+]
 
 
 class TestSchemaForSubstrait:
@@ -100,3 +126,29 @@ class TestArrowToVortexWithViews:
         expr = pc.field("col") == value  # pyright: ignore[reportUnknownVariableType]
         vortex_expr = arrow_to_vortex(expr, schema)  # pyright: ignore[reportUnknownArgumentType]
         assert vortex_expr is not None
+
+    def test_null_literal_expression(self):
+        schema = pa.schema([("id", pa.int64())])
+        expr = pc.field("id") == pa.scalar(None, type=pa.int64())
+        vortex_expr = arrow_to_vortex(expr, schema)
+        assert vortex_expr is not None
+
+    @pytest.mark.parametrize(("arrow_type", "width"), UNSIGNED_NULL_CASES)
+    def test_unsigned_null_literal_expression(self, arrow_type: pa.DataType, width: UIntWidth):
+        schema = pa.schema([("u", arrow_type)])
+        expr = pc.field("u") == pa.scalar(None, type=arrow_type)
+
+        actual = arrow_to_vortex(expr, schema)
+        expected = ve.column("u") == ve.literal(vx.uint(width, nullable=True), None)
+
+        assert str(actual) == str(expected)
+
+
+def test_substrait_typed_null_literal():
+    literal: Expression.Literal = Expression.Literal()
+    literal.null.i64.nullability = Type.NULLABILITY_NULLABLE
+
+    actual = vx_substrait.literal(literal)
+    expected = ve.literal(vx.int_(64, nullable=True), None)
+
+    assert str(actual) == str(expected)


### PR DESCRIPTION
## Summary

Closes #6905

Improves support for null literals, and also for some arrow-specific extensions like `null` and unsigned integers (yes - that's not a core Substrait thing)

