### PR TITLE
skip[fuzz]: new unstable encodings fuzzer run

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -100,6 +100,43 @@ jobs:
       incident_io_alert_token: ${{ secrets.INCIDENT_IO_ALERT_TOKEN }}
 
   # ============================================================================
+  # Array Operations Fuzzer (unstable encodings)
+  # ============================================================================
+  ops_fuzz_unstable:
+    name: "Array Operations Fuzz (unstable)"
+    uses: ./.github/workflows/run-fuzzer.yml
+    with:
+      fuzz_target: array_ops_unstable_encodings
+      extra_features: "vortex/unstable_encodings"
+      jobs: 16
+    secrets:
+      R2_FUZZ_ACCESS_KEY_ID: ${{ secrets.R2_FUZZ_ACCESS_KEY_ID }}
+      R2_FUZZ_SECRET_ACCESS_KEY: ${{ secrets.R2_FUZZ_SECRET_ACCESS_KEY }}
+
+  report-ops-unstable-fuzz-failures:
+    name: "Report Array Ops (unstable) Fuzz Failures"
+    needs: ops_fuzz_unstable
+    if: always() && needs.ops_fuzz_unstable.outputs.crashes_found == 'true'
+    permissions:
+      issues: write
+      contents: read
+      id-token: write
+      pull-requests: read
+    uses: ./.github/workflows/report-fuzz-crash.yml
+    with:
+      fuzz_target: array_ops_unstable_encodings
+      crash_file: ${{ needs.ops_fuzz_unstable.outputs.first_crash_name }}
+      artifact_url: ${{ needs.ops_fuzz_unstable.outputs.artifact_url }}
+      artifact_name: array_ops_unstable_encodings-crash-artifacts
+      logs_artifact_name: array_ops_unstable_encodings-logs
+      branch: ${{ github.ref_name }}
+      commit: ${{ github.sha }}
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      incident_io_alert_token: ${{ secrets.INCIDENT_IO_ALERT_TOKEN }}
+
+  # ============================================================================
   # FSST LIKE Fuzzer
   # ============================================================================
   fsst_like_fuzz:

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ version = { workspace = true }
 cargo-fuzz = true
 
 [features]
-default = ["native", "vortex/unstable_encodings"]
+default = ["native"]
 native = ["libfuzzer-sys", "zstd", "vortex-file", "vortex/files"]
 wasmfuzz = []
 zstd = ["vortex/zstd", "vortex-btrblocks/zstd", "vortex-btrblocks/pco"]
@@ -61,6 +61,14 @@ workspace = true
 bench = false
 doc = false
 name = "array_ops"
+path = "fuzz_targets/array_ops.rs"
+test = false
+required-features = ["native"]
+
+[[bin]]
+bench = false
+doc = false
+name = "array_ops_unstable_encodings"
 path = "fuzz_targets/array_ops.rs"
 test = false
 required-features = ["native"]


### PR DESCRIPTION
Add a new runner target for array_ops with unstable encodings to ensure we know that these bugs are not necessarily stable encodings 