### PR TITLE
fix(python): cap substrait-python before 0.29.0

### DIFF
--- a/vortex-python/pyproject.toml
+++ b/vortex-python/pyproject.toml
@@ -6,7 +6,7 @@ dynamic = ["version", "description", "authors"]
 readme = "README.md"
 dependencies = [
     "pyarrow>=17.0.0",
-    "substrait>=0.23.0,<0.85.0",
+    "substrait>=0.23.0,<0.29.0",
     "typing-extensions>=4.5.0",
 ]
 requires-python = ">= 3.11"


### PR DESCRIPTION
## Summary

I made a mistake in #7153, for details about the mistake, see this comment: https://github.com/vortex-data/vortex/pull/7153#issuecomment-4127482134

This PR correctly fixes the `substrait-python` dependency problem.

## Testing

- In a clean Python 3.12 virtual environment, `pip install vortex-data==0.64.0` resolved to `substrait==0.29.0`, `substrait-protobuf==0.85.0`, and `substrait-extensions==0.85.0`, and `import vortex` failed.
- In a clean Python 3.12 virtual environment, installing `vortex-data` from this PR branch resolved to `substrait==0.28.0`, `substrait-protobuf==0.79.0`, and `substrait-extensions==0.79.0`, and `import vortex` succeeded.
