### PR TITLE
fix[vortex-array]: fix offset_within_chunk underflow on patches array

### DIFF
--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -656,7 +656,7 @@ impl Patches {
         let values = self.values().slice(slice_start_idx..slice_end_idx)?;
         let indices = self.indices().slice(slice_start_idx..slice_end_idx)?;
 
-        let chunk_offsets = self
+        let new_chunk_offsets = self
             .chunk_offsets
             .as_ref()
             .map(|chunk_offsets| -> VortexResult<ArrayRef> {
@@ -667,15 +667,17 @@ impl Patches {
             })
             .transpose()?;
 
-        let offset_within_chunk = chunk_offsets
+        let offset_within_chunk = new_chunk_offsets
             .as_ref()
-            .map(|chunk_offsets| -> VortexResult<usize> {
-                let base_offset = chunk_offsets
+            .map(|new_chunk_offsets| -> VortexResult<usize> {
+                let new_chunk_base = new_chunk_offsets
                     .scalar_at(0)?
                     .as_primitive()
                     .as_::<usize>()
                     .ok_or_else(|| vortex_err!("chunk offset does not fit in usize"))?;
-                Ok(slice_start_idx - base_offset)
+                let parent_chunk_base = self.chunk_offset_at(0)?;
+                let parent_within = self.offset_within_chunk.unwrap_or(0);
+                Ok(parent_chunk_base + parent_within + slice_start_idx - new_chunk_base)
             })
             .transpose()?;
 
@@ -684,7 +686,7 @@ impl Patches {
             offset: range.start + self.offset(),
             indices,
             values,
-            chunk_offsets,
+            chunk_offsets: new_chunk_offsets,
             offset_within_chunk,
         }))
     }
@@ -2149,6 +2151,20 @@ mod test {
             sliced2.search_index(150).unwrap(),
             SearchResult::NotFound(1)
         );
+    }
+
+    #[test]
+    fn test_nested_slice_with_dropped_first_chunk() {
+        // PATCH_CHUNK_SIZE = 1024, so the two patches land in different chunks.
+        let indices = buffer![0u64, 1024].into_array();
+        let values = buffer![1i32, 2].into_array();
+        let chunk_offsets = buffer![0u64, 1].into_array();
+        let patches = Patches::new(2048, 0, indices, values, Some(chunk_offsets)).unwrap();
+
+        // Drop chunk 0, then re-slice the result.
+        let dropped_first = patches.slice(1024..2048).unwrap().unwrap();
+        let resliced = dropped_first.slice(0..1024).unwrap().unwrap();
+        assert_eq!(resliced.num_patches(), 1);
     }
 
     #[test]


### PR DESCRIPTION
slice_start_idx was missing normalization to absolute coordinates.

<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

## Summary

<!--
If this PR is related to a tracked effort, please link to the relevant issue
here (e.g., `Closes: #123`). Otherwise, feel free to ignore / delete this.

In this section, please:

1. Explain the rationale for this change.
2. Summarize the changes included in this PR.

A general rule of thumb is that larger PRs should have larger summaries. If
there are a lot of changes, please help us review the code by explaining what
was changed and why.

If there is an issue or discussion attached, there is no need to duplicate all
the details, but clarity is always preferred over brevity.
-->

<!--
## API Changes

Uncomment this section if there are any user-facing changes.

Consider whether the change affects users in one of the following ways:

1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the engine integrations.
3. Should some documentation be updated to reflect this change?

If a public API is changed in a breaking manner, make sure to add the
appropriate label. You can run `./scripts/public-api.sh` locally to see if there
are any public API changes (and this also runs in our CI).
-->

## Testing

<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
3. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
