### PR TITLE
fix(python): cap substrait below 0.85.0

### DIFF
--- a/vortex-python/pyproject.toml
+++ b/vortex-python/pyproject.toml
@@ -6,7 +6,7 @@ dynamic = ["version", "description", "authors"]
 readme = "README.md"
 dependencies = [
     "pyarrow>=17.0.0",
-    "substrait>=0.23.0",
+    "substrait>=0.23.0,<0.85.0",
     "typing-extensions>=4.5.0",
 ]
 requires-python = ">= 3.11"


### PR DESCRIPTION
## Summary

Fixes [https://github.com/vortex-data/vortex/issues/7152](https://github.com/vortex-data/vortex/issues/7152).

In Substrait 0.85.0, `SimpleExtensionURI` was removed. The Vortex Python bindings have not been updated to use the new implementation, and they also do not set an appropriate upper bound on the dependency version.

This change caps the Python dependency at `substrait<0.85.0` until the code is updated for the URN schema.

This workaround is used because it is currently difficult to make Vortex support the latest Substrait. Vortex currently consumes Substrait expressions produced by PyArrow. However, the current Arrow tree still uses Substrait v0.44.0. Until Arrow is updated, it is difficult for us to support the latest Substrait easily because of our dependency on Arrow.

See:

PyArrow uses `v0.44.0`: https://github.com/apache/arrow/blob/f9315d4e7fb61ac85a77c651dcee84dbfad88472/cpp/thirdparty/versions.txt#L109

We convert PyArrow Expression into Substrait type: https://github.com/vortex-data/vortex/blob/f2008239f4836b927622b143217165ed1259125a/vortex-python/python/vortex/arrow/expression.py#L47-L50

## Testing

Did not run tests. This is a dependency metadata change only.
