### PR TITLE
Fix TSan data race with FFI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
       ASAN_SYMBOLIZER_PATH: "/usr/bin/llvm-symbolizer"
       MSAN_OPTIONS: "symbolize=1"
       MSAN_SYMBOLIZER_PATH: "/usr/bin/llvm-symbolizer"
-      TSAN_OPTIONS: "symbolize=1"
+      TSAN_OPTIONS: "symbolize=1:suppressions=${{ github.workspace }}/vortex-ffi/tsan_suppressions.txt"
       TSAN_SYMBOLIZER_PATH: "/usr/bin/llvm-symbolizer"
       VORTEX_SKIP_SLOW_TESTS: "1"
       # -Cunsafe-allow-abi-mismatch=sanitizer: libraries like compiler_builtins

--- a/vortex-ffi/README.md
+++ b/vortex-ffi/README.md
@@ -76,6 +76,7 @@ cargo +nightly test -Zbuild-std \
 ThreadSanitizer:
 
 ```sh
+TSAN_OPTIONS="suppressions=$HOME/vortex/vortex-ffi/tsan_suppressions.txt" \
 RUSTFLAGS="-Z sanitizer=thread -Cunsafe-allow-abi-mismatch=sanitizer" \
 cargo +nightly test -Zbuild-std \
     --no-default-features --target <target triple> \

--- a/vortex-ffi/tsan_suppressions.txt
+++ b/vortex-ffi/tsan_suppressions.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+# https://github.com/vortex-data/vortex/pull/7244
+# This is likely a false positive in TSan for oneshot::channel and kanal
+# where ordering is correct but uses an explicit fence and not relaxed load
+race:oneshot-*/src/channel.rs


### PR DESCRIPTION
There are TSan data race reports like

https://github.com/vortex-data/vortex/actions/runs/23804465237/job/69373850775?pr=7018

Significant parts of stack trace

```
Read of size 8 at 0xffff888084a0 by thread T40:

#8 vx_array_sink_open_file::{closure#0}::{closure#0} vortex-ffi/src/sink.rs:75
#9 <vortex_io::runtime::handle::Handle>::spawn::<vx_array_sink_open_file::{closure#0}::{closure#0}, ...> vortex-io/src/runtime/handle.rs:73
#31 vx_array_sink_close::{closure#0} vortex-ffi/src/sink.rs:110
#33 vx_array_sink_close vortex-ffi/src/sink.rs:106
#34 test_sink_basic_workflow vortex-ffi/src/sink.rs:166

Previous write of size 8 at 0xffff888084a0 by thread T42:

#28 <vortex_io::runtime::current::CurrentThreadRuntime>::block_on::<vx_array_sink_close::{closure#0}::{closure#0}, ...> vortex-io/src/runtime/current.rs:102
#29 vx_array_sink_close::{closure#0} vortex-ffi/src/sink.rs:110
#31 vx_array_sink_close vortex-ffi/src/sink.rs:106
#32 test_sink_multiple_arrays

Location is heap block of size 112 at 0xffff88808490 allocated by thread T42:

#13 <vortex_file::writer::VortexWriteOptions>::write::<&mut async_fs::File, ...>::{closure#0} vortex-file/src/writer.rs:137
#14 vx_array_sink_open_file::{closure#0}::{closure#0} vortex-ffi/src/sink.rs:75
#15 <vortex_io::runtime::handle::Handle>::spawn::<vx_array_sink_open_file::{closure#0}::{closure#0}, ...>::{closure#0} vortex-io/src/runtime/handle.rs:73
#37 vx_array_sink_close::{closure#0} vortex-ffi/src/sink.rs:110
#40 test_sink_multiple_arrays vortex-ffi/src/sink.rs:208
```

which happens in sink FFI tests but can be narrowed down to

```rust
fn test(path: String) {
    let session = VortexSession::default().with_handle(RUNTIME.handle());
    let dtype = DType::Primitive(vortex::dtype::PType::I32, false.into());
    let (mut sink, rx) = mpsc::channel(32);
    let array_stream = ArrayStreamAdapter::new(dtype.clone(), rx.into_stream());

    let array = PrimitiveArray::new(buffer![3i32], Validity::NonNullable);
    RUNTIME.block_on(async move {
        sink.send(Ok(array.into())).await.unwrap();
        sink.close_channel();

        let mut file = File::create(path).await.unwrap();
        session
            .write_options()
            .write(&mut file, array_stream)
            .await.unwrap();
        file.sync_all()
            .await
            .map_err(|e| vortex_err!("sync error: {e}")).unwrap();
    });
}
#[test] fn test_f1() { test("1".to_string()); }
#[test] fn test_f2() { test("2".to_string()); }
```

The underlying issue is that RUNTIME in FFI is a smol::Executor, and as we don't
have a background thread pool, and we use CurrentThreadRuntime, it runs on host
program's threads, in our case, `cargo test`'s. If t1 and t2 are scheduled to
run on different threads, this triggers TSan in vortex-io's spawn() (case 1,
oneshot) and in vortex-file write_internal (case 2, kanal::bounded_async) which
don't protect multiple different thread consumers to read the state.

The solution here is to benchmark replacing oneshot with futures-rs oneshot
channel
