### PR TITLE
Split up binary ScalarFn

### DIFF
--- a/encodings/alp/public-api.lock
+++ b/encodings/alp/public-api.lock
@@ -34,7 +34,7 @@ pub fn vortex_alp::ALP::between(array: &vortex_alp::ALPArray, lower: &vortex_arr
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_alp::ALP
 
-pub fn vortex_alp::ALP::compare(lhs: &vortex_alp::ALPArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_alp::ALP::compare(lhs: &vortex_alp::ALPArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_alp::ALP
 

--- a/encodings/datetime-parts/public-api.lock
+++ b/encodings/datetime-parts/public-api.lock
@@ -28,7 +28,7 @@ pub fn vortex_datetime_parts::DateTimeParts::is_constant(&self, array: &vortex_d
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_datetime_parts::DateTimeParts
 
-pub fn vortex_datetime_parts::DateTimeParts::compare(lhs: &vortex_datetime_parts::DateTimePartsArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_datetime_parts::DateTimeParts::compare(lhs: &vortex_datetime_parts::DateTimePartsArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_datetime_parts::DateTimeParts
 

--- a/encodings/decimal-byte-parts/public-api.lock
+++ b/encodings/decimal-byte-parts/public-api.lock
@@ -28,7 +28,7 @@ pub fn vortex_decimal_byte_parts::DecimalByteParts::is_constant(&self, array: &v
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_decimal_byte_parts::DecimalByteParts
 
-pub fn vortex_decimal_byte_parts::DecimalByteParts::compare(lhs: &Self::Array, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_decimal_byte_parts::DecimalByteParts::compare(lhs: &Self::Array, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_decimal_byte_parts::DecimalByteParts
 

--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -436,7 +436,7 @@ pub fn vortex_fastlanes::FoR::is_strict_sorted(&self, array: &vortex_fastlanes::
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_fastlanes::FoR
 
-pub fn vortex_fastlanes::FoR::compare(lhs: &vortex_fastlanes::FoRArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::FoR::compare(lhs: &vortex_fastlanes::FoRArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::FoR
 

--- a/encodings/fsst/public-api.lock
+++ b/encodings/fsst/public-api.lock
@@ -24,7 +24,7 @@ pub fn vortex_fsst::FSST::slice(array: &Self::Array, range: core::ops::range::Ra
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_fsst::FSST
 
-pub fn vortex_fsst::FSST::compare(lhs: &vortex_fsst::FSSTArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fsst::FSST::compare(lhs: &vortex_fsst::FSSTArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fsst::FSST
 

--- a/encodings/runend/public-api.lock
+++ b/encodings/runend/public-api.lock
@@ -50,7 +50,7 @@ pub fn vortex_runend::RunEnd::min_max(&self, array: &vortex_runend::RunEndArray)
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_runend::RunEnd
 
-pub fn vortex_runend::RunEnd::compare(lhs: &vortex_runend::RunEndArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_runend::RunEnd::compare(lhs: &vortex_runend::RunEndArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_runend::RunEnd
 

--- a/encodings/sequence/public-api.lock
+++ b/encodings/sequence/public-api.lock
@@ -34,7 +34,7 @@ pub fn vortex_sequence::Sequence::min_max(&self, array: &vortex_sequence::Sequen
 
 impl vortex_array::scalar_fn::fns::binary::compare::CompareKernel for vortex_sequence::Sequence
 
-pub fn vortex_sequence::Sequence::compare(lhs: &vortex_sequence::SequenceArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_sequence::Sequence::compare(lhs: &vortex_sequence::SequenceArray, rhs: &vortex_array::array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_sequence::Sequence
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -9314,11 +9314,15 @@ pub mod vortex_array::builtins
 
 pub trait vortex_array::builtins::ArrayBuiltins: core::marker::Sized
 
+pub fn vortex_array::builtins::ArrayBuiltins::arithmetic(&self, rhs: vortex_array::ArrayRef, op: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
 pub fn vortex_array::builtins::ArrayBuiltins::between(self, lower: vortex_array::ArrayRef, upper: vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::builtins::ArrayBuiltins::binary(&self, rhs: vortex_array::ArrayRef, op: vortex_array::scalar_fn::fns::operators::Operator) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::builtins::ArrayBuiltins::cast(&self, dtype: vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::builtins::ArrayBuiltins::compare(&self, rhs: vortex_array::ArrayRef, op: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::builtins::ArrayBuiltins::fill_null(&self, fill_value: impl core::convert::Into<vortex_array::scalar::Scalar>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -9328,6 +9332,8 @@ pub fn vortex_array::builtins::ArrayBuiltins::is_null(&self) -> vortex_error::Vo
 
 pub fn vortex_array::builtins::ArrayBuiltins::list_contains(&self, value: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::builtins::ArrayBuiltins::logical(&self, rhs: vortex_array::ArrayRef, op: vortex_array::scalar_fn::fns::logical::LogicalOp) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
 pub fn vortex_array::builtins::ArrayBuiltins::mask(self, mask: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::builtins::ArrayBuiltins::not(&self) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -9336,11 +9342,15 @@ pub fn vortex_array::builtins::ArrayBuiltins::zip(&self, if_true: vortex_array::
 
 impl vortex_array::builtins::ArrayBuiltins for vortex_array::ArrayRef
 
+pub fn vortex_array::ArrayRef::arithmetic(&self, rhs: vortex_array::ArrayRef, op: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
 pub fn vortex_array::ArrayRef::between(self, lower: vortex_array::ArrayRef, upper: vortex_array::ArrayRef, options: vortex_array::scalar_fn::fns::between::BetweenOptions) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::ArrayRef::binary(&self, rhs: vortex_array::ArrayRef, op: vortex_array::scalar_fn::fns::operators::Operator) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::ArrayRef::cast(&self, dtype: vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::ArrayRef::compare(&self, rhs: vortex_array::ArrayRef, op: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::ArrayRef::fill_null(&self, fill_value: impl core::convert::Into<vortex_array::scalar::Scalar>) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
@@ -9350,6 +9360,8 @@ pub fn vortex_array::ArrayRef::is_null(&self) -> vortex_error::VortexResult<vort
 
 pub fn vortex_array::ArrayRef::list_contains(&self, value: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
+pub fn vortex_array::ArrayRef::logical(&self, rhs: vortex_array::ArrayRef, op: vortex_array::scalar_fn::fns::logical::LogicalOp) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
 pub fn vortex_array::ArrayRef::mask(self, mask: vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::ArrayRef::not(&self) -> vortex_error::VortexResult<vortex_array::ArrayRef>
@@ -9358,9 +9370,13 @@ pub fn vortex_array::ArrayRef::zip(&self, if_true: vortex_array::ArrayRef, if_fa
 
 pub trait vortex_array::builtins::ExprBuiltins: core::marker::Sized
 
+pub fn vortex_array::builtins::ExprBuiltins::arithmetic(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+
 pub fn vortex_array::builtins::ExprBuiltins::binary(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::operators::Operator) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub fn vortex_array::builtins::ExprBuiltins::cast(&self, dtype: vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+
+pub fn vortex_array::builtins::ExprBuiltins::compare(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub fn vortex_array::builtins::ExprBuiltins::fill_null(&self, fill_value: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
@@ -9370,6 +9386,8 @@ pub fn vortex_array::builtins::ExprBuiltins::is_null(&self) -> vortex_error::Vor
 
 pub fn vortex_array::builtins::ExprBuiltins::list_contains(&self, value: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
+pub fn vortex_array::builtins::ExprBuiltins::logical(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::logical::LogicalOp) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+
 pub fn vortex_array::builtins::ExprBuiltins::mask(&self, mask: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub fn vortex_array::builtins::ExprBuiltins::not(&self) -> vortex_error::VortexResult<vortex_array::expr::Expression>
@@ -9378,9 +9396,13 @@ pub fn vortex_array::builtins::ExprBuiltins::zip(&self, if_true: vortex_array::e
 
 impl vortex_array::builtins::ExprBuiltins for vortex_array::expr::Expression
 
+pub fn vortex_array::expr::Expression::arithmetic(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+
 pub fn vortex_array::expr::Expression::binary(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::operators::Operator) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub fn vortex_array::expr::Expression::cast(&self, dtype: vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+
+pub fn vortex_array::expr::Expression::compare(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub fn vortex_array::expr::Expression::fill_null(&self, fill_value: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
@@ -9389,6 +9411,8 @@ pub fn vortex_array::expr::Expression::get_item(&self, field_name: impl core::co
 pub fn vortex_array::expr::Expression::is_null(&self) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub fn vortex_array::expr::Expression::list_contains(&self, value: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+
+pub fn vortex_array::expr::Expression::logical(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::logical::LogicalOp) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub fn vortex_array::expr::Expression::mask(&self, mask: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
@@ -13768,9 +13792,13 @@ pub fn vortex_array::expr::Expression::drop(&mut self)
 
 impl vortex_array::builtins::ExprBuiltins for vortex_array::expr::Expression
 
+pub fn vortex_array::expr::Expression::arithmetic(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+
 pub fn vortex_array::expr::Expression::binary(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::operators::Operator) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub fn vortex_array::expr::Expression::cast(&self, dtype: vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+
+pub fn vortex_array::expr::Expression::compare(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub fn vortex_array::expr::Expression::fill_null(&self, fill_value: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
@@ -13779,6 +13807,8 @@ pub fn vortex_array::expr::Expression::get_item(&self, field_name: impl core::co
 pub fn vortex_array::expr::Expression::is_null(&self) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub fn vortex_array::expr::Expression::list_contains(&self, value: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
+
+pub fn vortex_array::expr::Expression::logical(&self, rhs: vortex_array::expr::Expression, op: vortex_array::scalar_fn::fns::logical::LogicalOp) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
 pub fn vortex_array::expr::Expression::mask(&self, mask: vortex_array::expr::Expression) -> vortex_error::VortexResult<vortex_array::expr::Expression>
 
@@ -17086,7 +17116,7 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::child_name(&self, _instance
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, _args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
@@ -19494,7 +19524,7 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::child_name(&self, _instance
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, _args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -1282,7 +1282,7 @@ pub fn vortex_array::arrays::dict::Dict::min_max(&self, array: &vortex_array::ar
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::Dict
 
@@ -1400,7 +1400,7 @@ pub fn vortex_array::arrays::dict::Dict::min_max(&self, array: &vortex_array::ar
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::Dict
 
@@ -1722,7 +1722,7 @@ pub fn vortex_array::arrays::Extension::sum(&self, array: &vortex_array::arrays:
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::Extension::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Extension
 
@@ -3992,7 +3992,7 @@ pub fn vortex_array::arrays::VarBin::min_max(&self, array: &vortex_array::arrays
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBin::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBin
 
@@ -5356,7 +5356,7 @@ pub fn vortex_array::arrays::dict::Dict::min_max(&self, array: &vortex_array::ar
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::dict::Dict
 
@@ -5536,7 +5536,7 @@ pub fn vortex_array::arrays::Extension::sum(&self, array: &vortex_array::arrays:
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::Extension::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::Extension
 
@@ -7416,7 +7416,7 @@ pub fn vortex_array::arrays::VarBin::min_max(&self, array: &vortex_array::arrays
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBin::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::VarBin
 
@@ -13852,7 +13852,7 @@ pub fn vortex_array::expr::col(field: impl core::convert::Into<vortex_array::dty
 
 pub fn vortex_array::expr::descendent_annotations<A: vortex_array::expr::AnnotationFn>(expr: &vortex_array::expr::Expression, annotate: A) -> vortex_array::expr::Annotations<'_, <A as vortex_array::expr::AnnotationFn>::Annotation>
 
-pub fn vortex_array::expr::dynamic(operator: vortex_array::scalar_fn::fns::operators::CompareOperator, rhs_value: impl core::ops::function::Fn() -> core::option::Option<vortex_array::scalar::ScalarValue> + core::marker::Send + core::marker::Sync + 'static, rhs_dtype: vortex_array::dtype::DType, default: bool, lhs: vortex_array::expr::Expression) -> vortex_array::expr::Expression
+pub fn vortex_array::expr::dynamic(operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, rhs_value: impl core::ops::function::Fn() -> core::option::Option<vortex_array::scalar::ScalarValue> + core::marker::Send + core::marker::Sync + 'static, rhs_dtype: vortex_array::dtype::DType, default: bool, lhs: vortex_array::expr::Expression) -> vortex_array::expr::Expression
 
 pub fn vortex_array::expr::eq(lhs: vortex_array::expr::Expression, rhs: vortex_array::expr::Expression) -> vortex_array::expr::Expression
 
@@ -14502,6 +14502,12 @@ pub type vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::Parent 
 
 pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::binary::Binary>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::binary::CompareKernel
+
+pub type vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::comparison::Comparison>
+
+pub fn vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::comparison::Comparison>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::cast::CastKernel
 
 pub type vortex_array::scalar_fn::fns::cast::CastExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::cast::Cast>
@@ -15067,6 +15073,10 @@ pub fn vortex_array::scalar::NumericOperator::eq(&self, other: &vortex_array::sc
 impl core::convert::From<vortex_array::scalar::NumericOperator> for vortex_array::scalar_fn::fns::operators::Operator
 
 pub fn vortex_array::scalar_fn::fns::operators::Operator::from(op: vortex_array::scalar::NumericOperator) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp> for vortex_array::scalar::NumericOperator
+
+pub fn vortex_array::scalar::NumericOperator::from(op: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> Self
 
 impl core::fmt::Debug for vortex_array::scalar::NumericOperator
 
@@ -16776,6 +16786,122 @@ pub mod vortex_array::scalar_fn
 
 pub mod vortex_array::scalar_fn::fns
 
+pub mod vortex_array::scalar_fn::fns::arithmetic
+
+pub enum vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::Add
+
+pub vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::Div
+
+pub vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::Mul
+
+pub vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::Sub
+
+impl core::clone::Clone for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::clone(&self) -> vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+impl core::cmp::Eq for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+impl core::cmp::PartialEq for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::eq(&self, other: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> bool
+
+impl core::cmp::PartialOrd for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::partial_cmp(&self, other: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> core::option::Option<core::cmp::Ordering>
+
+impl core::convert::From<vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp> for i32
+
+pub fn i32::from(value: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp> for vortex_array::scalar::NumericOperator
+
+pub fn vortex_array::scalar::NumericOperator::from(op: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp> for vortex_array::scalar_fn::fns::operators::Operator
+
+pub fn vortex_array::scalar_fn::fns::operators::Operator::from(value: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp> for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::from(value: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> Self
+
+impl core::convert::From<vortex_proto::expr::arithmetic_opts::ArithmeticOp> for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::from(value: vortex_proto::expr::arithmetic_opts::ArithmeticOp) -> Self
+
+impl core::convert::TryFrom<i32> for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub type vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::try_from(value: i32) -> core::result::Result<Self, Self::Error>
+
+impl core::convert::TryFrom<vortex_array::scalar_fn::fns::operators::Operator> for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub type vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::try_from(value: vortex_array::scalar_fn::fns::operators::Operator) -> core::result::Result<Self, Self::Error>
+
+impl core::fmt::Debug for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::fmt::Display for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+impl core::marker::StructuralPartialEq for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub struct vortex_array::scalar_fn::fns::arithmetic::Arithmetic
+
+impl core::clone::Clone for vortex_array::scalar_fn::fns::arithmetic::Arithmetic
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::clone(&self) -> vortex_array::scalar_fn::fns::arithmetic::Arithmetic
+
+impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::arithmetic::Arithmetic
+
+pub type vortex_array::scalar_fn::fns::arithmetic::Arithmetic::Options = vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::arity(&self, _options: &Self::Options) -> vortex_array::scalar_fn::Arity
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::child_name(&self, _options: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::deserialize(&self, metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::execute(&self, op: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::id(&self) -> vortex_array::scalar_fn::ScalarFnId
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::is_fallible(&self, _operator: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> bool
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::is_null_sensitive(&self, _operator: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> bool
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::return_dtype(&self, _operator: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::validity(&self, _operator: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
 pub mod vortex_array::scalar_fn::fns::between
 
 pub enum vortex_array::scalar_fn::fns::between::StrictComparison
@@ -16788,7 +16914,7 @@ impl vortex_array::scalar_fn::fns::between::StrictComparison
 
 pub const fn vortex_array::scalar_fn::fns::between::StrictComparison::is_strict(&self) -> bool
 
-pub const fn vortex_array::scalar_fn::fns::between::StrictComparison::to_compare_operator(&self) -> vortex_array::scalar_fn::fns::operators::CompareOperator
+pub const fn vortex_array::scalar_fn::fns::between::StrictComparison::to_compare_operator(&self) -> vortex_array::scalar_fn::fns::comparison::CompareOperator
 
 pub const fn vortex_array::scalar_fn::fns::between::StrictComparison::to_operator(&self) -> vortex_array::scalar_fn::fns::operators::Operator
 
@@ -16960,17 +17086,17 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::child_name(&self, _instance
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, _args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::id(&self) -> vortex_array::scalar_fn::ScalarFnId
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::is_fallible(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator) -> bool
+pub fn vortex_array::scalar_fn::fns::binary::Binary::is_fallible(&self, options: &Self::Options) -> bool
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::is_null_sensitive(&self, _operator: &vortex_array::scalar_fn::fns::operators::Operator) -> bool
+pub fn vortex_array::scalar_fn::fns::binary::Binary::is_null_sensitive(&self, options: &Self::Options) -> bool
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::reduce(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::return_dtype(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
@@ -16982,9 +17108,9 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::simplify_untyped(&self, opt
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_falsification(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::validity(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub struct vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>(pub V)
 
@@ -17002,29 +17128,41 @@ pub type vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::Parent 
 
 pub fn vortex_array::scalar_fn::fns::binary::CompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::binary::Binary>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
+pub struct vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V>(pub V)
+
+impl<V: core::default::Default> core::default::Default for vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V>
+
+pub fn vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V>::default() -> vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V>
+
+impl<V: core::fmt::Debug> core::fmt::Debug for vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V>
+
+pub fn vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V> vortex_array::kernel::ExecuteParentKernel<V> for vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V> where V: vortex_array::scalar_fn::fns::binary::CompareKernel
+
+pub type vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V>::Parent = vortex_array::arrays::scalar_fn::ExactScalarFn<vortex_array::scalar_fn::fns::comparison::Comparison>
+
+pub fn vortex_array::scalar_fn::fns::binary::ComparisonCompareExecuteAdaptor<V>::execute_parent(&self, array: &<V as vortex_array::vtable::VTable>::Array, parent: vortex_array::arrays::scalar_fn::ScalarFnArrayView<'_, vortex_array::scalar_fn::fns::comparison::Comparison>, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub trait vortex_array::scalar_fn::fns::binary::CompareKernel: vortex_array::vtable::VTable
 
-pub fn vortex_array::scalar_fn::fns::binary::CompareKernel::compare(lhs: &Self::Array, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::scalar_fn::fns::binary::CompareKernel::compare(lhs: &Self::Array, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::Extension::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::Extension::compare(lhs: &vortex_array::arrays::ExtensionArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBin::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::VarBin::compare(lhs: &vortex_array::arrays::VarBinArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::binary::CompareKernel for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::operators::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+pub fn vortex_array::arrays::dict::Dict::compare(lhs: &vortex_array::arrays::dict::DictArray, rhs: &vortex_array::ArrayRef, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
-pub fn vortex_array::scalar_fn::fns::binary::and_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::binary::compare_nested_arrow_arrays(lhs: &dyn arrow_array::array::Array, rhs: &dyn arrow_array::array::Array, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> vortex_error::VortexResult<arrow_array::array::boolean_array::BooleanArray>
 
-pub fn vortex_array::scalar_fn::fns::binary::compare_nested_arrow_arrays(lhs: &dyn arrow_array::array::Array, rhs: &dyn arrow_array::array::Array, operator: vortex_array::scalar_fn::fns::operators::CompareOperator) -> vortex_error::VortexResult<arrow_array::array::boolean_array::BooleanArray>
-
-pub fn vortex_array::scalar_fn::fns::binary::or_kleene(lhs: &vortex_array::ArrayRef, rhs: &vortex_array::ArrayRef) -> vortex_error::VortexResult<vortex_array::ArrayRef>
-
-pub fn vortex_array::scalar_fn::fns::binary::scalar_cmp(lhs: &vortex_array::scalar::Scalar, rhs: &vortex_array::scalar::Scalar, operator: vortex_array::scalar_fn::fns::operators::CompareOperator) -> vortex_array::scalar::Scalar
+pub fn vortex_array::scalar_fn::fns::binary::scalar_cmp(lhs: &vortex_array::scalar::Scalar, rhs: &vortex_array::scalar::Scalar, operator: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> vortex_array::scalar::Scalar
 
 pub mod vortex_array::scalar_fn::fns::case_when
 
@@ -17245,6 +17383,128 @@ pub fn vortex_array::arrays::dict::Dict::cast(array: &vortex_array::arrays::dict
 impl vortex_array::scalar_fn::fns::cast::CastReduce for vortex_array::arrays::null::Null
 
 pub fn vortex_array::arrays::null::Null::cast(array: &vortex_array::arrays::null::NullArray, dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
+pub mod vortex_array::scalar_fn::fns::comparison
+
+pub enum vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub vortex_array::scalar_fn::fns::comparison::CompareOperator::Eq
+
+pub vortex_array::scalar_fn::fns::comparison::CompareOperator::Gt
+
+pub vortex_array::scalar_fn::fns::comparison::CompareOperator::Gte
+
+pub vortex_array::scalar_fn::fns::comparison::CompareOperator::Lt
+
+pub vortex_array::scalar_fn::fns::comparison::CompareOperator::Lte
+
+pub vortex_array::scalar_fn::fns::comparison::CompareOperator::NotEq
+
+impl vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::inverse(self) -> Self
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::swap(self) -> Self
+
+impl core::clone::Clone for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::clone(&self) -> vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+impl core::cmp::Eq for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+impl core::cmp::PartialEq for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::eq(&self, other: &vortex_array::scalar_fn::fns::comparison::CompareOperator) -> bool
+
+impl core::cmp::PartialOrd for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::partial_cmp(&self, other: &vortex_array::scalar_fn::fns::comparison::CompareOperator) -> core::option::Option<core::cmp::Ordering>
+
+impl core::convert::From<vortex_array::scalar_fn::fns::comparison::CompareOperator> for i32
+
+pub fn i32::from(value: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::comparison::CompareOperator> for vortex_array::scalar_fn::fns::operators::Operator
+
+pub fn vortex_array::scalar_fn::fns::operators::Operator::from(value: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::comparison::CompareOperator> for vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::from(value: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> Self
+
+impl core::convert::From<vortex_proto::expr::comparison_opts::ComparisonOp> for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::from(value: vortex_proto::expr::comparison_opts::ComparisonOp) -> Self
+
+impl core::convert::TryFrom<i32> for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub type vortex_array::scalar_fn::fns::comparison::CompareOperator::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::try_from(value: i32) -> core::result::Result<Self, Self::Error>
+
+impl core::convert::TryFrom<vortex_array::scalar_fn::fns::operators::Operator> for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub type vortex_array::scalar_fn::fns::comparison::CompareOperator::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::try_from(value: vortex_array::scalar_fn::fns::operators::Operator) -> core::result::Result<Self, Self::Error>
+
+impl core::fmt::Debug for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::fmt::Display for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+impl core::marker::StructuralPartialEq for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub struct vortex_array::scalar_fn::fns::comparison::Comparison
+
+impl core::clone::Clone for vortex_array::scalar_fn::fns::comparison::Comparison
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::clone(&self) -> vortex_array::scalar_fn::fns::comparison::Comparison
+
+impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::comparison::Comparison
+
+pub type vortex_array::scalar_fn::fns::comparison::Comparison::Options = vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::arity(&self, _options: &Self::Options) -> vortex_array::scalar_fn::Arity
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::child_name(&self, _options: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::deserialize(&self, metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::execute(&self, op: &vortex_array::scalar_fn::fns::comparison::CompareOperator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::id(&self) -> vortex_array::scalar_fn::ScalarFnId
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::is_fallible(&self, _operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator) -> bool
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::is_null_sensitive(&self, _operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator) -> bool
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::return_dtype(&self, _operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::stat_falsification(&self, operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::validity(&self, _operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub mod vortex_array::scalar_fn::fns::dynamic
 
@@ -17774,6 +18034,114 @@ pub fn vortex_array::scalar_fn::fns::literal::Literal::stat_falsification(&self,
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::validity(&self, scalar: &vortex_array::scalar::Scalar, _expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
+pub mod vortex_array::scalar_fn::fns::logical
+
+pub enum vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub vortex_array::scalar_fn::fns::logical::LogicalOp::And
+
+pub vortex_array::scalar_fn::fns::logical::LogicalOp::Or
+
+impl core::clone::Clone for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::clone(&self) -> vortex_array::scalar_fn::fns::logical::LogicalOp
+
+impl core::cmp::Eq for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+impl core::cmp::PartialEq for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::eq(&self, other: &vortex_array::scalar_fn::fns::logical::LogicalOp) -> bool
+
+impl core::cmp::PartialOrd for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::partial_cmp(&self, other: &vortex_array::scalar_fn::fns::logical::LogicalOp) -> core::option::Option<core::cmp::Ordering>
+
+impl core::convert::From<vortex_array::scalar_fn::fns::logical::LogicalOp> for i32
+
+pub fn i32::from(value: vortex_array::scalar_fn::fns::logical::LogicalOp) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::logical::LogicalOp> for vortex_array::scalar_fn::fns::operators::Operator
+
+pub fn vortex_array::scalar_fn::fns::operators::Operator::from(value: vortex_array::scalar_fn::fns::logical::LogicalOp) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::logical::LogicalOp> for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::from(value: vortex_array::scalar_fn::fns::logical::LogicalOp) -> Self
+
+impl core::convert::From<vortex_proto::expr::logical_binary_opts::LogicalBinaryOp> for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::from(value: vortex_proto::expr::logical_binary_opts::LogicalBinaryOp) -> Self
+
+impl core::convert::TryFrom<i32> for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub type vortex_array::scalar_fn::fns::logical::LogicalOp::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::try_from(value: i32) -> core::result::Result<Self, Self::Error>
+
+impl core::convert::TryFrom<vortex_array::scalar_fn::fns::operators::Operator> for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub type vortex_array::scalar_fn::fns::logical::LogicalOp::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::try_from(value: vortex_array::scalar_fn::fns::operators::Operator) -> core::result::Result<Self, Self::Error>
+
+impl core::fmt::Debug for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::fmt::Display for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+impl core::marker::StructuralPartialEq for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub struct vortex_array::scalar_fn::fns::logical::LogicalBinary
+
+impl core::clone::Clone for vortex_array::scalar_fn::fns::logical::LogicalBinary
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::clone(&self) -> vortex_array::scalar_fn::fns::logical::LogicalBinary
+
+impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::logical::LogicalBinary
+
+pub type vortex_array::scalar_fn::fns::logical::LogicalBinary::Options = vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::arity(&self, _options: &Self::Options) -> vortex_array::scalar_fn::Arity
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::child_name(&self, _options: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::deserialize(&self, metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::execute(&self, op: &vortex_array::scalar_fn::fns::logical::LogicalOp, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::logical::LogicalOp, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::id(&self) -> vortex_array::scalar_fn::ScalarFnId
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::is_fallible(&self, _operator: &vortex_array::scalar_fn::fns::logical::LogicalOp) -> bool
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::is_null_sensitive(&self, _operator: &vortex_array::scalar_fn::fns::logical::LogicalOp) -> bool
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::return_dtype(&self, _operator: &vortex_array::scalar_fn::fns::logical::LogicalOp, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::stat_falsification(&self, operator: &vortex_array::scalar_fn::fns::logical::LogicalOp, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::validity(&self, _operator: &vortex_array::scalar_fn::fns::logical::LogicalOp, _expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
 pub mod vortex_array::scalar_fn::fns::mask
 
 pub struct vortex_array::scalar_fn::fns::mask::Mask
@@ -18084,6 +18452,78 @@ pub fn vortex_array::arrays::Constant::invert(array: &vortex_array::arrays::Cons
 
 pub mod vortex_array::scalar_fn::fns::operators
 
+pub enum vortex_array::scalar_fn::fns::operators::ArithmeticOp
+
+pub vortex_array::scalar_fn::fns::operators::ArithmeticOp::Add
+
+pub vortex_array::scalar_fn::fns::operators::ArithmeticOp::Div
+
+pub vortex_array::scalar_fn::fns::operators::ArithmeticOp::Mul
+
+pub vortex_array::scalar_fn::fns::operators::ArithmeticOp::Sub
+
+impl core::clone::Clone for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::clone(&self) -> vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+impl core::cmp::Eq for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+impl core::cmp::PartialEq for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::eq(&self, other: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> bool
+
+impl core::cmp::PartialOrd for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::partial_cmp(&self, other: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> core::option::Option<core::cmp::Ordering>
+
+impl core::convert::From<vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp> for i32
+
+pub fn i32::from(value: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp> for vortex_array::scalar::NumericOperator
+
+pub fn vortex_array::scalar::NumericOperator::from(op: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp> for vortex_array::scalar_fn::fns::operators::Operator
+
+pub fn vortex_array::scalar_fn::fns::operators::Operator::from(value: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp> for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::from(value: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> Self
+
+impl core::convert::From<vortex_proto::expr::arithmetic_opts::ArithmeticOp> for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::from(value: vortex_proto::expr::arithmetic_opts::ArithmeticOp) -> Self
+
+impl core::convert::TryFrom<i32> for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub type vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::try_from(value: i32) -> core::result::Result<Self, Self::Error>
+
+impl core::convert::TryFrom<vortex_array::scalar_fn::fns::operators::Operator> for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub type vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::try_from(value: vortex_array::scalar_fn::fns::operators::Operator) -> core::result::Result<Self, Self::Error>
+
+impl core::fmt::Debug for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::fmt::Display for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+impl core::marker::StructuralPartialEq for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
 pub enum vortex_array::scalar_fn::fns::operators::CompareOperator
 
 pub vortex_array::scalar_fn::fns::operators::CompareOperator::Eq
@@ -18098,51 +18538,133 @@ pub vortex_array::scalar_fn::fns::operators::CompareOperator::Lte
 
 pub vortex_array::scalar_fn::fns::operators::CompareOperator::NotEq
 
-impl vortex_array::scalar_fn::fns::operators::CompareOperator
+impl vortex_array::scalar_fn::fns::comparison::CompareOperator
 
-pub fn vortex_array::scalar_fn::fns::operators::CompareOperator::inverse(self) -> Self
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::inverse(self) -> Self
 
-pub fn vortex_array::scalar_fn::fns::operators::CompareOperator::swap(self) -> Self
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::swap(self) -> Self
 
-impl core::clone::Clone for vortex_array::scalar_fn::fns::operators::CompareOperator
+impl core::clone::Clone for vortex_array::scalar_fn::fns::comparison::CompareOperator
 
-pub fn vortex_array::scalar_fn::fns::operators::CompareOperator::clone(&self) -> vortex_array::scalar_fn::fns::operators::CompareOperator
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::clone(&self) -> vortex_array::scalar_fn::fns::comparison::CompareOperator
 
-impl core::cmp::Eq for vortex_array::scalar_fn::fns::operators::CompareOperator
+impl core::cmp::Eq for vortex_array::scalar_fn::fns::comparison::CompareOperator
 
-impl core::cmp::PartialEq for vortex_array::scalar_fn::fns::operators::CompareOperator
+impl core::cmp::PartialEq for vortex_array::scalar_fn::fns::comparison::CompareOperator
 
-pub fn vortex_array::scalar_fn::fns::operators::CompareOperator::eq(&self, other: &vortex_array::scalar_fn::fns::operators::CompareOperator) -> bool
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::eq(&self, other: &vortex_array::scalar_fn::fns::comparison::CompareOperator) -> bool
 
-impl core::cmp::PartialOrd for vortex_array::scalar_fn::fns::operators::CompareOperator
+impl core::cmp::PartialOrd for vortex_array::scalar_fn::fns::comparison::CompareOperator
 
-pub fn vortex_array::scalar_fn::fns::operators::CompareOperator::partial_cmp(&self, other: &vortex_array::scalar_fn::fns::operators::CompareOperator) -> core::option::Option<core::cmp::Ordering>
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::partial_cmp(&self, other: &vortex_array::scalar_fn::fns::comparison::CompareOperator) -> core::option::Option<core::cmp::Ordering>
 
-impl core::convert::From<vortex_array::scalar_fn::fns::operators::CompareOperator> for vortex_array::scalar_fn::fns::operators::Operator
+impl core::convert::From<vortex_array::scalar_fn::fns::comparison::CompareOperator> for i32
 
-pub fn vortex_array::scalar_fn::fns::operators::Operator::from(value: vortex_array::scalar_fn::fns::operators::CompareOperator) -> Self
+pub fn i32::from(value: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> Self
 
-impl core::convert::TryFrom<vortex_array::scalar_fn::fns::operators::Operator> for vortex_array::scalar_fn::fns::operators::CompareOperator
+impl core::convert::From<vortex_array::scalar_fn::fns::comparison::CompareOperator> for vortex_array::scalar_fn::fns::operators::Operator
 
-pub type vortex_array::scalar_fn::fns::operators::CompareOperator::Error = vortex_error::VortexError
+pub fn vortex_array::scalar_fn::fns::operators::Operator::from(value: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> Self
 
-pub fn vortex_array::scalar_fn::fns::operators::CompareOperator::try_from(value: vortex_array::scalar_fn::fns::operators::Operator) -> core::result::Result<Self, Self::Error>
+impl core::convert::From<vortex_array::scalar_fn::fns::comparison::CompareOperator> for vortex_proto::expr::comparison_opts::ComparisonOp
 
-impl core::fmt::Debug for vortex_array::scalar_fn::fns::operators::CompareOperator
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::from(value: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> Self
 
-pub fn vortex_array::scalar_fn::fns::operators::CompareOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::convert::From<vortex_proto::expr::comparison_opts::ComparisonOp> for vortex_array::scalar_fn::fns::comparison::CompareOperator
 
-impl core::fmt::Display for vortex_array::scalar_fn::fns::operators::CompareOperator
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::from(value: vortex_proto::expr::comparison_opts::ComparisonOp) -> Self
 
-pub fn vortex_array::scalar_fn::fns::operators::CompareOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::convert::TryFrom<i32> for vortex_array::scalar_fn::fns::comparison::CompareOperator
 
-impl core::hash::Hash for vortex_array::scalar_fn::fns::operators::CompareOperator
+pub type vortex_array::scalar_fn::fns::comparison::CompareOperator::Error = vortex_error::VortexError
 
-pub fn vortex_array::scalar_fn::fns::operators::CompareOperator::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::try_from(value: i32) -> core::result::Result<Self, Self::Error>
 
-impl core::marker::Copy for vortex_array::scalar_fn::fns::operators::CompareOperator
+impl core::convert::TryFrom<vortex_array::scalar_fn::fns::operators::Operator> for vortex_array::scalar_fn::fns::comparison::CompareOperator
 
-impl core::marker::StructuralPartialEq for vortex_array::scalar_fn::fns::operators::CompareOperator
+pub type vortex_array::scalar_fn::fns::comparison::CompareOperator::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::try_from(value: vortex_array::scalar_fn::fns::operators::Operator) -> core::result::Result<Self, Self::Error>
+
+impl core::fmt::Debug for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::fmt::Display for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+impl core::marker::StructuralPartialEq for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub enum vortex_array::scalar_fn::fns::operators::LogicalOp
+
+pub vortex_array::scalar_fn::fns::operators::LogicalOp::And
+
+pub vortex_array::scalar_fn::fns::operators::LogicalOp::Or
+
+impl core::clone::Clone for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::clone(&self) -> vortex_array::scalar_fn::fns::logical::LogicalOp
+
+impl core::cmp::Eq for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+impl core::cmp::PartialEq for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::eq(&self, other: &vortex_array::scalar_fn::fns::logical::LogicalOp) -> bool
+
+impl core::cmp::PartialOrd for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::partial_cmp(&self, other: &vortex_array::scalar_fn::fns::logical::LogicalOp) -> core::option::Option<core::cmp::Ordering>
+
+impl core::convert::From<vortex_array::scalar_fn::fns::logical::LogicalOp> for i32
+
+pub fn i32::from(value: vortex_array::scalar_fn::fns::logical::LogicalOp) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::logical::LogicalOp> for vortex_array::scalar_fn::fns::operators::Operator
+
+pub fn vortex_array::scalar_fn::fns::operators::Operator::from(value: vortex_array::scalar_fn::fns::logical::LogicalOp) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::logical::LogicalOp> for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::from(value: vortex_array::scalar_fn::fns::logical::LogicalOp) -> Self
+
+impl core::convert::From<vortex_proto::expr::logical_binary_opts::LogicalBinaryOp> for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::from(value: vortex_proto::expr::logical_binary_opts::LogicalBinaryOp) -> Self
+
+impl core::convert::TryFrom<i32> for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub type vortex_array::scalar_fn::fns::logical::LogicalOp::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::try_from(value: i32) -> core::result::Result<Self, Self::Error>
+
+impl core::convert::TryFrom<vortex_array::scalar_fn::fns::operators::Operator> for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub type vortex_array::scalar_fn::fns::logical::LogicalOp::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::try_from(value: vortex_array::scalar_fn::fns::operators::Operator) -> core::result::Result<Self, Self::Error>
+
+impl core::fmt::Debug for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::fmt::Display for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+impl core::marker::StructuralPartialEq for vortex_array::scalar_fn::fns::logical::LogicalOp
 
 pub enum vortex_array::scalar_fn::fns::operators::Operator
 
@@ -18200,9 +18722,17 @@ impl core::convert::From<vortex_array::scalar::NumericOperator> for vortex_array
 
 pub fn vortex_array::scalar_fn::fns::operators::Operator::from(op: vortex_array::scalar::NumericOperator) -> Self
 
-impl core::convert::From<vortex_array::scalar_fn::fns::operators::CompareOperator> for vortex_array::scalar_fn::fns::operators::Operator
+impl core::convert::From<vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp> for vortex_array::scalar_fn::fns::operators::Operator
 
-pub fn vortex_array::scalar_fn::fns::operators::Operator::from(value: vortex_array::scalar_fn::fns::operators::CompareOperator) -> Self
+pub fn vortex_array::scalar_fn::fns::operators::Operator::from(value: vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::comparison::CompareOperator> for vortex_array::scalar_fn::fns::operators::Operator
+
+pub fn vortex_array::scalar_fn::fns::operators::Operator::from(value: vortex_array::scalar_fn::fns::comparison::CompareOperator) -> Self
+
+impl core::convert::From<vortex_array::scalar_fn::fns::logical::LogicalOp> for vortex_array::scalar_fn::fns::operators::Operator
+
+pub fn vortex_array::scalar_fn::fns::operators::Operator::from(value: vortex_array::scalar_fn::fns::logical::LogicalOp) -> Self
 
 impl core::convert::From<vortex_array::scalar_fn::fns::operators::Operator> for i32
 
@@ -18222,11 +18752,23 @@ pub type vortex_array::scalar_fn::fns::operators::Operator::Error = vortex_error
 
 pub fn vortex_array::scalar_fn::fns::operators::Operator::try_from(value: i32) -> core::result::Result<Self, Self::Error>
 
-impl core::convert::TryFrom<vortex_array::scalar_fn::fns::operators::Operator> for vortex_array::scalar_fn::fns::operators::CompareOperator
+impl core::convert::TryFrom<vortex_array::scalar_fn::fns::operators::Operator> for vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
 
-pub type vortex_array::scalar_fn::fns::operators::CompareOperator::Error = vortex_error::VortexError
+pub type vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::Error = vortex_error::VortexError
 
-pub fn vortex_array::scalar_fn::fns::operators::CompareOperator::try_from(value: vortex_array::scalar_fn::fns::operators::Operator) -> core::result::Result<Self, Self::Error>
+pub fn vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp::try_from(value: vortex_array::scalar_fn::fns::operators::Operator) -> core::result::Result<Self, Self::Error>
+
+impl core::convert::TryFrom<vortex_array::scalar_fn::fns::operators::Operator> for vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub type vortex_array::scalar_fn::fns::comparison::CompareOperator::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::comparison::CompareOperator::try_from(value: vortex_array::scalar_fn::fns::operators::Operator) -> core::result::Result<Self, Self::Error>
+
+impl core::convert::TryFrom<vortex_array::scalar_fn::fns::operators::Operator> for vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub type vortex_array::scalar_fn::fns::logical::LogicalOp::Error = vortex_error::VortexError
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalOp::try_from(value: vortex_array::scalar_fn::fns::operators::Operator) -> core::result::Result<Self, Self::Error>
 
 impl core::fmt::Debug for vortex_array::scalar_fn::fns::operators::Operator
 
@@ -18870,6 +19412,42 @@ pub fn vortex_array::scalar_fn::ScalarFnVTable::stat_falsification(&self, option
 
 pub fn vortex_array::scalar_fn::ScalarFnVTable::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
+impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::arithmetic::Arithmetic
+
+pub type vortex_array::scalar_fn::fns::arithmetic::Arithmetic::Options = vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::arity(&self, _options: &Self::Options) -> vortex_array::scalar_fn::Arity
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::child_name(&self, _options: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::deserialize(&self, metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::execute(&self, op: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::id(&self) -> vortex_array::scalar_fn::ScalarFnId
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::is_fallible(&self, _operator: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> bool
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::is_null_sensitive(&self, _operator: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp) -> bool
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::return_dtype(&self, _operator: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::arithmetic::Arithmetic::validity(&self, _operator: &vortex_array::scalar_fn::fns::arithmetic::ArithmeticOp, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::between::Between
 
 pub type vortex_array::scalar_fn::fns::between::Between::Options = vortex_array::scalar_fn::fns::between::BetweenOptions
@@ -18916,17 +19494,17 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::child_name(&self, _instance
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::deserialize(&self, _metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::execute(&self, op: &vortex_array::scalar_fn::fns::operators::Operator, _args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::id(&self) -> vortex_array::scalar_fn::ScalarFnId
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::is_fallible(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator) -> bool
+pub fn vortex_array::scalar_fn::fns::binary::Binary::is_fallible(&self, options: &Self::Options) -> bool
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::is_null_sensitive(&self, _operator: &vortex_array::scalar_fn::fns::operators::Operator) -> bool
+pub fn vortex_array::scalar_fn::fns::binary::Binary::is_null_sensitive(&self, options: &Self::Options) -> bool
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::reduce(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::return_dtype(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
@@ -18938,9 +19516,9 @@ pub fn vortex_array::scalar_fn::fns::binary::Binary::simplify_untyped(&self, opt
 
 pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_falsification(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
-pub fn vortex_array::scalar_fn::fns::binary::Binary::validity(&self, operator: &vortex_array::scalar_fn::fns::operators::Operator, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+pub fn vortex_array::scalar_fn::fns::binary::Binary::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::case_when::CaseWhen
 
@@ -19013,6 +19591,42 @@ pub fn vortex_array::scalar_fn::fns::cast::Cast::stat_expression(&self, dtype: &
 pub fn vortex_array::scalar_fn::fns::cast::Cast::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::cast::Cast::validity(&self, dtype: &vortex_array::dtype::DType, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::comparison::Comparison
+
+pub type vortex_array::scalar_fn::fns::comparison::Comparison::Options = vortex_array::scalar_fn::fns::comparison::CompareOperator
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::arity(&self, _options: &Self::Options) -> vortex_array::scalar_fn::Arity
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::child_name(&self, _options: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::deserialize(&self, metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::execute(&self, op: &vortex_array::scalar_fn::fns::comparison::CompareOperator, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::id(&self) -> vortex_array::scalar_fn::ScalarFnId
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::is_fallible(&self, _operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator) -> bool
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::is_null_sensitive(&self, _operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator) -> bool
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::return_dtype(&self, _operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::stat_falsification(&self, operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::comparison::Comparison::validity(&self, _operator: &vortex_array::scalar_fn::fns::comparison::CompareOperator, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::dynamic::DynamicComparison
 
@@ -19265,6 +19879,42 @@ pub fn vortex_array::scalar_fn::fns::literal::Literal::stat_expression(&self, sc
 pub fn vortex_array::scalar_fn::fns::literal::Literal::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
 pub fn vortex_array::scalar_fn::fns::literal::Literal::validity(&self, scalar: &vortex_array::scalar::Scalar, _expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::logical::LogicalBinary
+
+pub type vortex_array::scalar_fn::fns::logical::LogicalBinary::Options = vortex_array::scalar_fn::fns::logical::LogicalOp
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::arity(&self, _options: &Self::Options) -> vortex_array::scalar_fn::Arity
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::child_name(&self, _options: &Self::Options, child_idx: usize) -> vortex_array::scalar_fn::ChildName
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::deserialize(&self, metadata: &[u8], _session: &vortex_session::VortexSession) -> vortex_error::VortexResult<Self::Options>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::execute(&self, op: &vortex_array::scalar_fn::fns::logical::LogicalOp, args: &dyn vortex_array::scalar_fn::ExecutionArgs, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::ArrayRef>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::fmt_sql(&self, operator: &vortex_array::scalar_fn::fns::logical::LogicalOp, expr: &vortex_array::expr::Expression, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::id(&self) -> vortex_array::scalar_fn::ScalarFnId
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::is_fallible(&self, _operator: &vortex_array::scalar_fn::fns::logical::LogicalOp) -> bool
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::is_null_sensitive(&self, _operator: &vortex_array::scalar_fn::fns::logical::LogicalOp) -> bool
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::reduce(&self, options: &Self::Options, node: &dyn vortex_array::scalar_fn::ReduceNode, ctx: &dyn vortex_array::scalar_fn::ReduceCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::scalar_fn::ReduceNodeRef>>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::return_dtype(&self, _operator: &vortex_array::scalar_fn::fns::logical::LogicalOp, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::serialize(&self, options: &Self::Options) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::simplify(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, ctx: &dyn vortex_array::scalar_fn::SimplifyCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::simplify_untyped(&self, options: &Self::Options, expr: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::stat_expression(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, stat: vortex_array::expr::stats::Stat, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::stat_falsification(&self, operator: &vortex_array::scalar_fn::fns::logical::LogicalOp, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
+
+pub fn vortex_array::scalar_fn::fns::logical::LogicalBinary::validity(&self, _operator: &vortex_array::scalar_fn::fns::logical::LogicalOp, _expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::mask::Mask
 

--- a/vortex-array/src/builtins.rs
+++ b/vortex-array/src/builtins.rs
@@ -22,14 +22,20 @@ use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
 use crate::scalar_fn::EmptyOptions;
 use crate::scalar_fn::ScalarFnVTableExt;
+use crate::scalar_fn::fns::arithmetic::Arithmetic;
+use crate::scalar_fn::fns::arithmetic::ArithmeticOp;
 use crate::scalar_fn::fns::between::Between;
 use crate::scalar_fn::fns::between::BetweenOptions;
 use crate::scalar_fn::fns::binary::Binary;
 use crate::scalar_fn::fns::cast::Cast;
+use crate::scalar_fn::fns::comparison::CompareOperator;
+use crate::scalar_fn::fns::comparison::Comparison;
 use crate::scalar_fn::fns::fill_null::FillNull;
 use crate::scalar_fn::fns::get_item::GetItem;
 use crate::scalar_fn::fns::is_null::IsNull;
 use crate::scalar_fn::fns::list_contains::ListContains;
+use crate::scalar_fn::fns::logical::LogicalBinary;
+use crate::scalar_fn::fns::logical::LogicalOp;
 use crate::scalar_fn::fns::mask::Mask;
 use crate::scalar_fn::fns::not::Not;
 use crate::scalar_fn::fns::operators::Operator;
@@ -65,6 +71,15 @@ pub trait ExprBuiltins: Sized {
 
     /// Apply a binary operator to this expression and another.
     fn binary(&self, rhs: Expression, op: Operator) -> VortexResult<Expression>;
+
+    /// Apply a comparison operator to this expression and another.
+    fn compare(&self, rhs: Expression, op: CompareOperator) -> VortexResult<Expression>;
+
+    /// Apply an arithmetic operator to this expression and another.
+    fn arithmetic(&self, rhs: Expression, op: ArithmeticOp) -> VortexResult<Expression>;
+
+    /// Apply a logical operator to this expression and another.
+    fn logical(&self, rhs: Expression, op: LogicalOp) -> VortexResult<Expression>;
 }
 
 impl ExprBuiltins for Expression {
@@ -103,6 +118,18 @@ impl ExprBuiltins for Expression {
     fn binary(&self, rhs: Expression, op: Operator) -> VortexResult<Expression> {
         Binary.try_new_expr(op, [self.clone(), rhs])
     }
+
+    fn compare(&self, rhs: Expression, op: CompareOperator) -> VortexResult<Expression> {
+        Comparison.try_new_expr(op, [self.clone(), rhs])
+    }
+
+    fn arithmetic(&self, rhs: Expression, op: ArithmeticOp) -> VortexResult<Expression> {
+        Arithmetic.try_new_expr(op, [self.clone(), rhs])
+    }
+
+    fn logical(&self, rhs: Expression, op: LogicalOp) -> VortexResult<Expression> {
+        LogicalBinary.try_new_expr(op, [self.clone(), rhs])
+    }
 }
 
 pub trait ArrayBuiltins: Sized {
@@ -134,6 +161,15 @@ pub trait ArrayBuiltins: Sized {
 
     /// Apply a binary operator to this array and another.
     fn binary(&self, rhs: ArrayRef, op: Operator) -> VortexResult<ArrayRef>;
+
+    /// Apply a comparison operator to this array and another.
+    fn compare(&self, rhs: ArrayRef, op: CompareOperator) -> VortexResult<ArrayRef>;
+
+    /// Apply an arithmetic operator to this array and another.
+    fn arithmetic(&self, rhs: ArrayRef, op: ArithmeticOp) -> VortexResult<ArrayRef>;
+
+    /// Apply a logical operator to this array and another.
+    fn logical(&self, rhs: ArrayRef, op: LogicalOp) -> VortexResult<ArrayRef>;
 
     /// Compare a values between lower </<= value </<= upper
     fn between(
@@ -204,6 +240,24 @@ impl ArrayBuiltins for ArrayRef {
 
     fn binary(&self, rhs: ArrayRef, op: Operator) -> VortexResult<ArrayRef> {
         Binary
+            .try_new_array(self.len(), op, [self.clone(), rhs])?
+            .optimize()
+    }
+
+    fn compare(&self, rhs: ArrayRef, op: CompareOperator) -> VortexResult<ArrayRef> {
+        Comparison
+            .try_new_array(self.len(), op, [self.clone(), rhs])?
+            .optimize()
+    }
+
+    fn arithmetic(&self, rhs: ArrayRef, op: ArithmeticOp) -> VortexResult<ArrayRef> {
+        Arithmetic
+            .try_new_array(self.len(), op, [self.clone(), rhs])?
+            .optimize()
+    }
+
+    fn logical(&self, rhs: ArrayRef, op: LogicalOp) -> VortexResult<ArrayRef> {
+        LogicalBinary
             .try_new_array(self.len(), op, [self.clone(), rhs])?
             .optimize()
     }

--- a/vortex-array/src/scalar_fn/fns/arithmetic.rs
+++ b/vortex-array/src/scalar_fn/fns/arithmetic.rs
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use core::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use prost::Message;
+use vortex_error::VortexError;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_proto::expr as pb;
+use vortex_proto::expr::arithmetic_opts::ArithmeticOp as PbArithmeticOp;
+use vortex_session::VortexSession;
+
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::dtype::DType;
+use crate::expr::and;
+use crate::expr::expression::Expression;
+use crate::scalar_fn::Arity;
+use crate::scalar_fn::ChildName;
+use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::ScalarFnId;
+use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::fns::binary::execute_numeric;
+use crate::scalar_fn::fns::operators::Operator;
+
+/// Arithmetic binary operators.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum ArithmeticOp {
+    /// Addition.
+    Add,
+    /// Subtraction.
+    Sub,
+    /// Multiplication.
+    Mul,
+    /// Division.
+    Div,
+}
+
+impl Display for ArithmeticOp {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let display = match self {
+            ArithmeticOp::Add => "+",
+            ArithmeticOp::Sub => "-",
+            ArithmeticOp::Mul => "*",
+            ArithmeticOp::Div => "/",
+        };
+        Display::fmt(display, f)
+    }
+}
+
+impl From<ArithmeticOp> for Operator {
+    fn from(value: ArithmeticOp) -> Self {
+        match value {
+            ArithmeticOp::Add => Operator::Add,
+            ArithmeticOp::Sub => Operator::Sub,
+            ArithmeticOp::Mul => Operator::Mul,
+            ArithmeticOp::Div => Operator::Div,
+        }
+    }
+}
+
+impl TryFrom<Operator> for ArithmeticOp {
+    type Error = VortexError;
+
+    fn try_from(value: Operator) -> Result<Self, Self::Error> {
+        match value {
+            Operator::Add => Ok(ArithmeticOp::Add),
+            Operator::Sub => Ok(ArithmeticOp::Sub),
+            Operator::Mul => Ok(ArithmeticOp::Mul),
+            Operator::Div => Ok(ArithmeticOp::Div),
+            other => Err(vortex_error::vortex_err!(
+                InvalidArgument: "{other} is not an arithmetic operator"
+            )),
+        }
+    }
+}
+
+impl From<ArithmeticOp> for PbArithmeticOp {
+    fn from(value: ArithmeticOp) -> Self {
+        match value {
+            ArithmeticOp::Add => PbArithmeticOp::Add,
+            ArithmeticOp::Sub => PbArithmeticOp::Sub,
+            ArithmeticOp::Mul => PbArithmeticOp::Mul,
+            ArithmeticOp::Div => PbArithmeticOp::Div,
+        }
+    }
+}
+
+impl From<ArithmeticOp> for i32 {
+    fn from(value: ArithmeticOp) -> Self {
+        let op: PbArithmeticOp = value.into();
+        op.into()
+    }
+}
+
+impl From<PbArithmeticOp> for ArithmeticOp {
+    fn from(value: PbArithmeticOp) -> Self {
+        match value {
+            PbArithmeticOp::Add => ArithmeticOp::Add,
+            PbArithmeticOp::Sub => ArithmeticOp::Sub,
+            PbArithmeticOp::Mul => ArithmeticOp::Mul,
+            PbArithmeticOp::Div => ArithmeticOp::Div,
+        }
+    }
+}
+
+impl TryFrom<i32> for ArithmeticOp {
+    type Error = VortexError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Ok(PbArithmeticOp::try_from(value)?.into())
+    }
+}
+
+impl From<ArithmeticOp> for crate::scalar::NumericOperator {
+    fn from(op: ArithmeticOp) -> Self {
+        match op {
+            ArithmeticOp::Add => crate::scalar::NumericOperator::Add,
+            ArithmeticOp::Sub => crate::scalar::NumericOperator::Sub,
+            ArithmeticOp::Mul => crate::scalar::NumericOperator::Mul,
+            ArithmeticOp::Div => crate::scalar::NumericOperator::Div,
+        }
+    }
+}
+
+/// An arithmetic binary scalar function.
+#[derive(Clone)]
+pub struct Arithmetic;
+
+impl ScalarFnVTable for Arithmetic {
+    type Options = ArithmeticOp;
+
+    fn id(&self) -> ScalarFnId {
+        ScalarFnId::from("vortex.arithmetic")
+    }
+
+    fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        Ok(Some(
+            pb::ArithmeticOpts {
+                op: (*options).into(),
+            }
+            .encode_to_vec(),
+        ))
+    }
+
+    fn deserialize(
+        &self,
+        metadata: &[u8],
+        _session: &VortexSession,
+    ) -> VortexResult<Self::Options> {
+        let opts = pb::ArithmeticOpts::decode(metadata)?;
+        ArithmeticOp::try_from(opts.op)
+    }
+
+    fn arity(&self, _options: &Self::Options) -> Arity {
+        Arity::Exact(2)
+    }
+
+    fn child_name(&self, _options: &Self::Options, child_idx: usize) -> ChildName {
+        match child_idx {
+            0 => ChildName::from("lhs"),
+            1 => ChildName::from("rhs"),
+            _ => unreachable!("Arithmetic has only two children"),
+        }
+    }
+
+    fn fmt_sql(
+        &self,
+        operator: &ArithmeticOp,
+        expr: &Expression,
+        f: &mut Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "(")?;
+        expr.child(0).fmt_sql(f)?;
+        write!(f, " {} ", operator)?;
+        expr.child(1).fmt_sql(f)?;
+        write!(f, ")")
+    }
+
+    fn return_dtype(&self, _operator: &ArithmeticOp, arg_dtypes: &[DType]) -> VortexResult<DType> {
+        let lhs = &arg_dtypes[0];
+        let rhs = &arg_dtypes[1];
+
+        if lhs.is_primitive() && lhs.eq_ignore_nullability(rhs) {
+            return Ok(lhs.with_nullability(lhs.nullability() | rhs.nullability()));
+        }
+        vortex_bail!(
+            "incompatible types for arithmetic operation: {} {}",
+            lhs,
+            rhs
+        );
+    }
+
+    fn execute(
+        &self,
+        op: &ArithmeticOp,
+        args: &dyn ExecutionArgs,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let lhs = args.get(0)?;
+        let rhs = args.get(1)?;
+        execute_numeric(&lhs, &rhs, (*op).into())
+    }
+
+    fn validity(
+        &self,
+        _operator: &ArithmeticOp,
+        expression: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        let lhs = expression.child(0).validity()?;
+        let rhs = expression.child(1).validity()?;
+        Ok(Some(and(lhs, rhs)))
+    }
+
+    fn is_null_sensitive(&self, _operator: &ArithmeticOp) -> bool {
+        false
+    }
+
+    fn is_fallible(&self, _operator: &ArithmeticOp) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+
+    use super::Arithmetic;
+    use super::ArithmeticOp;
+    use crate::IntoArray;
+    use crate::arrays::ConstantArray;
+    use crate::arrays::PrimitiveArray;
+    use crate::assert_arrays_eq;
+    use crate::builtins::ArrayBuiltins;
+    use crate::scalar::Scalar;
+    use crate::scalar_fn::ScalarFnVTableExt;
+    use crate::scalar_fn::fns::operators::Operator;
+
+    #[test]
+    fn test_display() {
+        use crate::expr::col;
+
+        let expr = Arithmetic.new_expr(ArithmeticOp::Add, [col("a"), col("b")]);
+        assert_eq!(format!("{expr}"), "($.a + $.b)");
+    }
+
+    #[test]
+    fn test_scalar_subtract_unsigned() {
+        let values = buffer![1u16, 2, 3].into_array();
+        let rhs = ConstantArray::new(Scalar::from(1u16), 3).into_array();
+        let result = values.binary(rhs, Operator::Sub).unwrap();
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([0u16, 1, 2]));
+    }
+
+    #[test]
+    fn test_scalar_subtract_signed() {
+        let values = buffer![1i64, 2, 3].into_array();
+        let rhs = ConstantArray::new(Scalar::from(-1i64), 3).into_array();
+        let result = values.binary(rhs, Operator::Sub).unwrap();
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([2i64, 3, 4]));
+    }
+
+    #[test]
+    fn test_scalar_subtract_nullable() {
+        let values = PrimitiveArray::from_option_iter([Some(1u16), Some(2), None, Some(3)]);
+        let rhs = ConstantArray::new(Scalar::from(Some(1u16)), 4).into_array();
+        let result = values.into_array().binary(rhs, Operator::Sub).unwrap();
+        assert_arrays_eq!(
+            result,
+            PrimitiveArray::from_option_iter([Some(0u16), Some(1), None, Some(2)])
+        );
+    }
+
+    #[test]
+    fn test_scalar_subtract_float() {
+        let values = buffer![1.0f64, 2.0, 3.0].into_array();
+        let rhs = ConstantArray::new(Scalar::from(-1f64), 3).into_array();
+        let result = values.binary(rhs, Operator::Sub).unwrap();
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([2.0f64, 3.0, 4.0]));
+    }
+
+    #[test]
+    fn test_scalar_add() {
+        let values = buffer![1i32, 2, 3].into_array();
+        let rhs = ConstantArray::new(Scalar::from(10i32), 3).into_array();
+        let result = values.binary(rhs, Operator::Add).unwrap();
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([11i32, 12, 13]));
+    }
+
+    #[test]
+    fn test_scalar_multiply() {
+        let values = buffer![2i32, 3, 4].into_array();
+        let rhs = ConstantArray::new(Scalar::from(3i32), 3).into_array();
+        let result = values.binary(rhs, Operator::Mul).unwrap();
+        assert_arrays_eq!(result, PrimitiveArray::from_iter([6i32, 9, 12]));
+    }
+}

--- a/vortex-array/src/scalar_fn/fns/binary/boolean.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/boolean.rs
@@ -13,7 +13,6 @@ use crate::arrays::Constant;
 use crate::arrays::ConstantArray;
 use crate::arrow::FromArrowArray;
 use crate::arrow::IntoArrowArray;
-use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::operators::Operator;

--- a/vortex-array/src/scalar_fn/fns/binary/boolean.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/boolean.rs
@@ -18,18 +18,6 @@ use crate::dtype::DType;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::operators::Operator;
 
-/// Point-wise Kleene logical _and_ between two Boolean arrays.
-#[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn and_kleene(lhs: &ArrayRef, rhs: &ArrayRef) -> VortexResult<ArrayRef> {
-    lhs.to_array().binary(rhs.to_array(), Operator::And)
-}
-
-/// Point-wise Kleene logical _or_ between two Boolean arrays.
-#[deprecated(note = "Use `ArrayBuiltins::binary` instead")]
-pub fn or_kleene(lhs: &ArrayRef, rhs: &ArrayRef) -> VortexResult<ArrayRef> {
-    lhs.to_array().binary(rhs.to_array(), Operator::Or)
-}
-
 /// Execute a Kleene boolean operation between two arrays.
 ///
 /// This is the entry point for boolean operations from the binary expression.

--- a/vortex-array/src/scalar_fn/fns/binary/compare.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare.rs
@@ -27,6 +27,7 @@ use crate::dtype::Nullability;
 use crate::kernel::ExecuteParentKernel;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::binary::Binary;
+use crate::scalar_fn::fns::comparison::Comparison;
 use crate::scalar_fn::fns::operators::CompareOperator;
 use crate::vtable::VTable;
 
@@ -95,6 +96,56 @@ where
         }
 
         // Null constant on either side → all-null bool result
+        if other.as_constant().is_some_and(|s| s.is_null()) {
+            return Ok(Some(
+                ConstantArray::new(Scalar::null(DType::Bool(nullable.into())), len).into_array(),
+            ));
+        }
+
+        V::compare(array, other, cmp_op, ctx)
+    }
+}
+
+/// Adaptor that bridges [`CompareKernel`] implementations to [`ExecuteParentKernel`] for the
+/// new [`Comparison`] scalar function.
+#[derive(Default, Debug)]
+pub struct ComparisonCompareExecuteAdaptor<V>(pub V);
+
+impl<V> ExecuteParentKernel<V> for ComparisonCompareExecuteAdaptor<V>
+where
+    V: CompareKernel,
+{
+    type Parent = ExactScalarFn<Comparison>;
+
+    fn execute_parent(
+        &self,
+        array: &V::Array,
+        parent: ScalarFnArrayView<'_, Comparison>,
+        child_idx: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let cmp_op = *parent.options;
+
+        let Some(scalar_fn_array) = parent.as_opt::<ScalarFnVTable>() else {
+            return Ok(None);
+        };
+        let children = scalar_fn_array.children();
+
+        let (cmp_op, other) = match child_idx {
+            0 => (cmp_op, &children[1]),
+            1 => (cmp_op.swap(), &children[0]),
+            _ => return Ok(None),
+        };
+
+        let len = array.len();
+        let nullable = array.dtype().is_nullable() || other.dtype().is_nullable();
+
+        if len == 0 {
+            return Ok(Some(
+                Canonical::empty(&DType::Bool(nullable.into())).into_array(),
+            ));
+        }
+
         if other.as_constant().is_some_and(|s| s.is_null()) {
             return Ok(Some(
                 ConstantArray::new(Scalar::null(DType::Bool(nullable.into())), len).into_array(),

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -5,7 +5,6 @@ use std::fmt::Formatter;
 
 use prost::Message;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
 use vortex_proto::expr as pb;
 use vortex_session::VortexSession;
 
@@ -13,6 +12,7 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::dtype::DType;
 use crate::expr::expression::Expression;
+use crate::scalar::NumericOperator;
 use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
@@ -112,13 +112,26 @@ impl ScalarFnVTable for Binary {
     fn execute(
         &self,
         op: &Operator,
-        _args: &dyn ExecutionArgs,
+        args: &dyn ExecutionArgs,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        vortex_bail!(
-            "Binary scalar function must be reduced before execution: {:?}",
-            op
-        );
+        let lhs = args.get(0)?;
+        let rhs = args.get(1)?;
+
+        match op {
+            Operator::Eq => execute_compare(&lhs, &rhs, CompareOperator::Eq),
+            Operator::NotEq => execute_compare(&lhs, &rhs, CompareOperator::NotEq),
+            Operator::Lt => execute_compare(&lhs, &rhs, CompareOperator::Lt),
+            Operator::Lte => execute_compare(&lhs, &rhs, CompareOperator::Lte),
+            Operator::Gt => execute_compare(&lhs, &rhs, CompareOperator::Gt),
+            Operator::Gte => execute_compare(&lhs, &rhs, CompareOperator::Gte),
+            Operator::And => execute_boolean(&lhs, &rhs, Operator::And),
+            Operator::Or => execute_boolean(&lhs, &rhs, Operator::Or),
+            Operator::Add => execute_numeric(&lhs, &rhs, NumericOperator::Add),
+            Operator::Sub => execute_numeric(&lhs, &rhs, NumericOperator::Sub),
+            Operator::Mul => execute_numeric(&lhs, &rhs, NumericOperator::Mul),
+            Operator::Div => execute_numeric(&lhs, &rhs, NumericOperator::Div),
+        }
     }
 
     fn reduce(

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -3,10 +3,6 @@
 
 use std::fmt::Formatter;
 
-#[expect(deprecated)]
-pub use boolean::and_kleene;
-#[expect(deprecated)]
-pub use boolean::or_kleene;
 use prost::Message;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -16,25 +12,23 @@ use vortex_session::VortexSession;
 use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::dtype::DType;
-use crate::expr::StatsCatalog;
-use crate::expr::and;
-use crate::expr::and_collect;
-use crate::expr::eq;
 use crate::expr::expression::Expression;
-use crate::expr::gt;
-use crate::expr::gt_eq;
-use crate::expr::lit;
-use crate::expr::lt;
-use crate::expr::lt_eq;
-use crate::expr::or_collect;
-use crate::expr::stats::Stat;
 use crate::scalar_fn::Arity;
 use crate::scalar_fn::ChildName;
 use crate::scalar_fn::ExecutionArgs;
 use crate::scalar_fn::ScalarFnId;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::ScalarFnVTableExt;
+use crate::scalar_fn::fns::arithmetic::Arithmetic;
+use crate::scalar_fn::fns::arithmetic::ArithmeticOp;
+use crate::scalar_fn::fns::comparison::Comparison;
+use crate::scalar_fn::fns::logical::LogicalBinary;
+use crate::scalar_fn::fns::logical::LogicalOp;
 use crate::scalar_fn::fns::operators::CompareOperator;
 use crate::scalar_fn::fns::operators::Operator;
+use crate::scalar_fn::vtable::ReduceCtx;
+use crate::scalar_fn::vtable::ReduceNode;
+use crate::scalar_fn::vtable::ReduceNodeRef;
 
 pub(crate) mod boolean;
 pub(crate) use boolean::*;
@@ -42,8 +36,6 @@ mod compare;
 pub use compare::*;
 mod numeric;
 pub(crate) use numeric::*;
-
-use crate::scalar::NumericOperator;
 
 #[derive(Clone)]
 pub struct Binary;
@@ -99,222 +91,68 @@ impl ScalarFnVTable for Binary {
     }
 
     fn return_dtype(&self, operator: &Operator, arg_dtypes: &[DType]) -> VortexResult<DType> {
-        let lhs = &arg_dtypes[0];
-        let rhs = &arg_dtypes[1];
-
-        if operator.is_arithmetic() {
-            if lhs.is_primitive() && lhs.eq_ignore_nullability(rhs) {
-                return Ok(lhs.with_nullability(lhs.nullability() | rhs.nullability()));
+        match operator {
+            Operator::Add | Operator::Sub | Operator::Mul | Operator::Div => {
+                Arithmetic.return_dtype(&ArithmeticOp::try_from(*operator)?, arg_dtypes)
             }
-            vortex_bail!(
-                "incompatible types for arithmetic operation: {} {}",
-                lhs,
-                rhs
-            );
+            Operator::Eq
+            | Operator::NotEq
+            | Operator::Gt
+            | Operator::Gte
+            | Operator::Lt
+            | Operator::Lte => {
+                Comparison.return_dtype(&CompareOperator::try_from(*operator)?, arg_dtypes)
+            }
+            Operator::And | Operator::Or => {
+                LogicalBinary.return_dtype(&LogicalOp::try_from(*operator)?, arg_dtypes)
+            }
         }
-
-        if operator.is_comparison()
-            && !lhs.eq_ignore_nullability(rhs)
-            && !lhs.is_extension()
-            && !rhs.is_extension()
-        {
-            vortex_bail!("Cannot compare different DTypes {} and {}", lhs, rhs);
-        }
-
-        Ok(DType::Bool((lhs.is_nullable() || rhs.is_nullable()).into()))
     }
 
     fn execute(
         &self,
         op: &Operator,
-        args: &dyn ExecutionArgs,
+        _args: &dyn ExecutionArgs,
         _ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let lhs = args.get(0)?;
-        let rhs = args.get(1)?;
-
-        match op {
-            Operator::Eq => execute_compare(&lhs, &rhs, CompareOperator::Eq),
-            Operator::NotEq => execute_compare(&lhs, &rhs, CompareOperator::NotEq),
-            Operator::Lt => execute_compare(&lhs, &rhs, CompareOperator::Lt),
-            Operator::Lte => execute_compare(&lhs, &rhs, CompareOperator::Lte),
-            Operator::Gt => execute_compare(&lhs, &rhs, CompareOperator::Gt),
-            Operator::Gte => execute_compare(&lhs, &rhs, CompareOperator::Gte),
-            Operator::And => execute_boolean(&lhs, &rhs, Operator::And),
-            Operator::Or => execute_boolean(&lhs, &rhs, Operator::Or),
-            Operator::Add => execute_numeric(&lhs, &rhs, NumericOperator::Add),
-            Operator::Sub => execute_numeric(&lhs, &rhs, NumericOperator::Sub),
-            Operator::Mul => execute_numeric(&lhs, &rhs, NumericOperator::Mul),
-            Operator::Div => execute_numeric(&lhs, &rhs, NumericOperator::Div),
-        }
-    }
-
-    fn stat_falsification(
-        &self,
-        operator: &Operator,
-        expr: &Expression,
-        catalog: &dyn StatsCatalog,
-    ) -> Option<Expression> {
-        // Wrap another predicate with an optional NaNCount check, if the stat is available.
-        //
-        // For example, regular pruning conversion for `A >= B` would be
-        //
-        //      A.max < B.min
-        //
-        // With NaN predicate introduction, we'd conjunct it with a check for NaNCount, resulting
-        // in:
-        //
-        //      (A.nan_count = 0) AND (B.nan_count = 0) AND A.max < B.min
-        //
-        // Non-floating point column and literal expressions should be unaffected as they do not
-        // have a nan_count statistic defined.
-        #[inline]
-        fn with_nan_predicate(
-            lhs: &Expression,
-            rhs: &Expression,
-            value_predicate: Expression,
-            catalog: &dyn StatsCatalog,
-        ) -> Expression {
-            let nan_predicate = and_collect(
-                lhs.stat_expression(Stat::NaNCount, catalog)
-                    .into_iter()
-                    .chain(rhs.stat_expression(Stat::NaNCount, catalog))
-                    .map(|nans| eq(nans, lit(0u64))),
-            );
-
-            if let Some(nan_check) = nan_predicate {
-                and(nan_check, value_predicate)
-            } else {
-                value_predicate
-            }
-        }
-
-        let lhs = expr.child(0);
-        let rhs = expr.child(1);
-        match operator {
-            Operator::Eq => {
-                let min_lhs = lhs.stat_min(catalog);
-                let max_lhs = lhs.stat_max(catalog);
-
-                let min_rhs = rhs.stat_min(catalog);
-                let max_rhs = rhs.stat_max(catalog);
-
-                let left = min_lhs.zip(max_rhs).map(|(a, b)| gt(a, b));
-                let right = min_rhs.zip(max_lhs).map(|(a, b)| gt(a, b));
-
-                let min_max_check = or_collect(left.into_iter().chain(right))?;
-
-                // NaN is not captured by the min/max stat, so we must check NaNCount before pruning
-                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
-            }
-            Operator::NotEq => {
-                let min_lhs = lhs.stat_min(catalog)?;
-                let max_lhs = lhs.stat_max(catalog)?;
-
-                let min_rhs = rhs.stat_min(catalog)?;
-                let max_rhs = rhs.stat_max(catalog)?;
-
-                let min_max_check = and(eq(min_lhs, max_rhs), eq(max_lhs, min_rhs));
-
-                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
-            }
-            Operator::Gt => {
-                let min_max_check = lt_eq(lhs.stat_max(catalog)?, rhs.stat_min(catalog)?);
-
-                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
-            }
-            Operator::Gte => {
-                // NaN is not captured by the min/max stat, so we must check NaNCount before pruning
-                let min_max_check = lt(lhs.stat_max(catalog)?, rhs.stat_min(catalog)?);
-
-                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
-            }
-            Operator::Lt => {
-                // NaN is not captured by the min/max stat, so we must check NaNCount before pruning
-                let min_max_check = gt_eq(lhs.stat_min(catalog)?, rhs.stat_max(catalog)?);
-
-                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
-            }
-            Operator::Lte => {
-                // NaN is not captured by the min/max stat, so we must check NaNCount before pruning
-                let min_max_check = gt(lhs.stat_min(catalog)?, rhs.stat_max(catalog)?);
-
-                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
-            }
-            Operator::And => or_collect(
-                lhs.stat_falsification(catalog)
-                    .into_iter()
-                    .chain(rhs.stat_falsification(catalog)),
-            ),
-            Operator::Or => Some(and(
-                lhs.stat_falsification(catalog)?,
-                rhs.stat_falsification(catalog)?,
-            )),
-            Operator::Add | Operator::Sub | Operator::Mul | Operator::Div => None,
-        }
-    }
-
-    fn validity(
-        &self,
-        operator: &Operator,
-        expression: &Expression,
-    ) -> VortexResult<Option<Expression>> {
-        let lhs = expression.child(0).validity()?;
-        let rhs = expression.child(1).validity()?;
-
-        Ok(match operator {
-            // AND and OR are kleene logic.
-            Operator::And => None,
-            Operator::Or => None,
-            _ => {
-                // All other binary operators are null if either side is null.
-                Some(and(lhs, rhs))
-            }
-        })
-    }
-
-    fn is_null_sensitive(&self, _operator: &Operator) -> bool {
-        false
-    }
-
-    fn is_fallible(&self, operator: &Operator) -> bool {
-        // Opt-in not out for fallibility.
-        // Arithmetic operations could be better modelled here.
-        let infallible = matches!(
-            operator,
-            Operator::Eq
-                | Operator::NotEq
-                | Operator::Gt
-                | Operator::Gte
-                | Operator::Lt
-                | Operator::Lte
-                | Operator::And
-                | Operator::Or
+        vortex_bail!(
+            "Binary scalar function must be reduced before execution: {:?}",
+            op
         );
+    }
 
-        !infallible
+    fn reduce(
+        &self,
+        operator: &Operator,
+        node: &dyn ReduceNode,
+        ctx: &dyn ReduceCtx,
+    ) -> VortexResult<Option<ReduceNodeRef>> {
+        let children = [node.child(0), node.child(1)];
+        let scalar_fn = match operator {
+            Operator::Eq => Comparison.bind(CompareOperator::Eq),
+            Operator::NotEq => Comparison.bind(CompareOperator::NotEq),
+            Operator::Gt => Comparison.bind(CompareOperator::Gt),
+            Operator::Gte => Comparison.bind(CompareOperator::Gte),
+            Operator::Lt => Comparison.bind(CompareOperator::Lt),
+            Operator::Lte => Comparison.bind(CompareOperator::Lte),
+            Operator::And => LogicalBinary.bind(LogicalOp::And),
+            Operator::Or => LogicalBinary.bind(LogicalOp::Or),
+            Operator::Add => Arithmetic.bind(ArithmeticOp::Add),
+            Operator::Sub => Arithmetic.bind(ArithmeticOp::Sub),
+            Operator::Mul => Arithmetic.bind(ArithmeticOp::Mul),
+            Operator::Div => Arithmetic.bind(ArithmeticOp::Div),
+        };
+        Ok(Some(ctx.new_node(scalar_fn, &children)?))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use vortex_error::VortexExpect;
-
-    use super::*;
-    use crate::assert_arrays_eq;
-    use crate::builtins::ArrayBuiltins;
-    use crate::dtype::DType;
-    use crate::dtype::Nullability;
     use crate::expr::Expression;
     use crate::expr::and_collect;
-    use crate::expr::col;
     use crate::expr::lit;
-    use crate::expr::lt;
-    use crate::expr::not_eq;
-    use crate::expr::or;
     use crate::expr::or_collect;
-    use crate::expr::test_harness;
-    use crate::scalar::Scalar;
+
     #[test]
     fn and_collect_balanced() {
         let values = vec![lit(1), lit(2), lit(3), lit(4), lit(5)];
@@ -365,229 +203,5 @@ mod tests {
             ├── lhs: vortex.literal(3i32)
             └── rhs: vortex.literal(4i32)
         ");
-    }
-
-    #[test]
-    fn dtype() {
-        let dtype = test_harness::struct_dtype();
-        let bool1: Expression = col("bool1");
-        let bool2: Expression = col("bool2");
-        assert_eq!(
-            and(bool1.clone(), bool2.clone())
-                .return_dtype(&dtype)
-                .unwrap(),
-            DType::Bool(Nullability::NonNullable)
-        );
-        assert_eq!(
-            or(bool1, bool2).return_dtype(&dtype).unwrap(),
-            DType::Bool(Nullability::NonNullable)
-        );
-
-        let col1: Expression = col("col1");
-        let col2: Expression = col("col2");
-
-        assert_eq!(
-            eq(col1.clone(), col2.clone()).return_dtype(&dtype).unwrap(),
-            DType::Bool(Nullability::Nullable)
-        );
-        assert_eq!(
-            not_eq(col1.clone(), col2.clone())
-                .return_dtype(&dtype)
-                .unwrap(),
-            DType::Bool(Nullability::Nullable)
-        );
-        assert_eq!(
-            gt(col1.clone(), col2.clone()).return_dtype(&dtype).unwrap(),
-            DType::Bool(Nullability::Nullable)
-        );
-        assert_eq!(
-            gt_eq(col1.clone(), col2.clone())
-                .return_dtype(&dtype)
-                .unwrap(),
-            DType::Bool(Nullability::Nullable)
-        );
-        assert_eq!(
-            lt(col1.clone(), col2.clone()).return_dtype(&dtype).unwrap(),
-            DType::Bool(Nullability::Nullable)
-        );
-        assert_eq!(
-            lt_eq(col1.clone(), col2.clone())
-                .return_dtype(&dtype)
-                .unwrap(),
-            DType::Bool(Nullability::Nullable)
-        );
-
-        assert_eq!(
-            or(lt(col1.clone(), col2.clone()), not_eq(col1, col2))
-                .return_dtype(&dtype)
-                .unwrap(),
-            DType::Bool(Nullability::Nullable)
-        );
-    }
-
-    #[test]
-    fn test_display_print() {
-        let expr = gt(lit(1), lit(2));
-        assert_eq!(format!("{expr}"), "(1i32 > 2i32)");
-    }
-
-    /// Regression test for GitHub issue #5947: struct comparison in filter expressions should work
-    /// using `make_comparator` instead of Arrow's `cmp` functions which don't support nested types.
-    #[test]
-    fn test_struct_comparison() {
-        use crate::IntoArray;
-        use crate::arrays::StructArray;
-
-        // Create a struct array with one element for testing.
-        let lhs_struct = StructArray::from_fields(&[
-            (
-                "a",
-                crate::arrays::PrimitiveArray::from_iter([1i32]).into_array(),
-            ),
-            (
-                "b",
-                crate::arrays::PrimitiveArray::from_iter([3i32]).into_array(),
-            ),
-        ])
-        .unwrap()
-        .into_array();
-
-        let rhs_struct_equal = StructArray::from_fields(&[
-            (
-                "a",
-                crate::arrays::PrimitiveArray::from_iter([1i32]).into_array(),
-            ),
-            (
-                "b",
-                crate::arrays::PrimitiveArray::from_iter([3i32]).into_array(),
-            ),
-        ])
-        .unwrap()
-        .into_array();
-
-        let rhs_struct_different = StructArray::from_fields(&[
-            (
-                "a",
-                crate::arrays::PrimitiveArray::from_iter([1i32]).into_array(),
-            ),
-            (
-                "b",
-                crate::arrays::PrimitiveArray::from_iter([4i32]).into_array(),
-            ),
-        ])
-        .unwrap()
-        .into_array();
-
-        // Test using binary method directly
-        let result_equal = lhs_struct.binary(rhs_struct_equal, Operator::Eq).unwrap();
-        assert_eq!(
-            result_equal.scalar_at(0).vortex_expect("value"),
-            Scalar::bool(true, Nullability::NonNullable),
-            "Equal structs should be equal"
-        );
-
-        let result_different = lhs_struct
-            .binary(rhs_struct_different, Operator::Eq)
-            .unwrap();
-        assert_eq!(
-            result_different.scalar_at(0).vortex_expect("value"),
-            Scalar::bool(false, Nullability::NonNullable),
-            "Different structs should not be equal"
-        );
-    }
-
-    #[test]
-    fn test_or_kleene_validity() {
-        use crate::IntoArray;
-        use crate::arrays::BoolArray;
-        use crate::arrays::StructArray;
-        use crate::expr::col;
-
-        let struct_arr = StructArray::from_fields(&[
-            ("a", BoolArray::from_iter([Some(true)]).into_array()),
-            (
-                "b",
-                BoolArray::from_iter([Option::<bool>::None]).into_array(),
-            ),
-        ])
-        .unwrap()
-        .into_array();
-
-        let expr = or(col("a"), col("b"));
-        let result = struct_arr.apply(&expr).unwrap();
-
-        assert_arrays_eq!(result, BoolArray::from_iter([Some(true)]).into_array())
-    }
-
-    #[test]
-    fn test_scalar_subtract_unsigned() {
-        use vortex_buffer::buffer;
-
-        use crate::IntoArray;
-        use crate::arrays::ConstantArray;
-        use crate::arrays::PrimitiveArray;
-
-        let values = buffer![1u16, 2, 3].into_array();
-        let rhs = ConstantArray::new(Scalar::from(1u16), 3).into_array();
-        let result = values.binary(rhs, Operator::Sub).unwrap();
-        assert_arrays_eq!(result, PrimitiveArray::from_iter([0u16, 1, 2]));
-    }
-
-    #[test]
-    fn test_scalar_subtract_signed() {
-        use vortex_buffer::buffer;
-
-        use crate::IntoArray;
-        use crate::arrays::ConstantArray;
-        use crate::arrays::PrimitiveArray;
-
-        let values = buffer![1i64, 2, 3].into_array();
-        let rhs = ConstantArray::new(Scalar::from(-1i64), 3).into_array();
-        let result = values.binary(rhs, Operator::Sub).unwrap();
-        assert_arrays_eq!(result, PrimitiveArray::from_iter([2i64, 3, 4]));
-    }
-
-    #[test]
-    fn test_scalar_subtract_nullable() {
-        use crate::IntoArray;
-        use crate::arrays::ConstantArray;
-        use crate::arrays::PrimitiveArray;
-
-        let values = PrimitiveArray::from_option_iter([Some(1u16), Some(2), None, Some(3)]);
-        let rhs = ConstantArray::new(Scalar::from(Some(1u16)), 4).into_array();
-        let result = values.into_array().binary(rhs, Operator::Sub).unwrap();
-        assert_arrays_eq!(
-            result,
-            PrimitiveArray::from_option_iter([Some(0u16), Some(1), None, Some(2)])
-        );
-    }
-
-    #[test]
-    fn test_scalar_subtract_float() {
-        use vortex_buffer::buffer;
-
-        use crate::IntoArray;
-        use crate::arrays::ConstantArray;
-        use crate::arrays::PrimitiveArray;
-
-        let values = buffer![1.0f64, 2.0, 3.0].into_array();
-        let rhs = ConstantArray::new(Scalar::from(-1f64), 3).into_array();
-        let result = values.binary(rhs, Operator::Sub).unwrap();
-        assert_arrays_eq!(result, PrimitiveArray::from_iter([2.0f64, 3.0, 4.0]));
-    }
-
-    #[test]
-    fn test_scalar_subtract_float_underflow_is_ok() {
-        use vortex_buffer::buffer;
-
-        use crate::IntoArray;
-        use crate::arrays::ConstantArray;
-
-        let values = buffer![f32::MIN, 2.0, 3.0].into_array();
-        let rhs1 = ConstantArray::new(Scalar::from(1.0f32), 3).into_array();
-        let _results = values.binary(rhs1, Operator::Sub).unwrap();
-        let values = buffer![f32::MIN, 2.0, 3.0].into_array();
-        let rhs2 = ConstantArray::new(Scalar::from(f32::MAX), 3).into_array();
-        let _results = values.binary(rhs2, Operator::Sub).unwrap();
     }
 }

--- a/vortex-array/src/scalar_fn/fns/comparison.rs
+++ b/vortex-array/src/scalar_fn/fns/comparison.rs
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use core::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use prost::Message;
+use vortex_error::VortexError;
+use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
+use vortex_proto::expr as pb;
+use vortex_proto::expr::comparison_opts::ComparisonOp as PbComparisonOp;
+use vortex_session::VortexSession;
+
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::dtype::DType;
+use crate::expr::StatsCatalog;
+use crate::expr::and;
+use crate::expr::and_collect;
+use crate::expr::eq;
+use crate::expr::expression::Expression;
+use crate::expr::gt;
+use crate::expr::gt_eq;
+use crate::expr::lit;
+use crate::expr::lt;
+use crate::expr::lt_eq;
+use crate::expr::or_collect;
+use crate::expr::stats::Stat;
+use crate::scalar_fn::Arity;
+use crate::scalar_fn::ChildName;
+use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::ScalarFnId;
+use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::fns::binary::execute_compare;
+use crate::scalar_fn::fns::operators::Operator;
+
+/// The six comparison operators, providing compile-time guarantees that only
+/// comparison variants are used where comparisons are expected.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum CompareOperator {
+    /// Expressions are equal.
+    Eq,
+    /// Expressions are not equal.
+    NotEq,
+    /// Expression is greater than another.
+    Gt,
+    /// Expression is greater or equal to another.
+    Gte,
+    /// Expression is less than another.
+    Lt,
+    /// Expression is less or equal to another.
+    Lte,
+}
+
+impl CompareOperator {
+    /// Return the logical inverse of this comparison operator.
+    pub fn inverse(self) -> Self {
+        match self {
+            CompareOperator::Eq => CompareOperator::NotEq,
+            CompareOperator::NotEq => CompareOperator::Eq,
+            CompareOperator::Gt => CompareOperator::Lte,
+            CompareOperator::Gte => CompareOperator::Lt,
+            CompareOperator::Lt => CompareOperator::Gte,
+            CompareOperator::Lte => CompareOperator::Gt,
+        }
+    }
+
+    /// Swap the sides of the operator so that swapping lhs and rhs preserves the result.
+    pub fn swap(self) -> Self {
+        match self {
+            CompareOperator::Eq => CompareOperator::Eq,
+            CompareOperator::NotEq => CompareOperator::NotEq,
+            CompareOperator::Gt => CompareOperator::Lt,
+            CompareOperator::Gte => CompareOperator::Lte,
+            CompareOperator::Lt => CompareOperator::Gt,
+            CompareOperator::Lte => CompareOperator::Gte,
+        }
+    }
+}
+
+impl Display for CompareOperator {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let display = match self {
+            CompareOperator::Eq => "=",
+            CompareOperator::NotEq => "!=",
+            CompareOperator::Gt => ">",
+            CompareOperator::Gte => ">=",
+            CompareOperator::Lt => "<",
+            CompareOperator::Lte => "<=",
+        };
+        Display::fmt(display, f)
+    }
+}
+
+impl From<CompareOperator> for Operator {
+    fn from(value: CompareOperator) -> Self {
+        match value {
+            CompareOperator::Eq => Operator::Eq,
+            CompareOperator::NotEq => Operator::NotEq,
+            CompareOperator::Gt => Operator::Gt,
+            CompareOperator::Gte => Operator::Gte,
+            CompareOperator::Lt => Operator::Lt,
+            CompareOperator::Lte => Operator::Lte,
+        }
+    }
+}
+
+impl TryFrom<Operator> for CompareOperator {
+    type Error = VortexError;
+
+    fn try_from(value: Operator) -> Result<Self, Self::Error> {
+        match value {
+            Operator::Eq => Ok(CompareOperator::Eq),
+            Operator::NotEq => Ok(CompareOperator::NotEq),
+            Operator::Gt => Ok(CompareOperator::Gt),
+            Operator::Gte => Ok(CompareOperator::Gte),
+            Operator::Lt => Ok(CompareOperator::Lt),
+            Operator::Lte => Ok(CompareOperator::Lte),
+            other => Err(vortex_error::vortex_err!(
+                InvalidArgument: "{other} is not a comparison operator"
+            )),
+        }
+    }
+}
+
+impl From<CompareOperator> for PbComparisonOp {
+    fn from(value: CompareOperator) -> Self {
+        match value {
+            CompareOperator::Eq => PbComparisonOp::Eq,
+            CompareOperator::NotEq => PbComparisonOp::NotEq,
+            CompareOperator::Gt => PbComparisonOp::Gt,
+            CompareOperator::Gte => PbComparisonOp::Gte,
+            CompareOperator::Lt => PbComparisonOp::Lt,
+            CompareOperator::Lte => PbComparisonOp::Lte,
+        }
+    }
+}
+
+impl From<CompareOperator> for i32 {
+    fn from(value: CompareOperator) -> Self {
+        let op: PbComparisonOp = value.into();
+        op.into()
+    }
+}
+
+impl From<PbComparisonOp> for CompareOperator {
+    fn from(value: PbComparisonOp) -> Self {
+        match value {
+            PbComparisonOp::Eq => CompareOperator::Eq,
+            PbComparisonOp::NotEq => CompareOperator::NotEq,
+            PbComparisonOp::Gt => CompareOperator::Gt,
+            PbComparisonOp::Gte => CompareOperator::Gte,
+            PbComparisonOp::Lt => CompareOperator::Lt,
+            PbComparisonOp::Lte => CompareOperator::Lte,
+        }
+    }
+}
+
+impl TryFrom<i32> for CompareOperator {
+    type Error = VortexError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Ok(PbComparisonOp::try_from(value)?.into())
+    }
+}
+
+/// A comparison scalar function for the six relational operators.
+#[derive(Clone)]
+pub struct Comparison;
+
+impl ScalarFnVTable for Comparison {
+    type Options = CompareOperator;
+
+    fn id(&self) -> ScalarFnId {
+        ScalarFnId::from("vortex.comparison")
+    }
+
+    fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        Ok(Some(
+            pb::ComparisonOpts {
+                op: (*options).into(),
+            }
+            .encode_to_vec(),
+        ))
+    }
+
+    fn deserialize(
+        &self,
+        metadata: &[u8],
+        _session: &VortexSession,
+    ) -> VortexResult<Self::Options> {
+        let opts = pb::ComparisonOpts::decode(metadata)?;
+        CompareOperator::try_from(opts.op)
+    }
+
+    fn arity(&self, _options: &Self::Options) -> Arity {
+        Arity::Exact(2)
+    }
+
+    fn child_name(&self, _options: &Self::Options, child_idx: usize) -> ChildName {
+        match child_idx {
+            0 => ChildName::from("lhs"),
+            1 => ChildName::from("rhs"),
+            _ => unreachable!("Comparison has only two children"),
+        }
+    }
+
+    fn fmt_sql(
+        &self,
+        operator: &CompareOperator,
+        expr: &Expression,
+        f: &mut Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "(")?;
+        expr.child(0).fmt_sql(f)?;
+        write!(f, " {} ", operator)?;
+        expr.child(1).fmt_sql(f)?;
+        write!(f, ")")
+    }
+
+    fn return_dtype(
+        &self,
+        _operator: &CompareOperator,
+        arg_dtypes: &[DType],
+    ) -> VortexResult<DType> {
+        let lhs = &arg_dtypes[0];
+        let rhs = &arg_dtypes[1];
+
+        if !lhs.eq_ignore_nullability(rhs) && !lhs.is_extension() && !rhs.is_extension() {
+            vortex_bail!("Cannot compare different DTypes {} and {}", lhs, rhs);
+        }
+
+        Ok(DType::Bool((lhs.is_nullable() || rhs.is_nullable()).into()))
+    }
+
+    fn execute(
+        &self,
+        op: &CompareOperator,
+        args: &dyn ExecutionArgs,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let lhs = args.get(0)?;
+        let rhs = args.get(1)?;
+        execute_compare(&lhs, &rhs, *op)
+    }
+
+    fn stat_falsification(
+        &self,
+        operator: &CompareOperator,
+        expr: &Expression,
+        catalog: &dyn StatsCatalog,
+    ) -> Option<Expression> {
+        #[inline]
+        fn with_nan_predicate(
+            lhs: &Expression,
+            rhs: &Expression,
+            value_predicate: Expression,
+            catalog: &dyn StatsCatalog,
+        ) -> Expression {
+            let nan_predicate = and_collect(
+                lhs.stat_expression(Stat::NaNCount, catalog)
+                    .into_iter()
+                    .chain(rhs.stat_expression(Stat::NaNCount, catalog))
+                    .map(|nans| eq(nans, lit(0u64))),
+            );
+
+            if let Some(nan_check) = nan_predicate {
+                and(nan_check, value_predicate)
+            } else {
+                value_predicate
+            }
+        }
+
+        let lhs = expr.child(0);
+        let rhs = expr.child(1);
+        match operator {
+            CompareOperator::Eq => {
+                let min_lhs = lhs.stat_min(catalog);
+                let max_lhs = lhs.stat_max(catalog);
+                let min_rhs = rhs.stat_min(catalog);
+                let max_rhs = rhs.stat_max(catalog);
+
+                let left = min_lhs.zip(max_rhs).map(|(a, b)| gt(a, b));
+                let right = min_rhs.zip(max_lhs).map(|(a, b)| gt(a, b));
+
+                let min_max_check = or_collect(left.into_iter().chain(right))?;
+                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
+            }
+            CompareOperator::NotEq => {
+                let min_lhs = lhs.stat_min(catalog)?;
+                let max_lhs = lhs.stat_max(catalog)?;
+                let min_rhs = rhs.stat_min(catalog)?;
+                let max_rhs = rhs.stat_max(catalog)?;
+
+                let min_max_check = and(eq(min_lhs, max_rhs), eq(max_lhs, min_rhs));
+                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
+            }
+            CompareOperator::Gt => {
+                let min_max_check = lt_eq(lhs.stat_max(catalog)?, rhs.stat_min(catalog)?);
+                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
+            }
+            CompareOperator::Gte => {
+                let min_max_check = lt(lhs.stat_max(catalog)?, rhs.stat_min(catalog)?);
+                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
+            }
+            CompareOperator::Lt => {
+                let min_max_check = gt_eq(lhs.stat_min(catalog)?, rhs.stat_max(catalog)?);
+                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
+            }
+            CompareOperator::Lte => {
+                let min_max_check = gt(lhs.stat_min(catalog)?, rhs.stat_max(catalog)?);
+                Some(with_nan_predicate(lhs, rhs, min_max_check, catalog))
+            }
+        }
+    }
+
+    fn validity(
+        &self,
+        _operator: &CompareOperator,
+        expression: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        let lhs = expression.child(0).validity()?;
+        let rhs = expression.child(1).validity()?;
+        Ok(Some(and(lhs, rhs)))
+    }
+
+    fn is_null_sensitive(&self, _operator: &CompareOperator) -> bool {
+        false
+    }
+
+    fn is_fallible(&self, _operator: &CompareOperator) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_buffer::buffer;
+    use vortex_error::VortexExpect;
+
+    use super::CompareOperator;
+    use super::Comparison;
+    use crate::IntoArray;
+    use crate::arrays::BoolArray;
+    use crate::arrays::ConstantArray;
+    use crate::arrays::StructArray;
+    use crate::assert_arrays_eq;
+    use crate::builtins::ArrayBuiltins;
+    use crate::dtype::DType;
+    use crate::dtype::Nullability;
+    use crate::scalar::Scalar;
+    use crate::scalar_fn::ScalarFnVTableExt;
+    use crate::scalar_fn::fns::operators::Operator;
+
+    #[test]
+    fn test_return_dtype() {
+        use crate::expr::Expression;
+        use crate::expr::col;
+        use crate::expr::test_harness;
+
+        let dtype = test_harness::struct_dtype();
+        let col1: Expression = col("col1");
+        let col2: Expression = col("col2");
+
+        let eq_expr = Comparison.new_expr(CompareOperator::Eq, [col1, col2]);
+        assert_eq!(
+            eq_expr.return_dtype(&dtype).unwrap(),
+            DType::Bool(Nullability::Nullable)
+        );
+    }
+
+    #[test]
+    fn test_display() {
+        use crate::expr::col;
+
+        let expr = Comparison.new_expr(CompareOperator::Gt, [col("a"), col("b")]);
+        assert_eq!(format!("{expr}"), "($.a > $.b)");
+    }
+
+    #[test]
+    fn test_constant_compare() {
+        let left = ConstantArray::new(Scalar::from(2u32), 10);
+        let right = ConstantArray::new(Scalar::from(10u32), 10);
+
+        let result = left
+            .into_array()
+            .binary(right.into_array(), Operator::Gt)
+            .unwrap();
+        assert_eq!(result.len(), 10);
+        let scalar = result.scalar_at(0).unwrap();
+        assert_eq!(scalar.as_bool().value(), Some(false));
+    }
+
+    #[test]
+    fn test_struct_comparison() {
+        use crate::arrays::PrimitiveArray;
+
+        let lhs_struct = StructArray::from_fields(&[
+            ("a", PrimitiveArray::from_iter([1i32]).into_array()),
+            ("b", PrimitiveArray::from_iter([3i32]).into_array()),
+        ])
+        .unwrap()
+        .into_array();
+
+        let rhs_struct_equal = StructArray::from_fields(&[
+            ("a", PrimitiveArray::from_iter([1i32]).into_array()),
+            ("b", PrimitiveArray::from_iter([3i32]).into_array()),
+        ])
+        .unwrap()
+        .into_array();
+
+        let result = lhs_struct.binary(rhs_struct_equal, Operator::Eq).unwrap();
+        assert_eq!(
+            result.scalar_at(0).vortex_expect("value"),
+            Scalar::bool(true, Nullability::NonNullable),
+        );
+    }
+
+    #[test]
+    fn test_varbin_compare() {
+        use crate::arrays::VarBinArray;
+        use crate::arrays::VarBinViewArray;
+
+        let left = VarBinArray::from(vec!["a", "b"]).into_array();
+        let right = VarBinViewArray::from_iter_str(["a", "b"]).into_array();
+        let res = left.binary(right, Operator::Eq).unwrap();
+        assert_arrays_eq!(res, BoolArray::from_iter([true, true]));
+    }
+
+    #[test]
+    fn test_scalar_compare() {
+        let values = buffer![1i32, 2, 3].into_array();
+        let rhs = ConstantArray::new(Scalar::from(2i32), 3).into_array();
+        let result = values.binary(rhs, Operator::Gt).unwrap();
+        assert_arrays_eq!(result, BoolArray::from_iter([false, false, true]));
+    }
+}

--- a/vortex-array/src/scalar_fn/fns/get_item.rs
+++ b/vortex-array/src/scalar_fn/fns/get_item.rs
@@ -231,6 +231,9 @@ mod tests {
     use crate::expr::lit;
     use crate::expr::pack;
     use crate::expr::root;
+    use crate::scalar_fn::ScalarFnVTableExt;
+    use crate::scalar_fn::fns::arithmetic::Arithmetic;
+    use crate::scalar_fn::fns::arithmetic::ArithmeticOp;
     use crate::scalar_fn::fns::get_item::StructArray;
     use crate::validity::Validity;
 
@@ -337,7 +340,8 @@ mod tests {
         let dtype = DType::Primitive(PType::I32, NonNullable);
 
         let result = get_result.optimize_recursive(&dtype).unwrap();
-        let expected = checked_add(lit(1), lit(10));
+        // After optimization, Binary(Add) is reduced to Arithmetic(Add).
+        let expected = Arithmetic.new_expr(ArithmeticOp::Add, [lit(1), lit(10)]);
         assert_eq!(&result, &expected);
     }
 

--- a/vortex-array/src/scalar_fn/fns/logical.rs
+++ b/vortex-array/src/scalar_fn/fns/logical.rs
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use core::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
+
+use prost::Message;
+use vortex_error::VortexError;
+use vortex_error::VortexResult;
+use vortex_proto::expr as pb;
+use vortex_proto::expr::logical_binary_opts::LogicalBinaryOp as PbLogicalBinaryOp;
+use vortex_session::VortexSession;
+
+use crate::ArrayRef;
+use crate::ExecutionCtx;
+use crate::dtype::DType;
+use crate::expr::StatsCatalog;
+use crate::expr::and;
+use crate::expr::expression::Expression;
+use crate::expr::or_collect;
+use crate::scalar_fn::Arity;
+use crate::scalar_fn::ChildName;
+use crate::scalar_fn::ExecutionArgs;
+use crate::scalar_fn::ScalarFnId;
+use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::fns::binary::execute_boolean;
+use crate::scalar_fn::fns::operators::Operator;
+
+/// Logical binary operators (Kleene three-valued logic).
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum LogicalOp {
+    /// Boolean AND (∧) with Kleene logic.
+    And,
+    /// Boolean OR (∨) with Kleene logic.
+    Or,
+}
+
+impl Display for LogicalOp {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let display = match self {
+            LogicalOp::And => "and",
+            LogicalOp::Or => "or",
+        };
+        Display::fmt(display, f)
+    }
+}
+
+impl From<LogicalOp> for Operator {
+    fn from(value: LogicalOp) -> Self {
+        match value {
+            LogicalOp::And => Operator::And,
+            LogicalOp::Or => Operator::Or,
+        }
+    }
+}
+
+impl TryFrom<Operator> for LogicalOp {
+    type Error = VortexError;
+
+    fn try_from(value: Operator) -> Result<Self, Self::Error> {
+        match value {
+            Operator::And => Ok(LogicalOp::And),
+            Operator::Or => Ok(LogicalOp::Or),
+            other => Err(vortex_error::vortex_err!(
+                InvalidArgument: "{other} is not a logical operator"
+            )),
+        }
+    }
+}
+
+impl From<LogicalOp> for PbLogicalBinaryOp {
+    fn from(value: LogicalOp) -> Self {
+        match value {
+            LogicalOp::And => PbLogicalBinaryOp::And,
+            LogicalOp::Or => PbLogicalBinaryOp::Or,
+        }
+    }
+}
+
+impl From<LogicalOp> for i32 {
+    fn from(value: LogicalOp) -> Self {
+        let op: PbLogicalBinaryOp = value.into();
+        op.into()
+    }
+}
+
+impl From<PbLogicalBinaryOp> for LogicalOp {
+    fn from(value: PbLogicalBinaryOp) -> Self {
+        match value {
+            PbLogicalBinaryOp::And => LogicalOp::And,
+            PbLogicalBinaryOp::Or => LogicalOp::Or,
+        }
+    }
+}
+
+impl TryFrom<i32> for LogicalOp {
+    type Error = VortexError;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Ok(PbLogicalBinaryOp::try_from(value)?.into())
+    }
+}
+
+/// A logical binary scalar function implementing Kleene three-valued logic.
+#[derive(Clone)]
+pub struct LogicalBinary;
+
+impl ScalarFnVTable for LogicalBinary {
+    type Options = LogicalOp;
+
+    fn id(&self) -> ScalarFnId {
+        ScalarFnId::from("vortex.logical_binary")
+    }
+
+    fn serialize(&self, options: &Self::Options) -> VortexResult<Option<Vec<u8>>> {
+        Ok(Some(
+            pb::LogicalBinaryOpts {
+                op: (*options).into(),
+            }
+            .encode_to_vec(),
+        ))
+    }
+
+    fn deserialize(
+        &self,
+        metadata: &[u8],
+        _session: &VortexSession,
+    ) -> VortexResult<Self::Options> {
+        let opts = pb::LogicalBinaryOpts::decode(metadata)?;
+        LogicalOp::try_from(opts.op)
+    }
+
+    fn arity(&self, _options: &Self::Options) -> Arity {
+        Arity::Exact(2)
+    }
+
+    fn child_name(&self, _options: &Self::Options, child_idx: usize) -> ChildName {
+        match child_idx {
+            0 => ChildName::from("lhs"),
+            1 => ChildName::from("rhs"),
+            _ => unreachable!("LogicalBinary has only two children"),
+        }
+    }
+
+    fn fmt_sql(
+        &self,
+        operator: &LogicalOp,
+        expr: &Expression,
+        f: &mut Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "(")?;
+        expr.child(0).fmt_sql(f)?;
+        write!(f, " {} ", operator)?;
+        expr.child(1).fmt_sql(f)?;
+        write!(f, ")")
+    }
+
+    fn return_dtype(&self, _operator: &LogicalOp, arg_dtypes: &[DType]) -> VortexResult<DType> {
+        let lhs = &arg_dtypes[0];
+        let rhs = &arg_dtypes[1];
+        Ok(DType::Bool((lhs.is_nullable() || rhs.is_nullable()).into()))
+    }
+
+    fn execute(
+        &self,
+        op: &LogicalOp,
+        args: &dyn ExecutionArgs,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        let lhs = args.get(0)?;
+        let rhs = args.get(1)?;
+        let operator: Operator = (*op).into();
+        execute_boolean(&lhs, &rhs, operator)
+    }
+
+    fn stat_falsification(
+        &self,
+        operator: &LogicalOp,
+        expr: &Expression,
+        catalog: &dyn StatsCatalog,
+    ) -> Option<Expression> {
+        let lhs = expr.child(0);
+        let rhs = expr.child(1);
+        match operator {
+            LogicalOp::And => or_collect(
+                lhs.stat_falsification(catalog)
+                    .into_iter()
+                    .chain(rhs.stat_falsification(catalog)),
+            ),
+            LogicalOp::Or => Some(and(
+                lhs.stat_falsification(catalog)?,
+                rhs.stat_falsification(catalog)?,
+            )),
+        }
+    }
+
+    fn validity(
+        &self,
+        _operator: &LogicalOp,
+        _expression: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        // Kleene logic: validity cannot be determined without evaluating the expression.
+        Ok(None)
+    }
+
+    fn is_null_sensitive(&self, _operator: &LogicalOp) -> bool {
+        false
+    }
+
+    fn is_fallible(&self, _operator: &LogicalOp) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::LogicalBinary;
+    use super::LogicalOp;
+    use crate::ArrayRef;
+    use crate::IntoArray;
+    use crate::arrays::BoolArray;
+    use crate::arrays::StructArray;
+    use crate::assert_arrays_eq;
+    use crate::builtins::ArrayBuiltins;
+    use crate::dtype::DType;
+    use crate::dtype::Nullability;
+    use crate::expr::Expression;
+    use crate::expr::col;
+    use crate::expr::test_harness;
+    use crate::scalar_fn::ScalarFnVTableExt;
+    use crate::scalar_fn::fns::operators::Operator;
+
+    #[rstest]
+    #[case(
+        BoolArray::from_iter([Some(true), Some(true), Some(false), Some(false)]).into_array(),
+        BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)]).into_array(),
+    )]
+    fn test_or(#[case] lhs: ArrayRef, #[case] rhs: ArrayRef) {
+        let r = lhs.binary(rhs, Operator::Or).unwrap();
+        let v0 = r.scalar_at(0).unwrap().as_bool().value();
+        let v1 = r.scalar_at(1).unwrap().as_bool().value();
+        let v2 = r.scalar_at(2).unwrap().as_bool().value();
+        let v3 = r.scalar_at(3).unwrap().as_bool().value();
+        assert!(v0.unwrap());
+        assert!(v1.unwrap());
+        assert!(v2.unwrap());
+        assert!(!v3.unwrap());
+    }
+
+    #[rstest]
+    #[case(
+        BoolArray::from_iter([Some(true), Some(true), Some(false), Some(false)]).into_array(),
+        BoolArray::from_iter([Some(true), Some(false), Some(true), Some(false)]).into_array(),
+    )]
+    fn test_and(#[case] lhs: ArrayRef, #[case] rhs: ArrayRef) {
+        let r = lhs.binary(rhs, Operator::And).unwrap();
+        let v0 = r.scalar_at(0).unwrap().as_bool().value();
+        let v1 = r.scalar_at(1).unwrap().as_bool().value();
+        let v2 = r.scalar_at(2).unwrap().as_bool().value();
+        let v3 = r.scalar_at(3).unwrap().as_bool().value();
+        assert!(v0.unwrap());
+        assert!(!v1.unwrap());
+        assert!(!v2.unwrap());
+        assert!(!v3.unwrap());
+    }
+
+    #[test]
+    fn test_or_kleene_validity() {
+        let struct_arr = StructArray::from_fields(&[
+            ("a", BoolArray::from_iter([Some(true)]).into_array()),
+            (
+                "b",
+                BoolArray::from_iter([Option::<bool>::None]).into_array(),
+            ),
+        ])
+        .unwrap()
+        .into_array();
+
+        let expr = LogicalBinary.new_expr(LogicalOp::Or, [col("a"), col("b")]);
+        let result = struct_arr.apply(&expr).unwrap();
+        assert_arrays_eq!(result, BoolArray::from_iter([Some(true)]).into_array());
+    }
+
+    #[test]
+    fn test_return_dtype() {
+        let dtype = test_harness::struct_dtype();
+        let bool1: Expression = col("bool1");
+        let bool2: Expression = col("bool2");
+
+        let and_expr = LogicalBinary.new_expr(LogicalOp::And, [bool1.clone(), bool2.clone()]);
+        assert_eq!(
+            and_expr.return_dtype(&dtype).unwrap(),
+            DType::Bool(Nullability::NonNullable)
+        );
+
+        let or_expr = LogicalBinary.new_expr(LogicalOp::Or, [bool1, bool2]);
+        assert_eq!(
+            or_expr.return_dtype(&dtype).unwrap(),
+            DType::Bool(Nullability::NonNullable)
+        );
+    }
+
+    #[test]
+    fn test_display() {
+        let expr = LogicalBinary.new_expr(LogicalOp::And, [col("a"), col("b")]);
+        assert_eq!(format!("{expr}"), "($.a and $.b)");
+    }
+}

--- a/vortex-array/src/scalar_fn/fns/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/mod.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+pub mod arithmetic;
 pub mod between;
 pub mod binary;
 pub mod case_when;
 pub mod cast;
+pub mod comparison;
 pub mod dynamic;
 pub mod fill_null;
 pub mod get_item;
@@ -12,6 +14,7 @@ pub mod is_null;
 pub mod like;
 pub mod list_contains;
 pub mod literal;
+pub mod logical;
 pub mod mask;
 pub mod merge;
 pub mod not;

--- a/vortex-array/src/scalar_fn/fns/operators.rs
+++ b/vortex-array/src/scalar_fn/fns/operators.rs
@@ -8,6 +8,12 @@ use std::fmt::Formatter;
 use vortex_error::VortexError;
 use vortex_proto::expr::binary_opts::BinaryOp;
 
+// Re-export operator types that have moved to their own modules, so that existing
+// `use …::operators::CompareOperator` paths continue to work.
+pub use super::arithmetic::ArithmeticOp;
+pub use super::comparison::CompareOperator;
+pub use super::logical::LogicalOp;
+
 /// Equalities, inequalities, and boolean operations over possibly null values.
 ///
 /// For most operations, if either side is null, the result is null.
@@ -175,95 +181,5 @@ impl Operator {
             self,
             Self::Eq | Self::NotEq | Self::Gt | Self::Gte | Self::Lt | Self::Lte
         )
-    }
-}
-
-/// The six comparison operators, providing compile-time guarantees that only
-/// comparison variants are used where comparisons are expected.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum CompareOperator {
-    /// Expressions are equal.
-    Eq,
-    /// Expressions are not equal.
-    NotEq,
-    /// Expression is greater than another.
-    Gt,
-    /// Expression is greater or equal to another.
-    Gte,
-    /// Expression is less than another.
-    Lt,
-    /// Expression is less or equal to another.
-    Lte,
-}
-
-impl CompareOperator {
-    /// Return the logical inverse of this comparison operator.
-    pub fn inverse(self) -> Self {
-        match self {
-            CompareOperator::Eq => CompareOperator::NotEq,
-            CompareOperator::NotEq => CompareOperator::Eq,
-            CompareOperator::Gt => CompareOperator::Lte,
-            CompareOperator::Gte => CompareOperator::Lt,
-            CompareOperator::Lt => CompareOperator::Gte,
-            CompareOperator::Lte => CompareOperator::Gt,
-        }
-    }
-
-    /// Swap the sides of the operator so that swapping lhs and rhs preserves the result.
-    pub fn swap(self) -> Self {
-        match self {
-            CompareOperator::Eq => CompareOperator::Eq,
-            CompareOperator::NotEq => CompareOperator::NotEq,
-            CompareOperator::Gt => CompareOperator::Lt,
-            CompareOperator::Gte => CompareOperator::Lte,
-            CompareOperator::Lt => CompareOperator::Gt,
-            CompareOperator::Lte => CompareOperator::Gte,
-        }
-    }
-}
-
-impl Display for CompareOperator {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let display = match self {
-            CompareOperator::Eq => "=",
-            CompareOperator::NotEq => "!=",
-            CompareOperator::Gt => ">",
-            CompareOperator::Gte => ">=",
-            CompareOperator::Lt => "<",
-            CompareOperator::Lte => "<=",
-        };
-        Display::fmt(display, f)
-    }
-}
-
-impl From<CompareOperator> for Operator {
-    fn from(value: CompareOperator) -> Self {
-        match value {
-            CompareOperator::Eq => Operator::Eq,
-            CompareOperator::NotEq => Operator::NotEq,
-            CompareOperator::Gt => Operator::Gt,
-            CompareOperator::Gte => Operator::Gte,
-            CompareOperator::Lt => Operator::Lt,
-            CompareOperator::Lte => Operator::Lte,
-        }
-    }
-}
-
-impl TryFrom<Operator> for CompareOperator {
-    type Error = VortexError;
-
-    fn try_from(value: Operator) -> Result<Self, Self::Error> {
-        match value {
-            Operator::Eq => Ok(CompareOperator::Eq),
-            Operator::NotEq => Ok(CompareOperator::NotEq),
-            Operator::Gt => Ok(CompareOperator::Gt),
-            Operator::Gte => Ok(CompareOperator::Gte),
-            Operator::Lt => Ok(CompareOperator::Lt),
-            Operator::Lte => Ok(CompareOperator::Lte),
-            other => Err(vortex_error::vortex_err!(
-                InvalidArgument: "{other} is not a comparison operator"
-            )),
-        }
     }
 }

--- a/vortex-array/src/scalar_fn/session.rs
+++ b/vortex-array/src/scalar_fn/session.rs
@@ -9,15 +9,18 @@ use vortex_session::registry::Registry;
 
 use crate::scalar_fn::ScalarFnPluginRef;
 use crate::scalar_fn::ScalarFnVTable;
+use crate::scalar_fn::fns::arithmetic::Arithmetic;
 use crate::scalar_fn::fns::between::Between;
 use crate::scalar_fn::fns::binary::Binary;
 use crate::scalar_fn::fns::cast::Cast;
+use crate::scalar_fn::fns::comparison::Comparison;
 use crate::scalar_fn::fns::fill_null::FillNull;
 use crate::scalar_fn::fns::get_item::GetItem;
 use crate::scalar_fn::fns::is_null::IsNull;
 use crate::scalar_fn::fns::like::Like;
 use crate::scalar_fn::fns::list_contains::ListContains;
 use crate::scalar_fn::fns::literal::Literal;
+use crate::scalar_fn::fns::logical::LogicalBinary;
 use crate::scalar_fn::fns::merge::Merge;
 use crate::scalar_fn::fns::not::Not;
 use crate::scalar_fn::fns::pack::Pack;
@@ -53,8 +56,10 @@ impl Default for ScalarFnSession {
         };
 
         // Register built-in expressions.
+        this.register(Arithmetic);
         this.register(Between);
         this.register(Binary);
+        this.register(Comparison);
         this.register(Cast);
         this.register(FillNull);
         this.register(GetItem);
@@ -62,6 +67,7 @@ impl Default for ScalarFnSession {
         this.register(Like);
         this.register(ListContains);
         this.register(Literal);
+        this.register(LogicalBinary);
         this.register(Merge);
         this.register(Not);
         this.register(Pack);

--- a/vortex-proto/proto/expr.proto
+++ b/vortex-proto/proto/expr.proto
@@ -81,6 +81,42 @@ message SelectOpts {
   }
 }
 
+// Options for `vortex.logical_binary`
+message LogicalBinaryOpts {
+  LogicalBinaryOp op = 1;
+
+  enum LogicalBinaryOp {
+    And = 0;
+    Or = 1;
+  }
+}
+
+// Options for `vortex.comparison`
+message ComparisonOpts {
+  ComparisonOp op = 1;
+
+  enum ComparisonOp {
+    Eq = 0;
+    NotEq = 1;
+    Gt = 2;
+    Gte = 3;
+    Lt = 4;
+    Lte = 5;
+  }
+}
+
+// Options for `vortex.arithmetic`
+message ArithmeticOpts {
+  ArithmeticOp op = 1;
+
+  enum ArithmeticOp {
+    Add = 0;
+    Sub = 1;
+    Mul = 2;
+    Div = 3;
+  }
+}
+
 // Options for `vortex.case_when`
 // Encodes num_when_then_pairs and has_else into a single u32 (num_children).
 // num_children = num_when_then_pairs * 2 + (has_else ? 1 : 0)

--- a/vortex-proto/public-api.lock
+++ b/vortex-proto/public-api.lock
@@ -610,6 +610,74 @@ pub fn vortex_proto::dtype::Utf8::encoded_len(&self) -> usize
 
 pub mod vortex_proto::expr
 
+pub mod vortex_proto::expr::arithmetic_opts
+
+#[repr(i32)] pub enum vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub vortex_proto::expr::arithmetic_opts::ArithmeticOp::Add = 0
+
+pub vortex_proto::expr::arithmetic_opts::ArithmeticOp::Div = 3
+
+pub vortex_proto::expr::arithmetic_opts::ArithmeticOp::Mul = 2
+
+pub vortex_proto::expr::arithmetic_opts::ArithmeticOp::Sub = 1
+
+impl vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::as_str_name(&self) -> &'static str
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::from_str_name(value: &str) -> core::option::Option<Self>
+
+impl vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::from_i32(value: i32) -> core::option::Option<vortex_proto::expr::arithmetic_opts::ArithmeticOp>
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::is_valid(value: i32) -> bool
+
+impl core::clone::Clone for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::clone(&self) -> vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+impl core::cmp::Eq for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+impl core::cmp::Ord for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::cmp(&self, other: &vortex_proto::expr::arithmetic_opts::ArithmeticOp) -> core::cmp::Ordering
+
+impl core::cmp::PartialEq for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::eq(&self, other: &vortex_proto::expr::arithmetic_opts::ArithmeticOp) -> bool
+
+impl core::cmp::PartialOrd for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::partial_cmp(&self, other: &vortex_proto::expr::arithmetic_opts::ArithmeticOp) -> core::option::Option<core::cmp::Ordering>
+
+impl core::convert::From<vortex_proto::expr::arithmetic_opts::ArithmeticOp> for i32
+
+pub fn i32::from(value: vortex_proto::expr::arithmetic_opts::ArithmeticOp) -> i32
+
+impl core::convert::TryFrom<i32> for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub type vortex_proto::expr::arithmetic_opts::ArithmeticOp::Error = prost::error::UnknownEnumValue
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::try_from(value: i32) -> core::result::Result<vortex_proto::expr::arithmetic_opts::ArithmeticOp, prost::error::UnknownEnumValue>
+
+impl core::default::Default for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::default() -> vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+impl core::fmt::Debug for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::arithmetic_opts::ArithmeticOp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+impl core::marker::StructuralPartialEq for vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
 pub mod vortex_proto::expr::binary_opts
 
 #[repr(i32)] pub enum vortex_proto::expr::binary_opts::BinaryOp
@@ -694,6 +762,142 @@ impl core::marker::Copy for vortex_proto::expr::binary_opts::BinaryOp
 
 impl core::marker::StructuralPartialEq for vortex_proto::expr::binary_opts::BinaryOp
 
+pub mod vortex_proto::expr::comparison_opts
+
+#[repr(i32)] pub enum vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub vortex_proto::expr::comparison_opts::ComparisonOp::Eq = 0
+
+pub vortex_proto::expr::comparison_opts::ComparisonOp::Gt = 2
+
+pub vortex_proto::expr::comparison_opts::ComparisonOp::Gte = 3
+
+pub vortex_proto::expr::comparison_opts::ComparisonOp::Lt = 4
+
+pub vortex_proto::expr::comparison_opts::ComparisonOp::Lte = 5
+
+pub vortex_proto::expr::comparison_opts::ComparisonOp::NotEq = 1
+
+impl vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::as_str_name(&self) -> &'static str
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::from_str_name(value: &str) -> core::option::Option<Self>
+
+impl vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::from_i32(value: i32) -> core::option::Option<vortex_proto::expr::comparison_opts::ComparisonOp>
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::is_valid(value: i32) -> bool
+
+impl core::clone::Clone for vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::clone(&self) -> vortex_proto::expr::comparison_opts::ComparisonOp
+
+impl core::cmp::Eq for vortex_proto::expr::comparison_opts::ComparisonOp
+
+impl core::cmp::Ord for vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::cmp(&self, other: &vortex_proto::expr::comparison_opts::ComparisonOp) -> core::cmp::Ordering
+
+impl core::cmp::PartialEq for vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::eq(&self, other: &vortex_proto::expr::comparison_opts::ComparisonOp) -> bool
+
+impl core::cmp::PartialOrd for vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::partial_cmp(&self, other: &vortex_proto::expr::comparison_opts::ComparisonOp) -> core::option::Option<core::cmp::Ordering>
+
+impl core::convert::From<vortex_proto::expr::comparison_opts::ComparisonOp> for i32
+
+pub fn i32::from(value: vortex_proto::expr::comparison_opts::ComparisonOp) -> i32
+
+impl core::convert::TryFrom<i32> for vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub type vortex_proto::expr::comparison_opts::ComparisonOp::Error = prost::error::UnknownEnumValue
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::try_from(value: i32) -> core::result::Result<vortex_proto::expr::comparison_opts::ComparisonOp, prost::error::UnknownEnumValue>
+
+impl core::default::Default for vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::default() -> vortex_proto::expr::comparison_opts::ComparisonOp
+
+impl core::fmt::Debug for vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub fn vortex_proto::expr::comparison_opts::ComparisonOp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_proto::expr::comparison_opts::ComparisonOp
+
+impl core::marker::StructuralPartialEq for vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub mod vortex_proto::expr::logical_binary_opts
+
+#[repr(i32)] pub enum vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::And = 0
+
+pub vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::Or = 1
+
+impl vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::as_str_name(&self) -> &'static str
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::from_str_name(value: &str) -> core::option::Option<Self>
+
+impl vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::from_i32(value: i32) -> core::option::Option<vortex_proto::expr::logical_binary_opts::LogicalBinaryOp>
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::is_valid(value: i32) -> bool
+
+impl core::clone::Clone for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::clone(&self) -> vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+impl core::cmp::Eq for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+impl core::cmp::Ord for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::cmp(&self, other: &vortex_proto::expr::logical_binary_opts::LogicalBinaryOp) -> core::cmp::Ordering
+
+impl core::cmp::PartialEq for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::eq(&self, other: &vortex_proto::expr::logical_binary_opts::LogicalBinaryOp) -> bool
+
+impl core::cmp::PartialOrd for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::partial_cmp(&self, other: &vortex_proto::expr::logical_binary_opts::LogicalBinaryOp) -> core::option::Option<core::cmp::Ordering>
+
+impl core::convert::From<vortex_proto::expr::logical_binary_opts::LogicalBinaryOp> for i32
+
+pub fn i32::from(value: vortex_proto::expr::logical_binary_opts::LogicalBinaryOp) -> i32
+
+impl core::convert::TryFrom<i32> for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub type vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::Error = prost::error::UnknownEnumValue
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::try_from(value: i32) -> core::result::Result<vortex_proto::expr::logical_binary_opts::LogicalBinaryOp, prost::error::UnknownEnumValue>
+
+impl core::default::Default for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::default() -> vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+impl core::fmt::Debug for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::logical_binary_opts::LogicalBinaryOp::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+impl core::marker::StructuralPartialEq for vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
 pub mod vortex_proto::expr::select_opts
 
 pub enum vortex_proto::expr::select_opts::Opts
@@ -729,6 +933,48 @@ impl core::hash::Hash for vortex_proto::expr::select_opts::Opts
 pub fn vortex_proto::expr::select_opts::Opts::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 
 impl core::marker::StructuralPartialEq for vortex_proto::expr::select_opts::Opts
+
+pub struct vortex_proto::expr::ArithmeticOpts
+
+pub vortex_proto::expr::ArithmeticOpts::op: i32
+
+impl vortex_proto::expr::ArithmeticOpts
+
+pub fn vortex_proto::expr::ArithmeticOpts::op(&self) -> vortex_proto::expr::arithmetic_opts::ArithmeticOp
+
+pub fn vortex_proto::expr::ArithmeticOpts::set_op(&mut self, value: vortex_proto::expr::arithmetic_opts::ArithmeticOp)
+
+impl core::clone::Clone for vortex_proto::expr::ArithmeticOpts
+
+pub fn vortex_proto::expr::ArithmeticOpts::clone(&self) -> vortex_proto::expr::ArithmeticOpts
+
+impl core::cmp::Eq for vortex_proto::expr::ArithmeticOpts
+
+impl core::cmp::PartialEq for vortex_proto::expr::ArithmeticOpts
+
+pub fn vortex_proto::expr::ArithmeticOpts::eq(&self, other: &vortex_proto::expr::ArithmeticOpts) -> bool
+
+impl core::default::Default for vortex_proto::expr::ArithmeticOpts
+
+pub fn vortex_proto::expr::ArithmeticOpts::default() -> Self
+
+impl core::fmt::Debug for vortex_proto::expr::ArithmeticOpts
+
+pub fn vortex_proto::expr::ArithmeticOpts::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_proto::expr::ArithmeticOpts
+
+pub fn vortex_proto::expr::ArithmeticOpts::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_proto::expr::ArithmeticOpts
+
+impl core::marker::StructuralPartialEq for vortex_proto::expr::ArithmeticOpts
+
+impl prost::message::Message for vortex_proto::expr::ArithmeticOpts
+
+pub fn vortex_proto::expr::ArithmeticOpts::clear(&mut self)
+
+pub fn vortex_proto::expr::ArithmeticOpts::encoded_len(&self) -> usize
 
 pub struct vortex_proto::expr::BetweenOpts
 
@@ -873,6 +1119,48 @@ impl prost::message::Message for vortex_proto::expr::CastOpts
 pub fn vortex_proto::expr::CastOpts::clear(&mut self)
 
 pub fn vortex_proto::expr::CastOpts::encoded_len(&self) -> usize
+
+pub struct vortex_proto::expr::ComparisonOpts
+
+pub vortex_proto::expr::ComparisonOpts::op: i32
+
+impl vortex_proto::expr::ComparisonOpts
+
+pub fn vortex_proto::expr::ComparisonOpts::op(&self) -> vortex_proto::expr::comparison_opts::ComparisonOp
+
+pub fn vortex_proto::expr::ComparisonOpts::set_op(&mut self, value: vortex_proto::expr::comparison_opts::ComparisonOp)
+
+impl core::clone::Clone for vortex_proto::expr::ComparisonOpts
+
+pub fn vortex_proto::expr::ComparisonOpts::clone(&self) -> vortex_proto::expr::ComparisonOpts
+
+impl core::cmp::Eq for vortex_proto::expr::ComparisonOpts
+
+impl core::cmp::PartialEq for vortex_proto::expr::ComparisonOpts
+
+pub fn vortex_proto::expr::ComparisonOpts::eq(&self, other: &vortex_proto::expr::ComparisonOpts) -> bool
+
+impl core::default::Default for vortex_proto::expr::ComparisonOpts
+
+pub fn vortex_proto::expr::ComparisonOpts::default() -> Self
+
+impl core::fmt::Debug for vortex_proto::expr::ComparisonOpts
+
+pub fn vortex_proto::expr::ComparisonOpts::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_proto::expr::ComparisonOpts
+
+pub fn vortex_proto::expr::ComparisonOpts::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_proto::expr::ComparisonOpts
+
+impl core::marker::StructuralPartialEq for vortex_proto::expr::ComparisonOpts
+
+impl prost::message::Message for vortex_proto::expr::ComparisonOpts
+
+pub fn vortex_proto::expr::ComparisonOpts::clear(&mut self)
+
+pub fn vortex_proto::expr::ComparisonOpts::encoded_len(&self) -> usize
 
 pub struct vortex_proto::expr::Expr
 
@@ -1043,6 +1331,48 @@ impl prost::message::Message for vortex_proto::expr::LiteralOpts
 pub fn vortex_proto::expr::LiteralOpts::clear(&mut self)
 
 pub fn vortex_proto::expr::LiteralOpts::encoded_len(&self) -> usize
+
+pub struct vortex_proto::expr::LogicalBinaryOpts
+
+pub vortex_proto::expr::LogicalBinaryOpts::op: i32
+
+impl vortex_proto::expr::LogicalBinaryOpts
+
+pub fn vortex_proto::expr::LogicalBinaryOpts::op(&self) -> vortex_proto::expr::logical_binary_opts::LogicalBinaryOp
+
+pub fn vortex_proto::expr::LogicalBinaryOpts::set_op(&mut self, value: vortex_proto::expr::logical_binary_opts::LogicalBinaryOp)
+
+impl core::clone::Clone for vortex_proto::expr::LogicalBinaryOpts
+
+pub fn vortex_proto::expr::LogicalBinaryOpts::clone(&self) -> vortex_proto::expr::LogicalBinaryOpts
+
+impl core::cmp::Eq for vortex_proto::expr::LogicalBinaryOpts
+
+impl core::cmp::PartialEq for vortex_proto::expr::LogicalBinaryOpts
+
+pub fn vortex_proto::expr::LogicalBinaryOpts::eq(&self, other: &vortex_proto::expr::LogicalBinaryOpts) -> bool
+
+impl core::default::Default for vortex_proto::expr::LogicalBinaryOpts
+
+pub fn vortex_proto::expr::LogicalBinaryOpts::default() -> Self
+
+impl core::fmt::Debug for vortex_proto::expr::LogicalBinaryOpts
+
+pub fn vortex_proto::expr::LogicalBinaryOpts::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_proto::expr::LogicalBinaryOpts
+
+pub fn vortex_proto::expr::LogicalBinaryOpts::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_proto::expr::LogicalBinaryOpts
+
+impl core::marker::StructuralPartialEq for vortex_proto::expr::LogicalBinaryOpts
+
+impl prost::message::Message for vortex_proto::expr::LogicalBinaryOpts
+
+pub fn vortex_proto::expr::LogicalBinaryOpts::clear(&mut self)
+
+pub fn vortex_proto::expr::LogicalBinaryOpts::encoded_len(&self) -> usize
 
 pub struct vortex_proto::expr::PackOpts
 

--- a/vortex-proto/src/generated/vortex.expr.rs
+++ b/vortex-proto/src/generated/vortex.expr.rs
@@ -145,6 +145,159 @@ pub mod select_opts {
         Exclude(super::FieldNames),
     }
 }
+/// Options for `vortex.logical_binary`
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct LogicalBinaryOpts {
+    #[prost(enumeration = "logical_binary_opts::LogicalBinaryOp", tag = "1")]
+    pub op: i32,
+}
+/// Nested message and enum types in `LogicalBinaryOpts`.
+pub mod logical_binary_opts {
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum LogicalBinaryOp {
+        And = 0,
+        Or = 1,
+    }
+    impl LogicalBinaryOp {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::And => "And",
+                Self::Or => "Or",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "And" => Some(Self::And),
+                "Or" => Some(Self::Or),
+                _ => None,
+            }
+        }
+    }
+}
+/// Options for `vortex.comparison`
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ComparisonOpts {
+    #[prost(enumeration = "comparison_opts::ComparisonOp", tag = "1")]
+    pub op: i32,
+}
+/// Nested message and enum types in `ComparisonOpts`.
+pub mod comparison_opts {
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum ComparisonOp {
+        Eq = 0,
+        NotEq = 1,
+        Gt = 2,
+        Gte = 3,
+        Lt = 4,
+        Lte = 5,
+    }
+    impl ComparisonOp {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::Eq => "Eq",
+                Self::NotEq => "NotEq",
+                Self::Gt => "Gt",
+                Self::Gte => "Gte",
+                Self::Lt => "Lt",
+                Self::Lte => "Lte",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "Eq" => Some(Self::Eq),
+                "NotEq" => Some(Self::NotEq),
+                "Gt" => Some(Self::Gt),
+                "Gte" => Some(Self::Gte),
+                "Lt" => Some(Self::Lt),
+                "Lte" => Some(Self::Lte),
+                _ => None,
+            }
+        }
+    }
+}
+/// Options for `vortex.arithmetic`
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ArithmeticOpts {
+    #[prost(enumeration = "arithmetic_opts::ArithmeticOp", tag = "1")]
+    pub op: i32,
+}
+/// Nested message and enum types in `ArithmeticOpts`.
+pub mod arithmetic_opts {
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum ArithmeticOp {
+        Add = 0,
+        Sub = 1,
+        Mul = 2,
+        Div = 3,
+    }
+    impl ArithmeticOp {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Self::Add => "Add",
+                Self::Sub => "Sub",
+                Self::Mul => "Mul",
+                Self::Div => "Div",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "Add" => Some(Self::Add),
+                "Sub" => Some(Self::Sub),
+                "Mul" => Some(Self::Mul),
+                "Div" => Some(Self::Div),
+                _ => None,
+            }
+        }
+    }
+}
 /// Options for `vortex.case_when`
 /// Encodes num_when_then_pairs and has_else into a single u32 (num_children).
 /// num_children = num_when_then_pairs * 2 + (has_else ? 1 : 0)


### PR DESCRIPTION
Edit: im not convinced of this PR, but the benchmarks have surfaced some interesting results. So digging in

---
Adds new scalar functions for comparison, arithmetic, and logical operators.

Previously the single binary function typically just switched on the logic for each of these, making it much harder to read and follow.

This also gives us more granular kernel selection, e.g. for arrays that wish to provide a comparison kernel we would previously have to invoke the kernel for _any_ binary function.