### PR TITLE
Silence unused warning

### DIFF
--- a/vortex-layout/src/layouts/buffered.rs
+++ b/vortex-layout/src/layouts/buffered.rs
@@ -71,9 +71,7 @@ impl LayoutStrategy for BufferedStrategy {
                 if stream.as_mut().peek().await.is_none() {
                     let mut sequence_ptr = sequence_id.descend();
                     while let Some(chunk) = chunks.pop_front() {
-                        let chunk_size = chunk.nbytes();
-                        nbytes -= chunk_size;
-                        buffered_bytes_counter.fetch_sub(chunk_size, Ordering::Relaxed);
+                        buffered_bytes_counter.fetch_sub(chunk.nbytes(), Ordering::Relaxed);
                         yield (sequence_ptr.advance(), chunk)
                     }
                     break;


### PR DESCRIPTION
## Summary

```
warning: value assigned to `nbytes` is never read
  --> vortex-layout/src/layouts/buffered.rs:75:25
   |
75 |                         nbytes -= chunk_size;
   |                         ^^^^^^^^^^^^^^^^^^^^
   |
   = help: maybe it is overwritten before being read?
   = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default
```

Because we break immediately after `nbytes` is never used again.

## Testing

N/A