### PR TITLE
Tensor Matchers

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -8756,9 +8756,9 @@ impl<V: vortex_array::dtype::extension::ExtVTable> vortex_array::dtype::extensio
 
 pub type V::Match<'a> = &'a <V as vortex_array::dtype::extension::ExtVTable>::Metadata
 
-pub fn V::matches(item: &vortex_array::dtype::extension::ExtDTypeRef) -> bool
+pub fn V::matches(ext_dtype: &vortex_array::dtype::extension::ExtDTypeRef) -> bool
 
-pub fn V::try_match<'a>(item: &'a vortex_array::dtype::extension::ExtDTypeRef) -> core::option::Option<<V as vortex_array::dtype::extension::Matcher>::Match>
+pub fn V::try_match<'a>(ext_dtype: &'a vortex_array::dtype::extension::ExtDTypeRef) -> core::option::Option<<V as vortex_array::dtype::extension::Matcher>::Match>
 
 pub type vortex_array::dtype::extension::ExtDTypePluginRef = alloc::sync::Arc<dyn vortex_array::dtype::extension::ExtDTypePlugin>
 

--- a/vortex-array/src/dtype/extension/matcher.rs
+++ b/vortex-array/src/dtype/extension/matcher.rs
@@ -22,12 +22,13 @@ pub trait Matcher {
 impl<V: ExtVTable> Matcher for V {
     type Match<'a> = &'a V::Metadata;
 
-    fn matches(item: &ExtDTypeRef) -> bool {
-        item.0.as_any().is::<ExtDType<V>>()
+    fn matches(ext_dtype: &ExtDTypeRef) -> bool {
+        ext_dtype.0.as_any().is::<ExtDType<V>>()
     }
 
-    fn try_match<'a>(item: &'a ExtDTypeRef) -> Option<Self::Match<'a>> {
-        item.0
+    fn try_match<'a>(ext_dtype: &'a ExtDTypeRef) -> Option<Self::Match<'a>> {
+        ext_dtype
+            .0
             .as_any()
             .downcast_ref::<ExtDType<V>>()
             .map(|inner| inner.metadata())

--- a/vortex-tensor/public-api.lock
+++ b/vortex-tensor/public-api.lock
@@ -14,7 +14,7 @@ pub const vortex_tensor::encodings::turboquant::TurboQuant::MIN_DIMENSION: u32
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuant::try_new_array(dtype: vortex_array::dtype::DType, codes: vortex_array::array::erased::ArrayRef, norms: vortex_array::array::erased::ArrayRef, centroids: vortex_array::array::erased::ArrayRef, rotation_signs: vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_tensor::encodings::turboquant::TurboQuantArray>
 
-pub fn vortex_tensor::encodings::turboquant::TurboQuant::validate_dtype(dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<&vortex_array::dtype::extension::erased::ExtDTypeRef>
+pub fn vortex_tensor::encodings::turboquant::TurboQuant::validate_dtype(dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_tensor::vector::VectorMatcherMetadata>
 
 impl core::clone::Clone for vortex_tensor::encodings::turboquant::TurboQuant
 
@@ -188,6 +188,14 @@ pub type vortex_tensor::encodings::turboquant::TurboQuantArray = vortex_array::a
 
 pub mod vortex_tensor::fixed_shape
 
+pub struct vortex_tensor::fixed_shape::AnyFixedShapeTensor
+
+impl vortex_array::dtype::extension::matcher::Matcher for vortex_tensor::fixed_shape::AnyFixedShapeTensor
+
+pub type vortex_tensor::fixed_shape::AnyFixedShapeTensor::Match<'a> = vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>
+
+pub fn vortex_tensor::fixed_shape::AnyFixedShapeTensor::try_match<'a>(ext_dtype: &'a vortex_array::dtype::extension::erased::ExtDTypeRef) -> core::option::Option<Self::Match>
+
 pub struct vortex_tensor::fixed_shape::FixedShapeTensor
 
 impl core::clone::Clone for vortex_tensor::fixed_shape::FixedShapeTensor
@@ -229,6 +237,34 @@ pub fn vortex_tensor::fixed_shape::FixedShapeTensor::serialize_metadata(&self, m
 pub fn vortex_tensor::fixed_shape::FixedShapeTensor::unpack_native<'a>(_ext_dtype: &'a vortex_array::dtype::extension::typed::ExtDType<Self>, storage_value: &'a vortex_array::scalar::scalar_value::ScalarValue) -> vortex_error::VortexResult<Self::NativeValue>
 
 pub fn vortex_tensor::fixed_shape::FixedShapeTensor::validate_dtype(ext_dtype: &vortex_array::dtype::extension::typed::ExtDType<Self>) -> vortex_error::VortexResult<()>
+
+pub struct vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>
+
+impl vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'_>
+
+pub fn vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'_>::element_ptype(&self) -> vortex_array::dtype::ptype::PType
+
+pub fn vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'_>::list_size(&self) -> usize
+
+pub fn vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'_>::metadata(&self) -> &vortex_tensor::fixed_shape::FixedShapeTensorMetadata
+
+impl<'a> core::clone::Clone for vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>
+
+pub fn vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>::clone(&self) -> vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>
+
+impl<'a> core::cmp::Eq for vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>
+
+impl<'a> core::cmp::PartialEq for vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>
+
+pub fn vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>::eq(&self, other: &vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>) -> bool
+
+impl<'a> core::fmt::Debug for vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>
+
+pub fn vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl<'a> core::marker::Copy for vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>
+
+impl<'a> core::marker::StructuralPartialEq for vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>
 
 pub struct vortex_tensor::fixed_shape::FixedShapeTensorMetadata
 
@@ -280,9 +316,19 @@ pub mod vortex_tensor::matcher
 
 pub enum vortex_tensor::matcher::TensorMatch<'a>
 
-pub vortex_tensor::matcher::TensorMatch::FixedShapeTensor(&'a vortex_tensor::fixed_shape::FixedShapeTensorMetadata)
+pub vortex_tensor::matcher::TensorMatch::FixedShapeTensor(vortex_tensor::fixed_shape::FixedShapeTensorMatcherMetadata<'a>)
 
-pub vortex_tensor::matcher::TensorMatch::Vector
+pub vortex_tensor::matcher::TensorMatch::Vector(vortex_tensor::vector::VectorMatcherMetadata)
+
+impl vortex_tensor::matcher::TensorMatch<'_>
+
+pub fn vortex_tensor::matcher::TensorMatch<'_>::element_ptype(self) -> vortex_array::dtype::ptype::PType
+
+pub fn vortex_tensor::matcher::TensorMatch<'_>::list_size(self) -> usize
+
+impl<'a> core::clone::Clone for vortex_tensor::matcher::TensorMatch<'a>
+
+pub fn vortex_tensor::matcher::TensorMatch<'a>::clone(&self) -> vortex_tensor::matcher::TensorMatch<'a>
 
 impl<'a> core::cmp::Eq for vortex_tensor::matcher::TensorMatch<'a>
 
@@ -294,6 +340,8 @@ impl<'a> core::fmt::Debug for vortex_tensor::matcher::TensorMatch<'a>
 
 pub fn vortex_tensor::matcher::TensorMatch<'a>::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 
+impl<'a> core::marker::Copy for vortex_tensor::matcher::TensorMatch<'a>
+
 impl<'a> core::marker::StructuralPartialEq for vortex_tensor::matcher::TensorMatch<'a>
 
 pub struct vortex_tensor::matcher::AnyTensor
@@ -302,7 +350,7 @@ impl vortex_array::dtype::extension::matcher::Matcher for vortex_tensor::matcher
 
 pub type vortex_tensor::matcher::AnyTensor::Match<'a> = vortex_tensor::matcher::TensorMatch<'a>
 
-pub fn vortex_tensor::matcher::AnyTensor::try_match<'a>(item: &'a vortex_array::dtype::extension::erased::ExtDTypeRef) -> core::option::Option<Self::Match>
+pub fn vortex_tensor::matcher::AnyTensor::try_match<'a>(ext_dtype: &'a vortex_array::dtype::extension::erased::ExtDTypeRef) -> core::option::Option<Self::Match>
 
 pub mod vortex_tensor::scalar_fns
 
@@ -456,6 +504,14 @@ impl core::marker::StructuralPartialEq for vortex_tensor::scalar_fns::ApproxOpti
 
 pub mod vortex_tensor::vector
 
+pub struct vortex_tensor::vector::AnyVector
+
+impl vortex_array::dtype::extension::matcher::Matcher for vortex_tensor::vector::AnyVector
+
+pub type vortex_tensor::vector::AnyVector::Match<'a> = vortex_tensor::vector::VectorMatcherMetadata
+
+pub fn vortex_tensor::vector::AnyVector::try_match<'a>(ext_dtype: &'a vortex_array::dtype::extension::erased::ExtDTypeRef) -> core::option::Option<Self::Match>
+
 pub struct vortex_tensor::vector::Vector
 
 impl core::clone::Clone for vortex_tensor::vector::Vector
@@ -497,5 +553,37 @@ pub fn vortex_tensor::vector::Vector::serialize_metadata(&self, _metadata: &Self
 pub fn vortex_tensor::vector::Vector::unpack_native<'a>(_ext_dtype: &'a vortex_array::dtype::extension::typed::ExtDType<Self>, storage_value: &'a vortex_array::scalar::scalar_value::ScalarValue) -> vortex_error::VortexResult<Self::NativeValue>
 
 pub fn vortex_tensor::vector::Vector::validate_dtype(ext_dtype: &vortex_array::dtype::extension::typed::ExtDType<Self>) -> vortex_error::VortexResult<()>
+
+pub struct vortex_tensor::vector::VectorMatcherMetadata
+
+impl vortex_tensor::vector::VectorMatcherMetadata
+
+pub fn vortex_tensor::vector::VectorMatcherMetadata::dimensions(&self) -> u32
+
+pub fn vortex_tensor::vector::VectorMatcherMetadata::element_ptype(&self) -> vortex_array::dtype::ptype::PType
+
+pub fn vortex_tensor::vector::VectorMatcherMetadata::try_new(element_ptype: vortex_array::dtype::ptype::PType, dimensions: u32) -> vortex_error::VortexResult<Self>
+
+impl core::clone::Clone for vortex_tensor::vector::VectorMatcherMetadata
+
+pub fn vortex_tensor::vector::VectorMatcherMetadata::clone(&self) -> vortex_tensor::vector::VectorMatcherMetadata
+
+impl core::cmp::Eq for vortex_tensor::vector::VectorMatcherMetadata
+
+impl core::cmp::PartialEq for vortex_tensor::vector::VectorMatcherMetadata
+
+pub fn vortex_tensor::vector::VectorMatcherMetadata::eq(&self, other: &vortex_tensor::vector::VectorMatcherMetadata) -> bool
+
+impl core::fmt::Debug for vortex_tensor::vector::VectorMatcherMetadata
+
+pub fn vortex_tensor::vector::VectorMatcherMetadata::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+
+impl core::hash::Hash for vortex_tensor::vector::VectorMatcherMetadata
+
+pub fn vortex_tensor::vector::VectorMatcherMetadata::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
+
+impl core::marker::Copy for vortex_tensor::vector::VectorMatcherMetadata
+
+impl core::marker::StructuralPartialEq for vortex_tensor::vector::VectorMatcherMetadata
 
 pub fn vortex_tensor::initialize(session: &vortex_session::VortexSession)

--- a/vortex-tensor/src/encodings/turboquant/array/data.rs
+++ b/vortex-tensor/src/encodings/turboquant/array/data.rs
@@ -15,8 +15,6 @@ use vortex_error::vortex_ensure_eq;
 
 use crate::encodings::turboquant::array::slots::Slot;
 use crate::encodings::turboquant::vtable::TurboQuant;
-use crate::utils::tensor_element_ptype;
-use crate::utils::tensor_list_size;
 
 /// TurboQuant array data.
 ///
@@ -41,16 +39,13 @@ pub struct TurboQuantData {
 }
 
 impl TurboQuantData {
-    /// Build a TurboQuant array with validation.
-    ///
-    /// The `dimension` and `bit_width` are derived from the inputs:
-    /// - `dimension` from the `dtype`'s `FixedSizeList` storage list size.
-    /// - `bit_width` from `log2(centroids.len())` (0 for degenerate empty arrays).
+    /// Build a `TurboQuantData` with validation.
     ///
     /// # Errors
     ///
-    /// Returns an error if the provided components do not satisfy the invariants documented
-    /// in [`new_unchecked`](Self::new_unchecked).
+    /// Returns an error if:
+    /// - `dimension` is less than [`MIN_DIMENSION`](TurboQuant::MIN_DIMENSION).
+    /// - `bit_width` is greater than 8.
     pub fn try_new(dimension: u32, bit_width: u8) -> VortexResult<Self> {
         vortex_ensure!(
             dimension >= TurboQuant::MIN_DIMENSION,
@@ -67,23 +62,14 @@ impl TurboQuantData {
         })
     }
 
-    /// Build a TurboQuant array without validation.
+    /// Build a `TurboQuantData` without validation.
     ///
     /// # Safety
     ///
     /// The caller must ensure:
     ///
-    /// - `dtype` is a [`Vector`](crate::vector::Vector) extension type whose storage list size
-    ///   is >= [`MIN_DIMENSION`](crate::encodings::turboquant::TurboQuant::MIN_DIMENSION).
-    /// - `codes` is a non-nullable `FixedSizeListArray<u8>` with `list_size == padded_dim` and
-    ///   `codes.len() == norms.len()`. Null vectors are represented by all-zero codes.
-    /// - `norms` is a primitive array whose ptype matches the element type of the Vector's storage
-    ///   dtype. The nullability must match `dtype.nullability()`. Norms carry the validity of the
-    ///   entire array, since null vectors have null norms.
-    /// - `centroids` is a non-nullable `PrimitiveArray<f32>` whose length is a power of 2 in
-    ///   `[2, 256]` (i.e., `2^bit_width` for bit_width 1-8), or empty for degenerate arrays.
-    /// - `rotation_signs` has `3 * padded_dim` elements, or is empty for degenerate arrays.
-    /// - For degenerate (empty) arrays: all children must be empty.
+    /// - `dimension` is >= [`MIN_DIMENSION`](TurboQuant::MIN_DIMENSION).
+    /// - `bit_width` is in the range `[0, 8]`.
     ///
     /// Violating these invariants may produce incorrect results during decompression.
     pub unsafe fn new_unchecked(dimension: u32, bit_width: u8) -> Self {
@@ -103,8 +89,8 @@ impl TurboQuantData {
         centroids: &ArrayRef,
         rotation_signs: &ArrayRef,
     ) -> VortexResult<()> {
-        let ext = TurboQuant::validate_dtype(dtype)?;
-        let dimension = tensor_list_size(ext)?;
+        let vector_metadata = TurboQuant::validate_dtype(dtype)?;
+        let dimension = vector_metadata.dimensions();
         let padded_dim = dimension.next_power_of_two();
 
         // Codes must be a non-nullable FixedSizeList<u8> with list_size == padded_dim.
@@ -159,7 +145,7 @@ impl TurboQuantData {
 
         // Norms dtype must match the element ptype of the Vector, with the parent's nullability.
         // Norms carry the validity of the entire TurboQuant array.
-        let element_ptype = tensor_element_ptype(ext)?;
+        let element_ptype = vector_metadata.element_ptype();
         let expected_norms_dtype = DType::Primitive(element_ptype, dtype.nullability());
         vortex_ensure_eq!(
             *norms.dtype(),

--- a/vortex-tensor/src/encodings/turboquant/array/scheme.rs
+++ b/vortex-tensor/src/encodings/turboquant/array/scheme.rs
@@ -15,8 +15,6 @@ use vortex_error::VortexResult;
 use crate::encodings::turboquant::TurboQuant;
 use crate::encodings::turboquant::TurboQuantConfig;
 use crate::encodings::turboquant::turboquant_encode;
-use crate::utils::tensor_element_ptype;
-use crate::utils::tensor_list_size;
 
 /// TurboQuant compression scheme for [`Vector`] extension types.
 ///
@@ -59,13 +57,14 @@ impl Scheme for TurboQuantScheme {
         let dtype = data.array().dtype();
         let len = data.array().len();
 
-        let ext = TurboQuant::validate_dtype(dtype).vortex_expect("invalid dtype for TurboQuant");
-        let element_ptype = tensor_element_ptype(ext).vortex_expect("invalid ptype for TurboQuant");
+        let vector_metadata =
+            TurboQuant::validate_dtype(dtype).vortex_expect("invalid dtype for TurboQuant");
+        let element_ptype = vector_metadata.element_ptype();
         let bit_width: u8 = element_ptype
             .bit_width()
             .try_into()
             .vortex_expect("invalid bit width for TurboQuant");
-        let dimension = tensor_list_size(ext).vortex_expect("invalid ptype for TurboQuant");
+        let dimension = vector_metadata.dimensions();
 
         Ok(estimate_compression_ratio(bit_width, dimension, len))
     }

--- a/vortex-tensor/src/encodings/turboquant/array/scheme.rs
+++ b/vortex-tensor/src/encodings/turboquant/array/scheme.rs
@@ -9,6 +9,7 @@ use vortex_compressor::CascadingCompressor;
 use vortex_compressor::ctx::CompressorContext;
 use vortex_compressor::scheme::Scheme;
 use vortex_compressor::stats::ArrayAndStats;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use crate::encodings::turboquant::TurboQuant;
@@ -58,15 +59,15 @@ impl Scheme for TurboQuantScheme {
         let dtype = data.array().dtype();
         let len = data.array().len();
 
-        let ext = TurboQuant::validate_dtype(dtype)?;
-        let element_ptype = tensor_element_ptype(ext)?;
-        let dimension = tensor_list_size(ext)?;
+        let ext = TurboQuant::validate_dtype(dtype).vortex_expect("invalid dtype for TurboQuant");
+        let element_ptype = tensor_element_ptype(ext).vortex_expect("invalid ptype for TurboQuant");
+        let bit_width: u8 = element_ptype
+            .bit_width()
+            .try_into()
+            .vortex_expect("invalid bit width for TurboQuant");
+        let dimension = tensor_list_size(ext).vortex_expect("invalid ptype for TurboQuant");
 
-        Ok(estimate_compression_ratio(
-            element_ptype.bit_width(),
-            dimension,
-            len,
-        ))
+        Ok(estimate_compression_ratio(bit_width, dimension, len))
     }
 
     fn compress(
@@ -84,7 +85,7 @@ impl Scheme for TurboQuantScheme {
 }
 
 /// Estimate the compression ratio for TurboQuant MSE encoding with the default config.
-fn estimate_compression_ratio(bits_per_element: usize, dimensions: u32, num_vectors: usize) -> f64 {
+fn estimate_compression_ratio(bits_per_element: u8, dimensions: u32, num_vectors: usize) -> f64 {
     let config = TurboQuantConfig::default();
     let padded_dim = dimensions.next_power_of_two() as usize;
 
@@ -99,7 +100,7 @@ fn estimate_compression_ratio(bits_per_element: usize, dimensions: u32, num_vect
         + 3 * padded_dim; // rotation signs, 1 bit each
 
     let compressed_size_bits = compressed_bits_per_vector * num_vectors + overhead_bits;
-    let uncompressed_size_bits = bits_per_element * num_vectors * dimensions as usize;
+    let uncompressed_size_bits = bits_per_element as usize * dimensions as usize * num_vectors;
     uncompressed_size_bits as f64 / compressed_size_bits as f64
 }
 
@@ -121,7 +122,7 @@ mod tests {
     #[case::f64_768d(64, 768, 1000, 5.0, 7.0)]
     #[case::f16_768d(16, 768, 1000, 1.2, 2.0)]
     fn compression_ratio_in_expected_range(
-        #[case] bits_per_element: usize,
+        #[case] bits_per_element: u8,
         #[case] dim: u32,
         #[case] num_vectors: usize,
         #[case] min_ratio: f64,
@@ -142,7 +143,7 @@ mod tests {
     #[case(32, 768, 10)]
     #[case(64, 256, 50)]
     fn ratio_always_greater_than_one(
-        #[case] bits_per_element: usize,
+        #[case] bits_per_element: u8,
         #[case] dim: u32,
         #[case] num_vectors: usize,
     ) {

--- a/vortex-tensor/src/encodings/turboquant/compute/cosine_similarity.rs
+++ b/vortex-tensor/src/encodings/turboquant/compute/cosine_similarity.rs
@@ -45,7 +45,7 @@ use vortex_error::vortex_ensure_eq;
 use crate::encodings::turboquant::TurboQuant;
 use crate::encodings::turboquant::TurboQuantArrayExt;
 use crate::encodings::turboquant::array::float_from_f32;
-use crate::utils::tensor_element_ptype;
+use crate::vector::AnyVector;
 
 /// Compute the per-row unit-norm dot products in f32 (centroids are always f32).
 ///
@@ -109,7 +109,11 @@ pub fn cosine_similarity_quantized_column(
         "TurboQuant quantized dot product requires matching dimensions",
     );
 
-    let element_ptype = tensor_element_ptype(lhs.dtype().as_extension())?;
+    let element_ptype = lhs
+        .dtype()
+        .as_extension()
+        .metadata::<AnyVector>()
+        .element_ptype();
     let validity = lhs.norms().validity()?.and(rhs.norms().validity()?)?;
     let dots = compute_unit_dots(&lhs, &rhs, ctx)?;
 
@@ -147,7 +151,11 @@ pub fn dot_product_quantized_column(
         "TurboQuant quantized dot product requires matching dimensions",
     );
 
-    let element_ptype = tensor_element_ptype(lhs.dtype().as_extension())?;
+    let element_ptype = lhs
+        .dtype()
+        .as_extension()
+        .metadata::<AnyVector>()
+        .element_ptype();
     let validity = lhs.norms().validity()?.and(rhs.norms().validity()?)?;
     let dots = compute_unit_dots(&lhs, &rhs, ctx)?;
     let num_rows = lhs.norms().len();

--- a/vortex-tensor/src/encodings/turboquant/decompress.rs
+++ b/vortex-tensor/src/encodings/turboquant/decompress.rs
@@ -24,12 +24,12 @@ use crate::encodings::turboquant::TurboQuant;
 use crate::encodings::turboquant::TurboQuantArrayExt;
 use crate::encodings::turboquant::array::float_from_f32;
 use crate::encodings::turboquant::array::rotation::RotationMatrix;
-use crate::utils::tensor_element_ptype;
+use crate::vector::AnyVector;
 
 /// Decompress a `TurboQuantArray` into a [`Vector`] extension array.
 ///
 /// The returned array is an [`ExtensionArray`] with the original Vector dtype wrapping a
-/// `FixedSizeListArray` of f32 elements.
+/// `FixedSizeListArray` of the original vector element type.
 ///
 /// [`Vector`]: crate::vector::Vector
 pub fn execute_decompress(
@@ -40,7 +40,7 @@ pub fn execute_decompress(
     let padded_dim = array.padded_dim() as usize;
     let num_rows = array.norms().len();
     let ext_dtype = array.dtype().as_extension().clone();
-    let element_ptype = tensor_element_ptype(&ext_dtype)?;
+    let element_ptype = ext_dtype.metadata::<AnyVector>().element_ptype();
 
     if num_rows == 0 {
         let fsl_validity = Validity::from(ext_dtype.storage_dtype().nullability());

--- a/vortex-tensor/src/encodings/turboquant/vtable.rs
+++ b/vortex-tensor/src/encodings/turboquant/vtable.rs
@@ -22,7 +22,6 @@ use vortex_array::buffer::BufferHandle;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
-use vortex_array::dtype::extension::ExtDTypeRef;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::vtable;
 use vortex_array::vtable::VTable;
@@ -42,9 +41,8 @@ use crate::encodings::turboquant::compute::rules::PARENT_KERNELS;
 use crate::encodings::turboquant::compute::rules::RULES;
 use crate::encodings::turboquant::decompress::execute_decompress;
 use crate::encodings::turboquant::metadata::TurboQuantMetadata;
-use crate::utils::tensor_element_ptype;
-use crate::utils::tensor_list_size;
-use crate::vector::Vector;
+use crate::vector::AnyVector;
+use crate::vector::VectorMatcherMetadata;
 
 /// Encoding marker type for TurboQuant.
 #[derive(Clone, Debug)]
@@ -59,24 +57,23 @@ impl TurboQuant {
     /// Validates that `dtype` is a [`Vector`](crate::vector::Vector) extension type with
     /// dimension >= [`MIN_DIMENSION`](Self::MIN_DIMENSION).
     ///
-    /// Returns the validated [`ExtDTypeRef`] on success, which can be used to extract the
-    /// element ptype and list size.
-    pub fn validate_dtype(dtype: &DType) -> VortexResult<&ExtDTypeRef> {
-        let ext = dtype
+    /// Returns the validated vector metadata on success.
+    pub fn validate_dtype(dtype: &DType) -> VortexResult<VectorMatcherMetadata> {
+        let vector_metadata = dtype
             .as_extension_opt()
-            .filter(|e| e.is::<Vector>())
+            .and_then(|ext| ext.metadata_opt::<AnyVector>())
             .ok_or_else(|| {
                 vortex_err!("TurboQuant dtype must be a Vector extension type, got {dtype}")
             })?;
 
-        let dimension = tensor_list_size(ext)?;
+        let dimensions = vector_metadata.dimensions();
         vortex_ensure!(
-            dimension >= Self::MIN_DIMENSION,
-            "TurboQuant requires dimension >= {}, got {dimension}",
+            dimensions >= Self::MIN_DIMENSION,
+            "TurboQuant requires dimension >= {}, got {dimensions}",
             Self::MIN_DIMENSION
         );
 
-        Ok(ext)
+        Ok(vector_metadata)
     }
 
     /// Creates a new [`TurboQuantArray`].
@@ -89,17 +86,18 @@ impl TurboQuant {
         centroids: ArrayRef,
         rotation_signs: ArrayRef,
     ) -> VortexResult<TurboQuantArray> {
-        let len = norms.len();
         TurboQuantData::validate(&dtype, &codes, &norms, &centroids, &rotation_signs)?;
-        let ext = TurboQuant::validate_dtype(&dtype)?;
-        let dimension = tensor_list_size(ext)?;
+
+        let len = norms.len();
+        let vector_metadata = TurboQuant::validate_dtype(&dtype)?;
+
         let bit_width = if centroids.is_empty() {
             0
         } else {
             u8::try_from(centroids.len().trailing_zeros())
                 .map_err(|_| vortex_err!("centroids bit_width does not fit in u8"))?
         };
-        let data = TurboQuantData::try_new(dimension, bit_width)?;
+        let data = TurboQuantData::try_new(vector_metadata.dimensions(), bit_width)?;
         let parts = ArrayParts::new(TurboQuant, dtype, len, data).with_slots(
             TurboQuantData::make_slots(codes, norms, centroids, rotation_signs),
         );
@@ -166,10 +164,7 @@ impl VTable for TurboQuant {
             len,
             "TurboQuant norms length does not match outer length",
         );
-        vortex_ensure_eq!(
-            data.dimension,
-            tensor_list_size(TurboQuant::validate_dtype(dtype)?)?
-        );
+        vortex_ensure_eq!(data.dimension, Self::validate_dtype(dtype)?.dimensions());
 
         let expected_bit_width = if centroids.is_empty() {
             0
@@ -224,11 +219,11 @@ impl VTable for TurboQuant {
         );
 
         // Validate and derive dimension and element ptype from the Vector extension dtype.
-        let ext = TurboQuant::validate_dtype(dtype)?;
-        let dimension = tensor_list_size(ext)?;
-        let element_ptype = tensor_element_ptype(ext)?;
+        let vector_metadata = TurboQuant::validate_dtype(dtype)?;
+        let dimensions = vector_metadata.dimensions();
+        let element_ptype = vector_metadata.element_ptype();
 
-        let padded_dim = dimension.next_power_of_two();
+        let padded_dim = dimensions.next_power_of_two();
 
         // Get the codes array (indices into the codebook). Codes are always non-nullable;
         // null vectors are represented by all-zero codes with a null norm.
@@ -261,7 +256,7 @@ impl VTable for TurboQuant {
             dtype.clone(),
             len,
             TurboQuantData {
-                dimension,
+                dimension: dimensions,
                 bit_width,
             },
         )

--- a/vortex-tensor/src/fixed_shape/matcher.rs
+++ b/vortex-tensor/src/fixed_shape/matcher.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::dtype::DType;
+use vortex_array::dtype::PType;
+use vortex_array::dtype::extension::ExtDTypeRef;
+use vortex_array::dtype::extension::Matcher;
+use vortex_error::VortexExpect;
+use vortex_error::vortex_panic;
+
+use crate::fixed_shape::FixedShapeTensor;
+use crate::fixed_shape::FixedShapeTensorMetadata;
+
+pub struct AnyFixedShapeTensor;
+
+/// Convenience metadata for fixed-shape tensors.
+///
+/// Fixed-shape tensors already store their logical metadata directly, but callers also often need
+/// the flattened storage list size and element primitive type from the storage dtype.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FixedShapeTensorMatcherMetadata<'a> {
+    /// The logical fixed-shape tensor metadata stored on the extension dtype.
+    metadata: &'a FixedShapeTensorMetadata,
+
+    /// The primitive element type of the tensor storage.
+    ///
+    /// Fixed-shape tensors currently require non-nullable primitive elements.
+    element_ptype: PType,
+
+    /// The flattened element count for each tensor row in storage order.
+    ///
+    /// This matches the `FixedSizeList` list size in the storage dtype, which is the product of
+    /// the logical shape dimensions.
+    flat_list_size: usize,
+}
+
+impl Matcher for AnyFixedShapeTensor {
+    type Match<'a> = FixedShapeTensorMatcherMetadata<'a>;
+
+    fn try_match<'a>(ext_dtype: &'a ExtDTypeRef) -> Option<Self::Match<'a>> {
+        if !ext_dtype.is::<FixedShapeTensor>() {
+            return None;
+        }
+
+        let metadata = ext_dtype
+            .metadata_opt::<FixedShapeTensor>()
+            .vortex_expect("`FixedShapeTensor` type somehow did not have metadata");
+
+        let DType::FixedSizeList(element_dtype, list_size, _) = ext_dtype.storage_dtype() else {
+            vortex_panic!(
+                "`FixedShapeTensor` type somehow did not have a `FixedSizeList` storage type"
+            )
+        };
+
+        assert!(
+            element_dtype.is_primitive(),
+            "element dtype must be primitive"
+        );
+        assert!(
+            !element_dtype.is_nullable(),
+            "element dtype must be non-nullable"
+        );
+
+        Some(FixedShapeTensorMatcherMetadata {
+            metadata,
+            element_ptype: element_dtype.as_ptype(),
+            flat_list_size: *list_size as usize,
+        })
+    }
+}
+
+impl FixedShapeTensorMatcherMetadata<'_> {
+    /// Returns the underlying fixed-shape tensor metadata.
+    pub fn metadata(&self) -> &FixedShapeTensorMetadata {
+        self.metadata
+    }
+
+    /// Returns the tensor element type.
+    pub fn element_ptype(&self) -> PType {
+        self.element_ptype
+    }
+
+    /// Returns the flattened element count for each tensor row.
+    pub fn list_size(&self) -> usize {
+        self.flat_list_size
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::dtype::PType;
+    use vortex_array::dtype::extension::ExtDType;
+    use vortex_array::extension::EmptyMetadata;
+    use vortex_error::VortexResult;
+
+    use super::*;
+    use crate::vector::Vector;
+
+    fn tensor_storage_dtype(element_ptype: PType, list_size: u32) -> DType {
+        DType::FixedSizeList(
+            Arc::new(DType::Primitive(element_ptype, Nullability::NonNullable)),
+            list_size,
+            Nullability::NonNullable,
+        )
+    }
+
+    #[test]
+    fn matches_fixed_shape_tensor_dtype_metadata() -> VortexResult<()> {
+        let ext_dtype = ExtDType::<FixedShapeTensor>::try_new(
+            FixedShapeTensorMetadata::new(vec![2, 3, 4]),
+            tensor_storage_dtype(PType::F32, 24),
+        )?
+        .erased();
+
+        let metadata = ext_dtype.metadata::<AnyFixedShapeTensor>();
+        assert_eq!(metadata.element_ptype(), PType::F32);
+        assert_eq!(metadata.list_size(), 24);
+        assert_eq!(metadata.metadata().logical_shape(), &[2, 3, 4]);
+        Ok(())
+    }
+
+    #[test]
+    fn does_not_match_vector() -> VortexResult<()> {
+        let ext_dtype =
+            ExtDType::<Vector>::try_new(EmptyMetadata, tensor_storage_dtype(PType::F32, 24))?
+                .erased();
+
+        assert!(ext_dtype.metadata_opt::<AnyFixedShapeTensor>().is_none());
+        Ok(())
+    }
+}

--- a/vortex-tensor/src/fixed_shape/mod.rs
+++ b/vortex-tensor/src/fixed_shape/mod.rs
@@ -12,3 +12,6 @@ pub use metadata::FixedShapeTensorMetadata;
 
 mod proto;
 mod vtable;
+
+// TODO(connor): Add a dedicated `AnyFixedShapeTensor` that also contains the element ptype and
+// the storage fixed size list size (which is just the product of all logical shapes).

--- a/vortex-tensor/src/fixed_shape/mod.rs
+++ b/vortex-tensor/src/fixed_shape/mod.rs
@@ -7,11 +7,12 @@
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct FixedShapeTensor;
 
+mod matcher;
+pub use matcher::AnyFixedShapeTensor;
+pub use matcher::FixedShapeTensorMatcherMetadata;
+
 mod metadata;
 pub use metadata::FixedShapeTensorMetadata;
 
 mod proto;
 mod vtable;
-
-// TODO(connor): Add a dedicated `AnyFixedShapeTensor` that also contains the element ptype and
-// the storage fixed size list size (which is just the product of all logical shapes).

--- a/vortex-tensor/src/matcher.rs
+++ b/vortex-tensor/src/matcher.rs
@@ -8,7 +8,8 @@ use vortex_array::dtype::extension::Matcher;
 
 use crate::fixed_shape::FixedShapeTensor;
 use crate::fixed_shape::FixedShapeTensorMetadata;
-use crate::vector::Vector;
+use crate::vector::AnyVector;
+use crate::vector::VectorMatcherMetadata;
 
 /// Matcher for any tensor-like extension type.
 ///
@@ -23,20 +24,26 @@ pub struct AnyTensor;
 pub enum TensorMatch<'a> {
     /// A [`FixedShapeTensor`] extension type.
     FixedShapeTensor(&'a FixedShapeTensorMetadata),
+
     /// A [`Vector`] extension type.
-    Vector,
+    ///
+    /// Note that we store an owned type here wrapping (copyable) data from the dtype.
+    Vector(VectorMatcherMetadata),
 }
 
 impl Matcher for AnyTensor {
     type Match<'a> = TensorMatch<'a>;
 
-    fn try_match<'a>(item: &'a ExtDTypeRef) -> Option<Self::Match<'a>> {
-        if let Some(metadata) = item.metadata_opt::<FixedShapeTensor>() {
+    fn try_match<'a>(ext_dtype: &'a ExtDTypeRef) -> Option<Self::Match<'a>> {
+        if let Some(metadata) = ext_dtype.metadata_opt::<FixedShapeTensor>() {
             return Some(TensorMatch::FixedShapeTensor(metadata));
         }
-        if item.metadata_opt::<Vector>().is_some() {
-            return Some(TensorMatch::Vector);
+
+        // Special logic for vectors to get convenience metadata (instead of `EmptyMetadata`).
+        if let Some(metadata) = ext_dtype.metadata_opt::<AnyVector>() {
+            return Some(TensorMatch::Vector(metadata));
         }
+
         None
     }
 }

--- a/vortex-tensor/src/matcher.rs
+++ b/vortex-tensor/src/matcher.rs
@@ -3,11 +3,12 @@
 
 //! Matcher for tensor-like extension types.
 
+use vortex_array::dtype::PType;
 use vortex_array::dtype::extension::ExtDTypeRef;
 use vortex_array::dtype::extension::Matcher;
 
-use crate::fixed_shape::FixedShapeTensor;
-use crate::fixed_shape::FixedShapeTensorMetadata;
+use crate::fixed_shape::AnyFixedShapeTensor;
+use crate::fixed_shape::FixedShapeTensorMatcherMetadata;
 use crate::vector::AnyVector;
 use crate::vector::VectorMatcherMetadata;
 
@@ -20,22 +21,40 @@ use crate::vector::VectorMatcherMetadata;
 pub struct AnyTensor;
 
 /// The matched variant of a tensor-like extension type.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TensorMatch<'a> {
-    /// A [`FixedShapeTensor`] extension type.
-    FixedShapeTensor(&'a FixedShapeTensorMetadata),
+    /// A [`FixedShapeTensor`](crate::fixed_shape::FixedShapeTensor) extension type.
+    FixedShapeTensor(FixedShapeTensorMatcherMetadata<'a>),
 
-    /// A [`Vector`] extension type.
+    /// A [`Vector`](crate::vector::Vector) extension type.
     ///
     /// Note that we store an owned type here wrapping (copyable) data from the dtype.
     Vector(VectorMatcherMetadata),
+}
+
+impl TensorMatch<'_> {
+    /// Returns the tensor element type for this tensor-like dtype.
+    pub fn element_ptype(self) -> PType {
+        match self {
+            Self::FixedShapeTensor(metadata) => metadata.element_ptype(),
+            Self::Vector(metadata) => metadata.element_ptype(),
+        }
+    }
+
+    /// Returns the flattened element count for each logical tensor row.
+    pub fn list_size(self) -> usize {
+        match self {
+            Self::FixedShapeTensor(metadata) => metadata.list_size(),
+            Self::Vector(metadata) => metadata.dimensions() as usize,
+        }
+    }
 }
 
 impl Matcher for AnyTensor {
     type Match<'a> = TensorMatch<'a>;
 
     fn try_match<'a>(ext_dtype: &'a ExtDTypeRef) -> Option<Self::Match<'a>> {
-        if let Some(metadata) = ext_dtype.metadata_opt::<FixedShapeTensor>() {
+        if let Some(metadata) = ext_dtype.metadata_opt::<AnyFixedShapeTensor>() {
             return Some(TensorMatch::FixedShapeTensor(metadata));
         }
 

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -30,10 +30,10 @@ use vortex_error::vortex_err;
 
 use crate::encodings::turboquant::TurboQuant;
 use crate::encodings::turboquant::compute::cosine_similarity;
+use crate::matcher::AnyTensor;
 use crate::scalar_fns::ApproxOptions;
 use crate::scalar_fns::inner_product::InnerProduct;
 use crate::scalar_fns::l2_norm::L2Norm;
-use crate::vector::AnyVector;
 
 /// Cosine similarity between two columns.
 ///
@@ -117,20 +117,22 @@ impl ScalarFnVTable for CosineSimilarity {
 
         // We don't need to look at rhs anymore since we know lhs and rhs are equal.
 
-        // Both inputs must be vector extension types.
+        // Both inputs must be tensor-like extension types.
         let lhs_ext = lhs.as_extension_opt().ok_or_else(|| {
             vortex_err!("CosineSimilarity lhs must be an extension type, got {lhs}")
         })?;
 
-        let vector_metadata = lhs_ext
-            .metadata_opt::<AnyVector>()
-            .ok_or_else(|| vortex_err!("can only apply an L2Norm expression on `Vector`s"))?;
+        let tensor_match = lhs_ext.metadata_opt::<AnyTensor>().ok_or_else(|| {
+            vortex_err!("CosineSimilarity inputs must be an `AnyTensor`, got {lhs}")
+        })?;
+        let ptype = tensor_match.element_ptype();
+        vortex_ensure!(
+            ptype.is_float(),
+            "CosineSimilarity element dtype must be a float primitive, got {ptype}"
+        );
 
         let nullability = Nullability::from(lhs.is_nullable() || rhs.is_nullable());
-        Ok(DType::Primitive(
-            vector_metadata.element_ptype(),
-            nullability,
-        ))
+        Ok(DType::Primitive(ptype, nullability))
     }
 
     fn execute(

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -30,11 +30,10 @@ use vortex_error::vortex_err;
 
 use crate::encodings::turboquant::TurboQuant;
 use crate::encodings::turboquant::compute::cosine_similarity;
-use crate::matcher::AnyTensor;
 use crate::scalar_fns::ApproxOptions;
 use crate::scalar_fns::inner_product::InnerProduct;
 use crate::scalar_fns::l2_norm::L2Norm;
-use crate::utils::tensor_element_ptype;
+use crate::vector::AnyVector;
 
 /// Cosine similarity between two columns.
 ///
@@ -118,24 +117,20 @@ impl ScalarFnVTable for CosineSimilarity {
 
         // We don't need to look at rhs anymore since we know lhs and rhs are equal.
 
-        // Both inputs must be tensor-like extension types.
+        // Both inputs must be vector extension types.
         let lhs_ext = lhs.as_extension_opt().ok_or_else(|| {
             vortex_err!("CosineSimilarity lhs must be an extension type, got {lhs}")
         })?;
 
-        vortex_ensure!(
-            lhs_ext.is::<AnyTensor>(),
-            "CosineSimilarity inputs must be an `AnyTensor`, got {lhs}"
-        );
-
-        let ptype = tensor_element_ptype(lhs_ext)?;
-        vortex_ensure!(
-            ptype.is_float(),
-            "CosineSimilarity element dtype must be a float primitive, got {ptype}"
-        );
+        let vector_metadata = lhs_ext
+            .metadata_opt::<AnyVector>()
+            .ok_or_else(|| vortex_err!("can only apply an L2Norm expression on `Vector`s"))?;
 
         let nullability = Nullability::from(lhs.is_nullable() || rhs.is_nullable());
-        Ok(DType::Primitive(ptype, nullability))
+        Ok(DType::Primitive(
+            vector_metadata.element_ptype(),
+            nullability,
+        ))
     }
 
     fn execute(

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -36,8 +36,6 @@ use crate::encodings::turboquant::compute::cosine_similarity;
 use crate::matcher::AnyTensor;
 use crate::scalar_fns::ApproxOptions;
 use crate::utils::extract_flat_elements;
-use crate::utils::tensor_element_ptype;
-use crate::vector::AnyVector;
 
 /// Inner product (dot product) between two columns.
 ///
@@ -129,7 +127,10 @@ impl ScalarFnVTable for InnerProduct {
             "InnerProduct inputs must be an `AnyTensor`, got {lhs}"
         );
 
-        let ptype = tensor_element_ptype(lhs_ext)?;
+        let tensor_match = lhs_ext
+            .metadata_opt::<AnyTensor>()
+            .ok_or_else(|| vortex_err!("InnerProduct inputs must be an `AnyTensor`, got {lhs}"))?;
+        let ptype = tensor_match.element_ptype();
         // TODO(connor): This should support integer tensors!
         vortex_ensure!(
             ptype.is_float(),
@@ -153,10 +154,10 @@ impl ScalarFnVTable for InnerProduct {
 
         // We validated that both inputs have the same type.
         let ext = lhs_ref.dtype().as_extension();
-        let vector_metadata = ext
-            .metadata_opt::<AnyVector>()
+        let tensor_match = ext
+            .metadata_opt::<AnyTensor>()
             .vortex_expect("we already validated this in `return_dtype`");
-        let dimensions = vector_metadata.dimensions() as usize;
+        let dimensions = tensor_match.list_size();
 
         // TurboQuant approximate path: check encoding before executing.
         if options.is_approx()

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -26,6 +26,7 @@ use vortex_array::scalar_fn::ScalarFn;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_buffer::Buffer;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
@@ -36,7 +37,7 @@ use crate::matcher::AnyTensor;
 use crate::scalar_fns::ApproxOptions;
 use crate::utils::extract_flat_elements;
 use crate::utils::tensor_element_ptype;
-use crate::utils::tensor_list_size;
+use crate::vector::AnyVector;
 
 /// Inner product (dot product) between two columns.
 ///
@@ -129,6 +130,7 @@ impl ScalarFnVTable for InnerProduct {
         );
 
         let ptype = tensor_element_ptype(lhs_ext)?;
+        // TODO(connor): This should support integer tensors!
         vortex_ensure!(
             ptype.is_float(),
             "InnerProduct element dtype must be a float primitive, got {ptype}"
@@ -149,6 +151,13 @@ impl ScalarFnVTable for InnerProduct {
 
         let row_count = args.row_count();
 
+        // We validated that both inputs have the same type.
+        let ext = lhs_ref.dtype().as_extension();
+        let vector_metadata = ext
+            .metadata_opt::<AnyVector>()
+            .vortex_expect("we already validated this in `return_dtype`");
+        let dimensions = vector_metadata.dimensions() as usize;
+
         // TurboQuant approximate path: check encoding before executing.
         if options.is_approx()
             && let (Some(lhs_tq), Some(rhs_tq)) = (
@@ -166,18 +175,13 @@ impl ScalarFnVTable for InnerProduct {
         let rhs_validity = rhs.as_ref().validity()?;
         let validity = lhs.as_ref().validity()?.and(rhs_validity)?;
 
-        // Get list size from the dtype. Both sides have the same dtype (validated by
-        // `return_dtype`).
-        let ext = lhs.dtype().as_extension();
-        let list_size = tensor_list_size(ext)? as usize;
-
         // Extract the storage array from each extension input. We pass the storage (FSL) rather
         // than the extension array to avoid canonicalizing the extension wrapper.
         let lhs_storage = lhs.storage_array();
         let rhs_storage = rhs.storage_array();
 
-        let lhs_flat = extract_flat_elements(lhs_storage, list_size, ctx)?;
-        let rhs_flat = extract_flat_elements(rhs_storage, list_size, ctx)?;
+        let lhs_flat = extract_flat_elements(lhs_storage, dimensions, ctx)?;
+        let rhs_flat = extract_flat_elements(rhs_storage, dimensions, ctx)?;
 
         match_each_float_ptype!(lhs_flat.ptype(), |T| {
             let buffer: Buffer<T> = (0..row_count)

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -27,14 +27,15 @@ use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_buffer::Buffer;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
 use vortex_error::vortex_err;
 
 use crate::encodings::turboquant::TurboQuant;
 use crate::encodings::turboquant::TurboQuantArrayExt;
+use crate::matcher::AnyTensor;
 use crate::scalar_fns::ApproxOptions;
 use crate::utils::extract_flat_elements;
-use crate::vector::AnyVector;
 
 /// L2 norm (Euclidean norm) of a tensor or vector column.
 ///
@@ -99,20 +100,22 @@ impl ScalarFnVTable for L2Norm {
     fn return_dtype(&self, _options: &Self::Options, arg_dtypes: &[DType]) -> VortexResult<DType> {
         let input_dtype = &arg_dtypes[0];
 
-        // Input must be a vector extension type.
+        // Input must be a tensor-like extension type.
         let ext = input_dtype.as_extension_opt().ok_or_else(|| {
             vortex_err!("L2Norm input must be an extension type, got {input_dtype}")
         })?;
 
-        let vector_metadata = ext
-            .metadata_opt::<AnyVector>()
-            .ok_or_else(|| vortex_err!("can only apply an L2Norm expression on `Vector`s"))?;
+        let tensor_match = ext
+            .metadata_opt::<AnyTensor>()
+            .ok_or_else(|| vortex_err!("L2Norm input must be an `AnyTensor`, got {input_dtype}"))?;
+        let ptype = tensor_match.element_ptype();
+        vortex_ensure!(
+            ptype.is_float(),
+            "L2Norm element dtype must be a float primitive, got {ptype}"
+        );
 
         let nullability = Nullability::from(input_dtype.is_nullable());
-        Ok(DType::Primitive(
-            vector_metadata.element_ptype(),
-            nullability,
-        ))
+        Ok(DType::Primitive(ptype, nullability))
     }
 
     fn execute(
@@ -125,9 +128,11 @@ impl ScalarFnVTable for L2Norm {
         let row_count = args.row_count();
 
         let ext = input_ref.dtype().as_extension();
-        let vector_metadata = ext
-            .metadata_opt::<AnyVector>()
+        let tensor_match = ext
+            .metadata_opt::<AnyTensor>()
             .vortex_expect("we already validated this in `return_dtype`");
+        let dimensions = tensor_match.list_size();
+        let element_ptype = tensor_match.element_ptype();
 
         // TODO(connor): TQ might not store norms in the future.
         // TurboQuant stores exact precomputed norms, so no decompression needed.
@@ -137,10 +142,7 @@ impl ScalarFnVTable for L2Norm {
             // Assert that the norms dtype has the correct output dtype and nullability.
             vortex_ensure_eq!(
                 norms.dtype(),
-                &DType::Primitive(
-                    vector_metadata.element_ptype(),
-                    input_ref.dtype().nullability(),
-                )
+                &DType::Primitive(element_ptype, input_ref.dtype().nullability(),)
             );
 
             return Ok(norms.into_array());
@@ -150,7 +152,7 @@ impl ScalarFnVTable for L2Norm {
         let validity = input.as_ref().validity()?;
 
         let storage = input.storage_array();
-        let flat = extract_flat_elements(storage, vector_metadata.dimensions() as usize, ctx)?;
+        let flat = extract_flat_elements(storage, dimensions, ctx)?;
 
         match_each_float_ptype!(flat.ptype(), |T| {
             let buffer: Buffer<T> = (0..row_count)

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -13,7 +13,6 @@ use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::ScalarFnArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
-use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
@@ -26,17 +25,16 @@ use vortex_array::scalar_fn::ScalarFn;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_buffer::Buffer;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
-use vortex_error::vortex_ensure;
+use vortex_error::vortex_ensure_eq;
 use vortex_error::vortex_err;
 
 use crate::encodings::turboquant::TurboQuant;
 use crate::encodings::turboquant::TurboQuantArrayExt;
-use crate::matcher::AnyTensor;
 use crate::scalar_fns::ApproxOptions;
 use crate::utils::extract_flat_elements;
-use crate::utils::tensor_element_ptype;
-use crate::utils::tensor_list_size;
+use crate::vector::AnyVector;
 
 /// L2 norm (Euclidean norm) of a tensor or vector column.
 ///
@@ -101,24 +99,20 @@ impl ScalarFnVTable for L2Norm {
     fn return_dtype(&self, _options: &Self::Options, arg_dtypes: &[DType]) -> VortexResult<DType> {
         let input_dtype = &arg_dtypes[0];
 
-        // Input must be a tensor-like extension type.
+        // Input must be a vector extension type.
         let ext = input_dtype.as_extension_opt().ok_or_else(|| {
             vortex_err!("L2Norm input must be an extension type, got {input_dtype}")
         })?;
 
-        vortex_ensure!(
-            ext.is::<AnyTensor>(),
-            "L2Norm input must be an `AnyTensor`, got {input_dtype}"
-        );
-
-        let ptype = tensor_element_ptype(ext)?;
-        vortex_ensure!(
-            ptype.is_float(),
-            "L2Norm element dtype must be a float primitive, got {ptype}"
-        );
+        let vector_metadata = ext
+            .metadata_opt::<AnyVector>()
+            .ok_or_else(|| vortex_err!("can only apply an L2Norm expression on `Vector`s"))?;
 
         let nullability = Nullability::from(input_dtype.is_nullable());
-        Ok(DType::Primitive(ptype, nullability))
+        Ok(DType::Primitive(
+            vector_metadata.element_ptype(),
+            nullability,
+        ))
     }
 
     fn execute(
@@ -130,26 +124,33 @@ impl ScalarFnVTable for L2Norm {
         let input_ref = args.get(0)?;
         let row_count = args.row_count();
 
-        // TurboQuant stores exact precomputed norms -- no decompression needed.
-        // Norms are currently stored as f32; cast to the target dtype if needed
-        // (e.g., if the input extension has f64 elements).
+        let ext = input_ref.dtype().as_extension();
+        let vector_metadata = ext
+            .metadata_opt::<AnyVector>()
+            .vortex_expect("we already validated this in `return_dtype`");
+
+        // TODO(connor): TQ might not store norms in the future.
+        // TurboQuant stores exact precomputed norms, so no decompression needed.
         if let Some(tq) = input_ref.as_opt::<TurboQuant>() {
-            let ext = input_ref.dtype().as_extension();
-            let target_ptype = tensor_element_ptype(ext)?;
             let norms: PrimitiveArray = tq.norms().clone().execute(ctx)?;
-            let target_dtype = DType::Primitive(target_ptype, input_ref.dtype().nullability());
-            return norms.into_array().cast(target_dtype);
+
+            // Assert that the norms dtype has the correct output dtype and nullability.
+            vortex_ensure_eq!(
+                norms.dtype(),
+                &DType::Primitive(
+                    vector_metadata.element_ptype(),
+                    input_ref.dtype().nullability(),
+                )
+            );
+
+            return Ok(norms.into_array());
         }
 
         let input: ExtensionArray = input_ref.execute(ctx)?;
         let validity = input.as_ref().validity()?;
 
-        // Get element ptype and list size from the dtype (validated by `return_dtype`).
-        let ext = input.dtype().as_extension();
-        let list_size = tensor_list_size(ext)? as usize;
-
         let storage = input.storage_array();
-        let flat = extract_flat_elements(storage, list_size, ctx)?;
+        let flat = extract_flat_elements(storage, vector_metadata.dimensions() as usize, ctx)?;
 
         match_each_float_ptype!(flat.ptype(), |T| {
             let buffer: Buffer<T> = (0..row_count)

--- a/vortex-tensor/src/utils.rs
+++ b/vortex-tensor/src/utils.rs
@@ -32,7 +32,7 @@ pub fn tensor_list_size(ext: &ExtDTypeRef) -> VortexResult<u32> {
     Ok(*list_size)
 }
 
-/// Extracts the float element [`PType`] from a tensor-like extension dtype.
+/// Extracts the element [`PType`] from a tensor-like extension dtype.
 ///
 /// The storage dtype must be a `FixedSizeList` of non-nullable primitives.
 pub fn tensor_element_ptype(ext: &ExtDTypeRef) -> VortexResult<PType> {

--- a/vortex-tensor/src/utils.rs
+++ b/vortex-tensor/src/utils.rs
@@ -9,50 +9,9 @@ use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
-use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::PType;
-use vortex_array::dtype::extension::ExtDTypeRef;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
-use vortex_error::vortex_ensure;
-use vortex_error::vortex_err;
-
-/// Extracts the list size from a tensor-like extension dtype.
-///
-/// The storage dtype must be a `FixedSizeList`.
-pub fn tensor_list_size(ext: &ExtDTypeRef) -> VortexResult<u32> {
-    let DType::FixedSizeList(_, list_size, _) = ext.storage_dtype() else {
-        vortex_bail!(
-            "expected FixedSizeList storage dtype, got {}",
-            ext.storage_dtype()
-        );
-    };
-
-    Ok(*list_size)
-}
-
-/// Extracts the element [`PType`] from a tensor-like extension dtype.
-///
-/// The storage dtype must be a `FixedSizeList` of non-nullable primitives.
-pub fn tensor_element_ptype(ext: &ExtDTypeRef) -> VortexResult<PType> {
-    let element_dtype = ext
-        .storage_dtype()
-        .as_fixed_size_list_element_opt()
-        .ok_or_else(|| {
-            vortex_err!(
-                "expected FixedSizeList storage dtype, got {}",
-                ext.storage_dtype()
-            )
-        })?;
-
-    vortex_ensure!(
-        !element_dtype.is_nullable(),
-        "element dtype must be non-nullable"
-    );
-
-    Ok(element_dtype.as_ptype())
-}
 
 /// The flat primitive elements of a tensor storage array, with typed row access.
 ///

--- a/vortex-tensor/src/vector/matcher.rs
+++ b/vortex-tensor/src/vector/matcher.rs
@@ -10,6 +10,8 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_panic;
 
+use crate::vector::Vector;
+
 pub struct AnyVector;
 
 /// Convenience metadata for vectors.
@@ -37,12 +39,17 @@ impl Matcher for AnyVector {
     type Match<'a> = VectorMatcherMetadata;
 
     fn try_match<'a>(ext_dtype: &'a ExtDTypeRef) -> Option<Self::Match<'a>> {
+        if !ext_dtype.is::<Vector>() {
+            return None;
+        }
+
         let DType::FixedSizeList(element_dtype, list_size, _) = ext_dtype.storage_dtype() else {
             vortex_panic!("`Vector` type somehow did not have a `FixedSizeList` storage type")
         };
 
         let dimensions = *list_size;
 
+        assert!(element_dtype.is_float(), "element dtype must be primitive");
         assert!(
             !element_dtype.is_nullable(),
             "element dtype must be non-nullable"
@@ -79,5 +86,53 @@ impl VectorMatcherMetadata {
     /// Returns the number of dimensions of the vector.
     pub fn dimensions(&self) -> u32 {
         self.dimensions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
+    use vortex_array::dtype::PType;
+    use vortex_array::dtype::extension::ExtDType;
+    use vortex_array::extension::EmptyMetadata;
+    use vortex_error::VortexResult;
+
+    use super::*;
+    use crate::fixed_shape::FixedShapeTensor;
+    use crate::fixed_shape::FixedShapeTensorMetadata;
+
+    fn vector_storage_dtype(element_ptype: PType, dimensions: u32) -> DType {
+        DType::FixedSizeList(
+            Arc::new(DType::Primitive(element_ptype, Nullability::NonNullable)),
+            dimensions,
+            Nullability::NonNullable,
+        )
+    }
+
+    #[test]
+    fn matches_vector_dtype_metadata() -> VortexResult<()> {
+        let ext_dtype =
+            ExtDType::<Vector>::try_new(EmptyMetadata, vector_storage_dtype(PType::F32, 256))?
+                .erased();
+
+        let metadata = ext_dtype.metadata::<AnyVector>();
+        assert_eq!(metadata.element_ptype(), PType::F32);
+        assert_eq!(metadata.dimensions(), 256);
+        Ok(())
+    }
+
+    #[test]
+    fn does_not_match_fixed_shape_tensor() -> VortexResult<()> {
+        let ext_dtype = ExtDType::<FixedShapeTensor>::try_new(
+            FixedShapeTensorMetadata::new(vec![16, 16]),
+            vector_storage_dtype(PType::F32, 256),
+        )?
+        .erased();
+
+        assert!(ext_dtype.metadata_opt::<AnyVector>().is_none());
+        Ok(())
     }
 }

--- a/vortex-tensor/src/vector/matcher.rs
+++ b/vortex-tensor/src/vector/matcher.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+use vortex_array::dtype::DType;
+use vortex_array::dtype::PType;
+use vortex_array::dtype::extension::ExtDTypeRef;
+use vortex_array::dtype::extension::Matcher;
+use vortex_error::VortexExpect;
+use vortex_error::VortexResult;
+use vortex_error::vortex_ensure;
+use vortex_error::vortex_panic;
+
+pub struct AnyVector;
+
+/// Convenience metadata for vectors.
+///
+/// Unlike `FixedShapeTensor`, the [`Vector`] type has `EmptyMetadata` as its metadata because all
+/// of the important information is already stored in the dtype.
+///
+/// However, it is quite inconvenient to repeatedly unwrap the dtype to get the element type of the
+/// vector and the number of dimensions.
+///
+/// Thus, we allow the matcher to return this metadata so that we can access this information more
+/// easily.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VectorMatcherMetadata {
+    /// The element type of the vectors. Note that vector elements are _always_ non-nullable.
+    ///
+    /// This MUST be a floating point type (f16, f32, f64).
+    element_ptype: PType,
+
+    /// The number of dimensions of the vector. This is always fixed.
+    dimensions: u32,
+}
+
+impl Matcher for AnyVector {
+    type Match<'a> = VectorMatcherMetadata;
+
+    fn try_match<'a>(ext_dtype: &'a ExtDTypeRef) -> Option<Self::Match<'a>> {
+        let DType::FixedSizeList(element_dtype, list_size, _) = ext_dtype.storage_dtype() else {
+            vortex_panic!("`Vector` type somehow did not have a `FixedSizeList` storage type")
+        };
+
+        let dimensions = *list_size;
+
+        assert!(
+            !element_dtype.is_nullable(),
+            "element dtype must be non-nullable"
+        );
+        let element_ptype = element_dtype.as_ptype();
+
+        let vector_metadata = VectorMatcherMetadata::try_new(element_ptype, dimensions)
+            .vortex_expect("`Vector` type somehow did not have float elements");
+
+        Some(vector_metadata)
+    }
+}
+
+impl VectorMatcherMetadata {
+    /// Tries to create a new `VectorMatcherMetadata`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the element type is not a float.
+    pub fn try_new(element_ptype: PType, dimensions: u32) -> VortexResult<Self> {
+        vortex_ensure!(element_ptype.is_float());
+
+        Ok(Self {
+            element_ptype,
+            dimensions,
+        })
+    }
+
+    /// Returns the element type of the vectors.
+    pub fn element_ptype(&self) -> PType {
+        self.element_ptype
+    }
+
+    /// Returns the number of dimensions of the vector.
+    pub fn dimensions(&self) -> u32 {
+        self.dimensions
+    }
+}

--- a/vortex-tensor/src/vector/mod.rs
+++ b/vortex-tensor/src/vector/mod.rs
@@ -8,7 +8,8 @@
 pub struct Vector;
 
 mod matcher;
-mod vtable;
 
 pub use matcher::AnyVector;
 pub use matcher::VectorMatcherMetadata;
+
+mod vtable;

--- a/vortex-tensor/src/vector/mod.rs
+++ b/vortex-tensor/src/vector/mod.rs
@@ -7,4 +7,8 @@
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Vector;
 
+mod matcher;
 mod vtable;
+
+pub use matcher::AnyVector;
+pub use matcher::VectorMatcherMetadata;


### PR DESCRIPTION
## Summary

Tracking issue: https://github.com/vortex-data/vortex/issues/7297

Instead of having weird helper functions extract information out of the FSL dtype, we can extract it into new matcher metadata via `AnyVector` and `AnyFixedShapeTensor` matchers.

Note that this is _separate_ from the metadata that needs to be serialized to disk on the array vtable. 

## Testing

N/A since the logic should be the same, just in a different place.