### PR TITLE
fix[vortex-array]: fix rebuild_trim_elements overflow

### DIFF
--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -14,8 +14,10 @@ use crate::arrays::ListViewArray;
 use crate::builders::builder_with_capacity;
 use crate::builtins::ArrayBuiltins;
 use crate::compute;
+use crate::dtype::DType;
 use crate::dtype::IntegerPType;
 use crate::dtype::Nullability;
+use crate::dtype::PType;
 use crate::match_each_integer_ptype;
 use crate::scalar::Scalar;
 use crate::scalar_fn::fns::operators::Operator;
@@ -294,21 +296,16 @@ impl ListViewArray {
             let last_size = self.size_at(self.len() - 1);
             last_offset + last_size
         } else {
-            // Offsets and sizes can have different primitive types (e.g. u32 vs u16).
-            // Cast the narrower to the wider since arithmetic requires identical operand types.
-            let (offsets, sizes) = if self.offsets().dtype().as_ptype().byte_width()
-                >= self.sizes().dtype().as_ptype().byte_width()
-            {
-                (
-                    self.offsets().clone(),
-                    self.sizes().cast(self.offsets().dtype().clone())?,
-                )
+            // Cast offsets and sizes to the widest integer type to prevent
+            // overflow when computing offsets + sizes. The end offset may not
+            // fit in the integer width otherwise.
+            let wide_dtype = DType::from(if self.offsets().dtype().as_ptype().is_unsigned_int() {
+                PType::U64
             } else {
-                (
-                    self.offsets().cast(self.sizes().dtype().clone())?,
-                    self.sizes().clone(),
-                )
-            };
+                PType::I64
+            });
+            let offsets = self.offsets().cast(wide_dtype.clone())?;
+            let sizes = self.sizes().cast(wide_dtype)?;
 
             let min_max = compute::min_max(
                 &offsets
@@ -611,5 +608,21 @@ mod tests {
         assert!(ListViewArray::should_use_take(127_000, 1_000));
         // avg = 128 → LBL
         assert!(!ListViewArray::should_use_take(128_000, 1_000));
+    }
+
+    /// Regression test for <https://github.com/vortex-data/vortex/issues/6973>.
+    /// Both offsets and sizes are u8, and offset + size exceeds u8::MAX.
+    #[test]
+    fn test_rebuild_trim_elements_sum_overflows_type() -> VortexResult<()> {
+        let elements = PrimitiveArray::from_iter(vec![0i32; 261]).into_array();
+        let offsets = PrimitiveArray::from_iter(vec![215u8, 0]).into_array();
+        let sizes = PrimitiveArray::from_iter(vec![46u8, 10]).into_array();
+
+        let listview = ListViewArray::new(elements, offsets, sizes, Validity::NonNullable);
+        let trimmed = listview.rebuild(ListViewRebuildMode::TrimElements)?;
+
+        // min(offsets) = 0, so nothing to trim; output should equal input.
+        assert_arrays_eq!(trimmed, listview);
+        Ok(())
     }
 }


### PR DESCRIPTION
This commit just casts offsets and sizes to u64/i64 before summing for simplicitly. We could make the logic more complicated but not sure it's worth it.

<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

<!--
If this PR is related to a tracked effort, please link to the relevant issue
here (e.g., `Closes: #123`). Otherwise, feel free to ignore / delete this.

In this section, please:

1. Explain the rationale for this change.
2. Summarize the changes included in this PR.

A general rule of thumb is that larger PRs should have larger summaries. If
there are a lot of changes, please help us review the code by explaining what
was changed and why.

If there is an issue or discussion attached, there is no need to duplicate all
the details, but clarity is always preferred over brevity.
-->

Closes: #6973 

<!--
## API Changes

Uncomment this section if there are any user-facing changes.

Consider whether the change affects users in one of the following ways:

1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the engine integrations.
3. Should some documentation be updated to reflect this change?

If a public API is changed in a breaking manner, make sure to add the
appropriate label. You can run `./scripts/public-api.sh` locally to see if there
are any public API changes (and this also runs in our CI).
-->

## Testing

<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
3. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
Regression test added