### PR TITLE
Python benchmarks script and  re-organize dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,9 @@ jobs:
       - name: Python Lint - PyRight
         env:
           MATURIN_PEP517_ARGS: "--profile dev"
-        run: uv run basedpyright vortex-python
+        run: |
+          uv sync --all-packages
+          uv run basedpyright vortex-python
 
   python-test:
     name: "Python (test)"

--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,6 @@ sweep.timestamp
 # Perfetto
 trace*.json
 trace*.pb
+
+# pytest-benchmark output\
+vortex-python/.benchmarks/

--- a/.gitignore
+++ b/.gitignore
@@ -239,5 +239,5 @@ sweep.timestamp
 trace*.json
 trace*.pb
 
-# pytest-benchmark output\
+# pytest-benchmark output
 vortex-python/.benchmarks/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,28 +14,17 @@ build-backend = "hatchling.build"
 packages = ["dummy"] # Required for workspace project
 
 [dependency-groups]
-# Currently, all dev dependencies live in the root since uv doesn't have transitive dev dependencies.
-#  See: https://github.com/astral-sh/uv/issues/7541
+# Shared dev tooling. Member-specific dev deps live in each member's pyproject.toml.
+# `uv sync --all-packages` picks up dev groups from all workspace members.
 dev = [
     "basedpyright>=1.31",
-    "duckdb>=1.1.2",
     "ipython>=8.26.0",
-    "maturin>=1.7.2",
-    "pandas-stubs>=2.2.3.241126",
-    "pandas[output-formatting]>=2.2.3",
-    "pcodec>=0.3.3",
     "pip>=23.3.2",
-    "polars>=1.9.0",
-    "pyarrow-stubs>=17.16",
-    "pytest-benchmark>=4.0.0",
     "pytest>=7.4.0",
     "ruff>=0.7.1",
-    "ray>=2.48",
-    "pytest-benchmark>=5.1.0",
     # forced transitive bumps
     "urllib3>=2.6.3",
     "filelock>=3.20.3",
-    "protobuf>=6.33.5",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -1904,13 +1904,18 @@ ray = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "basedpyright" },
+    { name = "duckdb" },
+    { name = "maturin" },
     { name = "numpy" },
+    { name = "pandas", extra = ["output-formatting"] },
     { name = "pandas-stubs" },
     { name = "pcodec" },
+    { name = "polars" },
+    { name = "protobuf" },
     { name = "pyarrow-stubs" },
     { name = "pytest-benchmark" },
     { name = "pytest-xdist" },
+    { name = "ray" },
 ]
 
 [package.metadata]
@@ -1928,13 +1933,18 @@ provides-extras = ["duckdb", "numpy", "pandas", "polars", "ray"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "basedpyright", specifier = ">=1.31" },
+    { name = "duckdb", specifier = ">=1.1.2" },
+    { name = "maturin", specifier = ">=1.7.2" },
     { name = "numpy", specifier = ">=2.2.2" },
+    { name = "pandas", extras = ["output-formatting"], specifier = ">=2.2.3" },
     { name = "pandas-stubs", specifier = ">=2.2.3.241126" },
     { name = "pcodec", specifier = ">=0.3.3" },
+    { name = "polars", specifier = ">=1.9.0" },
+    { name = "protobuf", specifier = ">=6.33.5" },
     { name = "pyarrow-stubs", specifier = ">=17.16" },
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "pytest-xdist", specifier = ">=3.5.0" },
+    { name = "ray", specifier = ">=2.48" },
 ]
 
 [[package]]
@@ -2085,20 +2095,10 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
-    { name = "duckdb" },
     { name = "filelock" },
     { name = "ipython" },
-    { name = "maturin" },
-    { name = "pandas", extra = ["output-formatting"] },
-    { name = "pandas-stubs" },
-    { name = "pcodec" },
     { name = "pip" },
-    { name = "polars" },
-    { name = "protobuf" },
-    { name = "pyarrow-stubs" },
     { name = "pytest" },
-    { name = "pytest-benchmark" },
-    { name = "ray" },
     { name = "ruff" },
     { name = "urllib3" },
 ]
@@ -2113,21 +2113,10 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.31" },
-    { name = "duckdb", specifier = ">=1.1.2" },
     { name = "filelock", specifier = ">=3.20.3" },
     { name = "ipython", specifier = ">=8.26.0" },
-    { name = "maturin", specifier = ">=1.7.2" },
-    { name = "pandas", extras = ["output-formatting"], specifier = ">=2.2.3" },
-    { name = "pandas-stubs", specifier = ">=2.2.3.241126" },
-    { name = "pcodec", specifier = ">=0.3.3" },
     { name = "pip", specifier = ">=23.3.2" },
-    { name = "polars", specifier = ">=1.9.0" },
-    { name = "protobuf", specifier = ">=6.33.5" },
-    { name = "pyarrow-stubs", specifier = ">=17.16" },
     { name = "pytest", specifier = ">=7.4.0" },
-    { name = "pytest-benchmark", specifier = ">=4.0.0" },
-    { name = "pytest-benchmark", specifier = ">=5.1.0" },
-    { name = "ray", specifier = ">=2.48" },
     { name = "ruff", specifier = ">=0.7.1" },
     { name = "urllib3", specifier = ">=2.6.3" },
 ]

--- a/vortex-python/pyproject.toml
+++ b/vortex-python/pyproject.toml
@@ -67,16 +67,22 @@ include = [
     { path = "python/vortex/py.typed", format = "sdist" },
 ]
 
-[tool.basedpyright]
-exclude = ["python/vortex/_lib/store/**.pyi"]
-
 [dependency-groups]
 dev = [
-    "basedpyright>=1.31",
+    "duckdb>=1.1.2",
+    "maturin>=1.7.2",
     "numpy>=2.2.2",
     "pandas-stubs>=2.2.3.241126",
+    "pandas[output-formatting]>=2.2.3",
     "pcodec>=0.3.3",
+    "polars>=1.9.0",
     "pyarrow-stubs>=17.16",
     "pytest-benchmark>=5.1.0",
     "pytest-xdist>=3.5.0",
+    "ray>=2.48",
+    # forced transitive bumps
+    "protobuf>=6.33.5",
 ]
+
+[tool.basedpyright]
+exclude = ["python/vortex/_lib/store/**.pyi"]

--- a/vortex-python/run_benchmarks.sh
+++ b/vortex-python/run_benchmarks.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# Run Python benchmarks with a release-profile build of the native extension.
+#
+# Usage:
+#   ./run_benchmarks.sh                     # run all benchmarks
+#   ./run_benchmarks.sh -k "test_scan"      # run benchmarks matching a pattern
+#   ./run_benchmarks.sh --benchmark-only    # skip non-benchmark tests (if any)
+#
+# All arguments are forwarded to pytest.
+
+set -ex -o pipefail
+
+ROOT=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
+PYTHON_DIR="$ROOT/vortex-python"
+
+# Ensure all packages are synced (includes pytest-benchmark dev dependency).
+uv sync --all-packages
+
+source "$ROOT/.venv/bin/activate"
+
+# Build the native extension in release mode so benchmarks reflect production performance.
+maturin develop --release --manifest-path "$PYTHON_DIR/Cargo.toml"
+
+# Run benchmarks. Extra args are forwarded to pytest.
+pytest "$PYTHON_DIR/benchmark" "$@"


### PR DESCRIPTION
## Summary

1. Add a script to run the python benchmarks which are basically a secret right now.
2. Re-organize dev-dependencies, now that UV does support transitive dev dependencies
