### PR TITLE
 Fix fuzzer issue template

### DIFF
--- a/.github/scripts/fuzz_report/templates/new_issue.md
+++ b/.github/scripts/fuzz_report/templates/new_issue.md
@@ -40,25 +40,33 @@ cargo +nightly fuzz run -D --sanitizer=none {{FUZZ_TARGET}} ./fuzz/artifacts/{{F
 ```
 
 <details>
-<summary>First-time setup: download and extract the crash artifact</summary>
+<summary>Reproduction Steps</summary>
 
-1. Download the crash artifact:
-   - **Direct download**: {{ARTIFACT_URL}}
-   - Extract the zip file (`unzip`)
-     - The path should look like `/path/to/{{FUZZ_TARGET}}/{{CRASH_FILE}}`
-     - You can create a `./fuzz/artifacts` directory that will be git-ignored in the `vortex` repo
-     - Full path would be `./fuzz/artifacts/{{FUZZ_TARGET}}/{{CRASH_FILE}}`
+1. Download the crash artifact: {{ARTIFACT_URL}}
 
 2. Assuming you download the zipfile to `~/Downloads`, and your working directory is the repository root:
 
 ```bash
+# Create the artifacts directory if you haven't already.
 mkdir -p ./fuzz/artifacts
+
+# Move the zipfile.
 mv ~/Downloads/{{FUZZ_TARGET}}-crash-artifacts.zip ./fuzz/artifacts/
+
+# Unzip the zipfile.
 unzip ./fuzz/artifacts/{{FUZZ_TARGET}}-crash-artifacts.zip -d ./fuzz/artifacts/
+
+# You can remove the zipfile now if you want to.
 rm ./fuzz/artifacts/{{FUZZ_TARGET}}-crash-artifacts.zip
 ```
 
-3. Get a backtrace:
+3. Reproduce the crash:
+
+```bash
+cargo +nightly fuzz run -D --sanitizer=none {{FUZZ_TARGET}} ./fuzz/artifacts/{{FUZZ_TARGET}}/{{CRASH_FILE}} -- -rss_limit_mb=0
+```
+
+If you want a backtrace:
 
 ```bash
 RUST_BACKTRACE=1 cargo +nightly fuzz run -D --sanitizer=none {{FUZZ_TARGET}} ./fuzz/artifacts/{{FUZZ_TARGET}}/{{CRASH_FILE}} -- -rss_limit_mb=0
@@ -66,6 +74,19 @@ RUST_BACKTRACE=1 cargo +nightly fuzz run -D --sanitizer=none {{FUZZ_TARGET}} ./f
 
 ```bash
 RUST_BACKTRACE=full cargo +nightly fuzz run -D --sanitizer=none {{FUZZ_TARGET}} ./fuzz/artifacts/{{FUZZ_TARGET}}/{{CRASH_FILE}} -- -rss_limit_mb=0
+```
+
+</details>
+
+<details>
+<summary>Single command to get a backtrace</summary>
+
+```bash
+mkdir -p ./fuzz/artifacts
+mv ~/Downloads/{{FUZZ_TARGET}}-crash-artifacts.zip ./fuzz/artifacts/
+unzip ./fuzz/artifacts/{{FUZZ_TARGET}}-crash-artifacts.zip -d ./fuzz/artifacts/
+rm ./fuzz/artifacts/{{FUZZ_TARGET}}-crash-artifacts.zip
+RUST_BACKTRACE=1 cargo +nightly fuzz run -D --sanitizer=none {{FUZZ_TARGET}} ./fuzz/artifacts/{{FUZZ_TARGET}}/{{CRASH_FILE}} -- -rss_limit_mb=0
 ```
 
 </details>


### PR DESCRIPTION
## Summary

From https://github.com/vortex-data/vortex/pull/6936 I do not understand why we are so against being descriptive in these templates given most of what claude says is complete nonsense. If we want concision, the reproduction steps still need to make sense.

This changes the fuzzer template to have 2 different details sections, one with a full and correct description of how to reproduce, and the other with a single command for people who know what they are doing. The maintainers do not need to look at the first section.

## Testing

N/A