### PR TITLE
Unify benchmark dispatch into a workflow

### DIFF
--- a/.github/workflows/bench-dispatch.yml
+++ b/.github/workflows/bench-dispatch.yml
@@ -1,0 +1,49 @@
+# Dispatches benchmark workflows when benchmark labels are added to pull requests.
+# This is a separate workflow so that non-benchmark label events don't create
+# phantom check suites that obscure in-progress benchmark runs on the PR.
+
+name: Benchmark Dispatch
+
+on:
+  pull_request:
+    types: [labeled]
+    branches: ["develop"]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write  # for label removal and PR comments
+  id-token: write  # enables AWS-GitHub OIDC
+
+jobs:
+  remove-bench-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: github.event.label.name == 'action/benchmark'
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        if: github.event.pull_request.head.repo.full_name == 'vortex-data/vortex'
+        with:
+          labels: action/benchmark
+          fail_on_error: true
+
+  bench:
+    needs: remove-bench-label
+    uses: ./.github/workflows/bench-pr.yml
+    secrets: inherit
+
+  remove-sql-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    if: github.event.label.name == 'action/benchmark-sql'
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        if: github.event.pull_request.head.repo.full_name == 'vortex-data/vortex'
+        with:
+          labels: action/benchmark-sql
+          fail_on_error: true
+
+  sql-bench:
+    needs: remove-sql-label
+    uses: ./.github/workflows/sql-pr.yml
+    secrets: inherit

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -4,7 +4,13 @@ name: PR Benchmarks
 
 concurrency:
   # The group causes runs to queue instead of running in parallel.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  # Use a unique group for non-benchmark label events so they don't interfere with in-progress benchmark runs.
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.label.name == 'action/benchmark'
+      && github.head_ref
+      || github.run_id
+    }}
   # Don't cancel benchmarks that are already running, instead just queue them up.
   cancel-in-progress: false
 

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,46 +1,25 @@
-# Runs all benchmarks once when we add the `action/benchmark` tag to a pull request.
+# Runs all benchmarks once for a pull request.
+# Called from bench-dispatch.yml when the `action/benchmark` label is added.
 
 name: PR Benchmarks
 
 concurrency:
   # The group causes runs to queue instead of running in parallel.
-  # Use a unique group for non-benchmark label events so they don't interfere with in-progress benchmark runs.
-  group: >-
-    ${{ github.workflow }}-${{
-      github.event.label.name == 'action/benchmark'
-      && github.head_ref
-      || github.run_id
-    }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   # Don't cancel benchmarks that are already running, instead just queue them up.
   cancel-in-progress: false
 
 on:
-  pull_request:
-    types: [labeled, synchronize]
-    branches: ["develop"]
+  workflow_call: { }
   workflow_dispatch: { }
 
 permissions:
-  actions: write  # for removing labels
   contents: read
   pull-requests: write  # for commenting on PRs
   id-token: write  # enables AWS-GitHub OIDC
 
 jobs:
-  label_trigger:
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    if: ${{ contains(github.event.head_commit.message, '[benchmark]') || github.event.label.name == 'action/benchmark' && github.event_name == 'pull_request' }}
-    steps:
-      # We remove the benchmark label first so that the workflow can be re-triggered.
-      - uses: actions-ecosystem/action-remove-labels@v1
-        if: ${{ github.event.pull_request.head.repo.full_name == 'vortex-data/vortex' }}
-        with:
-          labels: action/benchmark
-          fail_on_error: true
-
   bench:
-    needs: label_trigger
     timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
@@ -54,7 +33,6 @@ jobs:
             build_args: "--features lance"
           - id: compress-bench
             name: Compression
-    if: ${{ contains(github.event.head_commit.message, '[benchmark]') || github.event.label.name == 'action/benchmark' && github.event_name == 'pull_request' }}
     steps:
       - uses: runs-on/action@v2
         if: github.event.pull_request.head.repo.fork == false
@@ -143,17 +121,16 @@ jobs:
           comment-tag: bench-pr-comment-${{ matrix.benchmark.id }}
 
       - name: Comment PR on failure
-        if: failure() && inputs.mode == 'pr' && github.event.pull_request.head.repo.fork == false
+        if: failure() && github.event.pull_request.head.repo.fork == false
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
-            # 🚨🚨🚨❌❌❌ BENCHMARK FAILED ❌❌❌🚨🚨🚨
+            # BENCHMARK FAILED
 
             Benchmark `${{ matrix.benchmark.name }}` failed! Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
           comment-tag: bench-pr-comment-${{ matrix.benchmark.id }}
 
   sql:
-    needs: label_trigger
     uses: ./.github/workflows/sql-benchmarks.yml
     secrets: inherit
     with:

--- a/.github/workflows/sql-pr.yml
+++ b/.github/workflows/sql-pr.yml
@@ -1,44 +1,23 @@
-# Runs once when we add the `benchmark-sql` tag to a pull request.
+# Runs SQL benchmarks once for a pull request.
+# Called from bench-dispatch.yml when the `action/benchmark-sql` label is added.
 
 name: PR SQL Benchmarks
 
 concurrency:
-  # Use a unique group for non-benchmark label events so they don't interfere with in-progress benchmark runs.
-  group: >-
-    ${{ github.workflow }}-${{
-      github.event.label.name == 'action/benchmark-sql'
-      && github.head_ref
-      || github.run_id
-    }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:
-  pull_request:
-    types: [labeled, synchronize]
-    branches: ["develop"]
+  workflow_call: { }
   workflow_dispatch: { }
 
 permissions:
-  actions: write  # for removing labels
   contents: read
   pull-requests: write  # for commenting on PRs
   id-token: write  # enables AWS-GitHub OIDC
 
 jobs:
-  label_trigger:
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    if: ${{ contains(github.event.head_commit.message, '[benchmark-sql]') || github.event.label.name == 'action/benchmark-sql' && github.event_name == 'pull_request' }}
-    steps:
-      # We remove the benchmark label first so that the workflow can be re-triggered.
-      - uses: actions-ecosystem/action-remove-labels@v1
-        if: ${{ github.event.pull_request.head.repo.full_name == 'vortex-data/vortex' }}
-        with:
-          labels: action/benchmark-sql
-          fail_on_error: true
-
   sql:
-    needs: label_trigger
     uses: ./.github/workflows/sql-benchmarks.yml
     secrets: inherit
     with:

--- a/.github/workflows/sql-pr.yml
+++ b/.github/workflows/sql-pr.yml
@@ -3,7 +3,13 @@
 name: PR SQL Benchmarks
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  # Use a unique group for non-benchmark label events so they don't interfere with in-progress benchmark runs.
+  group: >-
+    ${{ github.workflow }}-${{
+      github.event.label.name == 'action/benchmark-sql'
+      && github.head_ref
+      || github.run_id
+    }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
This PR started as something else, but I still think its nicer to split the flows into another workflow to handle triggering the benchmarks themselves.