### PR TITLE
Show truncation indicator in array display

### DIFF
--- a/vortex-array/src/display/mod.rs
+++ b/vortex-array/src/display/mod.rs
@@ -477,7 +477,7 @@ impl dyn DynArray + '_ {
             DisplayOptions::CommaSeparatedScalars {
                 omit_comma_after_space,
             } => {
-                let opening_brace= if f.alternate() { "[\n" } else { "[" };
+                let opening_brace = if f.alternate() { "[\n" } else { "[" };
                 let closing_brace = if f.alternate() { "\n]" } else { "]" };
 
                 let sep = if *omit_comma_after_space { "," } else { ", " };
@@ -485,16 +485,19 @@ impl dyn DynArray + '_ {
                 let limit = self.len().min(f.precision().unwrap_or(DISPLAY_LIMIT));
                 let is_truncated = self.len() > limit;
 
-                let fmt_scalar = |i| self
-                    .scalar_at(i)
-                    .map_or_else(|e| format!("<error: {e}>"), |s| s.to_string());
-
+                let fmt_scalar = |i| {
+                    self.scalar_at(i)
+                        .map_or_else(|e| format!("<error: {e}>"), |s| s.to_string())
+                };
                 write!(
                     f,
                     "{opening_brace}{}{closing_brace}",
                     (0..limit.saturating_sub(3))
                         .map(fmt_scalar)
-                        .chain(std::iter::repeat_n("...".to_string(), is_truncated as usize))
+                        .chain(std::iter::repeat_n(
+                            "...".to_string(),
+                            is_truncated as usize
+                        ))
                         .chain((self.len().saturating_sub(3)..self.len()).map(fmt_scalar))
                         .format(sep)
                 )

--- a/vortex-array/src/display/mod.rs
+++ b/vortex-array/src/display/mod.rs
@@ -477,20 +477,27 @@ impl dyn DynArray + '_ {
             DisplayOptions::CommaSeparatedScalars {
                 omit_comma_after_space,
             } => {
-                write!(f, "{}", if f.alternate() { "[\n" } else { "[" })?;
+                let opening_brace= if f.alternate() { "[\n" } else { "[" };
+                let closing_brace = if f.alternate() { "\n]" } else { "]" };
+
                 let sep = if *omit_comma_after_space { "," } else { ", " };
                 let sep = if f.alternate() { ",\n" } else { sep };
-                let limit = std::cmp::min(self.len(), f.precision().unwrap_or(DISPLAY_LIMIT));
+                let limit = self.len().min(f.precision().unwrap_or(DISPLAY_LIMIT));
+                let is_truncated = self.len() > limit;
+
+                let fmt_scalar = |i| self
+                    .scalar_at(i)
+                    .map_or_else(|e| format!("<error: {e}>"), |s| s.to_string());
+
                 write!(
                     f,
-                    "{}",
-                    (0..limit)
-                        .map(|i| self
-                            .scalar_at(i)
-                            .map_or_else(|e| format!("<error: {e}>"), |s| s.to_string()))
+                    "{opening_brace}{}{closing_brace}",
+                    (0..limit.saturating_sub(3))
+                        .map(fmt_scalar)
+                        .chain(std::iter::repeat_n("...".to_string(), is_truncated as usize))
+                        .chain((self.len().saturating_sub(3)..self.len()).map(fmt_scalar))
                         .format(sep)
-                )?;
-                write!(f, "{}", if f.alternate() { "\n]" } else { "]" })
+                )
             }
             DisplayOptions::TreeDisplay {
                 buffers,
@@ -583,6 +590,7 @@ mod test {
     use crate::arrays::BoolArray;
     use crate::arrays::ListArray;
     use crate::arrays::StructArray;
+    use crate::display::DISPLAY_LIMIT;
     use crate::dtype::FieldNames;
     use crate::validity::Validity;
 
@@ -596,6 +604,15 @@ mod test {
 
         let x = buffer![1, 2, 3, 4].into_array();
         assert_eq!(x.display_values().to_string(), "[1i32, 2i32, 3i32, 4i32]");
+
+        let x = crate::arrays::PrimitiveArray::from_iter(
+            0i32..i32::try_from(DISPLAY_LIMIT).unwrap() + 1,
+        )
+        .into_array();
+        assert_eq!(
+            x.display_values().to_string(),
+            "[0i32, 1i32, 2i32, 3i32, 4i32, 5i32, 6i32, 7i32, 8i32, 9i32, 10i32, 11i32, 12i32, ..., 14i32, 15i32, 16i32]"
+        );
     }
 
     #[test]


### PR DESCRIPTION
When displaying array values that exceed the display limit (16), we now show `...` at the end instead of silently truncating. Makes it obvious the output is incomplete.