### PR TITLE
skip[ci]: remove `debug-assertions=yes` from codspeed runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -746,7 +746,7 @@ jobs:
           tool: cargo-codspeed
       - name: Build benchmarks
         env:
-          RUSTFLAGS: "-C target-feature=+avx2 -C debug-assertions=yes"
+          RUSTFLAGS: "-C target-feature=+avx2"
         run: cargo codspeed build ${{ matrix.features }} $(printf -- '-p %s ' ${{ matrix.packages }}) --profile bench
       - name: Run benchmarks
         uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2


### PR DESCRIPTION
This was accidentally added in https://github.com/vortex-data/vortex/pull/5440