### PR TITLE
Support execute/reduce for extension types

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -1688,6 +1688,34 @@ pub fn vortex_array::arrays::dict::take_canonical(values: vortex_array::Canonica
 
 pub mod vortex_array::arrays::extension
 
+pub struct vortex_array::arrays::extension::ExactExtArray<V: vortex_array::dtype::extension::ExtVTable>(_)
+
+impl<V: core::default::Default + vortex_array::dtype::extension::ExtVTable> core::default::Default for vortex_array::arrays::extension::ExactExtArray<V>
+
+pub fn vortex_array::arrays::extension::ExactExtArray<V>::default() -> vortex_array::arrays::extension::ExactExtArray<V>
+
+impl<V: core::fmt::Debug + vortex_array::dtype::extension::ExtVTable> core::fmt::Debug for vortex_array::arrays::extension::ExactExtArray<V>
+
+pub fn vortex_array::arrays::extension::ExactExtArray<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<V: vortex_array::dtype::extension::ExtVTable> vortex_array::matcher::Matcher for vortex_array::arrays::extension::ExactExtArray<V>
+
+pub type vortex_array::arrays::extension::ExactExtArray<V>::Match<'a> = vortex_array::arrays::extension::ExtArray<'a, V>
+
+pub fn vortex_array::arrays::extension::ExactExtArray<V>::matches(array: &dyn vortex_array::DynArray) -> bool
+
+pub fn vortex_array::arrays::extension::ExactExtArray<V>::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+
+pub struct vortex_array::arrays::extension::ExtArray<'a, V: vortex_array::dtype::extension::ExtVTable>
+
+impl<'a, V: vortex_array::dtype::extension::ExtVTable> vortex_array::arrays::extension::ExtArray<'a, V>
+
+pub fn vortex_array::arrays::extension::ExtArray<'a, V>::ext_dtype(&self) -> &vortex_array::dtype::extension::ExtDType<V>
+
+pub fn vortex_array::arrays::extension::ExtArray<'a, V>::storage_array(&self) -> &vortex_array::ArrayRef
+
+pub fn vortex_array::arrays::extension::ExtArray<'a, V>::try_new(array: &'a vortex_array::arrays::ExtensionArray) -> core::option::Option<Self>
+
 pub struct vortex_array::arrays::extension::Extension
 
 impl vortex_array::arrays::Extension
@@ -1805,6 +1833,8 @@ pub fn vortex_array::arrays::Extension::validity_child(array: &vortex_array::arr
 pub struct vortex_array::arrays::extension::ExtensionArray
 
 impl vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::downcast_ref<V: vortex_array::dtype::extension::ExtVTable>(&self) -> core::option::Option<vortex_array::arrays::extension::ExtArray<'_, V>>
 
 pub fn vortex_array::arrays::ExtensionArray::ext_dtype(&self) -> &vortex_array::dtype::extension::ExtDTypeRef
 
@@ -5619,6 +5649,8 @@ pub fn vortex_array::arrays::Extension::validity_child(array: &vortex_array::arr
 pub struct vortex_array::arrays::ExtensionArray
 
 impl vortex_array::arrays::ExtensionArray
+
+pub fn vortex_array::arrays::ExtensionArray::downcast_ref<V: vortex_array::dtype::extension::ExtVTable>(&self) -> core::option::Option<vortex_array::arrays::extension::ExtArray<'_, V>>
 
 pub fn vortex_array::arrays::ExtensionArray::ext_dtype(&self) -> &vortex_array::dtype::extension::ExtDTypeRef
 
@@ -10196,6 +10228,8 @@ impl vortex_array::dtype::extension::ExtDTypeRef
 
 pub fn vortex_array::dtype::extension::ExtDTypeRef::downcast<V: vortex_array::dtype::extension::ExtVTable>(self) -> alloc::sync::Arc<vortex_array::dtype::extension::ExtDType<V>>
 
+pub fn vortex_array::dtype::extension::ExtDTypeRef::downcast_ref<V: vortex_array::dtype::extension::ExtVTable>(&self) -> core::option::Option<&vortex_array::dtype::extension::ExtDType<V>>
+
 pub fn vortex_array::dtype::extension::ExtDTypeRef::is<M: vortex_array::dtype::extension::Matcher>(&self) -> bool
 
 pub fn vortex_array::dtype::extension::ExtDTypeRef::metadata<M: vortex_array::dtype::extension::Matcher>(&self) -> <M as vortex_array::dtype::extension::Matcher>::Match
@@ -10250,9 +10284,13 @@ pub fn vortex_array::dtype::extension::ExtVTable::can_coerce_to(&self, ext_dtype
 
 pub fn vortex_array::dtype::extension::ExtVTable::deserialize_metadata(&self, metadata: &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::dtype::extension::ExtVTable::execute_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::dtype::extension::ExtVTable::id(&self) -> vortex_array::dtype::extension::ExtId
 
 pub fn vortex_array::dtype::extension::ExtVTable::least_supertype(&self, ext_dtype: &vortex_array::dtype::extension::ExtDType<Self>, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::dtype::extension::ExtVTable::reduce_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::dtype::extension::ExtVTable::serialize_metadata(&self, metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -10274,9 +10312,13 @@ pub fn vortex_array::extension::datetime::Date::can_coerce_to(&self, ext_dtype: 
 
 pub fn vortex_array::extension::datetime::Date::deserialize_metadata(&self, metadata: &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::extension::datetime::Date::execute_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::extension::datetime::Date::id(&self) -> vortex_array::dtype::extension::ExtId
 
 pub fn vortex_array::extension::datetime::Date::least_supertype(&self, ext_dtype: &vortex_array::dtype::extension::ExtDType<Self>, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::extension::datetime::Date::reduce_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::extension::datetime::Date::serialize_metadata(&self, metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -10298,9 +10340,13 @@ pub fn vortex_array::extension::datetime::Time::can_coerce_to(&self, ext_dtype: 
 
 pub fn vortex_array::extension::datetime::Time::deserialize_metadata(&self, data: &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::extension::datetime::Time::execute_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::extension::datetime::Time::id(&self) -> vortex_array::dtype::extension::ExtId
 
 pub fn vortex_array::extension::datetime::Time::least_supertype(&self, ext_dtype: &vortex_array::dtype::extension::ExtDType<Self>, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::extension::datetime::Time::reduce_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::extension::datetime::Time::serialize_metadata(&self, metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -10322,9 +10368,13 @@ pub fn vortex_array::extension::datetime::Timestamp::can_coerce_to(&self, ext_dt
 
 pub fn vortex_array::extension::datetime::Timestamp::deserialize_metadata(&self, data: &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::extension::datetime::Timestamp::execute_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::extension::datetime::Timestamp::id(&self) -> vortex_array::dtype::extension::ExtId
 
 pub fn vortex_array::extension::datetime::Timestamp::least_supertype(&self, ext_dtype: &vortex_array::dtype::extension::ExtDType<Self>, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::extension::datetime::Timestamp::reduce_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::extension::datetime::Timestamp::serialize_metadata(&self, metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -10346,9 +10396,13 @@ pub fn vortex_array::extension::uuid::Uuid::can_coerce_to(&self, ext_dtype: &vor
 
 pub fn vortex_array::extension::uuid::Uuid::deserialize_metadata(&self, metadata: &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::extension::uuid::Uuid::execute_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::extension::uuid::Uuid::id(&self) -> vortex_array::dtype::extension::ExtId
 
 pub fn vortex_array::extension::uuid::Uuid::least_supertype(&self, ext_dtype: &vortex_array::dtype::extension::ExtDType<Self>, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::extension::uuid::Uuid::reduce_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::extension::uuid::Uuid::serialize_metadata(&self, metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -14070,6 +14124,8 @@ pub vortex_array::extension::datetime::TimeUnit::Seconds = 3
 
 impl vortex_array::extension::datetime::TimeUnit
 
+pub fn vortex_array::extension::datetime::TimeUnit::nanos_per_unit(&self) -> i64
+
 pub fn vortex_array::extension::datetime::TimeUnit::to_jiff_span(&self, v: i64) -> vortex_error::VortexResult<jiff::span::Span>
 
 impl core::clone::Clone for vortex_array::extension::datetime::TimeUnit
@@ -14212,9 +14268,13 @@ pub fn vortex_array::extension::datetime::Date::can_coerce_to(&self, ext_dtype: 
 
 pub fn vortex_array::extension::datetime::Date::deserialize_metadata(&self, metadata: &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::extension::datetime::Date::execute_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::extension::datetime::Date::id(&self) -> vortex_array::dtype::extension::ExtId
 
 pub fn vortex_array::extension::datetime::Date::least_supertype(&self, ext_dtype: &vortex_array::dtype::extension::ExtDType<Self>, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::extension::datetime::Date::reduce_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::extension::datetime::Date::serialize_metadata(&self, metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -14268,9 +14328,13 @@ pub fn vortex_array::extension::datetime::Time::can_coerce_to(&self, ext_dtype: 
 
 pub fn vortex_array::extension::datetime::Time::deserialize_metadata(&self, data: &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::extension::datetime::Time::execute_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::extension::datetime::Time::id(&self) -> vortex_array::dtype::extension::ExtId
 
 pub fn vortex_array::extension::datetime::Time::least_supertype(&self, ext_dtype: &vortex_array::dtype::extension::ExtDType<Self>, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::extension::datetime::Time::reduce_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::extension::datetime::Time::serialize_metadata(&self, metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -14326,9 +14390,13 @@ pub fn vortex_array::extension::datetime::Timestamp::can_coerce_to(&self, ext_dt
 
 pub fn vortex_array::extension::datetime::Timestamp::deserialize_metadata(&self, data: &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::extension::datetime::Timestamp::execute_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::extension::datetime::Timestamp::id(&self) -> vortex_array::dtype::extension::ExtId
 
 pub fn vortex_array::extension::datetime::Timestamp::least_supertype(&self, ext_dtype: &vortex_array::dtype::extension::ExtDType<Self>, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::extension::datetime::Timestamp::reduce_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::extension::datetime::Timestamp::serialize_metadata(&self, metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -14408,9 +14476,13 @@ pub fn vortex_array::extension::uuid::Uuid::can_coerce_to(&self, ext_dtype: &vor
 
 pub fn vortex_array::extension::uuid::Uuid::deserialize_metadata(&self, metadata: &[u8]) -> vortex_error::VortexResult<Self::Metadata>
 
+pub fn vortex_array::extension::uuid::Uuid::execute_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
+
 pub fn vortex_array::extension::uuid::Uuid::id(&self) -> vortex_array::dtype::extension::ExtId
 
 pub fn vortex_array::extension::uuid::Uuid::least_supertype(&self, ext_dtype: &vortex_array::dtype::extension::ExtDType<Self>, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
+pub fn vortex_array::extension::uuid::Uuid::reduce_parent_array(&self, array: &vortex_array::arrays::extension::ExtArray<'_, Self>, parent: &vortex_array::ArrayRef, child_idx: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::ArrayRef>>
 
 pub fn vortex_array::extension::uuid::Uuid::serialize_metadata(&self, metadata: &Self::Metadata) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
@@ -14705,6 +14777,14 @@ pub type vortex_array::arrays::scalar_fn::ExactScalarFn<F>::Match<'a> = vortex_a
 pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::matches(array: &dyn vortex_array::DynArray) -> bool
 
 pub fn vortex_array::arrays::scalar_fn::ExactScalarFn<F>::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
+
+impl<V: vortex_array::dtype::extension::ExtVTable> vortex_array::matcher::Matcher for vortex_array::arrays::extension::ExactExtArray<V>
+
+pub type vortex_array::arrays::extension::ExactExtArray<V>::Match<'a> = vortex_array::arrays::extension::ExtArray<'a, V>
+
+pub fn vortex_array::arrays::extension::ExactExtArray<V>::matches(array: &dyn vortex_array::DynArray) -> bool
+
+pub fn vortex_array::arrays::extension::ExactExtArray<V>::try_match(array: &dyn vortex_array::DynArray) -> core::option::Option<Self::Match>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::matcher::Matcher for V
 

--- a/vortex-array/src/arrays/extension/array.rs
+++ b/vortex-array/src/arrays/extension/array.rs
@@ -5,8 +5,10 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::arrays::extension::view::ExtArray;
 use crate::dtype::DType;
 use crate::dtype::extension::ExtDTypeRef;
+use crate::dtype::extension::ExtVTable;
 use crate::stats::ArrayStats;
 
 /// An extension array that wraps another array with additional type information.
@@ -124,5 +126,9 @@ impl ExtensionArray {
 
     pub fn storage_array(&self) -> &ArrayRef {
         &self.storage_array
+    }
+
+    pub fn downcast_ref<V: ExtVTable>(&self) -> Option<ExtArray<'_, V>> {
+        ExtArray::try_new(self)
     }
 }

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -11,20 +11,19 @@ use crate::scalar_fn::fns::cast::CastReduce;
 
 impl CastReduce for Extension {
     fn cast(array: &ExtensionArray, dtype: &DType) -> vortex_error::VortexResult<Option<ArrayRef>> {
-        // Try casting the internal storage of the extension array.
+        // Fast path: same extension type (ignoring nullability), just cast the storage.
         if array.dtype().eq_ignore_nullability(dtype) {
             let DType::Extension(ext_dtype) = dtype else {
                 unreachable!("Already verified we have an extension dtype");
             };
 
-            if let Some(new_storage) = array
+            let new_storage = array
                 .storage_array()
-                .cast(ext_dtype.storage_dtype().clone())?
-            {
-                return Ok(Some(
-                    ExtensionArray::new(ext_dtype.clone(), new_storage).into_array(),
-                ));
-            };
+                .cast(ext_dtype.storage_dtype().clone())?;
+
+            return Ok(Some(
+                ExtensionArray::new(ext_dtype.clone(), new_storage).into_array(),
+            ));
         }
 
         // Otherwise we defer to the extension vtable.
@@ -82,21 +81,68 @@ mod tests {
     }
 
     #[test]
-    fn cast_different_ext_dtype() {
-        let original_dtype =
+    fn cast_timestamp_ms_to_ns() {
+        let source_dtype =
             Timestamp::new(TimeUnit::Milliseconds, Nullability::NonNullable).erased();
-        // Note NS here instead of MS
         let target_dtype = Timestamp::new(TimeUnit::Nanoseconds, Nullability::NonNullable).erased();
 
-        let storage = buffer![1i64].into_array();
-        let arr = ExtensionArray::new(original_dtype, storage);
+        let storage = buffer![1i64, 2, 3].into_array();
+        let arr = ExtensionArray::new(source_dtype, storage).into_array();
 
-        assert!(
-            arr.into_array()
-                .cast(DType::Extension(target_dtype))
-                .and_then(|a| a.to_canonical().map(|c| c.into_array()))
-                .is_err()
-        );
+        let result = arr.cast(DType::Extension(target_dtype.clone())).unwrap();
+        assert_eq!(result.dtype(), &DType::Extension(target_dtype));
+
+        // Verify values were scaled: ms → ns is ×1_000_000
+        let ext = result.to_canonical().unwrap().as_extension().clone();
+        let prim = ext
+            .storage_array()
+            .to_canonical()
+            .unwrap()
+            .as_primitive()
+            .clone();
+        assert_eq!(prim.as_slice::<i64>(), &[1_000_000, 2_000_000, 3_000_000]);
+    }
+
+    #[test]
+    fn cast_timestamp_s_to_us() {
+        let source_dtype = Timestamp::new(TimeUnit::Seconds, Nullability::NonNullable).erased();
+        let target_dtype =
+            Timestamp::new(TimeUnit::Microseconds, Nullability::NonNullable).erased();
+
+        let storage = buffer![10i64, 20].into_array();
+        let arr = ExtensionArray::new(source_dtype, storage).into_array();
+
+        let result = arr.cast(DType::Extension(target_dtype)).unwrap();
+        let ext = result.to_canonical().unwrap().as_extension().clone();
+        let prim = ext
+            .storage_array()
+            .to_canonical()
+            .unwrap()
+            .as_primitive()
+            .clone();
+        assert_eq!(prim.as_slice::<i64>(), &[10_000_000, 20_000_000]);
+    }
+
+    #[test]
+    fn cast_timestamp_tz_mismatch_fails() {
+        use std::sync::Arc;
+
+        let utc_dtype = Timestamp::new_with_tz(
+            TimeUnit::Seconds,
+            Some(Arc::from("UTC")),
+            Nullability::NonNullable,
+        )
+        .erased();
+        let no_tz_dtype = Timestamp::new(TimeUnit::Nanoseconds, Nullability::NonNullable).erased();
+
+        let storage = buffer![1i64].into_array();
+        let arr = ExtensionArray::new(utc_dtype, storage).into_array();
+
+        // Timezone mismatch: cast creates a lazy expression, error surfaces on evaluation.
+        let result = arr
+            .cast(DType::Extension(no_tz_dtype))
+            .and_then(|a| a.to_canonical().map(|c| c.into_array()));
+        assert!(result.is_err());
     }
 
     #[rstest]

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -11,7 +11,7 @@ use crate::scalar_fn::fns::cast::CastReduce;
 
 impl CastReduce for Extension {
     fn cast(array: &ExtensionArray, dtype: &DType) -> vortex_error::VortexResult<Option<ArrayRef>> {
-        // Fast path: same extension type (ignoring nullability), just cast the storage.
+        // Same extension type (ignoring nullability): just cast the storage nullability.
         if array.dtype().eq_ignore_nullability(dtype) {
             let DType::Extension(ext_dtype) = dtype else {
                 unreachable!("Already verified we have an extension dtype");
@@ -26,8 +26,9 @@ impl CastReduce for Extension {
             ));
         }
 
-        // Otherwise we defer to the extension vtable.
-        array.ext_dtype().cast_from_ext(array, dtype)
+        // Type-specific casting (e.g. Timestamp(s) → Timestamp(ns)) is handled by
+        // ExtVTable::reduce_parent_array, which runs before this CastReduce fallback.
+        Ok(None)
     }
 }
 

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -11,28 +11,24 @@ use crate::scalar_fn::fns::cast::CastReduce;
 
 impl CastReduce for Extension {
     fn cast(array: &ExtensionArray, dtype: &DType) -> vortex_error::VortexResult<Option<ArrayRef>> {
-        if !array.dtype().eq_ignore_nullability(dtype) {
-            return Ok(None);
+        // Try casting the internal storage of the extension array.
+        if array.dtype().eq_ignore_nullability(dtype) {
+            let DType::Extension(ext_dtype) = dtype else {
+                unreachable!("Already verified we have an extension dtype");
+            };
+
+            if let Some(new_storage) = array
+                .storage_array()
+                .cast(ext_dtype.storage_dtype().clone())?
+            {
+                return Ok(Some(
+                    ExtensionArray::new(ext_dtype.clone(), new_storage).into_array(),
+                ));
+            };
         }
 
-        let DType::Extension(ext_dtype) = dtype else {
-            unreachable!("Already verified we have an extension dtype");
-        };
-
-        let new_storage = match array
-            .storage_array()
-            .cast(ext_dtype.storage_dtype().clone())
-        {
-            Ok(arr) => arr,
-            Err(e) => {
-                tracing::warn!("Failed to cast storage array: {e}");
-                return Ok(None);
-            }
-        };
-
-        Ok(Some(
-            ExtensionArray::new(ext_dtype.clone(), new_storage).into_array(),
-        ))
+        // Otherwise we defer to the extension vtable.
+        array.ext_dtype().cast_from_ext(array, dtype)
     }
 }
 

--- a/vortex-array/src/arrays/extension/mod.rs
+++ b/vortex-array/src/arrays/extension/mod.rs
@@ -5,6 +5,7 @@ mod array;
 pub use array::ExtensionArray;
 
 mod view;
+pub use view::ExactExtArray;
 pub use view::ExtArray;
 
 pub(crate) mod compute;

--- a/vortex-array/src/arrays/extension/mod.rs
+++ b/vortex-array/src/arrays/extension/mod.rs
@@ -4,7 +4,11 @@
 mod array;
 pub use array::ExtensionArray;
 
+mod view;
+pub use view::ExtArray;
+
 pub(crate) mod compute;
 
 mod vtable;
+
 pub use vtable::Extension;

--- a/vortex-array/src/arrays/extension/view.rs
+++ b/vortex-array/src/arrays/extension/view.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use crate::ArrayRef;
+use crate::arrays::ExtensionArray;
+use crate::dtype::extension::ExtDType;
+use crate::dtype::extension::ExtVTable;
+
+/// A typed view of an extension array.
+pub struct ExtArray<'a, V: ExtVTable> {
+    ext_dtype: &'a ExtDType<V>,
+    array: &'a ExtensionArray,
+}
+
+impl<'a, V: ExtVTable> ExtArray<'a, V> {
+    pub fn try_new(array: &'a ExtensionArray) -> Option<Self> {
+        let ext_dtype = array.ext_dtype().downcast_ref::<V>()?;
+        Some(Self { ext_dtype, array })
+    }
+
+    pub fn ext_dtype(&self) -> &ExtDType<V> {
+        self.ext_dtype
+    }
+
+    pub fn storage_array(&self) -> &ArrayRef {
+        self.array.storage_array()
+    }
+}

--- a/vortex-array/src/arrays/extension/view.rs
+++ b/vortex-array/src/arrays/extension/view.rs
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::marker::PhantomData;
+
 use crate::ArrayRef;
+use crate::DynArray;
+use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
 use crate::dtype::extension::ExtDType;
 use crate::dtype::extension::ExtVTable;
+use crate::matcher::Matcher;
 
 /// A typed view of an extension array.
 pub struct ExtArray<'a, V: ExtVTable> {
@@ -24,5 +29,29 @@ impl<'a, V: ExtVTable> ExtArray<'a, V> {
 
     pub fn storage_array(&self) -> &ArrayRef {
         self.array.storage_array()
+    }
+}
+
+/// A matcher that matches an [`ExtensionArray`] with a specific [`ExtVTable`] type.
+///
+/// Similar to [`ExactScalarFn`](crate::arrays::scalar_fn::ExactScalarFn) for scalar functions,
+/// this provides typed access to the extension array view ([`ExtArray<V>`]).
+#[derive(Debug, Default)]
+pub struct ExactExtArray<V: ExtVTable>(PhantomData<V>);
+
+impl<V: ExtVTable> Matcher for ExactExtArray<V> {
+    type Match<'a> = ExtArray<'a, V>;
+
+    fn matches(array: &dyn DynArray) -> bool {
+        if let Some(ext_array) = array.as_opt::<Extension>() {
+            ext_array.downcast_ref::<V>().is_some()
+        } else {
+            false
+        }
+    }
+
+    fn try_match(array: &dyn DynArray) -> Option<Self::Match<'_>> {
+        let ext_array = array.as_opt::<Extension>()?;
+        ext_array.downcast_ref::<V>()
     }
 }

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -157,21 +157,30 @@ impl VTable for Extension {
         Ok(ExecutionStep::Done(array.clone().into_array()))
     }
 
-    fn reduce_parent(
-        array: &Self::Array,
-        parent: &ArrayRef,
-        child_idx: usize,
-    ) -> VortexResult<Option<ArrayRef>> {
-        PARENT_RULES.evaluate(array, parent, child_idx)
-    }
-
     fn execute_parent(
         array: &Self::Array,
         parent: &ArrayRef,
         child_idx: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
+        if let Some(result) = array
+            .ext_dtype()
+            .execute_parent(array, parent, child_idx, ctx)?
+        {
+            return Ok(Some(result));
+        }
         PARENT_KERNELS.execute(array, parent, child_idx, ctx)
+    }
+
+    fn reduce_parent(
+        array: &Self::Array,
+        parent: &ArrayRef,
+        child_idx: usize,
+    ) -> VortexResult<Option<ArrayRef>> {
+        if let Some(result) = array.ext_dtype().reduce_parent(array, parent, child_idx)? {
+            return Ok(Some(result));
+        }
+        PARENT_RULES.evaluate(array, parent, child_idx)
     }
 }
 

--- a/vortex-array/src/dtype/coercion.rs
+++ b/vortex-array/src/dtype/coercion.rs
@@ -205,6 +205,13 @@ impl DType {
 
     /// Convenience — is there a path from `self` to `other`?
     pub fn can_coerce_to(&self, other: &DType) -> bool {
+        if let DType::Extension(ext) = self {
+            // Extension types can define coercions in either direction, so check both.
+            if ext.can_coerce_to(other) {
+                return true;
+            }
+        };
+
         other.can_coerce_from(self)
     }
 

--- a/vortex-array/src/dtype/extension/erased.rs
+++ b/vortex-array/src/dtype/extension/erased.rs
@@ -14,6 +14,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::arrays::ExtensionArray;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -117,23 +118,23 @@ impl ExtDTypeRef {
         self.0.coercion_least_supertype(other)
     }
 
-    /// Attempt to cast the extension array to the target dtype.
-    pub fn cast_into_ext(&self, array: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
-        self.0.cast_into_ext(array, self)
-    }
-
-    /// Attempt to cast the extension array to the target dtype.
-    pub fn cast_from_ext(
+    pub(crate) fn execute_parent(
         &self,
         array: &ExtensionArray,
-        target: &DType,
+        parent: &ArrayRef,
+        child_idx: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        if let Some(ext_dtype) = array.dtype().as_extension_opt()
-            && ext_dtype != self
-        {
-            return Ok(None);
-        }
-        self.0.cast_from_ext(array, target)
+        self.0.execute_parent_array(array, parent, child_idx, ctx)
+    }
+
+    pub(crate) fn reduce_parent(
+        &self,
+        array: &ExtensionArray,
+        parent: &ArrayRef,
+        child_idx: usize,
+    ) -> VortexResult<Option<ArrayRef>> {
+        self.0.reduce_parent_array(array, parent, child_idx)
     }
 }
 

--- a/vortex-array/src/dtype/extension/erased.rs
+++ b/vortex-array/src/dtype/extension/erased.rs
@@ -9,10 +9,12 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
 
+use arrow_array::ArrayRef;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
+use crate::arrays::ExtensionArray;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::extension::ExtDType;
@@ -114,6 +116,25 @@ impl ExtDTypeRef {
     pub fn least_supertype(&self, other: &DType) -> Option<DType> {
         self.0.coercion_least_supertype(other)
     }
+
+    /// Attempt to cast the extension array to the target dtype.
+    pub fn cast_into_ext(&self, array: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
+        self.0.cast_into_ext(array, self)
+    }
+
+    /// Attempt to cast the extension array to the target dtype.
+    pub fn cast_from_ext(
+        &self,
+        array: &ExtensionArray,
+        target: &DType,
+    ) -> VortexResult<Option<ArrayRef>> {
+        if let Some(ext_dtype) = array.dtype().as_extension_opt() {
+            if ext_dtype != self {
+                return Ok(None);
+            }
+        };
+        self.0.cast_from_ext(array, target)
+    }
 }
 
 /// Methods for downcasting type-erased extension dtypes.
@@ -165,6 +186,11 @@ impl ExtDTypeRef {
                 )
             })
             .vortex_expect("Failed to downcast ExtDTypeRef")
+    }
+
+    /// Downcast to the concrete [`ExtDType`].
+    pub fn downcast_ref<V: ExtVTable>(&self) -> Option<&ExtDType<V>> {
+        self.0.as_any().downcast_ref::<ExtDType<V>>()
     }
 }
 

--- a/vortex-array/src/dtype/extension/erased.rs
+++ b/vortex-array/src/dtype/extension/erased.rs
@@ -9,11 +9,11 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
 
-use arrow_array::ArrayRef;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
+use crate::ArrayRef;
 use crate::arrays::ExtensionArray;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -128,11 +128,11 @@ impl ExtDTypeRef {
         array: &ExtensionArray,
         target: &DType,
     ) -> VortexResult<Option<ArrayRef>> {
-        if let Some(ext_dtype) = array.dtype().as_extension_opt() {
-            if ext_dtype != self {
-                return Ok(None);
-            }
-        };
+        if let Some(ext_dtype) = array.dtype().as_extension_opt()
+            && ext_dtype != self
+        {
+            return Ok(None);
+        }
         self.0.cast_from_ext(array, target)
     }
 }

--- a/vortex-array/src/dtype/extension/typed.rs
+++ b/vortex-array/src/dtype/extension/typed.rs
@@ -18,6 +18,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::arrays::ExtensionArray;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -132,17 +133,18 @@ pub(super) trait DynExtDType: 'static + Send + Sync + super::sealed::Sealed {
     fn coercion_can_coerce_to(&self, other: &DType) -> bool;
     /// Compute the least supertype of this extension type and another type.
     fn coercion_least_supertype(&self, other: &DType) -> Option<DType>;
-    /// Attempt to cast an array into this extension dtype.
-    fn cast_into_ext(
-        &self,
-        array: &ArrayRef,
-        target: &ExtDTypeRef,
-    ) -> VortexResult<Option<ArrayRef>>;
-    /// Attempt to cast this extension array into a target dtype.
-    fn cast_from_ext(
+    fn execute_parent_array(
         &self,
         array: &ExtensionArray,
-        target: &DType,
+        parent: &ArrayRef,
+        child_idx: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>>;
+    fn reduce_parent_array(
+        &self,
+        array: &ExtensionArray,
+        parent: &ArrayRef,
+        child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>>;
 }
 
@@ -228,29 +230,35 @@ impl<V: ExtVTable> DynExtDType for ExtDType<V> {
         self.vtable.least_supertype(self, other)
     }
 
-    fn cast_into_ext(
-        &self,
-        array: &ArrayRef,
-        target: &ExtDTypeRef,
-    ) -> VortexResult<Option<ArrayRef>> {
-        self.vtable.cast_into_ext(
-            array,
-            target
-                .downcast_ref()
-                .ok_or_else(|| vortex_err!("Target is not an extension dtype"))?,
-        )
-    }
-
-    fn cast_from_ext(
+    fn execute_parent_array(
         &self,
         array: &ExtensionArray,
-        target: &DType,
+        parent: &ArrayRef,
+        child_idx: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        self.vtable.cast_from_ext(
+        self.vtable.execute_parent_array(
             &array
                 .downcast_ref()
                 .ok_or_else(|| vortex_err!("Array is not an extension array of this type"))?,
-            target,
+            parent,
+            child_idx,
+            ctx,
+        )
+    }
+
+    fn reduce_parent_array(
+        &self,
+        array: &ExtensionArray,
+        parent: &ArrayRef,
+        child_idx: usize,
+    ) -> VortexResult<Option<ArrayRef>> {
+        self.vtable.reduce_parent_array(
+            &array
+                .downcast_ref()
+                .ok_or_else(|| vortex_err!("Array is not an extension array of this type"))?,
+            parent,
+            child_idx,
         )
     }
 }

--- a/vortex-array/src/dtype/extension/typed.rs
+++ b/vortex-array/src/dtype/extension/typed.rs
@@ -15,7 +15,10 @@ use std::sync::Arc;
 
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_err;
 
+use crate::ArrayRef;
+use crate::arrays::ExtensionArray;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::extension::ExtDTypeRef;
@@ -129,6 +132,18 @@ pub(super) trait DynExtDType: 'static + Send + Sync + super::sealed::Sealed {
     fn coercion_can_coerce_to(&self, other: &DType) -> bool;
     /// Compute the least supertype of this extension type and another type.
     fn coercion_least_supertype(&self, other: &DType) -> Option<DType>;
+    /// Attempt to cast an array into this extension dtype.
+    fn cast_into_ext(
+        &self,
+        array: &ArrayRef,
+        target: &ExtDTypeRef,
+    ) -> VortexResult<Option<ArrayRef>>;
+    /// Attempt to cast this extension array into a target dtype.
+    fn cast_from_ext(
+        &self,
+        array: &ExtensionArray,
+        target: &DType,
+    ) -> VortexResult<Option<ArrayRef>>;
 }
 
 impl<V: ExtVTable> DynExtDType for ExtDType<V> {
@@ -211,5 +226,31 @@ impl<V: ExtVTable> DynExtDType for ExtDType<V> {
 
     fn coercion_least_supertype(&self, other: &DType) -> Option<DType> {
         self.vtable.least_supertype(self, other)
+    }
+
+    fn cast_into_ext(
+        &self,
+        array: &ArrayRef,
+        target: &ExtDTypeRef,
+    ) -> VortexResult<Option<ArrayRef>> {
+        self.vtable.cast_into_ext(
+            array,
+            target
+                .downcast_ref()
+                .ok_or_else(|| vortex_err!("Target is not an extension dtype"))?,
+        )
+    }
+
+    fn cast_from_ext(
+        &self,
+        array: &ExtensionArray,
+        target: &DType,
+    ) -> VortexResult<Option<ArrayRef>> {
+        self.vtable.cast_from_ext(
+            &array
+                .downcast_ref()
+                .ok_or_else(|| vortex_err!("Array is not an extension array of this type"))?,
+            target,
+        )
     }
 }

--- a/vortex-array/src/dtype/extension/vtable.rs
+++ b/vortex-array/src/dtype/extension/vtable.rs
@@ -101,6 +101,9 @@ pub trait ExtVTable: 'static + Sized + Send + Sync + Clone + Debug + Eq + Hash {
 
     /// Cast an array into this extension DType.
     ///
+    /// Note that this function does not take an execution context. It is expected that the
+    /// implementation can be expressed via operations on the storage array.
+    ///
     /// Returns `None` if the cast is not possible.
     fn cast_into_ext(
         &self,
@@ -112,6 +115,11 @@ pub trait ExtVTable: 'static + Sized + Send + Sync + Clone + Debug + Eq + Hash {
     }
 
     /// Cast an array of this extension DType into another DType.
+    ///
+    /// Note that this function does not take an execution context. It is expected that the
+    /// implementation can be expressed via operations on the storage array.
+    ///
+    /// Returns `None` if the cast is not possible.
     fn cast_from_ext(
         &self,
         array: &ExtArray<Self>,

--- a/vortex-array/src/dtype/extension/vtable.rs
+++ b/vortex-array/src/dtype/extension/vtable.rs
@@ -8,6 +8,7 @@ use std::hash::Hash;
 use vortex_error::VortexResult;
 
 use crate::ArrayRef;
+use crate::ExecutionCtx;
 use crate::arrays::extension::ExtArray;
 use crate::dtype::DType;
 use crate::dtype::extension::ExtDType;
@@ -67,8 +68,6 @@ pub trait ExtVTable: 'static + Sized + Send + Sync + Clone + Debug + Eq + Hash {
         None
     }
 
-    // Methods related to the extension scalar values.
-
     /// Validate the given storage value is compatible with the extension type.
     ///
     /// By default, this calls [`unpack_native()`](ExtVTable::unpack_native) and discards the result.
@@ -99,33 +98,30 @@ pub trait ExtVTable: 'static + Sized + Send + Sync + Clone + Debug + Eq + Hash {
         storage_value: &'a ScalarValue,
     ) -> VortexResult<Self::NativeValue<'a>>;
 
-    /// Cast an array into this extension DType.
+    /// Execute the extension array's parent.
     ///
-    /// Note that this function does not take an execution context. It is expected that the
-    /// implementation can be expressed via operations on the storage array.
-    ///
-    /// Returns `None` if the cast is not possible.
-    fn cast_into_ext(
+    /// See [`crate::vtable::VTable::execute_parent`]
+    fn execute_parent_array(
         &self,
-        array: &ArrayRef,
-        target: &ExtDType<Self>,
+        array: &ExtArray<Self>,
+        parent: &ArrayRef,
+        child_idx: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        let _ = (array, target);
+        let _ = (array, parent, child_idx, ctx);
         Ok(None)
     }
 
-    /// Cast an array of this extension DType into another DType.
+    /// Reduce the extension array's parent.
     ///
-    /// Note that this function does not take an execution context. It is expected that the
-    /// implementation can be expressed via operations on the storage array.
-    ///
-    /// Returns `None` if the cast is not possible.
-    fn cast_from_ext(
+    /// See [`crate::vtable::VTable::reduce_parent`]
+    fn reduce_parent_array(
         &self,
         array: &ExtArray<Self>,
-        target: &DType,
+        parent: &ArrayRef,
+        child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
-        let _ = (array, target);
+        let _ = (array, parent, child_idx);
         Ok(None)
     }
 }

--- a/vortex-array/src/dtype/extension/vtable.rs
+++ b/vortex-array/src/dtype/extension/vtable.rs
@@ -7,6 +7,8 @@ use std::hash::Hash;
 
 use vortex_error::VortexResult;
 
+use crate::ArrayRef;
+use crate::arrays::extension::ExtArray;
 use crate::dtype::DType;
 use crate::dtype::extension::ExtDType;
 use crate::dtype::extension::ExtId;
@@ -96,4 +98,26 @@ pub trait ExtVTable: 'static + Sized + Send + Sync + Clone + Debug + Eq + Hash {
         ext_dtype: &'a ExtDType<Self>,
         storage_value: &'a ScalarValue,
     ) -> VortexResult<Self::NativeValue<'a>>;
+
+    /// Cast an array into this extension DType.
+    ///
+    /// Returns `None` if the cast is not possible.
+    fn cast_into_ext(
+        &self,
+        array: &ArrayRef,
+        target: &ExtDType<Self>,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let _ = (array, target);
+        Ok(None)
+    }
+
+    /// Cast an array of this extension DType into another DType.
+    fn cast_from_ext(
+        &self,
+        array: &ExtArray<Self>,
+        target: &DType,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let _ = (array, target);
+        Ok(None)
+    }
 }

--- a/vortex-array/src/extension/datetime/date.rs
+++ b/vortex-array/src/extension/datetime/date.rs
@@ -15,6 +15,7 @@ use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::ExtensionArray;
 use crate::arrays::extension::ExtArray;
+use crate::arrays::scalar_fn::ExactScalarFn;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -23,7 +24,9 @@ use crate::dtype::extension::ExtDType;
 use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ExtVTable;
 use crate::extension::datetime::TimeUnit;
+use crate::matcher::Matcher;
 use crate::scalar::ScalarValue;
+use crate::scalar_fn::fns::cast::Cast;
 use crate::scalar_fn::fns::operators::Operator;
 
 /// The Unix epoch date (1970-01-01).
@@ -136,11 +139,18 @@ impl ExtVTable for Date {
         Some(DType::Extension(Date::new(finest, union_null).erased()))
     }
 
-    fn cast_from_ext(
+    fn reduce_parent_array(
         &self,
         array: &ExtArray<Self>,
-        target: &DType,
+        parent: &ArrayRef,
+        child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
+        let _ = child_idx;
+        let Some(cast_view) = ExactScalarFn::<Cast>::try_match(parent.as_ref()) else {
+            return Ok(None);
+        };
+        let target = cast_view.options;
+
         let DType::Extension(target_ext) = target else {
             return Ok(None);
         };

--- a/vortex-array/src/extension/datetime/date.rs
+++ b/vortex-array/src/extension/datetime/date.rs
@@ -10,6 +10,12 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 
+use crate::ArrayRef;
+use crate::IntoArray;
+use crate::arrays::ConstantArray;
+use crate::arrays::ExtensionArray;
+use crate::arrays::extension::ExtArray;
+use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
@@ -18,6 +24,7 @@ use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ExtVTable;
 use crate::extension::datetime::TimeUnit;
 use crate::scalar::ScalarValue;
+use crate::scalar_fn::fns::operators::Operator;
 
 /// The Unix epoch date (1970-01-01).
 const EPOCH: jiff::civil::Date = jiff::civil::Date::constant(1970, 1, 1);
@@ -129,6 +136,48 @@ impl ExtVTable for Date {
         Some(DType::Extension(Date::new(finest, union_null).erased()))
     }
 
+    fn cast_from_ext(
+        &self,
+        array: &ExtArray<Self>,
+        target: &DType,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let DType::Extension(target_ext) = target else {
+            return Ok(None);
+        };
+        let Some(target_unit) = target_ext.metadata_opt::<Date>() else {
+            return Ok(None);
+        };
+        let source_unit = array.ext_dtype().metadata();
+
+        let source_nanos = source_unit.nanos_per_unit();
+        let target_nanos = target_unit.nanos_per_unit();
+
+        // Cast storage to target ptype first (e.g. i32 → i64 for Days → Ms).
+        let storage = array
+            .storage_array()
+            .cast(target_ext.storage_dtype().clone())?;
+
+        let storage = if source_nanos == target_nanos {
+            storage
+        } else if source_nanos > target_nanos {
+            let factor = source_nanos / target_nanos;
+            storage.binary(
+                ConstantArray::new(factor, storage.len()).into_array(),
+                Operator::Mul,
+            )?
+        } else {
+            let factor = target_nanos / source_nanos;
+            storage.binary(
+                ConstantArray::new(factor, storage.len()).into_array(),
+                Operator::Div,
+            )?
+        };
+
+        Ok(Some(
+            ExtensionArray::new(target_ext.clone(), storage).into_array(),
+        ))
+    }
+
     fn unpack_native(
         &self,
         ext_dtype: &ExtDType<Self>,
@@ -209,5 +258,33 @@ mod tests {
         let ms = DType::Extension(Date::new(TimeUnit::Milliseconds, NonNullable).erased());
         assert!(ms.can_coerce_from(&days));
         assert!(!days.can_coerce_from(&ms));
+    }
+
+    #[test]
+    fn cast_date_days_to_ms() {
+        use vortex_buffer::buffer;
+
+        use crate::IntoArray;
+        use crate::arrays::ExtensionArray;
+        use crate::builtins::ArrayBuiltins;
+        use crate::dtype::Nullability::NonNullable;
+
+        let source_dtype = Date::new(TimeUnit::Days, NonNullable).erased();
+        let target_dtype = Date::new(TimeUnit::Milliseconds, NonNullable).erased();
+
+        // 1 day and 2 days since epoch
+        let storage = buffer![1i32, 2].into_array();
+        let arr = ExtensionArray::new(source_dtype, storage).into_array();
+
+        let result = arr.cast(DType::Extension(target_dtype)).unwrap();
+        let ext = result.to_canonical().unwrap().as_extension().clone();
+        let prim = ext
+            .storage_array()
+            .to_canonical()
+            .unwrap()
+            .as_primitive()
+            .clone();
+        // Days → Ms: ×86_400_000
+        assert_eq!(prim.as_slice::<i64>(), &[86_400_000i64, 172_800_000]);
     }
 }

--- a/vortex-array/src/extension/datetime/time.rs
+++ b/vortex-array/src/extension/datetime/time.rs
@@ -10,6 +10,12 @@ use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 
+use crate::ArrayRef;
+use crate::IntoArray;
+use crate::arrays::ConstantArray;
+use crate::arrays::ExtensionArray;
+use crate::arrays::extension::ExtArray;
+use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
@@ -18,6 +24,7 @@ use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ExtVTable;
 use crate::extension::datetime::TimeUnit;
 use crate::scalar::ScalarValue;
+use crate::scalar_fn::fns::operators::Operator;
 
 /// Time DType.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -129,6 +136,48 @@ impl ExtVTable for Time {
         Some(DType::Extension(Time::new(finest, union_null).erased()))
     }
 
+    fn cast_from_ext(
+        &self,
+        array: &ExtArray<Self>,
+        target: &DType,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let DType::Extension(target_ext) = target else {
+            return Ok(None);
+        };
+        let Some(target_unit) = target_ext.metadata_opt::<Time>() else {
+            return Ok(None);
+        };
+        let source_unit = array.ext_dtype().metadata();
+
+        let source_nanos = source_unit.nanos_per_unit();
+        let target_nanos = target_unit.nanos_per_unit();
+
+        // Cast storage to target ptype first (e.g. i32 → i64 for Seconds → Nanoseconds).
+        let storage = array
+            .storage_array()
+            .cast(target_ext.storage_dtype().clone())?;
+
+        let storage = if source_nanos == target_nanos {
+            storage
+        } else if source_nanos > target_nanos {
+            let factor = source_nanos / target_nanos;
+            storage.binary(
+                ConstantArray::new(factor, storage.len()).into_array(),
+                Operator::Mul,
+            )?
+        } else {
+            let factor = target_nanos / source_nanos;
+            storage.binary(
+                ConstantArray::new(factor, storage.len()).into_array(),
+                Operator::Div,
+            )?
+        };
+
+        Ok(Some(
+            ExtensionArray::new(target_ext.clone(), storage).into_array(),
+        ))
+    }
+
     fn unpack_native(
         &self,
         ext_dtype: &ExtDType<Self>,
@@ -219,5 +268,32 @@ mod tests {
         let expected = DType::Extension(Time::new(TimeUnit::Nanoseconds, NonNullable).erased());
         assert_eq!(secs.least_supertype(&ns).unwrap(), expected);
         assert_eq!(ns.least_supertype(&secs).unwrap(), expected);
+    }
+
+    #[test]
+    fn cast_time_seconds_to_nanoseconds() {
+        use vortex_buffer::buffer;
+
+        use crate::IntoArray;
+        use crate::arrays::ExtensionArray;
+        use crate::builtins::ArrayBuiltins;
+        use crate::dtype::Nullability::NonNullable;
+
+        let source_dtype = Time::new(TimeUnit::Seconds, NonNullable).erased();
+        let target_dtype = Time::new(TimeUnit::Nanoseconds, NonNullable).erased();
+
+        let storage = buffer![1i32, 2].into_array();
+        let arr = ExtensionArray::new(source_dtype, storage).into_array();
+
+        let result = arr.cast(DType::Extension(target_dtype)).unwrap();
+        let ext = result.to_canonical().unwrap().as_extension().clone();
+        let prim = ext
+            .storage_array()
+            .to_canonical()
+            .unwrap()
+            .as_primitive()
+            .clone();
+        // Seconds → Nanoseconds: ×1_000_000_000
+        assert_eq!(prim.as_slice::<i64>(), &[1_000_000_000i64, 2_000_000_000]);
     }
 }

--- a/vortex-array/src/extension/datetime/time.rs
+++ b/vortex-array/src/extension/datetime/time.rs
@@ -15,6 +15,7 @@ use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::ExtensionArray;
 use crate::arrays::extension::ExtArray;
+use crate::arrays::scalar_fn::ExactScalarFn;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -23,7 +24,9 @@ use crate::dtype::extension::ExtDType;
 use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ExtVTable;
 use crate::extension::datetime::TimeUnit;
+use crate::matcher::Matcher;
 use crate::scalar::ScalarValue;
+use crate::scalar_fn::fns::cast::Cast;
 use crate::scalar_fn::fns::operators::Operator;
 
 /// Time DType.
@@ -136,11 +139,18 @@ impl ExtVTable for Time {
         Some(DType::Extension(Time::new(finest, union_null).erased()))
     }
 
-    fn cast_from_ext(
+    fn reduce_parent_array(
         &self,
         array: &ExtArray<Self>,
-        target: &DType,
+        parent: &ArrayRef,
+        child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
+        let _ = child_idx;
+        let Some(cast_view) = ExactScalarFn::<Cast>::try_match(parent.as_ref()) else {
+            return Ok(None);
+        };
+        let target = cast_view.options;
+
         let DType::Extension(target_ext) = target else {
             return Ok(None);
         };

--- a/vortex-array/src/extension/datetime/timestamp.rs
+++ b/vortex-array/src/extension/datetime/timestamp.rs
@@ -14,6 +14,12 @@ use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 
+use crate::ArrayRef;
+use crate::IntoArray;
+use crate::arrays::ConstantArray;
+use crate::arrays::ExtensionArray;
+use crate::arrays::extension::ExtArray;
+use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
@@ -22,6 +28,7 @@ use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ExtVTable;
 use crate::extension::datetime::TimeUnit;
 use crate::scalar::ScalarValue;
+use crate::scalar_fn::fns::operators::Operator;
 
 /// Timestamp DType.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -195,6 +202,48 @@ impl ExtVTable for Timestamp {
         let union_null = ext_dtype.storage_dtype().nullability() | other.nullability();
         Some(DType::Extension(
             Timestamp::new_with_tz(finest, our_opts.tz.clone(), union_null).erased(),
+        ))
+    }
+
+    fn cast_from_ext(
+        &self,
+        array: &ExtArray<Self>,
+        target: &DType,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let DType::Extension(target_ext) = target else {
+            return Ok(None);
+        };
+        let Some(target_opts) = target_ext.metadata_opt::<Timestamp>() else {
+            return Ok(None);
+        };
+        let source_opts = array.ext_dtype().metadata();
+        if source_opts.tz != target_opts.tz {
+            return Ok(None);
+        }
+
+        let source_nanos = source_opts.unit.nanos_per_unit();
+        let target_nanos = target_opts.unit.nanos_per_unit();
+
+        let storage = if source_nanos == target_nanos {
+            array
+                .storage_array()
+                .cast(target_ext.storage_dtype().clone())?
+        } else if source_nanos > target_nanos {
+            let factor = source_nanos / target_nanos;
+            array.storage_array().binary(
+                ConstantArray::new(factor, array.storage_array().len()).into_array(),
+                Operator::Mul,
+            )?
+        } else {
+            let factor = target_nanos / source_nanos;
+            array.storage_array().binary(
+                ConstantArray::new(factor, array.storage_array().len()).into_array(),
+                Operator::Div,
+            )?
+        };
+
+        Ok(Some(
+            ExtensionArray::new(target_ext.clone(), storage).into_array(),
         ))
     }
 

--- a/vortex-array/src/extension/datetime/timestamp.rs
+++ b/vortex-array/src/extension/datetime/timestamp.rs
@@ -19,6 +19,7 @@ use crate::IntoArray;
 use crate::arrays::ConstantArray;
 use crate::arrays::ExtensionArray;
 use crate::arrays::extension::ExtArray;
+use crate::arrays::scalar_fn::ExactScalarFn;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
@@ -27,7 +28,9 @@ use crate::dtype::extension::ExtDType;
 use crate::dtype::extension::ExtId;
 use crate::dtype::extension::ExtVTable;
 use crate::extension::datetime::TimeUnit;
+use crate::matcher::Matcher;
 use crate::scalar::ScalarValue;
+use crate::scalar_fn::fns::cast::Cast;
 use crate::scalar_fn::fns::operators::Operator;
 
 /// Timestamp DType.
@@ -205,11 +208,18 @@ impl ExtVTable for Timestamp {
         ))
     }
 
-    fn cast_from_ext(
+    fn reduce_parent_array(
         &self,
         array: &ExtArray<Self>,
-        target: &DType,
+        parent: &ArrayRef,
+        child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
+        let _ = child_idx;
+        let Some(cast_view) = ExactScalarFn::<Cast>::try_match(parent.as_ref()) else {
+            return Ok(None);
+        };
+        let target = cast_view.options;
+
         let DType::Extension(target_ext) = target else {
             return Ok(None);
         };

--- a/vortex-array/src/extension/datetime/unit.rs
+++ b/vortex-array/src/extension/datetime/unit.rs
@@ -43,6 +43,17 @@ impl TryFrom<u8> for TimeUnit {
 }
 
 impl TimeUnit {
+    /// Returns the number of nanoseconds per unit of this time unit.
+    pub fn nanos_per_unit(&self) -> i64 {
+        match self {
+            TimeUnit::Nanoseconds => 1,
+            TimeUnit::Microseconds => 1_000,
+            TimeUnit::Milliseconds => 1_000_000,
+            TimeUnit::Seconds => 1_000_000_000,
+            TimeUnit::Days => 86_400_000_000_000,
+        }
+    }
+
     /// Convert to a Jiff span.
     pub fn to_jiff_span(&self, v: i64) -> VortexResult<Span> {
         Ok(match self {

--- a/vortex-array/src/scalar_fn/fns/cast/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/cast/mod.rs
@@ -109,6 +109,13 @@ impl ScalarFnVTable for Cast {
     ) -> VortexResult<ArrayRef> {
         let input = args.get(0)?;
 
+        // If the target is an extension DType, we give it a chance to intercept.
+        if let DType::Extension(ext_dtype) = target_dtype
+            && let Some(casted) = ext_dtype.cast_into_ext(&input)?
+        {
+            return Ok(casted);
+        }
+
         let Some(columnar) = input.as_opt::<AnyColumnar>() else {
             return input.execute::<ArrayRef>(ctx)?.cast(target_dtype.clone());
         };

--- a/vortex-array/src/scalar_fn/fns/cast/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/cast/mod.rs
@@ -109,13 +109,6 @@ impl ScalarFnVTable for Cast {
     ) -> VortexResult<ArrayRef> {
         let input = args.get(0)?;
 
-        // If the target is an extension DType, we give it a chance to intercept.
-        if let DType::Extension(ext_dtype) = target_dtype
-            && let Some(casted) = ext_dtype.cast_into_ext(&input)?
-        {
-            return Ok(casted);
-        }
-
         let Some(columnar) = input.as_opt::<AnyColumnar>() else {
             return input.execute::<ArrayRef>(ctx)?.cast(target_dtype.clone());
         };


### PR DESCRIPTION
This PR adds execute_parent and reduce_parent support to ExtensionArrays via the ExtVTable.

This is demonstrated by implementing support for casting temporal types.