### PR TITLE
chore: suppress warnings from DuckDB headers

### DIFF
--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -504,9 +504,6 @@ fn main() {
         .flag("-Wall")
         .flag("-Wextra")
         .flag("-Wpedantic")
-        // Unused parameter warnings are disabled as we include DuckDB
-        // headers with implementations that have unused parameters.
-        .flag("-Wno-unused-parameter")
         .cpp(true)
         .include(&duckdb_include_path)
         .include("cpp/include")

--- a/vortex-duckdb/cpp/client_context.cpp
+++ b/vortex-duckdb/cpp/client_context.cpp
@@ -3,9 +3,12 @@
 
 #include "duckdb_vx.h"
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+DUCKDB_INCLUDES_BEGIN
 #include <duckdb/main/client_context.hpp>
 #include <duckdb/main/connection.hpp>
 #include <duckdb/storage/object_cache.hpp>
+DUCKDB_INCLUDES_END
 
 extern "C" duckdb_client_context duckdb_vx_connection_get_client_context(duckdb_connection conn) {
     try {

--- a/vortex-duckdb/cpp/config.cpp
+++ b/vortex-duckdb/cpp/config.cpp
@@ -2,9 +2,14 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 #include "include/duckdb_vx/config.h"
+
+#include "duckdb_vx/duckdb_diagnostics.h"
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/main/config.hpp"
+DUCKDB_INCLUDES_END
+
 #include <string>
 #include <memory>
 #include <cstdlib>

--- a/vortex-duckdb/cpp/copy_function.cpp
+++ b/vortex-duckdb/cpp/copy_function.cpp
@@ -43,7 +43,7 @@ struct CCopyLocalData final : LocalFunctionData {
 
 static duckdb_vx_copy_func_vtab_t copy_vtab_one;
 
-unique_ptr<FunctionData> c_bind_one(ClientContext &context,
+unique_ptr<FunctionData> c_bind_one(ClientContext & /*context*/,
                                     CopyFunctionBindInput &info,
                                     const vector<string> &column_names,
                                     const vector<LogicalType> &column_types) {
@@ -94,7 +94,7 @@ c_init_global(ClientContext &context, FunctionData &bind_data, const string &fil
     return make_uniq<CCopyGlobalData>(unique_ptr<CData>(reinterpret_cast<CData *>(global_data)));
 }
 
-unique_ptr<LocalFunctionData> c_init_local(ExecutionContext &context, FunctionData &bind_data) {
+unique_ptr<LocalFunctionData> c_init_local(ExecutionContext & /*context*/, FunctionData &bind_data) {
     auto &bind = bind_data.Cast<CCopyBindData>();
     duckdb_vx_error error_out = nullptr;
     auto data = bind.vtab.init_local(bind.ffi_data->DataPtr(), &error_out);
@@ -105,7 +105,7 @@ unique_ptr<LocalFunctionData> c_init_local(ExecutionContext &context, FunctionDa
     return make_uniq<CCopyLocalData>(unique_ptr<CData>(reinterpret_cast<CData *>(data)));
 }
 
-void c_copy_to_sink(ExecutionContext &context,
+void c_copy_to_sink(ExecutionContext & /*context*/,
                     FunctionData &bind_data,
                     GlobalFunctionData &gstate,
                     LocalFunctionData &lstate,
@@ -124,7 +124,7 @@ void c_copy_to_sink(ExecutionContext &context,
     }
 }
 
-void copy_to_finalize(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate) {
+void copy_to_finalize(ClientContext & /*context*/, FunctionData &bind_data, GlobalFunctionData &gstate) {
     auto &bind = bind_data.Cast<CCopyBindData>();
     auto &global = gstate.Cast<CCopyGlobalData>();
     duckdb_vx_error error_out = nullptr;
@@ -156,7 +156,7 @@ extern "C" duckdb_state duckdb_vx_copy_func_register_vtab_one(duckdb_database ff
     copy_function.extension = copy_vtab_one.extension;
 
     // TODO(joe): expose this via c our api
-    copy_function.execution_mode = [](bool preserve_insertion_order, bool supports_batch_index) {
+    copy_function.execution_mode = [](bool /*preserve_insertion_order*/, bool /*supports_batch_index*/) {
         return CopyFunctionExecutionMode::REGULAR_COPY_TO_FILE;
     };
     // TODO(joe): handle parameters as in table_function

--- a/vortex-duckdb/cpp/copy_function.cpp
+++ b/vortex-duckdb/cpp/copy_function.cpp
@@ -3,12 +3,16 @@
 
 #include "duckdb_vx.h"
 #include "duckdb_vx/data.hpp"
+#include "duckdb_vx/error.hpp"
+
+#include "duckdb_vx/duckdb_diagnostics.h"
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/parser/parsed_data/create_copy_function_info.hpp"
-#include "duckdb_vx/error.hpp"
+DUCKDB_INCLUDES_END
 
 using namespace duckdb;
 

--- a/vortex-duckdb/cpp/data.cpp
+++ b/vortex-duckdb/cpp/data.cpp
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
 
 #include "duckdb_vx/data.hpp"
 

--- a/vortex-duckdb/cpp/data_chunk.cpp
+++ b/vortex-duckdb/cpp/data_chunk.cpp
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/common/types/data_chunk.hpp"
+DUCKDB_INCLUDES_END
 
 #include "duckdb_vx.h"
 

--- a/vortex-duckdb/cpp/error.cpp
+++ b/vortex-duckdb/cpp/error.cpp
@@ -4,9 +4,12 @@
 #include <cassert>
 #include <exception>
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/vector_buffer.hpp"
 #include "duckdb/common/types/vector.hpp"
+DUCKDB_INCLUDES_END
 
 #include "duckdb_vx.h"
 

--- a/vortex-duckdb/cpp/expr.cpp
+++ b/vortex-duckdb/cpp/expr.cpp
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 #include "duckdb_vx.h"
+
+#include "duckdb_vx/duckdb_diagnostics.h"
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/planner/expression/bound_between_expression.hpp"
 #include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_comparison_expression.hpp"
@@ -9,6 +12,7 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_operator_expression.hpp"
 #include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+DUCKDB_INCLUDES_END
 
 using namespace duckdb;
 

--- a/vortex-duckdb/cpp/file_system.cpp
+++ b/vortex-duckdb/cpp/file_system.cpp
@@ -4,10 +4,13 @@
 #include "duckdb_vx.h"
 #include "duckdb_vx/error.hpp"
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+DUCKDB_INCLUDES_BEGIN
 #include <duckdb/common/exception.hpp>
 #include <duckdb/common/file_system.hpp>
 #include <duckdb/common/helper.hpp>
 #include <duckdb/main/client_context.hpp>
+DUCKDB_INCLUDES_END
 
 #include <memory>
 #include <string>

--- a/vortex-duckdb/cpp/include/duckdb_vx/client_context.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/client_context.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
 
 #ifdef __cplusplus /* If compiled as C++, use C ABI */
 extern "C" {

--- a/vortex-duckdb/cpp/include/duckdb_vx/config.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/config.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
 
 #ifdef __cplusplus
 extern "C" {

--- a/vortex-duckdb/cpp/include/duckdb_vx/data.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/data.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
 
 #ifdef __cplusplus /* If compiled as C++, use C ABI */
 extern "C" {

--- a/vortex-duckdb/cpp/include/duckdb_vx/data_chunk.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/data_chunk.h
@@ -3,7 +3,12 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
+
 #include "error.h"
 
 #ifdef __cplusplus /* If compiled as C++, use C ABI */

--- a/vortex-duckdb/cpp/include/duckdb_vx/duckdb_diagnostics.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/duckdb_diagnostics.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+// Suppress warnings from DuckDB headers that we include but do not own.
+//
+// Usage:
+//   DUCKDB_INCLUDES_BEGIN
+//   #include "duckdb.h"
+//   #include "duckdb/main/client_context.hpp"
+//   DUCKDB_INCLUDES_END
+
+#pragma once
+
+// clang-format off
+#if defined(__clang__) || defined(__GNUC__)
+#define DUCKDB_INCLUDES_BEGIN                                                  \
+    _Pragma("GCC diagnostic push")                                             \
+    _Pragma("GCC diagnostic ignored \"-Wall\"")                                \
+    _Pragma("GCC diagnostic ignored \"-Wextra\"")                              \
+    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+#define DUCKDB_INCLUDES_END _Pragma("GCC diagnostic pop")
+#else
+#define DUCKDB_INCLUDES_BEGIN
+#define DUCKDB_INCLUDES_END
+#endif
+// clang-format on

--- a/vortex-duckdb/cpp/include/duckdb_vx/error.hpp
+++ b/vortex-duckdb/cpp/include/duckdb_vx/error.hpp
@@ -6,7 +6,12 @@
 #include <exception>
 #include <string>
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
+
 #include "duckdb_vx/error.h"
 
 namespace vortex {

--- a/vortex-duckdb/cpp/include/duckdb_vx/file_system.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/file_system.h
@@ -3,7 +3,12 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
+
 #include "duckdb_vx/client_context.h"
 #include "duckdb_vx/error.h"
 

--- a/vortex-duckdb/cpp/include/duckdb_vx/logical_type.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/logical_type.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
 
 #ifdef __cplusplus /* If compiled as C++, use C ABI */
 extern "C" {

--- a/vortex-duckdb/cpp/include/duckdb_vx/reusable_dict.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/reusable_dict.h
@@ -3,7 +3,12 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
+
 #include "duckdb_vx/error.h"
 
 #ifdef __cplusplus /* If compiled as C++, use C ABI */

--- a/vortex-duckdb/cpp/include/duckdb_vx/scalar_function.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/scalar_function.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
 
 #ifdef __cplusplus /* If compiled as C++, use C ABI */
 extern "C" {

--- a/vortex-duckdb/cpp/include/duckdb_vx/table_filter.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/table_filter.h
@@ -3,7 +3,12 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
+
 #include "duckdb_vx/expr.h"
 
 #ifdef __cplusplus /* If compiled as C++, use C ABI */

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector.h
@@ -3,7 +3,12 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
+
 #include "duckdb_vx/data.h"
 #include "duckdb_vx/error.h"
 #include "duckdb_vx/vector_buffer.h"

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.h
@@ -3,7 +3,12 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
+DUCKDB_INCLUDES_END
+
 #include "duckdb_vx/data.h"
 #include "duckdb_vx/error.h"
 

--- a/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.hpp
+++ b/vortex-duckdb/cpp/include/duckdb_vx/vector_buffer.hpp
@@ -3,8 +3,12 @@
 
 #pragma once
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/types/vector.hpp"
+DUCKDB_INCLUDES_END
 
 #include "duckdb_vx/data.hpp"
 

--- a/vortex-duckdb/cpp/logical_type.cpp
+++ b/vortex-duckdb/cpp/logical_type.cpp
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/common/types.hpp"
+DUCKDB_INCLUDES_END
 
 #include "duckdb_vx.h"
 #include "duckdb_vx/logical_type.h"
 
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/common/types.hpp"
+DUCKDB_INCLUDES_END
 #include <cassert>
 
 duckdb_logical_type duckdb_vx_logical_type_copy(duckdb_logical_type ty) {

--- a/vortex-duckdb/cpp/object_cache.cpp
+++ b/vortex-duckdb/cpp/object_cache.cpp
@@ -2,7 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 #include "duckdb_vx.h"
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/storage/object_cache.hpp"
+DUCKDB_INCLUDES_END
 
 #include <iostream>
 

--- a/vortex-duckdb/cpp/replacement_scan.cpp
+++ b/vortex-duckdb/cpp/replacement_scan.cpp
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/expression/function_expression.hpp"
 #include "duckdb/parser/tableref/table_function_ref.hpp"
+DUCKDB_INCLUDES_END
 
 #include "duckdb_vx.h"
 

--- a/vortex-duckdb/cpp/replacement_scan.cpp
+++ b/vortex-duckdb/cpp/replacement_scan.cpp
@@ -17,7 +17,7 @@ namespace vortex {
 static duckdb::unique_ptr<duckdb::TableRef>
 VortexScanReplacement(duckdb::ClientContext &context,
                       duckdb::ReplacementScanInput &input,
-                      duckdb::optional_ptr<duckdb::ReplacementScanData> data) {
+                      duckdb::optional_ptr<duckdb::ReplacementScanData> /*data*/) {
     auto table_name = duckdb::ReplacementScan::GetFullPath(input);
     if (!duckdb::ReplacementScan::CanReplace(table_name, {"vortex"})) {
         return nullptr;

--- a/vortex-duckdb/cpp/reusable_dict.cpp
+++ b/vortex-duckdb/cpp/reusable_dict.cpp
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/common/types/vector.hpp"
+DUCKDB_INCLUDES_END
 #include "duckdb_vx.h"
 
 using namespace duckdb;

--- a/vortex-duckdb/cpp/scalar_function.cpp
+++ b/vortex-duckdb/cpp/scalar_function.cpp
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/function/scalar_function.hpp"
+DUCKDB_INCLUDES_END
 
 #include "duckdb_vx.h"
 

--- a/vortex-duckdb/cpp/table_filter.cpp
+++ b/vortex-duckdb/cpp/table_filter.cpp
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-#include "duckdb/planner/table_filter.hpp"
 #include "duckdb_vx.h"
+
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
+#include "duckdb/planner/table_filter.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/dynamic_filter.hpp"
 #include "duckdb/planner/filter/optional_filter.hpp"
 #include "duckdb/planner/filter/expression_filter.hpp"
 #include "duckdb/planner/filter/struct_filter.hpp"
 #include "duckdb/planner/filter/in_filter.hpp"
+DUCKDB_INCLUDES_END
 
 using namespace duckdb;
 

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -184,8 +184,8 @@ void c_function(ClientContext &context, TableFunctionInput &input, DataChunk &ou
     }
 }
 
-void c_pushdown_complex_filter(ClientContext &context,
-                               LogicalGet &get,
+void c_pushdown_complex_filter(ClientContext & /*context*/,
+                               LogicalGet & /*get*/,
                                FunctionData *bind_data,
                                vector<unique_ptr<Expression>> &filters) {
     if (filters.empty()) {
@@ -213,7 +213,7 @@ void c_pushdown_complex_filter(ClientContext &context,
     }
 }
 
-unique_ptr<NodeStatistics> c_cardinality(ClientContext &context, const FunctionData *bind_data) {
+unique_ptr<NodeStatistics> c_cardinality(ClientContext & /*context*/, const FunctionData *bind_data) {
     auto &bind = bind_data->Cast<CTableBindData>();
 
     duckdb_vx_node_statistics node_stats_out = {
@@ -279,7 +279,8 @@ extern "C" void duckdb_vx_tfunc_bind_result_add_column(duckdb_vx_tfunc_bind_resu
     result->return_types.emplace_back(*logical_type);
 }
 
-virtual_column_map_t c_get_virtual_columns(ClientContext &context, optional_ptr<FunctionData> bind_data) {
+virtual_column_map_t c_get_virtual_columns(ClientContext & /*context*/,
+                                           optional_ptr<FunctionData> bind_data) {
     auto &bind = bind_data->Cast<CTableBindData>();
 
     auto result = virtual_column_map_t();
@@ -305,7 +306,8 @@ extern "C" void duckdb_vx_tfunc_virtual_columns_push(duckdb_vx_tfunc_virtual_col
     result->emplace(column_idx, std::move(table_col));
 }
 
-OperatorPartitionData c_get_partition_data(ClientContext &context, TableFunctionGetPartitionInput &input) {
+OperatorPartitionData c_get_partition_data(ClientContext & /*context*/,
+                                           TableFunctionGetPartitionInput &input) {
     if (input.partition_info.RequiresPartitionColumns()) {
         throw InternalException("TableScan::GetPartitionData: partition columns not supported");
     }

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -1,15 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb.h"
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/insertion_order_preserving_map.hpp"
+#include "duckdb/function/table_function.hpp"
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/main/connection.hpp"
-#include "duckdb/function/table_function.hpp"
-#include "duckdb/common/insertion_order_preserving_map.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+DUCKDB_INCLUDES_END
 
 #include "duckdb_vx.h"
-#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb_vx/data.hpp"
 #include "duckdb_vx/error.hpp"
 

--- a/vortex-duckdb/cpp/value.cpp
+++ b/vortex-duckdb/cpp/value.cpp
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/common/types/value.hpp"
+DUCKDB_INCLUDES_END
 
 #include "duckdb_vx.h"
 

--- a/vortex-duckdb/cpp/vector.cpp
+++ b/vortex-duckdb/cpp/vector.cpp
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/vector.hpp"
+DUCKDB_INCLUDES_END
 
 #include "duckdb_vx.h"
 #include "duckdb_vx/vector_buffer.hpp"

--- a/vortex-duckdb/cpp/vector_buffer.cpp
+++ b/vortex-duckdb/cpp/vector_buffer.cpp
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#include "duckdb_vx/duckdb_diagnostics.h"
+
+DUCKDB_INCLUDES_BEGIN
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/types/vector.hpp"
+DUCKDB_INCLUDES_END
 
 #include "duckdb_vx.h"
 #include "duckdb_vx/data.hpp"


### PR DESCRIPTION
Push/pop diagnostics to suppress warnings from DuckDB headers we include but do not own. Works on both GCC and Clang via #pragma GCC diagnostic.