### PR TITLE
move BitPacked slice from kernel -> parent reduce

### DIFF
--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -138,9 +138,9 @@ impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_fastlanes::Bi
 
 pub fn vortex_fastlanes::BitPacked::filter(array: &vortex_fastlanes::BitPackedArray, mask: &vortex_mask::Mask, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
-impl vortex_array::arrays::slice::SliceKernel for vortex_fastlanes::BitPacked
+impl vortex_array::arrays::slice::SliceReduce for vortex_fastlanes::BitPacked
 
-pub fn vortex_fastlanes::BitPacked::slice(array: &vortex_fastlanes::BitPackedArray, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
+pub fn vortex_fastlanes::BitPacked::slice(array: &vortex_fastlanes::BitPackedArray, range: core::ops::range::Range<usize>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::BitPacked
 

--- a/encodings/fastlanes/src/bitpacking/compute/slice.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/slice.rs
@@ -5,20 +5,15 @@ use std::cmp::max;
 use std::ops::Range;
 
 use vortex_array::ArrayRef;
-use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::arrays::slice::SliceKernel;
+use vortex_array::arrays::slice::SliceReduce;
 use vortex_error::VortexResult;
 
 use crate::BitPacked;
 use crate::BitPackedArray;
 
-impl SliceKernel for BitPacked {
-    fn slice(
-        array: &BitPackedArray,
-        range: Range<usize>,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Option<ArrayRef>> {
+impl SliceReduce for BitPacked {
+    fn slice(array: &BitPackedArray, range: Range<usize>) -> VortexResult<Option<ArrayRef>> {
         let offset_start = range.start + array.offset() as usize;
         let offset_stop = range.end + array.offset() as usize;
         let offset = offset_start % 1024;
@@ -51,35 +46,26 @@ impl SliceKernel for BitPacked {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::LazyLock;
-
     use vortex_array::DynArray;
     use vortex_array::IntoArray;
-    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::SliceArray;
-    use vortex_array::session::ArraySession;
     use vortex_error::VortexResult;
-    use vortex_session::VortexSession;
 
     use crate::BitPacked;
     use crate::bitpack_compress::bitpack_encode;
 
-    static SESSION: LazyLock<VortexSession> =
-        LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
-
     #[test]
-    fn test_execute_parent_returns_bitpacked_slice() -> VortexResult<()> {
+    fn test_reduce_parent_returns_bitpacked_slice() -> VortexResult<()> {
         let values = PrimitiveArray::from_iter(0u32..2048);
         let bitpacked = bitpack_encode(&values, 11, None)?;
 
         let slice_array = SliceArray::new(bitpacked.clone().into_array(), 500..1500);
 
-        let mut ctx = SESSION.create_execution_ctx();
         let bitpacked_ref = bitpacked.into_array();
         let reduced = bitpacked_ref
             .vtable()
-            .execute_parent(&bitpacked_ref, &slice_array.into_array(), 0, &mut ctx)?
+            .reduce_parent(&bitpacked_ref, &slice_array.into_array(), 0)?
             .expect("expected slice kernel to execute");
 
         assert!(reduced.is::<BitPacked>());

--- a/encodings/fastlanes/src/bitpacking/vtable/kernels.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/kernels.rs
@@ -3,13 +3,11 @@
 
 use vortex_array::arrays::dict::TakeExecuteAdaptor;
 use vortex_array::arrays::filter::FilterExecuteAdaptor;
-use vortex_array::arrays::slice::SliceExecuteAdaptor;
 use vortex_array::kernel::ParentKernelSet;
 
 use crate::BitPacked;
 
 pub(crate) const PARENT_KERNELS: ParentKernelSet<BitPacked> = ParentKernelSet::new(&[
     ParentKernelSet::lift(&FilterExecuteAdaptor(BitPacked)),
-    ParentKernelSet::lift(&SliceExecuteAdaptor(BitPacked)),
     ParentKernelSet::lift(&TakeExecuteAdaptor(BitPacked)),
 ]);

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -31,11 +31,9 @@ impl OperationsVTable<BitPacked> for BitPacked {
 #[cfg(test)]
 mod test {
     use std::ops::Range;
-    use std::sync::LazyLock;
 
     use vortex_array::DynArray;
     use vortex_array::IntoArray;
-    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::SliceArray;
     use vortex_array::assert_arrays_eq;
@@ -46,7 +44,6 @@ mod test {
     use vortex_array::dtype::PType;
     use vortex_array::patches::Patches;
     use vortex_array::scalar::Scalar;
-    use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::Alignment;
     use vortex_buffer::Buffer;
@@ -56,16 +53,12 @@ mod test {
     use crate::BitPacked;
     use crate::BitPackedArray;
 
-    static SESSION: LazyLock<vortex_session::VortexSession> =
-        LazyLock::new(|| vortex_session::VortexSession::empty().with::<ArraySession>());
-
-    fn slice_via_kernel(array: &BitPackedArray, range: Range<usize>) -> BitPackedArray {
+    fn slice_via_reduce(array: &BitPackedArray, range: Range<usize>) -> BitPackedArray {
         let array_ref = array.clone().into_array();
         let slice_array = SliceArray::new(array_ref.clone(), range);
-        let mut ctx = SESSION.create_execution_ctx();
         let sliced = array_ref
             .vtable()
-            .execute_parent(&array_ref, &slice_array.into_array(), 0, &mut ctx)
+            .reduce_parent(&array_ref, &slice_array.into_array(), 0)
             .expect("execute_parent failed")
             .expect("expected slice kernel to execute");
         sliced.as_::<BitPacked>().clone()
@@ -78,7 +71,7 @@ mod test {
             6,
         )
         .unwrap();
-        let sliced = slice_via_kernel(&arr, 1024..2048);
+        let sliced = slice_via_reduce(&arr, 1024..2048);
         assert_nth_scalar!(sliced, 0, 1024u32 % 64);
         assert_nth_scalar!(sliced, 1023, 2047u32 % 64);
         assert_eq!(sliced.offset(), 0);
@@ -92,7 +85,7 @@ mod test {
             6,
         )
         .unwrap();
-        let sliced = slice_via_kernel(&arr, 512..1434);
+        let sliced = slice_via_reduce(&arr, 512..1434);
         assert_nth_scalar!(sliced, 0, 512u32 % 64);
         assert_nth_scalar!(sliced, 921, 1433u32 % 64);
         assert_eq!(sliced.offset(), 512);
@@ -132,12 +125,12 @@ mod test {
             6,
         )
         .unwrap();
-        let sliced = slice_via_kernel(&arr, 512..1434);
+        let sliced = slice_via_reduce(&arr, 512..1434);
         assert_nth_scalar!(sliced, 0, 512u32 % 64);
         assert_nth_scalar!(sliced, 921, 1433u32 % 64);
         assert_eq!(sliced.offset(), 512);
         assert_eq!(sliced.len(), 922);
-        let doubly_sliced = slice_via_kernel(&sliced, 127..911);
+        let doubly_sliced = slice_via_reduce(&sliced, 127..911);
         assert_nth_scalar!(doubly_sliced, 0, (512u32 + 127) % 64);
         assert_nth_scalar!(doubly_sliced, 783, (512u32 + 910) % 64);
         assert_eq!(doubly_sliced.offset(), 639);
@@ -155,7 +148,7 @@ mod test {
         assert_eq!(patch_indices.len(), 1);
 
         // Slicing drops the empty patches array.
-        let sliced_bp = slice_via_kernel(&array, 0..64);
+        let sliced_bp = slice_via_reduce(&array, 0..64);
         assert!(sliced_bp.patches().is_none());
     }
 

--- a/encodings/fastlanes/src/bitpacking/vtable/rules.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/rules.rs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex_array::arrays::slice::SliceReduceAdaptor;
 use vortex_array::optimizer::rules::ParentRuleSet;
 use vortex_array::scalar_fn::fns::cast::CastReduceAdaptor;
 
 use crate::BitPacked;
 
-pub(crate) const RULES: ParentRuleSet<BitPacked> =
-    ParentRuleSet::new(&[ParentRuleSet::lift(&CastReduceAdaptor(BitPacked))]);
+pub(crate) const RULES: ParentRuleSet<BitPacked> = ParentRuleSet::new(&[
+    ParentRuleSet::lift(&CastReduceAdaptor(BitPacked)),
+    ParentRuleSet::lift(&SliceReduceAdaptor(BitPacked)),
+]);

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -169,12 +169,10 @@ where
 mod tests {
     use futures::executor::block_on;
     use rstest::rstest;
-    use vortex::array::ExecutionCtx;
     use vortex::array::IntoArray;
     use vortex::array::arrays::PrimitiveArray;
     use vortex::array::assert_arrays_eq;
     use vortex::array::dtype::NativePType;
-    use vortex::array::session::ArraySession;
     use vortex::array::validity::Validity::NonNullable;
     use vortex::buffer::Buffer;
     use vortex::error::VortexExpect;
@@ -521,10 +519,9 @@ mod tests {
             .vortex_expect("operation should succeed in test");
         let slice_ref = bitpacked_array.clone().into_array().slice(67..3969)?;
         let bitpacked_ref = bitpacked_array.into_array();
-        let mut exec_ctx = ExecutionCtx::new(VortexSession::empty().with::<ArraySession>());
         let sliced_array = bitpacked_ref
             .vtable()
-            .execute_parent(&bitpacked_ref, &slice_ref, 0, &mut exec_ctx)?
+            .reduce_parent(&bitpacked_ref, &slice_ref, 0)?
             .expect("expected slice kernel to execute");
         let cpu_result = sliced_array.to_canonical()?;
         let gpu_result = block_on(async {

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -517,12 +517,8 @@ mod tests {
 
         let bitpacked_array = BitPackedArray::encode(&primitive_array.into_array(), bit_width)
             .vortex_expect("operation should succeed in test");
-        let slice_ref = bitpacked_array.clone().into_array().slice(67..3969)?;
-        let bitpacked_ref = bitpacked_array.into_array();
-        let sliced_array = bitpacked_ref
-            .vtable()
-            .reduce_parent(&bitpacked_ref, &slice_ref, 0)?
-            .expect("expected slice kernel to execute");
+        let sliced_array = bitpacked_array.into_array().slice(67..3969)?;
+        assert!(sliced_array.is::<BitPacked>());
         let cpu_result = sliced_array.to_canonical()?;
         let gpu_result = block_on(async {
             BitPackedExecutor


### PR DESCRIPTION
This is free and cheap since we do not need to materialize any data to do it.

