### PR TITLE
Fix StructArray / StructData after migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -1475,9 +1475,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -8105,9 +8105,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -8117,6 +8117,7 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/fuzz/src/array/filter.rs
+++ b/fuzz/src/array/filter.rs
@@ -100,7 +100,7 @@ pub fn filter_canonical_array(array: &ArrayRef, filter: &[bool]) -> VortexResult
 
             StructArray::try_new_with_dtype(
                 filtered_children,
-                struct_array.struct_fields(),
+                struct_array.struct_fields().clone(),
                 filter.iter().filter(|b| **b).map(|b| *b as usize).sum(),
                 validity,
             )

--- a/fuzz/src/array/mask.rs
+++ b/fuzz/src/array/mask.rs
@@ -122,7 +122,7 @@ pub fn mask_canonical_array(canonical: Canonical, mask: &Mask) -> VortexResult<A
             let new_validity = mask_validity(&array.validity()?, mask);
             StructArray::try_new_with_dtype(
                 array.unmasked_fields(),
-                array.struct_fields(),
+                array.struct_fields().clone(),
                 array.len(),
                 new_validity,
             )

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -69,7 +69,7 @@ pub fn slice_canonical_array(
                 .collect::<VortexResult<Vec<_>>>()?;
             StructArray::try_new_with_dtype(
                 sliced_children,
-                struct_array.struct_fields(),
+                struct_array.struct_fields().clone(),
                 stop - start,
                 validity,
             )

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -4170,7 +4170,7 @@ pub fn vortex_array::arrays::Struct::serialize(_array: vortex_array::ArrayView<'
 
 pub fn vortex_array::arrays::Struct::slot_name(array: vortex_array::ArrayView<'_, Self>, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::Struct::validate(&self, data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Struct::validate(&self, _data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
 
 impl vortex_array::ValidityVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
 
@@ -4198,21 +4198,13 @@ pub fn vortex_array::arrays::Struct::zip(if_true: vortex_array::ArrayView<'_, vo
 
 pub struct vortex_array::arrays::struct_::StructData
 
-impl vortex_array::arrays::struct_::StructData
-
-pub fn vortex_array::arrays::struct_::StructData::build(names: vortex_array::dtype::FieldNames, fields: impl core::convert::Into<alloc::sync::Arc<[vortex_array::ArrayRef]>>, length: usize, validity: vortex_array::validity::Validity) -> Self
-
-pub fn vortex_array::arrays::struct_::StructData::names(&self) -> &vortex_array::dtype::FieldNames
-
-pub fn vortex_array::arrays::struct_::StructData::new_fieldless_with_len(len: usize) -> Self
-
-pub unsafe fn vortex_array::arrays::struct_::StructData::new_unchecked(dtype: vortex_array::dtype::StructFields, fieldless_len: core::option::Option<usize>) -> Self
-
-pub fn vortex_array::arrays::struct_::StructData::validate(fields: &[vortex_array::ArrayRef], dtype: &vortex_array::dtype::StructFields, length: usize, validity: &vortex_array::validity::Validity) -> vortex_error::VortexResult<()>
-
 impl core::clone::Clone for vortex_array::arrays::struct_::StructData
 
 pub fn vortex_array::arrays::struct_::StructData::clone(&self) -> vortex_array::arrays::struct_::StructData
+
+impl core::default::Default for vortex_array::arrays::struct_::StructData
+
+pub fn vortex_array::arrays::struct_::StructData::default() -> vortex_array::arrays::struct_::StructData
 
 impl core::fmt::Debug for vortex_array::arrays::struct_::StructData
 
@@ -4242,7 +4234,7 @@ pub fn vortex_array::arrays::struct_::StructArrayExt::names(&self) -> &vortex_ar
 
 pub fn vortex_array::arrays::struct_::StructArrayExt::nullability(&self) -> vortex_array::dtype::Nullability
 
-pub fn vortex_array::arrays::struct_::StructArrayExt::struct_fields(&self) -> vortex_array::dtype::StructFields
+pub fn vortex_array::arrays::struct_::StructArrayExt::struct_fields(&self) -> &vortex_array::dtype::StructFields
 
 pub fn vortex_array::arrays::struct_::StructArrayExt::struct_validity(&self) -> vortex_array::validity::Validity
 
@@ -4262,7 +4254,7 @@ pub fn T::names(&self) -> &vortex_array::dtype::FieldNames
 
 pub fn T::nullability(&self) -> vortex_array::dtype::Nullability
 
-pub fn T::struct_fields(&self) -> vortex_array::dtype::StructFields
+pub fn T::struct_fields(&self) -> &vortex_array::dtype::StructFields
 
 pub fn T::struct_validity(&self) -> vortex_array::validity::Validity
 
@@ -6416,7 +6408,7 @@ pub fn vortex_array::arrays::Struct::serialize(_array: vortex_array::ArrayView<'
 
 pub fn vortex_array::arrays::Struct::slot_name(array: vortex_array::ArrayView<'_, Self>, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::Struct::validate(&self, data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Struct::validate(&self, _data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
 
 impl vortex_array::ValidityVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
 
@@ -19458,7 +19450,7 @@ pub fn vortex_array::arrays::Struct::serialize(_array: vortex_array::ArrayView<'
 
 pub fn vortex_array::arrays::Struct::slot_name(array: vortex_array::ArrayView<'_, Self>, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::Struct::validate(&self, data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Struct::validate(&self, _data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
 
 impl vortex_array::VTable for vortex_array::arrays::VarBin
 
@@ -20474,7 +20466,7 @@ pub fn vortex_array::arrays::Struct::serialize(_array: vortex_array::ArrayView<'
 
 pub fn vortex_array::arrays::Struct::slot_name(array: vortex_array::ArrayView<'_, Self>, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::Struct::validate(&self, data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Struct::validate(&self, _data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
 
 impl vortex_array::VTable for vortex_array::arrays::VarBin
 
@@ -23196,7 +23188,7 @@ pub fn vortex_array::arrays::Struct::serialize(_array: vortex_array::ArrayView<'
 
 pub fn vortex_array::arrays::Struct::slot_name(array: vortex_array::ArrayView<'_, Self>, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::Struct::validate(&self, data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Struct::validate(&self, _data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
 
 impl vortex_array::VTable for vortex_array::arrays::VarBin
 
@@ -24460,7 +24452,7 @@ pub fn vortex_array::arrays::Struct::serialize(_array: vortex_array::ArrayView<'
 
 pub fn vortex_array::arrays::Struct::slot_name(array: vortex_array::ArrayView<'_, Self>, idx: usize) -> alloc::string::String
 
-pub fn vortex_array::arrays::Struct::validate(&self, data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
+pub fn vortex_array::arrays::Struct::validate(&self, _data: &vortex_array::arrays::struct_::StructData, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::ArrayRef>]) -> vortex_error::VortexResult<()>
 
 impl vortex_array::VTable for vortex_array::arrays::VarBin
 

--- a/vortex-array/src/arrays/filter/execute/struct_.rs
+++ b/vortex-array/src/arrays/filter/execute/struct_.rs
@@ -41,7 +41,7 @@ pub fn filter_struct(array: &StructArray, mask: &Arc<MaskValues>) -> StructArray
         length,
         filtered_validity,
     )
-        .vortex_expect("filtered StructArray fields have consistent lengths")
+    .vortex_expect("filtered StructArray fields have consistent lengths")
 }
 
 #[cfg(test)]

--- a/vortex-array/src/arrays/filter/execute/struct_.rs
+++ b/vortex-array/src/arrays/filter/execute/struct_.rs
@@ -35,7 +35,12 @@ pub fn filter_struct(array: &StructArray, mask: &Arc<MaskValues>) -> StructArray
         .map(|a| a.len())
         .unwrap_or_else(|| mask.true_count());
 
-    StructArray::try_new_with_dtype(fields, array.struct_fields(), length, filtered_validity)
+    StructArray::try_new_with_dtype(
+        fields,
+        array.struct_fields().clone(),
+        length,
+        filtered_validity,
+    )
         .vortex_expect("filtered StructArray fields have consistent lengths")
 }
 

--- a/vortex-array/src/arrays/masked/execute.rs
+++ b/vortex-array/src/arrays/masked/execute.rs
@@ -185,7 +185,7 @@ fn mask_validity_struct(
     let fields = array.unmasked_fields();
     let struct_fields = array.struct_fields();
     // SAFETY: We're only changing validity, not the data structure
-    Ok(unsafe { StructArray::new_unchecked(fields, struct_fields, len, new_validity) })
+    Ok(unsafe { StructArray::new_unchecked(fields, struct_fields.clone(), len, new_validity) })
 }
 
 fn mask_validity_extension(

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -269,7 +269,7 @@ impl Array<Struct> {
         validity: Validity,
     ) -> Self {
         let fields = fields.into();
-        let outer_dtype = DType::Struct(dtype.clone(), validity.nullability());
+        let outer_dtype = DType::Struct(dtype, validity.nullability());
         let slots = make_struct_slots(&fields, &validity, length);
         unsafe {
             Array::from_parts_unchecked(
@@ -286,9 +286,11 @@ impl Array<Struct> {
         validity: Validity,
     ) -> VortexResult<Self> {
         let fields = fields.into();
-        let outer_dtype = DType::Struct(dtype.clone(), validity.nullability());
+        let outer_dtype = DType::Struct(dtype, validity.nullability());
         let slots = make_struct_slots(&fields, &validity, length);
-        Array::try_from_parts(ArrayParts::new(Struct, outer_dtype, length, StructData).with_slots(slots))
+        Array::try_from_parts(
+            ArrayParts::new(Struct, outer_dtype, length, StructData).with_slots(slots),
+        )
     }
 
     /// Construct a `StructArray` from named fields.

--- a/vortex-array/src/arrays/struct_/array.rs
+++ b/vortex-array/src/arrays/struct_/array.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
-use vortex_error::vortex_bail;
 use vortex_error::vortex_err;
 
 use crate::ArrayRef;
@@ -150,11 +149,8 @@ pub(super) const FIELDS_OFFSET: usize = 1;
 /// let id_field = struct_array.unmasked_field_by_name("id").unwrap();
 /// assert_eq!(id_field.len(), 3);
 /// ```
-#[derive(Clone, Debug)]
-pub struct StructData {
-    pub(super) names: FieldNames,
-    pub(super) fieldless_len: Option<usize>,
-}
+#[derive(Clone, Debug, Default)]
+pub struct StructData;
 
 pub struct StructDataParts {
     pub struct_fields: StructFields,
@@ -162,169 +158,14 @@ pub struct StructDataParts {
     pub validity: Validity,
 }
 
-impl StructData {
-    pub fn names(&self) -> &FieldNames {
-        &self.names
-    }
-
-    pub(crate) fn make_slots(
-        fields: &[ArrayRef],
-        validity: &Validity,
-        length: usize,
-    ) -> Vec<Option<ArrayRef>> {
-        once(validity_to_child(validity, length))
-            .chain(fields.iter().cloned().map(Some))
-            .collect()
-    }
-
-    /// Create a new `StructArray` with the given length, but without any fields.
-    pub fn new_fieldless_with_len(len: usize) -> Self {
-        Self::try_build(
-            FieldNames::default(),
-            Vec::new(),
-            len,
-            Validity::NonNullable,
-        )
-        .vortex_expect("StructArray::new_with_len should not fail")
-    }
-
-    /// Creates a new `StructArray`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the provided components do not satisfy the invariants documented
-    /// in `StructArray::new_unchecked`.
-    pub fn build(
-        names: FieldNames,
-        fields: impl Into<Arc<[ArrayRef]>>,
-        length: usize,
-        validity: Validity,
-    ) -> Self {
-        Self::try_build(names, fields, length, validity)
-            .vortex_expect("StructArray construction failed")
-    }
-
-    /// Constructs a new `StructArray`.
-    ///
-    /// See `StructArray::new_unchecked` for more information.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the provided components do not satisfy the invariants documented in
-    /// `StructArray::new_unchecked`.
-    pub(crate) fn try_build(
-        names: FieldNames,
-        fields: impl Into<Arc<[ArrayRef]>>,
-        length: usize,
-        validity: Validity,
-    ) -> VortexResult<Self> {
-        let fields = fields.into();
-        let field_dtypes: Vec<_> = fields.iter().map(|d| d.dtype()).cloned().collect();
-        let dtype = StructFields::new(names, field_dtypes);
-
-        Self::validate(&fields, &dtype, length, &validity)?;
-
-        // SAFETY: validate ensures all invariants are met.
-        Ok(unsafe { Self::new_unchecked(dtype, fields.is_empty().then_some(length)) })
-    }
-
-    /// Creates a new `StructArray` without validation from these components:
-    ///
-    /// * `fields` is a vector of arrays, one for each field in the struct.
-    /// * `dtype` contains the field names and types.
-    /// * `length` is the number of struct rows.
-    /// * `validity` holds the null values.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure all of the following invariants are satisfied:
-    ///
-    /// ## Field Requirements
-    ///
-    /// - `fields.len()` must exactly equal `dtype.names().len()`.
-    /// - Every field array in `fields` must have length exactly equal to `length`.
-    /// - For each index `i`, `fields[i].dtype()` must exactly match `dtype.fields()[i]`.
-    ///
-    /// ## Type Requirements
-    ///
-    /// - Field names in `dtype` may be duplicated (this is explicitly allowed).
-    /// - The nullability of `dtype` must match the nullability of `validity`.
-    ///
-    /// ## Validity Requirements
-    ///
-    /// - If `validity` is [`Validity::Array`], its length must exactly equal `length`.
-    pub unsafe fn new_unchecked(dtype: StructFields, fieldless_len: Option<usize>) -> Self {
-        Self {
-            names: dtype.names().clone(),
-            fieldless_len,
-        }
-    }
-
-    /// Validates the components that would be used to create a `StructArray`.
-    ///
-    /// This function checks all the invariants required by `StructArray::new_unchecked`.
-    pub fn validate(
-        fields: &[ArrayRef],
-        dtype: &StructFields,
-        length: usize,
-        validity: &Validity,
-    ) -> VortexResult<()> {
-        // Check field count matches
-        if fields.len() != dtype.names().len() {
-            vortex_bail!(
-                InvalidArgument: "Got {} fields but dtype has {} names",
-                fields.len(),
-                dtype.names().len()
-            );
-        }
-
-        // Check each field's length and dtype
-        for (i, (field, struct_dt)) in fields.iter().zip(dtype.fields()).enumerate() {
-            if field.len() != length {
-                vortex_bail!(
-                    InvalidArgument: "Field {} has length {} but expected {}",
-                    i,
-                    field.len(),
-                    length
-                );
-            }
-
-            if field.dtype() != &struct_dt {
-                vortex_bail!(
-                    InvalidArgument: "Field {} has dtype {} but expected {}",
-                    i,
-                    field.dtype(),
-                    struct_dt
-                );
-            }
-        }
-
-        // Check validity length
-        if let Some(validity_len) = validity.maybe_len()
-            && validity_len != length
-        {
-            vortex_bail!(
-                InvalidArgument: "Validity has length {} but expected {}",
-                validity_len,
-                length
-            );
-        }
-
-        Ok(())
-    }
-
-    pub(crate) fn try_new_with_dtype(
-        fields: impl Into<Arc<[ArrayRef]>>,
-        dtype: StructFields,
-        length: usize,
-        validity: Validity,
-    ) -> VortexResult<Self> {
-        let fields = fields.into();
-        Self::validate(&fields, &dtype, length, &validity)?;
-
-        // SAFETY: validate ensures all invariants are met.
-        Ok(unsafe { Self::new_unchecked(dtype, fields.is_empty().then_some(length)) })
-    }
+pub(super) fn make_struct_slots(
+    fields: &[ArrayRef],
+    validity: &Validity,
+    length: usize,
+) -> Vec<Option<ArrayRef>> {
+    once(validity_to_child(validity, length))
+        .chain(fields.iter().cloned().map(Some))
+        .collect()
 }
 
 pub trait StructArrayExt: TypedArrayRef<Struct> {
@@ -336,7 +177,7 @@ pub trait StructArrayExt: TypedArrayRef<Struct> {
     }
 
     fn names(&self) -> &FieldNames {
-        StructData::names(self)
+        self.as_ref().dtype().as_struct_fields().names()
     }
 
     fn struct_validity(&self) -> Validity {
@@ -361,7 +202,9 @@ pub trait StructArrayExt: TypedArrayRef<Struct> {
 
     fn unmasked_field_by_name_opt(&self, name: impl AsRef<str>) -> Option<&ArrayRef> {
         let name = name.as_ref();
-        self.names().find(name).map(|idx| self.unmasked_field(idx))
+        self.struct_fields()
+            .find(name)
+            .map(|idx| self.unmasked_field(idx))
     }
 
     fn unmasked_field_by_name(&self, name: impl AsRef<str>) -> VortexResult<&ArrayRef> {
@@ -374,13 +217,8 @@ pub trait StructArrayExt: TypedArrayRef<Struct> {
         })
     }
 
-    fn struct_fields(&self) -> StructFields {
-        StructFields::new(
-            self.names().clone(),
-            self.iter_unmasked_fields()
-                .map(|field| field.dtype().clone())
-                .collect(),
-        )
+    fn struct_fields(&self) -> &StructFields {
+        self.as_ref().dtype().as_struct_fields()
     }
 }
 impl<T: TypedArrayRef<Struct>> StructArrayExt for T {}
@@ -393,19 +231,8 @@ impl Array<Struct> {
         length: usize,
         validity: Validity,
     ) -> Self {
-        let fields = fields.into();
-        let field_dtypes: Vec<_> = fields.iter().map(|d| d.dtype().clone()).collect();
-        let dtype = DType::Struct(
-            StructFields::new(names.clone(), field_dtypes),
-            validity.nullability(),
-        );
-        let slots = StructData::make_slots(&fields, &validity, length);
-        let data = StructData::build(names, fields, length, validity);
-        unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(Struct, dtype, length, data).with_slots(slots),
-            )
-        }
+        Self::try_new(names, fields, length, validity)
+            .vortex_expect("StructArray construction failed")
     }
 
     /// Constructs a new `StructArray`.
@@ -417,24 +244,24 @@ impl Array<Struct> {
     ) -> VortexResult<Self> {
         let fields = fields.into();
         let field_dtypes: Vec<_> = fields.iter().map(|d| d.dtype().clone()).collect();
-        let dtype = DType::Struct(
-            StructFields::new(names.clone(), field_dtypes),
-            validity.nullability(),
-        );
-        let slots = StructData::make_slots(&fields, &validity, length);
-        let data = StructData::try_build(names, fields, length, validity)?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(Struct, dtype, length, data).with_slots(slots),
+        let dtype = StructFields::new(names, field_dtypes);
+        let slots = make_struct_slots(&fields, &validity, length);
+        Array::try_from_parts(
+            ArrayParts::new(
+                Struct,
+                DType::Struct(dtype, validity.nullability()),
+                length,
+                StructData,
             )
-        })
+            .with_slots(slots),
+        )
     }
 
     /// Creates a new `StructArray` without validation.
     ///
     /// # Safety
     ///
-    /// See [`StructData::new_unchecked`].
+    /// Caller must ensure the field arrays match the supplied dtype, length, and validity.
     pub unsafe fn new_unchecked(
         fields: impl Into<Arc<[ArrayRef]>>,
         dtype: StructFields,
@@ -443,11 +270,10 @@ impl Array<Struct> {
     ) -> Self {
         let fields = fields.into();
         let outer_dtype = DType::Struct(dtype.clone(), validity.nullability());
-        let slots = StructData::make_slots(&fields, &validity, length);
-        let data = unsafe { StructData::new_unchecked(dtype, fields.is_empty().then_some(length)) };
+        let slots = make_struct_slots(&fields, &validity, length);
         unsafe {
             Array::from_parts_unchecked(
-                ArrayParts::new(Struct, outer_dtype, length, data).with_slots(slots),
+                ArrayParts::new(Struct, outer_dtype, length, StructData).with_slots(slots),
             )
         }
     }
@@ -461,13 +287,8 @@ impl Array<Struct> {
     ) -> VortexResult<Self> {
         let fields = fields.into();
         let outer_dtype = DType::Struct(dtype.clone(), validity.nullability());
-        let slots = StructData::make_slots(&fields, &validity, length);
-        let data = StructData::try_new_with_dtype(fields, dtype, length, validity)?;
-        Ok(unsafe {
-            Array::from_parts_unchecked(
-                ArrayParts::new(Struct, outer_dtype, length, data).with_slots(slots),
-            )
-        })
+        let slots = make_struct_slots(&fields, &validity, length);
+        Array::try_from_parts(ArrayParts::new(Struct, outer_dtype, length, StructData).with_slots(slots))
     }
 
     /// Construct a `StructArray` from named fields.
@@ -530,9 +351,8 @@ impl Array<Struct> {
 
         for f_name in projection {
             let idx = self
-                .names()
-                .iter()
-                .position(|name| name == f_name)
+                .struct_fields()
+                .find(f_name.as_ref())
                 .ok_or_else(|| vortex_err!("Unknown field {f_name}"))?;
 
             names.push(self.names()[idx].clone());
@@ -549,30 +369,27 @@ impl Array<Struct> {
 
     /// Create a fieldless `StructArray` with the given length.
     pub fn new_fieldless_with_len(len: usize) -> Self {
-        let data = StructData::new_fieldless_with_len(len);
         let dtype = DType::Struct(
             StructFields::new(FieldNames::default(), Vec::new()),
             crate::dtype::Nullability::NonNullable,
         );
-        let slots = StructData::make_slots(&[], &Validity::NonNullable, len);
+        let slots = make_struct_slots(&[], &Validity::NonNullable, len);
         unsafe {
-            Array::from_parts_unchecked(ArrayParts::new(Struct, dtype, len, data).with_slots(slots))
+            Array::from_parts_unchecked(
+                ArrayParts::new(Struct, dtype, len, StructData).with_slots(slots),
+            )
         }
     }
 
+    // TODO(ngates): remove this... it doesn't help to consume self.
     pub fn into_data_parts(self) -> StructDataParts {
         let fields: Arc<[ArrayRef]> = self.slots()[FIELDS_OFFSET..]
             .iter()
             .map(|s| s.as_ref().vortex_expect("StructArray field slot").clone())
             .collect();
-        let names = self.data().names.clone();
         let validity = self.validity().vortex_expect("StructArray validity");
-        let struct_fields = StructFields::new(
-            names,
-            fields.iter().map(|field| field.dtype().clone()).collect(),
-        );
         StructDataParts {
-            struct_fields,
+            struct_fields: self.struct_fields().clone(),
             fields,
             validity,
         }
@@ -583,10 +400,7 @@ impl Array<Struct> {
         let struct_dtype = self.struct_fields();
         let len = self.len();
 
-        let position = struct_dtype
-            .names()
-            .iter()
-            .position(|field_name| field_name.as_ref() == name.as_ref())?;
+        let position = struct_dtype.find(name.as_ref())?;
 
         let slot_position = FIELDS_OFFSET + position;
         let field = self.slots()[slot_position]
@@ -602,21 +416,13 @@ impl Array<Struct> {
             .collect();
 
         let new_dtype = struct_dtype.without_field(position).ok()?;
-        let data = StructData {
-            names: new_dtype.names().clone(),
-            fieldless_len: new_slots
-                .get(FIELDS_OFFSET)
-                .and_then(|slot| slot.as_ref())
-                .map(|_| None)
-                .unwrap_or(Some(len)),
-        };
         let new_array = unsafe {
             Array::from_parts_unchecked(
                 ArrayParts::new(
                     Struct,
                     DType::Struct(new_dtype, self.dtype().nullability()),
                     len,
-                    data,
+                    StructData,
                 )
                 .with_slots(new_slots),
             )

--- a/vortex-array/src/arrays/struct_/compute/mask.rs
+++ b/vortex-array/src/arrays/struct_/compute/mask.rs
@@ -16,7 +16,7 @@ impl MaskReduce for Struct {
     fn mask(array: ArrayView<'_, Struct>, mask: &ArrayRef) -> VortexResult<Option<ArrayRef>> {
         StructArray::try_new_with_dtype(
             array.unmasked_fields().iter().cloned().collect::<Vec<_>>(),
-            array.struct_fields(),
+            array.struct_fields().clone(),
             array.len(),
             array.validity()?.and(Validity::Array(mask.clone()))?,
         )

--- a/vortex-array/src/arrays/struct_/compute/rules.rs
+++ b/vortex-array/src/arrays/struct_/compute/rules.rs
@@ -108,9 +108,15 @@ impl ArrayParentReduceRule<Struct> for StructGetItemRule {
         _child_idx: usize,
     ) -> VortexResult<Option<ArrayRef>> {
         let field_name = parent.options;
-        let Some(field) = child.unmasked_field_by_name_opt(field_name) else {
-            return Ok(None);
-        };
+        let field = child
+            .unmasked_field_by_name_opt(field_name)
+            .ok_or_else(|| {
+                vortex_err!(
+                    "Field '{}' missing from struct array {}",
+                    field_name,
+                    child.struct_fields().names()
+                )
+            })?;
 
         match child.validity()? {
             Validity::NonNullable | Validity::AllValid => {

--- a/vortex-array/src/arrays/struct_/compute/slice.rs
+++ b/vortex-array/src/arrays/struct_/compute/slice.rs
@@ -26,7 +26,7 @@ impl SliceReduce for Struct {
             unsafe {
                 StructArray::new_unchecked(
                     fields,
-                    array.struct_fields(),
+                    array.struct_fields().clone(),
                     range.len(),
                     array.validity()?.slice(range)?,
                 )

--- a/vortex-array/src/arrays/struct_/compute/take.rs
+++ b/vortex-array/src/arrays/struct_/compute/take.rs
@@ -21,7 +21,7 @@ impl TakeReduce for Struct {
         if array.is_empty() {
             return StructArray::try_new_with_dtype(
                 array.iter_unmasked_fields().cloned().collect::<Vec<_>>(),
-                array.struct_fields(),
+                array.struct_fields().clone(),
                 indices.len(),
                 Validity::AllInvalid,
             )
@@ -42,7 +42,7 @@ impl TakeReduce for Struct {
                 .iter_unmasked_fields()
                 .map(|field| field.take(inner_indices.clone()))
                 .collect::<Result<Vec<_>, _>>()?,
-            array.struct_fields(),
+            array.struct_fields().clone(),
             indices.len(),
             array.validity()?.take(indices)?,
         )

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -23,6 +23,7 @@ use crate::array::child_to_validity;
 use crate::arrays::struct_::StructData;
 use crate::arrays::struct_::array::FIELDS_OFFSET;
 use crate::arrays::struct_::array::VALIDITY_SLOT;
+use crate::arrays::struct_::array::make_struct_slots;
 use crate::arrays::struct_::compute::rules::PARENT_RULES;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
@@ -64,7 +65,7 @@ impl VTable for Struct {
 
     fn validate(
         &self,
-        data: &StructData,
+        _data: &StructData,
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
@@ -72,14 +73,6 @@ impl VTable for Struct {
         let DType::Struct(struct_dtype, nullability) = dtype else {
             vortex_bail!("Expected struct dtype, found {:?}", dtype)
         };
-
-        if data.names() != struct_dtype.names() {
-            vortex_bail!(
-                InvalidArgument: "StructArray field names {:?} do not match dtype names {:?}",
-                data.names(),
-                struct_dtype.names()
-            );
-        }
 
         let expected_slots = struct_dtype.nfields() + 1;
         if slots.len() != expected_slots {
@@ -103,18 +96,7 @@ impl VTable for Struct {
 
         let field_slots = &slots[FIELDS_OFFSET..];
         if field_slots.is_empty() {
-            if data.fieldless_len != Some(len) {
-                vortex_bail!(
-                    InvalidArgument: "Fieldless StructArray length {:?} does not match outer length {}",
-                    data.fieldless_len,
-                    len
-                );
-            }
             return Ok(());
-        }
-
-        if data.fieldless_len.is_some() {
-            vortex_bail!("StructArray cannot have fieldless length and field slots");
         }
 
         for (idx, (slot, field_dtype)) in field_slots.iter().zip(struct_dtype.fields()).enumerate()
@@ -196,17 +178,15 @@ impl VTable for Struct {
             })
             .try_collect()?;
 
-        let slots = StructData::make_slots(&field_children, &validity, len);
-        let data =
-            StructData::try_new_with_dtype(field_children, struct_dtype.clone(), len, validity)?;
-        Ok(crate::array::ArrayParts::new(self.clone(), dtype.clone(), len, data).with_slots(slots))
+        let slots = make_struct_slots(&field_children, &validity, len);
+        Ok(crate::array::ArrayParts::new(self.clone(), dtype.clone(), len, StructData).with_slots(slots))
     }
 
     fn slot_name(array: ArrayView<'_, Self>, idx: usize) -> String {
         if idx == VALIDITY_SLOT {
             "validity".to_string()
         } else {
-            array.names()[idx - FIELDS_OFFSET].to_string()
+            array.dtype().as_struct_fields().names()[idx - FIELDS_OFFSET].to_string()
         }
     }
 

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -179,7 +179,10 @@ impl VTable for Struct {
             .try_collect()?;
 
         let slots = make_struct_slots(&field_children, &validity, len);
-        Ok(crate::array::ArrayParts::new(self.clone(), dtype.clone(), len, StructData).with_slots(slots))
+        Ok(
+            crate::array::ArrayParts::new(self.clone(), dtype.clone(), len, StructData)
+                .with_slots(slots),
+        )
     }
 
     fn slot_name(array: ArrayView<'_, Self>, idx: usize) -> String {

--- a/vortex-array/src/arrow/convert.rs
+++ b/vortex-array/src/arrow/convert.rs
@@ -694,6 +694,7 @@ mod tests {
     use crate::arrays::fixed_size_list::FixedSizeListArrayExt;
     use crate::arrays::list::ListArrayExt;
     use crate::arrays::listview::ListViewArrayExt;
+    use crate::arrays::struct_::StructArrayExt;
     use crate::arrow::FromArrowArray as _;
     use crate::arrow::convert::TemporalArray;
     use crate::dtype::DType;

--- a/vortex-array/src/scalar_fn/fns/select.rs
+++ b/vortex-array/src/scalar_fn/fns/select.rs
@@ -19,6 +19,7 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::arrays::StructArray;
+use crate::arrays::struct_::StructArrayExt;
 use crate::dtype::DType;
 use crate::dtype::FieldName;
 use crate::dtype::FieldNames;
@@ -307,6 +308,7 @@ mod tests {
 
     use crate::IntoArray;
     use crate::ToCanonical;
+    use crate::arrays::struct_::StructArrayExt;
     use crate::dtype::DType;
     use crate::dtype::FieldName;
     use crate::dtype::FieldNames;


### PR DESCRIPTION
Fixes a decompression regression on wide struct datasets by removing StructData metadata duplication and deriving struct metadata from the outer cached dtype/len.