### PR TITLE
Support reading SparseArray with non zero offset

### DIFF
--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -200,11 +200,6 @@ impl VTable for Sparse {
             "SparseArray expects 2 children for sparse encoding, found {}",
             children.len()
         );
-        vortex_ensure_eq!(
-            metadata.patches.offset()?,
-            0,
-            "Patches must start at offset 0"
-        );
 
         let patch_indices = children.get(
             0,
@@ -213,10 +208,14 @@ impl VTable for Sparse {
         )?;
         let patch_values = children.get(1, dtype, metadata.patches.len()?)?;
 
-        SparseArray::try_new(
-            patch_indices,
-            patch_values,
-            len,
+        SparseArray::try_new_from_patches(
+            Patches::new(
+                len,
+                metadata.patches.offset()?,
+                patch_indices,
+                patch_values,
+                None,
+            )?,
             metadata.fill_value.clone(),
         )
     }


### PR DESCRIPTION
Motivated by #7094 I tried simplifying offset handling in Patches.
Unfortunately because of how chunk_offsets and indices interact with each other
you need to store two offsets in order to support zero-copy slicing.

Since we want to support zero copy slicing there's nothing fundamentally better
we can do here than supporting non zero offsets.

Signed-off-by: Robert Kruszewski <github@robertk.io>
