### PR TITLE
Fix java docs build for real

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,7 @@ jobs:
           mkdir -p docs/_static/vortex-jni
           mkdir -p docs/_static/vortex-spark
           cp -r java/vortex-jni/build/docs/javadoc/* docs/_static/vortex-jni/
-          cp -r java/vortex-spark_2.13/build/docs/javadoc/* docs/_static/vortex-spark/
+          cp -r vortex-spark/build/vortex-spark_2.13/docs/javadoc/* docs/_static/vortex-spark/
       - name: build Python and Rust docs
         run: |
           uv run --all-packages make -C docs html


### PR DESCRIPTION
Previous pr used wrong directory after all

Signed-off-by: Robert Kruszewski <github@robertk.io>
