### PR TITLE
Fix `bitwise_unary_op`

### DIFF
--- a/vortex-buffer/src/bit/ops.rs
+++ b/vortex-buffer/src/bit/ops.rs
@@ -8,12 +8,9 @@ use crate::trusted_len::TrustedLenExt;
 
 #[inline]
 pub(super) fn bitwise_unary_op<F: FnMut(u64) -> u64>(buffer: &BitBuffer, op: F) -> BitBuffer {
-    let iter = buffer.unaligned_chunks().iter().map(op);
-    let iter = unsafe { iter.trusted_len() };
-
-    let result = Buffer::<u64>::from_trusted_len_iter(iter).into_byte_buffer();
-
-    BitBuffer::new_with_offset(result, buffer.len(), buffer.offset())
+    let mut buf = buffer.clone().into_mut();
+    bitwise_unary_op_mut(&mut buf, op);
+    buf.freeze()
 }
 
 #[inline]
@@ -89,6 +86,8 @@ pub(super) fn bitwise_binary_op<F: FnMut(u64, u64) -> u64>(
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Not;
+
     use super::*;
     use crate::bitbuffer;
     use crate::buffer;
@@ -125,5 +124,27 @@ mod tests {
         let right = BitBuffer::new(buffer![10u8], 4);
         let result = bitwise_binary_op(&left, &right, |l, r| l ^ r);
         assert_eq!(result, bitbuffer![false, true, true, false]);
+    }
+
+    /// Regression test for a bug where [`bitwise_unary_op`] produced corrupt results when
+    /// the [`BitBuffer`]'s underlying byte pointer was not u64-aligned. Slicing a buffer by
+    /// a non-multiple-of-8 number of bytes can cause this misalignment. The bug only
+    /// manifested for buffers larger than 16 bytes (> 128 bits), because Arrow's
+    /// `UnalignedBitChunk` switches from byte-copying to `align_to` at that threshold.
+    ///
+    /// Issue: <https://github.com/vortex-data/vortex/issues/6895>
+    #[test]
+    fn test_bitwise_unary_not_misaligned_buffer() {
+        // Slice off 1 byte to shift the pointer off u64 alignment. Use 129 bits (17 bytes)
+        // to exceed the 16-byte threshold where `UnalignedBitChunk` uses `align_to`.
+        let padded = BitBuffer::new_set(8 + 129);
+        let buf = padded.slice(8..8 + 129);
+
+        let result = buf.not();
+        assert_eq!(
+            result.true_count(),
+            0,
+            "expected all-false after NOT of all-true"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes: https://github.com/vortex-data/vortex/issues/6895 (which might seem completely unrelated but is relevant because of an incorrect mask)

Fixes a bug in `bitwise_unary_op` where the it used Arrow's `UnalignedBitChunk` iterator, which for buffers larger than 16 bytes (128 bits) uses `align_to::<u64>()` and introduces lead padding zeros when the byte pointer isn't u64-aligned. After applying the operation (e.g. NOT), those padding bits were written into a fresh, aligned output buffer at real data positions, corrupting the first padding bits of the result

This change just delegates to the correct `mut` implementation which is likely also faster.

## Testing

Adds a simple regression test.