### PR TITLE
use trait upcasting and drop the as_any/as_any_mut boilerplate

### DIFF
--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::hash::Hash;
 use std::sync::Arc;
 
@@ -281,8 +282,7 @@ impl VTable for BitPacked {
         match_each_integer_ptype!(array.ptype(), |T| {
             unpack_into_primitive_builder::<T>(
                 array,
-                builder
-                    .as_any_mut()
+                (builder as &mut dyn Any)
                     .downcast_mut()
                     .vortex_expect("bit packed array must canonicalize into a primitive array"),
                 ctx,

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::hash::Hash;
@@ -174,7 +175,7 @@ impl VTable for FSST {
         builder: &mut dyn ArrayBuilder,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
-        let Some(builder) = builder.as_any_mut().downcast_mut::<VarBinViewBuilder>() else {
+        let Some(builder) = (builder as &mut dyn Any).downcast_mut::<VarBinViewBuilder>() else {
             builder.extend_from_array(
                 &array
                     .clone()

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -3862,8 +3862,6 @@ pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::into_array(self) -> vorte
 
 impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
-
 pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
 pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child_count(&self) -> usize
@@ -7680,8 +7678,6 @@ pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::into_array(self) -> vorte
 
 impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::scalar_fn::ScalarFnArray
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
-
 pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
 pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child_count(&self) -> usize
@@ -9156,13 +9152,11 @@ impl vortex_array::ArrayHash for vortex_array::buffer::BufferHandle
 
 pub fn vortex_array::buffer::BufferHandle::array_hash<H: core::hash::Hasher>(&self, state: &mut H, precision: vortex_array::Precision)
 
-pub trait vortex_array::buffer::DeviceBuffer: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug + vortex_utils::dyn_traits::DynEq + vortex_utils::dyn_traits::DynHash
+pub trait vortex_array::buffer::DeviceBuffer: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug + vortex_utils::dyn_traits::DynEq + vortex_utils::dyn_traits::DynHash + core::any::Any
 
 pub fn vortex_array::buffer::DeviceBuffer::aligned(self: alloc::sync::Arc<Self>, alignment: vortex_buffer::alignment::Alignment) -> vortex_error::VortexResult<alloc::sync::Arc<dyn vortex_array::buffer::DeviceBuffer>>
 
 pub fn vortex_array::buffer::DeviceBuffer::alignment(&self) -> vortex_buffer::alignment::Alignment
-
-pub fn vortex_array::buffer::DeviceBuffer::as_any(&self) -> &dyn core::any::Any
 
 pub fn vortex_array::buffer::DeviceBuffer::copy_to_host(&self, alignment: vortex_buffer::alignment::Alignment) -> vortex_error::VortexResult<futures_core::future::BoxFuture<'static, vortex_error::VortexResult<vortex_buffer::ByteBuffer>>>
 
@@ -9286,10 +9280,6 @@ pub fn vortex_array::builders::BoolBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::BoolBuilder::append_zeros(&mut self, n: usize)
 
-pub fn vortex_array::builders::BoolBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::BoolBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
 pub fn vortex_array::builders::BoolBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::builders::BoolBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
@@ -9343,10 +9333,6 @@ pub fn vortex_array::builders::DecimalBuilder::append_scalar(&mut self, scalar: 
 pub fn vortex_array::builders::DecimalBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::DecimalBuilder::append_zeros(&mut self, n: usize)
-
-pub fn vortex_array::builders::DecimalBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::DecimalBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub fn vortex_array::builders::DecimalBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
@@ -9404,10 +9390,6 @@ pub fn vortex_array::builders::ExtensionBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::ExtensionBuilder::append_zeros(&mut self, n: usize)
 
-pub fn vortex_array::builders::ExtensionBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::ExtensionBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
 pub fn vortex_array::builders::ExtensionBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::builders::ExtensionBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
@@ -9464,10 +9446,6 @@ pub fn vortex_array::builders::FixedSizeListBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::FixedSizeListBuilder::append_zeros(&mut self, n: usize)
 
-pub fn vortex_array::builders::FixedSizeListBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::FixedSizeListBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
 pub fn vortex_array::builders::FixedSizeListBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::builders::FixedSizeListBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
@@ -9521,10 +9499,6 @@ pub fn vortex_array::builders::ListBuilder<O>::append_scalar(&mut self, scalar: 
 pub fn vortex_array::builders::ListBuilder<O>::append_zero(&mut self)
 
 pub fn vortex_array::builders::ListBuilder<O>::append_zeros(&mut self, n: usize)
-
-pub fn vortex_array::builders::ListBuilder<O>::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::ListBuilder<O>::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub fn vortex_array::builders::ListBuilder<O>::dtype(&self) -> &vortex_array::dtype::DType
 
@@ -9580,10 +9554,6 @@ pub fn vortex_array::builders::ListViewBuilder<O, S>::append_zero(&mut self)
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::append_zeros(&mut self, n: usize)
 
-pub fn vortex_array::builders::ListViewBuilder<O, S>::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::ListViewBuilder<O, S>::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
 pub fn vortex_array::builders::ListViewBuilder<O, S>::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
@@ -9631,10 +9601,6 @@ pub fn vortex_array::builders::NullBuilder::append_scalar(&mut self, scalar: &vo
 pub fn vortex_array::builders::NullBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::NullBuilder::append_zeros(&mut self, n: usize)
-
-pub fn vortex_array::builders::NullBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::NullBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub fn vortex_array::builders::NullBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
@@ -9696,10 +9662,6 @@ pub fn vortex_array::builders::PrimitiveBuilder<T>::append_zero(&mut self)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::append_zeros(&mut self, n: usize)
 
-pub fn vortex_array::builders::PrimitiveBuilder<T>::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::PrimitiveBuilder<T>::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
 pub fn vortex_array::builders::PrimitiveBuilder<T>::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
@@ -9751,10 +9713,6 @@ pub fn vortex_array::builders::StructBuilder::append_scalar(&mut self, scalar: &
 pub fn vortex_array::builders::StructBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::StructBuilder::append_zeros(&mut self, n: usize)
-
-pub fn vortex_array::builders::StructBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::StructBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub fn vortex_array::builders::StructBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
@@ -9836,10 +9794,6 @@ pub fn vortex_array::builders::VarBinViewBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::VarBinViewBuilder::append_zeros(&mut self, n: usize)
 
-pub fn vortex_array::builders::VarBinViewBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::VarBinViewBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
 pub fn vortex_array::builders::VarBinViewBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::builders::VarBinViewBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
@@ -9862,7 +9816,7 @@ pub unsafe fn vortex_array::builders::VarBinViewBuilder::set_validity_unchecked(
 
 pub const vortex_array::builders::DEFAULT_BUILDER_CAPACITY: usize
 
-pub trait vortex_array::builders::ArrayBuilder: core::marker::Send
+pub trait vortex_array::builders::ArrayBuilder: core::marker::Send + core::any::Any
 
 pub fn vortex_array::builders::ArrayBuilder::append_default(&mut self)
 
@@ -9879,10 +9833,6 @@ pub fn vortex_array::builders::ArrayBuilder::append_scalar(&mut self, scalar: &v
 pub fn vortex_array::builders::ArrayBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::ArrayBuilder::append_zeros(&mut self, n: usize)
-
-pub fn vortex_array::builders::ArrayBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::ArrayBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub fn vortex_array::builders::ArrayBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
@@ -9922,10 +9872,6 @@ pub fn vortex_array::builders::BoolBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::BoolBuilder::append_zeros(&mut self, n: usize)
 
-pub fn vortex_array::builders::BoolBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::BoolBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
 pub fn vortex_array::builders::BoolBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::builders::BoolBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
@@ -9963,10 +9909,6 @@ pub fn vortex_array::builders::DecimalBuilder::append_scalar(&mut self, scalar: 
 pub fn vortex_array::builders::DecimalBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::DecimalBuilder::append_zeros(&mut self, n: usize)
-
-pub fn vortex_array::builders::DecimalBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::DecimalBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub fn vortex_array::builders::DecimalBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
@@ -10006,10 +9948,6 @@ pub fn vortex_array::builders::ExtensionBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::ExtensionBuilder::append_zeros(&mut self, n: usize)
 
-pub fn vortex_array::builders::ExtensionBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::ExtensionBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
 pub fn vortex_array::builders::ExtensionBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::builders::ExtensionBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
@@ -10047,10 +9985,6 @@ pub fn vortex_array::builders::FixedSizeListBuilder::append_scalar(&mut self, sc
 pub fn vortex_array::builders::FixedSizeListBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::FixedSizeListBuilder::append_zeros(&mut self, n: usize)
-
-pub fn vortex_array::builders::FixedSizeListBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::FixedSizeListBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub fn vortex_array::builders::FixedSizeListBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
@@ -10090,10 +10024,6 @@ pub fn vortex_array::builders::NullBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::NullBuilder::append_zeros(&mut self, n: usize)
 
-pub fn vortex_array::builders::NullBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::NullBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
 pub fn vortex_array::builders::NullBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::builders::NullBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
@@ -10131,10 +10061,6 @@ pub fn vortex_array::builders::StructBuilder::append_scalar(&mut self, scalar: &
 pub fn vortex_array::builders::StructBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::StructBuilder::append_zeros(&mut self, n: usize)
-
-pub fn vortex_array::builders::StructBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::StructBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub fn vortex_array::builders::StructBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
@@ -10174,10 +10100,6 @@ pub fn vortex_array::builders::VarBinViewBuilder::append_zero(&mut self)
 
 pub fn vortex_array::builders::VarBinViewBuilder::append_zeros(&mut self, n: usize)
 
-pub fn vortex_array::builders::VarBinViewBuilder::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::VarBinViewBuilder::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
 pub fn vortex_array::builders::VarBinViewBuilder::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::builders::VarBinViewBuilder::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
@@ -10215,10 +10137,6 @@ pub fn vortex_array::builders::ListViewBuilder<O, S>::append_scalar(&mut self, s
 pub fn vortex_array::builders::ListViewBuilder<O, S>::append_zero(&mut self)
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::append_zeros(&mut self, n: usize)
-
-pub fn vortex_array::builders::ListViewBuilder<O, S>::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::ListViewBuilder<O, S>::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub fn vortex_array::builders::ListViewBuilder<O, S>::dtype(&self) -> &vortex_array::dtype::DType
 
@@ -10258,10 +10176,6 @@ pub fn vortex_array::builders::ListBuilder<O>::append_zero(&mut self)
 
 pub fn vortex_array::builders::ListBuilder<O>::append_zeros(&mut self, n: usize)
 
-pub fn vortex_array::builders::ListBuilder<O>::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::ListBuilder<O>::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
 pub fn vortex_array::builders::ListBuilder<O>::dtype(&self) -> &vortex_array::dtype::DType
 
 pub fn vortex_array::builders::ListBuilder<O>::extend_from_array(&mut self, array: &vortex_array::ArrayRef)
@@ -10299,10 +10213,6 @@ pub fn vortex_array::builders::PrimitiveBuilder<T>::append_scalar(&mut self, sca
 pub fn vortex_array::builders::PrimitiveBuilder<T>::append_zero(&mut self)
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::append_zeros(&mut self, n: usize)
-
-pub fn vortex_array::builders::PrimitiveBuilder<T>::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_array::builders::PrimitiveBuilder<T>::as_any_mut(&mut self) -> &mut dyn core::any::Any
 
 pub fn vortex_array::builders::PrimitiveBuilder<T>::dtype(&self) -> &vortex_array::dtype::DType
 
@@ -19426,9 +19336,7 @@ pub trait vortex_array::scalar_fn::ReduceCtx
 
 pub fn vortex_array::scalar_fn::ReduceCtx::new_node(&self, scalar_fn: vortex_array::scalar_fn::ScalarFnRef, children: &[vortex_array::scalar_fn::ReduceNodeRef]) -> vortex_error::VortexResult<vortex_array::scalar_fn::ReduceNodeRef>
 
-pub trait vortex_array::scalar_fn::ReduceNode
-
-pub fn vortex_array::scalar_fn::ReduceNode::as_any(&self) -> &dyn core::any::Any
+pub trait vortex_array::scalar_fn::ReduceNode: core::any::Any
 
 pub fn vortex_array::scalar_fn::ReduceNode::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
@@ -19440,8 +19348,6 @@ pub fn vortex_array::scalar_fn::ReduceNode::scalar_fn(&self) -> core::option::Op
 
 impl vortex_array::scalar_fn::ReduceNode for vortex_array::ArrayRef
 
-pub fn vortex_array::ArrayRef::as_any(&self) -> &dyn core::any::Any
-
 pub fn vortex_array::ArrayRef::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
 pub fn vortex_array::ArrayRef::child_count(&self) -> usize
@@ -19451,8 +19357,6 @@ pub fn vortex_array::ArrayRef::node_dtype(&self) -> vortex_error::VortexResult<v
 pub fn vortex_array::ArrayRef::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
 
 impl vortex_array::scalar_fn::ReduceNode for vortex_array::arrays::scalar_fn::ScalarFnArray
-
-pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::as_any(&self) -> &dyn core::any::Any
 
 pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
@@ -19464,8 +19368,6 @@ pub fn vortex_array::arrays::scalar_fn::ScalarFnArray::scalar_fn(&self) -> core:
 
 impl<V: vortex_array::vtable::VTable> vortex_array::scalar_fn::ReduceNode for vortex_array::ArrayAdapter<V>
 
-pub fn vortex_array::ArrayAdapter<V>::as_any(&self) -> &dyn core::any::Any
-
 pub fn vortex_array::ArrayAdapter<V>::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
 pub fn vortex_array::ArrayAdapter<V>::child_count(&self) -> usize
@@ -19475,8 +19377,6 @@ pub fn vortex_array::ArrayAdapter<V>::node_dtype(&self) -> vortex_error::VortexR
 pub fn vortex_array::ArrayAdapter<V>::scalar_fn(&self) -> core::option::Option<&vortex_array::scalar_fn::ScalarFnRef>
 
 impl<V: vortex_array::vtable::VTable> vortex_array::scalar_fn::ReduceNode for vortex_array::vtable::Array<V>
-
-pub fn vortex_array::vtable::Array<V>::as_any(&self) -> &dyn core::any::Any
 
 pub fn vortex_array::vtable::Array<V>::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
@@ -21068,8 +20968,6 @@ pub fn vortex_array::vtable::Array<V>::all_valid(&self) -> vortex_error::VortexR
 
 pub fn vortex_array::vtable::Array<V>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::vtable::Array<V>::as_any(&self) -> &dyn core::any::Any
-
 pub fn vortex_array::vtable::Array<V>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
 
 pub fn vortex_array::vtable::Array<V>::dtype(&self) -> &vortex_array::dtype::DType
@@ -21113,8 +21011,6 @@ impl<V: vortex_array::vtable::VTable> vortex_array::IntoArray for vortex_array::
 pub fn vortex_array::vtable::Array<V>::into_array(self) -> vortex_array::ArrayRef
 
 impl<V: vortex_array::vtable::VTable> vortex_array::scalar_fn::ReduceNode for vortex_array::vtable::Array<V>
-
-pub fn vortex_array::vtable::Array<V>::as_any(&self) -> &dyn core::any::Any
 
 pub fn vortex_array::vtable::Array<V>::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
@@ -24368,8 +24264,6 @@ pub fn vortex_array::ArrayAdapter<V>::all_valid(&self) -> vortex_error::VortexRe
 
 pub fn vortex_array::ArrayAdapter<V>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::ArrayAdapter<V>::as_any(&self) -> &dyn core::any::Any
-
 pub fn vortex_array::ArrayAdapter<V>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
 
 pub fn vortex_array::ArrayAdapter<V>::dtype(&self) -> &vortex_array::dtype::DType
@@ -24409,8 +24303,6 @@ pub fn vortex_array::ArrayAdapter<V>::validity_mask(&self) -> vortex_error::Vort
 pub fn vortex_array::ArrayAdapter<V>::vtable(&self) -> &dyn vortex_array::vtable::DynVTable
 
 impl<V: vortex_array::vtable::VTable> vortex_array::scalar_fn::ReduceNode for vortex_array::ArrayAdapter<V>
-
-pub fn vortex_array::ArrayAdapter<V>::as_any(&self) -> &dyn core::any::Any
 
 pub fn vortex_array::ArrayAdapter<V>::child(&self, idx: usize) -> vortex_array::scalar_fn::ReduceNodeRef
 
@@ -24812,15 +24704,13 @@ pub type vortex_array::ProstMetadata<M>::Output = M
 
 pub fn vortex_array::ProstMetadata<M>::deserialize(metadata: &[u8]) -> vortex_error::VortexResult<Self::Output>
 
-pub trait vortex_array::DynArray: 'static + vortex_array::array::private::Sealed + core::marker::Send + core::marker::Sync + core::fmt::Debug + vortex_array::DynArrayEq + vortex_array::DynArrayHash + vortex_array::ArrayVisitor + vortex_array::scalar_fn::ReduceNode
+pub trait vortex_array::DynArray: 'static + vortex_array::array::private::Sealed + core::marker::Send + core::marker::Sync + core::fmt::Debug + vortex_array::DynArrayEq + vortex_array::DynArrayHash + vortex_array::ArrayVisitor + vortex_array::scalar_fn::ReduceNode + core::any::Any
 
 pub fn vortex_array::DynArray::all_invalid(&self) -> vortex_error::VortexResult<bool>
 
 pub fn vortex_array::DynArray::all_valid(&self) -> vortex_error::VortexResult<bool>
 
 pub fn vortex_array::DynArray::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::DynArray::as_any(&self) -> &dyn core::any::Any
 
 pub fn vortex_array::DynArray::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
 
@@ -24868,8 +24758,6 @@ pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::all_valid(&self) -> vortex_
 
 pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::as_any(&self) -> &dyn core::any::Any
-
 pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
 
 pub fn alloc::sync::Arc<dyn vortex_array::DynArray>::dtype(&self) -> &vortex_array::dtype::DType
@@ -24916,8 +24804,6 @@ pub fn vortex_array::ArrayAdapter<V>::all_valid(&self) -> vortex_error::VortexRe
 
 pub fn vortex_array::ArrayAdapter<V>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
 
-pub fn vortex_array::ArrayAdapter<V>::as_any(&self) -> &dyn core::any::Any
-
 pub fn vortex_array::ArrayAdapter<V>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
 
 pub fn vortex_array::ArrayAdapter<V>::dtype(&self) -> &vortex_array::dtype::DType
@@ -24963,8 +24849,6 @@ pub fn vortex_array::vtable::Array<V>::all_invalid(&self) -> vortex_error::Vorte
 pub fn vortex_array::vtable::Array<V>::all_valid(&self) -> vortex_error::VortexResult<bool>
 
 pub fn vortex_array::vtable::Array<V>::append_to_builder(&self, builder: &mut dyn vortex_array::builders::ArrayBuilder, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<()>
-
-pub fn vortex_array::vtable::Array<V>::as_any(&self) -> &dyn core::any::Any
 
 pub fn vortex_array::vtable::Array<V>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
 

--- a/vortex-array/src/aggregate_fn/erased.rs
+++ b/vortex-array/src/aggregate_fn/erased.rs
@@ -3,6 +3,7 @@
 
 //! Type-erased aggregate function ([`AggregateFnRef`]).
 
+use std::any::Any;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -41,7 +42,7 @@ impl AggregateFnRef {
 
     /// Returns whether the aggregate function is of the given vtable type.
     pub fn is<V: AggregateFnVTable>(&self) -> bool {
-        self.0.as_any().is::<AggregateFnInner<V>>()
+        (self.0.as_ref() as &dyn Any).is::<AggregateFnInner<V>>()
     }
 
     /// Returns the typed options for this aggregate function if it matches the given vtable type.
@@ -56,7 +57,7 @@ impl AggregateFnRef {
 
     /// Downcast the inner to the concrete `AggregateFnInner<V>`.
     fn downcast_inner<V: AggregateFnVTable>(&self) -> Option<&AggregateFnInner<V>> {
-        self.0.as_any().downcast_ref::<AggregateFnInner<V>>()
+        (self.0.as_ref() as &dyn Any).downcast_ref::<AggregateFnInner<V>>()
     }
 
     /// Returns the typed options for this aggregate function if it matches the given vtable type.

--- a/vortex-array/src/aggregate_fn/typed.rs
+++ b/vortex-array/src/aggregate_fn/typed.rs
@@ -33,8 +33,9 @@ use crate::dtype::DType;
 ///
 /// Options are stored inside the implementing [`AggregateFnInner<V>`], not passed externally.
 /// This is the sole trait behind [`AggregateFnRef`]'s `Arc<dyn DynAggregateFn>`.
-pub(super) trait DynAggregateFn: 'static + Send + Sync + super::sealed::Sealed {
-    fn as_any(&self) -> &dyn Any;
+pub(super) trait DynAggregateFn:
+    'static + Send + Sync + Any + super::sealed::Sealed
+{
     fn id(&self) -> AggregateFnId;
     fn options_any(&self) -> &dyn Any;
 
@@ -62,11 +63,6 @@ pub(super) struct AggregateFnInner<V: AggregateFnVTable> {
 }
 
 impl<V: AggregateFnVTable> DynAggregateFn for AggregateFnInner<V> {
-    #[inline(always)]
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     #[inline(always)]
     fn id(&self) -> AggregateFnId {
         V::id(&self.vtable)

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -76,10 +76,8 @@ pub trait DynArray:
     + DynArrayHash
     + ArrayVisitor
     + ReduceNode
+    + Any
 {
-    /// Returns the array as a reference to a generic [`Any`] trait object.
-    fn as_any(&self) -> &dyn Any;
-
     /// Returns the array as an `Arc<dyn Any + Send + Sync>`.
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
 
@@ -165,11 +163,6 @@ pub trait DynArray:
 }
 
 impl DynArray for Arc<dyn DynArray> {
-    #[inline]
-    fn as_any(&self) -> &dyn Any {
-        DynArray::as_any(self.as_ref())
-    }
-
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self
     }
@@ -397,10 +390,6 @@ mod private {
 /// This is self-contained: identity methods use `Array<V>`'s own fields (dtype, len, stats),
 /// while data-access methods delegate to VTable methods on the inner `V::Array`.
 impl<V: VTable> DynArray for Array<V> {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self
     }
@@ -721,10 +710,6 @@ impl<V: VTable> ArrayVisitor for Array<V> {
 }
 
 impl<V: VTable> ReduceNode for Array<V> {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn node_dtype(&self) -> VortexResult<DType> {
         Ok(self.dtype.clone())
     }
@@ -778,10 +763,6 @@ impl<V: VTable> Debug for ArrayAdapter<V> {
 }
 
 impl<V: VTable> ReduceNode for ArrayAdapter<V> {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn node_dtype(&self) -> VortexResult<DType> {
         Ok(V::dtype(&self.0).clone())
     }
@@ -801,10 +782,6 @@ impl<V: VTable> ReduceNode for ArrayAdapter<V> {
 }
 
 impl<V: VTable> DynArray for ArrayAdapter<V> {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self
     }
@@ -1130,16 +1107,16 @@ impl<V: VTable> Matcher for V {
     type Match<'a> = &'a V::Array;
 
     fn matches(array: &dyn DynArray) -> bool {
-        DynArray::as_any(array).is::<Array<V>>() || DynArray::as_any(array).is::<ArrayAdapter<V>>()
+        (array as &dyn Any).is::<Array<V>>() || (array as &dyn Any).is::<ArrayAdapter<V>>()
     }
 
     fn try_match<'a>(array: &'a dyn DynArray) -> Option<Self::Match<'a>> {
         // Try new Array<V> first.
-        if let Some(typed) = DynArray::as_any(array).downcast_ref::<Array<V>>() {
+        if let Some(typed) = (array as &dyn Any).downcast_ref::<Array<V>>() {
             return Some(typed.inner());
         }
         // Fall back to legacy ArrayAdapter<V>.
-        DynArray::as_any(array)
+        (array as &dyn Any)
             .downcast_ref::<ArrayAdapter<V>>()
             .map(|adapter| adapter.as_inner())
     }

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -1107,10 +1107,22 @@ impl<V: VTable> Matcher for V {
     type Match<'a> = &'a V::Array;
 
     fn matches(array: &dyn DynArray) -> bool {
+        // Handle the case where ArrayRef (Arc<dyn DynArray>) is coerced to &dyn DynArray
+        // via the blanket impl. In this case, we need to unwrap the Arc to get to the
+        // actual array type.
+        if let Some(arc) = (array as &dyn Any).downcast_ref::<Arc<dyn DynArray>>() {
+            return Self::matches(arc.as_ref());
+        }
         (array as &dyn Any).is::<Array<V>>() || (array as &dyn Any).is::<ArrayAdapter<V>>()
     }
 
     fn try_match<'a>(array: &'a dyn DynArray) -> Option<Self::Match<'a>> {
+        // Handle the case where ArrayRef (Arc<dyn DynArray>) is coerced to &dyn DynArray
+        // via the blanket impl. In this case, we need to unwrap the Arc to get to the
+        // actual array type.
+        if let Some(arc) = (array as &dyn Any).downcast_ref::<Arc<dyn DynArray>>() {
+            return Self::try_match(arc.as_ref());
+        }
         // Try new Array<V> first.
         if let Some(typed) = (array as &dyn Any).downcast_ref::<Array<V>>() {
             return Some(typed.inner());

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -276,8 +277,7 @@ fn append_value_or_nulls<B: ArrayBuilder + 'static>(
     n: usize,
     fill: impl FnOnce(&mut B),
 ) {
-    let b = builder
-        .as_any_mut()
+    let b = (builder as &mut dyn Any)
         .downcast_mut::<B>()
         .vortex_expect("builder dtype must match array dtype");
     if is_null {

--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -5,6 +5,7 @@ mod kernels;
 mod operations;
 mod slice;
 
+use std::any::Any;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
@@ -216,8 +217,7 @@ impl VTable for Patched {
             .execute::<PrimitiveArray>(ctx)?;
 
         match_each_native_ptype!(ptype, |V| {
-            let typed_builder = builder
-                .as_any_mut()
+            let typed_builder = (builder as &mut dyn Any)
                 .downcast_mut::<PrimitiveBuilder<V>>()
                 .vortex_expect("correctly typed builder");
 

--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -182,7 +182,8 @@ impl ReduceCtx for ArrayReduceCtx {
                 children
                     .iter()
                     .map(|c| {
-                        (c as &dyn Any)
+                        // Dereference the Arc to get &dyn ReduceNode, then upcast to &dyn Any
+                        (c.as_ref() as &dyn Any)
                             .downcast_ref::<ArrayRef>()
                             .vortex_expect("ReduceNode is not an ArrayRef")
                             .clone()

--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -119,8 +119,7 @@ impl ArrayReduceRule<ScalarFnVTable> for ScalarFnAbstractReduceRule {
             .reduce(array, &ArrayReduceCtx { len: array.len })?
         {
             return Ok(Some(
-                reduced
-                    .as_any()
+                (reduced.as_ref() as &dyn Any)
                     .downcast_ref::<ArrayRef>()
                     .vortex_expect("ReduceNode is not an ArrayRef")
                     .clone(),
@@ -131,10 +130,6 @@ impl ArrayReduceRule<ScalarFnVTable> for ScalarFnAbstractReduceRule {
 }
 
 impl ReduceNode for ScalarFnArray {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn node_dtype(&self) -> VortexResult<DType> {
         Ok(self.dtype().clone())
     }
@@ -154,10 +149,6 @@ impl ReduceNode for ScalarFnArray {
 }
 
 impl ReduceNode for ArrayRef {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn node_dtype(&self) -> VortexResult<DType> {
         self.as_ref().node_dtype()
     }
@@ -191,7 +182,7 @@ impl ReduceCtx for ArrayReduceCtx {
                 children
                     .iter()
                     .map(|c| {
-                        c.as_any()
+                        (c as &dyn Any)
                             .downcast_ref::<ArrayRef>()
                             .vortex_expect("ReduceNode is not an ArrayRef")
                             .clone()

--- a/vortex-array/src/buffer.rs
+++ b/vortex-array/src/buffer.rs
@@ -43,10 +43,7 @@ enum Inner {
 }
 
 /// A buffer that is stored on the GPU.
-pub trait DeviceBuffer: 'static + Send + Sync + Debug + DynEq + DynHash {
-    /// Returns a reference as `Any` to enable downcasting.
-    fn as_any(&self) -> &dyn Any;
-
+pub trait DeviceBuffer: 'static + Send + Sync + Debug + DynEq + DynHash + Any {
     /// Returns the length of the buffer in bytes.
     fn len(&self) -> usize;
 

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
 use std::mem;
 
 use vortex_buffer::BitBufferMut;
@@ -70,14 +69,6 @@ impl BoolBuilder {
 }
 
 impl ArrayBuilder for BoolBuilder {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn dtype(&self) -> &DType {
         &self.dtype
     }

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
-
 use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -148,14 +146,6 @@ impl DecimalBuilder {
 }
 
 impl ArrayBuilder for DecimalBuilder {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn dtype(&self) -> &DType {
         &self.dtype
     }

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
-
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_mask::Mask;
@@ -62,14 +60,6 @@ impl ExtensionBuilder {
 }
 
 impl ArrayBuilder for ExtensionBuilder {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn dtype(&self) -> &DType {
         &self.dtype
     }

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
 use std::sync::Arc;
 
 use vortex_error::VortexExpect;
@@ -179,14 +178,6 @@ impl FixedSizeListBuilder {
 }
 
 impl ArrayBuilder for FixedSizeListBuilder {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn dtype(&self) -> &DType {
         &self.dtype
     }

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
 use std::sync::Arc;
 
 use vortex_error::VortexExpect;
@@ -165,14 +164,6 @@ impl<O: IntegerPType> ListBuilder<O> {
 }
 
 impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn dtype(&self) -> &DType {
         &self.dtype
     }

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -224,14 +224,6 @@ impl<O: IntegerPType, S: IntegerPType> ListViewBuilder<O, S> {
 }
 
 impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
-        self
-    }
-
     fn dtype(&self) -> &DType {
         &self.dtype
     }

--- a/vortex-array/src/builders/mod.rs
+++ b/vortex-array/src/builders/mod.rs
@@ -75,11 +75,7 @@ mod tests;
 /// This is equal to the default capacity for Arrow Arrays.
 pub const DEFAULT_BUILDER_CAPACITY: usize = 1024;
 
-pub trait ArrayBuilder: Send {
-    fn as_any(&self) -> &dyn Any;
-
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-
+pub trait ArrayBuilder: Send + Any {
     fn dtype(&self) -> &DType;
 
     fn len(&self) -> usize;

--- a/vortex-array/src/builders/null.rs
+++ b/vortex-array/src/builders/null.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
-
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_mask::Mask;
@@ -34,14 +32,6 @@ impl NullBuilder {
 }
 
 impl ArrayBuilder for NullBuilder {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn dtype(&self) -> &DType {
         &DType::Null
     }

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
 use std::mem::MaybeUninit;
 
 use vortex_buffer::BufferMut;
@@ -131,14 +130,6 @@ impl<T: NativePType> PrimitiveBuilder<T> {
 }
 
 impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn dtype(&self) -> &DType {
         &self.dtype
     }

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
-
 use itertools::Itertools;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -121,14 +119,6 @@ impl StructBuilder {
 }
 
 impl ArrayBuilder for StructBuilder {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn dtype(&self) -> &DType {
         &self.dtype
     }

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use std::any::Any;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -233,14 +232,6 @@ impl VarBinViewBuilder {
 }
 
 impl ArrayBuilder for VarBinViewBuilder {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
     fn dtype(&self) -> &DType {
         &self.dtype
     }

--- a/vortex-array/src/expr/optimize.rs
+++ b/vortex-array/src/expr/optimize.rs
@@ -79,8 +79,7 @@ impl Expression {
                 scope: scope.clone(),
             };
             if let Some(reduced) = current.scalar_fn().reduce(&reduce_node, &reduce_ctx)? {
-                let reduced_expr = reduced
-                    .as_any()
+                let reduced_expr = (reduced.as_ref() as &dyn Any)
                     .downcast_ref::<ExpressionReduceNode>()
                     .vortex_expect("ReduceNode not an ExpressionReduceNode")
                     .expression
@@ -241,10 +240,6 @@ struct ExpressionReduceNode {
 }
 
 impl ReduceNode for ExpressionReduceNode {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn node_dtype(&self) -> VortexResult<DType> {
         self.expression.return_dtype(&self.scope)
     }
@@ -279,7 +274,7 @@ impl ReduceCtx for ExpressionReduceCtx {
             children
                 .iter()
                 .map(|c| {
-                    c.as_any()
+                    (c as &dyn Any)
                         .downcast_ref::<ExpressionReduceNode>()
                         .vortex_expect("ReduceNode not an ExpressionReduceNode")
                         .expression

--- a/vortex-array/src/expr/optimize.rs
+++ b/vortex-array/src/expr/optimize.rs
@@ -274,7 +274,8 @@ impl ReduceCtx for ExpressionReduceCtx {
             children
                 .iter()
                 .map(|c| {
-                    (c as &dyn Any)
+                    // Dereference the Arc to get &dyn ReduceNode, then upcast to &dyn Any
+                    (c.as_ref() as &dyn Any)
                         .downcast_ref::<ExpressionReduceNode>()
                         .vortex_expect("ReduceNode not an ExpressionReduceNode")
                         .expression

--- a/vortex-array/src/hash.rs
+++ b/vortex-array/src/hash.rs
@@ -94,7 +94,7 @@ impl ArrayHash for dyn DynArray + '_ {
 
 impl ArrayEq for dyn DynArray + '_ {
     fn array_eq(&self, other: &Self, precision: Precision) -> bool {
-        self.dyn_array_eq(DynArray::as_any(other), precision)
+        self.dyn_array_eq(other as &dyn Any, precision)
     }
 }
 

--- a/vortex-array/src/scalar_fn/vtable.rs
+++ b/vortex-array/src/scalar_fn/vtable.rs
@@ -266,10 +266,7 @@ pub trait ReduceCtx {
 pub type ReduceNodeRef = Arc<dyn ReduceNode>;
 
 /// A node used for implementing abstract reduction rules.
-pub trait ReduceNode {
-    /// Downcast to Any.
-    fn as_any(&self) -> &dyn Any;
-
+pub trait ReduceNode: Any {
     /// Return the data type of this node.
     fn node_dtype(&self) -> VortexResult<DType>;
 

--- a/vortex-array/src/vtable/dyn_.rs
+++ b/vortex-array/src/vtable/dyn_.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -223,8 +224,7 @@ impl<V: VTable> DynVTable for V {
 
 /// Borrow-downcast an `ArrayRef` to `&Array<V>`.
 fn downcast<V: VTable>(array: &ArrayRef) -> &Array<V> {
-    array
-        .as_any()
+    (array.as_ref() as &dyn Any)
         .downcast_ref::<Array<V>>()
         .vortex_expect("Failed to downcast array to expected encoding type")
 }

--- a/vortex-cuda/benches/filter_cuda.rs
+++ b/vortex-cuda/benches/filter_cuda.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::cast_possible_truncation)]
 
+use std::any::Any;
 use std::ffi::c_void;
 use std::fmt::Debug;
 use std::mem::size_of;
@@ -173,9 +174,7 @@ where
                             let d_input_handle =
                                 block_on(cuda_ctx.copy_to_device(input_data.clone()).unwrap())
                                     .vortex_expect("failed to copy input to device");
-                            let d_input = d_input_handle
-                                .as_device()
-                                .as_any()
+                            let d_input = (d_input_handle.as_device().as_ref() as &dyn Any)
                                 .downcast_ref::<CudaDeviceBuffer>()
                                 .unwrap();
 
@@ -183,9 +182,7 @@ where
                             let d_bitmask_handle =
                                 block_on(cuda_ctx.copy_to_device(bitmask.clone()).unwrap())
                                     .vortex_expect("failed to copy bitmask to device");
-                            let d_bitmask = d_bitmask_handle
-                                .as_device()
-                                .as_any()
+                            let d_bitmask = (d_bitmask_handle.as_device().as_ref() as &dyn Any)
                                 .downcast_ref::<CudaDeviceBuffer>()
                                 .unwrap();
 

--- a/vortex-cuda/src/device_buffer.rs
+++ b/vortex-cuda/src/device_buffer.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::cmp::min;
 use std::fmt::Debug;
 use std::ops::Range;
@@ -114,7 +115,7 @@ impl CudaDeviceBuffer {
         // Return a new &[T]
         let new_len = self.len / size_of::<T>();
 
-        // SAFETY: All DeviecRepr types are aligned to < 256 bytes, which is what CUDA allocator
+        // SAFETY: All DeviceRepr types are aligned to < 256 bytes, which is what CUDA allocator
         //  gives us back. So we should not suffer any alignment issues at runtime.
         unsafe {
             self.allocation
@@ -152,8 +153,7 @@ impl CudaBufferExt for BufferHandle {
             .as_device_opt()
             .ok_or_else(|| vortex_err!("Buffer is not on device"))?;
 
-        let cuda_buf = device_buffer
-            .as_any()
+        let cuda_buf = (device_buffer.as_ref() as &dyn Any)
             .downcast_ref::<CudaDeviceBuffer>()
             .ok_or_else(|| vortex_err!("expected CudaDeviceBuffer, was {device_buffer:?}"))?;
 
@@ -161,10 +161,10 @@ impl CudaBufferExt for BufferHandle {
     }
 
     fn cuda_device_ptr(&self) -> VortexResult<sys::CUdeviceptr> {
-        let ptr = self
+        let device_buf = self
             .as_device_opt()
-            .ok_or_else(|| vortex_err!("Buffer is not on device"))?
-            .as_any()
+            .ok_or_else(|| vortex_err!("Buffer is not on device"))?;
+        let ptr = (device_buf.as_ref() as &dyn Any)
             .downcast_ref::<CudaDeviceBuffer>()
             .ok_or_else(|| vortex_err!("expected CudaDeviceBuffer"))?
             .offset_ptr();
@@ -320,10 +320,6 @@ impl DeviceBuffer for CudaDeviceBuffer {
             device_ptr: self.device_ptr,
             alignment: self.alignment,
         })
-    }
-
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
     }
 
     fn aligned(self: Arc<Self>, alignment: Alignment) -> VortexResult<Arc<dyn DeviceBuffer>> {

--- a/vortex-cuda/src/kernel/filter/mod.rs
+++ b/vortex-cuda/src/kernel/filter/mod.rs
@@ -7,6 +7,7 @@ mod decimal;
 mod primitive;
 mod varbinview;
 
+use std::any::Any;
 use std::ffi::c_void;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -116,18 +117,14 @@ async fn filter_sized<T: DeviceRepr + CubFilterable + Debug + Send + Sync + 'sta
     let stream_ptr = stream.cu_stream() as cudaStream_t;
 
     // Downcast input buffer to get device pointer.
-    let d_input_cuda = d_input
-        .as_device()
-        .as_any()
+    let d_input_cuda = (d_input.as_device().as_ref() as &dyn Any)
         .downcast_ref::<CudaDeviceBuffer>()
         .ok_or_else(|| vortex_err!("Expected CudaDeviceBuffer for input, was {d_input:?}",))?;
     let d_input_view = d_input_cuda.as_view::<T>();
     let (d_input_ptr, record_d_input) = d_input_view.device_ptr(stream);
 
     // Downcast to get device pointer.
-    let d_packed_cuda = d_flags
-        .as_device()
-        .as_any()
+    let d_packed_cuda = (d_flags.as_device().as_ref() as &dyn Any)
         .downcast_ref::<CudaDeviceBuffer>()
         .ok_or_else(|| vortex_err!("Expected CudaDeviceBuffer for packed flags"))?;
     let d_packed_view = d_packed_cuda.as_view::<u8>();

--- a/vortex-cuda/src/kernel/patches/mod.rs
+++ b/vortex-cuda/src/kernel/patches/mod.rs
@@ -98,6 +98,7 @@ pub(crate) async fn execute_patches<
 
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
     use std::sync::Arc;
 
     use cudarc::driver::DeviceRepr;
@@ -173,9 +174,7 @@ mod tests {
         } = values.into_parts();
 
         let handle = ctx.ensure_on_device(cuda_buffer).await.unwrap();
-        let device_buf = handle
-            .as_device()
-            .as_any()
+        let device_buf = (handle.as_device().as_ref() as &dyn Any)
             .downcast_ref::<CudaDeviceBuffer>()
             .unwrap()
             .clone();

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
+
 use arrow_array::ffi::FFI_ArrowArray;
 use arrow_array::ffi::FFI_ArrowSchema;
 use arrow_schema::DataType;
@@ -449,11 +451,12 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getUTF8_1ptr_1len<
             throw_runtime!("getUTF8_ptr_len expected UTF8 array");
         }
 
-        if let Some(varbin) = array_ref.inner.as_any().downcast_ref::<VarBinArray>() {
+        if let Some(varbin) = (array_ref.inner.as_ref() as &dyn Any).downcast_ref::<VarBinArray>() {
             let (ptr, len) = get_ptr_len_varbin(index, varbin);
             env.set_long_array_region(&out_ptr, 0, &[ptr as jlong])?;
             env.set_int_array_region(&out_len, 0, &[len as jint])?;
-        } else if let Some(varbinview) = array_ref.inner.as_any().downcast_ref::<VarBinViewArray>()
+        } else if let Some(varbinview) =
+            (array_ref.inner.as_ref() as &dyn Any).downcast_ref::<VarBinViewArray>()
         {
             let (ptr, len) = get_ptr_len_view(index, varbinview);
             env.set_long_array_region(&out_ptr, 0, &[ptr as jlong])?;

--- a/vortex-layout/public-api.lock
+++ b/vortex-layout/public-api.lock
@@ -1668,8 +1668,6 @@ pub fn vortex_layout::LayoutAdapter<V>::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl<V: vortex_layout::VTable> vortex_layout::Layout for vortex_layout::LayoutAdapter<V>
 
-pub fn vortex_layout::LayoutAdapter<V>::as_any(&self) -> &dyn core::any::Any
-
 pub fn vortex_layout::LayoutAdapter<V>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
 
 pub fn vortex_layout::LayoutAdapter<V>::child(&self, idx: usize) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
@@ -1699,8 +1697,6 @@ impl<V: vortex_layout::VTable> core::fmt::Debug for vortex_layout::LayoutEncodin
 pub fn vortex_layout::LayoutEncodingAdapter<V>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
 impl<V: vortex_layout::VTable> vortex_layout::LayoutEncoding for vortex_layout::LayoutEncodingAdapter<V>
-
-pub fn vortex_layout::LayoutEncodingAdapter<V>::as_any(&self) -> &dyn core::any::Any
 
 pub fn vortex_layout::LayoutEncodingAdapter<V>::build(&self, dtype: &vortex_array::dtype::DType, row_count: u64, metadata: &[u8], segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
@@ -1746,9 +1742,7 @@ impl vortex_layout::IntoLayout for vortex_layout::layouts::zoned::ZonedLayout
 
 pub fn vortex_layout::layouts::zoned::ZonedLayout::into_layout(self) -> vortex_layout::LayoutRef
 
-pub trait vortex_layout::Layout: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug + vortex_layout::layout::private::Sealed
-
-pub fn vortex_layout::Layout::as_any(&self) -> &dyn core::any::Any
+pub trait vortex_layout::Layout: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug + core::any::Any + vortex_layout::layout::private::Sealed
 
 pub fn vortex_layout::Layout::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
 
@@ -1773,8 +1767,6 @@ pub fn vortex_layout::Layout::segment_ids(&self) -> alloc::vec::Vec<vortex_layou
 pub fn vortex_layout::Layout::to_layout(&self) -> vortex_layout::LayoutRef
 
 impl<V: vortex_layout::VTable> vortex_layout::Layout for vortex_layout::LayoutAdapter<V>
-
-pub fn vortex_layout::LayoutAdapter<V>::as_any(&self) -> &dyn core::any::Any
 
 pub fn vortex_layout::LayoutAdapter<V>::as_any_arc(self: alloc::sync::Arc<Self>) -> alloc::sync::Arc<(dyn core::any::Any + core::marker::Send + core::marker::Sync)>
 
@@ -1818,17 +1810,13 @@ pub fn alloc::sync::Arc<dyn vortex_layout::LayoutChildren>::nchildren(&self) -> 
 
 pub fn alloc::sync::Arc<dyn vortex_layout::LayoutChildren>::to_arc(&self) -> alloc::sync::Arc<dyn vortex_layout::LayoutChildren>
 
-pub trait vortex_layout::LayoutEncoding: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug + vortex_layout::encoding::private::Sealed
-
-pub fn vortex_layout::LayoutEncoding::as_any(&self) -> &dyn core::any::Any
+pub trait vortex_layout::LayoutEncoding: 'static + core::marker::Send + core::marker::Sync + core::fmt::Debug + core::any::Any + vortex_layout::encoding::private::Sealed
 
 pub fn vortex_layout::LayoutEncoding::build(&self, dtype: &vortex_array::dtype::DType, row_count: u64, metadata: &[u8], segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 
 pub fn vortex_layout::LayoutEncoding::id(&self) -> vortex_layout::LayoutEncodingId
 
 impl<V: vortex_layout::VTable> vortex_layout::LayoutEncoding for vortex_layout::LayoutEncodingAdapter<V>
-
-pub fn vortex_layout::LayoutEncodingAdapter<V>::as_any(&self) -> &dyn core::any::Any
 
 pub fn vortex_layout::LayoutEncodingAdapter<V>::build(&self, dtype: &vortex_array::dtype::DType, row_count: u64, metadata: &[u8], segment_ids: alloc::vec::Vec<vortex_layout::segments::SegmentId>, children: &dyn vortex_layout::LayoutChildren, ctx: &vortex_session::registry::ReadContext) -> vortex_error::VortexResult<vortex_layout::LayoutRef>
 

--- a/vortex-layout/src/encoding.rs
+++ b/vortex-layout/src/encoding.rs
@@ -23,9 +23,7 @@ use crate::segments::SegmentId;
 pub type LayoutEncodingId = ArcRef<str>;
 pub type LayoutEncodingRef = ArcRef<dyn LayoutEncoding>;
 
-pub trait LayoutEncoding: 'static + Send + Sync + Debug + private::Sealed {
-    fn as_any(&self) -> &dyn Any;
-
+pub trait LayoutEncoding: 'static + Send + Sync + Debug + Any + private::Sealed {
     fn id(&self) -> LayoutEncodingId;
 
     fn build(
@@ -43,10 +41,6 @@ pub trait LayoutEncoding: 'static + Send + Sync + Debug + private::Sealed {
 pub struct LayoutEncodingAdapter<V: VTable>(V::Encoding);
 
 impl<V: VTable> LayoutEncoding for LayoutEncodingAdapter<V> {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn id(&self) -> LayoutEncodingId {
         V::id(&self.0)
     }
@@ -120,7 +114,7 @@ impl dyn LayoutEncoding + '_ {
     }
 
     pub fn as_opt<V: VTable>(&self) -> Option<&V::Encoding> {
-        self.as_any()
+        (self as &dyn Any)
             .downcast_ref::<LayoutEncodingAdapter<V>>()
             .map(|e| &e.0)
     }

--- a/vortex-layout/src/layout.rs
+++ b/vortex-layout/src/layout.rs
@@ -30,9 +30,7 @@ pub type LayoutId = ArcRef<str>;
 
 pub type LayoutRef = Arc<dyn Layout>;
 
-pub trait Layout: 'static + Send + Sync + Debug + private::Sealed {
-    fn as_any(&self) -> &dyn Any;
-
+pub trait Layout: 'static + Send + Sync + Debug + Any + private::Sealed {
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
 
     fn to_layout(&self) -> LayoutRef;
@@ -151,7 +149,7 @@ impl dyn Layout + '_ {
 
     /// Downcast a layout to a specific type.
     pub fn as_opt<V: VTable>(&self) -> Option<&V::Layout> {
-        self.as_any()
+        (self as &dyn Any)
             .downcast_ref::<LayoutAdapter<V>>()
             .map(|adapter| &adapter.0)
     }
@@ -261,10 +259,6 @@ impl<V: VTable> Debug for LayoutAdapter<V> {
 }
 
 impl<V: VTable> Layout for LayoutAdapter<V> {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self
     }

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -9,6 +9,8 @@ mod native;
 pub(crate) mod py;
 mod range_to_sequence;
 
+use std::any::Any;
+
 use arrow_array::Array as ArrowArray;
 use arrow_array::ArrayRef as ArrowArrayRef;
 use pyo3::IntoPyObjectExt;
@@ -119,7 +121,7 @@ impl<'py> IntoPyObject<'py> for PyArrayRef {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         // If the ArrayRef is a PyArrayInstance, extract the Python object.
-        if let Some(pyarray) = DynArray::as_any(&*self.0).downcast_ref::<PythonArray>() {
+        if let Some(pyarray) = (self.0.as_ref() as &dyn Any).downcast_ref::<PythonArray>() {
             return pyarray.clone().into_pyobject(py);
         }
 

--- a/vortex-python/src/arrays/native.rs
+++ b/vortex-python/src/arrays/native.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use std::any::Any;
 use std::ops::Deref;
 
 use pyo3::PyClass;
@@ -252,7 +253,7 @@ pub trait AsArrayRef<T> {
 
 impl<V: EncodingSubclass> AsArrayRef<<V::VTable as VTable>::Array> for PyRef<'_, V> {
     fn as_array_ref(&self) -> &<V::VTable as VTable>::Array {
-        let any = self.as_super().inner().as_any();
+        let any = self.as_super().inner().as_ref() as &dyn Any;
         // Try new Array<V> path first, then fall back to legacy ArrayAdapter<V>.
         if let Some(typed) = any.downcast_ref::<Array<V::VTable>>() {
             return typed.inner();

--- a/vortex-session/public-api.lock
+++ b/vortex-session/public-api.lock
@@ -160,12 +160,4 @@ pub fn vortex_session::VortexSession::session(&self) -> vortex_session::VortexSe
 
 pub trait vortex_session::SessionVar: core::any::Any + core::marker::Send + core::marker::Sync + core::fmt::Debug + 'static
 
-pub fn vortex_session::SessionVar::as_any(&self) -> &dyn core::any::Any
-
-pub fn vortex_session::SessionVar::as_any_mut(&mut self) -> &mut dyn core::any::Any
-
-impl<T: core::marker::Send + core::marker::Sync + core::fmt::Debug + 'static> vortex_session::SessionVar for T
-
-pub fn T::as_any(&self) -> &dyn core::any::Any
-
-pub fn T::as_any_mut(&mut self) -> &mut dyn core::any::Any
+impl<T: core::marker::Send + core::marker::Sync + core::fmt::Debug + core::any::Any + 'static> vortex_session::SessionVar for T

--- a/vortex-session/src/lib.rs
+++ b/vortex-session/src/lib.rs
@@ -92,8 +92,7 @@ impl SessionExt for VortexSession {
         //  would immediately acquire an exclusive write lock.
         if let Some(v) = self.0.get(&TypeId::of::<V>()) {
             return Ref(v.map(|v| {
-                (**v)
-                    .as_any()
+                (&**v as &dyn Any)
                     .downcast_ref::<V>()
                     .vortex_expect("Type mismatch - this is a bug")
             }));
@@ -106,8 +105,7 @@ impl SessionExt for VortexSession {
             .or_insert_with(|| Box::new(V::default()))
             .downgrade()
             .map(|v| {
-                (**v)
-                    .as_any()
+                (&**v as &dyn Any)
                     .downcast_ref::<V>()
                     .vortex_expect("Type mismatch - this is a bug")
             }))
@@ -116,8 +114,7 @@ impl SessionExt for VortexSession {
     fn get_opt<V: SessionVar>(&self) -> Option<Ref<'_, V>> {
         self.0.get(&TypeId::of::<V>()).map(|v| {
             Ref(v.map(|v| {
-                (**v)
-                    .as_any()
+                (&**v as &dyn Any)
                     .downcast_ref::<V>()
                     .vortex_expect("Type mismatch - this is a bug")
             }))
@@ -133,8 +130,7 @@ impl SessionExt for VortexSession {
                 .entry(TypeId::of::<V>())
                 .or_insert_with(|| Box::new(V::default()))
                 .map(|v| {
-                    (**v)
-                        .as_any_mut()
+                    (&mut **v as &mut dyn Any)
                         .downcast_mut::<V>()
                         .vortex_expect("Type mismatch - this is a bug")
                 }),
@@ -144,8 +140,7 @@ impl SessionExt for VortexSession {
     fn get_mut_opt<V: SessionVar>(&self) -> Option<RefMut<'_, V>> {
         self.0.get_mut(&TypeId::of::<V>()).map(|v| {
             RefMut(v.map(|v| {
-                (**v)
-                    .as_any_mut()
+                (&mut **v as &mut dyn Any)
                     .downcast_mut::<V>()
                     .vortex_expect("Type mismatch - this is a bug")
             }))
@@ -179,20 +174,9 @@ impl Hasher for IdHasher {
 }
 
 /// This trait defines variables that can be stored against a Vortex session.
-pub trait SessionVar: Any + Send + Sync + Debug + 'static {
-    fn as_any(&self) -> &dyn Any;
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-}
+pub trait SessionVar: Any + Send + Sync + Debug + 'static {}
 
-impl<T: Send + Sync + Debug + 'static> SessionVar for T {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-}
+impl<T: Send + Sync + Debug + Any + 'static> SessionVar for T {}
 
 // NOTE(ngates): we don't want to expose that the internals of a session is a DashMap, so we have
 // our own wrapped Ref type.


### PR DESCRIPTION
Since Rust 1.86 (which is before our MSRV) there has been builtin trait upcasting, meaning instead of forcing all our traits to have a dummy `fn as_any(&self) -> &dyn Any` methods with trivial impls, we can instead just take a pointer to the trait object and do `as &dyn Any`.

This reduces the amount of boilerplate in trait impls, which is nice. Another benefit is that in the past blanket impls like `SessionVar` would end up getting pulled in for dispatch of calls to as_any() which has caused me frustration. Now the dispatch is clearer.

This isn't a breaking change b/c it doesn't touch the VTables, which is the implementer surface area