### PR TITLE
Compress int dict array values

### DIFF
--- a/vortex-btrblocks/src/compressor/float/mod.rs
+++ b/vortex-btrblocks/src/compressor/float/mod.rs
@@ -433,13 +433,14 @@ impl Scheme for DictScheme {
         let has_all_values_referenced = dict.has_all_values_referenced();
         let DictArrayParts { codes, values, .. } = dict.into_parts();
 
+        // TODO(connor): This should probably be extending the `excludes` list.
         let compressed_codes = compressor.compress_canonical(
             Canonical::Primitive(codes.to_primitive()),
             ctx.descend(),
             Excludes::int_only(&[IntCode::Dict, IntCode::Sequence]),
         )?;
 
-        assert!(values.is_canonical());
+        // TODO(connor): This should probably be extending the `excludes` list.
         let compressed_values = compressor.compress_canonical(
             Canonical::Primitive(values.to_primitive()),
             ctx.descend(),

--- a/vortex-btrblocks/src/compressor/integer/mod.rs
+++ b/vortex-btrblocks/src/compressor/integer/mod.rs
@@ -703,21 +703,32 @@ impl Scheme for DictScheme {
 
         let dict = dictionary_encode(stats);
 
-        // Cascade the codes child
-        // Don't allow SequenceArray as the codes child as it merely adds extra indirection without actually compressing data.
-        let mut new_excludes = vec![IntCode::Dict, IntCode::Sequence];
-        new_excludes.extend_from_slice(excludes);
+        // Cascade the codes child.
+        // Don't allow SequenceArray as the codes child as it merely adds extra indirection without
+        // actually compressing data.
+        let mut codes_excludes = vec![IntCode::Dict, IntCode::Sequence];
+        codes_excludes.extend_from_slice(excludes);
 
         let compressed_codes = compressor.compress_canonical(
             Canonical::Primitive(dict.codes().to_primitive().narrow()?),
             ctx.descend(),
-            Excludes::int_only(&new_excludes),
+            Excludes::int_only(&codes_excludes),
         )?;
 
-        // SAFETY: compressing codes does not change their values
+        // Cascade the values child.
+        let mut values_excludes = vec![IntCode::Dict];
+        values_excludes.extend_from_slice(excludes);
+
+        let compressed_values = compressor.compress_canonical(
+            Canonical::Primitive(dict.values().to_primitive()),
+            ctx.descend(),
+            Excludes::int_only(&values_excludes),
+        )?;
+
+        // SAFETY: Compressing the arrays does not change their logical values.
         unsafe {
             Ok(
-                DictArray::new_unchecked(compressed_codes, dict.values().clone())
+                DictArray::new_unchecked(compressed_codes, compressed_values)
                     .set_all_values_referenced(dict.has_all_values_referenced())
                     .into_array(),
             )


### PR DESCRIPTION
## Summary

Compress dictionary-encoded integer array values.

Note that we already do this for dictionary-encoded float array values.

## Testing

N/A