### PR TITLE
take `VortexSession` by ref

### DIFF
--- a/encodings/alp/public-api.lock
+++ b/encodings/alp/public-api.lock
@@ -584,7 +584,7 @@ pub fn vortex_alp::alp_rd_decode<T: vortex_alp::ALPRDFloat>(left_parts: vortex_b
 
 pub fn vortex_alp::decompress_into_array(array: vortex_alp::ALPArray, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::primitive::vtable::PrimitiveArray>
 
-pub fn vortex_alp::initialize(session: &mut vortex_session::VortexSession)
+pub fn vortex_alp::initialize(session: &vortex_session::VortexSession)
 
 pub type vortex_alp::ALPArray = vortex_array::array::typed::Array<vortex_alp::ALP>
 

--- a/encodings/alp/src/lib.rs
+++ b/encodings/alp/src/lib.rs
@@ -28,7 +28,7 @@ mod alp;
 mod alp_rd;
 
 /// Initialize ALP encoding in the given session.
-pub fn initialize(session: &mut VortexSession) {
+pub fn initialize(session: &VortexSession) {
     session.arrays().register(ALP);
     session.arrays().register(ALPRD);
 

--- a/encodings/datetime-parts/public-api.lock
+++ b/encodings/datetime-parts/public-api.lock
@@ -216,7 +216,7 @@ pub vortex_datetime_parts::TemporalParts::seconds: vortex_array::array::erased::
 
 pub vortex_datetime_parts::TemporalParts::subseconds: vortex_array::array::erased::ArrayRef
 
-pub fn vortex_datetime_parts::initialize(session: &mut vortex_session::VortexSession)
+pub fn vortex_datetime_parts::initialize(session: &vortex_session::VortexSession)
 
 pub fn vortex_datetime_parts::split_temporal(array: vortex_array::arrays::datetime::TemporalArray) -> vortex_error::VortexResult<vortex_datetime_parts::TemporalParts>
 

--- a/encodings/datetime-parts/src/lib.rs
+++ b/encodings/datetime-parts/src/lib.rs
@@ -18,7 +18,7 @@ use vortex_array::session::ArraySessionExt;
 use vortex_session::VortexSession;
 
 /// Initialize datetime-parts encoding in the given session.
-pub fn initialize(session: &mut VortexSession) {
+pub fn initialize(session: &VortexSession) {
     session.arrays().register(DateTimeParts);
 
     session.aggregate_fns().register_aggregate_kernel(

--- a/encodings/decimal-byte-parts/public-api.lock
+++ b/encodings/decimal-byte-parts/public-api.lock
@@ -162,6 +162,6 @@ pub fn vortex_decimal_byte_parts::DecimalBytesPartsMetadata::clear(&mut self)
 
 pub fn vortex_decimal_byte_parts::DecimalBytesPartsMetadata::encoded_len(&self) -> usize
 
-pub fn vortex_decimal_byte_parts::initialize(session: &mut vortex_session::VortexSession)
+pub fn vortex_decimal_byte_parts::initialize(session: &vortex_session::VortexSession)
 
 pub type vortex_decimal_byte_parts::DecimalBytePartsArray = vortex_array::array::typed::Array<vortex_decimal_byte_parts::DecimalByteParts>

--- a/encodings/decimal-byte-parts/src/lib.rs
+++ b/encodings/decimal-byte-parts/src/lib.rs
@@ -20,7 +20,7 @@ use vortex_array::session::ArraySessionExt;
 use vortex_session::VortexSession;
 
 /// Initialize decimal-byte-parts encoding in the given session.
-pub fn initialize(session: &mut VortexSession) {
+pub fn initialize(session: &VortexSession) {
     session.arrays().register(DecimalByteParts);
 
     session.aggregate_fns().register_aggregate_kernel(

--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -658,7 +658,7 @@ pub fn vortex_fastlanes::RLEData::unsliced_child_and_slice(&self) -> (&vortex_ar
 
 pub fn vortex_fastlanes::delta_compress(array: &vortex_array::arrays::primitive::vtable::PrimitiveArray, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<(vortex_array::arrays::primitive::vtable::PrimitiveArray, vortex_array::arrays::primitive::vtable::PrimitiveArray)>
 
-pub fn vortex_fastlanes::initialize(session: &mut vortex_session::VortexSession)
+pub fn vortex_fastlanes::initialize(session: &vortex_session::VortexSession)
 
 pub type vortex_fastlanes::BitPackedArray = vortex_array::array::typed::Array<vortex_fastlanes::BitPacked>
 

--- a/encodings/fastlanes/src/lib.rs
+++ b/encodings/fastlanes/src/lib.rs
@@ -31,7 +31,7 @@ use vortex_array::session::ArraySessionExt;
 use vortex_session::VortexSession;
 
 /// Initialize fastlanes encodings in the given session.
-pub fn initialize(session: &mut VortexSession) {
+pub fn initialize(session: &VortexSession) {
     session.arrays().register(BitPacked);
     session.arrays().register(Delta);
     session.arrays().register(FoR);

--- a/encodings/runend/public-api.lock
+++ b/encodings/runend/public-api.lock
@@ -206,7 +206,7 @@ pub fn vortex_runend::RunEndMetadata::clear(&mut self)
 
 pub fn vortex_runend::RunEndMetadata::encoded_len(&self) -> usize
 
-pub fn vortex_runend::initialize(session: &mut vortex_session::VortexSession)
+pub fn vortex_runend::initialize(session: &vortex_session::VortexSession)
 
 pub fn vortex_runend::trimmed_ends_iter<E: vortex_array::dtype::ptype::IntegerPType>(run_ends: &[E], offset: usize, length: usize) -> impl core::iter::traits::iterator::Iterator<Item = usize> + use<'_, E>
 

--- a/encodings/runend/src/lib.rs
+++ b/encodings/runend/src/lib.rs
@@ -35,7 +35,7 @@ use vortex_array::session::ArraySessionExt;
 use vortex_session::VortexSession;
 
 /// Initialize run-end encoding in the given session.
-pub fn initialize(session: &mut VortexSession) {
+pub fn initialize(session: &VortexSession) {
     session.arrays().register(RunEnd);
 
     // Register the RunEnd-specific aggregate kernels.

--- a/encodings/sequence/public-api.lock
+++ b/encodings/sequence/public-api.lock
@@ -152,7 +152,7 @@ impl vortex_array::array::IntoArray for vortex_sequence::SequenceData
 
 pub fn vortex_sequence::SequenceData::into_array(self) -> vortex_array::array::erased::ArrayRef
 
-pub fn vortex_sequence::initialize(session: &mut vortex_session::VortexSession)
+pub fn vortex_sequence::initialize(session: &vortex_session::VortexSession)
 
 pub fn vortex_sequence::sequence_encode(primitive_array: &vortex_array::arrays::primitive::vtable::PrimitiveArray) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::erased::ArrayRef>>
 

--- a/encodings/sequence/src/lib.rs
+++ b/encodings/sequence/src/lib.rs
@@ -24,7 +24,7 @@ use vortex_array::session::ArraySessionExt;
 use vortex_session::VortexSession;
 
 /// Initialize sequence encoding in the given session.
-pub fn initialize(session: &mut VortexSession) {
+pub fn initialize(session: &VortexSession) {
     session.arrays().register(Sequence);
 
     // Register the Sequence-specific aggregate kernels.

--- a/vortex-cuda/src/hybrid_dispatch/mod.rs
+++ b/vortex-cuda/src/hybrid_dispatch/mod.rs
@@ -237,8 +237,8 @@ mod tests {
         use vortex::encodings::zstd::ZstdBuffers;
         use vortex::encodings::zstd::ZstdBuffersData;
 
-        let mut session = VortexSession::empty();
-        fastlanes::initialize(&mut session);
+        let session = VortexSession::empty();
+        fastlanes::initialize(&session);
         session.arrays().register(ZstdBuffers);
         let mut ctx = CudaSession::create_execution_ctx(&session).vortex_expect("ctx");
 

--- a/vortex-file/public-api.lock
+++ b/vortex-file/public-api.lock
@@ -416,4 +416,4 @@ impl<S: vortex_session::SessionExt> vortex_file::WriteOptionsSessionExt for S
 
 pub fn S::write_options(&self) -> vortex_file::VortexWriteOptions
 
-pub fn vortex_file::register_default_encodings(session: &mut vortex_session::VortexSession)
+pub fn vortex_file::register_default_encodings(session: &vortex_session::VortexSession)

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -155,7 +155,7 @@ mod forever_constant {
 ///
 /// NOTE: this function will be changed in the future to encapsulate logic for using different
 /// Vortex "Editions" that may support different sets of encodings.
-pub fn register_default_encodings(session: &mut VortexSession) {
+pub fn register_default_encodings(session: &VortexSession) {
     {
         let arrays = session.arrays();
         arrays.register(ByteBool);

--- a/vortex-file/src/open.rs
+++ b/vortex-file/src/open.rs
@@ -393,16 +393,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_initial_read_size() {
-        // Create a large file (> 1MB)
-        let mut buf = ByteBufferMut::empty();
-        let mut session = VortexSession::empty()
+        let session = VortexSession::empty()
             .with::<DTypeSession>()
             .with::<ArraySession>()
             .with::<LayoutSession>()
             .with::<ScalarFnSession>()
             .with::<RuntimeSession>();
 
-        crate::register_default_encodings(&mut session);
+        crate::register_default_encodings(&session);
+
+        // Create a large file (> 1MB)
+        let mut buf = ByteBufferMut::empty();
 
         // 1.5M integers -> ~6MB. We use a pattern to avoid Sequence encoding.
         let array = Buffer::from(

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -74,13 +74,13 @@ use crate::WriteOptionsSessionExt;
 use crate::footer::SegmentSpec;
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-    let mut session = VortexSession::empty()
+    let session = VortexSession::empty()
         .with::<ArraySession>()
         .with::<LayoutSession>()
         .with::<ScalarFnSession>()
         .with::<RuntimeSession>();
 
-    crate::register_default_encodings(&mut session);
+    crate::register_default_encodings(&session);
 
     session
 });

--- a/vortex-file/tests/test_write_table.rs
+++ b/vortex-file/tests/test_write_table.rs
@@ -31,13 +31,13 @@ use vortex_layout::session::LayoutSession;
 use vortex_session::VortexSession;
 
 static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
-    let mut session = VortexSession::empty()
+    let session = VortexSession::empty()
         .with::<ArraySession>()
         .with::<LayoutSession>()
         .with::<ScalarFnSession>()
         .with::<RuntimeSession>();
 
-    vortex_file::register_default_encodings(&mut session);
+    vortex_file::register_default_encodings(&session);
 
     session
 });

--- a/vortex/src/lib.rs
+++ b/vortex/src/lib.rs
@@ -159,9 +159,8 @@ pub trait VortexSessionDefault {
 }
 
 impl VortexSessionDefault for VortexSession {
-    #[allow(unused_mut)]
     fn default() -> VortexSession {
-        let mut session = VortexSession::empty()
+        let session = VortexSession::empty()
             .with::<DTypeSession>()
             .with::<ArraySession>()
             .with::<LayoutSession>()
@@ -170,7 +169,7 @@ impl VortexSessionDefault for VortexSession {
             .with::<RuntimeSession>();
 
         #[cfg(feature = "files")]
-        file::register_default_encodings(&mut session);
+        file::register_default_encodings(&session);
 
         session
     }


### PR DESCRIPTION
## Summary

`VortexSession` now has interior mutability

## API Changes

Changes several `initialize` functions to take by ref.

## Testing

N/A