### PR TITLE
New Parquet-Variant encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6777,6 +6777,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet-variant"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00ba4e5dcbc8ad65882b7337a95c12a0f9cbb6add237c53d93b803b7d7f70f02"
+dependencies = [
+ "arrow-schema 58.0.0",
+ "chrono",
+ "half",
+ "indexmap",
+ "simdutf8",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-compute"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec4cfb8da15565c8d211b6bc51e8eb481ea65d19132462af3f948b150ac8efe"
+dependencies = [
+ "arrow 58.0.0",
+ "arrow-schema 58.0.0",
+ "chrono",
+ "half",
+ "indexmap",
+ "parquet-variant",
+ "parquet-variant-json",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-json"
+version = "58.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3668ff00a6aeb29d172ba15f9d8fedf1675d79bff7d1916daa333efdeaa13e46"
+dependencies = [
+ "arrow-schema 58.0.0",
+ "base64",
+ "chrono",
+ "parquet-variant",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10723,6 +10768,26 @@ dependencies = [
  "reqwest 0.12.28",
  "tar",
  "vortex-cuda-macros",
+]
+
+[[package]]
+name = "vortex-parquet-variant"
+version = "0.1.0"
+dependencies = [
+ "arrow-array 58.0.0",
+ "arrow-buffer 58.0.0",
+ "arrow-schema 58.0.0",
+ "chrono",
+ "parquet-variant",
+ "parquet-variant-compute",
+ "prost 0.14.3",
+ "rstest",
+ "vortex-array",
+ "vortex-buffer",
+ "vortex-error",
+ "vortex-mask",
+ "vortex-proto",
+ "vortex-session",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "vortex-python",
     "vortex-tui",
     "vortex-web/crate",
+    "vortex-sqllogictest",
     "vortex-test/compat-gen",
     "vortex-test/e2e-cuda",
     "xtask",
@@ -49,13 +50,13 @@ members = [
     "encodings/zigzag",
     "encodings/zstd",
     "encodings/bytebool",
+    "encodings/parquet-variant",
     # Benchmarks
     "benchmarks/lance-bench",
     "benchmarks/compress-bench",
     "benchmarks/datafusion-bench",
     "benchmarks/duckdb-bench",
     "benchmarks/random-access-bench",
-    "vortex-sqllogictest",
 ]
 exclude = ["java/testfiles", "wasm-test"]
 resolver = "2"
@@ -184,6 +185,8 @@ opentelemetry-otlp = "0.31.0"
 opentelemetry_sdk = "0.31.0"
 parking_lot = { version = "0.12.3", features = ["nightly"] }
 parquet = "58"
+parquet-variant = "58"
+parquet-variant-compute = "58"
 paste = "1.0.15"
 pco = "1.0.1"
 pin-project-lite = "0.2.15"

--- a/encodings/parquet-variant/Cargo.toml
+++ b/encodings/parquet-variant/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "vortex-parquet-variant"
+authors = { workspace = true }
+categories = { workspace = true }
+description = "Vortex Parquet Variant array"
+edition = { workspace = true }
+homepage = { workspace = true }
+include = { workspace = true }
+keywords = { workspace = true }
+license = { workspace = true }
+readme = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+version = { workspace = true }
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+arrow-array = { workspace = true }
+arrow-buffer = { workspace = true }
+arrow-schema = { workspace = true }
+chrono = { workspace = true }
+parquet-variant = { workspace = true }
+parquet-variant-compute = { workspace = true }
+prost = { workspace = true }
+vortex-array = { workspace = true }
+vortex-buffer = { workspace = true }
+vortex-error = { workspace = true }
+vortex-mask = { workspace = true }
+vortex-proto = { workspace = true }
+vortex-session = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }
+vortex-array = { workspace = true, features = ["_test-harness"] }
+
+[package.metadata.cargo-machete]
+ignored = ["getrandom_v03"]

--- a/encodings/parquet-variant/src/array.rs
+++ b/encodings/parquet-variant/src/array.rs
@@ -20,6 +20,7 @@ use vortex_array::validity::Validity;
 use vortex_buffer::BitBuffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
+use vortex_error::vortex_ensure_eq;
 use vortex_mask::Mask;
 
 /// Array storage for Arrow's canonical `arrow.parquet.variant` extension type.
@@ -59,17 +60,8 @@ pub struct ParquetVariantArray {
 }
 
 impl ParquetVariantArray {
-    /// Creates a Parquet Variant array that follows the canonical extension storage layout.
-    pub fn try_new(
-        metadata: ArrayRef,
-        value: Option<ArrayRef>,
-        typed_value: Option<ArrayRef>,
-    ) -> VortexResult<Self> {
-        Self::try_new_with_validity(Validity::AllValid, metadata, value, typed_value)
-    }
-
     /// Creates a Parquet Variant array with explicit outer validity.
-    pub fn try_new_with_validity(
+    pub fn try_new(
         validity: Validity,
         metadata: ArrayRef,
         value: Option<ArrayRef>,
@@ -81,17 +73,19 @@ impl ParquetVariantArray {
         );
         let len = metadata.len();
         if let Some(validity_len) = validity.maybe_len() {
-            vortex_ensure!(
-                validity_len == len,
+            vortex_ensure_eq!(
+                validity_len,
+                len,
                 "validity length must match metadata length"
             );
         }
         if let Some(ref v) = value {
-            vortex_ensure!(v.len() == len, "value length must match metadata length");
+            vortex_ensure_eq!(v.len(), len, "value length must match metadata length");
         }
         if let Some(ref tv) = typed_value {
-            vortex_ensure!(
-                tv.len() == len,
+            vortex_ensure_eq!(
+                tv.len(),
+                len,
                 "typed_value length must match metadata length"
             );
         }
@@ -161,8 +155,7 @@ impl ParquetVariantArray {
             .map(|tv| ArrayRef::from_arrow(tv.as_ref(), typed_value_nullable))
             .transpose()?;
 
-        let pv =
-            ParquetVariantArray::try_new_with_validity(validity, metadata, value, typed_value)?;
+        let pv = ParquetVariantArray::try_new(validity, metadata, value, typed_value)?;
         Ok(VariantArray::new(pv.into_array()).into_array())
     }
 
@@ -243,6 +236,7 @@ mod tests {
     use vortex_array::arrays::Variant;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::Nullability;
+    use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
     use vortex_error::VortexResult;
 
@@ -356,7 +350,8 @@ mod tests {
     fn test_to_arrow_basic() -> VortexResult<()> {
         let metadata = VarBinViewArray::from_iter_bin([b"\x01\x00", b"\x01\x00"]).into_array();
         let value = VarBinViewArray::from_iter_bin([b"\x10", b"\x11"]).into_array();
-        let pv_array = ParquetVariantArray::try_new(metadata, Some(value), None)?;
+        let pv_array =
+            ParquetVariantArray::try_new(Validity::NonNullable, metadata, Some(value), None)?;
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let variant_arr = pv_array.to_arrow(&mut ctx)?;
@@ -373,7 +368,12 @@ mod tests {
         let metadata = VarBinViewArray::from_iter_bin([b"\x01\x00", b"\x01\x00"]).into_array();
         let value = VarBinViewArray::from_iter_bin([b"\x10", b"\x11"]).into_array();
         let typed_value = buffer![1i32, 2].into_array();
-        let pv_array = ParquetVariantArray::try_new(metadata, Some(value), Some(typed_value))?;
+        let pv_array = ParquetVariantArray::try_new(
+            Validity::NonNullable,
+            metadata,
+            Some(value),
+            Some(typed_value),
+        )?;
 
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let variant_arr = pv_array.to_arrow(&mut ctx)?;

--- a/encodings/parquet-variant/src/array.rs
+++ b/encodings/parquet-variant/src/array.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use arrow_array::Array as ArrowArray;
 use arrow_array::ArrayRef as ArrowArrayRef;
-use arrow_buffer::NullBuffer;
 use arrow_schema::Field;
 use parquet_variant_compute::VariantArray as ArrowVariantArray;
 use vortex_array::ArrayRef;
@@ -14,6 +13,7 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::VariantArray;
 use vortex_array::arrow::ArrowArrayExecutor;
 use vortex_array::arrow::FromArrowArray;
+use vortex_array::arrow::to_arrow_null_buffer;
 use vortex_array::dtype::DType;
 use vortex_array::stats::ArrayStats;
 use vortex_array::validity::Validity;
@@ -21,7 +21,6 @@ use vortex_buffer::BitBuffer;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
-use vortex_mask::Mask;
 
 /// Array storage for Arrow's canonical `arrow.parquet.variant` extension type.
 ///
@@ -162,20 +161,7 @@ impl ParquetVariantArray {
     /// Converts this array back to an Arrow [`parquet_variant_compute::VariantArray`].
     pub fn to_arrow(&self, ctx: &mut ExecutionCtx) -> VortexResult<ArrowVariantArray> {
         let len = self.metadata.len();
-        let nulls = match &self.validity {
-            Validity::NonNullable | Validity::AllValid => None,
-            Validity::AllInvalid => Some(NullBuffer::new_null(len)),
-            Validity::Array(array) => {
-                let mask = array.clone().execute::<Mask>(ctx)?;
-                match mask {
-                    Mask::AllTrue(_) => None,
-                    Mask::AllFalse(l) => Some(NullBuffer::new_null(l)),
-                    Mask::Values(values) => Some(NullBuffer::from(
-                        arrow_buffer::BooleanBuffer::from(values.bit_buffer().clone()),
-                    )),
-                }
-            }
-        };
+        let nulls = to_arrow_null_buffer(self.validity.clone(), len, ctx)?;
 
         let mut fields = Vec::with_capacity(3);
         let mut arrays: Vec<ArrowArrayRef> = Vec::with_capacity(3);

--- a/encodings/parquet-variant/src/array.rs
+++ b/encodings/parquet-variant/src/array.rs
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use arrow_array::Array as ArrowArray;
+use arrow_array::ArrayRef as ArrowArrayRef;
+use arrow_buffer::NullBuffer;
+use arrow_schema::Field;
+use parquet_variant_compute::VariantArray as ArrowVariantArray;
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::arrays::VariantArray;
+use vortex_array::arrow::ArrowArrayExecutor;
+use vortex_array::arrow::FromArrowArray;
+use vortex_array::dtype::DType;
+use vortex_array::stats::ArrayStats;
+use vortex_array::validity::Validity;
+use vortex_buffer::BitBuffer;
+use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
+use vortex_mask::Mask;
+
+/// Array storage for Arrow's canonical `arrow.parquet.variant` extension type.
+///
+/// `ParquetVariantArray` preserves semi-structured data stored as Parquet Variant values in a
+/// lossless form and supports both unshredded and shredded layouts. Its storage matches the
+/// canonical extension type contract:
+/// - `metadata` is always present and non-nullable.
+/// - `value` stores unshredded variant bytes when present
+/// - `typed_value` stores shredded data when present
+///
+/// At least one of `value` or `typed_value` must be present. `typed_value` may be a primitive,
+/// list, or struct, with nested shredded children following the same recursive rules as the
+/// Arrow canonical extension type docs.
+///
+/// # Nullability
+///
+/// There are three independent levels of nullability in this encoding:
+///
+/// 1. **Outer validity** (`validity`): controls which *rows* of the variant column are null.
+///    This drives the `DType::Variant(Nullable | NonNullable)` of the enclosing `VariantArray`.
+///
+/// 2. **Value child nullability**: the `value` child is `Binary` and may be nullable or
+///    non-nullable. In partially-shredded layouts some rows have their data in `typed_value`
+///    instead, so the corresponding `value` slot is null — making the child nullable.
+///
+/// 3. **Typed-value child nullability**: the `typed_value` child carries its own `DType`
+///    (which includes nullability).
+#[derive(Clone, Debug)]
+pub struct ParquetVariantArray {
+    pub(crate) dtype: DType,
+    pub(crate) validity: Validity,
+    pub(crate) metadata: ArrayRef,
+    pub(crate) value: Option<ArrayRef>,
+    pub(crate) typed_value: Option<ArrayRef>,
+    pub(crate) stats_set: ArrayStats,
+}
+
+impl ParquetVariantArray {
+    /// Creates a Parquet Variant array that follows the canonical extension storage layout.
+    pub fn try_new(
+        metadata: ArrayRef,
+        value: Option<ArrayRef>,
+        typed_value: Option<ArrayRef>,
+    ) -> VortexResult<Self> {
+        Self::try_new_with_validity(Validity::AllValid, metadata, value, typed_value)
+    }
+
+    /// Creates a Parquet Variant array with explicit outer validity.
+    pub fn try_new_with_validity(
+        validity: Validity,
+        metadata: ArrayRef,
+        value: Option<ArrayRef>,
+        typed_value: Option<ArrayRef>,
+    ) -> VortexResult<Self> {
+        vortex_ensure!(
+            value.is_some() || typed_value.is_some(),
+            "at least one of value or typed_value must be present"
+        );
+        let len = metadata.len();
+        if let Some(validity_len) = validity.maybe_len() {
+            vortex_ensure!(
+                validity_len == len,
+                "validity length must match metadata length"
+            );
+        }
+        if let Some(ref v) = value {
+            vortex_ensure!(v.len() == len, "value length must match metadata length");
+        }
+        if let Some(ref tv) = typed_value {
+            vortex_ensure!(
+                tv.len() == len,
+                "typed_value length must match metadata length"
+            );
+        }
+        let nullability = validity.nullability();
+
+        Ok(Self {
+            dtype: DType::Variant(nullability),
+            validity,
+            metadata,
+            value,
+            typed_value,
+            stats_set: ArrayStats::default(),
+        })
+    }
+
+    /// Returns a reference to the metadata child array.
+    pub fn metadata_array(&self) -> &ArrayRef {
+        &self.metadata
+    }
+
+    /// Returns a reference to the un-shredded value child array, if present.
+    pub fn value_array(&self) -> Option<&ArrayRef> {
+        self.value.as_ref()
+    }
+
+    /// Returns a reference to the shredded typed_value child array, if present.
+    pub fn typed_value_array(&self) -> Option<&ArrayRef> {
+        self.typed_value.as_ref()
+    }
+
+    /// Converts an Arrow `parquet_variant_compute::VariantArray` into a Vortex `ArrayRef`
+    /// wrapping `VariantArray(ParquetVariantArray(...))`.
+    pub fn from_arrow_variant(arrow_variant: &ArrowVariantArray) -> VortexResult<ArrayRef> {
+        let storage = arrow_variant.inner();
+        let value_nullable = storage
+            .fields()
+            .iter()
+            .find(|field| field.name() == "value")
+            .map(|field| field.is_nullable())
+            .unwrap_or(false);
+        let typed_value_nullable = storage
+            .fields()
+            .iter()
+            .find(|field| field.name() == "typed_value")
+            .map(|field| field.is_nullable())
+            .unwrap_or(false);
+        let validity = arrow_variant
+            .nulls()
+            .map(|nulls| {
+                if nulls.null_count() == nulls.len() {
+                    Validity::AllInvalid
+                } else {
+                    Validity::from(BitBuffer::from(nulls.inner().clone()))
+                }
+            })
+            .unwrap_or(Validity::NonNullable);
+        let metadata =
+            ArrayRef::from_arrow(arrow_variant.metadata_field() as &dyn ArrowArray, false)?;
+
+        let value = arrow_variant
+            .value_field()
+            .map(|v| ArrayRef::from_arrow(v as &dyn ArrowArray, value_nullable))
+            .transpose()?;
+
+        let typed_value = arrow_variant
+            .typed_value_field()
+            .map(|tv| ArrayRef::from_arrow(tv.as_ref(), typed_value_nullable))
+            .transpose()?;
+
+        let pv =
+            ParquetVariantArray::try_new_with_validity(validity, metadata, value, typed_value)?;
+        Ok(VariantArray::new(pv.into_array()).into_array())
+    }
+
+    /// Converts this array back to an Arrow [`parquet_variant_compute::VariantArray`].
+    pub fn to_arrow(&self, ctx: &mut ExecutionCtx) -> VortexResult<ArrowVariantArray> {
+        let len = self.metadata.len();
+        let nulls = match &self.validity {
+            Validity::NonNullable | Validity::AllValid => None,
+            Validity::AllInvalid => Some(NullBuffer::new_null(len)),
+            Validity::Array(array) => {
+                let mask = array.clone().execute::<Mask>(ctx)?;
+                match mask {
+                    Mask::AllTrue(_) => None,
+                    Mask::AllFalse(l) => Some(NullBuffer::new_null(l)),
+                    Mask::Values(values) => Some(NullBuffer::from(
+                        arrow_buffer::BooleanBuffer::from(values.bit_buffer().clone()),
+                    )),
+                }
+            }
+        };
+
+        let mut fields = Vec::with_capacity(3);
+        let mut arrays: Vec<ArrowArrayRef> = Vec::with_capacity(3);
+
+        let metadata_arrow = self.metadata.clone().execute_arrow(None, ctx)?;
+        fields.push(Arc::new(Field::new(
+            "metadata",
+            metadata_arrow.data_type().clone(),
+            false,
+        )));
+        arrays.push(metadata_arrow);
+
+        if let Some(ref value) = self.value {
+            let value_arrow = value.clone().execute_arrow(None, ctx)?;
+            fields.push(Arc::new(Field::new(
+                "value",
+                value_arrow.data_type().clone(),
+                value.dtype().is_nullable(),
+            )));
+            arrays.push(value_arrow);
+        }
+
+        if let Some(ref typed_value) = self.typed_value {
+            let tv_arrow = typed_value.clone().execute_arrow(None, ctx)?;
+            fields.push(Arc::new(Field::new(
+                "typed_value",
+                tv_arrow.data_type().clone(),
+                typed_value.dtype().is_nullable(),
+            )));
+            arrays.push(tv_arrow);
+        }
+
+        let struct_array = arrow_array::StructArray::try_new(fields.into(), arrays, nulls)?;
+        Ok(ArrowVariantArray::try_new(&struct_array)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::Array as _;
+    use arrow_array::ArrayRef as ArrowArrayRef;
+    use arrow_array::Int32Array;
+    use arrow_array::StructArray;
+    use arrow_array::builder::BinaryViewBuilder;
+    use arrow_buffer::NullBuffer;
+    use arrow_schema::DataType;
+    use arrow_schema::Field;
+    use arrow_schema::Fields;
+    use parquet_variant::Variant as PqVariant;
+    use parquet_variant_compute::VariantArray as ArrowVariantArray;
+    use parquet_variant_compute::VariantArrayBuilder;
+    use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::VarBinViewArray;
+    use vortex_array::arrays::Variant;
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
+
+    use crate::ParquetVariant;
+    use crate::ParquetVariantArray;
+
+    fn assert_arrow_variant_storage_roundtrip(struct_array: StructArray) -> VortexResult<()> {
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        let vortex_arr = ParquetVariantArray::from_arrow_variant(&arrow_variant)?;
+        let inner = vortex_arr
+            .as_opt::<Variant>()
+            .unwrap()
+            .child()
+            .as_opt::<ParquetVariant>()
+            .unwrap();
+
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let roundtripped = inner.to_arrow(&mut ctx)?;
+        let roundtripped = roundtripped.inner();
+
+        assert_eq!(struct_array.len(), roundtripped.len());
+        assert_eq!(struct_array.column_names(), roundtripped.column_names());
+        assert_eq!(struct_array.nulls(), roundtripped.nulls());
+        assert_eq!(struct_array.fields().len(), roundtripped.fields().len());
+
+        for (expected, actual) in struct_array
+            .fields()
+            .iter()
+            .zip(roundtripped.fields().iter())
+        {
+            assert_eq!(expected.name(), actual.name());
+            assert_eq!(expected.data_type(), actual.data_type());
+            assert_eq!(expected.is_nullable(), actual.is_nullable());
+        }
+
+        for (expected, actual) in struct_array
+            .columns()
+            .iter()
+            .zip(roundtripped.columns().iter())
+        {
+            assert_eq!(expected.to_data(), actual.to_data());
+        }
+
+        Ok(())
+    }
+
+    fn binary_view_array<const N: usize>(values: [&[u8]; N]) -> ArrowArrayRef {
+        let mut builder = BinaryViewBuilder::new();
+        for value in values {
+            builder.append_value(value);
+        }
+        Arc::new(builder.finish())
+    }
+
+    #[test]
+    fn test_from_arrow_variant_basic() -> VortexResult<()> {
+        let mut builder = VariantArrayBuilder::new(3);
+        builder.append_variant(PqVariant::from(42i32));
+        builder.append_variant(PqVariant::from("hello"));
+        builder.append_variant(PqVariant::from(true));
+        let arrow_variant = builder.build();
+
+        let vortex_arr = ParquetVariantArray::from_arrow_variant(&arrow_variant)?;
+
+        assert_eq!(vortex_arr.len(), 3);
+        assert_eq!(
+            vortex_arr.dtype(),
+            &DType::Variant(Nullability::NonNullable)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_arrow_variant_with_shredded_typed_value() -> VortexResult<()> {
+        let mut metadata_builder = BinaryViewBuilder::new();
+        let min_metadata = [1u8, 0];
+        for _ in 0..3 {
+            metadata_builder.append_value(min_metadata);
+        }
+        let metadata = metadata_builder.finish();
+
+        let typed_value: ArrowArrayRef = Arc::new(Int32Array::from(vec![10, 20, 30]));
+
+        let struct_fields: Fields = vec![
+            Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+            Arc::new(Field::new("typed_value", DataType::Int32, false)),
+        ]
+        .into();
+        let struct_array =
+            StructArray::try_new(struct_fields, vec![Arc::new(metadata), typed_value], None)
+                .unwrap();
+
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+
+        let vortex_arr = ParquetVariantArray::from_arrow_variant(&arrow_variant)?;
+        assert_eq!(vortex_arr.len(), 3);
+        assert_eq!(
+            vortex_arr.dtype(),
+            &DType::Variant(Nullability::NonNullable)
+        );
+
+        let variant_arr = vortex_arr.as_opt::<Variant>().unwrap();
+        let inner = variant_arr.child().as_opt::<ParquetVariant>().unwrap();
+        assert!(inner.typed_value_array().is_some());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_to_arrow_basic() -> VortexResult<()> {
+        let metadata = VarBinViewArray::from_iter_bin([b"\x01\x00", b"\x01\x00"]).into_array();
+        let value = VarBinViewArray::from_iter_bin([b"\x10", b"\x11"]).into_array();
+        let pv_array = ParquetVariantArray::try_new(metadata, Some(value), None)?;
+
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let variant_arr = pv_array.to_arrow(&mut ctx)?;
+        let struct_arr = variant_arr.inner();
+
+        assert_eq!(struct_arr.num_columns(), 2);
+        assert_eq!(struct_arr.column_names(), &["metadata", "value"]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_to_arrow_with_typed_value() -> VortexResult<()> {
+        let metadata = VarBinViewArray::from_iter_bin([b"\x01\x00", b"\x01\x00"]).into_array();
+        let value = VarBinViewArray::from_iter_bin([b"\x10", b"\x11"]).into_array();
+        let typed_value = buffer![1i32, 2].into_array();
+        let pv_array = ParquetVariantArray::try_new(metadata, Some(value), Some(typed_value))?;
+
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let variant_arr = pv_array.to_arrow(&mut ctx)?;
+        let struct_arr = variant_arr.inner();
+
+        assert_eq!(struct_arr.num_columns(), 3);
+        assert_eq!(
+            struct_arr.column_names(),
+            &["metadata", "value", "typed_value"]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_arrow_variant_roundtrip_unshredded_storage() -> VortexResult<()> {
+        let mut builder = VariantArrayBuilder::new(3);
+        builder.append_variant(PqVariant::from(42i32));
+        builder.append_variant(PqVariant::from("hello"));
+        builder.append_variant(PqVariant::from(true));
+
+        assert_arrow_variant_storage_roundtrip(builder.build().into_inner())
+    }
+
+    #[test]
+    fn test_arrow_variant_roundtrip_typed_value_only_storage() -> VortexResult<()> {
+        let metadata = binary_view_array([b"\x01\x00", b"\x01\x00", b"\x01\x00"]);
+        let typed_value: ArrowArrayRef = Arc::new(Int32Array::from(vec![10, 20, 30]));
+
+        let struct_array = StructArray::try_new(
+            vec![
+                Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+                Arc::new(Field::new("typed_value", DataType::Int32, false)),
+            ]
+            .into(),
+            vec![metadata, typed_value],
+            None,
+        )
+        .unwrap();
+
+        assert_arrow_variant_storage_roundtrip(struct_array)
+    }
+
+    #[test]
+    fn test_arrow_variant_roundtrip_value_and_typed_value_storage() -> VortexResult<()> {
+        let metadata = binary_view_array([b"\x01\x00", b"\x01\x00"]);
+        let value = binary_view_array([b"\x10", b"\x11"]);
+        let typed_value: ArrowArrayRef = Arc::new(Int32Array::from(vec![1, 2]));
+
+        let struct_array = StructArray::try_new(
+            vec![
+                Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+                Arc::new(Field::new("value", DataType::BinaryView, true)),
+                Arc::new(Field::new("typed_value", DataType::Int32, false)),
+            ]
+            .into(),
+            vec![metadata, value, typed_value],
+            None,
+        )
+        .unwrap();
+
+        assert_arrow_variant_storage_roundtrip(struct_array)
+    }
+
+    #[test]
+    fn test_arrow_variant_roundtrip_with_outer_nulls() -> VortexResult<()> {
+        let metadata = binary_view_array([b"\x01\x00", b"\x01\x00", b"\x01\x00"]);
+        let value = binary_view_array([b"\x10", b"\x00", b"\x11"]);
+        let struct_array = StructArray::try_new(
+            vec![
+                Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+                Arc::new(Field::new("value", DataType::BinaryView, true)),
+            ]
+            .into(),
+            vec![metadata, value],
+            Some(NullBuffer::from(vec![true, false, true])),
+        )
+        .unwrap();
+
+        assert_arrow_variant_storage_roundtrip(struct_array)
+    }
+}

--- a/encodings/parquet-variant/src/kernel.rs
+++ b/encodings/parquet-variant/src/kernel.rs
@@ -45,8 +45,7 @@ impl SliceKernel for ParquetVariant {
             .map(|tv| tv.slice(range))
             .transpose()?;
         Ok(Some(
-            ParquetVariantArray::try_new_with_validity(validity, metadata, value, typed_value)?
-                .into_array(),
+            ParquetVariantArray::try_new(validity, metadata, value, typed_value)?.into_array(),
         ))
     }
 }
@@ -70,8 +69,7 @@ impl FilterKernel for ParquetVariant {
             .map(|tv| tv.filter(mask.clone()))
             .transpose()?;
         Ok(Some(
-            ParquetVariantArray::try_new_with_validity(validity, metadata, value, typed_value)?
-                .into_array(),
+            ParquetVariantArray::try_new(validity, metadata, value, typed_value)?.into_array(),
         ))
     }
 }
@@ -95,8 +93,7 @@ impl TakeExecute for ParquetVariant {
             .map(|tv| tv.take(indices.to_array()))
             .transpose()?;
         Ok(Some(
-            ParquetVariantArray::try_new_with_validity(validity, metadata, value, typed_value)?
-                .into_array(),
+            ParquetVariantArray::try_new(validity, metadata, value, typed_value)?.into_array(),
         ))
     }
 }

--- a/encodings/parquet-variant/src/kernel.rs
+++ b/encodings/parquet-variant/src/kernel.rs
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::ops::Range;
+
+use vortex_array::ArrayRef;
+use vortex_array::DynArray;
+use vortex_array::ExecutionCtx;
+use vortex_array::IntoArray;
+use vortex_array::arrays::dict::TakeExecute;
+use vortex_array::arrays::dict::TakeExecuteAdaptor;
+use vortex_array::arrays::filter::FilterExecuteAdaptor;
+use vortex_array::arrays::filter::FilterKernel;
+use vortex_array::arrays::slice::SliceExecuteAdaptor;
+use vortex_array::arrays::slice::SliceKernel;
+use vortex_array::kernel::ParentKernelSet;
+use vortex_error::VortexResult;
+use vortex_mask::Mask;
+
+use crate::ParquetVariant;
+use crate::array::ParquetVariantArray;
+
+pub(crate) static PARENT_KERNELS: ParentKernelSet<ParquetVariant> = ParentKernelSet::new(&[
+    ParentKernelSet::lift(&FilterExecuteAdaptor(ParquetVariant)),
+    ParentKernelSet::lift(&SliceExecuteAdaptor(ParquetVariant)),
+    ParentKernelSet::lift(&TakeExecuteAdaptor(ParquetVariant)),
+]);
+
+impl SliceKernel for ParquetVariant {
+    fn slice(
+        array: &ParquetVariantArray,
+        range: Range<usize>,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let validity = array.validity.slice(range.clone())?;
+        let metadata = array.metadata.slice(range.clone())?;
+        let value = array
+            .value
+            .as_ref()
+            .map(|v| v.slice(range.clone()))
+            .transpose()?;
+        let typed_value = array
+            .typed_value
+            .as_ref()
+            .map(|tv| tv.slice(range))
+            .transpose()?;
+        Ok(Some(
+            ParquetVariantArray::try_new_with_validity(validity, metadata, value, typed_value)?
+                .into_array(),
+        ))
+    }
+}
+
+impl FilterKernel for ParquetVariant {
+    fn filter(
+        array: &ParquetVariantArray,
+        mask: &Mask,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let validity = array.validity.filter(mask)?;
+        let metadata = array.metadata.filter(mask.clone())?;
+        let value = array
+            .value
+            .as_ref()
+            .map(|v| v.filter(mask.clone()))
+            .transpose()?;
+        let typed_value = array
+            .typed_value
+            .as_ref()
+            .map(|tv| tv.filter(mask.clone()))
+            .transpose()?;
+        Ok(Some(
+            ParquetVariantArray::try_new_with_validity(validity, metadata, value, typed_value)?
+                .into_array(),
+        ))
+    }
+}
+
+impl TakeExecute for ParquetVariant {
+    fn take(
+        array: &ParquetVariantArray,
+        indices: &ArrayRef,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        let validity = array.validity.take(indices)?;
+        let metadata = array.metadata.take(indices.to_array())?;
+        let value = array
+            .value
+            .as_ref()
+            .map(|v| v.take(indices.to_array()))
+            .transpose()?;
+        let typed_value = array
+            .typed_value
+            .as_ref()
+            .map(|tv| tv.take(indices.to_array()))
+            .transpose()?;
+        Ok(Some(
+            ParquetVariantArray::try_new_with_validity(validity, metadata, value, typed_value)?
+                .into_array(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::ArrayRef as ArrowArrayRef;
+    use arrow_array::StructArray;
+    use arrow_buffer::NullBuffer;
+    use arrow_schema::DataType;
+    use arrow_schema::Field;
+    use parquet_variant::Variant as PqVariant;
+    use parquet_variant_compute::VariantArray as ArrowVariantArray;
+    use parquet_variant_compute::VariantArrayBuilder;
+    use vortex_array::ArrayRef;
+    use vortex_array::DynArray;
+    use vortex_array::IntoArray;
+    use vortex_array::arrays::PrimitiveArray;
+    use vortex_error::VortexResult;
+    use vortex_mask::Mask;
+
+    use crate::ParquetVariantArray;
+
+    fn make_unshredded_array() -> VortexResult<ArrayRef> {
+        let mut builder = VariantArrayBuilder::new(4);
+        builder.append_variant(PqVariant::from(42i32));
+        builder.append_variant(PqVariant::from("hello"));
+        builder.append_variant(PqVariant::from(true));
+        builder.append_variant(PqVariant::from(99i64));
+        ParquetVariantArray::from_arrow_variant(&builder.build())
+    }
+
+    fn make_nullable_array() -> VortexResult<ArrayRef> {
+        let mut builder = VariantArrayBuilder::new(4);
+        builder.append_variant(PqVariant::from(42i32));
+        builder.append_variant(PqVariant::from("hello"));
+        builder.append_variant(PqVariant::from(true));
+        builder.append_variant(PqVariant::from(99i64));
+        let inner = builder.build().into_inner();
+
+        let null_struct = StructArray::try_new(
+            inner.fields().clone(),
+            inner.columns().to_vec(),
+            Some(NullBuffer::from(vec![true, false, true, false])),
+        )
+        .unwrap();
+        let arrow_variant = ArrowVariantArray::try_new(&null_struct).unwrap();
+        ParquetVariantArray::from_arrow_variant(&arrow_variant)
+    }
+
+    #[test]
+    fn test_slice_basic() -> VortexResult<()> {
+        let arr = make_unshredded_array()?;
+        let sliced = arr.slice(1..3)?;
+
+        assert_eq!(sliced.len(), 2);
+        assert_eq!(sliced.scalar_at(0)?, arr.scalar_at(1)?);
+        assert_eq!(sliced.scalar_at(1)?, arr.scalar_at(2)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_slice_preserves_validity() -> VortexResult<()> {
+        let arr = make_nullable_array()?;
+        let sliced = arr.slice(0..3)?;
+
+        assert_eq!(sliced.len(), 3);
+        assert!(!sliced.scalar_at(0)?.is_null());
+        assert!(sliced.scalar_at(1)?.is_null());
+        assert!(!sliced.scalar_at(2)?.is_null());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_filter_basic() -> VortexResult<()> {
+        let arr = make_unshredded_array()?;
+        let mask = Mask::from_iter([true, false, true, false]);
+        let filtered = arr.filter(mask)?;
+
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered.scalar_at(0)?, arr.scalar_at(0)?);
+        assert_eq!(filtered.scalar_at(1)?, arr.scalar_at(2)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_filter_preserves_validity() -> VortexResult<()> {
+        let arr = make_nullable_array()?;
+        // Keep rows 0 (valid), 1 (null), 3 (null)
+        let mask = Mask::from_iter([true, true, false, true]);
+        let filtered = arr.filter(mask)?;
+
+        assert_eq!(filtered.len(), 3);
+        assert!(!filtered.scalar_at(0)?.is_null());
+        assert!(filtered.scalar_at(1)?.is_null());
+        assert!(filtered.scalar_at(2)?.is_null());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_take_basic() -> VortexResult<()> {
+        let arr = make_unshredded_array()?;
+        let indices = PrimitiveArray::from_iter([2u64, 0, 3]);
+        let taken = arr.take(indices.into_array())?;
+
+        assert_eq!(taken.len(), 3);
+        assert_eq!(taken.scalar_at(0)?, arr.scalar_at(2)?);
+        assert_eq!(taken.scalar_at(1)?, arr.scalar_at(0)?);
+        assert_eq!(taken.scalar_at(2)?, arr.scalar_at(3)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_take_preserves_validity() -> VortexResult<()> {
+        let arr = make_nullable_array()?;
+        // Take: valid (0), null (1), null (3), valid (2)
+        let indices = PrimitiveArray::from_iter([0u64, 1, 3, 2]);
+        let taken = arr.take(indices.into_array())?;
+
+        assert_eq!(taken.len(), 4);
+        assert!(!taken.scalar_at(0)?.is_null());
+        assert!(taken.scalar_at(1)?.is_null());
+        assert!(taken.scalar_at(2)?.is_null());
+        assert!(!taken.scalar_at(3)?.is_null());
+
+        Ok(())
+    }
+
+    fn binary_view_array(values: &[&[u8]]) -> ArrowArrayRef {
+        let mut builder = arrow_array::builder::BinaryViewBuilder::new();
+        for value in values {
+            builder.append_value(*value);
+        }
+        Arc::new(builder.finish())
+    }
+
+    #[test]
+    fn test_slice_shredded_typed_value() -> VortexResult<()> {
+        let metadata = binary_view_array(&[b"\x01\x00", b"\x01\x00", b"\x01\x00"]);
+        let typed_value: ArrowArrayRef = Arc::new(arrow_array::Int32Array::from(vec![10, 20, 30]));
+
+        let struct_array = StructArray::try_new(
+            vec![
+                Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+                Arc::new(Field::new("typed_value", DataType::Int32, false)),
+            ]
+            .into(),
+            vec![metadata, typed_value],
+            None,
+        )
+        .unwrap();
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        let arr = ParquetVariantArray::from_arrow_variant(&arrow_variant)?;
+
+        let sliced = arr.slice(1..3)?;
+        assert_eq!(sliced.len(), 2);
+        assert_eq!(sliced.scalar_at(0)?, arr.scalar_at(1)?);
+        assert_eq!(sliced.scalar_at(1)?, arr.scalar_at(2)?);
+
+        Ok(())
+    }
+}

--- a/encodings/parquet-variant/src/lib.rs
+++ b/encodings/parquet-variant/src/lib.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Vortex support for Arrow's canonical `arrow.parquet.variant` extension type.
+//!
+//! This encoding provides a lossless representation of semi-structured data stored as
+//! [Parquet Variant values] inside Arrow columns. It also supports [shredded variant values],
+//! allowing systems to pass variant-encoded data around without special handling unless they
+//! need to inspect the encoded contents directly.
+//!
+//! The storage type is a `Struct` that follows the Arrow canonical extension contract:
+//! - `metadata` (required): a non-nullable binary child containing variant metadata
+//! - `value` (optional): a binary child containing unshredded variant bytes
+//! - `typed_value` (optional): a shredded child with a primitive, list, or struct layout
+//!
+//! At least one of `value` or `typed_value` must be present. Nested shredded values recurse
+//! through the same `value` and `typed_value` structure described by the canonical extension
+//! type documentation.
+//!
+//! See the Arrow canonical extension docs for the storage rules, and the Parquet format
+//! specification for the binary representation.
+//!
+//! [Parquet Variant values]: https://github.com/apache/parquet-format/blob/master/VariantEncoding.md
+//! [shredded variant values]: https://github.com/apache/parquet-format/blob/master/VariantShredding.md
+//! [Arrow canonical extension type]: https://arrow.apache.org/docs/format/CanonicalExtensions.html#parquet-variant
+
+mod array;
+mod kernel;
+mod operations;
+mod validity;
+mod vtable;
+
+pub use array::ParquetVariantArray;
+pub use vtable::ParquetVariant;
+pub use vtable::ParquetVariantMetadata;

--- a/encodings/parquet-variant/src/operations.rs
+++ b/encodings/parquet-variant/src/operations.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use chrono::Timelike;
 use parquet_variant::Variant as PqVariant;
+use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::DecimalDType;
@@ -68,8 +69,8 @@ impl OperationsVTable<ParquetVariant> for ParquetVariant {
 
 fn scalar_from_variant_storage(
     metadata: &[u8],
-    value: Option<&vortex_array::ArrayRef>,
-    typed_value: Option<&vortex_array::ArrayRef>,
+    value: Option<&ArrayRef>,
+    typed_value: Option<&ArrayRef>,
     index: usize,
 ) -> VortexResult<Scalar> {
     if let Some(typed_value) = typed_value
@@ -89,8 +90,8 @@ fn scalar_from_variant_storage(
 
 fn scalar_from_typed_value_array(
     metadata: &[u8],
-    value: Option<&vortex_array::ArrayRef>,
-    typed_value: &vortex_array::ArrayRef,
+    value: Option<&ArrayRef>,
+    typed_value: &ArrayRef,
     index: usize,
 ) -> VortexResult<Scalar> {
     let value_scalar = match value {

--- a/encodings/parquet-variant/src/operations.rs
+++ b/encodings/parquet-variant/src/operations.rs
@@ -1,0 +1,706 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::sync::Arc;
+
+use chrono::Timelike;
+use parquet_variant::Variant as PqVariant;
+use vortex_array::ExecutionCtx;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::DecimalDType;
+use vortex_array::dtype::FieldName;
+use vortex_array::dtype::FieldNames;
+use vortex_array::dtype::Nullability;
+use vortex_array::dtype::StructFields;
+use vortex_array::extension::datetime::Date;
+use vortex_array::extension::datetime::Time;
+use vortex_array::extension::datetime::TimeUnit;
+use vortex_array::extension::datetime::Timestamp;
+use vortex_array::scalar::PValue;
+use vortex_array::scalar::Scalar;
+use vortex_array::scalar::ScalarValue;
+use vortex_array::vtable::OperationsVTable;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_err;
+
+use crate::array::ParquetVariantArray;
+use crate::vtable::ParquetVariant;
+
+impl OperationsVTable<ParquetVariant> for ParquetVariant {
+    /// Resolves a single variant value according to the Parquet Variant shredding spec:
+    ///
+    /// | value    | typed_value | Meaning                                              |
+    /// |----------|-------------|------------------------------------------------------|
+    /// | NULL     | NULL        | Missing (only valid for shredded object fields)       |
+    /// | non-NULL | NULL        | Un-shredded: decode from metadata + value bytes       |
+    /// | NULL     | non-NULL    | Perfectly shredded: use typed_value directly           |
+    /// | non-NULL | non-NULL    | Partially shredded object (typed_value takes priority) |
+    fn scalar_at(
+        array: &ParquetVariantArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
+        if array.validity.is_null(index)? {
+            return Ok(Scalar::null(DType::Variant(Nullability::Nullable)));
+        }
+
+        let metadata = array
+            .metadata_array()
+            .scalar_at(index)?
+            .as_binary()
+            .value()
+            .cloned()
+            .vortex_expect("non-null metadata row must have binary value");
+        let inner = scalar_from_variant_storage(
+            metadata.as_ref(),
+            array.value_array(),
+            array.typed_value_array(),
+            index,
+        )?;
+
+        Scalar::try_new(
+            array.dtype.clone(),
+            Some(ScalarValue::Variant(Box::new(inner))),
+        )
+    }
+}
+
+fn scalar_from_variant_storage(
+    metadata: &[u8],
+    value: Option<&vortex_array::ArrayRef>,
+    typed_value: Option<&vortex_array::ArrayRef>,
+    index: usize,
+) -> VortexResult<Scalar> {
+    if let Some(typed_value) = typed_value
+        && typed_value.is_valid(index)?
+    {
+        return scalar_from_typed_value_array(metadata, value, typed_value, index);
+    }
+
+    if let Some(value) = value
+        && value.is_valid(index)?
+    {
+        return scalar_from_unshredded_value(metadata, &value.scalar_at(index)?);
+    }
+
+    Ok(Scalar::null(DType::Null))
+}
+
+fn scalar_from_typed_value_array(
+    metadata: &[u8],
+    value: Option<&vortex_array::ArrayRef>,
+    typed_value: &vortex_array::ArrayRef,
+    index: usize,
+) -> VortexResult<Scalar> {
+    let value_scalar = match value {
+        Some(value) if value.is_valid(index)? => Some(value.scalar_at(index)?),
+        _ => None,
+    };
+    scalar_from_typed_value_scalar(metadata, value_scalar, typed_value.scalar_at(index)?)
+}
+
+fn scalar_from_typed_value_scalar(
+    metadata: &[u8],
+    value: Option<Scalar>,
+    typed_value: Scalar,
+) -> VortexResult<Scalar> {
+    match typed_value.dtype() {
+        DType::List(..) => {
+            let list = typed_value.as_list();
+            let children = list
+                .elements()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|element| {
+                    let nested = scalar_from_shredded_field_scalar(metadata, element)?;
+                    Ok(Scalar::variant(nested))
+                })
+                .collect::<VortexResult<Vec<_>>>()?;
+            Ok(Scalar::list(
+                DType::Variant(Nullability::NonNullable),
+                children,
+                Nullability::NonNullable,
+            ))
+        }
+        DType::Struct(..) => scalar_from_shredded_object_scalar(metadata, value, typed_value),
+        _ => Ok(typed_value),
+    }
+}
+
+fn scalar_from_shredded_field_scalar(
+    metadata: &[u8],
+    field_scalar: Scalar,
+) -> VortexResult<Scalar> {
+    if field_scalar.is_null() {
+        return Ok(Scalar::null(DType::Null));
+    }
+
+    let field = field_scalar.as_struct();
+    scalar_from_field_scalars(metadata, field.field("value"), field.field("typed_value"))
+}
+
+fn scalar_from_field_scalars(
+    metadata: &[u8],
+    value: Option<Scalar>,
+    typed_value: Option<Scalar>,
+) -> VortexResult<Scalar> {
+    if let Some(typed_value) = typed_value
+        && !typed_value.is_null()
+    {
+        return scalar_from_typed_value_scalar(metadata, value, typed_value);
+    }
+
+    if let Some(value) = value
+        && !value.is_null()
+    {
+        return scalar_from_unshredded_value(metadata, &value);
+    }
+
+    Ok(Scalar::null(DType::Null))
+}
+
+fn scalar_from_shredded_object_scalar(
+    metadata: &[u8],
+    value: Option<Scalar>,
+    typed_value: Scalar,
+) -> VortexResult<Scalar> {
+    let typed_value = typed_value.as_struct();
+    let mut names = Vec::new();
+    let mut dtypes = Vec::new();
+    let mut field_values = Vec::new();
+
+    for name in typed_value.names().iter() {
+        let nested = scalar_from_shredded_field_scalar(
+            metadata,
+            typed_value
+                .field(name.as_ref())
+                .vortex_expect("typed struct field must exist"),
+        )?;
+        names.push(FieldName::from(name.as_ref()));
+        dtypes.push(DType::Variant(Nullability::NonNullable));
+        field_values.push(Scalar::variant(nested).into_value());
+    }
+
+    if let Some(value) = value
+        && !value.is_null()
+    {
+        let unshredded = scalar_from_unshredded_value(metadata, &value)?;
+        if !unshredded.is_null() {
+            let unshredded = unshredded.as_struct();
+            for name in unshredded.names().iter() {
+                if typed_value.field(name.as_ref()).is_some() {
+                    continue;
+                }
+                let field = unshredded
+                    .field(name.as_ref())
+                    .vortex_expect("unshredded struct field must exist");
+                names.push(FieldName::from(name.as_ref()));
+                dtypes.push(DType::Variant(Nullability::NonNullable));
+                field_values.push(field.into_value());
+            }
+        }
+    }
+
+    let fields = StructFields::new(FieldNames::from(names), dtypes);
+    Scalar::try_new(
+        DType::Struct(fields, Nullability::NonNullable),
+        Some(ScalarValue::List(field_values)),
+    )
+}
+
+fn scalar_from_unshredded_value(metadata: &[u8], value: &Scalar) -> VortexResult<Scalar> {
+    let value = value
+        .as_binary()
+        .value()
+        .cloned()
+        .vortex_expect("non-null value row must have binary value");
+    parquet_variant_to_scalar(PqVariant::try_new(metadata, value.as_ref())?)
+}
+
+fn parquet_variant_to_scalar(variant: PqVariant<'_, '_>) -> VortexResult<Scalar> {
+    let nn = Nullability::NonNullable;
+
+    Ok(match variant {
+        PqVariant::Null => Scalar::null(DType::Null),
+        PqVariant::Int8(v) => Scalar::primitive(v, nn),
+        PqVariant::Int16(v) => Scalar::primitive(v, nn),
+        PqVariant::Int32(v) => Scalar::primitive(v, nn),
+        PqVariant::Int64(v) => Scalar::primitive(v, nn),
+        PqVariant::Float(v) => Scalar::primitive(v, nn),
+        PqVariant::Double(v) => Scalar::primitive(v, nn),
+        PqVariant::BooleanTrue => Scalar::bool(true, nn),
+        PqVariant::BooleanFalse => Scalar::bool(false, nn),
+        PqVariant::Decimal4(v) => Scalar::decimal(
+            v.integer().into(),
+            DecimalDType::new(9, v.scale() as i8),
+            nn,
+        ),
+        PqVariant::Decimal8(v) => Scalar::decimal(
+            v.integer().into(),
+            DecimalDType::new(18, v.scale() as i8),
+            nn,
+        ),
+        PqVariant::Decimal16(v) => Scalar::decimal(
+            v.integer().into(),
+            DecimalDType::new(38, v.scale() as i8),
+            nn,
+        ),
+        PqVariant::Binary(v) => Scalar::binary(v.to_vec(), nn),
+        PqVariant::String(v) => Scalar::utf8(v, nn),
+        PqVariant::ShortString(v) => Scalar::utf8(v.as_str(), nn),
+        PqVariant::Date(v) => {
+            let dtype = DType::Extension(Date::new(TimeUnit::Days, nn).erased());
+            Scalar::try_new(
+                dtype,
+                Some(ScalarValue::Primitive(PValue::I32(v.to_epoch_days()))),
+            )?
+        }
+        PqVariant::TimestampMicros(v) => {
+            let dtype = DType::Extension(
+                Timestamp::new_with_tz(TimeUnit::Microseconds, Some(Arc::from("UTC")), nn).erased(),
+            );
+            Scalar::try_new(
+                dtype,
+                Some(ScalarValue::Primitive(PValue::I64(v.timestamp_micros()))),
+            )?
+        }
+        PqVariant::TimestampNtzMicros(v) => {
+            let dtype = DType::Extension(Timestamp::new(TimeUnit::Microseconds, nn).erased());
+            Scalar::try_new(
+                dtype,
+                Some(ScalarValue::Primitive(PValue::I64(
+                    v.and_utc().timestamp_micros(),
+                ))),
+            )?
+        }
+        PqVariant::TimestampNanos(v) => {
+            let dtype = DType::Extension(
+                Timestamp::new_with_tz(TimeUnit::Nanoseconds, Some(Arc::from("UTC")), nn).erased(),
+            );
+            let nanos = v
+                .timestamp_nanos_opt()
+                .ok_or_else(|| vortex_err!("Timestamp nanoseconds value out of i64 range"))?;
+            Scalar::try_new(dtype, Some(ScalarValue::Primitive(PValue::I64(nanos))))?
+        }
+        PqVariant::TimestampNtzNanos(v) => {
+            let dtype = DType::Extension(Timestamp::new(TimeUnit::Nanoseconds, nn).erased());
+            let nanos = v
+                .and_utc()
+                .timestamp_nanos_opt()
+                .ok_or_else(|| vortex_err!("Timestamp nanoseconds value out of i64 range"))?;
+            Scalar::try_new(dtype, Some(ScalarValue::Primitive(PValue::I64(nanos))))?
+        }
+        PqVariant::Time(v) => {
+            // Parquet Variant spec stores Time as microseconds since midnight.
+            let micros =
+                v.num_seconds_from_midnight() as i64 * 1_000_000 + v.nanosecond() as i64 / 1_000;
+            let dtype = DType::Extension(Time::new(TimeUnit::Microseconds, nn).erased());
+            Scalar::try_new(dtype, Some(ScalarValue::Primitive(PValue::I64(micros))))?
+        }
+        // TODO: Should this depend on the new UUID-extension type? leaving this for now.
+        PqVariant::Uuid(v) => Scalar::utf8(v.to_string(), nn),
+        PqVariant::List(values) => {
+            let children = values
+                .iter()
+                .map(|v| parquet_variant_to_scalar(v).map(Scalar::variant))
+                .collect::<VortexResult<Vec<_>>>()?;
+            Scalar::list(DType::Variant(nn), children, nn)
+        }
+        PqVariant::Object(values) => {
+            let mut names = Vec::new();
+            let mut dtypes = Vec::new();
+            let mut field_values = Vec::new();
+            for (name, value) in values.iter() {
+                names.push(FieldName::from(name));
+                dtypes.push(DType::Variant(nn));
+                field_values.push(Some(ScalarValue::Variant(Box::new(
+                    parquet_variant_to_scalar(value)?,
+                ))));
+            }
+            let fields = StructFields::new(FieldNames::from(names), dtypes);
+            Scalar::try_new(
+                DType::Struct(fields, nn),
+                Some(ScalarValue::List(field_values)),
+            )?
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::Array as _;
+    use arrow_array::ArrayRef as ArrowArrayRef;
+    use arrow_array::Int32Array;
+    use arrow_array::ListArray;
+    use arrow_array::StructArray;
+    use arrow_array::builder::BinaryViewBuilder;
+    use arrow_buffer::NullBuffer;
+    use arrow_buffer::OffsetBuffer;
+    use arrow_schema::DataType;
+    use arrow_schema::Field;
+    use parquet_variant::Variant as PqVariant;
+    use parquet_variant::VariantBuilder;
+    use parquet_variant_compute::VariantArray as ArrowVariantArray;
+    use parquet_variant_compute::VariantArrayBuilder;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::Variant;
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::scalar::Scalar;
+    use vortex_array::scalar::ScalarValue;
+    use vortex_error::VortexResult;
+
+    use crate::ParquetVariant;
+    use crate::ParquetVariantArray;
+    use crate::operations::parquet_variant_to_scalar;
+
+    fn binary_view_array(values: &[&[u8]]) -> ArrowArrayRef {
+        let mut builder = BinaryViewBuilder::new();
+        for value in values {
+            builder.append_value(*value);
+        }
+        Arc::new(builder.finish())
+    }
+
+    fn assert_scalar_at_matches_arrow_try_value(
+        arrow_variant: &ArrowVariantArray,
+        rows: impl IntoIterator<Item = usize>,
+    ) -> VortexResult<()> {
+        let vortex_arr = ParquetVariantArray::from_arrow_variant(arrow_variant)?;
+
+        for index in rows {
+            let expected_inner =
+                parquet_variant_to_scalar(arrow_variant.try_value(index).unwrap())?;
+            let expected = Scalar::try_new(
+                vortex_arr.dtype().clone(),
+                Some(ScalarValue::Variant(Box::new(expected_inner))),
+            )
+            .unwrap();
+            assert_eq!(vortex_arr.scalar_at(index)?, expected);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_arrow_variant_nullable_validity() -> VortexResult<()> {
+        let mut builder = VariantArrayBuilder::new(3);
+        builder.append_variant(PqVariant::from(42i32));
+        builder.append_variant(PqVariant::from("hello"));
+        builder.append_variant(PqVariant::from(true));
+        let inner = builder.build().into_inner();
+
+        let null_struct = StructArray::try_new(
+            inner.fields().clone(),
+            inner.columns().to_vec(),
+            Some(NullBuffer::from(vec![true, false, true])),
+        )
+        .unwrap();
+
+        let arrow_variant = ArrowVariantArray::try_new(&null_struct).unwrap();
+        let vortex_arr = ParquetVariantArray::from_arrow_variant(&arrow_variant)?;
+
+        assert_eq!(vortex_arr.dtype(), &DType::Variant(Nullability::Nullable));
+
+        let variant = vortex_arr.as_opt::<Variant>().unwrap();
+        assert!(variant.dtype().is_nullable());
+
+        assert!(vortex_arr.scalar_at(1)?.is_null());
+        assert!(!vortex_arr.scalar_at(0)?.is_null());
+        assert!(!vortex_arr.scalar_at(2)?.is_null());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_arrow_variant_all_nulls() -> VortexResult<()> {
+        let mut builder = VariantArrayBuilder::new(2);
+        builder.append_variant(PqVariant::from(1i32));
+        builder.append_variant(PqVariant::from(2i32));
+        let inner = builder.build().into_inner();
+
+        let null_struct = StructArray::try_new(
+            inner.fields().clone(),
+            inner.columns().to_vec(),
+            Some(NullBuffer::from(vec![false, false])),
+        )
+        .unwrap();
+
+        let arrow_variant = ArrowVariantArray::try_new(&null_struct).unwrap();
+        let vortex_arr = ParquetVariantArray::from_arrow_variant(&arrow_variant)?;
+
+        assert_eq!(vortex_arr.dtype(), &DType::Variant(Nullability::Nullable));
+        assert!(vortex_arr.scalar_at(0)?.is_null());
+        assert!(vortex_arr.scalar_at(1)?.is_null());
+
+        let inner_pv = vortex_arr
+            .as_opt::<Variant>()
+            .unwrap()
+            .child()
+            .as_opt::<ParquetVariant>()
+            .unwrap();
+        let mut ctx = vortex_array::LEGACY_SESSION.create_execution_ctx();
+        let roundtripped = inner_pv.to_arrow(&mut ctx)?;
+        assert_eq!(roundtripped.inner().null_count(), 2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_from_arrow_variant_non_nullable() -> VortexResult<()> {
+        let mut builder = VariantArrayBuilder::new(2);
+        builder.append_variant(PqVariant::from(1i32));
+        builder.append_variant(PqVariant::from(2i32));
+        let arrow_variant = builder.build();
+
+        let vortex_arr = ParquetVariantArray::from_arrow_variant(&arrow_variant)?;
+
+        assert_eq!(
+            vortex_arr.dtype(),
+            &DType::Variant(Nullability::NonNullable)
+        );
+        assert!(!vortex_arr.scalar_at(0)?.is_null());
+        assert!(!vortex_arr.scalar_at(1)?.is_null());
+        assert_scalar_at_matches_arrow_try_value(&arrow_variant, [0, 1])?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_scalar_at_matches_arrow_try_value_unshredded_mixed_values() -> VortexResult<()> {
+        let mut builder = VariantArrayBuilder::new(3);
+        builder.append_variant(PqVariant::from(42i32));
+        builder.append_variant(PqVariant::from("hello"));
+        builder.append_variant(PqVariant::from(true));
+        let arrow_variant = builder.build();
+
+        assert_scalar_at_matches_arrow_try_value(&arrow_variant, [0, 1, 2])
+    }
+
+    #[test]
+    fn test_scalar_at_matches_arrow_try_value_shredded_primitive() -> VortexResult<()> {
+        let struct_array = StructArray::try_new(
+            vec![
+                Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+                Arc::new(Field::new("typed_value", DataType::Int32, false)),
+            ]
+            .into(),
+            vec![
+                binary_view_array(&[b"\x01\x00", b"\x01\x00", b"\x01\x00"]),
+                Arc::new(Int32Array::from(vec![10, 20, 30])),
+            ],
+            None,
+        )
+        .unwrap();
+
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        assert_scalar_at_matches_arrow_try_value(&arrow_variant, [0, 1, 2])
+    }
+
+    #[test]
+    fn test_scalar_at_matches_arrow_try_value_imperfectly_shredded_primitive() -> VortexResult<()> {
+        let (metadata0, value0) = VariantBuilder::new().with_value("fallback-0").finish();
+        let (metadata1, _value1) = VariantBuilder::new().with_value(20i32).finish();
+        let (metadata2, value2) = VariantBuilder::new().with_value("fallback-2").finish();
+
+        let metadata = binary_view_array(&[
+            metadata0.as_slice(),
+            metadata1.as_slice(),
+            metadata2.as_slice(),
+        ]);
+        let mut value_builder = BinaryViewBuilder::new();
+        value_builder.append_value(value0.as_slice());
+        value_builder.append_null();
+        value_builder.append_value(value2.as_slice());
+        let value = Arc::new(value_builder.finish());
+
+        let typed_value = Arc::new(Int32Array::from(vec![None, Some(20), None]));
+        let struct_array = StructArray::try_new(
+            vec![
+                Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+                Arc::new(Field::new("value", DataType::BinaryView, true)),
+                Arc::new(Field::new("typed_value", DataType::Int32, true)),
+            ]
+            .into(),
+            vec![metadata, value, typed_value],
+            None,
+        )
+        .unwrap();
+
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        assert_scalar_at_matches_arrow_try_value(&arrow_variant, [0, 1, 2])
+    }
+
+    #[test]
+    fn test_scalar_at_recursive_shredded_list() -> VortexResult<()> {
+        // Spec basis: for arrays, "value must be null" when the value is an array, and array
+        // elements cannot be missing.
+        // Source: https://github.com/apache/parquet-format/blob/master/VariantShredding.md
+        let element_struct = StructArray::try_new(
+            vec![Arc::new(Field::new("typed_value", DataType::Int32, false))].into(),
+            vec![Arc::new(Int32Array::from(vec![10, 20, 30]))],
+            None,
+        )
+        .unwrap();
+
+        let typed_value: ArrowArrayRef = Arc::new(
+            ListArray::try_new(
+                Arc::new(Field::new(
+                    "element",
+                    element_struct.data_type().clone(),
+                    false,
+                )),
+                OffsetBuffer::from_lengths([2, 1]),
+                Arc::new(element_struct),
+                None,
+            )
+            .unwrap(),
+        );
+
+        let struct_array = StructArray::try_new(
+            vec![
+                Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+                Arc::new(Field::new(
+                    "typed_value",
+                    typed_value.data_type().clone(),
+                    false,
+                )),
+            ]
+            .into(),
+            vec![binary_view_array(&[b"\x01\x00", b"\x01\x00"]), typed_value],
+            None,
+        )
+        .unwrap();
+
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        let vortex_arr = ParquetVariantArray::from_arrow_variant(&arrow_variant)?;
+
+        let row0 = vortex_arr.scalar_at(0)?;
+        let row0 = row0.as_variant().value().unwrap().as_list();
+        assert_eq!(row0.len(), 2);
+        assert_eq!(
+            row0.element(0)
+                .unwrap()
+                .as_variant()
+                .value()
+                .unwrap()
+                .as_primitive()
+                .typed_value::<i32>(),
+            Some(10)
+        );
+        assert_eq!(
+            row0.element(1)
+                .unwrap()
+                .as_variant()
+                .value()
+                .unwrap()
+                .as_primitive()
+                .typed_value::<i32>(),
+            Some(20)
+        );
+
+        let row1 = vortex_arr.scalar_at(1)?;
+        let row1 = row1.as_variant().value().unwrap().as_list();
+        assert_eq!(row1.len(), 1);
+        assert_eq!(
+            row1.element(0)
+                .unwrap()
+                .as_variant()
+                .value()
+                .unwrap()
+                .as_primitive()
+                .typed_value::<i32>(),
+            Some(30)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_scalar_at_partially_shredded_object_merges_fields() -> VortexResult<()> {
+        // Spec basis: non-null `value` + non-null `typed_value` means a "partially shredded
+        // object", so reconstruction must merge the shredded object with the fallback object.
+        // Source: https://github.com/apache/parquet-format/blob/master/VariantShredding.md
+        let mut builder = VariantBuilder::new();
+        builder
+            .new_object()
+            .with_field("a", 1i32)
+            .with_field("b", "leftover")
+            .finish();
+        let (metadata, value) = builder.finish();
+
+        let shredded_a = StructArray::try_new(
+            vec![Arc::new(Field::new("typed_value", DataType::Int32, false))].into(),
+            vec![Arc::new(Int32Array::from(vec![7]))],
+            None,
+        )
+        .unwrap();
+        let typed_value: ArrowArrayRef = Arc::new(
+            StructArray::try_new(
+                vec![Arc::new(Field::new(
+                    "a",
+                    shredded_a.data_type().clone(),
+                    false,
+                ))]
+                .into(),
+                vec![Arc::new(shredded_a)],
+                None,
+            )
+            .unwrap(),
+        );
+
+        let struct_array = StructArray::try_new(
+            vec![
+                Arc::new(Field::new("metadata", DataType::BinaryView, false)),
+                Arc::new(Field::new("value", DataType::BinaryView, true)),
+                Arc::new(Field::new(
+                    "typed_value",
+                    typed_value.data_type().clone(),
+                    false,
+                )),
+            ]
+            .into(),
+            vec![
+                binary_view_array(&[metadata.as_slice()]),
+                binary_view_array(&[value.as_slice()]),
+                typed_value,
+            ],
+            None,
+        )
+        .unwrap();
+
+        let arrow_variant = ArrowVariantArray::try_new(&struct_array).unwrap();
+        let vortex_arr = ParquetVariantArray::from_arrow_variant(&arrow_variant)?;
+        let object = vortex_arr.scalar_at(0)?;
+        let object = object.as_variant().value().unwrap().as_struct();
+
+        assert_eq!(
+            object
+                .field("a")
+                .unwrap()
+                .as_variant()
+                .value()
+                .unwrap()
+                .as_primitive()
+                .typed_value::<i32>(),
+            Some(7)
+        );
+        assert_eq!(
+            object
+                .field("b")
+                .unwrap()
+                .as_variant()
+                .value()
+                .unwrap()
+                .as_utf8()
+                .value()
+                .map(|value| value.as_str()),
+            Some("leftover")
+        );
+
+        Ok(())
+    }
+}

--- a/encodings/parquet-variant/src/validity.rs
+++ b/encodings/parquet-variant/src/validity.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::validity::Validity;
+use vortex_array::vtable::ValidityHelper;
+
+use crate::array::ParquetVariantArray;
+
+impl ValidityHelper for ParquetVariantArray {
+    fn validity(&self) -> &Validity {
+        &self.validity
+    }
+}

--- a/encodings/parquet-variant/src/vtable.rs
+++ b/encodings/parquet-variant/src/vtable.rs
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::sync::Arc;
+
+use prost::Message;
+use vortex_array::ArrayEq;
+use vortex_array::ArrayHash;
+use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
+use vortex_array::ExecutionResult;
+use vortex_array::IntoArray;
+use vortex_array::Precision;
+use vortex_array::arrays::VariantArray;
+use vortex_array::buffer::BufferHandle;
+use vortex_array::dtype::DType;
+use vortex_array::dtype::Nullability;
+use vortex_array::serde::ArrayChildren;
+use vortex_array::stats::StatsSetRef;
+use vortex_array::validity::Validity;
+use vortex_array::vtable;
+use vortex_array::vtable::Array;
+use vortex_array::vtable::ArrayId;
+use vortex_array::vtable::VTable;
+use vortex_array::vtable::ValidityVTableFromValidityHelper;
+use vortex_array::vtable::validity_nchildren;
+use vortex_array::vtable::validity_to_child;
+use vortex_error::VortexExpect as _;
+use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
+use vortex_error::vortex_err;
+use vortex_error::vortex_panic;
+use vortex_proto::dtype as pb;
+use vortex_session::VortexSession;
+
+use crate::array::ParquetVariantArray;
+use crate::kernel::PARENT_KERNELS;
+
+/// VTable for [`ParquetVariantArray`].
+#[derive(Debug, Clone)]
+pub struct ParquetVariant;
+
+impl ParquetVariant {
+    pub const ID: ArrayId = ArrayId::new_ref("vortex.parquet.variant");
+}
+
+/// Serialized metadata for a [`ParquetVariantArray`].
+#[derive(Clone, Debug)]
+pub struct ParquetVariantMetadata {
+    /// Whether the un-shredded `value` child is present.
+    pub has_value: bool,
+    /// Whether the `value` child is nullable.
+    ///
+    /// In partially-shredded layouts, rows whose data lives entirely in `typed_value` have a
+    /// null `value` slot, so the Arrow field is marked nullable. This flag preserves that
+    /// distinction across serialization round-trips.
+    pub value_nullable: bool,
+    /// DType of the shredded `typed_value`, if present.
+    ///
+    /// This is required to deserialize non-variant shredded children.
+    pub typed_value_dtype: Option<DType>,
+}
+
+#[derive(Clone, prost::Message)]
+struct ParquetVariantMetadataProto {
+    /// Whether the un-shredded `value` child is present.
+    #[prost(bool, tag = "1")]
+    pub has_value: bool,
+    /// DType of the shredded `typed_value`, if present.
+    #[prost(message, optional, tag = "2")]
+    pub typed_value_dtype: Option<pb::DType>,
+    /// Whether the `value` child is nullable.
+    #[prost(bool, tag = "3")]
+    pub value_nullable: bool,
+}
+
+vtable!(ParquetVariant);
+
+impl VTable for ParquetVariant {
+    type Array = ParquetVariantArray;
+    type Metadata = ParquetVariantMetadata;
+    type OperationsVTable = Self;
+    type ValidityVTable = ValidityVTableFromValidityHelper;
+
+    fn vtable(_array: &Self::Array) -> &Self {
+        &ParquetVariant
+    }
+
+    fn id(&self) -> ArrayId {
+        Self::ID
+    }
+
+    fn len(array: &ParquetVariantArray) -> usize {
+        array.metadata.len()
+    }
+
+    fn dtype(array: &ParquetVariantArray) -> &DType {
+        &array.dtype
+    }
+
+    fn stats(array: &ParquetVariantArray) -> StatsSetRef<'_> {
+        array.stats_set.to_ref(array.as_ref())
+    }
+
+    fn array_hash<H: Hasher>(array: &ParquetVariantArray, state: &mut H, precision: Precision) {
+        array.validity.array_hash(state, precision);
+        array.metadata.array_hash(state, precision);
+        // Hash discriminators so that (value=Some, typed_value=None) and
+        // (value=None, typed_value=Some) produce different hashes.
+        array.value.is_some().hash(state);
+        if let Some(ref value) = array.value {
+            value.array_hash(state, precision);
+        }
+        array.typed_value.is_some().hash(state);
+        if let Some(ref typed_value) = array.typed_value {
+            typed_value.array_hash(state, precision);
+        }
+    }
+
+    fn array_eq(
+        array: &ParquetVariantArray,
+        other: &ParquetVariantArray,
+        precision: Precision,
+    ) -> bool {
+        if !array.validity.array_eq(&other.validity, precision)
+            || !array.metadata.array_eq(&other.metadata, precision)
+        {
+            return false;
+        }
+        match (&array.value, &other.value) {
+            (Some(a), Some(b)) => {
+                if !a.array_eq(b, precision) {
+                    return false;
+                }
+            }
+            (None, None) => {}
+            _ => return false,
+        }
+        match (&array.typed_value, &other.typed_value) {
+            (Some(a), Some(b)) => a.array_eq(b, precision),
+            (None, None) => true,
+            _ => false,
+        }
+    }
+
+    fn nbuffers(_array: &ParquetVariantArray) -> usize {
+        0
+    }
+
+    fn buffer(_array: &ParquetVariantArray, idx: usize) -> BufferHandle {
+        vortex_panic!("ParquetVariantArray buffer index {idx} out of bounds")
+    }
+
+    fn buffer_name(_array: &ParquetVariantArray, _idx: usize) -> Option<String> {
+        None
+    }
+
+    fn nchildren(array: &ParquetVariantArray) -> usize {
+        1 + validity_nchildren(&array.validity)
+            + array.value.is_some() as usize
+            + array.typed_value.is_some() as usize
+    }
+
+    fn child(array: &ParquetVariantArray, idx: usize) -> ArrayRef {
+        let vc = validity_nchildren(&array.validity);
+        if idx < vc {
+            validity_to_child(&array.validity, array.metadata.len())
+                .vortex_expect("ParquetVariantArray validity child out of bounds")
+        } else {
+            match idx - vc {
+                0 => array.metadata.clone(),
+                1 if array.value.is_some() => array
+                    .value
+                    .clone()
+                    .vortex_expect("ParquetVariantArray missing value child"),
+                1 => array
+                    .typed_value
+                    .clone()
+                    .vortex_expect("ParquetVariantArray missing typed_value child"),
+                2 => array
+                    .typed_value
+                    .clone()
+                    .vortex_expect("ParquetVariantArray missing typed_value child"),
+                _ => vortex_panic!("ParquetVariantArray child index {idx} out of bounds"),
+            }
+        }
+    }
+
+    fn child_name(array: &ParquetVariantArray, idx: usize) -> String {
+        let vc = validity_nchildren(&array.validity);
+        match idx {
+            idx if idx < vc => "validity".to_string(),
+            idx => match idx - vc {
+                0 => "metadata".to_string(),
+                1 if array.value.is_some() => "value".to_string(),
+                1 => "typed_value".to_string(),
+                2 => "typed_value".to_string(),
+                _ => vortex_panic!("ParquetVariantArray child_name index {idx} out of bounds"),
+            },
+        }
+    }
+
+    fn metadata(array: &ParquetVariantArray) -> VortexResult<Self::Metadata> {
+        Ok(ParquetVariantMetadata {
+            has_value: array.value.is_some(),
+            value_nullable: array
+                .value
+                .as_ref()
+                .is_some_and(|v| v.dtype().is_nullable()),
+            typed_value_dtype: array.typed_value.as_ref().map(|tv| tv.dtype().clone()),
+        })
+    }
+
+    fn serialize(metadata: Self::Metadata) -> VortexResult<Option<Vec<u8>>> {
+        let typed_value_dtype = metadata
+            .typed_value_dtype
+            .as_ref()
+            .map(|dtype| dtype.try_into())
+            .transpose()?;
+        Ok(Some(
+            ParquetVariantMetadataProto {
+                has_value: metadata.has_value,
+                typed_value_dtype,
+                value_nullable: metadata.value_nullable,
+            }
+            .encode_to_vec(),
+        ))
+    }
+
+    fn deserialize(
+        bytes: &[u8],
+        _dtype: &DType,
+        _len: usize,
+        _buffers: &[BufferHandle],
+        session: &VortexSession,
+    ) -> VortexResult<Self::Metadata> {
+        let proto = ParquetVariantMetadataProto::decode(bytes)?;
+        let typed_value_dtype = match proto.typed_value_dtype.as_ref() {
+            Some(dtype) => Some(DType::from_proto(dtype, session)?),
+            None => None,
+        };
+        Ok(ParquetVariantMetadata {
+            has_value: proto.has_value,
+            value_nullable: proto.value_nullable,
+            typed_value_dtype,
+        })
+    }
+
+    fn build(
+        dtype: &DType,
+        len: usize,
+        metadata: &Self::Metadata,
+        _buffers: &[BufferHandle],
+        children: &dyn ArrayChildren,
+    ) -> VortexResult<ParquetVariantArray> {
+        vortex_ensure!(matches!(dtype, DType::Variant(_)), "Expected Variant DType");
+        let has_typed_value = metadata.typed_value_dtype.is_some();
+        vortex_ensure!(
+            metadata.has_value || has_typed_value,
+            "At least one of value or typed_value must be present"
+        );
+
+        let expected_children = 1 + metadata.has_value as usize + has_typed_value as usize;
+        vortex_ensure!(
+            children.len() == expected_children || children.len() == expected_children + 1,
+            "Expected {} or {} children, got {}",
+            expected_children,
+            expected_children + 1,
+            children.len()
+        );
+
+        let (validity, mut child_idx) = if children.len() == expected_children {
+            (Validity::from(dtype.nullability()), 0)
+        } else {
+            (Validity::Array(children.get(0, &Validity::DTYPE, len)?), 1)
+        };
+        let variant_metadata =
+            children.get(child_idx, &DType::Binary(Nullability::NonNullable), len)?;
+        child_idx += 1;
+
+        let value = if metadata.has_value {
+            let v = children.get(
+                child_idx,
+                &DType::Binary(metadata.value_nullable.into()),
+                len,
+            )?;
+            child_idx += 1;
+            Some(v)
+        } else {
+            None
+        };
+
+        let typed_value = if has_typed_value {
+            // typed_value can be any type — primitive, list, struct, etc.
+            let dtype = metadata
+                .typed_value_dtype
+                .clone()
+                .ok_or_else(|| vortex_err!("typed_value_dtype missing for typed_value child"))?;
+            let tv = children.get(child_idx, &dtype, len)?;
+            Some(tv)
+        } else {
+            None
+        };
+
+        ParquetVariantArray::try_new_with_validity(validity, variant_metadata, value, typed_value)
+    }
+
+    fn with_children(array: &mut Self::Array, children: Vec<ArrayRef>) -> VortexResult<()> {
+        vortex_ensure!(
+            children.len() == array.nchildren(),
+            "ParquetVariantArray expects {} children, got {}",
+            array.nchildren(),
+            children.len()
+        );
+        let mut iter = children.into_iter();
+        if validity_nchildren(&array.validity) == 1 {
+            array.validity = Validity::Array(
+                iter.next()
+                    .vortex_expect("ParquetVariantArray missing validity child"),
+            );
+        }
+        array.metadata = iter
+            .next()
+            .vortex_expect("ParquetVariantArray missing metadata child");
+        if array.value.is_some() {
+            array.value = Some(
+                iter.next()
+                    .vortex_expect("ParquetVariantArray missing value child in with_children"),
+            );
+        }
+        if array.typed_value.is_some() {
+            array.typed_value =
+                Some(iter.next().vortex_expect(
+                    "ParquetVariantArray missing typed_value child in with_children",
+                ));
+        }
+        Ok(())
+    }
+
+    fn execute(array: Arc<Array<Self>>, _ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult> {
+        Ok(ExecutionResult::done(
+            VariantArray::new(array.as_ref().clone().into_array()).into_array(),
+        ))
+    }
+
+    fn execute_parent(
+        array: &Array<Self>,
+        parent: &ArrayRef,
+        child_idx: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        PARENT_KERNELS.execute(array, parent, child_idx, ctx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vortex_array::ArrayContext;
+    use vortex_array::ArrayEq;
+    use vortex_array::ArrayRef;
+    use vortex_array::IntoArray;
+    use vortex_array::Precision;
+    use vortex_array::arrays::VarBinViewArray;
+    use vortex_array::arrays::Variant;
+    use vortex_array::arrays::VariantArray;
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::dtype::PType;
+    use vortex_array::serde::ArrayParts;
+    use vortex_array::serde::SerializeOptions;
+    use vortex_array::session::ArraySessionExt;
+    use vortex_buffer::BitBuffer;
+    use vortex_buffer::ByteBufferMut;
+    use vortex_buffer::buffer;
+    use vortex_session::VortexSession;
+    use vortex_session::registry::ReadContext;
+
+    use crate::ParquetVariant;
+    use crate::ParquetVariantArray;
+
+    fn roundtrip(array: ArrayRef) -> ArrayRef {
+        let dtype = array.dtype().clone();
+        let len = array.len();
+
+        let ctx = ArrayContext::empty();
+        let serialized = array.serialize(&ctx, &SerializeOptions::default()).unwrap();
+
+        let mut concat = ByteBufferMut::empty();
+        for buf in serialized {
+            concat.extend_from_slice(buf.as_ref());
+        }
+        let concat = concat.freeze();
+
+        let session = VortexSession::empty().with::<vortex_array::session::ArraySession>();
+        session.arrays().register(ParquetVariant);
+        session.arrays().register(Variant);
+
+        let parts = ArrayParts::try_from(concat).unwrap();
+        parts
+            .decode(&dtype, len, &ReadContext::new(ctx.to_ids()), &session)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_serde_roundtrip_typed_value_variant() {
+        let outer_metadata =
+            VarBinViewArray::from_iter_bin([b"\x01\x00", b"\x01\x00", b"\x01\x00"]).into_array();
+
+        let inner_metadata =
+            VarBinViewArray::from_iter_bin([b"\x01\x00", b"\x01\x00", b"\x01\x00"]).into_array();
+        let inner_value = VarBinViewArray::from_iter_bin([b"\x02", b"\x03", b"\x04"]).into_array();
+        let inner_pv =
+            ParquetVariantArray::try_new(inner_metadata, Some(inner_value), None).unwrap();
+        let typed_value = VariantArray::new(inner_pv.into_array()).into_array();
+
+        let outer_pv =
+            ParquetVariantArray::try_new(outer_metadata, None, Some(typed_value)).unwrap();
+        let array = outer_pv.into_array();
+        let decoded = roundtrip(array.clone());
+
+        assert!(array.array_eq(&decoded, Precision::Value));
+        let decoded_pv = decoded.as_opt::<ParquetVariant>().unwrap();
+        let typed = decoded_pv.typed_value_array().unwrap();
+        assert_eq!(typed.dtype(), &DType::Variant(Nullability::Nullable));
+    }
+
+    #[test]
+    fn test_serde_roundtrip_with_nullable_validity() {
+        let metadata =
+            VarBinViewArray::from_iter_bin([b"\x01\x00", b"\x01\x00", b"\x01\x00"]).into_array();
+        let value = VarBinViewArray::from_iter_bin([b"\x10", b"\x11", b"\x12"]).into_array();
+        let validity =
+            vortex_array::validity::Validity::from(BitBuffer::from_iter([true, false, true]));
+
+        let pv = ParquetVariantArray::try_new_with_validity(validity, metadata, Some(value), None)
+            .unwrap();
+        let array = pv.into_array();
+        let decoded = roundtrip(array.clone());
+
+        assert!(array.array_eq(&decoded, Precision::Value));
+        assert_eq!(decoded.dtype(), &DType::Variant(Nullability::Nullable));
+        let decoded_pv = decoded.as_opt::<ParquetVariant>().unwrap();
+        assert!(decoded_pv.value_array().is_some());
+        assert!(decoded_pv.typed_value_array().is_none());
+    }
+
+    #[test]
+    fn test_serde_roundtrip_typed_value_int32() {
+        let outer_metadata =
+            VarBinViewArray::from_iter_bin([b"\x01\x00", b"\x01\x00", b"\x01\x00"]).into_array();
+        let typed_value = buffer![10i32, 20, 30].into_array();
+
+        let outer_pv =
+            ParquetVariantArray::try_new(outer_metadata, None, Some(typed_value)).unwrap();
+        let array = outer_pv.into_array();
+        let decoded = roundtrip(array.clone());
+
+        assert!(array.array_eq(&decoded, Precision::Value));
+        let decoded_pv = decoded.as_opt::<ParquetVariant>().unwrap();
+        let typed = decoded_pv.typed_value_array().unwrap();
+        assert_eq!(
+            typed.dtype(),
+            &DType::Primitive(PType::I32, Nullability::NonNullable)
+        );
+    }
+}

--- a/encodings/parquet-variant/src/vtable.rs
+++ b/encodings/parquet-variant/src/vtable.rs
@@ -304,7 +304,7 @@ impl VTable for ParquetVariant {
             None
         };
 
-        ParquetVariantArray::try_new_with_validity(validity, variant_metadata, value, typed_value)
+        ParquetVariantArray::try_new(validity, variant_metadata, value, typed_value)
     }
 
     fn with_children(array: &mut Self::Array, children: Vec<ArrayRef>) -> VortexResult<()> {
@@ -371,6 +371,7 @@ mod tests {
     use vortex_array::serde::ArrayParts;
     use vortex_array::serde::SerializeOptions;
     use vortex_array::session::ArraySessionExt;
+    use vortex_array::validity::Validity;
     use vortex_buffer::BitBuffer;
     use vortex_buffer::ByteBufferMut;
     use vortex_buffer::buffer;
@@ -411,19 +412,29 @@ mod tests {
         let inner_metadata =
             VarBinViewArray::from_iter_bin([b"\x01\x00", b"\x01\x00", b"\x01\x00"]).into_array();
         let inner_value = VarBinViewArray::from_iter_bin([b"\x02", b"\x03", b"\x04"]).into_array();
-        let inner_pv =
-            ParquetVariantArray::try_new(inner_metadata, Some(inner_value), None).unwrap();
+        let inner_pv = ParquetVariantArray::try_new(
+            Validity::NonNullable,
+            inner_metadata,
+            Some(inner_value),
+            None,
+        )
+        .unwrap();
         let typed_value = VariantArray::new(inner_pv.into_array()).into_array();
 
-        let outer_pv =
-            ParquetVariantArray::try_new(outer_metadata, None, Some(typed_value)).unwrap();
+        let outer_pv = ParquetVariantArray::try_new(
+            Validity::NonNullable,
+            outer_metadata,
+            None,
+            Some(typed_value),
+        )
+        .unwrap();
         let array = outer_pv.into_array();
         let decoded = roundtrip(array.clone());
 
         assert!(array.array_eq(&decoded, Precision::Value));
         let decoded_pv = decoded.as_opt::<ParquetVariant>().unwrap();
         let typed = decoded_pv.typed_value_array().unwrap();
-        assert_eq!(typed.dtype(), &DType::Variant(Nullability::Nullable));
+        assert_eq!(typed.dtype(), &DType::Variant(Nullability::NonNullable));
     }
 
     #[test]
@@ -431,11 +442,9 @@ mod tests {
         let metadata =
             VarBinViewArray::from_iter_bin([b"\x01\x00", b"\x01\x00", b"\x01\x00"]).into_array();
         let value = VarBinViewArray::from_iter_bin([b"\x10", b"\x11", b"\x12"]).into_array();
-        let validity =
-            vortex_array::validity::Validity::from(BitBuffer::from_iter([true, false, true]));
+        let validity = Validity::from(BitBuffer::from_iter([true, false, true]));
 
-        let pv = ParquetVariantArray::try_new_with_validity(validity, metadata, Some(value), None)
-            .unwrap();
+        let pv = ParquetVariantArray::try_new(validity, metadata, Some(value), None).unwrap();
         let array = pv.into_array();
         let decoded = roundtrip(array.clone());
 
@@ -452,8 +461,13 @@ mod tests {
             VarBinViewArray::from_iter_bin([b"\x01\x00", b"\x01\x00", b"\x01\x00"]).into_array();
         let typed_value = buffer![10i32, 20, 30].into_array();
 
-        let outer_pv =
-            ParquetVariantArray::try_new(outer_metadata, None, Some(typed_value)).unwrap();
+        let outer_pv = ParquetVariantArray::try_new(
+            Validity::NonNullable,
+            outer_metadata,
+            None,
+            Some(typed_value),
+        )
+        .unwrap();
         let array = outer_pv.into_array();
         let decoded = roundtrip(array.clone());
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -8542,6 +8542,10 @@ pub fn vortex_array::ArrayRef::into_arrow_preferred(self) -> vortex_error::Vorte
 
 pub fn vortex_array::arrow::from_arrow_array_with_len<A>(array: A, len: usize, nullable: bool) -> vortex_error::VortexResult<vortex_array::ArrayRef> where vortex_array::ArrayRef: vortex_array::arrow::FromArrowArray<A>
 
+pub fn vortex_array::arrow::to_arrow_null_buffer(validity: vortex_array::validity::Validity, len: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<arrow_buffer::buffer::null::NullBuffer>>
+
+pub fn vortex_array::arrow::to_null_buffer(mask: vortex_mask::Mask) -> core::option::Option<arrow_buffer::buffer::null::NullBuffer>
+
 pub mod vortex_array::buffer
 
 pub struct vortex_array::buffer::BufferHandle(_)

--- a/vortex-array/src/arrow/executor/validity.rs
+++ b/vortex-array/src/arrow/executor/validity.rs
@@ -1,22 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use arrow_buffer::NullBuffer;
-use vortex_error::VortexResult;
-use vortex_mask::Mask;
-
-use crate::ExecutionCtx;
-use crate::arrow::null_buffer::to_null_buffer;
-use crate::validity::Validity;
-
-pub(super) fn to_arrow_null_buffer(
-    validity: Validity,
-    len: usize,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<Option<NullBuffer>> {
-    Ok(match validity {
-        Validity::NonNullable | Validity::AllValid => None,
-        Validity::AllInvalid => Some(NullBuffer::new_null(len)),
-        Validity::Array(array) => to_null_buffer(array.execute::<Mask>(ctx)?),
-    })
-}
+pub(super) use crate::arrow::null_buffer::to_arrow_null_buffer;

--- a/vortex-array/src/arrow/mod.rs
+++ b/vortex-array/src/arrow/mod.rs
@@ -17,7 +17,10 @@ mod record_batch;
 pub use datum::*;
 pub use executor::*;
 pub use iter::*;
+pub use null_buffer::to_arrow_null_buffer;
+pub use null_buffer::to_null_buffer;
 
+use crate::ArrayRef;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 
@@ -33,7 +36,7 @@ pub trait IntoArrowArray {
     fn into_arrow(self, data_type: &DataType) -> VortexResult<ArrowArrayRef>;
 }
 
-impl IntoArrowArray for crate::ArrayRef {
+impl IntoArrowArray for ArrayRef {
     /// Convert this [`crate::ArrayRef`] into an Arrow [`crate::ArrayRef`] by using the array's
     /// preferred (cheapest) Arrow [`DataType`].
     fn into_arrow_preferred(self) -> VortexResult<ArrowArrayRef> {

--- a/vortex-array/src/arrow/null_buffer.rs
+++ b/vortex-array/src/arrow/null_buffer.rs
@@ -3,7 +3,24 @@
 
 use arrow_buffer::BooleanBuffer;
 use arrow_buffer::NullBuffer;
+use vortex_error::VortexResult;
 use vortex_mask::Mask;
+
+use crate::ExecutionCtx;
+use crate::validity::Validity;
+
+/// Converts a [`Validity`] to an Arrow [`NullBuffer`], executing the validity array if needed.
+pub fn to_arrow_null_buffer(
+    validity: Validity,
+    len: usize,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Option<NullBuffer>> {
+    Ok(match validity {
+        Validity::NonNullable | Validity::AllValid => None,
+        Validity::AllInvalid => Some(NullBuffer::new_null(len)),
+        Validity::Array(array) => to_null_buffer(array.execute::<Mask>(ctx)?),
+    })
+}
 
 /// Converts a mask to a null buffer.
 pub fn to_null_buffer(mask: Mask) -> Option<NullBuffer> {

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -1002,6 +1002,7 @@ impl Matcher for AnyCanonical {
             || array.is::<VarBinView>()
             || array.is::<Variant>()
             || array.is::<Extension>()
+            || array.is::<Variant>()
     }
 
     fn try_match<'a>(array: &'a dyn DynArray) -> Option<Self::Match<'a>> {


### PR DESCRIPTION
## Summary

This PR introduces a new encoding to support Arrow's canonical extension type, but does not integrate it with anything else.

It does include basic pieces like slice/take/filter, and it can (or at least should) roundtrip with the equivalent arrow array.

## Testing

The encoding includes a bunch of basic tests, both for making sure it roundtrips with arrow and for the various nullability cases.
