### PR TITLE
Remove unused approvals workflow triggers

### DIFF
--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -3,8 +3,6 @@ name: PR Approval Check
 on:
   pull_request_review:
     types: [submitted, dismissed]
-  pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   check-approvals:


### PR DESCRIPTION
They triggered at the wrong time and caused the workflow to show as failed