### PR TITLE
chore: clean up `#[inline]` annotations

### DIFF
--- a/encodings/fastlanes/src/bit_transpose/aarch64.rs
+++ b/encodings/fastlanes/src/bit_transpose/aarch64.rs
@@ -114,7 +114,6 @@ static SCATTER_8X8_NEON: [[u8; 16]; 4] = [
 
 /// Perform 8x8 bit transpose on two u64s packed in a `uint64x2_t`.
 #[allow(unsafe_op_in_unsafe_fn)]
-#[inline]
 unsafe fn bit_transpose_8x8_neon(mut v: uint64x2_t) -> uint64x2_t {
     let mask1 = vdupq_n_u64(TRANSPOSE_2X2);
     let t = vandq_u64(veorq_u64(v, vshrq_n_u64::<7>(v)), mask1);

--- a/encodings/fastlanes/src/bit_transpose/scalar.rs
+++ b/encodings/fastlanes/src/bit_transpose/scalar.rs
@@ -15,7 +15,6 @@ use crate::bit_transpose::TRANSPOSE_8X8;
 #[allow(dead_code)]
 pub fn transpose_bits_scalar(input: &[u8; 128], output: &mut [u8; 128]) {
     // Helper to perform 8x8 bit transpose on a u64 (each byte becomes a row)
-    #[inline]
     fn transpose_8x8(mut x: u64) -> u64 {
         // Step 1: Transpose 2x2 bit blocks
         let t = (x ^ (x >> 7)) & TRANSPOSE_2X2;
@@ -29,7 +28,6 @@ pub fn transpose_bits_scalar(input: &[u8; 128], output: &mut [u8; 128]) {
     }
 
     // Helper to gather 8 bytes at stride 16 into a u64
-    #[inline]
     fn gather(input: &[u8; 128], base: usize) -> u64 {
         u64::from(input[base])
             | (u64::from(input[base + 16]) << 8)
@@ -89,7 +87,6 @@ pub fn transpose_bits_scalar(input: &[u8; 128], output: &mut [u8; 128]) {
 #[inline(never)]
 #[allow(dead_code)]
 pub fn untranspose_bits_scalar(input: &[u8; 128], output: &mut [u8; 128]) {
-    #[inline]
     fn transpose_8x8(mut x: u64) -> u64 {
         let t = (x ^ (x >> 7)) & TRANSPOSE_2X2;
         x = x ^ t ^ (t << 7);
@@ -99,7 +96,6 @@ pub fn untranspose_bits_scalar(input: &[u8; 128], output: &mut [u8; 128]) {
         x ^ t ^ (t << 28)
     }
 
-    #[inline]
     fn gather_transposed(input: &[u8; 128], base_group: usize, offset: usize) -> u64 {
         let mut result: u64 = 0;
         for bit_pos in 0..8 {
@@ -108,7 +104,6 @@ pub fn untranspose_bits_scalar(input: &[u8; 128], output: &mut [u8; 128]) {
         result
     }
 
-    #[inline]
     fn scatter(output: &mut [u8; 128], base: usize, val: u64) {
         output[base] = val as u8;
         output[base + 16] = (val >> 8) as u8;

--- a/encodings/fastlanes/src/bit_transpose/x86.rs
+++ b/encodings/fastlanes/src/bit_transpose/x86.rs
@@ -49,7 +49,6 @@ pub fn has_vbmi() -> bool {
 #[allow(unsafe_op_in_unsafe_fn)]
 pub unsafe fn transpose_bits_bmi2(input: &[u8; 128], output: &mut [u8; 128]) {
     // Helper to gather 8 bytes at stride 16 into a u64
-    #[inline]
     fn gather(input: &[u8; 128], base: usize) -> u64 {
         (input[base] as u64)
             | ((input[base + 16] as u64) << 8)
@@ -238,7 +237,6 @@ pub unsafe fn transpose_bits_bmi2(input: &[u8; 128], output: &mut [u8; 128]) {
 #[allow(unsafe_op_in_unsafe_fn)]
 pub unsafe fn untranspose_bits_bmi2(input: &[u8; 128], output: &mut [u8; 128]) {
     // Helper: scatter a u64 to 8 output bytes at stride 16
-    #[inline]
     fn scatter(output: &mut [u8; 128], base: usize, val: u64) {
         output[base] = val as u8;
         output[base + 16] = (val >> 8) as u8;

--- a/encodings/fastlanes/src/bitpacking/array/unpack_iter.rs
+++ b/encodings/fastlanes/src/bitpacking/array/unpack_iter.rs
@@ -256,12 +256,10 @@ impl<T: PhysicalPType, S: UnpackStrategy<T>> UnpackedChunks<T, S> {
         })
     }
 
-    #[inline]
     fn last_chunk_is_sliced(&self) -> bool {
         self.last_chunk_length != 0
     }
 
-    #[inline]
     fn first_chunk_is_sliced(&self) -> bool {
         self.offset != 0
     }

--- a/encodings/fastlanes/src/delta/array/mod.rs
+++ b/encodings/fastlanes/src/delta/array/mod.rs
@@ -161,7 +161,6 @@ impl DeltaArray {
         &self.deltas
     }
 
-    #[inline]
     pub(crate) fn lanes(&self) -> usize {
         let ptype =
             PType::try_from(self.dtype()).vortex_expect("DeltaArray DType must be primitive");
@@ -189,17 +188,14 @@ impl DeltaArray {
         self.offset
     }
 
-    #[inline]
     pub(crate) fn bases_len(&self) -> usize {
         self.bases.len()
     }
 
-    #[inline]
     pub(crate) fn deltas_len(&self) -> usize {
         self.deltas.len()
     }
 
-    #[inline]
     pub(crate) fn stats_set(&self) -> &ArrayStats {
         &self.stats_set
     }

--- a/encodings/fastlanes/src/for/array/mod.rs
+++ b/encodings/fastlanes/src/for/array/mod.rs
@@ -63,7 +63,6 @@ impl FoRArray {
         &self.reference
     }
 
-    #[inline]
     pub(crate) fn stats_set(&self) -> &ArrayStats {
         &self.stats_set
     }

--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -207,7 +207,6 @@ impl RLEArray {
         self.offset
     }
 
-    #[inline]
     pub(crate) fn stats_set(&self) -> &ArrayStats {
         &self.stats_set
     }

--- a/encodings/runend/src/iter.rs
+++ b/encodings/runend/src/iter.rs
@@ -6,7 +6,6 @@ use std::cmp::min;
 use vortex_array::dtype::IntegerPType;
 use vortex_error::vortex_panic;
 
-#[inline]
 pub fn trimmed_ends_iter<E: IntegerPType>(
     run_ends: &[E],
     offset: usize,

--- a/vortex-array/src/aggregate_fn/fns/nan_count/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/nan_count/primitive.rs
@@ -15,7 +15,6 @@ pub(super) fn accumulate_primitive(count: &mut u64, p: &PrimitiveArray) -> Vorte
     Ok(())
 }
 
-#[inline]
 fn compute_nan_count_with_validity<T: NativePType>(values: &[T], validity: Mask) -> usize {
     match validity {
         Mask::AllTrue(_) => values.iter().filter(|v| v.is_nan()).count(),

--- a/vortex-array/src/arrays/decimal/compute/min_max.rs
+++ b/vortex-array/src/arrays/decimal/compute/min_max.rs
@@ -28,7 +28,6 @@ impl MinMaxKernel for Decimal {
 
 register_kernel!(MinMaxKernelAdapter(Decimal).lift());
 
-#[inline]
 fn compute_min_max_with_validity<D>(array: &DecimalArray) -> VortexResult<Option<MinMaxResult>>
 where
     D: Into<DecimalValue> + NativeDecimalType,

--- a/vortex-array/src/arrays/decimal/compute/take.rs
+++ b/vortex-array/src/arrays/decimal/compute/take.rs
@@ -42,7 +42,6 @@ impl TakeExecute for Decimal {
     }
 }
 
-#[inline]
 fn take_to_buffer<I: IntegerPType, T: NativeDecimalType>(indices: &[I], values: &[T]) -> Buffer<T> {
     indices.iter().map(|idx| values[idx.as_()]).collect()
 }

--- a/vortex-array/src/arrays/primitive/array/patch.rs
+++ b/vortex-array/src/arrays/primitive/array/patch.rs
@@ -92,7 +92,6 @@ pub fn chunk_range(chunk_idx: usize, offset: usize, array_len: usize) -> Range<u
 /// * `chunk_offsets_slice` - Slice containing offsets for each chunk
 /// * `chunk_idx` - Index of the chunk to patch
 /// * `offset_within_chunk` - Number of patches to skip at the start of the first chunk
-#[inline]
 pub fn patch_chunk<T, I, C>(
     decoded_values: &mut [T],
     patches_indices: &[I],

--- a/vortex-array/src/arrays/primitive/compute/min_max.rs
+++ b/vortex-array/src/arrays/primitive/compute/min_max.rs
@@ -27,7 +27,6 @@ impl MinMaxKernel for Primitive {
 
 register_kernel!(MinMaxKernelAdapter(Primitive).lift());
 
-#[inline]
 fn compute_min_max_with_validity<T>(array: &PrimitiveArray) -> VortexResult<Option<MinMaxResult>>
 where
     T: NativePType,

--- a/vortex-array/src/arrays/primitive/compute/take/avx2.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/avx2.rs
@@ -118,7 +118,6 @@ where
 /// The caller must ensure the `avx2` feature is enabled.
 #[allow(dead_code, unused_variables, reason = "TODO(connor): Implement this")]
 #[target_feature(enable = "avx2")]
-#[inline]
 #[doc(hidden)]
 unsafe fn take_avx2<V: NativePType, I: UnsignedPType>(buffer: &[V], indices: &[I]) -> Buffer<V> {
     macro_rules! dispatch_avx2 {

--- a/vortex-array/src/arrays/primitive/compute/take/portable.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/portable.rs
@@ -79,7 +79,6 @@ const SIMD_WIDTH: usize = 64;
 ///
 /// This function handles the type matching required to satisfy [`simd::SimdElement`] bounds. For
 /// `f16` values, it reinterprets them as `u16` since `f16` doesn't implement `SimdElement`.
-#[inline]
 fn take_portable<T: NativePType, I: UnsignedPType>(buffer: &[T], indices: &[I]) -> Buffer<T> {
     if T::PTYPE == PType::F16 {
         assert_eq!(size_of::<f16>(), size_of::<T>());
@@ -106,7 +105,6 @@ fn take_portable<T: NativePType, I: UnsignedPType>(buffer: &[T], indices: &[I]) 
 /// Helper that matches on index type and calls [`take_portable_simd`].
 ///
 /// We separate this code out from above to add the [`simd::SimdElement`] constraint.
-#[inline]
 fn take_with_indices<T: NativePType + simd::SimdElement, I: UnsignedPType>(
     buffer: &[T],
     indices: &[I],

--- a/vortex-array/src/arrays/varbinview/compute/zip.rs
+++ b/vortex-array/src/arrays/varbinview/compute/zip.rs
@@ -174,7 +174,6 @@ fn push_range(
     }
 }
 
-#[inline]
 fn push_view(
     view: BinaryView,
     buffer_lookup: &[u32],

--- a/vortex-array/src/arrays/varbinview/view.rs
+++ b/vortex-array/src/arrays/varbinview/view.rs
@@ -47,7 +47,6 @@ pub struct Inlined {
 
 impl Inlined {
     /// Creates a new inlined representation from the provided value of constant size.
-    #[inline]
     fn new<const N: usize>(value: &[u8]) -> Self {
         debug_assert_eq!(value.len(), N);
         let mut inlined = Self {

--- a/vortex-array/src/builders/dict/bytes.rs
+++ b/vortex-array/src/builders/dict/bytes.rs
@@ -71,7 +71,6 @@ impl<Code: UnsignedPType> BytesDictBuilder<Code> {
         self.views.len() * size_of::<BinaryView>() + self.values.len()
     }
 
-    #[inline]
     fn lookup_bytes(&self, idx: usize) -> Option<&[u8]> {
         self.values_nulls.value(idx).then(|| {
             let bin_view = &self.views[idx];
@@ -83,7 +82,6 @@ impl<Code: UnsignedPType> BytesDictBuilder<Code> {
         })
     }
 
-    #[inline]
     fn encode_value(&mut self, lookup: &mut HashTable<Code>, val: Option<&[u8]>) -> Option<Code> {
         match lookup.entry(
             self.hasher.hash_one(val),

--- a/vortex-array/src/builders/dict/primitive.rs
+++ b/vortex-array/src/builders/dict/primitive.rs
@@ -79,7 +79,6 @@ where
         }
     }
 
-    #[inline]
     fn encode_value(&mut self, v: Option<T>) -> Option<Code> {
         match self.lookup.entry(v.map(NativeValue)) {
             Entry::Occupied(o) => Some(*o.get()),

--- a/vortex-array/src/builders/lazy_null_builder.rs
+++ b/vortex-array/src/builders/lazy_null_builder.rs
@@ -134,7 +134,6 @@ impl LazyBitBufferBuilder {
         }
     }
 
-    #[inline]
     fn materialize_if_needed(&mut self) {
         if self.inner.is_none() {
             self.materialize()

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -359,7 +359,6 @@ impl ArrayBuilder for VarBinViewBuilder {
 }
 
 impl VarBinViewBuilder {
-    #[inline]
     fn push_view(
         &mut self,
         view: BinaryView,
@@ -752,7 +751,6 @@ enum PrecomputedViewAdjustment {
 }
 
 impl PrecomputedViewAdjustment {
-    #[inline]
     fn adjust_view(&self, view: &BinaryView) -> BinaryView {
         if view.is_inlined() {
             return *view;

--- a/vortex-array/src/dtype/struct_.rs
+++ b/vortex-array/src/dtype/struct_.rs
@@ -106,7 +106,6 @@ impl FieldDType {
 }
 
 impl FieldDTypeInner {
-    #[inline]
     fn value(&self) -> VortexResult<DType> {
         match &self {
             FieldDTypeInner::Owned(owned) => Ok(owned.clone()),

--- a/vortex-array/src/scalar/typed_view/struct_.rs
+++ b/vortex-array/src/scalar/typed_view/struct_.rs
@@ -114,7 +114,6 @@ impl Hash for StructScalar<'_> {
 
 impl<'a> StructScalar<'a> {
     /// Creates a new [`StructScalar`] from a [`DType`] and optional [`ScalarValue`].
-    #[inline]
     pub(crate) fn try_new(dtype: &'a DType, value: Option<&'a ScalarValue>) -> VortexResult<Self> {
         if !matches!(dtype, DType::Struct(..)) {
             vortex_bail!("Expected struct scalar, found {}", dtype)

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -182,7 +182,6 @@ impl ScalarFnVTable for Binary {
         //
         // Non-floating point column and literal expressions should be unaffected as they do not
         // have a nan_count statistic defined.
-        #[inline]
         fn with_nan_predicate(
             lhs: &Expression,
             rhs: &Expression,

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -374,7 +374,6 @@ impl Validity {
     ///
     /// Note: You want to pass the nullability of parent array and not the nullability of the validity array itself
     ///     as that is always nonnullable
-    #[inline]
     fn from_array(value: ArrayRef, nullability: Nullability) -> Self {
         if !matches!(value.dtype(), DType::Bool(Nullability::NonNullable)) {
             vortex_panic!("Expected a non-nullable boolean array")

--- a/vortex-buffer/src/bit/buf.rs
+++ b/vortex-buffer/src/bit/buf.rs
@@ -405,6 +405,7 @@ impl FromIterator<bool> for BitBuffer {
 impl BitOr for BitBuffer {
     type Output = Self;
 
+    #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
         BitOr::bitor(&self, &rhs)
     }
@@ -413,6 +414,7 @@ impl BitOr for BitBuffer {
 impl BitOr for &BitBuffer {
     type Output = BitBuffer;
 
+    #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
         bitwise_binary_op(self, rhs, |a, b| a | b)
     }
@@ -421,6 +423,7 @@ impl BitOr for &BitBuffer {
 impl BitOr<&BitBuffer> for BitBuffer {
     type Output = BitBuffer;
 
+    #[inline]
     fn bitor(self, rhs: &BitBuffer) -> Self::Output {
         (&self).bitor(rhs)
     }
@@ -429,6 +432,7 @@ impl BitOr<&BitBuffer> for BitBuffer {
 impl BitAnd for &BitBuffer {
     type Output = BitBuffer;
 
+    #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
         bitwise_binary_op(self, rhs, |a, b| a & b)
     }
@@ -437,6 +441,7 @@ impl BitAnd for &BitBuffer {
 impl BitAnd<BitBuffer> for &BitBuffer {
     type Output = BitBuffer;
 
+    #[inline]
     fn bitand(self, rhs: BitBuffer) -> Self::Output {
         self.bitand(&rhs)
     }
@@ -445,6 +450,7 @@ impl BitAnd<BitBuffer> for &BitBuffer {
 impl BitAnd<&BitBuffer> for BitBuffer {
     type Output = BitBuffer;
 
+    #[inline]
     fn bitand(self, rhs: &BitBuffer) -> Self::Output {
         (&self).bitand(rhs)
     }
@@ -453,6 +459,7 @@ impl BitAnd<&BitBuffer> for BitBuffer {
 impl BitAnd<BitBuffer> for BitBuffer {
     type Output = BitBuffer;
 
+    #[inline]
     fn bitand(self, rhs: BitBuffer) -> Self::Output {
         (&self).bitand(&rhs)
     }
@@ -461,6 +468,7 @@ impl BitAnd<BitBuffer> for BitBuffer {
 impl Not for &BitBuffer {
     type Output = BitBuffer;
 
+    #[inline]
     fn not(self) -> Self::Output {
         bitwise_unary_op(self, |a| !a)
     }
@@ -469,6 +477,7 @@ impl Not for &BitBuffer {
 impl Not for BitBuffer {
     type Output = BitBuffer;
 
+    #[inline]
     fn not(self) -> Self::Output {
         (&self).not()
     }
@@ -477,6 +486,7 @@ impl Not for BitBuffer {
 impl BitXor for &BitBuffer {
     type Output = BitBuffer;
 
+    #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
         bitwise_binary_op(self, rhs, |a, b| a ^ b)
     }
@@ -485,6 +495,7 @@ impl BitXor for &BitBuffer {
 impl BitXor<&BitBuffer> for BitBuffer {
     type Output = BitBuffer;
 
+    #[inline]
     fn bitxor(self, rhs: &BitBuffer) -> Self::Output {
         (&self).bitxor(rhs)
     }

--- a/vortex-duckdb/src/duckdb/mod.rs
+++ b/vortex-duckdb/src/duckdb/mod.rs
@@ -53,7 +53,6 @@ use vortex::error::VortexResult;
 use crate::cpp;
 
 /// Try to execute a Rust function, or else return a null pointer and set the error.
-#[inline]
 pub(crate) fn try_or_null<T>(
     error_out: *mut cpp::duckdb_vx_error,
     function: impl FnOnce() -> VortexResult<*mut T>,
@@ -73,7 +72,6 @@ pub(crate) fn try_or_null<T>(
 }
 
 /// Try to execute a Rust function, or else return the default value and set the error.
-#[inline]
 pub(crate) fn try_or<T: Default>(
     error_out: *mut cpp::duckdb_vx_error,
     function: impl FnOnce() -> VortexResult<T>,

--- a/vortex-ffi/src/error.rs
+++ b/vortex-ffi/src/error.rs
@@ -19,7 +19,6 @@ box_wrapper!(
     vx_error
 );
 
-#[inline]
 pub fn try_or_default<T: Default>(
     error_out: *mut *mut vx_error,
     function: impl FnOnce() -> VortexResult<T>,

--- a/vortex-jni/src/errors.rs
+++ b/vortex-jni/src/errors.rs
@@ -83,7 +83,6 @@ impl JNIDefault for jobject {
     clippy::expect_used,
     reason = "JNI operations must succeed for proper error handling"
 )]
-#[inline]
 pub fn try_or_throw<'a, F, T>(env: &mut JNIEnv<'a>, function: F) -> T
 where
     F: FnOnce(&mut JNIEnv<'a>) -> Result<T, JNIError>,

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -93,7 +93,6 @@ impl ZonedReader {
         })
     }
 
-    #[inline]
     fn data_child(&self) -> VortexResult<&LayoutReaderRef> {
         self.lazy_children.get(0)
     }


### PR DESCRIPTION
Remove `#[inline]` from private, pub(crate), and inner functions where the compiler already has full visibility, and from large (>20 line) functions.

Add `#[inline]` to `BitBuffer` operator trait impls (BitOr, BitAnd, Not, BitXor) - non-generic impls on a concrete type that are otherwise opaque cross-crate with LTO disabled.