### PR TITLE
chore[gpu]: split plan into unmaterialized / materialized

### DIFF
--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -38,8 +38,9 @@ use vortex::session::VortexSession;
 use vortex_cuda::CudaDeviceBuffer;
 use vortex_cuda::CudaExecutionCtx;
 use vortex_cuda::CudaSession;
-use vortex_cuda::dynamic_dispatch;
-use vortex_cuda::dynamic_dispatch::DynamicDispatchPlan;
+use vortex_cuda::dynamic_dispatch::CudaDispatchPlan;
+use vortex_cuda::dynamic_dispatch::MaterializedPlan;
+use vortex_cuda::dynamic_dispatch::UnmaterializedPlan;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
 
@@ -51,14 +52,14 @@ const BENCH_ARGS: &[(usize, &str)] = &[
 
 /// Launch the dynamic_dispatch kernel and return GPU-timed duration.
 ///
-/// This deliberately does not use `DynamicDispatchPlan::execute` because the
+/// This deliberately does not use `CudaDispatchPlan::execute` because the
 /// benchmark pre-allocates the output buffer and device plan once, then reuses
 /// them across iterations.
 fn run_timed(
     cuda_ctx: &mut CudaExecutionCtx,
     array_len: usize,
     output_buf: &CudaDeviceBuffer,
-    device_plan: &Arc<cudarc::driver::CudaSlice<DynamicDispatchPlan>>,
+    device_plan: &Arc<cudarc::driver::CudaSlice<CudaDispatchPlan>>,
     shared_mem_bytes: u32,
 ) -> VortexResult<Duration> {
     let cuda_function = cuda_ctx.load_function("dynamic_dispatch", &[PType::U32])?;
@@ -111,40 +112,43 @@ fn run_timed(
 
 /// Benchmark runner: builds a dynamic plan and launches the kernel.
 struct BenchRunner {
-    _plan: DynamicDispatchPlan,
+    _plan: CudaDispatchPlan,
     smem_bytes: u32,
     len: usize,
     // Keep alive
-    device_plan: Arc<cudarc::driver::CudaSlice<DynamicDispatchPlan>>,
+    device_plan: Arc<cudarc::driver::CudaSlice<CudaDispatchPlan>>,
     output_buf: CudaDeviceBuffer,
     _plan_buffers: Vec<vortex::array::buffer::BufferHandle>,
 }
 
 impl BenchRunner {
     fn new(array: &vortex::array::ArrayRef, len: usize, cuda_ctx: &CudaExecutionCtx) -> Self {
-        let (plan, plan_buffers) =
-            dynamic_dispatch::build_plan(array, cuda_ctx).vortex_expect("build_plan");
-        let smem_bytes = plan.shared_mem_bytes::<u32>();
+        let MaterializedPlan {
+            dispatch_plan,
+            device_buffers,
+            shared_mem_bytes,
+        } = UnmaterializedPlan::new(array)
+            .and_then(|p| p.materialize(cuda_ctx))
+            .vortex_expect("build_dyn_dispatch_plan");
 
         let device_plan = Arc::new(
             cuda_ctx
                 .stream()
-                .clone_htod(std::slice::from_ref(&plan))
+                .clone_htod(std::slice::from_ref(&dispatch_plan))
                 .expect("htod plan"),
         );
 
-        let output_slice = cuda_ctx
-            .device_alloc::<u32>(len.next_multiple_of(1024))
-            .expect("alloc output");
-        let output_buf = CudaDeviceBuffer::new(output_slice);
-
         Self {
-            _plan: plan,
-            smem_bytes,
+            _plan: dispatch_plan,
+            smem_bytes: shared_mem_bytes,
             len,
             device_plan,
-            output_buf,
-            _plan_buffers: plan_buffers,
+            output_buf: CudaDeviceBuffer::new(
+                cuda_ctx
+                    .device_alloc::<u32>(len.next_multiple_of(1024))
+                    .expect("alloc output"),
+            ),
+            _plan_buffers: device_buffers,
         }
     }
 

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -3,16 +3,17 @@
 
 //! Host interface for dynamic CUDA kernel dispatch.
 //!
-//! A [`DynamicDispatchPlan`] is a linear sequence of stages produced by
-//! [`build_plan`], which walks an encoding tree (e.g., `ALP(FoR(BitPacked))`)
-//! and flattens it into input stages followed by a single output stage.
+//! An [`UnmaterializedPlan`] walks an encoding tree (e.g., `ALP(FoR(BitPacked))`)
+//! and flattens it into a linear sequence of stages. Call
+//! [`materialize`](UnmaterializedPlan::materialize) to copy source buffers to
+//! the device, producing a [`MaterializedPlan`] ready for kernel launch.
 //!
-//! Input stages write intermediate results (dictionary values, run-end
-//! endpoints) into bump-allocated shared memory regions. The output stage
-//! references those regions and writes final results to global memory.
+//! For partially-fusable trees, [`find_unfusable_nodes`] identifies nodes
+//! that need separate kernels, and [`UnmaterializedPlan::new_with_subtree_inputs`] builds a plan
+//!  that incorporates their pre-executed arrays.
 //!
 //! Shared memory is dynamically sized at launch time via
-//! [`DynamicDispatchPlan::shared_mem_bytes`].
+//! [`UnmaterializedPlan::shared_mem_bytes`].
 
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
@@ -40,13 +41,18 @@ use crate::CudaDeviceBuffer;
 use crate::executor::CudaExecutionCtx;
 
 pub(crate) mod plan_builder;
-pub use plan_builder::build_plan;
+pub use plan_builder::MaterializedPlan;
+pub use plan_builder::UnmaterializedPlan;
+pub use plan_builder::find_unfusable_nodes;
 
 include!(concat!(env!("OUT_DIR"), "/dynamic_dispatch.rs"));
 
 // SAFETY: C ABI structs with contiguous memory.
 unsafe impl cudarc::driver::DeviceRepr for DynamicDispatchPlan {}
 unsafe impl cudarc::driver::DeviceRepr for Stage {}
+
+/// Type alias for the bindgen-generated C ABI struct.
+pub type CudaDispatchPlan = DynamicDispatchPlan;
 
 impl SourceOp {
     /// Unpack bit-packed data using FastLanes layout.
@@ -151,9 +157,7 @@ impl ScalarOp {
 }
 
 impl Stage {
-    /// Create an input stage that decodes an input into a shared memory region.
-    /// The output persists at `smem_offset` for the output stage to reference.
-    pub fn input(
+    pub fn new(
         input_ptr: u64,
         smem_offset: u32,
         len: u32,
@@ -172,20 +176,9 @@ impl Stage {
             scalar_ops: ops,
         }
     }
-
-    /// Create the output stage. The kernel tiles `ELEMENTS_PER_BLOCK` elements
-    /// through a [`SMEM_TILE_SIZE`] shared-memory region to reduce usage.
-    pub fn output(
-        input_ptr: u64,
-        smem_offset: u32,
-        source: SourceOp,
-        scalar_ops: &[ScalarOp],
-    ) -> Self {
-        Self::input(input_ptr, smem_offset, SMEM_TILE_SIZE, source, scalar_ops)
-    }
 }
 
-impl DynamicDispatchPlan {
+impl CudaDispatchPlan {
     /// Create a dispatch plan from a sequence of stages.
     /// The last stage is the output pipeline; earlier stages are input stages.
     ///
@@ -203,25 +196,9 @@ impl DynamicDispatchPlan {
             stages: buf,
         }
     }
+}
 
-    /// Compute the dynamic shared memory bytes needed for this plan.
-    ///
-    /// All input stage outputs must remain in shared memory simultaneously
-    /// so the output stage can reference them (e.g., dictionary lookups,
-    /// run-end resolution). The total is `max(smem_offset + len)` across
-    /// all stages, multiplied by the element size.
-    pub fn shared_mem_bytes<T>(&self) -> u32 {
-        let elem_size = size_of::<T>() as u32;
-        let mut max_end: u32 = 0;
-        for i in 0..self.num_stages as usize {
-            let end = self.stages[i].smem_offset + self.stages[i].len;
-            if end > max_end {
-                max_end = end;
-            }
-        }
-        max_end * elem_size
-    }
-
+impl MaterializedPlan {
     /// Allocate output, upload the plan to the device, and launch the
     /// `dynamic_dispatch` kernel.
     ///
@@ -234,7 +211,6 @@ impl DynamicDispatchPlan {
         self,
         output_ptype: PType,
         len: usize,
-        device_buffers: Vec<BufferHandle>,
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<Canonical> {
         let unsigned_ptype = match output_ptype {
@@ -245,7 +221,7 @@ impl DynamicDispatchPlan {
             other => vortex_bail!("dynamic dispatch does not support PType {:?}", other),
         };
         match_each_unsigned_integer_ptype!(unsigned_ptype, |T| {
-            self.execute_typed::<T>(output_ptype, len, device_buffers, ctx)
+            self.execute_typed::<T>(output_ptype, len, ctx)
         })
     }
 
@@ -253,7 +229,6 @@ impl DynamicDispatchPlan {
         self,
         output_ptype: PType,
         len: usize,
-        device_buffers: Vec<BufferHandle>,
         ctx: &mut CudaExecutionCtx,
     ) -> VortexResult<Canonical>
     where
@@ -268,17 +243,16 @@ impl DynamicDispatchPlan {
         let output_buf = CudaDeviceBuffer::new(ctx.device_alloc::<T>(len.next_multiple_of(1024))?);
         let device_plan = Arc::new(
             ctx.stream()
-                .clone_htod(std::slice::from_ref(&self))
+                .clone_htod(std::slice::from_ref(&self.dispatch_plan))
                 .map_err(|e| vortex_err!("copy plan to device: {e}"))?,
         );
 
-        let shared_mem_bytes = self.shared_mem_bytes::<T>();
         let cuda_function = ctx.load_function("dynamic_dispatch", &[T::PTYPE])?;
         let num_blocks = u32::try_from(len.div_ceil(2048))?;
         let config = LaunchConfig {
             grid_dim: (num_blocks, 1, 1),
             block_dim: (64, 1, 1),
-            shared_mem_bytes,
+            shared_mem_bytes: self.shared_mem_bytes,
         };
 
         let output_ptr = output_buf.offset_ptr();
@@ -290,9 +264,6 @@ impl DynamicDispatchPlan {
             args.arg(&array_len_u64);
             args.arg(&plan_ptr);
         })?;
-
-        drop(device_buffers);
-        drop(device_plan);
 
         Ok(Canonical::Primitive(PrimitiveArray::from_buffer_handle(
             BufferHandle::new_device(output_buf.slice_typed::<T>(0..len)),
@@ -330,12 +301,12 @@ mod tests {
     use vortex::error::VortexResult;
     use vortex::session::VortexSession;
 
-    use super::DynamicDispatchPlan;
+    use super::CudaDispatchPlan;
     use super::SMEM_TILE_SIZE;
     use super::ScalarOp;
     use super::SourceOp;
     use super::Stage;
-    use super::build_plan;
+    use super::UnmaterializedPlan;
     use crate::CudaBufferExt;
     use crate::CudaDeviceBuffer;
     use crate::CudaExecutionCtx;
@@ -374,15 +345,17 @@ mod tests {
             .map(|&r| ScalarOp::frame_of_ref(r as u64))
             .collect();
 
-        let plan = DynamicDispatchPlan::new([Stage::output(
+        let plan = CudaDispatchPlan::new([Stage::new(
             input_ptr,
             0,
+            len as u32,
             SourceOp::bitunpack(bit_width, 0),
             &scalar_ops,
         )]);
         assert_eq!(plan.stages[0].num_scalar_ops, 4);
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan)?;
+        let smem_bytes = (SMEM_TILE_SIZE) * size_of::<u32>() as u32;
+        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan, smem_bytes)?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -392,17 +365,18 @@ mod tests {
     fn test_plan_structure() {
         // Stage 0: input dict values (BP→FoR) into smem[0..256)
         // Stage 1: output codes (BP→FoR→DICT) into smem[256..2304), gather from smem[0]
-        let plan = DynamicDispatchPlan::new([
-            Stage::input(
+        let plan = CudaDispatchPlan::new([
+            Stage::new(
                 0xAAAA,
                 0,
                 256,
                 SourceOp::bitunpack(4, 0),
                 &[ScalarOp::frame_of_ref(10)],
             ),
-            Stage::output(
+            Stage::new(
                 0xBBBB,
                 256,
+                1024,
                 SourceOp::bitunpack(6, 0),
                 &[ScalarOp::frame_of_ref(42), ScalarOp::dict(0)],
             ),
@@ -459,9 +433,10 @@ mod tests {
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let (input_ptr, _di) = copy_raw_to_device(&cuda_ctx, &data)?;
 
-        let plan = DynamicDispatchPlan::new([Stage::output(
+        let plan = CudaDispatchPlan::new([Stage::new(
             input_ptr,
             0,
+            len as u32,
             SourceOp::load(),
             &[
                 ScalarOp::frame_of_ref(reference as u64),
@@ -470,7 +445,8 @@ mod tests {
             ],
         )]);
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan)?;
+        let smem_bytes = (100 + SMEM_TILE_SIZE) * size_of::<u32>() as u32;
+        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan, smem_bytes)?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -480,10 +456,9 @@ mod tests {
     fn run_dynamic_dispatch_plan(
         cuda_ctx: &CudaExecutionCtx,
         output_len: usize,
-        plan: &DynamicDispatchPlan,
+        plan: &CudaDispatchPlan,
+        shared_mem_bytes: u32,
     ) -> VortexResult<Vec<u32>> {
-        let smem_bytes = plan.shared_mem_bytes::<u32>();
-
         let output_slice = cuda_ctx
             .device_alloc::<u32>(output_len)
             .vortex_expect("alloc output");
@@ -514,7 +489,7 @@ mod tests {
         let config = LaunchConfig {
             grid_dim: (num_blocks, 1, 1),
             block_dim: (64, 1, 1),
-            shared_mem_bytes: smem_bytes,
+            shared_mem_bytes,
         };
         unsafe {
             launch_builder.launch(config).expect("kernel launch");
@@ -530,9 +505,10 @@ mod tests {
     fn run_dispatch_plan_f32(
         cuda_ctx: &CudaExecutionCtx,
         output_len: usize,
-        plan: &DynamicDispatchPlan,
+        plan: &CudaDispatchPlan,
+        shared_mem_bytes: u32,
     ) -> VortexResult<Vec<f32>> {
-        let actual = run_dynamic_dispatch_plan(cuda_ctx, output_len, plan)?;
+        let actual = run_dynamic_dispatch_plan(cuda_ctx, output_len, plan, shared_mem_bytes)?;
         // SAFETY: f32 and u32 have identical size and alignment.
         Ok(unsafe { std::mem::transmute::<Vec<u32>, Vec<f32>>(actual) })
     }
@@ -548,9 +524,10 @@ mod tests {
 
         let bp = make_bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&bp.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&bp.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan)?;
+        let actual =
+            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -572,9 +549,10 @@ mod tests {
         let for_arr = FoRArray::try_new(bp.into_array(), Scalar::from(reference))?;
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&for_arr.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&for_arr.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan)?;
+        let actual =
+            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -597,9 +575,10 @@ mod tests {
         let re = RunEndArray::new(ends_arr, values_arr);
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&re.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&re.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan)?;
+        let actual =
+            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -629,9 +608,10 @@ mod tests {
         let dict = DictArray::try_new(codes_bp.into_array(), dict_for.into_array())?;
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&dict.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&dict.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan)?;
+        let actual =
+            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -660,9 +640,10 @@ mod tests {
         );
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&tree.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&tree.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual = run_dispatch_plan_f32(&cuda_ctx, len, &plan)?;
+        let actual =
+            run_dispatch_plan_f32(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, floats);
 
         Ok(())
@@ -688,9 +669,10 @@ mod tests {
         let zz = ZigZagArray::try_new(bp.into_array())?;
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&zz.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&zz.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan)?;
+        let actual =
+            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -716,9 +698,10 @@ mod tests {
         let for_arr = FoRArray::try_new(re.into_array(), Scalar::from(reference))?;
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&for_arr.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&for_arr.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan)?;
+        let actual =
+            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -744,9 +727,10 @@ mod tests {
         let for_arr = FoRArray::try_new(dict.into_array(), Scalar::from(reference))?;
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&for_arr.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&for_arr.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan)?;
+        let actual =
+            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -771,9 +755,10 @@ mod tests {
         let dict = DictArray::try_new(codes_for.into_array(), values_prim.into_array())?;
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&dict.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&dict.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan)?;
+        let actual =
+            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -795,9 +780,10 @@ mod tests {
         let dict = DictArray::try_new(codes_bp.into_array(), values_prim.into_array())?;
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&dict.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&dict.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, len, &plan)?;
+        let actual =
+            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -813,9 +799,8 @@ mod tests {
         let values_prim = PrimitiveArray::new(Buffer::from(dict_values), NonNullable);
         let dict = DictArray::try_new(codes_prim.into_array(), values_prim.into_array())?;
 
-        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        // build_plan should fail because u8 codes != u32 values in byte width.
-        assert!(build_plan(&dict.into_array(), &cuda_ctx).is_err());
+        // UnmaterializedPlan::new should fail because u8 codes != u32 values in byte width.
+        assert!(UnmaterializedPlan::new(&dict.into_array()).is_err());
 
         Ok(())
     }
@@ -829,9 +814,8 @@ mod tests {
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
         let re = RunEndArray::new(ends_arr, values_arr);
 
-        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        // build_plan should fail because u64 ends != i32 values in byte width.
-        assert!(build_plan(&re.into_array(), &cuda_ctx).is_err());
+        // UnmaterializedPlan::new should fail because u64 ends != i32 values in byte width.
+        assert!(UnmaterializedPlan::new(&re.into_array()).is_err());
 
         Ok(())
     }
@@ -866,9 +850,14 @@ mod tests {
         let expected: Vec<u32> = data[slice_start..slice_end].to_vec();
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&sliced, &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&sliced)?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, expected.len(), &plan)?;
+        let actual = run_dynamic_dispatch_plan(
+            &cuda_ctx,
+            expected.len(),
+            &plan.dispatch_plan,
+            plan.shared_mem_bytes,
+        )?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -912,9 +901,14 @@ mod tests {
         let expected: Vec<u32> = all_decoded[slice_start..slice_end].to_vec();
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&sliced, &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&sliced)?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, expected.len(), &plan)?;
+        let actual = run_dynamic_dispatch_plan(
+            &cuda_ctx,
+            expected.len(),
+            &plan.dispatch_plan,
+            plan.shared_mem_bytes,
+        )?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -957,9 +951,14 @@ mod tests {
             .collect();
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&sliced, &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&sliced)?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, expected.len(), &plan)?;
+        let actual = run_dynamic_dispatch_plan(
+            &cuda_ctx,
+            expected.len(),
+            &plan.dispatch_plan,
+            plan.shared_mem_bytes,
+        )?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -997,9 +996,14 @@ mod tests {
         let expected: Vec<u32> = data[slice_start..slice_end].to_vec();
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&sliced, &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&sliced)?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, expected.len(), &plan)?;
+        let actual = run_dynamic_dispatch_plan(
+            &cuda_ctx,
+            expected.len(),
+            &plan.dispatch_plan,
+            plan.shared_mem_bytes,
+        )?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -1041,9 +1045,14 @@ mod tests {
         let expected: Vec<u32> = all_decoded[slice_start..slice_end].to_vec();
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&sliced, &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&sliced)?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, expected.len(), &plan)?;
+        let actual = run_dynamic_dispatch_plan(
+            &cuda_ctx,
+            expected.len(),
+            &plan.dispatch_plan,
+            plan.shared_mem_bytes,
+        )?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -1088,9 +1097,14 @@ mod tests {
         let expected: Vec<u32> = all_decoded[slice_start..slice_end].to_vec();
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&sliced, &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&sliced)?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, expected.len(), &plan)?;
+        let actual = run_dynamic_dispatch_plan(
+            &cuda_ctx,
+            expected.len(),
+            &plan.dispatch_plan,
+            plan.shared_mem_bytes,
+        )?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -1140,9 +1154,14 @@ mod tests {
         let expected: Vec<u32> = all_decoded[slice_start..slice_end].to_vec();
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&sliced, &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&sliced)?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, expected.len(), &plan)?;
+        let actual = run_dynamic_dispatch_plan(
+            &cuda_ctx,
+            expected.len(),
+            &plan.dispatch_plan,
+            plan.shared_mem_bytes,
+        )?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -1167,9 +1186,14 @@ mod tests {
         let seq = SequenceArray::try_new_typed(base, multiplier, Nullability::NonNullable, len)?;
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&seq.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&seq.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual = run_dynamic_dispatch_plan(&cuda_ctx, expected.len(), &plan)?;
+        let actual = run_dynamic_dispatch_plan(
+            &cuda_ctx,
+            expected.len(),
+            &plan.dispatch_plan,
+            plan.shared_mem_bytes,
+        )?;
         assert_eq!(actual, expected);
 
         Ok(())
@@ -1195,9 +1219,14 @@ mod tests {
         let seq = SequenceArray::try_new_typed(base, multiplier, Nullability::NonNullable, len)?;
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let (plan, _bufs) = build_plan(&seq.into_array(), &cuda_ctx)?;
+        let plan = UnmaterializedPlan::new(&seq.into_array())?.materialize(&cuda_ctx)?;
 
-        let actual_u32 = run_dynamic_dispatch_plan(&cuda_ctx, expected.len(), &plan)?;
+        let actual_u32 = run_dynamic_dispatch_plan(
+            &cuda_ctx,
+            expected.len(),
+            &plan.dispatch_plan,
+            plan.shared_mem_bytes,
+        )?;
         let actual: Vec<i32> = actual_u32.into_iter().map(|v| v as i32).collect();
         assert_eq!(actual, expected);
 

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -1,15 +1,33 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-//! Walks an encoding tree and builds a [`DynamicDispatchPlan`].
+//! Walks an encoding tree and produces a dispatch plan for a single GPU kernel launch.
+//! [`UnmaterializedPlan::new`] builds the plan without a CUDA context, then
+//! [`materialize`](UnmaterializedPlan::materialize) copies buffers to the device.
 //!
-//! The builder recursively inspects the array's encoding, moves leaf buffers
-//! to the device, computes shared memory offsets, and produces a plan that the
-//! dynamic dispatch kernel can execute in a single launch.
+//! For partially-fusable trees (where some nodes can't be fused into the
+//! dispatch plan), the free function [`with_subtree_inputs`] builds a plan
+//! that incorporates pre-executed subtree outputs as `LOAD` sources.
+//!
+//! The two-phase design allows callers to query shared memory requirements
+//! before committing to device allocation, and keeps the bulk of the logic
+//! independent of the CUDA runtime.
+//!
+//! # Known limitations
+//!
+//! TODO(0ax1): Optimize device buffer allocation and copying.
+//!
+//! Ideally, there would be a buffer pool of preallocated device memory such
+//! that retrieving a device pointer is O(1) during materialization. In the
+//! current setup, we allocate via the global allocator, which does not pin
+//! host memory to physical addresses (unlike `cudaHostAlloc`). This means
+//! the host-to-device copy is synchronous and cannot be pushed to the CUDA
+//! stream as an async operation.
 
 use std::sync::Arc;
 
 use vortex::array::ArrayRef;
+use vortex::array::ArrayVisitor;
 use vortex::array::DynArray;
 use vortex::array::ExecutionCtx;
 use vortex::array::arrays::Dict;
@@ -35,131 +53,45 @@ use vortex::error::vortex_bail;
 use vortex::error::vortex_err;
 use vortex::session::VortexSession;
 
-use super::DynamicDispatchPlan;
+use super::CudaDispatchPlan;
 use super::MAX_SCALAR_OPS;
 use super::MAX_STAGES;
+use super::SMEM_TILE_SIZE;
 use super::ScalarOp;
 use super::SourceOp;
 use super::Stage;
 use crate::CudaBufferExt;
 use crate::CudaExecutionCtx;
 
-/// The result of walking a subtree: a source op, scalar ops to apply after,
-/// and the device pointer to the leaf buffer.
-struct Pipeline {
-    source: SourceOp,
-    scalar_ops: Vec<ScalarOp>,
-    input_ptr: u64,
+/// A plan whose source buffers have been copied to the device, ready for kernel launch.
+pub struct MaterializedPlan {
+    /// The C ABI plan struct, ready to upload to the device.
+    pub dispatch_plan: CudaDispatchPlan,
+    /// Device buffer handles that must be kept alive while the plan is in use.
+    pub device_buffers: Vec<BufferHandle>,
+    /// Dynamic shared memory bytes needed to launch this plan.
+    pub shared_mem_bytes: u32,
 }
 
-/// Walk the encoding tree of `array` and build a [`DynamicDispatchPlan`].
+/// Find encoding-tree nodes that cannot be fused into a dynamic-dispatch plan.
 ///
-/// Leaf buffers are moved to the device if not already there. The returned
-/// buffer handles must be kept alive while the plan's device pointers are
-/// in use.
+/// Each returned node is the root of a branch that must be executed by a
+/// separate kernel. Their outputs can then be fed into
+/// [`UnmaterializedPlan::new_with_subtree_inputs`] as `LOAD` sources.
 ///
-/// # Plan construction
-///
-/// The builder walks the encoding tree from root to leaf. Single-child
-/// encodings (FoR, ZigZag, ALP) recurse into their child and append an
-/// element-wise transform to the pipeline. Leaf encodings (BitPacked,
-/// Primitive) produce a source op and a device pointer.
-///
-/// Encodings with multiple children (Dict, RunEnd) emit an input stage
-/// for each child, writing its output to shared memory. The root of the
-/// tree becomes the final output stage, which writes directly to global
-/// memory instead.
-///
-/// Shared memory offsets are bump-allocated: each input stage claims
-/// the next available region. Since the output stage may reference any
-/// input stage's output (e.g., dictionary lookup, run-end resolution),
-/// all regions must coexist simultaneously — the total shared memory
-/// is `max(smem_offset + len) * sizeof(T)` across all stages.
-///
-/// # Supported encodings
-///
-/// - `PrimitiveArray` → `LOAD` source
-/// - `BitPackedArray` → `BITUNPACK` source (no patches)
-/// - `FoRArray` → recurse + `FoR` scalar op
-/// - `ZigZagArray` → recurse + `ZigZag` scalar op
-/// - `ALPArray` → recurse + `ALP` scalar op (f32 only, no patches)
-/// - `DictArray` → input stage for values + recurse codes + `DICT` scalar op
-/// - `RunEndArray` → input stages for ends/values + `RUNEND` source
-/// - `SequenceArray` → `SEQUENCE` source (integer ptypes only)
-/// - `SliceArray` → resolve via child's slice reduce/kernel
-///
-/// # Limitations
-///
-/// **Nullability**: validity bitmaps are silently ignored. All output elements
-/// receive a value regardless of whether the input was null. Only arrays with
-/// `NonNullable` or `AllValid` validity produce correct results.
-///
-/// **Patches**: `BitPackedArray` with patches and `ALPArray` with patches are
-/// not supported and will return an error.
-///
-/// **f64 ALP**: Only f32 ALP is supported. The CUDA kernel's `AlpParams`
-/// stores multipliers as `float`, so f64 ALP arrays will return an error.
-pub fn build_plan(
-    array: &ArrayRef,
-    ctx: &CudaExecutionCtx,
-) -> VortexResult<(DynamicDispatchPlan, Vec<BufferHandle>)> {
-    build_plan_with_subtrees(array, ctx, &[])
-}
-
-/// Build a [`DynamicDispatchPlan`] with subtrees run as separate
-/// kernels that provide device buffers as inputs integrated via `LOAD`.
-pub fn build_plan_with_subtrees(
-    array: &ArrayRef,
-    ctx: &CudaExecutionCtx,
-    subtree_inputs: &[(ArrayRef, BufferHandle)],
-) -> VortexResult<(DynamicDispatchPlan, Vec<BufferHandle>)> {
-    let sub_map = subtree_inputs
-        .iter()
-        .map(|(arr, handle)| {
-            let ptr = handle.cuda_device_ptr()?;
-            Ok((Arc::as_ptr(arr) as *const () as usize, ptr))
-        })
-        .collect::<VortexResult<Vec<_>>>()?;
-
-    let mut state = PlanBuilderState {
-        ctx,
-        stages: Vec::new(),
-        smem_cursor: 0,
-        device_buffers: Vec::new(),
-        subtree_inputs: sub_map,
-    };
-
-    let pipeline = state.walk(array.clone())?;
-    let output_stage = Stage::output(
-        pipeline.input_ptr,
-        state.smem_cursor,
-        pipeline.source,
-        &pipeline.scalar_ops,
-    );
-    state.stages.push(output_stage);
-
-    assert!(state.stages.len() <= MAX_STAGES as usize);
-    assert!(
-        state
-            .stages
-            .iter()
-            .all(|&stage| (stage.num_scalar_ops as u32) <= MAX_SCALAR_OPS)
-    );
-
-    Ok((DynamicDispatchPlan::new(state.stages), state.device_buffers))
-}
-
-/// Walk the encoding tree and find subtrees that cannot be fused into a
-/// dynamic-dispatch plan. The root of each subtree has a node that cannot
-/// be fused.
-///
-/// Returns an empty vec if the root itself cannot be fused.
-pub fn find_subtrees(array: &ArrayRef) -> Vec<ArrayRef> {
+/// Returns an empty vec if the root itself is not fusable.
+pub fn find_unfusable_nodes(array: &ArrayRef) -> Vec<ArrayRef> {
     if !is_dyn_dispatch_compatible(array) {
         return Vec::new();
     }
     let mut out = Vec::new();
-    collect_subtrees(array, &mut out);
+    for child in array.children() {
+        if is_dyn_dispatch_compatible(&child) {
+            out.extend(find_unfusable_nodes(&child));
+        } else {
+            out.push(child);
+        }
+    }
     out
 }
 
@@ -213,81 +145,188 @@ fn is_dyn_dispatch_compatible(array: &ArrayRef) -> bool {
         || id == Sequence::ID
 }
 
-/// Walk the children of a dynamic dispatch compatible root node. Any child
-/// that is not dyn dispatch compatible is recorded as a subtree that must be
-/// executed separately.
-fn collect_subtrees(array: &ArrayRef, out: &mut Vec<ArrayRef>) {
-    let id = array.encoding_id();
-
-    fn visit_child(child: &ArrayRef, out: &mut Vec<ArrayRef>) {
-        if is_dyn_dispatch_compatible(child) {
-            collect_subtrees(child, out);
-        } else {
-            out.push(child.clone());
-        }
+/// Extract a FoR reference scalar as u64 bits.
+fn extract_for_reference(for_arr: &FoRArray) -> VortexResult<u64> {
+    if let Ok(v) = u32::try_from(for_arr.reference_scalar()) {
+        Ok(v as u64)
+    } else if let Ok(v) = i32::try_from(for_arr.reference_scalar()) {
+        Ok(v as u32 as u64)
+    } else if let Ok(v) = u64::try_from(for_arr.reference_scalar()) {
+        Ok(v)
+    } else if let Ok(v) = i64::try_from(for_arr.reference_scalar()) {
+        Ok(v as u64)
+    } else {
+        vortex_bail!("Cannot extract FoR reference as an integer type")
     }
-
-    if id == FoR::ID {
-        if let Ok(a) = array.clone().try_into::<FoR>() {
-            visit_child(a.encoded(), out);
-        }
-    } else if id == ZigZag::ID {
-        if let Ok(a) = array.clone().try_into::<ZigZag>() {
-            visit_child(a.encoded(), out);
-        }
-    } else if id == ALP::ID {
-        if let Ok(a) = array.clone().try_into::<ALP>() {
-            visit_child(a.encoded(), out);
-        }
-    } else if id == Slice::ID {
-        if let Some(a) = array.as_opt::<Slice>() {
-            visit_child(a.child(), out);
-        }
-    } else if id == Dict::ID
-        && let Ok(a) = array.clone().try_into::<Dict>()
-    {
-        visit_child(a.values(), out);
-        visit_child(a.codes(), out);
-    } else if id == RunEnd::ID
-        && let Ok(a) = array.clone().try_into::<RunEnd>()
-    {
-        visit_child(a.ends(), out);
-        visit_child(a.values(), out);
-    }
-    // BitPacked, Primitive, Sequence — leaves, no children.
 }
 
-/// Internal mutable state for the recursive tree walk.
-struct PlanBuilderState<'a> {
-    ctx: &'a CudaExecutionCtx,
-    /// Stages to process in the dynamic dispatch kernel.
-    stages: Vec<Stage>,
-    /// Next available element offset in shared memory.
-    smem_cursor: u32,
-    /// Device buffers to keep alive.
-    device_buffers: Vec<BufferHandle>,
-    /// Pre-executed subtree outputs injected as `LOAD` sources: `(identity, device_ptr)`.
-    subtree_inputs: Vec<(usize, u64)>,
+/// An unmaterialized stage: a source op, scalar ops, and optional source buffer reference.
+struct UnmaterializedStage {
+    source: SourceOp,
+    scalar_ops: Vec<ScalarOp>,
+    /// Index into `UnmaterializedPlan::source_buffers`, or `None`
+    /// for sources that don't read from a device buffer.
+    source_buffer_index: Option<usize>,
 }
 
-impl PlanBuilderState<'_> {
-    /// If `array` matches a pre-executed subtree input, return a `LOAD` pipeline pointing at its device buffer.
-    fn find_subtree(&self, array: &ArrayRef) -> Option<Pipeline> {
-        let subtree_id = Arc::as_ptr(array) as *const () as usize;
-        self.subtree_inputs
+impl UnmaterializedStage {
+    fn new(source: SourceOp, source_buffer_index: Option<usize>) -> Self {
+        Self {
+            source,
+            scalar_ops: vec![],
+            source_buffer_index,
+        }
+    }
+}
+
+type SmemOffset = u32;
+type StageLen = u32;
+type ArrayId = usize;
+type SourceBufferIdx = usize;
+
+/// A dispatch plan before device materialization.
+///
+/// Created by [`UnmaterializedPlan::new`] or [`new_with_subtree_inputs`](Self::new_with_subtree_inputs).
+/// Query shared memory requirements via [`shared_mem_bytes`](Self::shared_mem_bytes),
+/// then copy source buffers to the device via [`materialize`](Self::materialize).
+pub struct UnmaterializedPlan {
+    /// Input stages followed by one output stage.
+    stages: Vec<(UnmaterializedStage, SmemOffset, StageLen)>,
+    smem_cursor: SmemOffset,
+    source_buffers: Vec<BufferHandle>,
+    elem_bytes: u32,
+    subtree_inputs: Vec<(ArrayId, SourceBufferIdx)>,
+}
+
+impl UnmaterializedPlan {
+    /// Construct a plan by walking the encoding tree from root to leaf.
+    ///
+    /// No CUDA context is needed — source buffers are extracted but not
+    /// yet copied to the device. Call [`materialize`](Self::materialize)
+    /// to do the device copy.
+    ///
+    /// # Limitations
+    ///
+    /// - Validity bitmaps are ignored; only `NonNullable`/`AllValid` is supported.
+    /// - `BitPackedArray` and `ALPArray` with patches are not supported.
+    /// - Only f32 ALP is supported (kernel stores multipliers as `float`).
+    pub fn new(array: &ArrayRef) -> VortexResult<Self> {
+        Self::new_with_subtree_inputs(array, &[])
+    }
+
+    /// Build an [`UnmaterializedPlan`] with pre-executed subtree outputs
+    /// injected as `LOAD` sources.
+    ///
+    /// Used by hybrid dispatch when some nodes in the encoding tree cannot
+    /// be fused. Those nodes are executed separately, and their device buffers
+    /// are passed here so the remaining fusable tree can reference them.
+    pub fn new_with_subtree_inputs(
+        array: &ArrayRef,
+        subtree_inputs: &[(ArrayRef, BufferHandle)],
+    ) -> VortexResult<UnmaterializedPlan> {
+        let elem_bytes = PType::try_from(array.dtype())
+            .map_err(|_| {
+                vortex_err!(
+                    "dyn dispatch requires primitive dtype, got {:?}",
+                    array.dtype()
+                )
+            })?
+            .byte_width() as u32;
+
+        let subtree_map: Vec<(ArrayId, SourceBufferIdx)> = subtree_inputs
             .iter()
-            .find(|(id, _)| *id == subtree_id)
-            .map(|(_, ptr)| Pipeline {
-                source: SourceOp::load(),
-                scalar_ops: vec![],
-                input_ptr: *ptr,
-            })
+            .enumerate()
+            .map(|(leaf_idx, (arr, _handle))| (Arc::as_ptr(arr) as *const () as usize, leaf_idx))
+            .collect();
+
+        // Subtree source buffers get indices 0..n
+        let source_buffers: Vec<BufferHandle> = subtree_inputs
+            .iter()
+            .map(|(_, handle)| handle.clone())
+            .collect();
+
+        let mut plan = Self {
+            stages: Vec::new(),
+            smem_cursor: SmemOffset::from(0u32),
+            source_buffers,
+            elem_bytes,
+            subtree_inputs: subtree_map,
+        };
+
+        let len = array.len() as u32;
+        let output = plan.walk(array.clone())?;
+        plan.stages.push((output, plan.smem_cursor, len));
+
+        assert!(plan.stages.len() <= MAX_STAGES as usize);
+        assert!(
+            plan.stages
+                .iter()
+                .all(|(s, ..)| (s.scalar_ops.len() as u32) <= MAX_SCALAR_OPS)
+        );
+
+        Ok(plan)
     }
 
-    /// Recursively walk the encoding tree.
-    fn walk(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
-        if let Some(pipeline) = self.find_subtree(&array) {
-            return Ok(pipeline);
+    /// Shared memory bytes needed to launch this plan.
+    ///
+    /// Shared memory holds the *output* of each stage so later stages can
+    /// reference it (e.g., dictionary values, run-end endpoints). The total
+    /// is the sum of all input stage lengths plus the output tile size,
+    /// multiplied by the element byte width.
+    pub fn shared_mem_bytes(&self) -> u32 {
+        (self.smem_cursor + SMEM_TILE_SIZE) * self.elem_bytes
+    }
+
+    /// Copy source buffers to the device, producing a [`MaterializedPlan`].
+    pub fn materialize(self, ctx: &CudaExecutionCtx) -> VortexResult<MaterializedPlan> {
+        let shared_mem_bytes = self.shared_mem_bytes();
+        let mut device_buffers = Vec::new();
+        let mut device_ptrs: Vec<u64> = Vec::new();
+
+        // Copy each source buffer to the device and record its pointer.
+        for source_buf in self.source_buffers {
+            let device_buf = ctx.ensure_on_device_sync(source_buf)?;
+            let ptr = device_buf.cuda_device_ptr()?;
+            device_ptrs.push(ptr);
+            device_buffers.push(device_buf);
+        }
+
+        // Resolve the device pointer for a stage's source buffer.
+        // RUNEND and SEQUENCE sources don't read from global memory —
+        // they use shared memory or generate data on the fly, so
+        // `input_ptr = 0` is safe (the kernel never dereferences it).
+        let resolve_ptr = |stage: &UnmaterializedStage| -> u64 {
+            match stage.source_buffer_index {
+                Some(idx) => device_ptrs[idx],
+                None => 0,
+            }
+        };
+
+        let mut stages = Vec::with_capacity(self.stages.len());
+
+        for (stage, smem_offset, len) in &self.stages {
+            stages.push(Stage::new(
+                resolve_ptr(stage),
+                *smem_offset,
+                *len,
+                stage.source,
+                &stage.scalar_ops,
+            ));
+        }
+
+        Ok(MaterializedPlan {
+            dispatch_plan: CudaDispatchPlan::new(stages),
+            device_buffers,
+            shared_mem_bytes,
+        })
+    }
+
+    /// Walk the encoding tree, producing an [`UnmaterializedStage`] for the root.
+    fn walk(&mut self, array: ArrayRef) -> VortexResult<UnmaterializedStage> {
+        // Check if this array matches a pre-executed subtree input.
+        let subtree_id = Arc::as_ptr(&array) as *const () as usize;
+        if let Some((_, buf_idx)) = self.subtree_inputs.iter().find(|(id, _)| *id == subtree_id) {
+            return Ok(UnmaterializedStage::new(SourceOp::load(), Some(*buf_idx)));
         }
 
         if !is_dyn_dispatch_compatible(&array) {
@@ -329,7 +368,7 @@ impl PlanBuilderState<'_> {
     ///
     /// When the plan builder encounters a `SliceArray`, it resolves the slice
     /// by invoking the child's `reduce_parent`, `execute_parent`.
-    fn walk_slice(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
+    fn walk_slice(&mut self, array: ArrayRef) -> VortexResult<UnmaterializedStage> {
         let slice_arr = array.as_::<Slice>();
         let child = slice_arr.child().clone();
 
@@ -350,38 +389,15 @@ impl PlanBuilderState<'_> {
         )
     }
 
-    /// Canonical primitive array → LOAD source op.
-    ///
-    /// The device pointer accounts for buffer slicing, so no offset parameter is needed.
-    fn walk_primitive(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
+    fn walk_primitive(&mut self, array: ArrayRef) -> VortexResult<UnmaterializedStage> {
         let prim = array.to_canonical()?.into_primitive();
         let PrimitiveArrayParts { buffer, .. } = prim.into_parts();
-
-        // TODO(0ax1): Optimize device buffer allocation and copying.
-        //
-        // Ideally, there would be a buffer pool of preallocated device memory
-        // such that retrieving a device pointer is O(1) when building the
-        // dynamic dispatch plan. In the current setup, we need to allocate the
-        // buffer before we can get the device pointer. As the memory is
-        // allocated via the global allocator, which does not pin the host
-        // memory to physical addresses unlike `cudaHostAlloc`, the subsequent
-        // memory copy from host to device is sync and cannot be pushed to the
-        // CUDA stream as an async operation.
-        let device_buf = self.ctx.ensure_on_device_sync(buffer)?;
-        let ptr = device_buf.cuda_device_ptr()?;
-        self.device_buffers.push(device_buf);
-        Ok(Pipeline {
-            source: SourceOp::load(),
-            scalar_ops: vec![],
-            input_ptr: ptr,
-        })
+        let buf_index = self.source_buffers.len();
+        self.source_buffers.push(buffer);
+        Ok(UnmaterializedStage::new(SourceOp::load(), Some(buf_index)))
     }
 
-    /// BitPackedArray → BITUNPACK source op.
-    ///
-    /// The sub-byte element offset (0..=1023) is passed as a kernel parameter
-    /// as it cannot be expressed as pointer arithmetic on the device pointer.
-    fn walk_bitpacked(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
+    fn walk_bitpacked(&mut self, array: ArrayRef) -> VortexResult<UnmaterializedStage> {
         let bp = array
             .try_into::<BitPacked>()
             .map_err(|_| vortex_err!("Expected BitPackedArray"))?;
@@ -397,18 +413,15 @@ impl PlanBuilderState<'_> {
             vortex_bail!("Dynamic dispatch does not support BitPackedArray with patches");
         }
 
-        let device_buf = self.ctx.ensure_on_device_sync(packed)?;
-        let ptr = device_buf.cuda_device_ptr()?;
-        self.device_buffers.push(device_buf);
-        Ok(Pipeline {
-            source: SourceOp::bitunpack(bit_width, offset),
-            scalar_ops: vec![],
-            input_ptr: ptr,
-        })
+        let buf_index = self.source_buffers.len();
+        self.source_buffers.push(packed);
+        Ok(UnmaterializedStage::new(
+            SourceOp::bitunpack(bit_width, offset),
+            Some(buf_index),
+        ))
     }
 
-    /// FoRArray → recurse into encoded child, add FoR scalar op.
-    fn walk_for(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
+    fn walk_for(&mut self, array: ArrayRef) -> VortexResult<UnmaterializedStage> {
         let for_arr = array
             .try_into::<FoR>()
             .map_err(|_| vortex_err!("Expected FoRArray"))?;
@@ -420,8 +433,7 @@ impl PlanBuilderState<'_> {
         Ok(pipeline)
     }
 
-    /// ZigZagArray → recurse into encoded child, add ZigZag scalar op.
-    fn walk_zigzag(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
+    fn walk_zigzag(&mut self, array: ArrayRef) -> VortexResult<UnmaterializedStage> {
         let zz = array
             .try_into::<ZigZag>()
             .map_err(|_| vortex_err!("Expected ZigZagArray"))?;
@@ -432,8 +444,7 @@ impl PlanBuilderState<'_> {
         Ok(pipeline)
     }
 
-    /// ALPArray → recurse into encoded child, add ALP scalar op (f32 only).
-    fn walk_alp(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
+    fn walk_alp(&mut self, array: ArrayRef) -> VortexResult<UnmaterializedStage> {
         let alp = array
             .try_into::<ALP>()
             .map_err(|_| vortex_err!("Expected ALPArray"))?;
@@ -460,8 +471,7 @@ impl PlanBuilderState<'_> {
         Ok(pipeline)
     }
 
-    /// DictArray → add input stage for values, recurse into codes, add DICT scalar op.
-    fn walk_dict(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
+    fn walk_dict(&mut self, array: ArrayRef) -> VortexResult<UnmaterializedStage> {
         let dict = array
             .try_into::<Dict>()
             .map_err(|_| vortex_err!("Expected DictArray"))?;
@@ -475,10 +485,7 @@ impl PlanBuilderState<'_> {
         Ok(pipeline)
     }
 
-    /// SequenceArray → SEQUENCE source op
-    ///
-    /// Generates `value[i] = base + i * multiplier` on the GPU.
-    fn walk_sequence(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
+    fn walk_sequence(&mut self, array: ArrayRef) -> VortexResult<UnmaterializedStage> {
         let seq = array
             .try_into::<Sequence>()
             .map_err(|_| vortex_err!("Expected SequenceArray"))?;
@@ -486,16 +493,13 @@ impl PlanBuilderState<'_> {
             base, multiplier, ..
         } = seq.into_parts();
 
-        Ok(Pipeline {
-            source: SourceOp::sequence(base.cast()?, multiplier.cast()?),
-            scalar_ops: vec![],
-            // SEQUENCE does not have an input pointer.
-            input_ptr: 0,
-        })
+        Ok(UnmaterializedStage::new(
+            SourceOp::sequence(base.cast()?, multiplier.cast()?),
+            None,
+        ))
     }
 
-    /// RunEndArray → add input stages for ends and values, RUNEND source op.
-    fn walk_runend(&mut self, array: ArrayRef) -> VortexResult<Pipeline> {
+    fn walk_runend(&mut self, array: ArrayRef) -> VortexResult<UnmaterializedStage> {
         let re = array
             .try_into::<RunEnd>()
             .map_err(|_| vortex_err!("Expected RunEndArray"))?;
@@ -506,43 +510,18 @@ impl PlanBuilderState<'_> {
         let ends_smem = self.add_input_stage(ends)?;
         let values_smem = self.add_input_stage(values)?;
 
-        Ok(Pipeline {
-            source: SourceOp::runend(ends_smem, values_smem, num_runs, offset),
-            scalar_ops: vec![],
-            input_ptr: 0,
-        })
+        Ok(UnmaterializedStage::new(
+            SourceOp::runend(ends_smem, values_smem, num_runs, offset),
+            None,
+        ))
     }
 
-    /// Recursively walk `array` and add it as an input stage in shared memory.
-    /// Claims the next `array.len()` elements from the bump allocator and
-    /// returns the smem element offset where this stage's output begins.
     fn add_input_stage(&mut self, array: ArrayRef) -> VortexResult<u32> {
         let smem_offset = self.smem_cursor;
         let len = array.len() as u32;
-        let pipeline = self.walk(array)?;
-        self.stages.push(Stage::input(
-            pipeline.input_ptr,
-            smem_offset,
-            len,
-            pipeline.source,
-            &pipeline.scalar_ops,
-        ));
+        let spec = self.walk(array)?;
+        self.stages.push((spec, smem_offset, len));
         self.smem_cursor += len;
         Ok(smem_offset)
-    }
-}
-
-/// Extract a FoR reference scalar as u64 bits.
-fn extract_for_reference(for_arr: &FoRArray) -> VortexResult<u64> {
-    if let Ok(v) = u32::try_from(for_arr.reference_scalar()) {
-        Ok(v as u64)
-    } else if let Ok(v) = i32::try_from(for_arr.reference_scalar()) {
-        Ok(v as u32 as u64)
-    } else if let Ok(v) = u64::try_from(for_arr.reference_scalar()) {
-        Ok(v)
-    } else if let Ok(v) = i64::try_from(for_arr.reference_scalar()) {
-        Ok(v as u64)
-    } else {
-        vortex_bail!("Cannot extract FoR reference as an integer type")
     }
 }

--- a/vortex-cuda/src/hybrid_dispatch/mod.rs
+++ b/vortex-cuda/src/hybrid_dispatch/mod.rs
@@ -4,31 +4,30 @@
 //! Hybrid dispatch: fuses dynamic-dispatch plans with single-kernel fallbacks.
 //!
 //! When an array is executed on the GPU, we fuse as much of its encoding
-//! tree as possible into dynamic-dispatch kernel launches.  Encodings the
-//! plan builder cannot handle are executed by their own kernels, and their
-//! outputs are fed back into the fused plan as `LOAD` source ops.
+//! tree as possible into a single kernel launch via [`UnmaterializedPlan`].
+//! Nodes the plan builder cannot handle are found by [`find_unfusable_nodes`],
+//! executed by their own kernels, and their outputs fed back into the fused
+//! plan as `LOAD` sources via [`UnmaterializedPlan::new_with_subtree_inputs`].
 //!
 //! ```text
-//!   Dict                       <-- dyn-dispatch-compatible
-//!   ├── codes: FoR(BP)         <-- dyn-dispatch-compatible
-//!   └── values: Zstd(FoR(BP)) <-- Zstd is NOT compatible ("subtree")
-//!                 └── FoR(BP)  <-- compatible (fuses inside the subtree)
+//!   Dict                       <-- fusable
+//!   ├── codes: FoR(BP)         <-- fusable
+//!   └── values: Zstd(FoR(BP)) <-- Zstd is NOT fusable (unfusable node)
+//!                 └── FoR(BP)  <-- fusable (fuses inside the subtree)
 //! ```
-//!
-//! A "subtree" is a branch with a root node that is not dyn dispatch compatible
-//! (below a compatible parent). It is executed via `execute_cuda`, which
-//! re-enters `try_gpu_dispatch` so compatible descendants still get fused.
 //!
 //! Strategies tried in order:
 //!
-//! 1. Fully fused — no subtrees, whole tree is one `DynamicDispatchPlan`.
+//! 1. Fully fused — no unfusable nodes, entire tree compiles into one
+//!    [`UnmaterializedPlan`] → [`MaterializedPlan`](crate::dynamic_dispatch::MaterializedPlan) → kernel launch.
 //!
-//! 2. Partial fusion — subtrees are executed first (sequentially, same
-//!    stream), their device buffers become `LOAD` ops in a fused plan.
-//!    Each subtree re-enters `try_gpu_dispatch` and may itself fuse.
+//! 2. Partial fusion — unfusable nodes are executed first (sequentially,
+//!    same stream), their device buffers become `LOAD` ops in a fused plan
+//!    via [`UnmaterializedPlan::new_with_subtree_inputs`]. Each node re-enters [`try_gpu_dispatch`]
+//!    and may itself fuse.
 //!
-//! 3. Fallback — root is not compatible.  Delegate to its registered
-//!    `CudaExecute` kernel; its children re-enter `try_gpu_dispatch`.
+//! 3. Fallback — root is not fusable. Delegate to its registered
+//!    `CudaExecute` kernel; its children re-enter [`try_gpu_dispatch`].
 //!
 //! All three compose recursively to arbitrary depth.
 //!
@@ -52,24 +51,20 @@ use vortex::dtype::PType;
 use vortex::error::VortexResult;
 use vortex::error::vortex_err;
 
-use crate::dynamic_dispatch::plan_builder::build_plan;
-use crate::dynamic_dispatch::plan_builder::build_plan_with_subtrees;
-use crate::dynamic_dispatch::plan_builder::find_subtrees;
+use crate::dynamic_dispatch::plan_builder::UnmaterializedPlan;
+use crate::dynamic_dispatch::plan_builder::find_unfusable_nodes;
 use crate::executor::CudaArrayExt;
 use crate::executor::CudaExecutionCtx;
 
 /// Try to execute `array` on the GPU, attempting three strategies in order:
 ///
-/// 1. Fully fused — the entire encoding tree compiles into one
-///    `DynamicDispatchPlan` kernel launch.
-/// 2. Partially fused — incompatible subtrees are executed first
-///    (via recursive `execute_cuda`), then the remaining compatible tree
-///    is fused into a single plan with their outputs as `LOAD` sources.
-/// 3. Single-kernel fallback — the root encoding's registered
-///    `CudaExecute` kernel handles one layer; its children re-enter
-///    this function recursively.
+/// 1. Fully fused — [`UnmaterializedPlan::new`] + [`materialize`](UnmaterializedPlan::materialize).
+/// 2. Partially fused — unfusable nodes executed first, then
+///    [`UnmaterializedPlan::new_with_subtree_inputs`] + [`materialize`](UnmaterializedPlan::materialize).
+/// 3. Fallback — root encoding's `CudaExecute` kernel; children
+///    re-enter this function recursively.
 ///
-/// Returns `Ok(Canonical)` on success.  Returns `Err` when the array
+/// Returns `Ok(Canonical)` on success. Returns `Err` when the array
 /// cannot be handled (non-primitive output dtype, no registered kernel).
 pub async fn try_gpu_dispatch(
     array: &ArrayRef,
@@ -84,13 +79,13 @@ pub async fn try_gpu_dispatch(
 
     trace!(encoding = %array.encoding_id(), ptype = %output_ptype, len = array.len(), "attempting dyn dispatch");
 
-    let subtrees = find_subtrees(array);
+    let subtrees = find_unfusable_nodes(array);
 
     if subtrees.is_empty() {
         // Whole tree is dyn-dispatch-compatible.
-        if let Ok((plan, bufs)) = build_plan(array, ctx) {
-            debug!(encoding = %array.encoding_id(), num_stages = plan.num_stages, "fully-fused dyn dispatch");
-            return plan.execute(output_ptype, array.len(), bufs, ctx);
+        if let Ok(plan) = UnmaterializedPlan::new(array).and_then(|p| p.materialize(ctx)) {
+            debug!(encoding = %array.encoding_id(), num_stages = plan.dispatch_plan.num_stages, "fully-fused dyn dispatch");
+            return plan.execute(output_ptype, array.len(), ctx);
         }
     } else if let Some(result) =
         // Incompatible subtrees are executed first (re-entering try_gpu_dispatch),
@@ -108,8 +103,8 @@ pub async fn try_gpu_dispatch(
         .await
 }
 
-/// Execute each subtree that is not dyn-dispatch-compatible, then build a fused
-/// plan that reads their outputs via `LOAD`. Returns `None` if partial fusion
+/// Execute each unfusable node separately, then build a fused plan that reads
+/// their outputs via [`with_subtree_inputs`]. Returns `None` if partial fusion
 /// isn't possible (e.g. a subtree produced a non-primitive result).
 async fn try_partial_fuse(
     array: &ArrayRef,
@@ -134,14 +129,17 @@ async fn try_partial_fuse(
         ));
     }
 
-    let Ok((plan, mut bufs)) = build_plan_with_subtrees(array, ctx, &subtree_inputs) else {
+    let Ok(mut plan) = UnmaterializedPlan::new_with_subtree_inputs(array, &subtree_inputs)
+        .and_then(|p| p.materialize(ctx))
+    else {
         return Ok(None);
     };
 
     let n = subtree_inputs.len();
-    bufs.extend(subtree_inputs.into_iter().map(|(_, h)| h));
-    debug!(encoding = %array.encoding_id(), num_stages = plan.num_stages, num_subtrees = n, "partially-fused dyn dispatch");
-    plan.execute(output_ptype, array.len(), bufs, ctx).map(Some)
+    plan.device_buffers
+        .extend(subtree_inputs.into_iter().map(|(_, h)| h));
+    debug!(encoding = %array.encoding_id(), num_stages = plan.dispatch_plan.num_stages, num_subtrees = n, "partially-fused dyn dispatch");
+    plan.execute(output_ptype, array.len(), ctx).map(Some)
 }
 
 #[cfg(test)]
@@ -189,7 +187,7 @@ mod tests {
     }
 
     /// ALP(FoR(BP)) f32 — fully fused, output is f32 but kernel runs as u32.
-    /// Exercises the unsigned type reinterpretation in DynamicDispatchPlan::execute.
+    /// Exercises the unsigned type reinterpretation in CudaDispatchPlan::execute.
     #[crate::test]
     async fn test_fused_f32() -> VortexResult<()> {
         use vortex::encodings::alp::ALPArray;


### PR DESCRIPTION
This allows for checking whether the shared memory usage blows past the max GPU device shared memory before launching the dyn dispatch kernel, as well as having a separate materialize step we can fine tune that moves buffers from the host to the GPU.