### PR TITLE
Fix docs deploy after java changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
           mkdir -p docs/_static/vortex-jni
           mkdir -p docs/_static/vortex-spark
           cp -r java/vortex-jni/build/docs/javadoc/* docs/_static/vortex-jni/
-          cp -r java/vortex-spark/build/docs/javadoc/* docs/_static/vortex-spark/
+          cp -r java/vortex-spark_2.13/build/docs/javadoc/* docs/_static/vortex-spark/
       - name: build Python and Rust docs
         run: |
           uv run --all-packages make -C docs html

--- a/docs/developer-guide/internals/architecture.md
+++ b/docs/developer-guide/internals/architecture.md
@@ -76,12 +76,12 @@ Language bindings expose Vortex to non-Rust environments.
 
 Query engine integrations allow Vortex files to be queried through existing analytics engines.
 
-| Crate / Directory    | Engine     | Notes                                        |
-| -------------------- | ---------- | -------------------------------------------- |
-| `vortex-datafusion/` | DataFusion | `TableProvider` and `FileFormat` integration |
-| `vortex-duckdb/`     | DuckDB     | Table function integration                   |
-| `java/vortex-spark/` | Spark      | DataSource V2 connector via JNI              |
-| `java/vortex-trino/` | Trino      | Trino connector (in development)             |
+| Crate / Directory                | Engine     | Notes                                        |
+|----------------------------------| ---------- |----------------------------------------------|
+| `vortex-datafusion/`             | DataFusion | `TableProvider` and `FileFormat` integration |
+| `vortex-duckdb/`                 | DuckDB     | Table function integration                   |
+| `java/vortex-spark_{2.12,2.13}/` | Spark      | Spark DataSource V2 connector via JNI        |
+| `java/vortex-trino/`             | Trino      | Trino connector (in development)             |
 
 ## Other Crates
 


### PR DESCRIPTION
Copy docs from vortex-spark_2.13 as vortex-spark no longer exists

Signed-off-by: Robert Kruszewski <github@robertk.io>
