### PR TITLE
chore: only ignore c++ diagnostics for ddb headers

### DIFF
--- a/vortex-duckdb/build.rs
+++ b/vortex-duckdb/build.rs
@@ -325,14 +325,7 @@ fn c2rust(crate_dir: &Path, duckdb_include_dir: &Path) {
 fn cpp(duckdb_include_dir: &Path) {
     cc::Build::new()
         .std("c++20")
-        // Duckdb sources fail -Wno-unused-parameter and -Wno-type-limits
-        .flags([
-            "-Wall",
-            "-Wextra",
-            "-Wpedantic",
-            "-Wno-unused-parameter",
-            "-Wno-type-limits",
-        ])
+        .flags(["-Wall", "-Wextra", "-Wpedantic"])
         .cpp(true)
         .include(duckdb_include_dir)
         .include("cpp/include")

--- a/vortex-duckdb/cpp/CMakeLists.txt
+++ b/vortex-duckdb/cpp/CMakeLists.txt
@@ -23,7 +23,7 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Enable compiler warnings (matching build.rs flags).
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wno-type-limits")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 
 # Find DuckDB include directory via the symlink created by build.rs.
 # The symlink points to target/duckdb-source-vX.Y.Z which contains duckdb-X.Y.Z/

--- a/vortex-duckdb/cpp/include/duckdb_vx/duckdb_diagnostics.h
+++ b/vortex-duckdb/cpp/include/duckdb_vx/duckdb_diagnostics.h
@@ -17,7 +17,9 @@
     _Pragma("GCC diagnostic push")                                             \
     _Pragma("GCC diagnostic ignored \"-Wall\"")                                \
     _Pragma("GCC diagnostic ignored \"-Wextra\"")                              \
-    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")
+    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")                           \
+    _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")                   \
+    _Pragma("GCC diagnostic ignored \"-Wtype-limits\"")
 #define DUCKDB_INCLUDES_END _Pragma("GCC diagnostic pop")
 #else
 #define DUCKDB_INCLUDES_BEGIN


### PR DESCRIPTION
DDB warnings to ignore need to be part of the `DUCKDB_INCLUDES_BEGIN` macro:
```
#define DUCKDB_INCLUDES_BEGIN                                                  \
    _Pragma("GCC diagnostic push")                                             \
    _Pragma("GCC diagnostic ignored \"-Wall\"")                                \
    _Pragma("GCC diagnostic ignored \"-Wextra\"")                              \
    _Pragma("GCC diagnostic ignored \"-Wpedantic\"")                           \
    _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")                   \
    _Pragma("GCC diagnostic ignored \"-Wtype-limits\"")
#define DUCKDB_INCLUDES_END _Pragma("GCC diagnostic pop")
```

Warnings originating from our own code should simply be addressed.