### PR TITLE
Fuzzer uses same mask for expected and actual value

### DIFF
--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -398,7 +398,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                         current_array
                             .to_canonical()
                             .vortex_expect("to_canonical should succeed in fuzz test"),
-                        &!Mask::from_iter(mask.clone()),
+                        &Mask::from_iter(mask.clone()),
                     )
                     .vortex_expect("mask_canonical_array should succeed in fuzz test");
                     // Update current_array to the result for chaining

--- a/fuzz/src/error.rs
+++ b/fuzz/src/error.rs
@@ -114,10 +114,10 @@ impl Display for VortexFuzzError {
                     f,
                     "Mismatch at step {step} at index {idx}\n\
                     Expected scalar:\n{expected_scalar}\n\
-                    Actual scalar:\n{actual_scalar}\n\
+                    Actual scalar:\n{actual_scalar}\n\n\
                     Expected tree:\n{expected_tree}\n\
-                    Current tree:\n{current_tree}\
-                    Expected values:\n{expected_values:#}\n\
+                    Current tree:\n{current_tree}\n\
+                    Expected values:\n{expected_values:#}\n\n\
                     Current values:\n{current_values:#}\
                     \n{backtrace}"
                 )


### PR DESCRIPTION
I think this is a typo that got in https://github.com/vortex-data/vortex/pull/6867/changes#r2978043644. This fixes latest fuzzer issue.

Signed-off-by: Robert Kruszewski <github@robertk.io>
