### PR TITLE
Add backwards compatibly handling of sum stats of extension types

### DIFF
--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -80,6 +80,15 @@ impl ZoneMap {
                     .iter()
                     .filter_map(|stat| {
                         stat.dtype(column_dtype)
+                            .or_else(|| {
+                                // Backward compat: older files may have stored stats (e.g. Sum)
+                                // for extension types by resolving through the storage dtype.
+                                if let DType::Extension(ext) = column_dtype {
+                                    stat.dtype(ext.storage_dtype())
+                                } else {
+                                    None
+                                }
+                            })
                             .map(|dtype| (stat, dtype.as_nullable()))
                     })
                     .flat_map(|(s, dt)| match s {


### PR DESCRIPTION
After #6910, Older files with extension types will have zone stats that are just based on the storage type (which might be arbitrary) and which is rarely useful. we currently don't handle its existence at all, so reading these files might panic or otherwise error. This PR falls back to the storage type on the read path, but might not be the desirable solution.