### PR TITLE
docs: add back array children docs moved from slots

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -214,9 +214,13 @@ impl VTable for ALP {
     }
 }
 
+/// The ALP-encoded values array.
 pub(super) const ENCODED_SLOT: usize = 0;
+/// The indices of exception values that could not be ALP-encoded.
 pub(super) const PATCH_INDICES_SLOT: usize = 1;
+/// The exception values that could not be ALP-encoded.
 pub(super) const PATCH_VALUES_SLOT: usize = 2;
+/// Chunk offsets for the patch indices/values.
 pub(super) const PATCH_CHUNK_OFFSETS_SLOT: usize = 3;
 pub(super) const NUM_SLOTS: usize = 4;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = [

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -344,10 +344,15 @@ impl VTable for ALPRD {
     }
 }
 
+/// The left (most significant) parts of the real-double encoded values.
 pub(super) const LEFT_PARTS_SLOT: usize = 0;
+/// The right (least significant) parts of the real-double encoded values.
 pub(super) const RIGHT_PARTS_SLOT: usize = 1;
+/// The indices of left-parts exception values that could not be dictionary-encoded.
 pub(super) const LP_PATCH_INDICES_SLOT: usize = 2;
+/// The exception values for left-parts that could not be dictionary-encoded.
 pub(super) const LP_PATCH_VALUES_SLOT: usize = 3;
+/// Chunk offsets for the left-parts patch indices/values.
 pub(super) const LP_PATCH_CHUNK_OFFSETS_SLOT: usize = 4;
 pub(super) const NUM_SLOTS: usize = 5;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = [

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -193,6 +193,7 @@ impl VTable for ByteBool {
     }
 }
 
+/// The validity bitmap indicating which elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["validity"];

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -237,8 +237,11 @@ impl VTable for DateTimeParts {
     }
 }
 
+/// The days component of the datetime, stored as an integer array.
 pub(super) const DAYS_SLOT: usize = 0;
+/// The seconds component of the datetime (within the day).
 pub(super) const SECONDS_SLOT: usize = 1;
+/// The sub-second component of the datetime.
 pub(super) const SUBSECONDS_SLOT: usize = 2;
 pub(super) const NUM_SLOTS: usize = 3;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["days", "seconds", "subseconds"];

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -203,6 +203,7 @@ impl VTable for DecimalByteParts {
     }
 }
 
+/// The most significant parts of the decimal values.
 pub(super) const MSP_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["msp"];

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -26,9 +26,13 @@ use crate::bitpack_compress::bitpack_encode;
 use crate::unpack_iter::BitPacked;
 use crate::unpack_iter::BitUnpackedChunks;
 
+/// The indices of exception values that don't fit in the bit-packed representation.
 pub(super) const PATCH_INDICES_SLOT: usize = 0;
+/// The exception values that don't fit in the bit-packed representation.
 pub(super) const PATCH_VALUES_SLOT: usize = 1;
+/// Chunk offsets for the patch indices/values.
 pub(super) const PATCH_CHUNK_OFFSETS_SLOT: usize = 2;
+/// The validity bitmap indicating which elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 3;
 pub(super) const NUM_SLOTS: usize = 4;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = [

--- a/encodings/fastlanes/src/delta/array/mod.rs
+++ b/encodings/fastlanes/src/delta/array/mod.rs
@@ -18,7 +18,9 @@ use vortex_error::vortex_ensure;
 pub mod delta_compress;
 pub mod delta_decompress;
 
+/// The base values for each block of deltas.
 pub(super) const BASES_SLOT: usize = 0;
+/// The delta-encoded values relative to the base values.
 pub(super) const DELTAS_SLOT: usize = 1;
 pub(super) const NUM_SLOTS: usize = 2;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["bases", "deltas"];

--- a/encodings/fastlanes/src/for/array/mod.rs
+++ b/encodings/fastlanes/src/for/array/mod.rs
@@ -12,6 +12,7 @@ use vortex_error::vortex_bail;
 pub mod for_compress;
 pub mod for_decompress;
 
+/// The encoded array with the frame-of-reference (minimum value) subtracted.
 pub(super) const ENCODED_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["encoded"];

--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -15,8 +15,19 @@ use crate::FL_CHUNK_SIZE;
 pub mod rle_compress;
 pub mod rle_decompress;
 
+/// Run values in the dictionary.
 pub(super) const VALUES_SLOT: usize = 0;
+/// Chunk-local indices from all chunks. The start of each chunk is looked up in `values_idx_offsets`.
 pub(super) const INDICES_SLOT: usize = 1;
+/// Index start positions of each value chunk.
+///
+/// # Example
+/// ```text
+/// // Chunk 0: [10, 20] (starts at index 0)
+/// // Chunk 1: [30, 40] (starts at index 2)
+/// let values = [10, 20, 30, 40];           // Global values array
+/// let values_idx_offsets = [0, 2];         // Chunk 0 starts at index 0, Chunk 1 starts at index 2
+/// ```
 pub(super) const VALUES_IDX_OFFSETS_SLOT: usize = 2;
 pub(super) const NUM_SLOTS: usize = 3;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["values", "indices", "values_idx_offsets"];

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -346,8 +346,11 @@ impl VTable for FSST {
     }
 }
 
+/// Lengths of the original values before compression, can be compressed.
 pub(crate) const UNCOMPRESSED_LENGTHS_SLOT: usize = 0;
+/// The offsets array for the FSST-compressed codes.
 pub(crate) const CODES_OFFSETS_SLOT: usize = 1;
+/// The validity bitmap for the compressed codes.
 pub(crate) const CODES_VALIDITY_SLOT: usize = 2;
 pub(crate) const NUM_SLOTS: usize = 3;
 pub(crate) const SLOT_NAMES: [&str; NUM_SLOTS] =

--- a/encodings/parquet-variant/src/array.rs
+++ b/encodings/parquet-variant/src/array.rs
@@ -24,9 +24,13 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
 
+/// The validity bitmap indicating which elements are non-null.
 pub(crate) const VALIDITY_SLOT: usize = 0;
+/// The metadata array for the Parquet variant values.
 pub(crate) const METADATA_SLOT: usize = 1;
+/// The value array containing the Parquet variant data.
 pub(crate) const VALUE_SLOT: usize = 2;
+/// The typed value array for strongly-typed Parquet variant data.
 pub(crate) const TYPED_VALUE_SLOT: usize = 3;
 pub(crate) const NUM_SLOTS: usize = 4;
 pub(crate) const SLOT_NAMES: [&str; NUM_SLOTS] = ["validity", "metadata", "value", "typed_value"];

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -307,6 +307,7 @@ impl Pco {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.pco");
 }
 
+/// The validity bitmap indicating which elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["validity"];

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -199,7 +199,9 @@ impl VTable for RunEnd {
     }
 }
 
+/// The run-end positions marking where each run terminates.
 pub(super) const ENDS_SLOT: usize = 0;
+/// The values for each run.
 pub(super) const VALUES_SLOT: usize = 1;
 pub(super) const NUM_SLOTS: usize = 2;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["ends", "values"];

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -263,8 +263,11 @@ impl VTable for Sparse {
     }
 }
 
+/// The indices of non-fill values in the sparse array.
 pub(crate) const PATCH_INDICES_SLOT: usize = 0;
+/// The non-fill values at the corresponding patch indices.
 pub(crate) const PATCH_VALUES_SLOT: usize = 1;
+/// Chunk offsets for the patch indices/values.
 pub(crate) const PATCH_CHUNK_OFFSETS_SLOT: usize = 2;
 pub(crate) const NUM_SLOTS: usize = 3;
 pub(crate) const SLOT_NAMES: [&str; NUM_SLOTS] =

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -170,6 +170,7 @@ impl VTable for ZigZag {
     }
 }
 
+/// The zigzag-encoded values (signed integers mapped to unsigned).
 pub(super) const ENCODED_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["encoded"];

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -294,6 +294,7 @@ impl Zstd {
     pub const ID: ArrayId = ArrayId::new_ref("vortex.zstd");
 }
 
+/// The validity bitmap indicating which elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["validity"];

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -18,6 +18,7 @@ use crate::validity::Validity;
 use crate::vtable::child_to_validity;
 use crate::vtable::validity_to_child;
 
+/// The validity bitmap indicating which elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["validity"];

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -57,6 +57,7 @@ pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["validity"];
 /// ```
 #[derive(Clone, Debug)]
 pub struct BoolArray {
+    /// Child arrays stored as slots. See [`VTable::slots`] for design rationale.
     pub(super) slots: Vec<Option<ArrayRef>>,
     pub(super) dtype: DType,
     pub(super) bits: BufferHandle,

--- a/vortex-array/src/arrays/decimal/array.rs
+++ b/vortex-array/src/arrays/decimal/array.rs
@@ -30,6 +30,7 @@ use crate::validity::Validity;
 use crate::vtable::child_to_validity;
 use crate::vtable::validity_to_child;
 
+/// The validity bitmap indicating which elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["validity"];

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -38,20 +38,6 @@ pub(super) const VALUES_SLOT: usize = 1;
 pub(super) const NUM_SLOTS: usize = 2;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["codes", "values"];
 
-struct DictArrayChildren<'a> {
-    slots: &'a Vec<Option<ArrayRef>>,
-}
-
-impl<'a> DictArrayChildren<'a> {
-    fn values(&self) -> ArrayRef {
-        todo!()
-    }
-
-    fn codes(&self) -> ArrayRef {
-        todo!()
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct DictArray {
     pub(super) slots: Vec<Option<ArrayRef>>,

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -31,10 +31,26 @@ pub struct DictMetadata {
     pub(super) all_values_referenced: Option<bool>,
 }
 
+/// The codes array mapping each element to a dictionary entry.
 pub(super) const CODES_SLOT: usize = 0;
+/// The dictionary values array containing the unique values.
 pub(super) const VALUES_SLOT: usize = 1;
 pub(super) const NUM_SLOTS: usize = 2;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["codes", "values"];
+
+struct DictArrayChildren<'a> {
+    slots: &'a Vec<Option<ArrayRef>>,
+}
+
+impl<'a> DictArrayChildren<'a> {
+    fn values(&self) -> ArrayRef {
+        todo!()
+    }
+
+    fn codes(&self) -> ArrayRef {
+        todo!()
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct DictArray {

--- a/vortex-array/src/arrays/extension/array.rs
+++ b/vortex-array/src/arrays/extension/array.rs
@@ -9,6 +9,7 @@ use crate::dtype::DType;
 use crate::dtype::extension::ExtDTypeRef;
 use crate::stats::ArrayStats;
 
+/// The backing storage array for this extension array.
 pub(super) const STORAGE_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["storage"];

--- a/vortex-array/src/arrays/filter/array.rs
+++ b/vortex-array/src/arrays/filter/array.rs
@@ -9,6 +9,7 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::stats::ArrayStats;
 
+/// The source array being filtered.
 pub(super) const CHILD_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["child"];

--- a/vortex-array/src/arrays/fixed_size_list/array.rs
+++ b/vortex-array/src/arrays/fixed_size_list/array.rs
@@ -14,7 +14,17 @@ use crate::stats::ArrayStats;
 use crate::validity::Validity;
 use crate::vtable::validity_to_child;
 
+/// The `elements` data array, where each fixed-size list scalar is a _slice_ of the `elements`
+/// array, and each inner list element is a _scalar_ of the `elements` array.
+///
+/// The fixed-size list scalars are contiguous (regardless of nullability for easy lookups),
+/// each with equal size in memory.
 pub(super) const ELEMENTS_SLOT: usize = 0;
+/// The validity / null map of the array.
+///
+/// Note that this null map refers to which fixed-size list scalars are null, **not** which
+/// sub-elements of fixed-size list scalars are null. The `elements` array will track individual
+/// value nullability.
 pub(super) const VALIDITY_SLOT: usize = 1;
 pub(super) const NUM_SLOTS: usize = 2;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["elements", "validity"];

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -29,8 +29,11 @@ use crate::stats::ArrayStats;
 use crate::validity::Validity;
 use crate::vtable::validity_to_child;
 
+/// The elements data array containing all list elements concatenated together.
 pub(super) const ELEMENTS_SLOT: usize = 0;
+/// The offsets array defining the start/end of each list within the elements array.
 pub(super) const OFFSETS_SLOT: usize = 1;
+/// The validity bitmap indicating which list elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 2;
 pub(super) const NUM_SLOTS: usize = 3;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["elements", "offsets", "validity"];

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -23,9 +23,20 @@ use crate::stats::ArrayStats;
 use crate::validity::Validity;
 use crate::vtable::validity_to_child;
 
+/// The `elements` data array, where each list scalar is a _slice_ of the `elements` array, and
+/// each inner list element is a _scalar_ of the `elements` array.
 pub(super) const ELEMENTS_SLOT: usize = 0;
+/// The `offsets` array indicating the start position of each list in elements.
+///
+/// Since we also store `sizes`, this `offsets` field is allowed to be stored out-of-order
+/// (which is different from [`ListArray`](crate::arrays::ListArray)).
 pub(super) const OFFSETS_SLOT: usize = 1;
+/// The `sizes` array indicating the length of each list.
+///
+/// This field is intended to be paired with a corresponding offset to determine the list scalar
+/// we want to access.
 pub(super) const SIZES_SLOT: usize = 2;
+/// The validity bitmap indicating which list elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 3;
 pub(super) const NUM_SLOTS: usize = 4;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["elements", "offsets", "sizes", "validity"];

--- a/vortex-array/src/arrays/masked/array.rs
+++ b/vortex-array/src/arrays/masked/array.rs
@@ -12,7 +12,9 @@ use crate::validity::Validity;
 use crate::vtable::child_to_validity;
 use crate::vtable::validity_to_child;
 
+/// The underlying child array being masked.
 pub(super) const CHILD_SLOT: usize = 0;
+/// The validity bitmap defining which elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 1;
 pub(super) const NUM_SLOTS: usize = 2;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["child", "validity"];

--- a/vortex-array/src/arrays/patched/array.rs
+++ b/vortex-array/src/arrays/patched/array.rs
@@ -93,9 +93,13 @@ use crate::validity::Validity;
 ///
 /// It turns out that this layout is optimal for executing patching on GPUs, because the
 /// `lane_offsets` allows each thread in a warp to seek to its patches in constant time.
+/// The inner array containing the base unpatched values.
 pub(super) const INNER_SLOT: usize = 0;
+/// The lane offsets array for locating patches within lanes.
 pub(super) const LANE_OFFSETS_SLOT: usize = 1;
+/// The indices of patched (exception) values.
 pub(super) const INDICES_SLOT: usize = 2;
+/// The patched (exception) values at the corresponding indices.
 pub(super) const VALUES_SLOT: usize = 3;
 pub(super) const NUM_SLOTS: usize = 4;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] =

--- a/vortex-array/src/arrays/primitive/array/mod.rs
+++ b/vortex-array/src/arrays/primitive/array/mod.rs
@@ -35,6 +35,7 @@ use crate::buffer::BufferHandle;
 use crate::vtable::child_to_validity;
 use crate::vtable::validity_to_child;
 
+/// The validity bitmap indicating which elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["validity"];

--- a/vortex-array/src/arrays/shared/array.rs
+++ b/vortex-array/src/arrays/shared/array.rs
@@ -16,6 +16,7 @@ use crate::IntoArray;
 use crate::dtype::DType;
 use crate::stats::ArrayStats;
 
+/// The source array that is shared and lazily computed.
 pub(super) const SOURCE_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["source"];

--- a/vortex-array/src/arrays/slice/array.rs
+++ b/vortex-array/src/arrays/slice/array.rs
@@ -10,6 +10,7 @@ use vortex_error::vortex_panic;
 use crate::ArrayRef;
 use crate::stats::ArrayStats;
 
+/// The underlying child array being sliced.
 pub(super) const CHILD_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["child"];

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -23,7 +23,9 @@ use crate::vtable::child_to_validity;
 use crate::vtable::validity_to_child;
 
 // StructArray has a variable number of slots: [validity?, field_0, ..., field_N]
+/// The validity bitmap indicating which struct elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 0;
+/// The offset at which the struct field arrays begin in the slots vector.
 pub(super) const FIELDS_OFFSET: usize = 1;
 
 /// A struct array that stores multiple named fields as columns, similar to a database row.

--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -22,7 +22,9 @@ use crate::validity::Validity;
 use crate::vtable::child_to_validity;
 use crate::vtable::validity_to_child;
 
+/// The offsets array defining the start/end of each variable-length binary element.
 pub(super) const OFFSETS_SLOT: usize = 0;
+/// The validity bitmap indicating which elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 1;
 pub(super) const NUM_SLOTS: usize = 2;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["offsets", "validity"];

--- a/vortex-array/src/arrays/varbinview/array.rs
+++ b/vortex-array/src/arrays/varbinview/array.rs
@@ -25,6 +25,7 @@ use crate::validity::Validity;
 use crate::vtable::child_to_validity;
 use crate::vtable::validity_to_child;
 
+/// The validity bitmap indicating which elements are non-null.
 pub(super) const VALIDITY_SLOT: usize = 0;
 pub(super) const NUM_SLOTS: usize = 1;
 pub(super) const SLOT_NAMES: [&str; NUM_SLOTS] = ["validity"];

--- a/vortex-array/src/vtable/mod.rs
+++ b/vortex-array/src/vtable/mod.rs
@@ -171,9 +171,20 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
 
     /// Returns the slots of the array as a slice.
     ///
-    /// Slots provide fixed-position storage for child arrays, enabling direct access
-    /// by slot index without the overhead of dynamic child lookups. Optional children
-    /// (like validity) are represented as `None` slots rather than shifting dense indices.
+    /// Slots provide fixed-position storage for child arrays. Each encoding defines named
+    /// constants (e.g. `VALIDITY_SLOT`, `ELEMENTS_SLOT`) that index into this slice, so child
+    /// access is a direct index rather than a dynamic lookup.
+    ///
+    /// Slots are `Option<ArrayRef>` to allow individual children to be _taken_ (moved out)
+    /// without invalidating the indices of other slots. For example, removing the validity
+    /// child leaves a `None` at `VALIDITY_SLOT` while all other slot indices remain stable.
+    ///
+    /// The backing storage is a `Vec` (rather than a fixed-size array) so that it can be
+    /// moved out of an `ArrayData` into the concrete `Array` type during deserialization
+    /// without copying.
+    ///
+    /// TODO: once no encodings rely on side-effects in [`Self::with_slots`], replace the
+    /// `slots`/`with_slots` pair with a single `slots_mut` returning `&mut [Option<ArrayRef>]`.
     fn slots(array: &Self::Array) -> &[Option<ArrayRef>];
 
     /// Returns the name of the slot at the given index.
@@ -182,7 +193,10 @@ pub trait VTable: 'static + Clone + Sized + Send + Sync + Debug {
     /// Panics if `idx >= slots(array).len()`.
     fn slot_name(array: &Self::Array, idx: usize) -> String;
 
-    /// Replaces the slots in `array` with `slots`.
+    /// Replaces the slots in `array` with the given `slots` vec.
+    ///
+    /// Some encodings use this to perform side-effects (e.g. cache invalidation) when
+    /// slots change. Once those are removed, this will be replaced by `slots_mut`.
     fn with_slots(array: &mut Self::Array, slots: Vec<Option<ArrayRef>>) -> VortexResult<()>;
 
     /// Execute this array by returning an [`ExecutionResult`].


### PR DESCRIPTION
Add back docs for each array child removed in https://github.com/vortex-data/vortex/pull/6870