### PR TITLE
Add FixedSizedList to Arbitrary DType implementation

### DIFF
--- a/vortex-array/src/arrow/executor/fixed_size_list.rs
+++ b/vortex-array/src/arrow/executor/fixed_size_list.rs
@@ -55,10 +55,13 @@ fn list_to_list(
 
     let null_buffer = to_arrow_null_buffer(array.validity().clone(), array.len(), ctx)?;
 
-    Ok(Arc::new(arrow_array::FixedSizeListArray::new(
-        elements_field.clone(),
-        list_size,
-        elements,
-        null_buffer,
-    )))
+    Ok(Arc::new(
+        arrow_array::FixedSizeListArray::try_new_with_length(
+            elements_field.clone(),
+            list_size,
+            elements,
+            null_buffer,
+            array.len(),
+        )?,
+    ))
 }

--- a/vortex-array/src/dtype/arbitrary/mod.rs
+++ b/vortex-array/src/dtype/arbitrary/mod.rs
@@ -2,11 +2,11 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::sync::Arc;
-use vortex_error::VortexExpect;
 
 use arbitrary::Arbitrary;
 use arbitrary::Result;
 use arbitrary::Unstructured;
+use vortex_error::VortexExpect;
 
 use crate::dtype::DType;
 use crate::dtype::DecimalDType;

--- a/vortex-array/src/dtype/arbitrary/mod.rs
+++ b/vortex-array/src/dtype/arbitrary/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use std::sync::Arc;
+use vortex_error::VortexExpect;
 
 use arbitrary::Arbitrary;
 use arbitrary::Result;
@@ -34,8 +35,7 @@ impl<'a> Arbitrary<'a> for FieldName {
 
 fn random_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<DType> {
     const BASE_TYPE_COUNT: i32 = 5;
-    // TODO(joe): update to 3 once fsl works
-    const CONTAINER_TYPE_COUNT: i32 = 2;
+    const CONTAINER_TYPE_COUNT: i32 = 3;
     let max_dtype_kind = if depth == 0 {
         BASE_TYPE_COUNT
     } else {
@@ -52,12 +52,12 @@ fn random_dtype(u: &mut Unstructured<'_>, depth: u8) -> Result<DType> {
         // container types
         6 => DType::Struct(random_struct_dtype(u, depth - 1)?, u.arbitrary()?),
         7 => DType::List(Arc::new(random_dtype(u, depth - 1)?), u.arbitrary()?),
-        // 8 => DType::FixedSizeList(
-        //     Arc::new(random_dtype(u, depth - 1)?),
-        //     // We limit the list size to 3 rather (following random struct fields).
-        //     u.choose_index(3)?.try_into().vortex_expect("impossible"),
-        //     u.arbitrary()?,
-        // ),
+        8 => DType::FixedSizeList(
+            Arc::new(random_dtype(u, depth - 1)?),
+            // We limit the list size to 3 rather (following random struct fields).
+            u.choose_index(3)?.try_into().vortex_expect("impossible"),
+            u.arbitrary()?,
+        ),
         // Null,
         // Extension(ExtDType, Nullability),
         _ => unreachable!("Number out of range"),


### PR DESCRIPTION
Even though we implemented all the arbitrary generation logic for FixedSizedList
arrays we didn't enable them in the fuzzer, i.e. added them to DType generation
logic

Signed-off-by: Robert Kruszewski <github@robertk.io>

