### PR TITLE
fix[back-compat]: use superset not subset in the check mod

### DIFF
--- a/vortex-test/compat-gen/README.md
+++ b/vortex-test/compat-gen/README.md
@@ -110,7 +110,7 @@ fixtures). Use `exact` for the current version.
 
 1. Read `versions.json` from store
 2. For each version, download `arrays/manifest.json` + all `.vortex` files
-3. Run `vortex-compat check --dir <tmpdir> --mode subset`
+3. Run `vortex-compat check --dir <tmpdir> --mode superset`
 4. Aggregate results, exit 1 if any failures
 
 ### `generate --output <DIR> [--git-ref <REF>] [--exclude <CSV>]`

--- a/vortex-test/compat-gen/README.md
+++ b/vortex-test/compat-gen/README.md
@@ -89,12 +89,12 @@ Check modes:
 
 | Mode | Extra files in dir | Missing fixtures |
 |------|--------------------|------------------|
-| `subset` (default) | Skipped | Error |
+| `superset` (default) | Error | Skipped |
 | `exact` | Error | Error |
-| `superset` | Error | Skipped |
+| `subset` | Skipped | Error |
 
-Use `subset` when checking old versions (they may have extra fixtures not in
-current code). Use `exact` for the current version.
+Use `superset` when checking old versions (they may be missing newly-added
+fixtures). Use `exact` for the current version.
 
 ## Python Orchestrator: `compat.py`
 

--- a/vortex-test/compat-gen/scripts/compat.py
+++ b/vortex-test/compat-gen/scripts/compat.py
@@ -598,7 +598,7 @@ def cmd_check(args: argparse.Namespace) -> None:
                 total_failed += 1
 
             _info(f"  checking v{version}...")
-            result = _run_rust_check(tmppath, mode="subset", profile=args.profile)
+            result = _run_rust_check(tmppath, mode="superset", profile=args.profile)
 
             passed = len(result.get("passed", []))
             failed_list = result.get("failed", [])
@@ -822,7 +822,7 @@ def _run_rust_generate(output: Path, profile: str = "release") -> None:
     _run_cmd([bin_path, "generate", "--output", str(output)], check=True)
 
 
-def _run_rust_check(dir: Path, mode: str = "subset", profile: str = "release") -> dict:
+def _run_rust_check(dir: Path, mode: str = "superset", profile: str = "release") -> dict:
     """Run `vortex-compat check --dir <dir> --mode <mode>` and parse JSON stdout."""
     bin_path = _build_compat_bin(profile)
     cmd = [bin_path, "check", "--dir", str(dir), "--mode", mode]

--- a/vortex-test/compat-gen/src/main.rs
+++ b/vortex-test/compat-gen/src/main.rs
@@ -29,8 +29,8 @@ EXAMPLES:\n\
   Generate fixtures into a directory:\n\
     vortex-compat generate --output /tmp/fixtures\n\
 \n\
-  Check fixtures (allow extra files from older versions):\n\
-    vortex-compat check --dir /tmp/v0.62.0 --mode subset\n\
+  Check fixtures (default, old dir may be missing new fixtures):\n\
+    vortex-compat check --dir /tmp/v0.62.0\n\
 \n\
   Check fixtures (strict, must match exactly):\n\
     vortex-compat check --dir /tmp/v0.63.0 --mode exact\n\
@@ -78,11 +78,11 @@ enum Commands {
 
         /// How to handle mismatches between directory contents and known fixtures.
         ///
-        /// subset  — directory may have extra files (skipped), all known must be present.
-        ///           Best for checking old versions that may have since-removed fixtures.
-        /// exact   — directory must match current fixtures 1:1. No extras, no missing.
         /// superset — directory may be missing files (skipped), no unknown files allowed.
-        #[arg(long, default_value = "subset", value_name = "MODE")]
+        ///            Best for checking old versions that predate newly-added fixtures.
+        /// exact    — directory must match current fixtures 1:1. No extras, no missing.
+        /// subset   — directory may have extra files (skipped), all known must be present.
+        #[arg(long, default_value = "superset", value_name = "MODE")]
         mode: check::Mode,
 
         /// Fixture name substrings to exclude from checking (comma-separated).


### PR DESCRIPTION
We where checking the wrong direction (subset) should ensure all fixtures are a superset of the previous