### PR TITLE
Update vtables docs regarding forwarding from erased to typed

### DIFF
--- a/docs/developer-guide/internals/vtables.md
+++ b/docs/developer-guide/internals/vtables.md
@@ -43,6 +43,8 @@ via normal method resolution.
 **Sealed trait** `DynFoo` is object-safe and has a blanket `impl<V: FooVTable> DynFoo for Foo<V>`.
 This blanket impl is a thin forwarder to `Foo<V>` inherent methods — no logic of its own.
 Its purpose is to enable dynamic dispatch from `FooRef` through to the typed `Foo<V>`.
+`DynFoo` must stay private (`pub(super)`) because it exposes internal plumbing
+(`as_any`, `metadata_any`) that should not be part of the public API.
 
 **Erased form** `FooRef` wraps `Arc<dyn DynFoo>`. It delegates to `DynFoo` methods, which
 forward to `Foo<V>`. It can be stored in collections, serialized, and threaded through APIs
@@ -63,13 +65,13 @@ registered in the session by their ID.
 
 For a concept `Foo`, the components are organized into these files:
 
-| File         | Contains                                                             |
-|--------------|----------------------------------------------------------------------|
-| `vtable.rs`  | `FooVTable` trait definition                                         |
-| `typed.rs`   | `Foo<V>` data struct, inherent methods, `Deref` impl                 |
-| `erased.rs`  | `FooRef` struct, `DynFoo` sealed trait, blanket impl                 |
-| `plugin.rs`  | `FooPlugin` trait, registration                                      |
-| `matcher.rs` | Downcasting helpers (`is`, `as_`, `as_opt`, pattern matching traits) |
+| File         | Contains                                                                    |
+|--------------|-----------------------------------------------------------------------------|
+| `vtable.rs`  | `FooVTable` trait definition                                                |
+| `typed.rs`   | `Foo<V>` data struct, inherent methods, `DynFoo` sealed trait, blanket impl |
+| `erased.rs`  | `FooRef` struct                                                             |
+| `plugin.rs`  | `FooPlugin` trait, registration                                             |
+| `matcher.rs` | Downcasting helpers (`is`, `as_`, `as_opt`, pattern matching traits)        |
 
 For Array encodings, each encoding has its own module (e.g. `arrays/primitive/`):
 
@@ -129,6 +131,48 @@ enabling type-safe APIs for plugin authors while the erased form handles heterog
 plugin authors implement) from the public API (what callers use). The public API can validate
 inputs, enforce invariants, and transform outputs without exposing those concerns to vtable
 implementors. With `dyn Trait`, the trait surface is the public API.
+
+## Method Overlap and `same_name_method`
+
+`Foo<V>` and `DynFoo` necessarily share method names: `Foo<V>` needs inherent methods
+so callers (including VTable authors who receive `&Foo<Self>`) can use them directly,
+and `DynFoo` needs the same methods for object-safe dispatch from `FooRef`.
+
+Because `Foo<V>` implements `DynFoo`, having both an inherent `id()` and a trait `id()`
+on the same type triggers `clippy::same_name_method`. The correct handling is:
+
+1. **Logic lives in `Foo<V>` inherent methods.** Pre/post-conditions, field access, and
+   delegation to `FooVTable` all happen here.
+2. **`DynFoo` blanket impl is a thin forwarder.** Each method body is just `self.method()`.
+   Rust's method resolution picks inherent methods over trait methods, so this calls the
+   inherent impl — no infinite recursion.
+3. **`#[allow(clippy::same_name_method)]`** on the `Foo<V>` inherent impl block
+   acknowledges the intentional shadowing.
+
+```rust
+#[allow(clippy::same_name_method)]
+impl<V: FooVTable> Foo<V> {
+    pub fn id(&self) -> FooId {
+        self.vtable.id()            // logic lives here
+    }
+}
+
+impl<V: FooVTable> DynFoo for Foo<V> {
+    fn id(&self) -> FooId {
+        self.id()                   // thin forwarder to inherent
+    }
+}
+```
+
+`DynFoo` must stay **private** (`pub(super)`) because it exposes internal plumbing
+(`as_any`, `metadata_any`) that external callers should never reach. Making it public
+or implementing it for `FooRef` would leak these internals. Instead, `FooRef` has its
+own inherent methods that delegate to `DynFoo` — providing a clean public API without
+exposing the dispatch machinery.
+
+Methods that exist only for erased dispatch (e.g. `as_any`, `metadata_any`,
+`metadata_hash`) have no inherent counterpart on `Foo<V>` and live exclusively in
+`DynFoo`.
 
 ## Registration and Deserialization
 

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -10222,17 +10222,29 @@ pub fn vortex_array::dtype::extension::ExtDType<V>::try_new(metadata: <V as vort
 
 impl<V: vortex_array::dtype::extension::ExtVTable> vortex_array::dtype::extension::ExtDType<V>
 
+pub fn vortex_array::dtype::extension::ExtDType<V>::can_coerce_from(&self, other: &vortex_array::dtype::DType) -> bool
+
+pub fn vortex_array::dtype::extension::ExtDType<V>::can_coerce_to(&self, other: &vortex_array::dtype::DType) -> bool
+
 pub fn vortex_array::dtype::extension::ExtDType<V>::erased(self) -> vortex_array::dtype::extension::ExtDTypeRef
 
 pub fn vortex_array::dtype::extension::ExtDType<V>::id(&self) -> vortex_array::dtype::extension::ExtId
 
+pub fn vortex_array::dtype::extension::ExtDType<V>::least_supertype(&self, other: &vortex_array::dtype::DType) -> core::option::Option<vortex_array::dtype::DType>
+
 pub fn vortex_array::dtype::extension::ExtDType<V>::metadata(&self) -> &<V as vortex_array::dtype::extension::ExtVTable>::Metadata
+
+pub fn vortex_array::dtype::extension::ExtDType<V>::serialize_metadata(&self) -> vortex_error::VortexResult<alloc::vec::Vec<u8>>
 
 pub fn vortex_array::dtype::extension::ExtDType<V>::storage_dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::dtype::extension::ExtDType<V>::try_with_vtable(vtable: V, metadata: <V as vortex_array::dtype::extension::ExtVTable>::Metadata, storage_dtype: vortex_array::dtype::DType) -> vortex_error::VortexResult<Self>
 
+pub fn vortex_array::dtype::extension::ExtDType<V>::validate_scalar_value(&self, storage_value: &vortex_array::scalar::ScalarValue) -> vortex_error::VortexResult<()>
+
 pub fn vortex_array::dtype::extension::ExtDType<V>::vtable(&self) -> &V
+
+pub fn vortex_array::dtype::extension::ExtDType<V>::with_nullability(&self, nullability: vortex_array::dtype::Nullability) -> vortex_array::dtype::extension::ExtDTypeRef
 
 impl<V: core::clone::Clone + vortex_array::dtype::extension::ExtVTable> core::clone::Clone for vortex_array::dtype::extension::ExtDType<V> where <V as vortex_array::dtype::extension::ExtVTable>::Metadata: core::clone::Clone
 

--- a/vortex-array/src/dtype/extension/erased.rs
+++ b/vortex-array/src/dtype/extension/erased.rs
@@ -39,12 +39,12 @@ pub struct ExtDTypeRef(pub(super) Arc<dyn DynExtDType>);
 impl ExtDTypeRef {
     /// Returns the [`ExtId`] identifying this extension type.
     pub fn id(&self) -> ExtId {
-        self.0.ext_id()
+        self.0.id()
     }
 
     /// Returns the storage dtype of the extension type.
     pub fn storage_dtype(&self) -> &DType {
-        self.0.ext_storage_dtype()
+        self.0.storage_dtype()
     }
 
     /// Returns the nullability of the storage dtype.
@@ -78,7 +78,7 @@ impl ExtDTypeRef {
     // TODO(connor): We should add a different type that returns something that can be serialized.
     /// Serialize the metadata into a byte vector.
     pub fn serialize_metadata(&self) -> VortexResult<Vec<u8>> {
-        self.0.metadata_serialize()
+        self.0.serialize_metadata()
     }
 
     /// Returns a `Display`-able view of just the metadata.
@@ -97,22 +97,22 @@ impl ExtDTypeRef {
 
     /// Validates that the given storage scalar value is valid for this dtype.
     pub(crate) fn validate_storage_value(&self, storage_value: &ScalarValue) -> VortexResult<()> {
-        self.0.value_validate(storage_value)
+        self.0.validate_scalar_value(storage_value)
     }
 
     /// Can a value of `other` be implicitly coerced into this extension type?
     pub fn can_coerce_from(&self, other: &DType) -> bool {
-        self.0.coercion_can_coerce_from(other)
+        self.0.can_coerce_from(other)
     }
 
     /// Can this extension type be implicitly coerced into `other`?
     pub fn can_coerce_to(&self, other: &DType) -> bool {
-        self.0.coercion_can_coerce_to(other)
+        self.0.can_coerce_to(other)
     }
 
     /// Compute the least supertype of this extension type and another type.
     pub fn least_supertype(&self, other: &DType) -> Option<DType> {
-        self.0.coercion_least_supertype(other)
+        self.0.least_supertype(other)
     }
 }
 
@@ -160,7 +160,7 @@ impl ExtDTypeRef {
             .map_err(|this| {
                 vortex_err!(
                     "Failed to downcast ExtDTypeRef {} to {}",
-                    this.0.ext_id(),
+                    this.0.id(),
                     type_name::<V>(),
                 )
             })

--- a/vortex-array/src/dtype/extension/typed.rs
+++ b/vortex-array/src/dtype/extension/typed.rs
@@ -4,7 +4,6 @@
 //! Typed and inner representations of extension dtypes.
 //!
 //! - [`ExtDType<V>`]: The public typed wrapper, parameterized by a concrete [`ExtVTable`].
-//! - [`ExtDTypeInner<V>`]: The private inner struct that holds the vtable + data.
 //! - [`DynExtDType`]: The private sealed trait for type-erased dispatch.
 
 use std::any::Any;
@@ -49,6 +48,7 @@ impl<V: ExtVTable + Default> ExtDType<V> {
     }
 }
 
+#[allow(clippy::same_name_method)]
 impl<V: ExtVTable> ExtDType<V> {
     /// Creates a new extension dtype with the given metadata and storage dtype.
     pub fn try_with_vtable(
@@ -87,61 +87,87 @@ impl<V: ExtVTable> ExtDType<V> {
         &self.storage_dtype
     }
 
+    /// Returns a new [`ExtDTypeRef`] with the given nullability.
+    pub fn with_nullability(&self, nullability: Nullability) -> ExtDTypeRef {
+        let storage_dtype = self.storage_dtype.with_nullability(nullability);
+        ExtDType::<V>::try_with_vtable(self.vtable.clone(), self.metadata.clone(), storage_dtype)
+            .vortex_expect(
+                "Extension DType should not fail validation with the same storage type \
+                 but different nullability",
+            )
+            .erased()
+    }
+
+    /// Serializes the metadata into a byte vector.
+    pub fn serialize_metadata(&self) -> VortexResult<Vec<u8>> {
+        V::serialize_metadata(&self.vtable, &self.metadata)
+    }
+
+    /// Validates that the given storage scalar value is valid for this dtype.
+    pub fn validate_scalar_value(&self, storage_value: &ScalarValue) -> VortexResult<()> {
+        V::validate_scalar_value(self, storage_value)
+    }
+
+    /// Can a value of `other` be implicitly coerced into this extension type?
+    pub fn can_coerce_from(&self, other: &DType) -> bool {
+        V::can_coerce_from(self, other)
+    }
+
+    /// Can this extension type be implicitly coerced into `other`?
+    pub fn can_coerce_to(&self, other: &DType) -> bool {
+        V::can_coerce_to(self, other)
+    }
+
+    /// Compute the least supertype of this extension type and another type.
+    pub fn least_supertype(&self, other: &DType) -> Option<DType> {
+        V::least_supertype(self, other)
+    }
+
     /// Erase the concrete type information, returning a type-erased extension dtype.
     pub fn erased(self) -> ExtDTypeRef {
         ExtDTypeRef(Arc::new(self))
     }
 }
 
-/// An object-safe, sealed trait encapsulating the behavior for extension dtypes.
+/// An object-safe, sealed trait for type-erased extension dtype dispatch.
 ///
-/// This provides type-erased access to the extension dtype's identity, storage dtype, and
-/// metadata. The only implementor is [`ExtDTypeInner`].
+/// Methods that have a corresponding inherent method on [`ExtDType<V>`] are thin forwarders
+/// (e.g. `id`, `storage_dtype`). Methods that exist only for erased dispatch have no
+/// inherent counterpart (e.g. `as_any`, `metadata_any`, `metadata_eq`).
 pub(super) trait DynExtDType: 'static + Send + Sync + super::sealed::Sealed {
-    /// Returns `self` as a trait object for downcasting.
     fn as_any(&self) -> &dyn Any;
-    /// Returns the [`ExtId`] identifying this extension type.
-    fn ext_id(&self) -> ExtId;
-    /// Returns a reference to the storage [`DType`].
-    fn ext_storage_dtype(&self) -> &DType;
-    /// Returns the metadata as a trait object for downcasting.
+    fn id(&self) -> ExtId;
+    fn storage_dtype(&self) -> &DType;
     fn metadata_any(&self) -> &dyn Any;
-    /// Formats the metadata using [`Debug`].
     fn metadata_debug(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
-    /// Formats the metadata using [`Display`].
     fn metadata_display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
-    /// Checks equality of the metadata against a type-erased value.
     fn metadata_eq(&self, other: &dyn Any) -> bool;
-    /// Hashes the metadata into the given [`Hasher`].
     fn metadata_hash(&self, state: &mut dyn Hasher);
-    /// Serializes the metadata into a byte vector.
-    fn metadata_serialize(&self) -> VortexResult<Vec<u8>>;
-    /// Returns a new [`ExtDTypeRef`] with the given nullability.
+    fn serialize_metadata(&self) -> VortexResult<Vec<u8>>;
     fn with_nullability(&self, nullability: Nullability) -> ExtDTypeRef;
-    /// Validates that the given storage scalar value is valid for this dtype.
-    fn value_validate(&self, storage_value: &ScalarValue) -> VortexResult<()>;
-    /// Formats an extension scalar value using the current dtype for metadata context.
+    fn validate_scalar_value(&self, storage_value: &ScalarValue) -> VortexResult<()>;
     fn value_display(&self, f: &mut fmt::Formatter<'_>, storage_value: &ScalarValue)
     -> fmt::Result;
-    /// Can a value of `other` be implicitly coerced into this extension type?
-    fn coercion_can_coerce_from(&self, other: &DType) -> bool;
-    /// Can this extension type be implicitly coerced into `other`?
-    fn coercion_can_coerce_to(&self, other: &DType) -> bool;
-    /// Compute the least supertype of this extension type and another type.
-    fn coercion_least_supertype(&self, other: &DType) -> Option<DType>;
+    fn can_coerce_from(&self, other: &DType) -> bool;
+    fn can_coerce_to(&self, other: &DType) -> bool;
+    fn least_supertype(&self, other: &DType) -> Option<DType>;
 }
 
+/// Blanket impl: thin forwarder to `ExtDType<V>` inherent methods.
+///
+/// Rust's method resolution picks inherent methods over trait methods, so `self.id()` etc.
+/// call the inherent impl, not this trait impl (no infinite recursion).
 impl<V: ExtVTable> DynExtDType for ExtDType<V> {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
-    fn ext_id(&self) -> ExtId {
-        self.vtable.id()
+    fn id(&self) -> ExtId {
+        self.id()
     }
 
-    fn ext_storage_dtype(&self) -> &DType {
-        &self.storage_dtype
+    fn storage_dtype(&self) -> &DType {
+        self.storage_dtype()
     }
 
     fn metadata_any(&self) -> &dyn Any {
@@ -167,22 +193,16 @@ impl<V: ExtVTable> DynExtDType for ExtDType<V> {
         <V::Metadata as Hash>::hash(&self.metadata, &mut state);
     }
 
-    fn metadata_serialize(&self) -> VortexResult<Vec<u8>> {
-        V::serialize_metadata(&self.vtable, &self.metadata)
+    fn serialize_metadata(&self) -> VortexResult<Vec<u8>> {
+        self.serialize_metadata()
     }
 
     fn with_nullability(&self, nullability: Nullability) -> ExtDTypeRef {
-        let storage_dtype = self.storage_dtype.with_nullability(nullability);
-        ExtDType::<V>::try_with_vtable(self.vtable.clone(), self.metadata.clone(), storage_dtype)
-            .vortex_expect(
-                "Extension DType should not fail validation with the same storage type \
-                 but different nullability",
-            )
-            .erased()
+        self.with_nullability(nullability)
     }
 
-    fn value_validate(&self, storage_value: &ScalarValue) -> VortexResult<()> {
-        V::validate_scalar_value(self, storage_value)
+    fn validate_scalar_value(&self, storage_value: &ScalarValue) -> VortexResult<()> {
+        self.validate_scalar_value(storage_value)
     }
 
     fn value_display(
@@ -201,15 +221,15 @@ impl<V: ExtVTable> DynExtDType for ExtDType<V> {
         }
     }
 
-    fn coercion_can_coerce_from(&self, other: &DType) -> bool {
-        V::can_coerce_from(self, other)
+    fn can_coerce_from(&self, other: &DType) -> bool {
+        self.can_coerce_from(other)
     }
 
-    fn coercion_can_coerce_to(&self, other: &DType) -> bool {
-        V::can_coerce_to(self, other)
+    fn can_coerce_to(&self, other: &DType) -> bool {
+        self.can_coerce_to(other)
     }
 
-    fn coercion_least_supertype(&self, other: &DType) -> Option<DType> {
-        V::least_supertype(self, other)
+    fn least_supertype(&self, other: &DType) -> Option<DType> {
+        self.least_supertype(other)
     }
 }


### PR DESCRIPTION
DynFoo is a thin wrapper calling into functions on Foo<V>.