### PR TITLE
ffi: expose array validity, allow creating primitive arrays

### DIFF
--- a/vortex-ffi/cinclude/vortex.h
+++ b/vortex-ffi/cinclude/vortex.h
@@ -19,6 +19,52 @@
 #define BinaryView_MAX_INLINED_SIZE 12
 
 /**
+ * The variant tag for a Vortex data type.
+ */
+typedef enum {
+    /**
+     * Null type.
+     */
+    DTYPE_NULL = 0,
+    /**
+     * Boolean type.
+     */
+    DTYPE_BOOL = 1,
+    /**
+     * Primitive types (e.g., u8, i16, f32, etc.).
+     */
+    DTYPE_PRIMITIVE = 2,
+    /**
+     * Variable-length UTF-8 string type.
+     */
+    DTYPE_UTF8 = 3,
+    /**
+     * Variable-length binary data type.
+     */
+    DTYPE_BINARY = 4,
+    /**
+     * Nested struct type.
+     */
+    DTYPE_STRUCT = 5,
+    /**
+     * Nested list type.
+     */
+    DTYPE_LIST = 6,
+    /**
+     * User-defined extension type.
+     */
+    DTYPE_EXTENSION = 7,
+    /**
+     * Decimal type with fixed precision and scale.
+     */
+    DTYPE_DECIMAL = 8,
+    /**
+     * Nested fixed-size list type.
+     */
+    DTYPE_FIXED_SIZE_LIST = 9,
+} vx_dtype_variant;
+
+/**
  * Variant enum for Vortex primitive types.
  */
 typedef enum {
@@ -68,51 +114,25 @@ typedef enum {
     PTYPE_F64 = 10,
 } vx_ptype;
 
-/**
- * The variant tag for a Vortex data type.
- */
 typedef enum {
     /**
-     * Null type.
+     * Items can't be null
      */
-    DTYPE_NULL = 0,
+    VX_VALIDITY_NON_NULLABLE = 0,
     /**
-     * Boolean type.
+     * All items are valid
      */
-    DTYPE_BOOL = 1,
+    VX_VALIDITY_ALL_VALID = 1,
     /**
-     * Primitive types (e.g., u8, i16, f32, etc.).
+     * All items are invalid
      */
-    DTYPE_PRIMITIVE = 2,
+    VX_VALIDITY_ALL_INVALID = 2,
     /**
-     * Variable-length UTF-8 string type.
+     * Items validity is determined by a boolean array. True values in boolean
+     * array are valid, false values are invalid (null)
      */
-    DTYPE_UTF8 = 3,
-    /**
-     * Variable-length binary data type.
-     */
-    DTYPE_BINARY = 4,
-    /**
-     * Nested struct type.
-     */
-    DTYPE_STRUCT = 5,
-    /**
-     * Nested list type.
-     */
-    DTYPE_LIST = 6,
-    /**
-     * User-defined extension type.
-     */
-    DTYPE_EXTENSION = 7,
-    /**
-     * Decimal type with fixed precision and scale.
-     */
-    DTYPE_DECIMAL = 8,
-    /**
-     * Nested fixed-size list type.
-     */
-    DTYPE_FIXED_SIZE_LIST = 9,
-} vx_dtype_variant;
+    VX_VALIDITY_ARRAY = 3,
+} vx_validity_type;
 
 /**
  * Equalities, inequalities, and boolean operations over possibly null values.
@@ -296,15 +316,20 @@ typedef struct Nullability Nullability;
 typedef struct Primitive Primitive;
 
 /**
- * Base type for all Vortex arrays.
+ * Arrays are reference-counted handles to owned memory buffers that hold
+ * scalars. These buffers can be held in a number of physical encodings to
+ * perform lightweight compression that exploits the particular data
+ * distribution of the array's values.
  *
- * All built-in Vortex array types can be safely cast to this type to pass into functions that
- * expect a generic array type. e.g.
+ * Every data type recognized by Vortex also has a canonical physical
+ * encoding format, which arrays can be canonicalized into for ease of
+ * access in compute functions.
  *
- * ```cpp
- * auto primitive_array = vx_array_primitive_new(...);
- * vx_array_len((*vx_array) primitive_array));
- * ```
+ * As an implementation detail, vx_array Arc'ed inside, so cloning an
+ * array is a cheap operation.
+ *
+ * Unless stated explicitly, all operations with vx_array don't take
+ * ownership of it, and thus it must be freed by the caller.
  */
 typedef struct vx_array vx_array;
 
@@ -398,6 +423,16 @@ typedef struct vx_struct_fields vx_struct_fields;
  */
 typedef struct vx_struct_fields_builder vx_struct_fields_builder;
 
+typedef struct {
+    vx_validity_type type;
+    /**
+     * If type is not VX_VALIDITY_ARRAY, this is NULL.
+     * If type is VX_VALIDITY_ARRAY, this is set to an owned boolean validity
+     * array which must be freed by the caller.
+     */
+    const vx_array *array;
+} vx_validity;
+
 /**
  * Options supplied for opening a file.
  */
@@ -478,6 +513,40 @@ const vx_array *vx_array_clone(const vx_array *ptr);
 void vx_array_free(const vx_array *ptr);
 
 /**
+ * Check if array's dtype is nullable.
+ * As a particular example, a Null array is nullable.
+ */
+bool vx_array_is_nullable(const vx_array *array);
+
+/**
+ * Check array's dtype against a variant.
+ * Equivalent to vx_get_dtype_variant(vx_array_dtype(array)).
+ *
+ * Example:
+ *
+ * const vx_array* array = vx_array_new_null(1);
+ * assert(vx_array_has_dtype(array, DTYPE_NULL));
+ * vx_array_free(array);
+ *
+ */
+bool vx_array_has_dtype(const vx_array *array, vx_dtype_variant variant);
+
+/**
+ * Check whether array has a Primitive dtype with a specific ptype.
+ *
+ * const vx_array* array = vx_array_new_null(1);
+ * assert(!vx_array_is_primitive(array, PTYPE_U32));
+ * vx_array_free(array);
+ *
+ */
+bool vx_array_is_primitive(const vx_array *array, vx_ptype ptype);
+
+/**
+ * Return array's validity as a type and a boolean array.
+ */
+void vx_array_get_validity(const vx_array *array, vx_validity *validity, vx_error **error);
+
+/**
  * Get the length of the array.
  */
 size_t vx_array_len(const vx_array *array);
@@ -490,57 +559,93 @@ size_t vx_array_len(const vx_array *array);
  */
 const vx_dtype *vx_array_dtype(const vx_array *array);
 
-const vx_array *vx_array_get_field(const vx_array *array, uint32_t index, vx_error **error_out);
+const vx_array *vx_array_get_field(const vx_array *array, size_t index, vx_error **error_out);
 
-const vx_array *vx_array_slice(const vx_array *array, uint32_t start, uint32_t stop, vx_error **error_out);
+const vx_array *vx_array_slice(const vx_array *array, size_t start, size_t stop, vx_error **error_out);
 
-bool vx_array_is_null(const vx_array *array, uint32_t index, vx_error **_error_out);
+/**
+ * Check whether array's element at index is invalid (null) according to the
+ * validity array. Sets error if index is out of bounds or underlying validity
+ * array is corrupted.
+ */
+bool vx_array_element_is_invalid(const vx_array *array, size_t index, vx_error **error);
 
-uint32_t vx_array_null_count(const vx_array *array, vx_error **error_out);
+/**
+ * Check how many items in the array are invalid (null).
+ */
+size_t vx_array_invalid_count(const vx_array *array, vx_error **error_out);
 
-uint8_t vx_array_get_u8(const vx_array *array, uint32_t index);
+/**
+ * Create a new array with DTYPE_NULL dtype.
+ */
+const vx_array *vx_array_new_null(size_t len);
 
-uint8_t vx_array_get_storage_u8(const vx_array *array, uint32_t index);
+/**
+ * Create a new primitive array from an existing buffer.
+ * It is caller's responsibility to ensure ptr points to a buffer of correct
+ * type. ptr buffer contents are copied.
+ * validity can't be NULL.
+ *
+ * Example:
+ *
+ * const vx_error* error = nullptr;
+ * vx_validity validity = {};
+ * validity.type = VX_VALIDITY_NON_NULLABLE;
+ * uint32_t buffer[] = {1, 2, 3};
+ * const vx_array* array = vx_array_new_primitive(PTYPE_U32, buffer, 3,
+ *     &validity, &error);
+ * vx_array_free(array);
+ *
+ */
+const vx_array *vx_array_new_primitive(vx_ptype ptype,
+                                       const void *ptr,
+                                       size_t len,
+                                       const vx_validity *validity,
+                                       vx_error **error);
 
-uint16_t vx_array_get_u16(const vx_array *array, uint32_t index);
+uint8_t vx_array_get_u8(const vx_array *array, size_t index);
 
-uint16_t vx_array_get_storage_u16(const vx_array *array, uint32_t index);
+uint8_t vx_array_get_storage_u8(const vx_array *array, size_t index);
 
-uint32_t vx_array_get_u32(const vx_array *array, uint32_t index);
+uint16_t vx_array_get_u16(const vx_array *array, size_t index);
 
-uint32_t vx_array_get_storage_u32(const vx_array *array, uint32_t index);
+uint16_t vx_array_get_storage_u16(const vx_array *array, size_t index);
 
-uint64_t vx_array_get_u64(const vx_array *array, uint32_t index);
+uint32_t vx_array_get_u32(const vx_array *array, size_t index);
 
-uint64_t vx_array_get_storage_u64(const vx_array *array, uint32_t index);
+uint32_t vx_array_get_storage_u32(const vx_array *array, size_t index);
 
-int8_t vx_array_get_i8(const vx_array *array, uint32_t index);
+uint64_t vx_array_get_u64(const vx_array *array, size_t index);
 
-int8_t vx_array_get_storage_i8(const vx_array *array, uint32_t index);
+uint64_t vx_array_get_storage_u64(const vx_array *array, size_t index);
 
-int16_t vx_array_get_i16(const vx_array *array, uint32_t index);
+int8_t vx_array_get_i8(const vx_array *array, size_t index);
 
-int16_t vx_array_get_storage_i16(const vx_array *array, uint32_t index);
+int8_t vx_array_get_storage_i8(const vx_array *array, size_t index);
 
-int32_t vx_array_get_i32(const vx_array *array, uint32_t index);
+int16_t vx_array_get_i16(const vx_array *array, size_t index);
 
-int32_t vx_array_get_storage_i32(const vx_array *array, uint32_t index);
+int16_t vx_array_get_storage_i16(const vx_array *array, size_t index);
 
-int64_t vx_array_get_i64(const vx_array *array, uint32_t index);
+int32_t vx_array_get_i32(const vx_array *array, size_t index);
 
-int64_t vx_array_get_storage_i64(const vx_array *array, uint32_t index);
+int32_t vx_array_get_storage_i32(const vx_array *array, size_t index);
 
-uint16_t vx_array_get_f16(const vx_array *array, uint32_t index);
+int64_t vx_array_get_i64(const vx_array *array, size_t index);
 
-uint16_t vx_array_get_storage_f16(const vx_array *array, uint32_t index);
+int64_t vx_array_get_storage_i64(const vx_array *array, size_t index);
 
-float vx_array_get_f32(const vx_array *array, uint32_t index);
+uint16_t vx_array_get_f16(const vx_array *array, size_t index);
 
-float vx_array_get_storage_f32(const vx_array *array, uint32_t index);
+uint16_t vx_array_get_storage_f16(const vx_array *array, size_t index);
 
-double vx_array_get_f64(const vx_array *array, uint32_t index);
+float vx_array_get_f32(const vx_array *array, size_t index);
 
-double vx_array_get_storage_f64(const vx_array *array, uint32_t index);
+float vx_array_get_storage_f32(const vx_array *array, size_t index);
+
+double vx_array_get_f64(const vx_array *array, size_t index);
+
+double vx_array_get_storage_f64(const vx_array *array, size_t index);
 
 /**
  * Return the utf-8 string at `index` in the array. The pointer will be null if the value at `index` is null.
@@ -956,7 +1061,8 @@ vx_array_sink *vx_array_sink_open_file(const vx_session *session,
                                        vx_error **error_out);
 
 /**
- * Pushed a single array chunk into a file sink.
+ * Push an array into a file sink.
+ * Does not take ownership of array
  */
 void vx_array_sink_push(vx_array_sink *sink, const vx_array *array, vx_error **error_out);
 

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -1,12 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
+#![allow(non_camel_case_types)]
 
 //! FFI interface for working with Vortex Arrays.
+use std::ffi::c_void;
 use std::ptr;
 use std::sync::Arc;
 
+use paste::paste;
 use vortex::array::DynArray;
+use vortex::array::IntoArray;
 use vortex::array::ToCanonical;
+use vortex::array::arrays::NullArray;
+use vortex::array::arrays::PrimitiveArray;
+use vortex::array::validity::Validity;
+use vortex::buffer::Buffer;
+use vortex::dtype::DType;
 use vortex::dtype::half::f16;
 use vortex::error::VortexExpect;
 use vortex::error::vortex_ensure;
@@ -15,24 +24,158 @@ use vortex::error::vortex_err;
 use crate::arc_dyn_wrapper;
 use crate::binary::vx_binary;
 use crate::dtype::vx_dtype;
+use crate::dtype::vx_dtype_variant;
 use crate::error::try_or_default;
 use crate::error::vx_error;
+use crate::error::write_error;
 use crate::expression::vx_expression;
+use crate::ptype::vx_ptype;
 use crate::string::vx_string;
 
 arc_dyn_wrapper!(
-    /// Base type for all Vortex arrays.
+    /// Arrays are reference-counted handles to owned memory buffers that hold
+    /// scalars. These buffers can be held in a number of physical encodings to
+    /// perform lightweight compression that exploits the particular data
+    /// distribution of the array's values.
     ///
-    /// All built-in Vortex array types can be safely cast to this type to pass into functions that
-    /// expect a generic array type. e.g.
+    /// Every data type recognized by Vortex also has a canonical physical
+    /// encoding format, which arrays can be canonicalized into for ease of
+    /// access in compute functions.
     ///
-    /// ```cpp
-    /// auto primitive_array = vx_array_primitive_new(...);
-    /// vx_array_len((*vx_array) primitive_array));
-    /// ```
+    /// As an implementation detail, vx_array Arc'ed inside, so cloning an
+    /// array is a cheap operation.
+    ///
+    /// Unless stated explicitly, all operations with vx_array don't take
+    /// ownership of it, and thus it must be freed by the caller.
     dyn DynArray,
     vx_array
 );
+
+/// Check if array's dtype is nullable.
+/// As a particular example, a Null array is nullable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vx_array_is_nullable(array: *const vx_array) -> bool {
+    if array.is_null() {
+        return false;
+    }
+    vx_array::as_ref(array).dtype().is_nullable()
+}
+
+/// Check array's dtype against a variant.
+/// Equivalent to vx_get_dtype_variant(vx_array_dtype(array)).
+///
+/// Example:
+///
+/// const vx_array* array = vx_array_new_null(1);
+/// assert(vx_array_has_dtype(array, DTYPE_NULL));
+/// vx_array_free(array);
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_array_has_dtype(
+    array: *const vx_array,
+    variant: vx_dtype_variant,
+) -> bool {
+    if array.is_null() {
+        return false;
+    }
+    let other: vx_dtype_variant = vx_array::as_ref(array).dtype().into();
+    other == variant
+}
+
+/// Check whether array has a Primitive dtype with a specific ptype.
+///
+/// const vx_array* array = vx_array_new_null(1);
+/// assert(!vx_array_is_primitive(array, PTYPE_U32));
+/// vx_array_free(array);
+///
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_array_is_primitive(
+    array: *const vx_array,
+    ptype: vx_ptype,
+) -> bool {
+    if array.is_null() {
+        return false;
+    }
+    let ptype = ptype.into();
+    match vx_array::as_ref(array).dtype() {
+        DType::Primitive(other, _) => other == &ptype,
+        _ => false,
+    }
+}
+
+#[repr(C)]
+pub enum vx_validity_type {
+    /// Items can't be null
+    VX_VALIDITY_NON_NULLABLE = 0,
+    /// All items are valid
+    VX_VALIDITY_ALL_VALID = 1,
+    /// All items are invalid
+    VX_VALIDITY_ALL_INVALID = 2,
+    /// Items validity is determined by a boolean array. True values in boolean
+    /// array are valid, false values are invalid (null)
+    VX_VALIDITY_ARRAY = 3,
+}
+
+#[repr(C)]
+pub struct vx_validity {
+    r#type: vx_validity_type,
+    /// If type is not VX_VALIDITY_ARRAY, this is NULL.
+    /// If type is VX_VALIDITY_ARRAY, this is set to an owned boolean validity
+    /// array which must be freed by the caller.
+    array: *const vx_array,
+}
+
+impl From<&vx_validity> for Validity {
+    fn from(validity: &vx_validity) -> Self {
+        match validity.r#type {
+            vx_validity_type::VX_VALIDITY_NON_NULLABLE => Validity::NonNullable,
+            vx_validity_type::VX_VALIDITY_ALL_VALID => Validity::AllValid,
+            vx_validity_type::VX_VALIDITY_ALL_INVALID => Validity::AllInvalid,
+            vx_validity_type::VX_VALIDITY_ARRAY => {
+                Validity::Array(vx_array::as_ref(validity.array).clone())
+            }
+        }
+    }
+}
+
+impl From<Validity> for vx_validity {
+    fn from(validity: Validity) -> Self {
+        match validity {
+            Validity::NonNullable => vx_validity {
+                r#type: vx_validity_type::VX_VALIDITY_NON_NULLABLE,
+                array: ptr::null(),
+            },
+            Validity::AllValid => vx_validity {
+                r#type: vx_validity_type::VX_VALIDITY_ALL_VALID,
+                array: ptr::null(),
+            },
+            Validity::AllInvalid => vx_validity {
+                r#type: vx_validity_type::VX_VALIDITY_ALL_INVALID,
+                array: ptr::null(),
+            },
+            Validity::Array(array) => vx_validity {
+                r#type: vx_validity_type::VX_VALIDITY_ARRAY,
+                array: vx_array::new(array),
+            },
+        }
+    }
+}
+
+/// Return array's validity as a type and a boolean array.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_array_get_validity(
+    array: *const vx_array,
+    validity: *mut vx_validity,
+    error: *mut *mut vx_error,
+) {
+    try_or_default(error, || {
+        vortex_ensure!(!array.is_null());
+        vortex_ensure!(!validity.is_null());
+        let array = vx_array::as_ref(array);
+        *unsafe { &mut *validity } = array.validity()?.into();
+        Ok(())
+    });
+}
 
 /// Get the length of the array.
 #[unsafe(no_mangle)]
@@ -52,18 +195,18 @@ pub unsafe extern "C-unwind" fn vx_array_dtype(array: *const vx_array) -> *const
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_array_get_field(
     array: *const vx_array,
-    index: u32,
+    index: usize,
     error_out: *mut *mut vx_error,
 ) -> *const vx_array {
     try_or_default(error_out, || {
         let array = vx_array::as_ref(array);
 
-        let struct_array = array.to_struct();
-        let idx = index as usize;
-        if idx >= struct_array.struct_fields().nfields() {
-            return Err(vortex_err!("Field index out of bounds"));
-        }
-        let field_array = struct_array.unmasked_field(idx).clone();
+        let field_array = array
+            .to_struct()
+            .unmasked_fields()
+            .get(index)
+            .ok_or_else(|| vortex_err!("Field index out of bounds"))?
+            .clone();
 
         Ok(vx_array::new(field_array))
     })
@@ -72,48 +215,117 @@ pub unsafe extern "C-unwind" fn vx_array_get_field(
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_array_slice(
     array: *const vx_array,
-    start: u32,
-    stop: u32,
+    start: usize,
+    stop: usize,
     error_out: *mut *mut vx_error,
 ) -> *const vx_array {
     try_or_default(error_out, || {
         let array = vx_array::as_ref(array);
-        let sliced = array.slice(start as usize..stop as usize)?;
+        let sliced = array.slice(start..stop)?;
         Ok(vx_array::new(sliced))
     })
 }
 
+/// Check whether array's element at index is invalid (null) according to the
+/// validity array. Sets error if index is out of bounds or underlying validity
+/// array is corrupted.
 #[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_array_is_null(
+pub unsafe extern "C-unwind" fn vx_array_element_is_invalid(
     array: *const vx_array,
-    index: u32,
-    _error_out: *mut *mut vx_error,
+    index: usize,
+    error: *mut *mut vx_error,
 ) -> bool {
-    let array = vx_array::as_ref(array);
-    // TODO(joe): propagate this error up instead of expecting
-    array
-        .is_invalid(index as usize)
-        .vortex_expect("is_invalid failed")
+    try_or_default(error, || {
+        vortex_ensure!(!array.is_null());
+        vx_array::as_ref(array).is_invalid(index)
+    })
 }
 
-// TODO(robert): Make this return usize and remove error
+/// Check how many items in the array are invalid (null).
 #[unsafe(no_mangle)]
-pub unsafe extern "C-unwind" fn vx_array_null_count(
+pub unsafe extern "C-unwind" fn vx_array_invalid_count(
     array: *const vx_array,
     error_out: *mut *mut vx_error,
-) -> u32 {
-    let array = vx_array::as_ref(array);
-    try_or_default(error_out, || Ok(array.invalid_count()?.try_into()?))
+) -> usize {
+    try_or_default(error_out, || {
+        vortex_ensure!(!array.is_null());
+        let array = vx_array::as_ref(array);
+        array.invalid_count()
+    })
+}
+
+/// Create a new array with DTYPE_NULL dtype.
+#[unsafe(no_mangle)]
+pub unsafe extern "C-unwind" fn vx_array_new_null(len: usize) -> *const vx_array {
+    vx_array::new(NullArray::new(len).into_array())
+}
+
+/// SAFETY:
+/// `ptr` must be valid for `len` reads of `T`, properly aligned,
+/// and must not be null if `len > 0`.
+unsafe fn primitive_from_raw<T: vortex::dtype::NativePType>(
+    ptr: *const T,
+    len: usize,
+    validity: &vx_validity,
+) -> *const vx_array {
+    let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
+    let buffer = Buffer::copy_from(slice);
+    let array = PrimitiveArray::new(buffer, validity.into());
+    vx_array::new(array.into_array())
+}
+
+/// Create a new primitive array from an existing buffer.
+/// It is caller's responsibility to ensure ptr points to a buffer of correct
+/// type. ptr buffer contents are copied.
+/// validity can't be NULL.
+///
+/// Example:
+///
+/// const vx_error* error = nullptr;
+/// vx_validity validity = {};
+/// validity.type = VX_VALIDITY_NON_NULLABLE;
+/// uint32_t buffer[] = {1, 2, 3};
+/// const vx_array* array = vx_array_new_primitive(PTYPE_U32, buffer, 3,
+///     &validity, &error);
+/// vx_array_free(array);
+///
+#[unsafe(no_mangle)]
+pub extern "C-unwind" fn vx_array_new_primitive(
+    ptype: vx_ptype,
+    ptr: *const c_void,
+    len: usize,
+    validity: *const vx_validity,
+    error: *mut *mut vx_error,
+) -> *const vx_array {
+    if validity.is_null() {
+        write_error(error, "validity is NULL");
+        return ptr::null();
+    }
+    let validity = unsafe { &*validity };
+
+    match ptype {
+        vx_ptype::PTYPE_U8 => unsafe { primitive_from_raw(ptr as *const u8, len, validity) },
+        vx_ptype::PTYPE_U16 => unsafe { primitive_from_raw(ptr as *const u16, len, validity) },
+        vx_ptype::PTYPE_U32 => unsafe { primitive_from_raw(ptr as *const u32, len, validity) },
+        vx_ptype::PTYPE_U64 => unsafe { primitive_from_raw(ptr as *const u64, len, validity) },
+        vx_ptype::PTYPE_I8 => unsafe { primitive_from_raw(ptr as *const i8, len, validity) },
+        vx_ptype::PTYPE_I16 => unsafe { primitive_from_raw(ptr as *const i16, len, validity) },
+        vx_ptype::PTYPE_I32 => unsafe { primitive_from_raw(ptr as *const i32, len, validity) },
+        vx_ptype::PTYPE_I64 => unsafe { primitive_from_raw(ptr as *const i64, len, validity) },
+        vx_ptype::PTYPE_F16 => unsafe { primitive_from_raw(ptr as *const f16, len, validity) },
+        vx_ptype::PTYPE_F32 => unsafe { primitive_from_raw(ptr as *const f32, len, validity) },
+        vx_ptype::PTYPE_F64 => unsafe { primitive_from_raw(ptr as *const f64, len, validity) },
+    }
 }
 
 macro_rules! ffiarray_get_ptype {
     ($ptype:ident) => {
-        paste::paste! {
+        paste! {
             #[unsafe(no_mangle)]
-            pub unsafe extern "C-unwind" fn [<vx_array_get_ $ptype>](array: *const vx_array, index: u32) -> $ptype {
+            pub unsafe extern "C-unwind" fn [<vx_array_get_ $ptype>](array: *const vx_array, index: usize) -> $ptype {
                 let array = vx_array::as_ref(array);
                 // TODO(joe): propagate this error up instead of expecting
-                let value = array.scalar_at(index as usize).vortex_expect("scalar_at failed");
+                let value = array.scalar_at(index).vortex_expect("scalar_at failed");
                 // TODO(joe): propagate this error up instead of expecting
                 value.as_primitive()
                     .as_::<$ptype>()
@@ -121,10 +333,10 @@ macro_rules! ffiarray_get_ptype {
             }
 
             #[unsafe(no_mangle)]
-            pub unsafe extern "C-unwind" fn [<vx_array_get_storage_ $ptype>](array: *const vx_array, index: u32) -> $ptype {
+            pub unsafe extern "C-unwind" fn [<vx_array_get_storage_ $ptype>](array: *const vx_array, index: usize) -> $ptype {
                 let array = vx_array::as_ref(array);
                 // TODO(joe): propagate this error up instead of expecting
-                let value = array.scalar_at(index as usize).vortex_expect("scalar_at failed");
+                let value = array.scalar_at(index).vortex_expect("scalar_at failed");
                 // TODO(joe): propagate this error up instead of expecting
                 value.as_extension()
                     .to_storage_scalar()
@@ -216,7 +428,6 @@ mod tests {
     use vortex::array::arrays::StructArray;
     use vortex::array::arrays::VarBinViewArray;
     use vortex::array::validity::Validity;
-    use vortex::buffer::Buffer;
     use vortex::buffer::buffer;
     #[cfg(not(miri))]
     use vortex::dtype::half::f16;
@@ -257,6 +468,19 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_simple_is() {
+        unsafe {
+            let primitive =
+                PrimitiveArray::new(buffer![1i32, 2i32, 3i32, 4i32, 5i32], Validity::NonNullable);
+            let array = vx_array::new(primitive.into_array());
+            assert!(!vx_array_is_nullable(array));
+            assert!(vx_array_is_primitive(array, vx_ptype::PTYPE_I32));
+            vx_array_free(array);
+        }
+    }
+
+    #[test]
     // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
     #[cfg_attr(miri, ignore)]
     fn test_slice() {
@@ -290,14 +514,14 @@ mod tests {
             let ffi_array = vx_array::new(primitive.into_array());
 
             let mut error = ptr::null_mut();
-            assert!(!vx_array_is_null(ffi_array, 0, &raw mut error));
+            assert!(!vx_array_element_is_invalid(ffi_array, 0, &raw mut error));
             assert!(error.is_null());
-            assert!(vx_array_is_null(ffi_array, 1, &raw mut error));
+            assert!(vx_array_element_is_invalid(ffi_array, 1, &raw mut error));
             assert!(error.is_null());
-            assert!(!vx_array_is_null(ffi_array, 2, &raw mut error));
+            assert!(!vx_array_element_is_invalid(ffi_array, 2, &raw mut error));
             assert!(error.is_null());
 
-            let null_count = vx_array_null_count(ffi_array, &raw mut error);
+            let null_count = vx_array_invalid_count(ffi_array, &raw mut error);
             assert!(error.is_null());
             assert_eq!(null_count, 1);
 
@@ -354,29 +578,58 @@ mod tests {
             // The macro generates identical code for all types, so exhaustive testing is redundant
 
             // Test signed integer with edge cases
-            let i32_array =
-                PrimitiveArray::new(buffer![i32::MAX, i32::MIN, 0i32], Validity::NonNullable);
-            let ffi_i32 = vx_array::new(i32_array.into_array());
+            let mut error = ptr::null_mut();
+            let validity = vx_validity {
+                r#type: vx_validity_type::VX_VALIDITY_NON_NULLABLE,
+                array: ptr::null(),
+            };
+
+            let i32_array = [i32::MAX, i32::MIN, 0];
+            let ffi_i32 = vx_array_new_primitive(
+                vx_ptype::PTYPE_I32,
+                i32_array.as_ptr() as *const c_void,
+                i32_array.len(),
+                &raw const validity,
+                &raw mut error,
+            );
+            assert!(error.is_null());
+            assert!(!ffi_i32.is_null());
+
+            assert!(vx_array_is_primitive(ffi_i32, vx_ptype::PTYPE_I32));
             assert_eq!(vx_array_get_i32(ffi_i32, 0), i32::MAX);
             assert_eq!(vx_array_get_i32(ffi_i32, 1), i32::MIN);
             assert_eq!(vx_array_get_i32(ffi_i32, 2), 0);
             vx_array_free(ffi_i32);
 
             // Test unsigned integer
-            let u64_array =
-                PrimitiveArray::new(buffer![u64::MAX, 0u64, 42u64], Validity::NonNullable);
-            let ffi_u64 = vx_array::new(u64_array.into_array());
+            let u64_array = [u64::MAX, 0u64, 42u64];
+            let ffi_u64 = vx_array_new_primitive(
+                vx_ptype::PTYPE_U64,
+                u64_array.as_ptr() as *const c_void,
+                u64_array.len(),
+                &raw const validity,
+                &raw mut error,
+            );
+            assert!(error.is_null());
+            assert!(!ffi_u64.is_null());
+            assert!(vx_array_is_primitive(ffi_u64, vx_ptype::PTYPE_U64));
             assert_eq!(vx_array_get_u64(ffi_u64, 0), u64::MAX);
             assert_eq!(vx_array_get_u64(ffi_u64, 1), 0);
             assert_eq!(vx_array_get_u64(ffi_u64, 2), 42);
             vx_array_free(ffi_u64);
 
             // Test floating point including special values
-            let f64_array = PrimitiveArray::new(
-                buffer![f64::NEG_INFINITY, 0.0f64, f64::NAN],
-                Validity::NonNullable,
+            let f64_array = [f64::NEG_INFINITY, 0.0f64, f64::NAN];
+            let ffi_f64 = vx_array_new_primitive(
+                vx_ptype::PTYPE_F64,
+                f64_array.as_ptr() as *const c_void,
+                f64_array.len(),
+                &raw const validity,
+                &raw mut error,
             );
-            let ffi_f64 = vx_array::new(f64_array.into_array());
+            assert!(error.is_null());
+            assert!(!ffi_f64.is_null());
+            assert!(vx_array_is_primitive(ffi_f64, vx_ptype::PTYPE_F64));
             assert_eq!(vx_array_get_f64(ffi_f64, 0), f64::NEG_INFINITY);
             assert_eq!(vx_array_get_f64(ffi_f64, 1), 0.0);
             assert!(vx_array_get_f64(ffi_f64, 2).is_nan());
@@ -385,11 +638,16 @@ mod tests {
             // Test f16 (special half-precision type) - skip in Miri due to inline assembly
             #[cfg(not(miri))]
             {
-                let f16_array = PrimitiveArray::new(
-                    buffer![f16::from_f32(1.0), f16::from_f32(-0.5)],
-                    Validity::NonNullable,
+                let f16_array = [f16::from_f32(1.0), f16::from_f32(-0.5)];
+                let ffi_f16 = vx_array_new_primitive(
+                    vx_ptype::PTYPE_F16,
+                    f16_array.as_ptr() as *const c_void,
+                    f16_array.len(),
+                    &raw const validity,
+                    &raw mut error,
                 );
-                let ffi_f16 = vx_array::new(f16_array.into_array());
+                assert!(error.is_null());
+                assert!(!ffi_f16.is_null());
                 assert_eq!(vx_array_get_f16(ffi_f16, 0), f16::from_f32(1.0));
                 assert_eq!(vx_array_get_f16(ffi_f16, 1), f16::from_f32(-0.5));
                 vx_array_free(ffi_f16);
@@ -404,6 +662,7 @@ mod tests {
         unsafe {
             let utf8_array = VarBinViewArray::from_iter_str(["hello", "world", "test"]);
             let ffi_array = vx_array::new(utf8_array.into_array());
+            assert!(vx_array_has_dtype(ffi_array, vx_dtype_variant::DTYPE_UTF8));
 
             let vx_str1 = vx_array_get_utf8(ffi_array, 0);
             assert_eq!(vx_string::as_str(vx_str1), "hello");
@@ -432,6 +691,10 @@ mod tests {
                 vec![0xAA, 0xBB, 0xCC, 0xDD],
             ]);
             let ffi_array = vx_array::new(binary_array.into_array());
+            assert!(vx_array_has_dtype(
+                ffi_array,
+                vx_dtype_variant::DTYPE_BINARY
+            ));
 
             let vx_bin1 = vx_array_get_binary(ffi_array, 0);
             assert_eq!(vx_binary::as_slice(vx_bin1), &[0x01, 0x02, 0x03]);
@@ -512,6 +775,7 @@ mod tests {
             .into_array()
         };
         let vx_arr = vx_array::new(array);
+        assert!(unsafe { vx_array_has_dtype(vx_arr, vx_dtype_variant::DTYPE_STRUCT) });
 
         // Get dtype reference - this is valid as long as array lives
         let dtype_ptr = unsafe { vx_array_dtype(vx_arr) };

--- a/vortex-ffi/src/error.rs
+++ b/vortex-ffi/src/error.rs
@@ -19,6 +19,15 @@ box_wrapper!(
     vx_error
 );
 
+/// Write an error message to `error` which has not been populated before.
+pub(crate) fn write_error(error: *mut *mut vx_error, message: &str) {
+    assert!(!error.is_null());
+    let err = vx_error::new(Box::new(VortexError {
+        message: message.into(),
+    }));
+    unsafe { error.write(err) };
+}
+
 pub fn try_or_default<T: Default>(
     error_out: *mut *mut vx_error,
     function: impl FnOnce() -> VortexResult<T>,

--- a/vortex-ffi/src/sink.rs
+++ b/vortex-ffi/src/sink.rs
@@ -10,9 +10,9 @@ use futures::channel::mpsc;
 use futures::channel::mpsc::Sender;
 use vortex::array::ArrayRef;
 use vortex::array::stream::ArrayStreamAdapter;
-use vortex::error::VortexExpect;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
+use vortex::error::vortex_ensure;
 use vortex::error::vortex_err;
 use vortex::file::WriteOptionsSessionExt;
 use vortex::file::WriteSummary;
@@ -79,20 +79,23 @@ pub unsafe extern "C-unwind" fn vx_array_sink_open_file(
     })
 }
 
-/// Pushed a single array chunk into a file sink.
+/// Push an array into a file sink.
+/// Does not take ownership of array
 #[unsafe(no_mangle)]
 pub unsafe extern "C-unwind" fn vx_array_sink_push(
     sink: *mut vx_array_sink,
     array: *const vx_array,
     error_out: *mut *mut vx_error,
 ) {
-    let array = vx_array::as_ref(array);
-    // TODO(joe): propagate this error up instead of expecting
-    let sink = unsafe { sink.as_mut().vortex_expect("null array stream") };
     try_or_default(error_out, || {
+        vortex_ensure!(!array.is_null());
+        vortex_ensure!(!sink.is_null());
+
+        let array = vx_array::as_ref(array);
+        let sink = unsafe { &mut *sink };
         RUNTIME
             .block_on(sink.sink.send(Ok(array.clone())))
-            .map_err(|e| vortex_err!("send error {}", e.to_string()))
+            .map_err(|e| vortex_err!("Send error: {e}"))
     })
 }
 

--- a/vortex-ffi/test/CMakeLists.txt
+++ b/vortex-ffi/test/CMakeLists.txt
@@ -12,6 +12,7 @@ FetchContent_MakeAvailable(Catch)
 include(Catch)
 
 file(GLOB TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+message(NOTICE "Test files ${TEST_FILES}")
 add_executable(vortex_ffi_test ${TEST_FILES})
 target_link_libraries(vortex_ffi_test PRIVATE vortex_ffi_shared Catch2::Catch2WithMain)
 catch_discover_tests(vortex_ffi_test)

--- a/vortex-ffi/test/array.cpp
+++ b/vortex-ffi/test/array.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+#include <catch2/catch_test_macros.hpp>
+#include "common.h"
+
+TEST_CASE("Null array creation", "[array]") {
+    const vx_array *array = vx_array_new_null(1999);
+    REQUIRE(array != nullptr);
+    REQUIRE(vx_array_is_nullable(array));
+    REQUIRE(vx_array_has_dtype(array, DTYPE_NULL));
+    REQUIRE(vx_dtype_get_variant(vx_array_dtype(array)) == DTYPE_NULL);
+    REQUIRE(vx_array_len(array) == 1999);
+    vx_array_free(array);
+}
+
+TEST_CASE("Primitive array creation", "[array]") {
+    std::vector<uint8_t> buffer(20, 1);
+    buffer[3] = 8;
+
+    vx_validity validity = {};
+    validity.type = VX_VALIDITY_ALL_VALID;
+    vx_error *error = nullptr;
+    const vx_array *array = vx_array_new_primitive(PTYPE_U8, buffer.data(), buffer.size(), &validity, &error);
+
+    require_no_error(error);
+    REQUIRE(array != nullptr);
+    REQUIRE(vx_array_has_dtype(array, DTYPE_PRIMITIVE));
+    REQUIRE(vx_dtype_get_variant(vx_array_dtype(array)) == DTYPE_PRIMITIVE);
+    REQUIRE(vx_array_is_primitive(array, PTYPE_U8));
+    REQUIRE(vx_array_len(array) == buffer.size());
+
+    for (size_t i = 0; i < buffer.size(); ++i) {
+        REQUIRE(buffer[i] == vx_array_get_u8(array, i));
+    }
+
+    buffer = {};
+
+    for (size_t i = 0; i < 20; ++i) {
+        REQUIRE(vx_array_get_u8(array, i) == (i == 3 ? 8 : 1));
+    }
+
+    vx_array_free(array);
+}

--- a/vortex-ffi/test/common.h
+++ b/vortex-ffi/test/common.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+#include <string>
+#include "vortex.h"
+
+inline std::string to_string(vx_error *err) {
+    const vx_string *msg = vx_error_get_message(err);
+    return {vx_string_ptr(msg), vx_string_len(msg)};
+}
+
+inline std::string_view to_string_view(const vx_string *msg) {
+    return {vx_string_ptr(msg), vx_string_len(msg)};
+}
+
+inline std::string_view to_string_view(vx_error *err) {
+    return to_string_view(vx_error_get_message(err));
+}
+
+inline void require_no_error(vx_error *err) {
+    if (err) {
+        FAIL(to_string(err));
+    }
+}


### PR DESCRIPTION
- Allow querying array validity from FFI.
- Allow creating null and primitive vx_arrays from FFI.
- Expose utility functions to query dtype and ptype from array
  directly instead of array -> dtype -> variant [-> ptype] chain.

Breaking changes:
- rename `vx_array_is_null` to `vx_array_element_is_invalid`.
- rename `vx_array_null_count` to `vx_array_invalid_count`.
- make functions operating on indices take size_t instead of u32.
