### PR TITLE
make Mimalloc opt-in for ffi

### DIFF
--- a/vortex-ffi/Cargo.toml
+++ b/vortex-ffi/Cargo.toml
@@ -39,7 +39,6 @@ tempfile = { workspace = true }
 cbindgen = { workspace = true }
 
 [features]
-default = ["mimalloc"]
 mimalloc = ["dep:mimalloc"]
 
 [lib]


### PR DESCRIPTION
FFI library should not bring own allocator.
Also, in CI Mimalloc makes sanitizers not detect leaks
