### PR TITLE
fix: restrict wasm-bindgen to browser wasm, fixing wasip1 builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,6 +315,7 @@ unexpected_cfgs = { level = "deny", check-cfg = [
     "cfg(codspeed)",
     "cfg(disable_loom)",
     "cfg(vortex_nightly)",
+    'cfg(target_os, values("unknown"))',
 ] }
 warnings = "warn"
 

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -64,7 +64,9 @@ pub use native_runtime::RUNTIME;
 #[cfg(not(target_arch = "wasm32"))]
 pub use native_runtime::SESSION;
 
-#[cfg(target_arch = "wasm32")]
+// target_os = "unknown" matches wasm32-unknown-unknown (browser), excluding WASI targets
+// where wasm-bindgen's JS interop is not available.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 mod wasm_runtime {
     use std::sync::LazyLock;
 
@@ -77,5 +79,20 @@ mod wasm_runtime {
         LazyLock::new(|| VortexSession::default().with_handle(WasmRuntime::handle()));
 }
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub use wasm_runtime::SESSION;
+
+/// WASI targets get a session without an async runtime handle since wasm-bindgen
+/// is not available. The fuzz workloads are synchronous, so this is sufficient.
+#[cfg(all(target_arch = "wasm32", not(target_os = "unknown")))]
+mod wasi_runtime {
+    use std::sync::LazyLock;
+
+    use vortex::VortexSessionDefault;
+    use vortex_session::VortexSession;
+
+    pub static SESSION: LazyLock<VortexSession> = LazyLock::new(VortexSession::default);
+}
+
+#[cfg(all(target_arch = "wasm32", not(target_os = "unknown")))]
+pub use wasi_runtime::SESSION;

--- a/vortex-io/Cargo.toml
+++ b/vortex-io/Cargo.toml
@@ -49,7 +49,9 @@ custom-labels = { workspace = true }
 # Smol is our default impl, so we don't want it to be optional, but it cannot be part of wasm
 smol = { workspace = true }
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+# target_os = "unknown" matches wasm32-unknown-unknown (browser), excluding WASI targets
+# where wasm-bindgen's JS interop is not available.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen-futures = { workspace = true }
 
 [dev-dependencies]

--- a/vortex-io/src/runtime/mod.rs
+++ b/vortex-io/src/runtime/mod.rs
@@ -29,7 +29,9 @@ pub mod single;
 mod smol;
 #[cfg(feature = "tokio")]
 pub mod tokio;
-#[cfg(target_arch = "wasm32")]
+// target_os = "unknown" matches wasm32-unknown-unknown (browser), excluding WASI targets
+// where wasm-bindgen's JS interop is not available.
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub mod wasm;
 
 #[cfg(test)]


### PR DESCRIPTION
wasm-bindgen 0.2.115 changed its cfg guard from
`cfg(all(target_arch = "wasm32", target_os = "unknown"))` to `cfg(target_family = "wasm")`, causing `__wbindgen_*` imports to be emitted for all wasm targets including wasm32-wasip1. Combined with wasm-test/Cargo.lock being untracked (deleted in #6187), CI picked up the new version and the wasmer integration test broke.

Narrow the `wasm-bindgen-futures` dependency and the wasm runtime module in vortex-io from `cfg(target_arch = "wasm32")` to `cfg(all(target_arch = "wasm32", target_os = "unknown"))`, which matches only wasm32-unknown-unknown (browser) and excludes WASI targets. For the fuzz crate's wasip1 target, provide a session without an async runtime handle since the fuzz workloads are synchronous.
