### PR TITLE
scalar_at take execution_ctx

### DIFF
--- a/encodings/alp/public-api.lock
+++ b/encodings/alp/public-api.lock
@@ -102,7 +102,7 @@ pub fn vortex_alp::ALP::with_children(array: &mut Self::Array, children: alloc::
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_alp::ALP> for vortex_alp::ALP
 
-pub fn vortex_alp::ALP::scalar_at(array: &vortex_alp::ALPArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_alp::ALP::scalar_at(array: &vortex_alp::ALPArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityChild<vortex_alp::ALP> for vortex_alp::ALP
 
@@ -266,7 +266,7 @@ pub fn vortex_alp::ALPRD::with_children(array: &mut Self::Array, children: alloc
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_alp::ALPRD> for vortex_alp::ALPRD
 
-pub fn vortex_alp::ALPRD::scalar_at(array: &vortex_alp::ALPRDArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_alp::ALPRD::scalar_at(array: &vortex_alp::ALPRDArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityChild<vortex_alp::ALPRD> for vortex_alp::ALPRD
 

--- a/encodings/alp/src/alp/ops.rs
+++ b/encodings/alp/src/alp/ops.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::ExecutionCtx;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexExpect;
@@ -12,7 +13,7 @@ use crate::ALPFloat;
 use crate::match_each_alp_float_ptype;
 
 impl OperationsVTable<ALP> for ALP {
-    fn scalar_at(array: &ALPArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(array: &ALPArray, index: usize, _ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
         if let Some(patches) = array.patches()
             && let Some(patch) = patches.get_patched(index)?
         {

--- a/encodings/alp/src/alp_rd/ops.rs
+++ b/encodings/alp/src/alp_rd/ops.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::DynArray;
+use vortex_array::ExecutionCtx;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexExpect;
@@ -11,7 +12,11 @@ use crate::ALPRD;
 use crate::ALPRDArray;
 
 impl OperationsVTable<ALPRD> for ALPRD {
-    fn scalar_at(array: &ALPRDArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &ALPRDArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         // The left value can either be a direct value, or an exception.
         // The exceptions array represents exception positions with non-null values.
         let maybe_patched_value = match array.left_parts_patches() {

--- a/encodings/bytebool/public-api.lock
+++ b/encodings/bytebool/public-api.lock
@@ -84,7 +84,7 @@ pub fn vortex_bytebool::ByteBool::with_children(array: &mut Self::Array, childre
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_bytebool::ByteBool> for vortex_bytebool::ByteBool
 
-pub fn vortex_bytebool::ByteBool::scalar_at(array: &vortex_bytebool::ByteBoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_bytebool::ByteBool::scalar_at(array: &vortex_bytebool::ByteBoolArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub struct vortex_bytebool::ByteBoolArray
 

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -266,7 +266,11 @@ impl ValidityHelper for ByteBoolArray {
 }
 
 impl OperationsVTable<ByteBool> for ByteBool {
-    fn scalar_at(array: &ByteBoolArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &ByteBoolArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         Ok(Scalar::bool(
             array.buffer.as_host()[index] == 1,
             array.dtype().nullability(),

--- a/encodings/datetime-parts/public-api.lock
+++ b/encodings/datetime-parts/public-api.lock
@@ -92,7 +92,7 @@ pub fn vortex_datetime_parts::DateTimeParts::with_children(array: &mut Self::Arr
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_datetime_parts::DateTimeParts> for vortex_datetime_parts::DateTimeParts
 
-pub fn vortex_datetime_parts::DateTimeParts::scalar_at(array: &vortex_datetime_parts::DateTimePartsArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_datetime_parts::DateTimeParts::scalar_at(array: &vortex_datetime_parts::DateTimePartsArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityChild<vortex_datetime_parts::DateTimeParts> for vortex_datetime_parts::DateTimeParts
 

--- a/encodings/datetime-parts/src/ops.rs
+++ b/encodings/datetime-parts/src/ops.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::DynArray;
+use vortex_array::ExecutionCtx;
 use vortex_array::dtype::DType;
 use vortex_array::extension::datetime::Timestamp;
 use vortex_array::scalar::Scalar;
@@ -16,7 +17,11 @@ use crate::timestamp;
 use crate::timestamp::TimestampParts;
 
 impl OperationsVTable<DateTimeParts> for DateTimeParts {
-    fn scalar_at(array: &DateTimePartsArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &DateTimePartsArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         let DType::Extension(ext) = array.dtype().clone() else {
             vortex_panic!(
                 "DateTimePartsArray must have extension dtype, found {}",

--- a/encodings/decimal-byte-parts/public-api.lock
+++ b/encodings/decimal-byte-parts/public-api.lock
@@ -92,7 +92,7 @@ pub fn vortex_decimal_byte_parts::DecimalByteParts::with_children(array: &mut Se
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_decimal_byte_parts::DecimalByteParts> for vortex_decimal_byte_parts::DecimalByteParts
 
-pub fn vortex_decimal_byte_parts::DecimalByteParts::scalar_at(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_decimal_byte_parts::DecimalByteParts::scalar_at(array: &vortex_decimal_byte_parts::DecimalBytePartsArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityChild<vortex_decimal_byte_parts::DecimalByteParts> for vortex_decimal_byte_parts::DecimalByteParts
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -307,7 +307,11 @@ fn to_canonical_decimal(
 }
 
 impl OperationsVTable<DecimalByteParts> for DecimalByteParts {
-    fn scalar_at(array: &DecimalBytePartsArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &DecimalBytePartsArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         // TODO(joe): support parts len != 1
         let scalar = array.msp.scalar_at(index)?;
 

--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -202,7 +202,7 @@ pub fn vortex_fastlanes::BitPacked::with_children(array: &mut Self::Array, child
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::BitPacked> for vortex_fastlanes::BitPacked
 
-pub fn vortex_fastlanes::BitPacked::scalar_at(array: &vortex_fastlanes::BitPackedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fastlanes::BitPacked::scalar_at(array: &vortex_fastlanes::BitPackedArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub struct vortex_fastlanes::BitPackedArray
 
@@ -356,7 +356,7 @@ pub fn vortex_fastlanes::Delta::with_children(array: &mut Self::Array, children:
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::Delta> for vortex_fastlanes::Delta
 
-pub fn vortex_fastlanes::Delta::scalar_at(array: &vortex_fastlanes::DeltaArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fastlanes::Delta::scalar_at(array: &vortex_fastlanes::DeltaArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityVTable<vortex_fastlanes::Delta> for vortex_fastlanes::Delta
 
@@ -502,7 +502,7 @@ pub fn vortex_fastlanes::FoR::with_children(array: &mut Self::Array, children: a
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::FoR> for vortex_fastlanes::FoR
 
-pub fn vortex_fastlanes::FoR::scalar_at(array: &vortex_fastlanes::FoRArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fastlanes::FoR::scalar_at(array: &vortex_fastlanes::FoRArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityChild<vortex_fastlanes::FoR> for vortex_fastlanes::FoR
 
@@ -632,7 +632,7 @@ pub fn vortex_fastlanes::RLE::with_children(array: &mut Self::Array, children: a
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_fastlanes::RLE> for vortex_fastlanes::RLE
 
-pub fn vortex_fastlanes::RLE::scalar_at(array: &vortex_fastlanes::RLEArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fastlanes::RLE::scalar_at(array: &vortex_fastlanes::RLEArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityChild<vortex_fastlanes::RLE> for vortex_fastlanes::RLE
 

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::ExecutionCtx;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexResult;
@@ -10,7 +11,11 @@ use crate::BitPackedArray;
 use crate::bitpack_decompress;
 
 impl OperationsVTable<BitPacked> for BitPacked {
-    fn scalar_at(array: &BitPackedArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &BitPackedArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         Ok(
             if let Some(patches) = array.patches()
                 && let Some(patch) = patches.get_patched(index)?

--- a/encodings/fastlanes/src/delta/vtable/operations.rs
+++ b/encodings/fastlanes/src/delta/vtable/operations.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::ExecutionCtx;
 use vortex_array::ToCanonical;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
@@ -10,7 +11,11 @@ use super::Delta;
 use crate::DeltaArray;
 
 impl OperationsVTable<Delta> for Delta {
-    fn scalar_at(array: &DeltaArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &DeltaArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         let decompressed = array.slice(index..index + 1)?.to_primitive();
         decompressed.scalar_at(0)
     }

--- a/encodings/fastlanes/src/for/vtable/operations.rs
+++ b/encodings/fastlanes/src/for/vtable/operations.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::ExecutionCtx;
 use vortex_array::match_each_integer_ptype;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
@@ -11,7 +12,7 @@ use super::FoR;
 use crate::FoRArray;
 
 impl OperationsVTable<FoR> for FoR {
-    fn scalar_at(array: &FoRArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(array: &FoRArray, index: usize, _ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
         let encoded_pvalue = array.encoded().scalar_at(index)?;
         let encoded_pvalue = encoded_pvalue.as_primitive();
         let reference = array.reference_scalar();

--- a/encodings/fastlanes/src/rle/vtable/operations.rs
+++ b/encodings/fastlanes/src/rle/vtable/operations.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::ExecutionCtx;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexExpect;
@@ -11,7 +12,7 @@ use crate::FL_CHUNK_SIZE;
 use crate::RLEArray;
 
 impl OperationsVTable<RLE> for RLE {
-    fn scalar_at(array: &RLEArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(array: &RLEArray, index: usize, _ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
         let offset_in_chunk = array.offset();
         let chunk_relative_idx = array.indices().scalar_at(offset_in_chunk + index)?;
 

--- a/encodings/fsst/public-api.lock
+++ b/encodings/fsst/public-api.lock
@@ -94,7 +94,7 @@ pub fn vortex_fsst::FSST::with_children(array: &mut Self::Array, children: alloc
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_fsst::FSST> for vortex_fsst::FSST
 
-pub fn vortex_fsst::FSST::scalar_at(array: &vortex_fsst::FSSTArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fsst::FSST::scalar_at(array: &vortex_fsst::FSSTArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityChild<vortex_fsst::FSST> for vortex_fsst::FSST
 

--- a/encodings/fsst/src/ops.rs
+++ b/encodings/fsst/src/ops.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::ExecutionCtx;
 use vortex_array::arrays::varbin::varbin_scalar;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
@@ -12,7 +13,7 @@ use crate::FSST;
 use crate::FSSTArray;
 
 impl OperationsVTable<FSST> for FSST {
-    fn scalar_at(array: &FSSTArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(array: &FSSTArray, index: usize, _ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
         let compressed = array.codes().scalar_at(index)?;
         let binary_datum = compressed.as_binary().value().vortex_expect("non-null");
 

--- a/encodings/pco/public-api.lock
+++ b/encodings/pco/public-api.lock
@@ -74,7 +74,7 @@ pub fn vortex_pco::Pco::with_children(array: &mut Self::Array, children: alloc::
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_pco::Pco> for vortex_pco::Pco
 
-pub fn vortex_pco::Pco::scalar_at(array: &vortex_pco::PcoArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_pco::Pco::scalar_at(array: &vortex_pco::PcoArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub struct vortex_pco::PcoArray
 

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -573,7 +573,7 @@ impl ValiditySliceHelper for PcoArray {
 }
 
 impl OperationsVTable<Pco> for Pco {
-    fn scalar_at(array: &PcoArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(array: &PcoArray, index: usize, _ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         array
             ._slice(index, index + 1)

--- a/encodings/runend/public-api.lock
+++ b/encodings/runend/public-api.lock
@@ -104,7 +104,7 @@ pub fn vortex_runend::RunEnd::with_children(array: &mut Self::Array, children: a
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_runend::RunEnd> for vortex_runend::RunEnd
 
-pub fn vortex_runend::RunEnd::scalar_at(array: &vortex_runend::RunEndArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_runend::RunEnd::scalar_at(array: &vortex_runend::RunEndArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityVTable<vortex_runend::RunEnd> for vortex_runend::RunEnd
 

--- a/encodings/runend/src/ops.rs
+++ b/encodings/runend/src/ops.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::scalar::PValue;
 use vortex_array::scalar::Scalar;
 use vortex_array::search_sorted::SearchResult;
@@ -14,7 +15,11 @@ use crate::RunEnd;
 use crate::RunEndArray;
 
 impl OperationsVTable<RunEnd> for RunEnd {
-    fn scalar_at(array: &RunEndArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &RunEndArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         array.values().scalar_at(array.find_physical_index(index)?)
     }
 }

--- a/encodings/sequence/public-api.lock
+++ b/encodings/sequence/public-api.lock
@@ -92,7 +92,7 @@ pub fn vortex_sequence::Sequence::with_children(_array: &mut Self::Array, childr
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_sequence::Sequence> for vortex_sequence::Sequence
 
-pub fn vortex_sequence::Sequence::scalar_at(array: &vortex_sequence::SequenceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_sequence::Sequence::scalar_at(array: &vortex_sequence::SequenceArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityVTable<vortex_sequence::Sequence> for vortex_sequence::Sequence
 

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -409,7 +409,11 @@ impl VTable for Sequence {
 }
 
 impl OperationsVTable<Sequence> for Sequence {
-    fn scalar_at(array: &SequenceArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &SequenceArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         Scalar::try_new(
             array.dtype().clone(),
             Some(ScalarValue::Primitive(array.index_value(index))),

--- a/encodings/sparse/public-api.lock
+++ b/encodings/sparse/public-api.lock
@@ -108,7 +108,7 @@ pub fn vortex_sparse::Sparse::with_children(array: &mut Self::Array, children: a
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_sparse::Sparse> for vortex_sparse::Sparse
 
-pub fn vortex_sparse::Sparse::scalar_at(array: &vortex_sparse::SparseArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_sparse::Sparse::scalar_at(array: &vortex_sparse::SparseArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityVTable<vortex_sparse::Sparse> for vortex_sparse::Sparse
 

--- a/encodings/sparse/src/ops.rs
+++ b/encodings/sparse/src/ops.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::ExecutionCtx;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexResult;
@@ -9,7 +10,11 @@ use crate::Sparse;
 use crate::SparseArray;
 
 impl OperationsVTable<Sparse> for Sparse {
-    fn scalar_at(array: &SparseArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &SparseArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         Ok(array
             .patches()
             .get_patched(index)?

--- a/encodings/zigzag/public-api.lock
+++ b/encodings/zigzag/public-api.lock
@@ -88,7 +88,7 @@ pub fn vortex_zigzag::ZigZag::with_children(array: &mut Self::Array, children: a
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_zigzag::ZigZag> for vortex_zigzag::ZigZag
 
-pub fn vortex_zigzag::ZigZag::scalar_at(array: &vortex_zigzag::ZigZagArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_zigzag::ZigZag::scalar_at(array: &vortex_zigzag::ZigZagArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::validity::ValidityChild<vortex_zigzag::ZigZag> for vortex_zigzag::ZigZag
 

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -223,7 +223,11 @@ impl ZigZagArray {
 }
 
 impl OperationsVTable<ZigZag> for ZigZag {
-    fn scalar_at(array: &ZigZagArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &ZigZagArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         let scalar = array.encoded().scalar_at(index)?;
         if scalar.is_null() {
             return scalar.primitive_reinterpret_cast(array.ptype());

--- a/encodings/zstd/public-api.lock
+++ b/encodings/zstd/public-api.lock
@@ -74,7 +74,7 @@ pub fn vortex_zstd::Zstd::with_children(array: &mut Self::Array, children: alloc
 
 impl vortex_array::vtable::operations::OperationsVTable<vortex_zstd::Zstd> for vortex_zstd::Zstd
 
-pub fn vortex_zstd::Zstd::scalar_at(array: &vortex_zstd::ZstdArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_zstd::Zstd::scalar_at(array: &vortex_zstd::ZstdArray, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub struct vortex_zstd::ZstdArray
 

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -962,7 +962,7 @@ impl ValiditySliceHelper for ZstdArray {
 }
 
 impl OperationsVTable<Zstd> for Zstd {
-    fn scalar_at(array: &ZstdArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(array: &ZstdArray, index: usize, _ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         array
             ._slice(index, index + 1)

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -481,7 +481,11 @@ impl VTable for ZstdBuffers {
 }
 
 impl OperationsVTable<ZstdBuffers> for ZstdBuffers {
-    fn scalar_at(array: &ZstdBuffersArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &ZstdBuffersArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         // TODO(os): maybe we should not support scalar_at, it is really slow, and adding a cache
         // layer here is weird. Valid use of zstd buffers array would be by executing it first into
         // canonical

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -888,7 +888,7 @@ pub fn vortex_array::arrays::Bool::mask(array: &vortex_array::arrays::BoolArray,
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Bool> for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::Bool::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Bool::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Bool
 
@@ -1104,7 +1104,7 @@ pub fn vortex_array::arrays::Chunked::zip(if_true: &vortex_array::arrays::Chunke
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::Chunked::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Chunked::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Chunked
 
@@ -1278,7 +1278,7 @@ pub fn vortex_array::arrays::Constant::invert(array: &vortex_array::arrays::Cons
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::Constant::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Constant::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Constant
 
@@ -1492,7 +1492,7 @@ pub fn vortex_array::arrays::Decimal::mask(array: &vortex_array::arrays::Decimal
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Decimal> for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::Decimal::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Decimal::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Decimal
 
@@ -1708,7 +1708,7 @@ pub fn vortex_array::arrays::dict::Dict::mask(array: &vortex_array::arrays::dict
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::dict::Dict
 
@@ -1818,7 +1818,7 @@ pub fn vortex_array::arrays::dict::Dict::mask(array: &vortex_array::arrays::dict
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::dict::Dict
 
@@ -2122,7 +2122,7 @@ pub fn vortex_array::arrays::Extension::mask(array: &vortex_array::arrays::Exten
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::Extension::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Extension::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Extension
 
@@ -2266,7 +2266,7 @@ pub fn vortex_array::arrays::Filter::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::Filter::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Filter::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Filter
 
@@ -2490,7 +2490,7 @@ pub fn vortex_array::arrays::FixedSizeList::mask(array: &vortex_array::arrays::F
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FixedSizeList> for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::FixedSizeList
 
@@ -2646,7 +2646,7 @@ pub fn vortex_array::arrays::List::mask(array: &vortex_array::arrays::ListArray,
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::List> for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::List::scalar_at(array: &vortex_array::arrays::ListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::List::scalar_at(array: &vortex_array::arrays::ListArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::List
 
@@ -2822,7 +2822,7 @@ pub fn vortex_array::arrays::ListView::mask(array: &vortex_array::arrays::ListVi
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListView> for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListView::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::ListView::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::ListView
 
@@ -3008,7 +3008,7 @@ pub fn vortex_array::arrays::Masked::mask(array: &vortex_array::arrays::MaskedAr
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Masked> for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::Masked::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Masked::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Masked
 
@@ -3154,7 +3154,7 @@ pub fn vortex_array::arrays::null::Null::mask(array: &vortex_array::arrays::null
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::Null::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::null::Null::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::null::Null
 
@@ -3372,7 +3372,7 @@ pub fn vortex_array::arrays::Primitive::mask(array: &vortex_array::arrays::Primi
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Primitive> for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::Primitive::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Primitive::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Primitive
 
@@ -3682,7 +3682,7 @@ pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::fmt(&self, f: &mut core:
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
@@ -3770,7 +3770,7 @@ pub fn vortex_array::arrays::Shared::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
 
-pub fn vortex_array::arrays::Shared::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Shared::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Shared
 
@@ -3896,7 +3896,7 @@ pub fn vortex_array::arrays::slice::Slice::slice(array: &Self::Array, range: cor
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::slice::Slice::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::slice::Slice::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::slice::Slice
 
@@ -4158,7 +4158,7 @@ pub fn vortex_array::arrays::Struct::zip(if_true: &vortex_array::arrays::StructA
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::Struct::scalar_at(array: &vortex_array::arrays::StructArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Struct::scalar_at(array: &vortex_array::arrays::StructArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Struct
 
@@ -4382,7 +4382,7 @@ pub fn vortex_array::arrays::VarBin::mask(array: &vortex_array::arrays::VarBinAr
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBin> for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBin::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBin::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::VarBin
 
@@ -4792,7 +4792,7 @@ pub fn vortex_array::arrays::VarBinView::zip(if_true: &vortex_array::arrays::Var
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinView> for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinView::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBinView::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinView
 
@@ -4990,7 +4990,7 @@ pub fn vortex_array::arrays::Variant::fmt(&self, f: &mut core::fmt::Formatter<'_
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Variant> for vortex_array::arrays::Variant
 
-pub fn vortex_array::arrays::Variant::scalar_at(array: &<vortex_array::arrays::Variant as vortex_array::vtable::VTable>::Array, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Variant::scalar_at(array: &<vortex_array::arrays::Variant as vortex_array::vtable::VTable>::Array, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Variant
 
@@ -5138,7 +5138,7 @@ pub fn vortex_array::arrays::Bool::mask(array: &vortex_array::arrays::BoolArray,
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Bool> for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::Bool::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Bool::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Bool
 
@@ -5326,7 +5326,7 @@ pub fn vortex_array::arrays::Chunked::zip(if_true: &vortex_array::arrays::Chunke
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::Chunked::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Chunked::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Chunked
 
@@ -5498,7 +5498,7 @@ pub fn vortex_array::arrays::Constant::invert(array: &vortex_array::arrays::Cons
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::Constant::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Constant::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Constant
 
@@ -5648,7 +5648,7 @@ pub fn vortex_array::arrays::Decimal::mask(array: &vortex_array::arrays::Decimal
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Decimal> for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::Decimal::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Decimal::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Decimal
 
@@ -5832,7 +5832,7 @@ pub fn vortex_array::arrays::dict::Dict::mask(array: &vortex_array::arrays::dict
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::dict::Dict
 
@@ -5994,7 +5994,7 @@ pub fn vortex_array::arrays::Extension::mask(array: &vortex_array::arrays::Exten
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::Extension::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Extension::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Extension
 
@@ -6136,7 +6136,7 @@ pub fn vortex_array::arrays::Filter::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::Filter::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Filter::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Filter
 
@@ -6276,7 +6276,7 @@ pub fn vortex_array::arrays::FixedSizeList::mask(array: &vortex_array::arrays::F
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FixedSizeList> for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::FixedSizeList
 
@@ -6430,7 +6430,7 @@ pub fn vortex_array::arrays::List::mask(array: &vortex_array::arrays::ListArray,
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::List> for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::List::scalar_at(array: &vortex_array::arrays::ListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::List::scalar_at(array: &vortex_array::arrays::ListArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::List
 
@@ -6584,7 +6584,7 @@ pub fn vortex_array::arrays::ListView::mask(array: &vortex_array::arrays::ListVi
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListView> for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListView::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::ListView::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::ListView
 
@@ -6750,7 +6750,7 @@ pub fn vortex_array::arrays::Masked::mask(array: &vortex_array::arrays::MaskedAr
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Masked> for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::Masked::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Masked::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Masked
 
@@ -6892,7 +6892,7 @@ pub fn vortex_array::arrays::null::Null::mask(array: &vortex_array::arrays::null
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::Null::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::null::Null::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::null::Null
 
@@ -7042,7 +7042,7 @@ pub fn vortex_array::arrays::Primitive::mask(array: &vortex_array::arrays::Primi
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Primitive> for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::Primitive::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Primitive::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Primitive
 
@@ -7278,7 +7278,7 @@ pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::fmt(&self, f: &mut core:
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
@@ -7356,7 +7356,7 @@ pub fn vortex_array::arrays::Shared::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
 
-pub fn vortex_array::arrays::Shared::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Shared::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Shared
 
@@ -7480,7 +7480,7 @@ pub fn vortex_array::arrays::slice::Slice::slice(array: &Self::Array, range: cor
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::slice::Slice::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::slice::Slice::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::slice::Slice
 
@@ -7624,7 +7624,7 @@ pub fn vortex_array::arrays::Struct::zip(if_true: &vortex_array::arrays::StructA
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::Struct::scalar_at(array: &vortex_array::arrays::StructArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Struct::scalar_at(array: &vortex_array::arrays::StructArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Struct
 
@@ -7872,7 +7872,7 @@ pub fn vortex_array::arrays::VarBin::mask(array: &vortex_array::arrays::VarBinAr
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBin> for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBin::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBin::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::VarBin
 
@@ -8096,7 +8096,7 @@ pub fn vortex_array::arrays::VarBinView::zip(if_true: &vortex_array::arrays::Var
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinView> for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinView::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBinView::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::VarBinView
 
@@ -8282,7 +8282,7 @@ pub fn vortex_array::arrays::Variant::fmt(&self, f: &mut core::fmt::Formatter<'_
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Variant> for vortex_array::arrays::Variant
 
-pub fn vortex_array::arrays::Variant::scalar_at(array: &<vortex_array::arrays::Variant as vortex_array::vtable::VTable>::Array, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Variant::scalar_at(array: &<vortex_array::arrays::Variant as vortex_array::vtable::VTable>::Array, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::VTable for vortex_array::arrays::Variant
 
@@ -20834,7 +20834,7 @@ pub struct vortex_array::vtable::NotSupported
 
 impl<V: vortex_array::vtable::VTable> vortex_array::vtable::OperationsVTable<V> for vortex_array::vtable::NotSupported
 
-pub fn vortex_array::vtable::NotSupported::scalar_at(array: &<V as vortex_array::vtable::VTable>::Array, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::vtable::NotSupported::scalar_at(array: &<V as vortex_array::vtable::VTable>::Array, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub struct vortex_array::vtable::ValidityVTableFromChild
 
@@ -22070,91 +22070,91 @@ pub fn V::with_children(&self, array: &vortex_array::ArrayRef, children: alloc::
 
 pub trait vortex_array::vtable::OperationsVTable<V: vortex_array::vtable::VTable>
 
-pub fn vortex_array::vtable::OperationsVTable::scalar_at(array: &<V as vortex_array::vtable::VTable>::Array, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::vtable::OperationsVTable::scalar_at(array: &<V as vortex_array::vtable::VTable>::Array, index: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Bool> for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::Bool::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Bool::scalar_at(array: &vortex_array::arrays::BoolArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::Chunked::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Chunked::scalar_at(array: &vortex_array::arrays::ChunkedArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::Constant::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Constant::scalar_at(array: &vortex_array::arrays::ConstantArray, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Decimal> for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::Decimal::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Decimal::scalar_at(array: &vortex_array::arrays::DecimalArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::Extension::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Extension::scalar_at(array: &vortex_array::arrays::ExtensionArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::Filter::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Filter::scalar_at(array: &vortex_array::arrays::FilterArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::FixedSizeList> for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: &vortex_array::arrays::FixedSizeListArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::List> for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::List::scalar_at(array: &vortex_array::arrays::ListArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::List::scalar_at(array: &vortex_array::arrays::ListArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::ListView> for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListView::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::ListView::scalar_at(array: &vortex_array::arrays::ListViewArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Masked> for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::Masked::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Masked::scalar_at(array: &vortex_array::arrays::MaskedArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Primitive> for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::Primitive::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Primitive::scalar_at(array: &vortex_array::arrays::PrimitiveArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
 
-pub fn vortex_array::arrays::Shared::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Shared::scalar_at(array: &vortex_array::arrays::SharedArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::Struct::scalar_at(array: &vortex_array::arrays::StructArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Struct::scalar_at(array: &vortex_array::arrays::StructArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBin> for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBin::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBin::scalar_at(array: &vortex_array::arrays::VarBinArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::VarBinView> for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinView::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBinView::scalar_at(array: &vortex_array::arrays::VarBinViewArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::Variant> for vortex_array::arrays::Variant
 
-pub fn vortex_array::arrays::Variant::scalar_at(array: &<vortex_array::arrays::Variant as vortex_array::vtable::VTable>::Array, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Variant::scalar_at(array: &<vortex_array::arrays::Variant as vortex_array::vtable::VTable>::Array, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: &vortex_array::arrays::dict::DictArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::Null::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::null::Null::scalar_at(_array: &vortex_array::arrays::null::NullArray, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: &vortex_array::arrays::scalar_fn::ScalarFnArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::vtable::OperationsVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::slice::Slice::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::slice::Slice::scalar_at(array: &vortex_array::arrays::slice::SliceArray, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::vtable::OperationsVTable<V> for vortex_array::vtable::NotSupported
 
-pub fn vortex_array::vtable::NotSupported::scalar_at(array: &<V as vortex_array::vtable::VTable>::Array, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::vtable::NotSupported::scalar_at(array: &<V as vortex_array::vtable::VTable>::Array, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub trait vortex_array::vtable::VTable: 'static + core::clone::Clone + core::marker::Sized + core::marker::Send + core::marker::Sync + core::fmt::Debug
 

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -501,7 +501,11 @@ impl<V: VTable> DynArray for Array<V> {
         if self.is_invalid(index)? {
             return Ok(Scalar::null(self.dtype.clone()));
         }
-        let scalar = <V::OperationsVTable as OperationsVTable<V>>::scalar_at(&self.array, index)?;
+        let scalar = <V::OperationsVTable as OperationsVTable<V>>::scalar_at(
+            &self.array,
+            index,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         vortex_ensure!(&self.dtype == scalar.dtype(), "Scalar dtype mismatch");
         Ok(scalar)
     }
@@ -913,7 +917,9 @@ impl<V: VTable> DynArray for ArrayAdapter<V> {
         if self.is_invalid(index)? {
             return Ok(Scalar::null(self.dtype().clone()));
         }
-        let scalar = <V::OperationsVTable as OperationsVTable<V>>::scalar_at(&self.0, index)?;
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let scalar =
+            <V::OperationsVTable as OperationsVTable<V>>::scalar_at(&self.0, index, &mut ctx)?;
         vortex_ensure!(self.dtype() == scalar.dtype(), "Scalar dtype mismatch");
         Ok(scalar)
     }

--- a/vortex-array/src/arrays/bool/vtable/operations.rs
+++ b/vortex-array/src/arrays/bool/vtable/operations.rs
@@ -3,13 +3,14 @@
 
 use vortex_error::VortexResult;
 
+use crate::ExecutionCtx;
 use crate::arrays::Bool;
 use crate::arrays::bool::vtable::BoolArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<Bool> for Bool {
-    fn scalar_at(array: &BoolArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(array: &BoolArray, index: usize, _ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
         Ok(Scalar::bool(
             array.to_bit_buffer().value(index),
             array.dtype().nullability(),

--- a/vortex-array/src/arrays/chunked/vtable/operations.rs
+++ b/vortex-array/src/arrays/chunked/vtable/operations.rs
@@ -4,13 +4,18 @@
 use vortex_error::VortexResult;
 
 use crate::DynArray;
+use crate::ExecutionCtx;
 use crate::arrays::Chunked;
 use crate::arrays::chunked::vtable::ChunkedArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<Chunked> for Chunked {
-    fn scalar_at(array: &ChunkedArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &ChunkedArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         let (chunk_index, chunk_offset) = array.find_chunk_idx(index)?;
         array.chunk(chunk_index).scalar_at(chunk_offset)
     }

--- a/vortex-array/src/arrays/constant/vtable/operations.rs
+++ b/vortex-array/src/arrays/constant/vtable/operations.rs
@@ -3,13 +3,18 @@
 
 use vortex_error::VortexResult;
 
+use crate::ExecutionCtx;
 use crate::arrays::Constant;
 use crate::arrays::constant::vtable::ConstantArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<Constant> for Constant {
-    fn scalar_at(array: &ConstantArray, _index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &ConstantArray,
+        _index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         Ok(array.scalar.clone())
     }
 }

--- a/vortex-array/src/arrays/decimal/vtable/operations.rs
+++ b/vortex-array/src/arrays/decimal/vtable/operations.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 
+use crate::ExecutionCtx;
 use crate::arrays::Decimal;
 use crate::arrays::decimal::vtable::DecimalArray;
 use crate::match_each_decimal_value_type;
@@ -11,7 +12,11 @@ use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<Decimal> for Decimal {
-    fn scalar_at(array: &DecimalArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &DecimalArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         Ok(match_each_decimal_value_type!(array.values_type(), |D| {
             Scalar::decimal(
                 DecimalValue::from(array.buffer::<D>()[index]),

--- a/vortex-array/src/arrays/dict/vtable/operations.rs
+++ b/vortex-array/src/arrays/dict/vtable/operations.rs
@@ -6,12 +6,13 @@ use vortex_error::VortexResult;
 
 use super::Dict;
 use crate::DynArray;
+use crate::ExecutionCtx;
 use crate::arrays::DictArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<Dict> for Dict {
-    fn scalar_at(array: &DictArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(array: &DictArray, index: usize, _ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
         let Some(dict_index) = array
             .codes()
             .scalar_at(index)?

--- a/vortex-array/src/arrays/extension/vtable/operations.rs
+++ b/vortex-array/src/arrays/extension/vtable/operations.rs
@@ -4,13 +4,18 @@
 use vortex_error::VortexResult;
 
 use crate::DynArray;
+use crate::ExecutionCtx;
 use crate::arrays::Extension;
 use crate::arrays::ExtensionArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<Extension> for Extension {
-    fn scalar_at(array: &ExtensionArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &ExtensionArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         Ok(Scalar::extension_ref(
             array.ext_dtype().clone(),
             array.storage_array().scalar_at(index)?,

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -188,7 +188,11 @@ impl VTable for Filter {
     }
 }
 impl OperationsVTable<Filter> for Filter {
-    fn scalar_at(array: &FilterArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &FilterArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         let rank_idx = array.mask.rank(index);
         array.child.scalar_at(rank_idx)
     }

--- a/vortex-array/src/arrays/fixed_size_list/vtable/operations.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/operations.rs
@@ -3,13 +3,18 @@
 
 use vortex_error::VortexResult;
 
+use crate::ExecutionCtx;
 use crate::arrays::FixedSizeList;
 use crate::arrays::fixed_size_list::vtable::FixedSizeListArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<FixedSizeList> for FixedSizeList {
-    fn scalar_at(array: &FixedSizeListArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &FixedSizeListArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
         let list = array.fixed_size_list_elements_at(index)?;
         let children_elements: Vec<Scalar> = (0..list.len())

--- a/vortex-array/src/arrays/list/vtable/operations.rs
+++ b/vortex-array/src/arrays/list/vtable/operations.rs
@@ -5,13 +5,14 @@ use std::sync::Arc;
 
 use vortex_error::VortexResult;
 
+use crate::ExecutionCtx;
 use crate::arrays::List;
 use crate::arrays::list::vtable::ListArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<List> for List {
-    fn scalar_at(array: &ListArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(array: &ListArray, index: usize, _ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
         let elems = array.list_elements_at(index)?;
         let scalars: Vec<Scalar> = (0..elems.len())

--- a/vortex-array/src/arrays/listview/vtable/operations.rs
+++ b/vortex-array/src/arrays/listview/vtable/operations.rs
@@ -5,13 +5,18 @@ use std::sync::Arc;
 
 use vortex_error::VortexResult;
 
+use crate::ExecutionCtx;
 use crate::arrays::ListView;
 use crate::arrays::listview::vtable::ListViewArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<ListView> for ListView {
-    fn scalar_at(array: &ListViewArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &ListViewArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
         let list = array.list_elements_at(index)?;
         let children: Vec<Scalar> = (0..list.len())

--- a/vortex-array/src/arrays/masked/vtable/operations.rs
+++ b/vortex-array/src/arrays/masked/vtable/operations.rs
@@ -4,13 +4,18 @@
 use vortex_error::VortexResult;
 
 use crate::DynArray;
+use crate::ExecutionCtx;
 use crate::arrays::Masked;
 use crate::arrays::MaskedArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<Masked> for Masked {
-    fn scalar_at(array: &MaskedArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &MaskedArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         // Invalid indices are handled by the entrypoint function.
         Ok(array.child.scalar_at(index)?.into_nullable())
     }

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -190,7 +190,11 @@ impl NullArray {
     }
 }
 impl OperationsVTable<Null> for Null {
-    fn scalar_at(_array: &NullArray, _index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        _array: &NullArray,
+        _index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         Ok(Scalar::null(DType::Null))
     }
 }

--- a/vortex-array/src/arrays/primitive/vtable/operations.rs
+++ b/vortex-array/src/arrays/primitive/vtable/operations.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 
+use crate::ExecutionCtx;
 use crate::arrays::Primitive;
 use crate::arrays::primitive::vtable::PrimitiveArray;
 use crate::match_each_native_ptype;
@@ -10,7 +11,11 @@ use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<Primitive> for Primitive {
-    fn scalar_at(array: &PrimitiveArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &PrimitiveArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         Ok(match_each_native_ptype!(array.ptype(), |T| {
             Scalar::primitive(array.as_slice::<T>()[index], array.dtype().nullability())
         }))

--- a/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
@@ -4,6 +4,7 @@
 use vortex_error::VortexResult;
 
 use crate::DynArray;
+use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
@@ -16,7 +17,11 @@ use crate::scalar_fn::VecExecutionArgs;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<ScalarFnVTable> for ScalarFnVTable {
-    fn scalar_at(array: &ScalarFnArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &ScalarFnArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         let inputs: Vec<_> = array
             .children
             .iter()

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -157,7 +157,11 @@ impl VTable for Shared {
     }
 }
 impl OperationsVTable<Shared> for Shared {
-    fn scalar_at(array: &SharedArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &SharedArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         array.current_array_ref().scalar_at(index)
     }
 }

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -188,7 +188,11 @@ impl VTable for Slice {
     }
 }
 impl OperationsVTable<Slice> for Slice {
-    fn scalar_at(array: &SliceArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &SliceArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         array.child.scalar_at(array.range.start + index)
     }
 }

--- a/vortex-array/src/arrays/struct_/vtable/operations.rs
+++ b/vortex-array/src/arrays/struct_/vtable/operations.rs
@@ -4,13 +4,18 @@
 use vortex_error::VortexResult;
 
 use crate::DynArray;
+use crate::ExecutionCtx;
 use crate::arrays::Struct;
 use crate::arrays::StructArray;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<Struct> for Struct {
-    fn scalar_at(array: &StructArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &StructArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         let field_scalars: VortexResult<Vec<Scalar>> = array
             .unmasked_fields()
             .iter()

--- a/vortex-array/src/arrays/varbin/vtable/operations.rs
+++ b/vortex-array/src/arrays/varbin/vtable/operations.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 
+use crate::ExecutionCtx;
 use crate::arrays::VarBin;
 use crate::arrays::VarBinArray;
 use crate::arrays::varbin::varbin_scalar;
@@ -10,7 +11,11 @@ use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<VarBin> for VarBin {
-    fn scalar_at(array: &VarBinArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &VarBinArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         Ok(varbin_scalar(array.bytes_at(index), array.dtype()))
     }
 }

--- a/vortex-array/src/arrays/varbinview/vtable/operations.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/operations.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 
+use crate::ExecutionCtx;
 use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::varbin::varbin_scalar;
@@ -10,7 +11,11 @@ use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
 
 impl OperationsVTable<VarBinView> for VarBinView {
-    fn scalar_at(array: &VarBinViewArray, index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        array: &VarBinViewArray,
+        index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         Ok(varbin_scalar(array.bytes_at(index), array.dtype()))
     }
 }

--- a/vortex-array/src/arrays/variant/vtable/operations.rs
+++ b/vortex-array/src/arrays/variant/vtable/operations.rs
@@ -3,6 +3,7 @@
 
 use vortex_error::VortexResult;
 
+use crate::ExecutionCtx;
 use crate::arrays::Variant;
 use crate::scalar::Scalar;
 use crate::vtable::OperationsVTable;
@@ -11,6 +12,7 @@ impl OperationsVTable<Variant> for Variant {
     fn scalar_at(
         array: &<Variant as crate::vtable::VTable>::Array,
         index: usize,
+        _ctx: &mut ExecutionCtx,
     ) -> VortexResult<Scalar> {
         array.child().scalar_at(index)
     }

--- a/vortex-array/src/vtable/operations.rs
+++ b/vortex-array/src/vtable/operations.rs
@@ -4,6 +4,7 @@
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
+use crate::ExecutionCtx;
 use crate::scalar::Scalar;
 use crate::vtable::NotSupported;
 use crate::vtable::VTable;
@@ -15,11 +16,11 @@ pub trait OperationsVTable<V: VTable> {
     ///
     /// Bounds-checking has already been performed by the time this function is called,
     /// and the index is guaranteed to be non-null.
-    fn scalar_at(array: &V::Array, index: usize) -> VortexResult<Scalar>;
+    fn scalar_at(array: &V::Array, index: usize, ctx: &mut ExecutionCtx) -> VortexResult<Scalar>;
 }
 
 impl<V: VTable> OperationsVTable<V> for NotSupported {
-    fn scalar_at(array: &V::Array, _index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(array: &V::Array, _index: usize, _ctx: &mut ExecutionCtx) -> VortexResult<Scalar> {
         vortex_bail!(
             "Legacy scalar_at operation is not supported for {} arrays",
             array.encoding_id()

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -208,6 +208,8 @@ mod tests {
     use crate::string::vx_string_free;
 
     #[test]
+    // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
+    #[cfg_attr(miri, ignore)]
     fn test_simple() {
         unsafe {
             let primitive = PrimitiveArray::new(buffer![1i32, 2i32, 3i32], Validity::NonNullable);
@@ -230,6 +232,8 @@ mod tests {
     }
 
     #[test]
+    // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
+    #[cfg_attr(miri, ignore)]
     fn test_slice() {
         unsafe {
             let primitive =
@@ -250,8 +254,8 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
+    #[cfg_attr(miri, ignore)]
     fn test_null_operations() {
         unsafe {
             let primitive = PrimitiveArray::new(
@@ -277,8 +281,8 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
+    #[cfg_attr(miri, ignore)]
     fn test_get_field() {
         unsafe {
             let names = VarBinViewArray::from_iter_str(["Alice", "Bob", "Charlie"]);
@@ -317,6 +321,8 @@ mod tests {
     }
 
     #[test]
+    // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
+    #[cfg_attr(miri, ignore)]
     fn test_primitive_getters() {
         unsafe {
             // Test a representative sample of primitive types
@@ -367,6 +373,8 @@ mod tests {
     }
 
     #[test]
+    // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
+    #[cfg_attr(miri, ignore)]
     fn test_get_utf8() {
         unsafe {
             let utf8_array = VarBinViewArray::from_iter_str(["hello", "world", "test"]);
@@ -389,6 +397,8 @@ mod tests {
     }
 
     #[test]
+    // TODO(joe): enable once this is fixed https://github.com/Amanieu/parking_lot/issues/477
+    #[cfg_attr(miri, ignore)]
     fn test_get_binary() {
         unsafe {
             let binary_array = VarBinViewArray::from_iter_bin(vec![

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -167,7 +167,11 @@ impl VTable for PythonVTable {
 }
 
 impl OperationsVTable<PythonVTable> for PythonVTable {
-    fn scalar_at(_array: &PythonArray, _index: usize) -> VortexResult<Scalar> {
+    fn scalar_at(
+        _array: &PythonArray,
+        _index: usize,
+        _ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Scalar> {
         todo!()
     }
 }


### PR DESCRIPTION
## Summary

This updates the `OperationsVTable` to inject an execution context for `scalar_at`.

This will allow the PatchedArray to execute a range of its indices child for linear search instead of issuing a `scalar_at` and cast in a loop.