### PR TITLE
feat[compat-gen]: add `expected_encodings` to validate fixture construction

### DIFF
--- a/vortex-test/compat-gen/src/adapter.rs
+++ b/vortex-test/compat-gen/src/adapter.rs
@@ -7,6 +7,7 @@
 // Read:  session.open_options().open_buffer(buf) (sync), into_array_stream() (async)
 
 use std::path::Path;
+use std::sync::Arc;
 
 use futures::stream;
 use tokio::runtime::Runtime;
@@ -14,7 +15,9 @@ use vortex::VortexSessionDefault;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::io::session::RuntimeSessionExt;
+use vortex::layout::layouts::flat::writer::FlatLayoutStrategy;
 use vortex_array::ArrayRef;
+use vortex_array::DynArray;
 use vortex_array::stream::ArrayStreamAdapter;
 use vortex_array::stream::ArrayStreamExt;
 use vortex_buffer::ByteBuffer;
@@ -25,27 +28,34 @@ fn runtime() -> VortexResult<Runtime> {
     Runtime::new().map_err(|e| vortex_error::vortex_err!("failed to create tokio runtime: {e}"))
 }
 
-/// Write a sequence of array chunks as a `.vortex` file.
-pub fn write_file(path: &Path, chunks: Vec<ArrayRef>) -> VortexResult<()> {
-    let dtype = chunks[0].dtype().clone();
-    let stream = ArrayStreamAdapter::new(dtype, stream::iter(chunks.into_iter().map(Ok)));
+/// Write a sequence of array chunks as a `.vortex` file with no compression.
+///
+/// Uses `FlatLayoutStrategy` directly — no repartitioning, no zone maps, no dictionary
+/// encoding, no compression. Each chunk is serialized as a single flat segment.
+pub fn write_file(path: &Path, chunk: ArrayRef) -> VortexResult<()> {
+    let stream = ArrayStreamAdapter::new(chunk.dtype().clone(), stream::iter([Ok(chunk)]));
+
+    let strategy: Arc<dyn vortex::layout::LayoutStrategy> = Arc::new(FlatLayoutStrategy::default());
 
     runtime()?.block_on(async {
         let session = VortexSession::default().with_tokio();
         let mut file = tokio::fs::File::create(path)
             .await
             .map_err(|e| vortex_error::vortex_err!("failed to create {}: {e}", path.display()))?;
-        let _summary = session.write_options().write(&mut file, stream).await?;
+        let _summary = session
+            .write_options()
+            .with_strategy(strategy)
+            .write(&mut file, stream)
+            .await?;
         Ok(())
     })
 }
 
 /// Read a `.vortex` file from bytes, returning the arrays.
-pub fn read_file(bytes: ByteBuffer) -> VortexResult<Vec<ArrayRef>> {
+pub fn read_file(bytes: ByteBuffer) -> VortexResult<ArrayRef> {
     runtime()?.block_on(async {
         let session = VortexSession::default().with_tokio();
         let file = session.open_options().open_buffer(bytes)?;
-        let arr = file.scan()?.into_array_stream()?.read_all().await?;
-        Ok(vec![arr])
+        file.scan()?.into_array_stream()?.read_all().await
     })
 }

--- a/vortex-test/compat-gen/src/fixtures/clickbench.rs
+++ b/vortex-test/compat-gen/src/fixtures/clickbench.rs
@@ -4,6 +4,8 @@
 use arrow_array::RecordBatch;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
+use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::Struct;
 use vortex_array::arrays::VarBin;
@@ -18,7 +20,7 @@ use super::ArrayFixture;
 const CLICKBENCH_URL: &str =
     "https://pub-3ba949c0f0354ac18db1f0f14f0a2c52.r2.dev/clickbench/parquet_many/hits_0.parquet";
 
-pub struct ClickBenchHits1kFixture;
+struct ClickBenchHits1kFixture;
 
 impl ArrayFixture for ClickBenchHits1kFixture {
     fn name(&self) -> &str {
@@ -29,7 +31,7 @@ impl ArrayFixture for ClickBenchHits1kFixture {
         vec![Struct::ID, Primitive::ID, VarBin::ID]
     }
 
-    fn build(&self) -> VortexResult<Vec<ArrayRef>> {
+    fn build(&self) -> VortexResult<ArrayRef> {
         let bytes = reqwest::blocking::get(CLICKBENCH_URL)
             .map_err(|e| vortex_err!("failed to download ClickBench parquet: {e}"))?
             .bytes()
@@ -46,9 +48,16 @@ impl ArrayFixture for ClickBenchHits1kFixture {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| vortex_err!("failed to read parquet batches: {e}"))?;
 
-        batches
-            .into_iter()
-            .map(|batch| ArrayRef::from_arrow(batch, false))
-            .collect()
+        Ok(ChunkedArray::from_iter(
+            batches
+                .into_iter()
+                .map(|batch| ArrayRef::from_arrow(batch, false))
+                .collect::<VortexResult<Vec<_>>>()?,
+        )
+        .into_array())
     }
+}
+
+pub fn fixtures() -> Vec<Box<dyn ArrayFixture>> {
+    vec![Box::new(ClickBenchHits1kFixture)]
 }

--- a/vortex-test/compat-gen/src/fixtures/clickbench.rs
+++ b/vortex-test/compat-gen/src/fixtures/clickbench.rs
@@ -4,11 +4,15 @@
 use arrow_array::RecordBatch;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use vortex_array::ArrayRef;
+use vortex_array::arrays::Primitive;
+use vortex_array::arrays::Struct;
+use vortex_array::arrays::VarBin;
 use vortex_array::arrow::FromArrowArray;
+use vortex_array::vtable::ArrayId;
 use vortex_error::VortexResult;
 use vortex_error::vortex_err;
 
-use super::Fixture;
+use super::ArrayFixture;
 
 /// First partition of ClickBench hits, limited to 1000 rows.
 const CLICKBENCH_URL: &str =
@@ -16,9 +20,13 @@ const CLICKBENCH_URL: &str =
 
 pub struct ClickBenchHits1kFixture;
 
-impl Fixture for ClickBenchHits1kFixture {
+impl ArrayFixture for ClickBenchHits1kFixture {
     fn name(&self) -> &str {
         "clickbench_hits_1k.vortex"
+    }
+
+    fn expected_encodings(&self) -> Vec<ArrayId> {
+        vec![Struct::ID, Primitive::ID, VarBin::ID]
     }
 
     fn build(&self) -> VortexResult<Vec<ArrayRef>> {

--- a/vortex-test/compat-gen/src/fixtures/clickbench.rs
+++ b/vortex-test/compat-gen/src/fixtures/clickbench.rs
@@ -27,6 +27,10 @@ impl ArrayFixture for ClickBenchHits1kFixture {
         "clickbench_hits_1k.vortex"
     }
 
+    fn description(&self) -> &str {
+        "First 1000 rows of ClickBench hits dataset with wide schema of primitives and strings"
+    }
+
     fn expected_encodings(&self) -> Vec<ArrayId> {
         vec![Struct::ID, Primitive::ID, VarBin::ID]
     }

--- a/vortex-test/compat-gen/src/fixtures/mod.rs
+++ b/vortex-test/compat-gen/src/fixtures/mod.rs
@@ -16,11 +16,8 @@ pub trait ArrayFixture: Send + Sync {
     /// The filename for this fixture, e.g. "primitives.vortex".
     fn name(&self) -> &str;
 
-    /// Build the expected arrays. Must be deterministic.
-    ///
-    /// Returns a `Vec` to support chunked fixtures (multiple chunks).
-    /// Single-array fixtures return a one-element vec.
-    fn build(&self) -> VortexResult<Vec<ArrayRef>>;
+    /// Build the expected arrays. Must be deterministic under all version of vortex.
+    fn build(&self) -> VortexResult<ArrayRef>;
 
     /// Encoding IDs that must appear somewhere in the array tree produced by [`Self::build`].
     ///
@@ -33,24 +30,19 @@ pub trait ArrayFixture: Send + Sync {
     }
 }
 
-/// Walk every array in `chunks`, collect encoding IDs, and assert that all expected encodings
+/// Walk the array tree, collect encoding IDs, and assert that all expected encodings
 /// are present. This is a no-op when [`ArrayFixture::expected_encodings`] returns an empty vec.
-pub fn check_expected_encodings(
-    chunks: &[ArrayRef],
-    fixture: &dyn ArrayFixture,
-) -> VortexResult<()> {
+pub fn check_expected_encodings(array: &ArrayRef, fixture: &dyn ArrayFixture) -> VortexResult<()> {
     let expected = fixture.expected_encodings();
     if expected.is_empty() {
         return Ok(());
     }
 
     let mut found: Vec<ArrayId> = Vec::new();
-    for chunk in chunks {
-        for array in chunk.depth_first_traversal() {
-            let id = array.encoding_id();
-            if !found.contains(&id) {
-                found.push(id);
-            }
+    for node in array.depth_first_traversal() {
+        let id = node.encoding_id();
+        if !found.contains(&id) {
+            found.push(id);
         }
     }
 
@@ -70,15 +62,9 @@ pub fn check_expected_encodings(
 
 /// All registered fixtures.
 pub fn all_fixtures() -> Vec<Box<dyn ArrayFixture>> {
-    vec![
-        Box::new(synthetic::PrimitivesFixture),
-        Box::new(synthetic::StringsFixture),
-        Box::new(synthetic::BooleansFixture),
-        Box::new(synthetic::NullableFixture),
-        Box::new(synthetic::StructNestedFixture),
-        Box::new(synthetic::ChunkedFixture),
-        Box::new(tpch::TpchLineitemFixture),
-        Box::new(tpch::TpchOrdersFixture),
-        Box::new(clickbench::ClickBenchHits1kFixture),
-    ]
+    let mut fixtures = Vec::new();
+    fixtures.extend(synthetic::fixtures());
+    fixtures.extend(tpch::fixtures());
+    fixtures.extend(clickbench::fixtures());
+    fixtures
 }

--- a/vortex-test/compat-gen/src/fixtures/mod.rs
+++ b/vortex-test/compat-gen/src/fixtures/mod.rs
@@ -16,6 +16,9 @@ pub trait ArrayFixture: Send + Sync {
     /// The filename for this fixture, e.g. "primitives.vortex".
     fn name(&self) -> &str;
 
+    /// A short human-readable description of what this fixture tests.
+    fn description(&self) -> &str;
+
     /// Build the expected arrays. Must be deterministic under all version of vortex.
     fn build(&self) -> VortexResult<ArrayRef>;
 

--- a/vortex-test/compat-gen/src/fixtures/mod.rs
+++ b/vortex-test/compat-gen/src/fixtures/mod.rs
@@ -6,10 +6,13 @@ mod synthetic;
 mod tpch;
 
 use vortex_array::ArrayRef;
+use vortex_array::ArrayVisitorExt;
+use vortex_array::vtable::ArrayId;
 use vortex_error::VortexResult;
+use vortex_error::vortex_bail;
 
 /// A deterministic fixture that produces the same arrays every time.
-pub trait Fixture: Send + Sync {
+pub trait ArrayFixture: Send + Sync {
     /// The filename for this fixture, e.g. "primitives.vortex".
     fn name(&self) -> &str;
 
@@ -18,10 +21,55 @@ pub trait Fixture: Send + Sync {
     /// Returns a `Vec` to support chunked fixtures (multiple chunks).
     /// Single-array fixtures return a one-element vec.
     fn build(&self) -> VortexResult<Vec<ArrayRef>>;
+
+    /// Encoding IDs that must appear somewhere in the array tree produced by [`Self::build`].
+    ///
+    /// Only include encodings that the fixture is specifically testing, not incidental ones
+    /// (e.g. a primitives fixture should not list struct even if it wraps values in one).
+    ///
+    /// An empty slice (the default) disables the check.
+    fn expected_encodings(&self) -> Vec<ArrayId> {
+        vec![]
+    }
+}
+
+/// Walk every array in `chunks`, collect encoding IDs, and assert that all expected encodings
+/// are present. This is a no-op when [`ArrayFixture::expected_encodings`] returns an empty vec.
+pub fn check_expected_encodings(
+    chunks: &[ArrayRef],
+    fixture: &dyn ArrayFixture,
+) -> VortexResult<()> {
+    let expected = fixture.expected_encodings();
+    if expected.is_empty() {
+        return Ok(());
+    }
+
+    let mut found: Vec<ArrayId> = Vec::new();
+    for chunk in chunks {
+        for array in chunk.depth_first_traversal() {
+            let id = array.encoding_id();
+            if !found.contains(&id) {
+                found.push(id);
+            }
+        }
+    }
+
+    let missing: Vec<&ArrayId> = expected.iter().filter(|id| !found.contains(id)).collect();
+
+    if !missing.is_empty() {
+        vortex_bail!(
+            "fixture '{}' is missing expected encodings: {:?} (found: {:?})",
+            fixture.name(),
+            missing,
+            found,
+        );
+    }
+
+    Ok(())
 }
 
 /// All registered fixtures.
-pub fn all_fixtures() -> Vec<Box<dyn Fixture>> {
+pub fn all_fixtures() -> Vec<Box<dyn ArrayFixture>> {
     vec![
         Box::new(synthetic::PrimitivesFixture),
         Box::new(synthetic::StringsFixture),

--- a/vortex-test/compat-gen/src/fixtures/synthetic.rs
+++ b/vortex-test/compat-gen/src/fixtures/synthetic.rs
@@ -3,22 +3,32 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Bool;
 use vortex_array::arrays::BoolArray;
+use vortex_array::arrays::Chunked;
+use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::Struct;
 use vortex_array::arrays::StructArray;
+use vortex_array::arrays::VarBin;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::dtype::FieldNames;
 use vortex_array::validity::Validity;
+use vortex_array::vtable::ArrayId;
 use vortex_buffer::buffer;
 use vortex_error::VortexResult;
 
-use super::Fixture;
+use super::ArrayFixture;
 
 pub struct PrimitivesFixture;
 
-impl Fixture for PrimitivesFixture {
+impl ArrayFixture for PrimitivesFixture {
     fn name(&self) -> &str {
         "primitives.vortex"
+    }
+
+    fn expected_encodings(&self) -> Vec<ArrayId> {
+        vec![Primitive::ID]
     }
 
     fn build(&self) -> VortexResult<Vec<ArrayRef>> {
@@ -56,9 +66,13 @@ impl Fixture for PrimitivesFixture {
 
 pub struct StringsFixture;
 
-impl Fixture for StringsFixture {
+impl ArrayFixture for StringsFixture {
     fn name(&self) -> &str {
         "strings.vortex"
+    }
+
+    fn expected_encodings(&self) -> Vec<ArrayId> {
+        vec![VarBin::ID]
     }
 
     fn build(&self) -> VortexResult<Vec<ArrayRef>> {
@@ -75,9 +89,13 @@ impl Fixture for StringsFixture {
 
 pub struct BooleansFixture;
 
-impl Fixture for BooleansFixture {
+impl ArrayFixture for BooleansFixture {
     fn name(&self) -> &str {
         "booleans.vortex"
+    }
+
+    fn expected_encodings(&self) -> Vec<ArrayId> {
+        vec![Bool::ID]
     }
 
     fn build(&self) -> VortexResult<Vec<ArrayRef>> {
@@ -94,9 +112,13 @@ impl Fixture for BooleansFixture {
 
 pub struct NullableFixture;
 
-impl Fixture for NullableFixture {
+impl ArrayFixture for NullableFixture {
     fn name(&self) -> &str {
         "nullable.vortex"
+    }
+
+    fn expected_encodings(&self) -> Vec<ArrayId> {
+        vec![Primitive::ID, VarBin::ID]
     }
 
     fn build(&self) -> VortexResult<Vec<ArrayRef>> {
@@ -116,9 +138,13 @@ impl Fixture for NullableFixture {
 
 pub struct StructNestedFixture;
 
-impl Fixture for StructNestedFixture {
+impl ArrayFixture for StructNestedFixture {
     fn name(&self) -> &str {
         "struct_nested.vortex"
+    }
+
+    fn expected_encodings(&self) -> Vec<ArrayId> {
+        vec![Struct::ID]
     }
 
     fn build(&self) -> VortexResult<Vec<ArrayRef>> {
@@ -147,9 +173,13 @@ impl Fixture for StructNestedFixture {
 
 pub struct ChunkedFixture;
 
-impl Fixture for ChunkedFixture {
+impl ArrayFixture for ChunkedFixture {
     fn name(&self) -> &str {
         "chunked.vortex"
+    }
+
+    fn expected_encodings(&self) -> Vec<ArrayId> {
+        vec![Chunked::ID]
     }
 
     fn build(&self) -> VortexResult<Vec<ArrayRef>> {

--- a/vortex-test/compat-gen/src/fixtures/synthetic.rs
+++ b/vortex-test/compat-gen/src/fixtures/synthetic.rs
@@ -29,6 +29,10 @@ impl ArrayFixture for PrimitivesFixture {
         "primitives.vortex"
     }
 
+    fn description(&self) -> &str {
+        "All primitive types (u8-u64, i32, i64, f32, f64) including a nullable i32 column"
+    }
+
     fn expected_encodings(&self) -> Vec<ArrayId> {
         vec![Primitive::ID]
     }
@@ -84,6 +88,10 @@ impl ArrayFixture for VarBinFixture {
         "varbin.vortex"
     }
 
+    fn description(&self) -> &str {
+        "VarBin-encoded strings including empty, unicode, emoji, and a nullable column"
+    }
+
     fn expected_encodings(&self) -> Vec<ArrayId> {
         vec![VarBin::ID]
     }
@@ -109,6 +117,10 @@ impl ArrayFixture for VarBinViewFixture {
         "varbinview.vortex"
     }
 
+    fn description(&self) -> &str {
+        "VarBinView-encoded strings including empty, unicode, and emoji"
+    }
+
     fn expected_encodings(&self) -> Vec<ArrayId> {
         vec![VarBinView::ID]
     }
@@ -132,6 +144,10 @@ impl ArrayFixture for BooleansFixture {
         "booleans.vortex"
     }
 
+    fn description(&self) -> &str {
+        "Boolean array with mixed true/false values"
+    }
+
     fn expected_encodings(&self) -> Vec<ArrayId> {
         vec![Bool::ID]
     }
@@ -153,6 +169,10 @@ struct StructNestedFixture;
 impl ArrayFixture for StructNestedFixture {
     fn name(&self) -> &str {
         "struct_nested.vortex"
+    }
+
+    fn description(&self) -> &str {
+        "Nested struct: outer struct containing an inner struct with primitive and string fields"
     }
 
     fn expected_encodings(&self) -> Vec<ArrayId> {
@@ -188,6 +208,10 @@ struct ChunkedFixture;
 impl ArrayFixture for ChunkedFixture {
     fn name(&self) -> &str {
         "chunked.vortex"
+    }
+
+    fn description(&self) -> &str {
+        "ChunkedArray with 3 chunks of 1000 rows each containing deterministic u32 values"
     }
 
     fn expected_encodings(&self) -> Vec<ArrayId> {

--- a/vortex-test/compat-gen/src/fixtures/synthetic.rs
+++ b/vortex-test/compat-gen/src/fixtures/synthetic.rs
@@ -5,13 +5,15 @@ use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::arrays::Bool;
 use vortex_array::arrays::BoolArray;
-use vortex_array::arrays::Chunked;
+use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::Struct;
 use vortex_array::arrays::StructArray;
 use vortex_array::arrays::VarBin;
 use vortex_array::arrays::VarBinArray;
+use vortex_array::arrays::VarBinView;
+use vortex_array::arrays::VarBinViewArray;
 use vortex_array::dtype::FieldNames;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::ArrayId;
@@ -20,7 +22,7 @@ use vortex_error::VortexResult;
 
 use super::ArrayFixture;
 
-pub struct PrimitivesFixture;
+struct PrimitivesFixture;
 
 impl ArrayFixture for PrimitivesFixture {
     fn name(&self) -> &str {
@@ -31,9 +33,19 @@ impl ArrayFixture for PrimitivesFixture {
         vec![Primitive::ID]
     }
 
-    fn build(&self) -> VortexResult<Vec<ArrayRef>> {
+    fn build(&self) -> VortexResult<ArrayRef> {
         let arr = StructArray::try_new(
-            FieldNames::from(["u8", "u16", "u32", "u64", "i32", "i64", "f32", "f64"]),
+            FieldNames::from([
+                "u8",
+                "u16",
+                "u32",
+                "u64",
+                "i32",
+                "i64",
+                "f32",
+                "f64",
+                "nullable_i32",
+            ]),
             vec![
                 PrimitiveArray::new(buffer![0u8, 128, 255], Validity::NonNullable).into_array(),
                 PrimitiveArray::new(buffer![0u16, 32768, 65535], Validity::NonNullable)
@@ -56,38 +68,64 @@ impl ArrayFixture for PrimitivesFixture {
                     .into_array(),
                 PrimitiveArray::new(buffer![f64::MIN, 0.0f64, f64::MAX], Validity::NonNullable)
                     .into_array(),
+                PrimitiveArray::from_option_iter([Some(1i32), None, Some(42)]).into_array(),
             ],
             3,
             Validity::NonNullable,
         )?;
-        Ok(vec![arr.into_array()])
+        Ok(arr.into_array())
     }
 }
 
-pub struct StringsFixture;
+struct VarBinFixture;
 
-impl ArrayFixture for StringsFixture {
+impl ArrayFixture for VarBinFixture {
     fn name(&self) -> &str {
-        "strings.vortex"
+        "varbin.vortex"
     }
 
     fn expected_encodings(&self) -> Vec<ArrayId> {
         vec![VarBin::ID]
     }
 
-    fn build(&self) -> VortexResult<Vec<ArrayRef>> {
+    fn build(&self) -> VortexResult<ArrayRef> {
         let strings = VarBinArray::from(vec!["", "hello", "こんにちは", "\u{1f980}"]);
+        let nullable_strings =
+            VarBinArray::from(vec![Some("hello"), None, Some("world"), Some("")]);
+        let arr = StructArray::try_new(
+            FieldNames::from(["text", "nullable_text"]),
+            vec![strings.into_array(), nullable_strings.into_array()],
+            4,
+            Validity::NonNullable,
+        )?;
+        Ok(arr.into_array())
+    }
+}
+
+struct VarBinViewFixture;
+
+impl ArrayFixture for VarBinViewFixture {
+    fn name(&self) -> &str {
+        "varbinview.vortex"
+    }
+
+    fn expected_encodings(&self) -> Vec<ArrayId> {
+        vec![VarBinView::ID]
+    }
+
+    fn build(&self) -> VortexResult<ArrayRef> {
+        let strings = VarBinViewArray::from_iter_bin(vec!["", "hello", "こんにちは", "\u{1f980}"]);
         let arr = StructArray::try_new(
             FieldNames::from(["text"]),
             vec![strings.into_array()],
             4,
             Validity::NonNullable,
         )?;
-        Ok(vec![arr.into_array()])
+        Ok(arr.into_array())
     }
 }
 
-pub struct BooleansFixture;
+struct BooleansFixture;
 
 impl ArrayFixture for BooleansFixture {
     fn name(&self) -> &str {
@@ -98,7 +136,7 @@ impl ArrayFixture for BooleansFixture {
         vec![Bool::ID]
     }
 
-    fn build(&self) -> VortexResult<Vec<ArrayRef>> {
+    fn build(&self) -> VortexResult<ArrayRef> {
         let bools = BoolArray::from_iter([true, false, true, true, false]);
         let arr = StructArray::try_new(
             FieldNames::from(["flag"]),
@@ -106,37 +144,11 @@ impl ArrayFixture for BooleansFixture {
             5,
             Validity::NonNullable,
         )?;
-        Ok(vec![arr.into_array()])
+        Ok(arr.into_array())
     }
 }
 
-pub struct NullableFixture;
-
-impl ArrayFixture for NullableFixture {
-    fn name(&self) -> &str {
-        "nullable.vortex"
-    }
-
-    fn expected_encodings(&self) -> Vec<ArrayId> {
-        vec![Primitive::ID, VarBin::ID]
-    }
-
-    fn build(&self) -> VortexResult<Vec<ArrayRef>> {
-        let nullable_ints =
-            PrimitiveArray::from_option_iter([Some(1i32), None, Some(42), None, Some(-7)]);
-        let nullable_strings =
-            VarBinArray::from(vec![Some("hello"), None, Some("world"), Some(""), None]);
-        let arr = StructArray::try_new(
-            FieldNames::from(["int_col", "str_col"]),
-            vec![nullable_ints.into_array(), nullable_strings.into_array()],
-            5,
-            Validity::NonNullable,
-        )?;
-        Ok(vec![arr.into_array()])
-    }
-}
-
-pub struct StructNestedFixture;
+struct StructNestedFixture;
 
 impl ArrayFixture for StructNestedFixture {
     fn name(&self) -> &str {
@@ -147,7 +159,7 @@ impl ArrayFixture for StructNestedFixture {
         vec![Struct::ID]
     }
 
-    fn build(&self) -> VortexResult<Vec<ArrayRef>> {
+    fn build(&self) -> VortexResult<ArrayRef> {
         let inner = StructArray::try_new(
             FieldNames::from(["a", "b"]),
             vec![
@@ -167,11 +179,11 @@ impl ArrayFixture for StructNestedFixture {
             3,
             Validity::NonNullable,
         )?;
-        Ok(vec![arr.into_array()])
+        Ok(arr.into_array())
     }
 }
 
-pub struct ChunkedFixture;
+struct ChunkedFixture;
 
 impl ArrayFixture for ChunkedFixture {
     fn name(&self) -> &str {
@@ -179,24 +191,40 @@ impl ArrayFixture for ChunkedFixture {
     }
 
     fn expected_encodings(&self) -> Vec<ArrayId> {
-        vec![Chunked::ID]
+        vec![Primitive::ID]
     }
 
-    fn build(&self) -> VortexResult<Vec<ArrayRef>> {
+    fn build(&self) -> VortexResult<ArrayRef> {
+        let value_gen = |chunk_idx| {
+            let values: Vec<u32> = (0u32..1000).map(|i| chunk_idx * 1000 + i).collect();
+            let primitives =
+                PrimitiveArray::new(vortex_buffer::Buffer::from(values), Validity::NonNullable);
+            Ok(StructArray::try_new(
+                FieldNames::from(["id"]),
+                vec![primitives.into_array()],
+                1000,
+                Validity::NonNullable,
+            )?
+            .into_array())
+        };
+
         // 3 chunks of 1000 rows each. Values are deterministic: chunk_idx * 1000 + row_idx.
-        (0u32..3)
-            .map(|chunk_idx| {
-                let values: Vec<u32> = (0u32..1000).map(|i| chunk_idx * 1000 + i).collect();
-                let primitives =
-                    PrimitiveArray::new(vortex_buffer::Buffer::from(values), Validity::NonNullable);
-                Ok(StructArray::try_new(
-                    FieldNames::from(["id"]),
-                    vec![primitives.into_array()],
-                    1000,
-                    Validity::NonNullable,
-                )?
-                .into_array())
-            })
-            .collect()
+        Ok(
+            ChunkedArray::from_iter((0u32..3).map(value_gen).collect::<VortexResult<Vec<_>>>()?)
+                .into_array(),
+        )
     }
+}
+
+/// All synthetic fixtures. Structs are module-private, so adding a new fixture struct without
+/// including it here will produce a dead-code warning from the compiler.
+pub fn fixtures() -> Vec<Box<dyn ArrayFixture>> {
+    vec![
+        Box::new(PrimitivesFixture),
+        Box::new(VarBinFixture),
+        Box::new(VarBinViewFixture),
+        Box::new(BooleansFixture),
+        Box::new(StructNestedFixture),
+        Box::new(ChunkedFixture),
+    ]
 }

--- a/vortex-test/compat-gen/src/fixtures/tpch.rs
+++ b/vortex-test/compat-gen/src/fixtures/tpch.rs
@@ -6,10 +6,16 @@ use tpchgen::generators::LineItemGenerator;
 use tpchgen::generators::OrderGenerator;
 use tpchgen_arrow::RecordBatchIterator;
 use vortex_array::ArrayRef;
+use vortex_array::arrays::Decimal;
+use vortex_array::arrays::Extension;
+use vortex_array::arrays::Primitive;
+use vortex_array::arrays::Struct;
+use vortex_array::arrays::VarBinView;
 use vortex_array::arrow::FromArrowArray;
+use vortex_array::vtable::ArrayId;
 use vortex_error::VortexResult;
 
-use super::Fixture;
+use super::ArrayFixture;
 
 const SCALE_FACTOR: f64 = 0.01;
 
@@ -23,9 +29,19 @@ fn collect_batches_as_vortex(iter: impl RecordBatchIterator) -> VortexResult<Vec
 
 pub struct TpchLineitemFixture;
 
-impl Fixture for TpchLineitemFixture {
+impl ArrayFixture for TpchLineitemFixture {
     fn name(&self) -> &str {
         "tpch_lineitem.vortex"
+    }
+
+    fn expected_encodings(&self) -> Vec<ArrayId> {
+        vec![
+            Struct::ID,
+            Primitive::ID,
+            Decimal::ID,
+            VarBinView::ID,
+            Extension::ID,
+        ]
     }
 
     fn build(&self) -> VortexResult<Vec<ArrayRef>> {
@@ -37,9 +53,19 @@ impl Fixture for TpchLineitemFixture {
 
 pub struct TpchOrdersFixture;
 
-impl Fixture for TpchOrdersFixture {
+impl ArrayFixture for TpchOrdersFixture {
     fn name(&self) -> &str {
         "tpch_orders.vortex"
+    }
+
+    fn expected_encodings(&self) -> Vec<ArrayId> {
+        vec![
+            Struct::ID,
+            Primitive::ID,
+            Decimal::ID,
+            VarBinView::ID,
+            Extension::ID,
+        ]
     }
 
     fn build(&self) -> VortexResult<Vec<ArrayRef>> {

--- a/vortex-test/compat-gen/src/fixtures/tpch.rs
+++ b/vortex-test/compat-gen/src/fixtures/tpch.rs
@@ -39,6 +39,10 @@ impl ArrayFixture for TpchLineitemFixture {
         "tpch_lineitem.vortex"
     }
 
+    fn description(&self) -> &str {
+        "TPC-H lineitem table at scale factor 0.01 with decimals, dates, and strings"
+    }
+
     fn expected_encodings(&self) -> Vec<ArrayId> {
         vec![
             Struct::ID,
@@ -61,6 +65,10 @@ struct TpchOrdersFixture;
 impl ArrayFixture for TpchOrdersFixture {
     fn name(&self) -> &str {
         "tpch_orders.vortex"
+    }
+
+    fn description(&self) -> &str {
+        "TPC-H orders table at scale factor 0.01 with decimals, dates, and strings"
     }
 
     fn expected_encodings(&self) -> Vec<ArrayId> {

--- a/vortex-test/compat-gen/src/fixtures/tpch.rs
+++ b/vortex-test/compat-gen/src/fixtures/tpch.rs
@@ -6,6 +6,8 @@ use tpchgen::generators::LineItemGenerator;
 use tpchgen::generators::OrderGenerator;
 use tpchgen_arrow::RecordBatchIterator;
 use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
+use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::Decimal;
 use vortex_array::arrays::Extension;
 use vortex_array::arrays::Primitive;
@@ -19,15 +21,18 @@ use super::ArrayFixture;
 
 const SCALE_FACTOR: f64 = 0.01;
 
-fn collect_batches_as_vortex(iter: impl RecordBatchIterator) -> VortexResult<Vec<ArrayRef>> {
+fn collect_batches_as_vortex(iter: impl RecordBatchIterator) -> VortexResult<ArrayRef> {
     let batches: Vec<RecordBatch> = iter.collect();
-    batches
-        .into_iter()
-        .map(|batch| ArrayRef::from_arrow(batch, false))
-        .collect()
+    Ok(ChunkedArray::from_iter(
+        batches
+            .into_iter()
+            .map(|batch| ArrayRef::from_arrow(batch, false))
+            .collect::<VortexResult<Vec<_>>>()?,
+    )
+    .into_array())
 }
 
-pub struct TpchLineitemFixture;
+struct TpchLineitemFixture;
 
 impl ArrayFixture for TpchLineitemFixture {
     fn name(&self) -> &str {
@@ -44,14 +49,14 @@ impl ArrayFixture for TpchLineitemFixture {
         ]
     }
 
-    fn build(&self) -> VortexResult<Vec<ArrayRef>> {
+    fn build(&self) -> VortexResult<ArrayRef> {
         let generator = LineItemGenerator::new(SCALE_FACTOR, 1, 1);
         let arrow_iter = tpchgen_arrow::LineItemArrow::new(generator).with_batch_size(65_536);
         collect_batches_as_vortex(arrow_iter)
     }
 }
 
-pub struct TpchOrdersFixture;
+struct TpchOrdersFixture;
 
 impl ArrayFixture for TpchOrdersFixture {
     fn name(&self) -> &str {
@@ -68,9 +73,13 @@ impl ArrayFixture for TpchOrdersFixture {
         ]
     }
 
-    fn build(&self) -> VortexResult<Vec<ArrayRef>> {
+    fn build(&self) -> VortexResult<ArrayRef> {
         let generator = OrderGenerator::new(SCALE_FACTOR, 1, 1);
         let arrow_iter = tpchgen_arrow::OrderArrow::new(generator).with_batch_size(65_536);
         collect_batches_as_vortex(arrow_iter)
     }
+}
+
+pub fn fixtures() -> Vec<Box<dyn ArrayFixture>> {
+    vec![Box::new(TpchLineitemFixture), Box::new(TpchOrdersFixture)]
 }

--- a/vortex-test/compat-gen/src/main.rs
+++ b/vortex-test/compat-gen/src/main.rs
@@ -36,10 +36,10 @@ fn main() -> VortexResult<()> {
     let mut entries = Vec::with_capacity(fixtures.len());
 
     for fixture in &fixtures {
-        let chunks = fixture.build()?;
-        check_expected_encodings(&chunks, fixture.as_ref())?;
+        let array = fixture.build()?;
+        check_expected_encodings(&array, fixture.as_ref())?;
         let path = cli.output.join(fixture.name());
-        vortex_compat::adapter::write_file(&path, chunks)?;
+        vortex_compat::adapter::write_file(&path, array)?;
 
         entries.push(FixtureEntry {
             name: fixture.name().to_string(),

--- a/vortex-test/compat-gen/src/main.rs
+++ b/vortex-test/compat-gen/src/main.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 use chrono::Utc;
 use clap::Parser;
 use vortex_compat::fixtures::all_fixtures;
+use vortex_compat::fixtures::check_expected_encodings;
 use vortex_compat::manifest::FixtureEntry;
 use vortex_compat::manifest::Manifest;
 use vortex_error::VortexResult;
@@ -36,6 +37,7 @@ fn main() -> VortexResult<()> {
 
     for fixture in &fixtures {
         let chunks = fixture.build()?;
+        check_expected_encodings(&chunks, fixture.as_ref())?;
         let path = cli.output.join(fixture.name());
         vortex_compat::adapter::write_file(&path, chunks)?;
 

--- a/vortex-test/compat-gen/src/main.rs
+++ b/vortex-test/compat-gen/src/main.rs
@@ -29,8 +29,23 @@ struct Cli {
 fn main() -> VortexResult<()> {
     let cli = Cli::parse();
 
-    std::fs::create_dir_all(&cli.output)
-        .map_err(|e| vortex_error::vortex_err!("failed to create output dir: {e}"))?;
+    if cli.output.exists() {
+        let is_empty = cli
+            .output
+            .read_dir()
+            .map_err(|e| vortex_error::vortex_err!("failed to read output dir: {e}"))?
+            .next()
+            .is_none();
+        if !is_empty {
+            vortex_error::vortex_bail!(
+                "output directory '{}' is not empty; use a fresh directory",
+                cli.output.display()
+            );
+        }
+    } else {
+        std::fs::create_dir_all(&cli.output)
+            .map_err(|e| vortex_error::vortex_err!("failed to create output dir: {e}"))?;
+    }
 
     let fixtures = all_fixtures();
     let mut entries = Vec::with_capacity(fixtures.len());
@@ -43,7 +58,7 @@ fn main() -> VortexResult<()> {
 
         entries.push(FixtureEntry {
             name: fixture.name().to_string(),
-            since: cli.version.clone(),
+            description: fixture.description().to_string(),
         });
         eprintln!("  wrote {}", fixture.name());
     }

--- a/vortex-test/compat-gen/src/manifest.rs
+++ b/vortex-test/compat-gen/src/manifest.rs
@@ -19,6 +19,6 @@ pub struct Manifest {
 pub struct FixtureEntry {
     /// Filename, e.g. "primitives.vortex".
     pub name: String,
-    /// First version that introduced this fixture, e.g. "0.62.0".
-    pub since: String,
+    /// Short description of what this fixture tests.
+    pub description: String,
 }

--- a/vortex-test/compat-gen/src/validate.rs
+++ b/vortex-test/compat-gen/src/validate.rs
@@ -3,8 +3,6 @@
 
 use std::path::PathBuf;
 
-use vortex_array::IntoArray;
-use vortex_array::arrays::ChunkedArray;
 use vortex_array::assert_arrays_eq;
 use vortex_buffer::ByteBuffer;
 use vortex_error::VortexResult;
@@ -64,7 +62,7 @@ fn validate_version(
 
         eprintln!("  checking {} from v{version}...", entry.name);
         let bytes = source.fetch_fixture(version, &entry.name)?;
-        match validate_one(bytes, *fixture) {
+        match validate(bytes, *fixture) {
             Ok(()) => passed += 1,
             Err(e) => {
                 eprintln!("  FAIL: {} from v{version}: {e}", entry.name);
@@ -81,16 +79,11 @@ fn validate_version(
     })
 }
 
-fn validate_one(bytes: ByteBuffer, fixture: &dyn ArrayFixture) -> VortexResult<()> {
+fn validate(bytes: ByteBuffer, fixture: &dyn ArrayFixture) -> VortexResult<()> {
     let actual = adapter::read_file(bytes)?;
     let expected = fixture.build()?;
 
-    let actual_dtype = actual[0].dtype().clone();
-    let expected_dtype = expected[0].dtype().clone();
-    let actual_arr = ChunkedArray::try_new(actual, actual_dtype)?.into_array();
-    let expected_arr = ChunkedArray::try_new(expected, expected_dtype)?.into_array();
-
-    assert_arrays_eq!(actual_arr, expected_arr);
+    assert_arrays_eq!(actual, expected);
     Ok(())
 }
 

--- a/vortex-test/compat-gen/src/validate.rs
+++ b/vortex-test/compat-gen/src/validate.rs
@@ -13,7 +13,7 @@ use vortex_error::vortex_err;
 use vortex_utils::aliases::hash_map::HashMap;
 
 use crate::adapter;
-use crate::fixtures::Fixture;
+use crate::fixtures::ArrayFixture;
 use crate::fixtures::all_fixtures;
 use crate::manifest::Manifest;
 
@@ -31,7 +31,7 @@ pub fn validate_all(
     versions: &[String],
 ) -> VortexResult<Vec<VersionResult>> {
     let fixtures = all_fixtures();
-    let fixture_map: HashMap<&str, &dyn Fixture> =
+    let fixture_map: HashMap<&str, &dyn ArrayFixture> =
         fixtures.iter().map(|f| (f.name(), f.as_ref())).collect();
 
     let mut results = Vec::new();
@@ -45,7 +45,7 @@ pub fn validate_all(
 fn validate_version(
     source: &FixtureSource,
     version: &str,
-    fixture_map: &HashMap<&str, &dyn Fixture>,
+    fixture_map: &HashMap<&str, &dyn ArrayFixture>,
 ) -> VortexResult<VersionResult> {
     let manifest = source.fetch_manifest(version)?;
     let mut passed = 0;
@@ -81,7 +81,7 @@ fn validate_version(
     })
 }
 
-fn validate_one(bytes: ByteBuffer, fixture: &dyn Fixture) -> VortexResult<()> {
+fn validate_one(bytes: ByteBuffer, fixture: &dyn ArrayFixture) -> VortexResult<()> {
     let actual = adapter::read_file(bytes)?;
     let expected = fixture.build()?;
 


### PR DESCRIPTION
As part of the adding back-compat checks to vortex we want to ensure that the fixtures generated contain the encodings we think they do.

This add a field to each fixture checked on construction that ensure each array has that encoding