### PR TITLE
Migrate to maintained version of setup-zig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           enable-sccache: "false"
-      - uses: mlugg/setup-zig@v2.2.1
+      - uses: https://codeberg.org/mlugg/setup-zig@v2
       - name: Install uv
         uses: spiraldb/actions/.github/actions/setup-uv@0.18.5
         with:


### PR DESCRIPTION
Zig has moved to codeberg, there were no updates to the action yet since the
migration

Signed-off-by: Robert Kruszewski <github@robertk.io>
