### PR TITLE
Cache python class imports

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1921,7 +1921,7 @@ requires-dist = [
     { name = "polars", marker = "extra == 'polars'", specifier = ">=1.31.0" },
     { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "ray", marker = "extra == 'ray'", specifier = ">=2.48" },
-    { name = "substrait", specifier = ">=0.23.0,<0.85.0" },
+    { name = "substrait", specifier = ">=0.23.0,<0.29.0" },
     { name = "typing-extensions", specifier = ">=4.5.0" },
 ]
 provides-extras = ["duckdb", "numpy", "pandas", "polars", "ray"]

--- a/vortex-python/build.rs
+++ b/vortex-python/build.rs
@@ -2,9 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 fn main() {
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-
-    if target_os == "macos" {
+    #[cfg(target_os = "macos")]
+    {
         // For pyo3 to successfully link on macOS.
         // See https://stackoverflow.com/a/77382609
         println!("cargo:rustc-link-arg=-undefined");

--- a/vortex-python/src/arrays/from_arrow.rs
+++ b/vortex-python/src/arrays/from_arrow.rs
@@ -20,22 +20,25 @@ use vortex::error::VortexResult;
 
 use crate::arrays::PyArrayRef;
 use crate::arrow::FromPyArrow;
+use crate::classes::array_class;
+use crate::classes::chunked_array_class;
+use crate::classes::table_class;
 use crate::error::PyVortexError;
 use crate::error::PyVortexResult;
 
 /// Convert an Arrow object to a Vortex array.
 pub(super) fn from_arrow(obj: &Borrowed<'_, '_, PyAny>) -> PyVortexResult<PyArrayRef> {
-    let pa = obj.py().import("pyarrow")?;
-    let pa_array = pa.getattr("Array")?;
-    let chunked_array = pa.getattr("ChunkedArray")?;
-    let table = pa.getattr("Table")?;
+    let py = obj.py();
+    let pa_array = array_class(py)?;
+    let chunked_array = chunked_array_class(py)?;
+    let table = table_class(py)?;
 
-    if obj.is_instance(&pa_array)? {
+    if obj.is_instance(pa_array)? {
         let arrow_array = ArrowArrayData::from_pyarrow(&obj.as_borrowed()).map(make_array)?;
         let is_nullable = arrow_array.is_nullable();
         let enc_array = ArrayRef::from_arrow(arrow_array.as_ref(), is_nullable)?;
         Ok(PyArrayRef::from(enc_array))
-    } else if obj.is_instance(&chunked_array)? {
+    } else if obj.is_instance(chunked_array)? {
         let chunks: Vec<Bound<PyAny>> = obj.getattr("chunks")?.extract()?;
         let encoded_chunks = chunks
             .iter()
@@ -51,7 +54,7 @@ pub(super) fn from_arrow(obj: &Borrowed<'_, '_, PyAny>) -> PyVortexResult<PyArra
         Ok(PyArrayRef::from(
             ChunkedArray::try_new(encoded_chunks, dtype)?.into_array(),
         ))
-    } else if obj.is_instance(&table)? {
+    } else if obj.is_instance(table)? {
         let array_stream = ArrowArrayStreamReader::from_pyarrow(&obj.as_borrowed())?;
         let dtype = DType::from_arrow(array_stream.schema());
         let chunks = array_stream

--- a/vortex-python/src/arrays/from_arrow.rs
+++ b/vortex-python/src/arrays/from_arrow.rs
@@ -8,6 +8,7 @@ use arrow_data::ArrayData as ArrowArrayData;
 use arrow_schema::DataType;
 use arrow_schema::Field;
 use pyo3::exceptions::PyValueError;
+use pyo3::intern;
 use pyo3::prelude::*;
 use vortex::array::ArrayRef;
 use vortex::array::IntoArray;
@@ -39,7 +40,7 @@ pub(super) fn from_arrow(obj: &Borrowed<'_, '_, PyAny>) -> PyVortexResult<PyArra
         let enc_array = ArrayRef::from_arrow(arrow_array.as_ref(), is_nullable)?;
         Ok(PyArrayRef::from(enc_array))
     } else if obj.is_instance(chunked_array)? {
-        let chunks: Vec<Bound<PyAny>> = obj.getattr("chunks")?.extract()?;
+        let chunks: Vec<Bound<PyAny>> = obj.getattr(intern!(py, "chunks"))?.extract()?;
         let encoded_chunks = chunks
             .iter()
             .map(|a| {
@@ -48,7 +49,7 @@ pub(super) fn from_arrow(obj: &Borrowed<'_, '_, PyAny>) -> PyVortexResult<PyArra
             })
             .collect::<PyVortexResult<Vec<_>>>()?;
         let dtype: DType = obj
-            .getattr("type")
+            .getattr(intern!(py, "type"))
             .and_then(|v| DataType::from_pyarrow(&v.as_borrowed()))
             .map(|dt| DType::from_arrow(&Field::new("_", dt, false)))?;
         Ok(PyArrayRef::from(

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -15,6 +15,7 @@ use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyIndexError;
 use pyo3::exceptions::PyTypeError;
 use pyo3::exceptions::PyValueError;
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use pyo3::types::PyList;
@@ -742,7 +743,7 @@ impl PyArray {
         let dtype_buffers: Vec<Vec<u8>> = dtype_buffers.iter().map(|b| b.to_vec()).collect();
 
         let vortex_module = PyModule::import(py, "vortex")?;
-        let unpickle_fn = vortex_module.getattr("_unpickle_array")?;
+        let unpickle_fn = vortex_module.getattr(intern!(py, "_unpickle_array"))?;
 
         let args = (array_buffers, dtype_buffers).into_pyobject(py)?;
         Ok((unpickle_fn, args.into_any()))
@@ -769,7 +770,7 @@ impl PyArray {
         let dtype_buffers = encoder.encode(EncoderMessage::DType(array.dtype()))?;
 
         let pickle_module = PyModule::import(py, "pickle")?;
-        let pickle_buffer_class = pickle_module.getattr("PickleBuffer")?;
+        let pickle_buffer_class = pickle_module.getattr(intern!(py, "PickleBuffer"))?;
 
         let mut pickle_buffers = Vec::new();
         for buf in array_buffers.into_iter() {
@@ -788,7 +789,7 @@ impl PyArray {
         }
 
         let vortex_module = PyModule::import(py, "vortex")?;
-        let unpickle_fn = vortex_module.getattr("_unpickle_array")?;
+        let unpickle_fn = vortex_module.getattr(intern!(py, "_unpickle_array"))?;
 
         let args = (pickle_buffers, dtype_pickle_buffers).into_pyobject(py)?;
         Ok((unpickle_fn, args.into_any()))

--- a/vortex-python/src/arrays/py/mod.rs
+++ b/vortex-python/src/arrays/py/mod.rs
@@ -9,6 +9,7 @@ pub(crate) use array::*;
 use pyo3::Bound;
 use pyo3::PyAny;
 use pyo3::exceptions::PyValueError;
+use pyo3::intern;
 use pyo3::prelude::PyAnyMethods;
 pub(crate) use python::*;
 use vortex::array::vtable::ArrayId;
@@ -19,7 +20,7 @@ use crate::error::PyVortexResult;
 /// Extract the array id from a Python class `id` attribute.
 pub fn id_from_obj(cls: &Bound<PyAny>) -> PyVortexResult<ArrayId> {
     Ok(ArrayId::new_arc(
-        cls.getattr("id")
+        cls.getattr(intern!(cls.py(), "id"))
             .map_err(|_| {
                 PyValueError::new_err(format!(
                     "PyEncoding subclass {cls:?} must have an 'id' attribute"

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -118,7 +118,7 @@ impl VTable for PythonVTable {
             }
 
             let bytes = obj
-                .call_method("__vx_metadata__", (), None)
+                .call_method(intern!(py, "__vx_metadata__"), (), None)
                 .map_err(|e| vortex_err!("{}", e))?
                 .cast::<PyBytes>()
                 .map_err(|_| vortex_err!("Expected array metadata to be Python bytes"))?

--- a/vortex-python/src/arrow.rs
+++ b/vortex-python/src/arrow.rs
@@ -35,6 +35,12 @@ use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
 use pyo3::types::PyTuple;
 
+use crate::classes::array_class;
+use crate::classes::data_type_class;
+use crate::classes::field_class;
+use crate::classes::record_batch_reader_class;
+use crate::classes::schema_class;
+
 const SCHEMA_NAME: &CStr = c_str!("arrow_schema");
 const ARRAY_NAME: &CStr = c_str!("arrow_array");
 const ARRAY_STREAM_NAME: &CStr = c_str!("arrow_array_stream");
@@ -92,9 +98,8 @@ impl<'py> FromPyArrow<'_, 'py> for DataType {
 impl ToPyArrow for DataType {
     fn to_pyarrow(&self, py: Python) -> PyResult<Py<PyAny>> {
         let c_schema = FFI_ArrowSchema::try_from(self).map_err(to_py_err)?;
-        let module = py.import("pyarrow")?;
-        let class = module.getattr("DataType")?;
-        let dtype = class.call_method1("_import_from_c", (&raw const c_schema as Py_uintptr_t,))?;
+        let dtype = data_type_class(py)?
+            .call_method1("_import_from_c", (&raw const c_schema as Py_uintptr_t,))?;
         Ok(dtype.into())
     }
 }
@@ -124,9 +129,8 @@ impl<'py> FromPyArrow<'_, 'py> for Field {
 impl ToPyArrow for Field {
     fn to_pyarrow(&self, py: Python) -> PyResult<Py<PyAny>> {
         let c_schema = FFI_ArrowSchema::try_from(self).map_err(to_py_err)?;
-        let module = py.import("pyarrow")?;
-        let class = module.getattr("Field")?;
-        let dtype = class.call_method1("_import_from_c", (&raw const c_schema as Py_uintptr_t,))?;
+        let dtype = field_class(py)?
+            .call_method1("_import_from_c", (&raw const c_schema as Py_uintptr_t,))?;
         Ok(dtype.into())
     }
 }
@@ -157,10 +161,8 @@ impl<'py> FromPyArrow<'_, 'py> for Schema {
 impl ToPyArrow for Schema {
     fn to_pyarrow(&self, py: Python) -> PyResult<Py<PyAny>> {
         let c_schema = FFI_ArrowSchema::try_from(self).map_err(to_py_err)?;
-        let module = py.import("pyarrow")?;
-        let class = module.getattr("Schema")?;
-        let schema =
-            class.call_method1("_import_from_c", (&raw const c_schema as Py_uintptr_t,))?;
+        let schema = schema_class(py)?
+            .call_method1("_import_from_c", (&raw const c_schema as Py_uintptr_t,))?;
         Ok(schema.into())
     }
 }
@@ -207,9 +209,7 @@ impl ToPyArrow for ArrayData {
         let array = FFI_ArrowArray::new(self);
         let schema = FFI_ArrowSchema::try_from(self.data_type()).map_err(to_py_err)?;
 
-        let module = py.import("pyarrow")?;
-        let class = module.getattr("Array")?;
-        let array = class.call_method1(
+        let array = array_class(py)?.call_method1(
             "_import_from_c",
             (
                 addr_of!(array) as Py_uintptr_t,
@@ -323,10 +323,8 @@ impl IntoPyArrow for Box<dyn RecordBatchReader + Send> {
     fn into_pyarrow(self, py: Python) -> PyResult<Py<PyAny>> {
         let mut stream = FFI_ArrowArrayStream::new(self);
 
-        let module = py.import("pyarrow")?;
-        let class = module.getattr("RecordBatchReader")?;
         let args = PyTuple::new(py, [&raw mut stream as Py_uintptr_t])?;
-        let reader = class.call_method1("_import_from_c", args)?;
+        let reader = record_batch_reader_class(py)?.call_method1("_import_from_c", args)?;
 
         Ok(Py::from(reader))
     }

--- a/vortex-python/src/arrow.rs
+++ b/vortex-python/src/arrow.rs
@@ -31,6 +31,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::ffi::Py_uintptr_t;
 use pyo3::ffi::c_str;
 use pyo3::import_exception;
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
 use pyo3::types::PyTuple;
@@ -75,13 +76,14 @@ pub trait IntoPyArrow {
 
 impl<'py> FromPyArrow<'_, 'py> for DataType {
     fn from_pyarrow(value: &Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
-        if !value.hasattr("__arrow_c_schema__")? {
+        let py = value.py();
+        if !value.hasattr(intern!(py, "__arrow_c_schema__"))? {
             return Err(PyValueError::new_err(
                 "Expected __arrow_c_schema__ attribute to be set.",
             ));
         }
 
-        let capsule = value.getattr("__arrow_c_schema__")?.call0()?;
+        let capsule = value.getattr(intern!(py, "__arrow_c_schema__"))?.call0()?;
         let capsule = capsule.cast::<PyCapsule>()?;
 
         let schema_ptr = unsafe {
@@ -98,21 +100,24 @@ impl<'py> FromPyArrow<'_, 'py> for DataType {
 impl ToPyArrow for DataType {
     fn to_pyarrow(&self, py: Python) -> PyResult<Py<PyAny>> {
         let c_schema = FFI_ArrowSchema::try_from(self).map_err(to_py_err)?;
-        let dtype = data_type_class(py)?
-            .call_method1("_import_from_c", (&raw const c_schema as Py_uintptr_t,))?;
+        let dtype = data_type_class(py)?.call_method1(
+            intern!(py, "_import_from_c"),
+            (&raw const c_schema as Py_uintptr_t,),
+        )?;
         Ok(dtype.into())
     }
 }
 
 impl<'py> FromPyArrow<'_, 'py> for Field {
     fn from_pyarrow(value: &Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
-        if !value.hasattr("__arrow_c_schema__")? {
+        let py = value.py();
+        if !value.hasattr(intern!(py, "__arrow_c_schema__"))? {
             return Err(PyValueError::new_err(
                 "Expected __arrow_c_schema__ attribute to be set.",
             ));
         }
 
-        let capsule = value.getattr("__arrow_c_schema__")?.call0()?;
+        let capsule = value.getattr(intern!(py, "__arrow_c_schema__"))?.call0()?;
         let capsule = capsule.cast::<PyCapsule>()?;
 
         let schema_ptr = unsafe {
@@ -129,21 +134,24 @@ impl<'py> FromPyArrow<'_, 'py> for Field {
 impl ToPyArrow for Field {
     fn to_pyarrow(&self, py: Python) -> PyResult<Py<PyAny>> {
         let c_schema = FFI_ArrowSchema::try_from(self).map_err(to_py_err)?;
-        let dtype = field_class(py)?
-            .call_method1("_import_from_c", (&raw const c_schema as Py_uintptr_t,))?;
+        let dtype = field_class(py)?.call_method1(
+            intern!(py, "_import_from_c"),
+            (&raw const c_schema as Py_uintptr_t,),
+        )?;
         Ok(dtype.into())
     }
 }
 
 impl<'py> FromPyArrow<'_, 'py> for Schema {
     fn from_pyarrow(value: &Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
-        if !value.hasattr("__arrow_c_schema__")? {
+        let py = value.py();
+        if !value.hasattr(intern!(py, "__arrow_c_schema__"))? {
             return Err(PyValueError::new_err(
                 "Expected __arrow_c_schema__ attribute to be set.",
             ));
         }
 
-        let capsule = value.getattr("__arrow_c_schema__")?.call0()?;
+        let capsule = value.getattr(intern!(py, "__arrow_c_schema__"))?.call0()?;
         let capsule = capsule.cast::<PyCapsule>()?;
 
         let schema_ptr = unsafe {
@@ -161,21 +169,24 @@ impl<'py> FromPyArrow<'_, 'py> for Schema {
 impl ToPyArrow for Schema {
     fn to_pyarrow(&self, py: Python) -> PyResult<Py<PyAny>> {
         let c_schema = FFI_ArrowSchema::try_from(self).map_err(to_py_err)?;
-        let schema = schema_class(py)?
-            .call_method1("_import_from_c", (&raw const c_schema as Py_uintptr_t,))?;
+        let schema = schema_class(py)?.call_method1(
+            intern!(py, "_import_from_c"),
+            (&raw const c_schema as Py_uintptr_t,),
+        )?;
         Ok(schema.into())
     }
 }
 
 impl<'py> FromPyArrow<'_, 'py> for ArrayData {
     fn from_pyarrow(value: &Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
-        if !value.hasattr("__arrow_c_array__")? {
+        let py = value.py();
+        if !value.hasattr(intern!(py, "__arrow_c_array__"))? {
             return Err(PyValueError::new_err(
                 "Expected __arrow_c_array__ attribute to be set.",
             ));
         }
 
-        let tuple = value.getattr("__arrow_c_array__")?.call0()?;
+        let tuple = value.getattr(intern!(py, "__arrow_c_array__"))?.call0()?;
 
         if !tuple.is_instance_of::<PyTuple>() {
             return Err(PyTypeError::new_err(
@@ -210,7 +221,7 @@ impl ToPyArrow for ArrayData {
         let schema = FFI_ArrowSchema::try_from(self.data_type()).map_err(to_py_err)?;
 
         let array = array_class(py)?.call_method1(
-            "_import_from_c",
+            intern!(py, "_import_from_c"),
             (
                 addr_of!(array) as Py_uintptr_t,
                 addr_of!(schema) as Py_uintptr_t,
@@ -222,13 +233,14 @@ impl ToPyArrow for ArrayData {
 
 impl<'py> FromPyArrow<'_, 'py> for RecordBatch {
     fn from_pyarrow(value: &Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
-        if !value.hasattr("__arrow_c_array__")? {
+        let py = value.py();
+        if !value.hasattr(intern!(py, "__arrow_c_array__"))? {
             return Err(PyValueError::new_err(
                 "Expected __arrow_c_array__ attribute to be set.",
             ));
         }
 
-        let tuple = value.getattr("__arrow_c_array__")?.call0()?;
+        let tuple = value.getattr(intern!(py, "__arrow_c_array__"))?.call0()?;
 
         if !tuple.is_instance_of::<PyTuple>() {
             return Err(PyTypeError::new_err(
@@ -286,20 +298,21 @@ impl ToPyArrow for RecordBatch {
         let reader = RecordBatchIterator::new(vec![Ok(self.clone())], self.schema());
         let reader: Box<dyn RecordBatchReader + Send> = Box::new(reader);
         let py_reader = reader.into_pyarrow(py)?;
-        py_reader.call_method0(py, "read_next_batch")
+        py_reader.call_method0(py, intern!(py, "read_next_batch"))
     }
 }
 
 /// Supports conversion from `pyarrow.RecordBatchReader` to [ArrowArrayStreamReader].
 impl<'py> FromPyArrow<'_, 'py> for ArrowArrayStreamReader {
     fn from_pyarrow(value: &Borrowed<'_, 'py, PyAny>) -> PyResult<Self> {
-        if !value.hasattr("__arrow_c_stream__")? {
+        let py = value.py();
+        if !value.hasattr(intern!(py, "__arrow_c_stream__"))? {
             return Err(PyValueError::new_err(
                 "Expected __arrow_c_stream__ attribute to be set.",
             ));
         }
 
-        let capsule = value.getattr("__arrow_c_stream__")?.call0()?;
+        let capsule = value.getattr(intern!(py, "__arrow_c_stream__"))?.call0()?;
         let capsule = capsule.cast::<PyCapsule>()?;
 
         let array_ptr = capsule
@@ -324,7 +337,8 @@ impl IntoPyArrow for Box<dyn RecordBatchReader + Send> {
         let mut stream = FFI_ArrowArrayStream::new(self);
 
         let args = PyTuple::new(py, [&raw mut stream as Py_uintptr_t])?;
-        let reader = record_batch_reader_class(py)?.call_method1("_import_from_c", args)?;
+        let reader =
+            record_batch_reader_class(py)?.call_method1(intern!(py, "_import_from_c"), args)?;
 
         Ok(Py::from(reader))
     }

--- a/vortex-python/src/classes.rs
+++ b/vortex-python/src/classes.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Caching often accesses classes that are accessed across the C ABI
+
+use pyo3::Bound;
+use pyo3::Py;
+use pyo3::PyResult;
+use pyo3::Python;
+use pyo3::sync::PyOnceLock;
+use pyo3::types::PyType;
+
+/// Returns the pyarrow.DataType class
+pub fn data_type_class(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+    TYPE.import(py, "pyarrow", "DataType")
+}
+
+/// Returns the pyarrow.Field class
+pub fn field_class(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+    TYPE.import(py, "pyarrow", "Field")
+}
+
+/// Returns the pyarrow.Schema class
+pub fn schema_class(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+    TYPE.import(py, "pyarrow", "Schema")
+}
+
+/// Returns the pyarrow.Array class
+pub fn array_class(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+    TYPE.import(py, "pyarrow", "Array")
+}
+
+/// Returns the pyarrow.ChunkedArray class
+pub fn chunked_array_class(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+    TYPE.import(py, "pyarrow", "ChunkedArray")
+}
+
+/// Returns the pyarrow.RecordBatchReader class
+pub fn record_batch_reader_class(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+    TYPE.import(py, "pyarrow", "RecordBatchReader")
+}
+
+/// Returns the pyarrow.Table class
+pub fn table_class(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+    TYPE.import(py, "pyarrow", "Table")
+}
+
+/// Returns the pyarrow.Decimal class
+pub fn decimal_class(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {
+    static TYPE: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+    TYPE.import(py, "decimal", "Decimal")
+}

--- a/vortex-python/src/io.rs
+++ b/vortex-python/src/io.rs
@@ -30,6 +30,8 @@ use crate::TOKIO_RUNTIME;
 use crate::arrays::PyArray;
 use crate::arrays::PyArrayRef;
 use crate::arrow::FromPyArrow;
+use crate::classes::record_batch_reader_class;
+use crate::classes::table_class;
 use crate::dataset::PyVortexDataset;
 use crate::error::PyVortexResult;
 use crate::expr::PyExpr;
@@ -425,11 +427,11 @@ fn try_arrow_stream_to_iterator(
     ob: &Borrowed<'_, '_, PyAny>,
 ) -> PyResult<Box<dyn ArrayIterator + Send>> {
     let py = ob.py();
-    let pa = py.import("pyarrow")?;
-    let pa_table = pa.getattr("Table")?;
-    let pa_record_batch_reader = pa.getattr("RecordBatchReader")?;
 
-    if ob.is_instance(&pa_table)? || ob.is_instance(&pa_record_batch_reader)? {
+    let pa_table = table_class(py)?;
+    let pa_record_batch_reader = record_batch_reader_class(py)?;
+
+    if ob.is_instance(pa_table)? || ob.is_instance(pa_record_batch_reader)? {
         // Convert to Arrow stream using FFI
         let arrow_stream = ArrowArrayStreamReader::from_pyarrow(ob)?;
         let dtype = DType::from_arrow(arrow_stream.schema());

--- a/vortex-python/src/lib.rs
+++ b/vortex-python/src/lib.rs
@@ -13,6 +13,7 @@ use pyo3::prelude::*;
 
 pub(crate) mod arrays;
 pub mod arrow;
+pub(crate) mod classes;
 #[cfg(feature = "tui")]
 mod cli;
 mod compress;

--- a/vortex-python/src/lib.rs
+++ b/vortex-python/src/lib.rs
@@ -9,6 +9,7 @@ use std::ops::Deref;
 use std::sync::LazyLock;
 
 use pyo3::exceptions::PyRuntimeError;
+use pyo3::intern;
 use pyo3::prelude::*;
 
 pub(crate) mod arrays;
@@ -112,10 +113,10 @@ pub fn install_module(name: &str, module: &Bound<PyModule>) -> PyResult<()> {
     module
         .py()
         .import("sys")?
-        .getattr("modules")?
+        .getattr(intern!(module.py(), "modules"))?
         .set_item(name, module)?;
     // needs to be set *after* `add_submodule()`
-    module.setattr("__name__", name)?;
+    module.setattr(intern!(module.py(), "__name__"), name)?;
     Ok(())
 }
 

--- a/vortex-python/src/scalar/into_py.rs
+++ b/vortex-python/src/scalar/into_py.rs
@@ -31,6 +31,7 @@ use vortex::scalar::Scalar;
 use vortex::scalar::StructScalar;
 
 use crate::PyVortex;
+use crate::classes::decimal_class;
 
 impl<'py> IntoPyObject<'py> for PyVortex<&'_ Scalar> {
     type Target = PyAny;
@@ -204,8 +205,7 @@ fn decimal_value_to_py(
     scale: i8,
     decimal_value: DecimalValue,
 ) -> PyResult<Bound<PyAny>> {
-    let m = py.import("decimal")?;
-    let decimal_class = m.getattr("Decimal")?;
+    let decimal_class = decimal_class(py)?;
 
     match_each_decimal_value!(decimal_value, |value| {
         let (whole, decimal) = value.decimal_parts(scale);

--- a/vortex-python/src/serde/parts.rs
+++ b/vortex-python/src/serde/parts.rs
@@ -7,6 +7,7 @@ use pyo3::Bound;
 use pyo3::PyAny;
 use pyo3::PyRef;
 use pyo3::Python;
+use pyo3::intern;
 use pyo3::prelude::PyAnyMethods;
 use pyo3::pyclass;
 use pyo3::pymethods;
@@ -100,7 +101,8 @@ impl PyArrayParts {
             let addr = buffer.as_ptr() as usize;
             let size = buffer.len();
             let base = &slf;
-            let pa_buffer = pyarrow.call_method("foreign_buffer", (addr, size, base), None)?;
+            let pa_buffer =
+                pyarrow.call_method(intern!(py, "foreign_buffer"), (addr, size, base), None)?;
             buffers.push(pa_buffer);
         }
 


### PR DESCRIPTION
## Summary

Was reading the arrow-rs changelog and I ran into [this](https://github.com/apache/arrow-rs/pull/9439) PR, seems like `PyOnceLock` was built for this and they have some very promising benchmarks [there](https://github.com/apache/arrow-rs/pull/9439/changes#r2955818325).

I've also wrapped all static strings that are passed into `pyo3` with the `intern` macro, which prevents allocating a new `PyString` on every call.
