### PR TITLE
default mimalloc for vortex-python wheels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10423,6 +10423,7 @@ dependencies = [
  "bytes",
  "itertools 0.14.0",
  "log",
+ "mimalloc",
  "object_store",
  "parking_lot",
  "pyo3",

--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -40,6 +40,7 @@ arrow-schema = { workspace = true }
 bytes = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
+mimalloc = { workspace = true, optional = true }
 object_store = { workspace = true, features = [
     "fs",
     "aws",
@@ -47,7 +48,6 @@ object_store = { workspace = true, features = [
     "azure",
     "http",
 ] }
-mimalloc = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 pyo3 = { workspace = true, features = ["abi3", "abi3-py311"] }
 pyo3-bytes = { workspace = true }

--- a/vortex-python/Cargo.toml
+++ b/vortex-python/Cargo.toml
@@ -28,6 +28,10 @@ default = ["extension-module", "tui"]
 # duplicate PyInit__lib symbols.
 extension-module = []
 tui = ["dep:vortex-tui"]
+# Set the default allocator to mimalloc, this is enabled by default
+# for the maturin wheels, but it is not a default feature to not conflict
+# with users that set a different global allocator.
+mimalloc = ["dep:mimalloc"]
 
 [dependencies]
 arrow-array = { workspace = true }
@@ -43,6 +47,7 @@ object_store = { workspace = true, features = [
     "azure",
     "http",
 ] }
+mimalloc = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 pyo3 = { workspace = true, features = ["abi3", "abi3-py311"] }
 pyo3-bytes = { workspace = true }

--- a/vortex-python/pyproject.toml
+++ b/vortex-python/pyproject.toml
@@ -59,7 +59,7 @@ managed = true
 [tool.maturin]
 python-source = "python"
 module-name = "vortex._lib"
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "mimalloc"]
 compatibility = "manylinux2014"
 include = [
     { path = "rust-toolchain.toml", format = "sdist" },

--- a/vortex-python/src/lib.rs
+++ b/vortex-python/src/lib.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use std::ops::Deref;
 use std::sync::LazyLock;
 


### PR DESCRIPTION

## Summary

Switches the vortex-python wheels to have mimalloc as the default allocator. This is feature flagged on rust, and any rust code that depends on vortex-python wouldn't get this by default, so they are free to set a different allocator.

Wheel would have a vortex-python.so in them so it is safe to set mimalloc as default inside that dylib, because each dylib can set its own allocator and they won't conflict
