### PR TITLE
feat(cuda): hybrid GPU dispatch - fuse dyn + standalone kernels

### DIFF
--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -50,6 +50,10 @@ const BENCH_ARGS: &[(usize, &str)] = &[
 ];
 
 /// Launch the dynamic_dispatch kernel and return GPU-timed duration.
+///
+/// This deliberately does not use `DynamicDispatchPlan::execute` because the
+/// benchmark pre-allocates the output buffer and device plan once, then reuses
+/// them across iterations.
 fn run_timed(
     cuda_ctx: &mut CudaExecutionCtx,
     array_len: usize,

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -19,7 +19,27 @@
 #![allow(non_snake_case)]
 #![allow(clippy::cast_possible_truncation)]
 
-mod plan_builder;
+use std::sync::Arc;
+
+use cudarc::driver::DevicePtr;
+use cudarc::driver::LaunchConfig;
+use cudarc::driver::PushKernelArg;
+use vortex::array::Canonical;
+use vortex::array::arrays::PrimitiveArray;
+use vortex::array::buffer::BufferHandle;
+use vortex::array::buffer::DeviceBufferExt;
+use vortex::array::match_each_unsigned_integer_ptype;
+use vortex::array::validity::Validity;
+use vortex::dtype::Nullability;
+use vortex::dtype::PType;
+use vortex::error::VortexResult;
+use vortex::error::vortex_bail;
+use vortex::error::vortex_err;
+
+use crate::CudaDeviceBuffer;
+use crate::executor::CudaExecutionCtx;
+
+pub(crate) mod plan_builder;
 pub use plan_builder::build_plan;
 
 include!(concat!(env!("OUT_DIR"), "/dynamic_dispatch.rs"));
@@ -200,6 +220,85 @@ impl DynamicDispatchPlan {
             }
         }
         max_end * elem_size
+    }
+
+    /// Allocate output, upload the plan to the device, and launch the
+    /// `dynamic_dispatch` kernel.
+    ///
+    /// The CUDA kernels are instantiated for unsigned types only.
+    /// Encoding transforms (FoR, ZigZag, ALP) are bit-identical
+    /// regardless of signedness.
+    ///
+    /// `CudaSlice::drop` enqueues `free` on the stream after kernel execution.
+    pub fn execute(
+        self,
+        output_ptype: PType,
+        len: usize,
+        device_buffers: Vec<BufferHandle>,
+        ctx: &mut CudaExecutionCtx,
+    ) -> VortexResult<Canonical> {
+        let unsigned_ptype = match output_ptype {
+            PType::U8 | PType::I8 => PType::U8,
+            PType::U16 | PType::I16 => PType::U16,
+            PType::U32 | PType::I32 | PType::F32 => PType::U32,
+            PType::U64 | PType::I64 => PType::U64,
+            other => vortex_bail!("dynamic dispatch does not support PType {:?}", other),
+        };
+        match_each_unsigned_integer_ptype!(unsigned_ptype, |T| {
+            self.execute_typed::<T>(output_ptype, len, device_buffers, ctx)
+        })
+    }
+
+    fn execute_typed<T>(
+        self,
+        output_ptype: PType,
+        len: usize,
+        device_buffers: Vec<BufferHandle>,
+        ctx: &mut CudaExecutionCtx,
+    ) -> VortexResult<Canonical>
+    where
+        T: cudarc::driver::DeviceRepr + vortex::dtype::NativePType,
+    {
+        if len == 0 {
+            return Ok(Canonical::Primitive(PrimitiveArray::empty::<T>(
+                Nullability::NonNullable,
+            )));
+        }
+
+        let output_buf = CudaDeviceBuffer::new(ctx.device_alloc::<T>(len.next_multiple_of(1024))?);
+        let device_plan = Arc::new(
+            ctx.stream()
+                .clone_htod(std::slice::from_ref(&self))
+                .map_err(|e| vortex_err!("copy plan to device: {e}"))?,
+        );
+
+        let shared_mem_bytes = self.shared_mem_bytes::<T>();
+        let cuda_function = ctx.load_function("dynamic_dispatch", &[T::PTYPE])?;
+        let num_blocks = u32::try_from(len.div_ceil(2048))?;
+        let config = LaunchConfig {
+            grid_dim: (num_blocks, 1, 1),
+            block_dim: (64, 1, 1),
+            shared_mem_bytes,
+        };
+
+        let output_ptr = output_buf.offset_ptr();
+        let plan_ptr = device_plan.device_ptr(ctx.stream()).0;
+        let array_len_u64 = len as u64;
+
+        ctx.launch_kernel_config(&cuda_function, config, len, |args| {
+            args.arg(&output_ptr);
+            args.arg(&array_len_u64);
+            args.arg(&plan_ptr);
+        })?;
+
+        drop(device_buffers);
+        drop(device_plan);
+
+        Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
+            BufferHandle::new_device(output_buf.slice_typed::<T>(0..len)),
+            output_ptype,
+            Validity::NonNullable,
+        )))
     }
 }
 

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -7,6 +7,8 @@
 //! to the device, computes shared memory offsets, and produces a plan that the
 //! dynamic dispatch kernel can execute in a single launch.
 
+use std::sync::Arc;
+
 use futures::executor::block_on;
 use vortex::array::ArrayRef;
 use vortex::array::DynArray;
@@ -102,11 +104,30 @@ pub fn build_plan(
     array: &ArrayRef,
     ctx: &CudaExecutionCtx,
 ) -> VortexResult<(DynamicDispatchPlan, Vec<BufferHandle>)> {
+    build_plan_with_subtrees(array, ctx, &[])
+}
+
+/// Build a [`DynamicDispatchPlan`] with subtrees run as separate
+/// kernels that provide device buffers as inputs integrated via `LOAD`.
+pub fn build_plan_with_subtrees(
+    array: &ArrayRef,
+    ctx: &CudaExecutionCtx,
+    subtree_inputs: &[(ArrayRef, BufferHandle)],
+) -> VortexResult<(DynamicDispatchPlan, Vec<BufferHandle>)> {
+    let sub_map = subtree_inputs
+        .iter()
+        .map(|(arr, handle)| {
+            let ptr = handle.cuda_device_ptr()?;
+            Ok((Arc::as_ptr(arr) as *const () as usize, ptr))
+        })
+        .collect::<VortexResult<Vec<_>>>()?;
+
     let mut state = PlanBuilderState {
         ctx,
         stages: Vec::new(),
         smem_cursor: 0,
         device_buffers: Vec::new(),
+        subtree_inputs: sub_map,
     };
 
     let pipeline = state.walk(array.clone())?;
@@ -129,6 +150,88 @@ pub fn build_plan(
     Ok((DynamicDispatchPlan::new(state.stages), state.device_buffers))
 }
 
+/// Walk the encoding tree and find subtrees that cannot be fused into a
+/// dynamic-dispatch plan. The root of each subtree has a node that cannot
+/// be fused.
+///
+/// Returns an empty vec if the root itself cannot be fused.
+pub fn find_subtrees(array: &ArrayRef) -> Vec<ArrayRef> {
+    if !is_dyn_dispatch_compatible(array) {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    collect_subtrees(array, &mut out);
+    out
+}
+
+/// Checks whether the encoding of an array can be fused into a dynamic-dispatch plan.
+fn is_dyn_dispatch_compatible(array: &ArrayRef) -> bool {
+    let id = array.encoding_id();
+    if id == ALP::ID {
+        if let Ok(a) = array.clone().try_into::<ALP>() {
+            return a.patches().is_none() && a.dtype().as_ptype() == PType::F32;
+        }
+        return false;
+    }
+    if id == BitPacked::ID {
+        if let Ok(a) = array.clone().try_into::<BitPacked>() {
+            return a.patches().is_none();
+        }
+        return false;
+    }
+    id == FoR::ID
+        || id == ZigZag::ID
+        || id == Dict::ID
+        || id == RunEnd::ID
+        || id == Primitive::ID
+        || id == Slice::ID
+        || id == Sequence::ID
+}
+
+/// Walk the children of a dynamic dispatch compatible root node. Any child
+/// that is not dyn dispatch compatible is recorded as a subtree that must be
+/// executed separately.
+fn collect_subtrees(array: &ArrayRef, out: &mut Vec<ArrayRef>) {
+    let id = array.encoding_id();
+
+    fn visit_child(child: &ArrayRef, out: &mut Vec<ArrayRef>) {
+        if is_dyn_dispatch_compatible(child) {
+            collect_subtrees(child, out);
+        } else {
+            out.push(child.clone());
+        }
+    }
+
+    if id == FoR::ID {
+        if let Ok(a) = array.clone().try_into::<FoR>() {
+            visit_child(a.encoded(), out);
+        }
+    } else if id == ZigZag::ID {
+        if let Ok(a) = array.clone().try_into::<ZigZag>() {
+            visit_child(a.encoded(), out);
+        }
+    } else if id == ALP::ID {
+        if let Ok(a) = array.clone().try_into::<ALP>() {
+            visit_child(a.encoded(), out);
+        }
+    } else if id == Slice::ID {
+        if let Some(a) = array.as_opt::<Slice>() {
+            visit_child(a.child(), out);
+        }
+    } else if id == Dict::ID
+        && let Ok(a) = array.clone().try_into::<Dict>()
+    {
+        visit_child(a.values(), out);
+        visit_child(a.codes(), out);
+    } else if id == RunEnd::ID
+        && let Ok(a) = array.clone().try_into::<RunEnd>()
+    {
+        visit_child(a.ends(), out);
+        visit_child(a.values(), out);
+    }
+    // BitPacked, Primitive, Sequence — leaves, no children.
+}
+
 /// Internal mutable state for the recursive tree walk.
 struct PlanBuilderState<'a> {
     ctx: &'a CudaExecutionCtx,
@@ -138,11 +241,30 @@ struct PlanBuilderState<'a> {
     smem_cursor: u32,
     /// Device buffers to keep alive.
     device_buffers: Vec<BufferHandle>,
+    /// Pre-executed subtree outputs injected as `LOAD` sources: `(identity, device_ptr)`.
+    subtree_inputs: Vec<(usize, u64)>,
 }
 
 impl PlanBuilderState<'_> {
+    /// If `array` matches a pre-executed subtree input, return a `LOAD` pipeline pointing at its device buffer.
+    fn find_subtree(&self, array: &ArrayRef) -> Option<Pipeline> {
+        let subtree_id = Arc::as_ptr(array) as *const () as usize;
+        self.subtree_inputs
+            .iter()
+            .find(|(id, _)| *id == subtree_id)
+            .map(|(_, ptr)| Pipeline {
+                source: SourceOp::load(),
+                scalar_ops: vec![],
+                input_ptr: *ptr,
+            })
+    }
+
     /// Recursively walk the encoding tree.
     fn walk(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
+        if let Some(pipeline) = self.find_subtree(&array) {
+            return Ok(pipeline);
+        }
+
         let id = array.encoding_id();
 
         if id == BitPacked::ID {

--- a/vortex-cuda/src/executor.rs
+++ b/vortex-cuda/src/executor.rs
@@ -30,6 +30,7 @@ use vortex::error::vortex_err;
 
 use crate::CudaSession;
 use crate::ExportDeviceArray;
+use crate::hybrid_dispatch;
 use crate::kernel::DefaultLaunchStrategy;
 use crate::kernel::LaunchStrategy;
 use crate::kernel::LaunchStrategyExt;
@@ -265,6 +266,11 @@ impl CudaExecutionCtx {
         self.ctx.session()
     }
 
+    /// Returns a reference to the CUDA session.
+    pub(crate) fn cuda_session(&self) -> &CudaSession {
+        &self.cuda_session
+    }
+
     /// Get a handle to the exporter that can convert arrays into `ArrowDeviceArray`.
     pub fn exporter(&self) -> &Arc<dyn ExportDeviceArray> {
         self.cuda_session.export_device_array()
@@ -362,6 +368,19 @@ impl CudaArrayExt for ArrayRef {
         if self.is_canonical() || self.is_empty() {
             trace!(encoding = ?self.encoding_id(), "skipping canonical");
             return self.execute(&mut ctx.ctx);
+        }
+
+        // Try to fuse the encoding tree (or parts of it) into dynamic-dispatch
+        // kernel launches. See hybrid_dispatch module docs for details.
+        match hybrid_dispatch::try_dyn_dispatch(&self, ctx).await {
+            Ok(canonical) => return Ok(canonical),
+            Err(e) => {
+                trace!(
+                    encoding = %self.encoding_id(),
+                    error = %e,
+                    "Hybrid dispatch not applicable, trying registered single kernel"
+                );
+            }
         }
 
         let Some(support) = ctx.cuda_session.kernel(&self.encoding_id()) else {

--- a/vortex-cuda/src/hybrid_dispatch/mod.rs
+++ b/vortex-cuda/src/hybrid_dispatch/mod.rs
@@ -1,0 +1,350 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Hybrid dispatch: fuses dynamic-dispatch plans with single-kernel fallbacks.
+//!
+//! When an array is executed on the GPU, we fuse as much of its encoding
+//! tree as possible into dynamic-dispatch kernel launches.  Encodings the
+//! plan builder cannot handle are executed by their own kernels, and their
+//! outputs are fed back into the fused plan as `LOAD` source ops.
+//!
+//! ```text
+//!   Dict                       <-- dyn-dispatch-compatible
+//!   ├── codes: FoR(BP)         <-- dyn-dispatch-compatible
+//!   └── values: Zstd(FoR(BP)) <-- Zstd is NOT compatible ("subtree")
+//!                 └── FoR(BP)  <-- compatible (fuses inside the subtree)
+//! ```
+//!
+//! A "subtree" is a branch with a root node that is not dyn dispatch compatible
+//! (below a compatible parent). It is executed via `execute_cuda`, which
+//! re-enters `try_dyn_dispatch` so compatible descendants still get fused.
+//!
+//! Strategies tried in order:
+//!
+//! 1. Fully fused — no subtrees, whole tree is one `DynamicDispatchPlan`.
+//!
+//! 2. Partial fusion — subtrees are executed first (sequentially, same
+//!    stream), their device buffers become `LOAD` ops in a fused plan.
+//!    Each subtree re-enters `try_dyn_dispatch` and may itself fuse.
+//!
+//! 3. Fallback — root is not compatible.  Delegate to its registered
+//!    `CudaExecute` kernel; its children re-enter `try_dyn_dispatch`.
+//!
+//! All three compose recursively to arbitrary depth.
+//!
+//! Zone-map pruning is handled by ZonedReader before chunks reach the plan
+//! builder. Filtering within a chunk is done after decompression, not as push-down.
+//!
+//! ```text
+//!   ZonedReader (zone-map pruning, skips whole chunks)
+//!     └── CudaFlatReader (per chunk)
+//!           └── try_dyn_dispatch (fused decompression)
+//!                 └── FilterExecutor (CUB DeviceSelect on full output)
+//! ```
+
+use tracing::debug;
+use tracing::trace;
+use vortex::array::ArrayRef;
+use vortex::array::Canonical;
+use vortex::array::DynArray;
+use vortex::array::buffer::BufferHandle;
+use vortex::dtype::PType;
+use vortex::error::VortexResult;
+use vortex::error::vortex_err;
+
+use crate::dynamic_dispatch::plan_builder::build_plan;
+use crate::dynamic_dispatch::plan_builder::build_plan_with_subtrees;
+use crate::dynamic_dispatch::plan_builder::find_subtrees;
+use crate::executor::CudaArrayExt;
+use crate::executor::CudaExecutionCtx;
+
+/// Try to execute `array` via dynamic dispatch, fusing as much of the
+/// encoding tree as possible into single kernel launches and falling back
+/// to individual kernels for nodes not compatible with dynamic dispatch.
+///
+/// Returns `Ok(Canonical)` on success.  Returns `Err` when the array
+/// cannot be handled (non-primitive output dtype, no registered kernel).
+pub async fn try_dyn_dispatch(
+    array: &ArrayRef,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<Canonical> {
+    let output_ptype = PType::try_from(array.dtype()).map_err(|_| {
+        vortex_err!(
+            "hybrid dispatch requires primitive dtype, got {:?}",
+            array.dtype()
+        )
+    })?;
+
+    trace!(encoding = %array.encoding_id(), ptype = %output_ptype, len = array.len(), "attempting dyn dispatch");
+
+    let subtrees = find_subtrees(array);
+
+    if subtrees.is_empty() {
+        // Whole tree is dyn-dispatch-compatible.
+        if let Ok((plan, bufs)) = build_plan(array, ctx) {
+            debug!(encoding = %array.encoding_id(), num_stages = plan.num_stages, "fully-fused dyn dispatch");
+            return plan.execute(output_ptype, array.len(), bufs, ctx);
+        }
+    } else if let Some(result) = try_partial_fuse(array, &subtrees, output_ptype, ctx).await? {
+        return Ok(result);
+    }
+
+    // Pure fallback — single kernel, children re-enter try_dyn_dispatch.
+    ctx.cuda_session()
+        .kernel(&array.encoding_id())
+        .ok_or_else(|| vortex_err!("No CUDA kernel for encoding {:?}", array.encoding_id()))?
+        .execute(array.clone(), ctx)
+        .await
+}
+
+/// Execute each subtree that is not dyn-dispatch-compatible, then build a fused
+/// plan that reads their outputs via `LOAD`. Returns `None` if partial fusion
+/// isn't possible (e.g. a subtree produced a non-primitive result).
+async fn try_partial_fuse(
+    array: &ArrayRef,
+    subtrees: &[ArrayRef],
+    output_ptype: PType,
+    ctx: &mut CudaExecutionCtx,
+) -> VortexResult<Option<Canonical>> {
+    let mut subtree_inputs: Vec<(ArrayRef, BufferHandle)> = Vec::new();
+
+    // A fused plan can only LOAD flat primitive buffers, so bail
+    // early if any subtree has a non-primitive output dtype.
+    if subtrees.iter().any(|s| PType::try_from(s.dtype()).is_err()) {
+        return Ok(None);
+    }
+
+    // TODO(0ax1): execute subtrees concurrently using separate CUDA streams.
+    for subtree in subtrees {
+        let canonical = subtree.clone().execute_cuda(ctx).await?;
+        subtree_inputs.push((
+            subtree.clone(),
+            canonical.into_primitive().into_parts().buffer,
+        ));
+    }
+
+    let Ok((plan, mut bufs)) = build_plan_with_subtrees(array, ctx, &subtree_inputs) else {
+        return Ok(None);
+    };
+
+    let n = subtree_inputs.len();
+    bufs.extend(subtree_inputs.into_iter().map(|(_, h)| h));
+    debug!(encoding = %array.encoding_id(), num_stages = plan.num_stages, num_subtrees = n, "partially-fused dyn dispatch");
+    plan.execute(output_ptype, array.len(), bufs, ctx).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex::array::DynArray;
+    use vortex::array::IntoArray;
+    use vortex::array::arrays::PrimitiveArray;
+    use vortex::array::assert_arrays_eq;
+    use vortex::array::validity::Validity::NonNullable;
+    use vortex::buffer::Buffer;
+    use vortex::encodings::fastlanes::BitPackedArray;
+    use vortex::encodings::fastlanes::FoRArray;
+    use vortex::error::VortexExpect;
+    use vortex::error::VortexResult;
+    use vortex::mask::Mask;
+    use vortex::session::VortexSession;
+
+    use crate::CanonicalCudaExt;
+    use crate::executor::CudaArrayExt;
+    use crate::session::CudaSession;
+
+    /// FoR(BitPacked) u32 — entire tree compiles into a single fused plan.
+    #[crate::test]
+    async fn test_fused() -> VortexResult<()> {
+        let mut ctx =
+            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        let values: Vec<u32> = (0..2048).map(|i| (i % 128) as u32).collect();
+        let bp = BitPackedArray::encode(
+            &PrimitiveArray::new(Buffer::from(values), NonNullable).into_array(),
+            7,
+        )
+        .vortex_expect("bp");
+        let arr = FoRArray::try_new(bp.into_array(), 1000u32.into()).vortex_expect("for");
+
+        let cpu = arr.to_canonical()?.into_array();
+        let gpu = arr
+            .into_array()
+            .execute_cuda(&mut ctx)
+            .await?
+            .into_host()
+            .await?
+            .into_array();
+        assert_arrays_eq!(cpu, gpu);
+        Ok(())
+    }
+
+    /// ALP(FoR(BP)) f32 — fully fused, output is f32 but kernel runs as u32.
+    /// Exercises the unsigned type reinterpretation in DynamicDispatchPlan::execute.
+    #[crate::test]
+    async fn test_fused_f32() -> VortexResult<()> {
+        use vortex::encodings::alp::ALPArray;
+        use vortex::encodings::alp::Exponents;
+
+        let mut ctx =
+            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        let encoded: Vec<i32> = (0i32..2048).map(|i| i % 500).collect();
+        let bp = BitPackedArray::encode(
+            &PrimitiveArray::new(Buffer::from(encoded), NonNullable).into_array(),
+            9,
+        )
+        .vortex_expect("bp");
+        let alp = ALPArray::try_new(
+            FoRArray::try_new(bp.into_array(), 0i32.into())
+                .vortex_expect("for")
+                .into_array(),
+            Exponents { e: 0, f: 2 },
+            None,
+        )?;
+
+        let cpu = alp.to_canonical()?.into_array();
+        let gpu = alp
+            .into_array()
+            .execute_cuda(&mut ctx)
+            .await?
+            .into_host()
+            .await?
+            .into_array();
+        assert_arrays_eq!(cpu, gpu);
+        Ok(())
+    }
+
+    /// ALP with patches — plan builder rejects it, falls back to ALPExecutor.
+    #[crate::test]
+    async fn test_fallback() -> VortexResult<()> {
+        use vortex::array::patches::Patches;
+        use vortex::array::validity::Validity::NonNullable as NN;
+        use vortex::buffer::buffer;
+        use vortex::encodings::alp::ALPArray;
+        use vortex::encodings::alp::Exponents;
+
+        let mut ctx =
+            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        let encoded = PrimitiveArray::new(
+            Buffer::from((0i32..2048).map(|i| i % 500).collect::<Vec<_>>()),
+            NonNullable,
+        )
+        .into_array();
+        let patches = Patches::new(
+            2048,
+            0,
+            PrimitiveArray::new(buffer![0u32, 1024u32], NN).into_array(),
+            PrimitiveArray::new(buffer![99.9f32, 88.8f32], NN).into_array(),
+            None,
+        )
+        .unwrap();
+        let arr = ALPArray::try_new(encoded, Exponents { e: 0, f: 2 }, Some(patches))?;
+
+        let cpu = arr.to_canonical()?.into_array();
+        let gpu = arr
+            .into_array()
+            .execute_cuda(&mut ctx)
+            .await?
+            .into_host()
+            .await?
+            .into_array();
+        assert_arrays_eq!(cpu, gpu);
+        Ok(())
+    }
+
+    /// Dict(values=ZstdBuffers(FoR(BP)), codes=FoR(BP)) — ZstdBuffers is
+    /// executed separately, then Dict+FoR+BP fuses with its output as a LOAD.
+    /// 3 launches: nvcomp + fused FoR+BP + fused LOAD+FoR+BP+DICT.
+    #[cfg(feature = "unstable_encodings")]
+    #[crate::test]
+    async fn test_partial_fusion() -> VortexResult<()> {
+        use vortex::array::arrays::DictArray;
+        use vortex::array::session::ArraySessionExt;
+        use vortex::encodings::fastlanes;
+        use vortex::encodings::zstd::ZstdBuffers;
+        use vortex::encodings::zstd::ZstdBuffersArray;
+
+        let mut session = VortexSession::empty();
+        fastlanes::initialize(&mut session);
+        session.arrays().register(ZstdBuffers);
+        let mut ctx = CudaSession::create_execution_ctx(&session).vortex_expect("ctx");
+
+        let num_values: u32 = 64;
+        let len: u32 = 2048;
+
+        // values = ZstdBuffers(FoR(BitPacked))
+        let vals = PrimitiveArray::new(
+            Buffer::from((0..num_values).collect::<Vec<_>>()),
+            NonNullable,
+        )
+        .into_array();
+        let vals = FoRArray::try_new(
+            BitPackedArray::encode(&vals, 6)
+                .vortex_expect("bp")
+                .into_array(),
+            0u32.into(),
+        )
+        .vortex_expect("for");
+        let vals = ZstdBuffersArray::compress(&vals.into_array(), 3).vortex_expect("zstd");
+
+        // codes = FoR(BitPacked)
+        let codes = PrimitiveArray::new(
+            Buffer::from((0..len).map(|i| i % num_values).collect::<Vec<_>>()),
+            NonNullable,
+        )
+        .into_array();
+        let codes = FoRArray::try_new(
+            BitPackedArray::encode(&codes, 6)
+                .vortex_expect("bp")
+                .into_array(),
+            0u32.into(),
+        )
+        .vortex_expect("for");
+
+        let dict = DictArray::try_new(codes.into_array(), vals.into_array()).vortex_expect("dict");
+
+        let cpu = PrimitiveArray::new(
+            Buffer::from((0..len).map(|i| i % num_values).collect::<Vec<_>>()),
+            NonNullable,
+        )
+        .into_array();
+        let gpu = dict
+            .into_array()
+            .execute_cuda(&mut ctx)
+            .await?
+            .into_host()
+            .await?
+            .into_array();
+        assert_arrays_eq!(cpu, gpu);
+        Ok(())
+    }
+
+    /// Filter(FoR(BP), mask) — FoR+BP fuses via dyn dispatch, then CUB filters the result.
+    #[crate::test]
+    async fn test_filter_fused_child() -> VortexResult<()> {
+        let mut ctx =
+            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+
+        let len = 2048u32;
+        let data: Vec<u32> = (0..len).map(|i| i % 128).collect();
+        let bp = BitPackedArray::encode(
+            &PrimitiveArray::new(Buffer::from(data.clone()), NonNullable).into_array(),
+            7,
+        )
+        .vortex_expect("bp");
+        let for_arr = FoRArray::try_new(bp.into_array(), 100u32.into()).vortex_expect("for");
+
+        // Keep every other element.
+        let mask = Mask::from_iter((0..len as usize).map(|i| i % 2 == 0));
+        let filtered = for_arr.into_array().filter(mask)?;
+
+        let expected: Vec<u32> = data.iter().step_by(2).map(|v| v + 100).collect();
+        let cpu = PrimitiveArray::new(Buffer::from(expected), NonNullable).into_array();
+        let gpu = filtered
+            .execute_cuda(&mut ctx)
+            .await?
+            .into_host()
+            .await?
+            .into_array();
+        assert_arrays_eq!(cpu, gpu);
+        Ok(())
+    }
+}

--- a/vortex-cuda/src/lib.rs
+++ b/vortex-cuda/src/lib.rs
@@ -13,6 +13,7 @@ mod device_buffer;
 mod device_read_at;
 pub mod dynamic_dispatch;
 pub mod executor;
+pub mod hybrid_dispatch;
 mod kernel;
 pub mod layout;
 mod pinned;


### PR DESCRIPTION
Add a hybrid_dispatch module that integrates subtrees with separate kernel dispatch with dynamic dispatch kernels. Subtrees with unsupported encodings (e.g. Zstd) are executed separately and their device buffers are fed back as `LOAD` ops in the fused plan.

Note that this implicitly enables filtering via the CUDA CUB filter implementation.