### PR TITLE
Extract pub const NAME for all array encoding structs

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -273,7 +273,8 @@ pub struct ALPArray {
 pub struct ALP;
 
 impl ALP {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.alp");
+    pub const NAME: &str = "vortex.alp";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 #[derive(Clone, prost::Message)]

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -371,7 +371,8 @@ pub struct ALPRDArray {
 pub struct ALPRD;
 
 impl ALPRD {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.alprd");
+    pub const NAME: &str = "vortex.alprd";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl ALPRDArray {

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -213,7 +213,8 @@ pub struct ByteBoolArray {
 pub struct ByteBool;
 
 impl ByteBool {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.bytebool");
+    pub const NAME: &str = "vortex.bytebool";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl ByteBoolArray {

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -267,7 +267,8 @@ pub struct DateTimePartsArrayParts {
 pub struct DateTimeParts;
 
 impl DateTimeParts {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.datetimeparts");
+    pub const NAME: &str = "vortex.datetimeparts";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl DateTimePartsArray {

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -274,7 +274,8 @@ impl DecimalBytePartsArray {
 pub struct DecimalByteParts;
 
 impl DecimalByteParts {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.decimal_byte_parts");
+    pub const NAME: &str = "vortex.decimal_byte_parts";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 /// Converts a DecimalBytePartsArray to its canonical DecimalArray representation.

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -372,5 +372,6 @@ impl VTable for BitPacked {
 pub struct BitPacked;
 
 impl BitPacked {
-    pub const ID: ArrayId = ArrayId::new_ref("fastlanes.bitpacked");
+    pub const NAME: &str = "fastlanes.bitpacked";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -201,7 +201,8 @@ impl VTable for Delta {
 pub struct Delta;
 
 impl Delta {
-    pub const ID: ArrayId = ArrayId::new_ref("fastlanes.delta");
+    pub const NAME: &str = "fastlanes.delta";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 #[cfg(test)]

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -184,5 +184,6 @@ impl VTable for FoR {
 pub struct FoR;
 
 impl FoR {
-    pub const ID: ArrayId = ArrayId::new_ref("fastlanes.for");
+    pub const NAME: &str = "fastlanes.for";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -242,7 +242,8 @@ impl VTable for RLE {
 pub struct RLE;
 
 impl RLE {
-    pub const ID: ArrayId = ArrayId::new_ref("fastlanes.rle");
+    pub const NAME: &str = "fastlanes.rle";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 #[cfg(test)]

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -393,7 +393,8 @@ impl Debug for FSSTArray {
 pub struct FSST;
 
 impl FSST {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.fsst");
+    pub const NAME: &str = "vortex.fsst";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl FSSTArray {

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -312,7 +312,8 @@ pub(crate) fn vortex_err_from_pco(err: PcoError) -> VortexError {
 pub struct Pco;
 
 impl Pco {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.pco");
+    pub const NAME: &str = "vortex.pco";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 #[derive(Clone, Debug)]

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -226,7 +226,8 @@ pub struct RunEndArrayParts {
 pub struct RunEnd;
 
 impl RunEnd {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.runend");
+    pub const NAME: &str = "vortex.runend";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl RunEndArray {

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -422,7 +422,8 @@ impl ValidityVTable<Sequence> for Sequence {
 pub struct Sequence;
 
 impl Sequence {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.sequence");
+    pub const NAME: &str = "vortex.sequence";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 #[cfg(test)]

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -272,7 +272,8 @@ pub struct SparseArray {
 pub struct Sparse;
 
 impl Sparse {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.sparse");
+    pub const NAME: &str = "vortex.sparse";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl SparseArray {

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -184,7 +184,8 @@ pub struct ZigZagArray {
 pub struct ZigZag;
 
 impl ZigZag {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.zigzag");
+    pub const NAME: &str = "vortex.zigzag";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl ZigZagArray {

--- a/encodings/zigzag/src/compute/cast.rs
+++ b/encodings/zigzag/src/compute/cast.rs
@@ -37,6 +37,7 @@ mod tests {
     use vortex_array::dtype::Nullability;
     use vortex_array::dtype::PType;
 
+    use crate::ZigZag;
     use crate::ZigZagArray;
     use crate::zigzag_encode;
 
@@ -58,7 +59,7 @@ mod tests {
         // Note: The result might be wrapped, so let's check the encoding ID
         assert_eq!(
             casted.encoding_id().as_ref(),
-            "vortex.zigzag",
+            ZigZag::NAME,
             "Cast should preserve ZigZag encoding"
         );
 
@@ -77,7 +78,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             casted.encoding_id().as_ref(),
-            "vortex.zigzag",
+            ZigZag::NAME,
             "Should remain ZigZag encoded"
         );
 
@@ -96,7 +97,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             casted64.encoding_id().as_ref(),
-            "vortex.zigzag",
+            ZigZag::NAME,
             "Should remain ZigZag encoded"
         );
 

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -294,7 +294,8 @@ impl VTable for Zstd {
 pub struct Zstd;
 
 impl Zstd {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.zstd");
+    pub const NAME: &str = "vortex.zstd";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 #[derive(Clone, Debug)]

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -41,7 +41,8 @@ vtable!(ZstdBuffers);
 pub struct ZstdBuffers;
 
 impl ZstdBuffers {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.zstd_buffers");
+    pub const NAME: &str = "vortex.zstd_buffers";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 /// An encoding that ZSTD-compresses the buffers of any wrapped array.

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -211,5 +211,6 @@ impl VTable for Bool {
 pub struct Bool;
 
 impl Bool {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.bool");
+    pub const NAME: &str = "vortex.bool";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -46,7 +46,8 @@ vtable!(Chunked);
 pub struct Chunked;
 
 impl Chunked {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.chunked");
+    pub const NAME: &str = "vortex.chunked";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl VTable for Chunked {

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -48,7 +48,8 @@ vtable!(Constant);
 pub struct Constant;
 
 impl Constant {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.constant");
+    pub const NAME: &str = "vortex.constant";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl VTable for Constant {

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -233,7 +233,8 @@ impl VTable for Decimal {
 pub struct Decimal;
 
 impl Decimal {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.decimal");
+    pub const NAME: &str = "vortex.decimal";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -48,7 +48,8 @@ vtable!(Dict);
 pub struct Dict;
 
 impl Dict {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.dict");
+    pub const NAME: &str = "vortex.dict";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl VTable for Dict {

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -179,5 +179,6 @@ impl VTable for Extension {
 pub struct Extension;
 
 impl Extension {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.ext");
+    pub const NAME: &str = "vortex.ext";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -44,7 +44,8 @@ vtable!(Filter);
 pub struct Filter;
 
 impl Filter {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.filter");
+    pub const NAME: &str = "vortex.filter";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl VTable for Filter {

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -40,7 +40,8 @@ vtable!(FixedSizeList);
 pub struct FixedSizeList;
 
 impl FixedSizeList {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.fixed_size_list");
+    pub const NAME: &str = "vortex.fixed_size_list";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl VTable for FixedSizeList {

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -231,5 +231,6 @@ impl VTable for List {
 pub struct List;
 
 impl List {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.list");
+    pub const NAME: &str = "vortex.list";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -43,7 +43,8 @@ vtable!(ListView);
 pub struct ListView;
 
 impl ListView {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.listview");
+    pub const NAME: &str = "vortex.listview";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 #[derive(Clone, prost::Message)]

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -44,7 +44,8 @@ vtable!(Masked);
 pub struct Masked;
 
 impl Masked {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.masked");
+    pub const NAME: &str = "vortex.masked";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl VTable for Masked {

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -174,7 +174,8 @@ pub struct NullArray {
 pub struct Null;
 
 impl Null {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.null");
+    pub const NAME: &str = "vortex.null";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl NullArray {

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -225,5 +225,6 @@ impl VTable for Primitive {
 pub struct Primitive;
 
 impl Primitive {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.primitive");
+    pub const NAME: &str = "vortex.primitive";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -36,7 +36,8 @@ vtable!(Shared);
 pub struct Shared;
 
 impl Shared {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.shared");
+    pub const NAME: &str = "vortex.shared";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl VTable for Shared {

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -43,7 +43,8 @@ vtable!(Slice);
 pub struct Slice;
 
 impl Slice {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.slice");
+    pub const NAME: &str = "vortex.slice";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl VTable for Slice {

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -233,5 +233,6 @@ impl VTable for Struct {
 pub struct Struct;
 
 impl Struct {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.struct");
+    pub const NAME: &str = "vortex.struct";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -230,5 +230,6 @@ impl VTable for VarBin {
 pub struct VarBin;
 
 impl VarBin {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.varbin");
+    pub const NAME: &str = "vortex.varbin";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -45,7 +45,8 @@ vtable!(VarBinView);
 pub struct VarBinView;
 
 impl VarBinView {
-    pub const ID: ArrayId = ArrayId::new_ref("vortex.varbinview");
+    pub const NAME: &str = "vortex.varbinview";
+    pub const ID: ArrayId = ArrayId::new_ref(Self::NAME);
 }
 
 impl VTable for VarBinView {


### PR DESCRIPTION

## Summary

Add a `pub const NAME: &str` to every array encoding struct and derive `pub const ID: ArrayId` from `Self::NAME` instead of an inline string literal. This eliminates duplicated encoding name strings and gives external code a stable constant to reference when matching on encoding IDs.

relative to https://github.com/vortex-data/vortex/pull/6974

## Testing

N/A
