### PR TITLE
fix: compat check CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -886,6 +886,23 @@ jobs:
           enable-sccache: "false"
       - run: cargo build --package vortex-jni
 
+  compat-check:
+    name: "Compat check"
+    timeout-minutes: 120
+    runs-on: >-
+      ${{ github.repository == 'vortex-data/vortex'
+          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre/tag=compat-check', github.run_id)
+          || 'ubuntu-latest' }}
+    steps:
+      - uses: runs-on/action@v2
+        if: github.repository == 'vortex-data/vortex'
+        with:
+          sccache: s3
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-prebuild
+      - name: Run compat check (latest version)
+        run: python3 vortex-test/compat-gen/scripts/compat.py check --mode last
+
   rust-publish-dry-run:
     name: "Rust publish dry-run"
     timeout-minutes: 120

--- a/.github/workflows/compat-validation.yml
+++ b/.github/workflows/compat-validation.yml
@@ -8,27 +8,28 @@ on:
       mode:
         description: "Validation mode"
         required: true
-        default: "last"
+        default: "all"
         type: choice
         options:
-          - last
           - all
-
-env:
-  FIXTURES_URL: https://vortex-compat-fixtures.s3.amazonaws.com
+          - last
 
 jobs:
   compat-test:
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ github.repository == 'vortex-data/vortex'
+          && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre/tag=compat-validation', github.run_id)
+          || 'ubuntu-latest' }}
+    timeout-minutes: 120
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-
+      - uses: runs-on/action@v2
+        if: github.repository == 'vortex-data/vortex'
+        with:
+          sccache: s3
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-prebuild
       - name: Run compat tests
         run: |
-          MODE="${{ inputs.mode || 'last' }}"
+          MODE="${{ inputs.mode || 'all' }}"
           python3 vortex-test/compat-gen/scripts/compat.py check \
             --mode "$MODE"

--- a/vortex-test/compat-gen/scripts/compat.py
+++ b/vortex-test/compat-gen/scripts/compat.py
@@ -580,17 +580,14 @@ def cmd_check(args: argparse.Namespace) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmppath = Path(tmpdir)
 
-            for entry in manifest["fixtures"]:
-                name = entry["name"]
-                data = store.read(f"{prefix}/{name}")
-                if data is None:
-                    _info(f"  v{version}: {name} not found at {prefix}/{name}")
-                    all_failures.append((version, name, "fixture file not found in store"))
-                    total_failed += 1
-                    continue
-                (tmppath / name).write_bytes(data)
-                _info(f"  downloaded {name} ({len(data)} bytes)")
+            _info(f"  downloading {len(manifest['fixtures'])} fixtures...")
+            download_failures = _parallel_download(store, manifest["fixtures"], prefix, tmppath)
+            for name, error in download_failures:
+                _info(f"  v{version}: {name} {error}")
+                all_failures.append((version, name, error))
+                total_failed += 1
 
+            _info(f"  checking v{version}...")
             result = _run_rust_check(tmppath, mode="subset")
 
             passed = len(result.get("passed", []))
@@ -749,18 +746,76 @@ def _parallel_upload(store: Store, items: list[tuple[str, Path]], max_workers: i
             future.result()
 
 
+def _parallel_download(
+    store: Store,
+    fixtures: list[dict],
+    prefix: str,
+    dest: Path,
+    max_workers: int = 8,
+) -> list[tuple[str, str]]:
+    """Download fixture files from the store in parallel.
+
+    Returns a list of (name, error) for any failures.
+    """
+    failures: list[tuple[str, str]] = []
+    total_bytes = 0
+
+    def _download_one(entry: dict) -> tuple[str, bytes | None]:
+        name = entry["name"]
+        data = store.read(f"{prefix}/{name}")
+        return name, data
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_download_one, entry): entry["name"] for entry in fixtures}
+        for future in as_completed(futures):
+            name, data = future.result()
+            if data is None:
+                failures.append((name, f"not found at {prefix}/{name}"))
+            else:
+                (dest / name).write_bytes(data)
+                total_bytes += len(data)
+
+    _info(f"  downloaded {len(fixtures) - len(failures)} fixtures ({total_bytes} bytes)")
+    return failures
+
+
+def _build_compat_bin() -> str:
+    """Build vortex-compat and return the path to the binary.
+
+    If VORTEX_COMPAT_BIN is set, skips the build and returns that path.
+    Otherwise runs `cargo build` with visible output, then locates the binary.
+    """
+    bin_path = os.environ.get("VORTEX_COMPAT_BIN")
+    if bin_path:
+        return bin_path
+
+    _info("building vortex-compat (release)...")
+    _run_cmd(["cargo", "build", "-p", CARGO_BIN, "--release"], check=True)
+
+    # Ask cargo where the binary is.
+    result = subprocess.run(
+        ["cargo", "metadata", "--format-version=1", "--no-deps"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    target_dir = json.loads(result.stdout)["target_directory"]
+    bin_path = str(Path(target_dir) / "release" / CARGO_BIN)
+    return bin_path
+
+
 def _run_rust_generate(output: Path) -> None:
     """Run `vortex-compat generate --output <dir>`."""
-    cmd = _cargo_run_cmd() + ["generate", "--output", str(output)]
-    _run_cmd(cmd, check=True)
+    bin_path = _build_compat_bin()
+    _run_cmd([bin_path, "generate", "--output", str(output)], check=True)
 
 
 def _run_rust_check(dir: Path, mode: str = "subset") -> dict:
     """Run `vortex-compat check --dir <dir> --mode <mode>` and parse JSON stdout."""
-    cmd = _cargo_run_cmd() + ["check", "--dir", str(dir), "--mode", mode]
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if result.stderr:
-        print(result.stderr, end="", file=sys.stderr)
+    bin_path = _build_compat_bin()
+    cmd = [bin_path, "check", "--dir", str(dir), "--mode", mode]
+    _info(f"  $ {' '.join(cmd)}")
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, text=True)
 
     if result.stdout.strip():
         return json.loads(result.stdout)
@@ -772,14 +827,6 @@ def _run_rust_check(dir: Path, mode: str = "subset") -> dict:
             "skipped": [],
         }
     return {"passed": [], "failed": [], "skipped": []}
-
-
-def _cargo_run_cmd() -> list[str]:
-    """Build the command to invoke vortex-compat (pre-built binary or cargo run)."""
-    bin_path = os.environ.get("VORTEX_COMPAT_BIN")
-    if bin_path:
-        return [bin_path]
-    return ["cargo", "run", "-p", CARGO_BIN, "--release", "--"]
 
 
 def _run_cmd(cmd: list[str], check: bool = False, cwd: Path | None = None) -> subprocess.CompletedProcess:

--- a/vortex-test/compat-gen/scripts/compat.py
+++ b/vortex-test/compat-gen/scripts/compat.py
@@ -79,6 +79,7 @@ examples:
 
   # Check all versions, or specific ones
   uv run compat.py check
+  uv run compat.py check --mode last
   uv run compat.py check --versions 0.62.0,0.63.0
 
   # Inspect store contents
@@ -541,10 +542,16 @@ def cmd_check(args: argparse.Namespace) -> None:
     """Download fixtures from store and check with Rust binary."""
     store = _parse_store(args.store)
 
+    if args.versions and args.mode != "all":
+        print("error: --versions and --mode are mutually exclusive", file=sys.stderr)
+        sys.exit(1)
+
     if args.versions:
         versions = [v.strip() for v in args.versions.split(",")]
     else:
         versions = store.list_versions()
+        if args.mode == "last" and versions:
+            versions = versions[-1:]
 
     if not versions:
         _info("no versions found in store")
@@ -902,6 +909,7 @@ def main() -> None:
         epilog=(
             "examples:\n"
             "  uv run compat.py check\n"
+            "  uv run compat.py check --mode last\n"
             "  uv run compat.py check --versions 0.62.0,0.63.0\n"
             "  uv run compat.py check --store /tmp/store"
         ),
@@ -910,7 +918,14 @@ def main() -> None:
     p.add_argument("--store", default=DEFAULT_STORE, help="Store spec (default: %(default)s)")
     p.add_argument(
         "--versions",
-        help="Comma-separated versions to check (default: all)",
+        help="Comma-separated versions to check (mutually exclusive with --mode)",
+    )
+    p.add_argument(
+        "--mode",
+        choices=["all", "last"],
+        default="all",
+        help="Which versions to check: 'all' (default) or 'last' (most recent only). "
+        "Mutually exclusive with --versions.",
     )
 
     # -- list --


### PR DESCRIPTION
## Summary
- Add `--mode` argument to `compat.py check` (`all`/`last`, mutually exclusive with `--versions`)
- Add `compat-check` job to CI that runs `compat.py check --mode last` on every PR
- Fix hang: split `cargo run` into explicit build + run so compilation output is visible
- Parallel fixture downloads using `ThreadPoolExecutor`
- Update `compat-validation.yml` to use repo action patterns (`checkout@v6`, `setup-prebuild`, runs-on runners)

## Test plan
- [ ] CI `compat-check` job passes on this PR
- [ ] `python3 vortex-test/compat-gen/scripts/compat.py check --mode last` runs without hanging
- [ ] `--versions` and `--mode last` together produces an error
- [ ] Weekly `compat-validation` workflow still works with `--mode all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)