### PR TITLE
Print to stdout in `compress-bench` and `random-access-bench`

### DIFF
--- a/benchmarks/compress-bench/src/main.rs
+++ b/benchmarks/compress-bench/src/main.rs
@@ -13,7 +13,6 @@ use indicatif::ProgressBar;
 use itertools::Itertools;
 use regex::Regex;
 use vortex::utils::aliases::hash_map::HashMap;
-use vortex_bench::BenchmarkOutput;
 use vortex_bench::Engine;
 use vortex_bench::Format;
 use vortex_bench::Target;
@@ -23,6 +22,7 @@ use vortex_bench::compress::Compressor;
 use vortex_bench::compress::benchmark_compress;
 use vortex_bench::compress::benchmark_decompress;
 use vortex_bench::compress::calculate_ratios;
+use vortex_bench::create_output_writer;
 use vortex_bench::datasets::Dataset;
 use vortex_bench::datasets::struct_list_of_ints::StructListOfInts;
 use vortex_bench::datasets::taxi_data::TaxiData;
@@ -169,8 +169,7 @@ async fn run_compress(
 
     progress.finish();
 
-    let output = BenchmarkOutput::with_path(BENCHMARK_ID, output_path);
-    let mut writer = output.create_writer()?;
+    let mut writer = create_output_writer(&display_format, output_path, BENCHMARK_ID)?;
 
     match display_format {
         DisplayFormat::Table => {

--- a/benchmarks/random-access-bench/src/main.rs
+++ b/benchmarks/random-access-bench/src/main.rs
@@ -14,10 +14,10 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand_distr::Distribution;
 use rand_distr::Exp;
-use vortex_bench::BenchmarkOutput;
 use vortex_bench::Engine;
 use vortex_bench::Format;
 use vortex_bench::Target;
+use vortex_bench::create_output_writer;
 use vortex_bench::datasets::feature_vectors::FeatureVectorsData;
 use vortex_bench::datasets::nested_lists::NestedListsData;
 use vortex_bench::datasets::nested_structs::NestedStructsData;
@@ -416,8 +416,7 @@ async fn run_random_access(
 
     progress.finish();
 
-    let output = BenchmarkOutput::with_path(BENCHMARK_ID, output_path);
-    let mut writer = output.create_writer()?;
+    let mut writer = create_output_writer(&display_format, output_path, BENCHMARK_ID)?;
 
     match display_format {
         DisplayFormat::Table => {


### PR DESCRIPTION
## Summary

For these 2, if you don't specify an output file it doesn't print to stdout. This change fixes that (brings it in line with the other benchmarks).

## Testing

N/A