### PR TITLE
skip[ci]: use prebuild images for some runs

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,1 +1,7 @@
 _extends: .github-private
+images:
+  ubuntu24-full-x64-pre:
+    platform: "linux"
+    arch: "x64"
+    name: "vortex-ci-x64-*"
+    owner: "245040174862"

--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,7 +1,1 @@
 _extends: .github-private
-images:
-  ubuntu24-full-x64-pre:
-    platform: "linux"
-    arch: "x64"
-    name: "vortex-ci-x64-*"
-    owner: "245040174862"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
     timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64/tag=rust-lint', github.run_id)
+          && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64-pre/tag=rust-lint', github.run_id)
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2
@@ -625,7 +625,7 @@ jobs:
       matrix:
         include:
           - os: windows-x64
-            runner: runs-on=${{ github.run_id }}/pool=windows-x64
+            runner: runs-on=${{ github.run_id }}/pool=windows-x64/image=windows25-full-x64-pre
             fallback_runner: windows-latest
           - os: linux-arm64
             runner: runs-on=${{ github.run_id }}/runner=arm64-medium/image=ubuntu24-full-arm64-pre/tag=rust-test-linux-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,7 +642,7 @@ jobs:
         run: |
           $flags = '-C debuginfo=0'
           echo "RUSTFLAGS=$flags" >> $env:GITHUB_ENV
-          echo "C:\Users\Administrator\.cargo\bin" >> $env:GITHUB_PATH
+          echo "C:\rust\cargo\bin" >> $env:GITHUB_PATH
       - uses: ./.github/actions/setup-prebuild
       - name: Rust Tests (Windows)
         if: matrix.os == 'windows-x64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
     timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-large/tag=rust-lint', github.run_id)
+          && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64-pre/tag=rust-lint', github.run_id)
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2
@@ -276,12 +276,7 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v6
-      - id: setup-rust
-        uses: ./.github/actions/setup-rust
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install nightly for fmt
-        run: rustup toolchain install $NIGHTLY_TOOLCHAIN --component rustfmt
+      - uses: ./.github/actions/setup-prebuild
       - name: Rust Lint - Format
         run: cargo +$NIGHTLY_TOOLCHAIN fmt --all --check
       - name: Rustc check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,7 +623,7 @@ jobs:
       matrix:
         include:
           - os: windows-x64
-            runner: runs-on=${{ github.run_id }}/pool=windows-x64/image=windows25-full-x64-pre
+            runner: runs-on=${{ github.run_id }}/runner=windows-x64/image=windows25-full-x64-pre
             fallback_runner: windows-latest
           - os: linux-arm64
             runner: runs-on=${{ github.run_id }}/runner=arm64-medium/image=ubuntu24-full-arm64-pre/tag=rust-test-linux-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,31 +637,12 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v5
-      - name: Install Visual Studio Build Tools (Windows)
+      - name: Set RUSTFLAGS (Windows)
         if: matrix.os == 'windows-x64'
         run: |
           $flags = '-C debuginfo=0'
           echo "RUSTFLAGS=$flags" >> $env:GITHUB_ENV
-          choco install visualstudio2022buildtools --package-parameters `
-            "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.26100 --passive" -y
-      - name: Setup Python (Windows)
-        if: matrix.os == 'windows-x64'
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - id: setup-rust
-        if: matrix.os == 'windows-x64'
-        uses: ./.github/actions/setup-rust
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install nextest
-        if: matrix.os == 'windows-x64'
-        uses: taiki-e/install-action@v2
-        with:
-          tool: nextest
-      - name: Setup Prebuild
-        if: matrix.os != 'windows-x64'
-        uses: ./.github/actions/setup-prebuild
+      - uses: ./.github/actions/setup-prebuild
       - name: Rust Tests (Windows)
         if: matrix.os == 'windows-x64'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,8 @@ jobs:
           sccache: s3
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-prebuild
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Install nightly for fmt
         run: rustup toolchain install $NIGHTLY_TOOLCHAIN --component rustfmt
       - name: Rust Lint - Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,7 +623,7 @@ jobs:
       matrix:
         include:
           - os: windows-x64
-            runner: runs-on=${{ github.run_id }}/runner=windows-x64/image=windows25-full-x64-pre
+            runner: runs-on=${{ github.run_id }}/pool=windows-x64/image=windows25-full-x64-pre
             fallback_runner: windows-latest
           - os: linux-arm64
             runner: runs-on=${{ github.run_id }}/runner=arm64-medium/image=ubuntu24-full-arm64-pre/tag=rust-test-linux-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,8 +277,6 @@ jobs:
           sccache: s3
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-prebuild
-      - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Install protoc
         uses: ./.github/actions/setup-protoc
       - name: Install nightly for fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,11 +637,12 @@ jobs:
         with:
           sccache: s3
       - uses: actions/checkout@v5
-      - name: Set RUSTFLAGS (Windows)
+      - name: Setup (Windows)
         if: matrix.os == 'windows-x64'
         run: |
           $flags = '-C debuginfo=0'
           echo "RUSTFLAGS=$flags" >> $env:GITHUB_ENV
+          echo "$env:USERPROFILE\.cargo\bin" >> $env:GITHUB_PATH
       - uses: ./.github/actions/setup-prebuild
       - name: Rust Tests (Windows)
         if: matrix.os == 'windows-x64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,7 +268,7 @@ jobs:
     timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
-          && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64-pre/tag=rust-lint', github.run_id)
+          && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64/tag=rust-lint', github.run_id)
           || 'ubuntu-latest' }}
     steps:
       - uses: runs-on/action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,7 +623,7 @@ jobs:
       matrix:
         include:
           - os: windows-x64
-            runner: runs-on=${{ github.run_id }}/runner=windows-x64/image=windows25-full-x64-pre/tag=rust-test-windows-x64
+            runner: runs-on=${{ github.run_id }}/pool=windows-x64-pre
             fallback_runner: windows-latest
           - os: linux-arm64
             runner: runs-on=${{ github.run_id }}/runner=arm64-medium/image=ubuntu24-full-arm64-pre/tag=rust-test-linux-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,7 +623,7 @@ jobs:
       matrix:
         include:
           - os: windows-x64
-            runner: runs-on=${{ github.run_id }}/pool=windows-x64/image=windows25-full-x64-pre
+            runner: runs-on=${{ github.run_id }}/runner=windows-x64/image=windows25-full-x64-pre/tag=rust-test-windows-x64
             fallback_runner: windows-latest
           - os: linux-arm64
             runner: runs-on=${{ github.run_id }}/runner=arm64-medium/image=ubuntu24-full-arm64-pre/tag=rust-test-linux-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,7 +642,7 @@ jobs:
         run: |
           $flags = '-C debuginfo=0'
           echo "RUSTFLAGS=$flags" >> $env:GITHUB_ENV
-          echo "$env:USERPROFILE\.cargo\bin" >> $env:GITHUB_PATH
+          echo "C:\Users\Administrator\.cargo\bin" >> $env:GITHUB_PATH
       - uses: ./.github/actions/setup-prebuild
       - name: Rust Tests (Windows)
         if: matrix.os == 'windows-x64'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,6 +279,8 @@ jobs:
       - uses: ./.github/actions/setup-prebuild
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Install protoc
+        uses: ./.github/actions/setup-protoc
       - name: Install nightly for fmt
         run: rustup toolchain install $NIGHTLY_TOOLCHAIN --component rustfmt
       - name: Rust Lint - Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,8 @@ jobs:
           sccache: s3
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-prebuild
+      - name: Install nightly for fmt
+        run: rustup toolchain install $NIGHTLY_TOOLCHAIN --component rustfmt
       - name: Rust Lint - Format
         run: cargo +$NIGHTLY_TOOLCHAIN fmt --all --check
       - name: Rustc check


### PR DESCRIPTION
Uses a pre-build CI image for some of the CI runs. I will monitor for a week and then move over everything.

runs:
 - windows
 - Rust lint
 - Rust arm64