### PR TITLE
fix fuzz_report script

### DIFF
--- a/.github/scripts/fuzz_report/cli.py
+++ b/.github/scripts/fuzz_report/cli.py
@@ -363,8 +363,9 @@ def cmd_report(args: argparse.Namespace) -> int:
         print(f"Commented on #{existing_issue}", file=sys.stderr)
         _write_github_output("issue_number", str(existing_issue))
     else:
-        fuzz_target = variables.get("FUZZ_TARGET", "unknown")
-        title = f"Fuzzing Crash: {crash_info.error_variant} in {fuzz_target}"
+        # Use FUZZ_NAME for the title (descriptive name), fall back to FUZZ_TARGET
+        fuzz_name = variables.get("FUZZ_NAME") or variables.get("FUZZ_TARGET", "unknown")
+        title = f"Fuzzing Crash: {crash_info.error_variant} in {fuzz_name}"
 
         body = render_template(str(TEMPLATES_DIR / "new_issue.md"), variables, use_env=False)
         body_file = Path("issue_body.md")

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,7 +38,6 @@ jobs:
     uses: ./.github/workflows/report-fuzz-crash.yml
     with:
       fuzz_target: file_io
-      fuzz_name: file_io
       crash_file: ${{ needs.io_fuzz.outputs.first_crash_name }}
       artifact_url: ${{ needs.io_fuzz.outputs.artifact_url }}
       artifact_name: file_io-crash-artifacts
@@ -89,7 +88,6 @@ jobs:
     uses: ./.github/workflows/report-fuzz-crash.yml
     with:
       fuzz_target: array_ops
-      fuzz_name: array_ops
       crash_file: ${{ needs.ops_fuzz.outputs.first_crash_name }}
       artifact_url: ${{ needs.ops_fuzz.outputs.artifact_url }}
       artifact_name: array_ops-crash-artifacts
@@ -165,7 +163,6 @@ jobs:
     uses: ./.github/workflows/report-fuzz-crash.yml
     with:
       fuzz_target: fsst_like
-      fuzz_name: fsst_like
       crash_file: ${{ needs.fsst_like_fuzz.outputs.first_crash_name }}
       artifact_url: ${{ needs.fsst_like_fuzz.outputs.artifact_url }}
       artifact_name: fsst_like-crash-artifacts

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,6 +38,7 @@ jobs:
     uses: ./.github/workflows/report-fuzz-crash.yml
     with:
       fuzz_target: file_io
+      fuzz_name: file_io
       crash_file: ${{ needs.io_fuzz.outputs.first_crash_name }}
       artifact_url: ${{ needs.io_fuzz.outputs.artifact_url }}
       artifact_name: file_io-crash-artifacts
@@ -88,6 +89,7 @@ jobs:
     uses: ./.github/workflows/report-fuzz-crash.yml
     with:
       fuzz_target: array_ops
+      fuzz_name: array_ops
       crash_file: ${{ needs.ops_fuzz.outputs.first_crash_name }}
       artifact_url: ${{ needs.ops_fuzz.outputs.artifact_url }}
       artifact_name: array_ops-crash-artifacts
@@ -125,7 +127,8 @@ jobs:
       pull-requests: read
     uses: ./.github/workflows/report-fuzz-crash.yml
     with:
-      fuzz_target: array_ops_unstable_encodings
+      fuzz_target: array_ops
+      fuzz_name: array_ops_unstable_encodings
       crash_file: ${{ needs.ops_fuzz_unstable.outputs.first_crash_name }}
       artifact_url: ${{ needs.ops_fuzz_unstable.outputs.artifact_url }}
       artifact_name: array_ops_unstable_encodings-crash-artifacts
@@ -162,6 +165,7 @@ jobs:
     uses: ./.github/workflows/report-fuzz-crash.yml
     with:
       fuzz_target: fsst_like
+      fuzz_name: fsst_like
       crash_file: ${{ needs.fsst_like_fuzz.outputs.first_crash_name }}
       artifact_url: ${{ needs.fsst_like_fuzz.outputs.artifact_url }}
       artifact_name: fsst_like-crash-artifacts

--- a/.github/workflows/report-fuzz-crash.yml
+++ b/.github/workflows/report-fuzz-crash.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       fuzz_name:
-        required: true
+        required: false
         type: string
       crash_file:
         required: true
@@ -151,7 +151,7 @@ jobs:
             --dedup-result dedup_result.json \
             --claude-analysis claude_analysis.txt \
             -v "FUZZ_TARGET=${{ inputs.fuzz_target }}" \
-            -v "FUZZ_NAME=${{ inputs.fuzz_name }}" \
+            -v "FUZZ_NAME=${{ inputs.fuzz_name || inputs.fuzz_target }}" \
             -v "CRASH_FILE=${{ inputs.crash_file }}" \
             -v "BRANCH=${{ inputs.branch }}" \
             -v "COMMIT=${{ inputs.commit }}" \

--- a/.github/workflows/report-fuzz-crash.yml
+++ b/.github/workflows/report-fuzz-crash.yml
@@ -6,6 +6,9 @@ on:
       fuzz_target:
         required: true
         type: string
+      fuzz_name:
+        required: true
+        type: string
       crash_file:
         required: true
         type: string
@@ -148,6 +151,7 @@ jobs:
             --dedup-result dedup_result.json \
             --claude-analysis claude_analysis.txt \
             -v "FUZZ_TARGET=${{ inputs.fuzz_target }}" \
+            -v "FUZZ_NAME=${{ inputs.fuzz_name }}" \
             -v "CRASH_FILE=${{ inputs.crash_file }}" \
             -v "BRANCH=${{ inputs.branch }}" \
             -v "COMMIT=${{ inputs.commit }}" \


### PR DESCRIPTION
Use the fuzz_target instead of the fuzz_name for the templated commands in the the fuzzer issues.

Before it would use the name as the target, e.g. array_ops_unstable_encodings which when you copy-paste would fail due to no such fuzzer target.

<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

<!--
If this PR is related to a tracked effort, please link to the relevant issue
here (e.g., `Closes: #123`). Otherwise, feel free to ignore / delete this.

In this section, please:

1. Explain the rationale for this change.
2. Summarize the changes included in this PR.

A general rule of thumb is that larger PRs should have larger summaries. If
there are a lot of changes, please help us review the code by explaining what
was changed and why.

If there is an issue or discussion attached, there is no need to duplicate all
the details, but clarity is always preferred over brevity.
-->

Closes: #000

<!--
## API Changes

Uncomment this section if there are any user-facing changes.

Consider whether the change affects users in one of the following ways:

1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the engine integrations.
3. Should some documentation be updated to reflect this change?

If a public API is changed in a breaking manner, make sure to add the
appropriate label. You can run `./scripts/public-api.sh` locally to see if there
are any public API changes (and this also runs in our CI).
-->

## Testing

<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
3. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
