### PR TITLE
Ensure that serialized arrays have 0 offset

### DIFF
--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -247,6 +247,18 @@ impl VTable for BitPacked {
     }
 
     fn serialize(metadata: Self::Metadata) -> VortexResult<Option<Vec<u8>>> {
+        vortex_ensure!(
+            metadata.offset == 0,
+            "BitPackedArray offset must be 0 for serialization, got {}",
+            metadata.offset
+        );
+        if let Some(ref patches) = metadata.patches {
+            vortex_ensure!(
+                patches.offset()? == 0,
+                "BitPackedArray patches offset must be 0 for serialization, got {}",
+                patches.offset()?
+            );
+        }
         Ok(Some(metadata.serialize()))
     }
 

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -152,6 +152,11 @@ impl VTable for Delta {
     }
 
     fn serialize(metadata: Self::Metadata) -> VortexResult<Option<Vec<u8>>> {
+        vortex_ensure!(
+            metadata.offset == 0,
+            "DeltaArray offset must be 0 for serialization, got {}",
+            metadata.offset
+        );
         Ok(Some(metadata.0.encode_to_vec()))
     }
 

--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -504,18 +504,16 @@ mod tests {
         let concat = concat.freeze();
 
         let parts = ArrayParts::try_from(concat).unwrap();
-        let decoded = parts
-            .decode(
-                sliced.dtype(),
-                sliced.len(),
-                &ReadContext::new(ctx.to_ids()),
-                &SESSION,
-            )
-            .unwrap();
+        let decoded = parts.decode(
+            sliced.dtype(),
+            sliced.len(),
+            &ReadContext::new(ctx.to_ids()),
+            &SESSION,
+        );
 
-        let original_data = sliced.to_primitive();
-        let decoded_data = decoded.to_primitive();
-
-        assert_arrays_eq!(original_data, decoded_data);
+        assert_eq!(
+            decoded.err().unwrap().to_string(),
+            "Other error: RLEArray offset must be 0 for serialization, got 100"
+        );
     }
 }

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -171,6 +171,11 @@ impl VTable for RLE {
     }
 
     fn serialize(metadata: Self::Metadata) -> VortexResult<Option<Vec<u8>>> {
+        vortex_ensure!(
+            metadata.offset == 0,
+            "RLEArray offset must be 0 for serialization, got {}",
+            metadata.offset
+        );
         Ok(Some(metadata.0.encode_to_vec()))
     }
 

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -137,6 +137,11 @@ impl VTable for RunEnd {
     }
 
     fn serialize(metadata: Self::Metadata) -> VortexResult<Option<Vec<u8>>> {
+        vortex_ensure!(
+            metadata.offset == 0,
+            "RunEndArray offset must be 0 for serialization, got {}",
+            metadata.offset
+        );
         Ok(Some(metadata.serialize()))
     }
 

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -123,13 +123,17 @@ impl VTable for Bool {
     }
 
     fn metadata(array: &BoolArray) -> VortexResult<Self::Metadata> {
-        assert!(array.offset < 8, "Offset must be <8, got {}", array.offset);
         Ok(ProstMetadata(BoolMetadata {
             offset: u32::try_from(array.offset).vortex_expect("checked"),
         }))
     }
 
     fn serialize(metadata: Self::Metadata) -> VortexResult<Option<Vec<u8>>> {
+        vortex_ensure!(
+            metadata.offset == 0,
+            "BoolArray offset must be 0 for serialization, got {}",
+            metadata.offset
+        );
         Ok(Some(metadata.serialize()))
     }
 

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -123,17 +123,13 @@ impl VTable for Bool {
     }
 
     fn metadata(array: &BoolArray) -> VortexResult<Self::Metadata> {
+        assert!(array.offset < 8, "Offset must be <8, got {}", array.offset);
         Ok(ProstMetadata(BoolMetadata {
             offset: u32::try_from(array.offset).vortex_expect("checked"),
         }))
     }
 
     fn serialize(metadata: Self::Metadata) -> VortexResult<Option<Vec<u8>>> {
-        vortex_ensure!(
-            metadata.offset == 0,
-            "BoolArray offset must be 0 for serialization, got {}",
-            metadata.offset
-        );
         Ok(Some(metadata.serialize()))
     }
 


### PR DESCRIPTION
While the writer will always make sure this is the case users of the api can
serialise arrays with arbitrary offsets which then fail to deserialise

fix #7094 

Signed-off-by: Robert Kruszewski <github@robertk.io>
