### PR TITLE
fix[vortex-array]: update an overflow test

### DIFF
--- a/vortex-array/src/arrays/fixed_size_list/tests/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/take.rs
@@ -12,6 +12,7 @@ use super::common::create_single_element_fsl;
 use crate::ArrayRef;
 use crate::DynArray;
 use crate::IntoArray;
+use crate::ToCanonical;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::PrimitiveArray;
 use crate::assert_arrays_eq;
@@ -136,22 +137,23 @@ fn test_take_fsl_with_null_indices_preserves_elements() {
 #[rstest]
 #[case::non_nullable(
     FixedSizeListArray::new(
-        buffer![0u8; 320].into_array(), 16, Validity::NonNullable, 20,
+        PrimitiveArray::from_iter(0u32..320).into_array(), 16, Validity::NonNullable, 20,
     ),
-    buffer![0u8, 16, 19].into_array(),
+    buffer![0u8, 16, 5].into_array(),
     FixedSizeListArray::new(
-        buffer![0u8; 48].into_array(), 16, Validity::NonNullable, 3,
+        PrimitiveArray::from_iter((0u32..16).chain(256..272).chain(80..96)).into_array(),
+        16, Validity::NonNullable, 3,
     ),
 )]
 #[case::nullable(
     FixedSizeListArray::new(
-        buffer![0u8; 320].into_array(), 16,
+        PrimitiveArray::from_iter(0u32..320).into_array(), 16,
         Validity::from_iter((0..20).map(|i| i != 5)), 20,
     ),
     buffer![0u8, 16, 5].into_array(),
     FixedSizeListArray::new(
-        buffer![0u8; 48].into_array(), 16,
-        Validity::from_iter([true, true, false]), 3,
+        PrimitiveArray::from_iter((0u32..16).chain(256..272).chain(80..96)).into_array(),
+        16, Validity::from_iter([true, true, false]), 3,
     ),
 )]
 fn test_element_index_overflow(
@@ -159,7 +161,7 @@ fn test_element_index_overflow(
     #[case] indices: ArrayRef,
     #[case] expected: FixedSizeListArray,
 ) {
-    let result = fsl.take(indices.to_array()).unwrap();
+    let result = fsl.take(indices).unwrap().to_fixed_size_list();
     assert_arrays_eq!(expected, result);
 }
 


### PR DESCRIPTION
The elements were incorrectly refactored by claude when I got it to clean up and parameterize tests.
This commit actually makes the elements interesting.
Additionally, this adds a to_fixed_size_list to the take so it actually gets executed and would fail without #7214.

<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

<!--
If this PR is related to a tracked effort, please link to the relevant issue
here (e.g., `Closes: #123`). Otherwise, feel free to ignore / delete this.

In this section, please:

1. Explain the rationale for this change.
2. Summarize the changes included in this PR.

A general rule of thumb is that larger PRs should have larger summaries. If
there are a lot of changes, please help us review the code by explaining what
was changed and why.

If there is an issue or discussion attached, there is no need to duplicate all
the details, but clarity is always preferred over brevity.
-->

Closes: #000

<!--
## API Changes

Uncomment this section if there are any user-facing changes.

Consider whether the change affects users in one of the following ways:

1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the engine integrations.
3. Should some documentation be updated to reflect this change?

If a public API is changed in a breaking manner, make sure to add the
appropriate label. You can run `./scripts/public-api.sh` locally to see if there
are any public API changes (and this also runs in our CI).
-->

## Testing

<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
3. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
