### PR TITLE
Correctly gate zstd

### DIFF
--- a/vortex-btrblocks/src/builder.rs
+++ b/vortex-btrblocks/src/builder.rs
@@ -143,7 +143,6 @@ impl BtrBlocksCompressorBuilder {
     /// With the `unstable_encodings` feature, buffer-level Zstd compression is used which
     /// preserves the array buffer layout for zero-conversion GPU decompression. Without it,
     /// interleaved Zstd compression is used.
-    #[cfg(feature = "zstd")]
     pub fn only_cuda_compatible(self) -> Self {
         let builder = self.exclude_schemes([
             integer::SparseScheme.id(),
@@ -154,9 +153,9 @@ impl BtrBlocksCompressorBuilder {
             string::FSSTScheme.id(),
         ]);
 
-        #[cfg(feature = "unstable_encodings")]
+        #[cfg(all(feature = "zstd", feature = "unstable_encodings"))]
         let builder = builder.with_new_scheme(&string::ZstdBuffersScheme);
-        #[cfg(not(feature = "unstable_encodings"))]
+        #[cfg(all(feature = "zstd", not(feature = "unstable_encodings")))]
         let builder = builder.with_new_scheme(&string::ZstdScheme);
 
         builder


### PR DESCRIPTION
## Summary

Gates `zstd` lower for schemes.

Is this actually correct? Also unsure of how this actually the feature gate works with the cuda code to begin with, afaik this doesn't change any logic.

## Testing

N/A