### PR TITLE
Fuzzer includes unstable_encodings

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ version = { workspace = true }
 cargo-fuzz = true
 
 [features]
-default = ["native"]
+default = ["native", "vortex/unstable_encodings"]
 native = ["libfuzzer-sys", "zstd", "vortex-file", "vortex/files"]
 wasmfuzz = []
 zstd = ["vortex/zstd", "vortex-btrblocks/zstd", "vortex-btrblocks/pco"]


### PR DESCRIPTION
We should know if there's something broken with them even if they're not enabled
by default so we can enable them by default

Signed-off-by: Robert Kruszewski <github@robertk.io>
