### PR TITLE
Filter indices without an iterator for Bool

### DIFF
--- a/vortex-array/src/arrays/bool/compute/filter.rs
+++ b/vortex-array/src/arrays/bool/compute/filter.rs
@@ -28,11 +28,7 @@ impl FilterReduce for Bool {
             .vortex_expect("AllTrue and AllFalse are handled by filter fn");
 
         let buffer = match mask_values.threshold_iter(FILTER_SLICES_DENSITY_THRESHOLD) {
-            MaskIter::Indices(indices) => filter_indices(
-                &array.to_bit_buffer(),
-                mask.true_count(),
-                indices.iter().copied(),
-            ),
+            MaskIter::Indices(indices) => filter_indices(&array.to_bit_buffer(), indices),
             MaskIter::Slices(slices) => filter_slices(
                 &array.to_bit_buffer(),
                 mask.true_count(),
@@ -44,24 +40,18 @@ impl FilterReduce for Bool {
     }
 }
 
-/// Select indices from a boolean buffer.
-/// NOTE: it was benchmarked to be faster using collect_bool to index into a slice than to
-///  pass the indices as an iterator of usize. So we keep this alternate implementation.
-pub fn filter_indices(
-    bools: &BitBuffer,
-    indices_len: usize,
-    mut indices: impl Iterator<Item = usize>,
-) -> BitBuffer {
+fn filter_indices(bools: &BitBuffer, indices: &[usize]) -> BitBuffer {
     let buffer = bools.inner().as_ref();
-    BitBuffer::collect_bool(indices_len, |_idx| {
-        let idx = indices
-            .next()
-            .vortex_expect("iterator is guaranteed to be within the length of the array.");
-        get_bit(buffer, bools.offset() + idx)
+    let offset = bools.offset();
+    BitBuffer::collect_bool(indices.len(), |idx| {
+        // Safety:
+        // We iterate over the slice's length.
+        let idx = unsafe { indices.get_unchecked(idx) } + offset;
+        get_bit(buffer, idx)
     })
 }
 
-pub fn filter_slices(
+fn filter_slices(
     buffer: &BitBuffer,
     indices_len: usize,
     slices: impl Iterator<Item = (usize, usize)>,
@@ -76,13 +66,13 @@ pub fn filter_slices(
 
 #[cfg(test)]
 mod test {
+
     use itertools::Itertools;
     use vortex_mask::Mask;
 
+    use super::*;
     use crate::IntoArray;
     use crate::arrays::BoolArray;
-    use crate::arrays::bool::compute::filter::filter_indices;
-    use crate::arrays::bool::compute::filter::filter_slices;
     use crate::assert_arrays_eq;
     use crate::compute::conformance::filter::test_filter_conformance;
 
@@ -107,7 +97,7 @@ mod test {
     fn filter_bool_by_index_test() {
         let arr = BoolArray::from_iter([true, true, false]);
 
-        let filtered = filter_indices(&arr.to_bit_buffer(), 2, [0, 2].into_iter());
+        let filtered = filter_indices(&arr.to_bit_buffer(), &[0, 2]);
         assert_eq!(vec![true, false], filtered.iter().collect_vec())
     }
 


### PR DESCRIPTION
## Summary

Noticed this difference as part of #6740 that changed some of the inlining around `collect_bool`, making the closure not inlined.
The comment over `filter_indices` used to be on a different function, and the iterator and generics seems wasteful.

This seems to be about 30µs faster than develop pre #6470 for most affected benchmarks, which is about 3% (probably within the noise, but the affect seems very consistent).
