### PR TITLE
break[array]: remove old `vtable!` macro

### DIFF
--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -27,7 +27,6 @@ use vortex_array::patches::PatchesMetadata;
 use vortex_array::require_child;
 use vortex_array::require_patches;
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityVTableFromChild;
@@ -44,7 +43,8 @@ use crate::alp::decompress::execute_decompress;
 use crate::alp::rules::PARENT_KERNELS;
 use crate::alp::rules::RULES;
 
-vtable!(ALP, ALP, ALPData);
+/// A [`ALP`]-encoded Vortex array.
+pub type ALPArray = Array<ALP>;
 
 impl ArrayHash for ALPData {
     fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -31,7 +31,6 @@ use vortex_array::require_child;
 use vortex_array::require_patches;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityVTableFromChild;
@@ -48,7 +47,8 @@ use crate::alp_rd::kernel::PARENT_KERNELS;
 use crate::alp_rd::rules::RULES;
 use crate::alp_rd_decode;
 
-vtable!(ALPRD, ALPRD, ALPRDData);
+/// A [`ALPRD`]-encoded Vortex array.
+pub type ALPRDArray = Array<ALPRD>;
 
 #[derive(Clone, prost::Message)]
 pub struct ALPRDMetadata {

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -22,7 +22,6 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar::Scalar;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
@@ -39,7 +38,8 @@ use vortex_session::VortexSession;
 
 use crate::kernel::PARENT_KERNELS;
 
-vtable!(ByteBool, ByteBool, ByteBoolData);
+/// A [`ByteBool`]-encoded Vortex array.
+pub type ByteBoolArray = Array<ByteBool>;
 
 impl ArrayHash for ByteBoolData {
     fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -23,7 +23,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityVTableFromChild;
@@ -41,7 +40,8 @@ use crate::compute::kernel::PARENT_KERNELS;
 use crate::compute::rules::PARENT_RULES;
 use crate::split_temporal;
 
-vtable!(DateTimeParts, DateTimeParts, DateTimePartsData);
+/// A [`DateTimeParts`]-encoded Vortex array.
+pub type DateTimePartsArray = Array<DateTimeParts>;
 
 impl ArrayHash for DateTimePartsData {
     fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -31,7 +31,6 @@ use vortex_array::scalar::DecimalValue;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar::ScalarValue;
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityChild;
@@ -46,7 +45,8 @@ use vortex_session::VortexSession;
 use crate::decimal_byte_parts::compute::kernel::PARENT_KERNELS;
 use crate::decimal_byte_parts::rules::PARENT_RULES;
 
-vtable!(DecimalByteParts, DecimalByteParts, DecimalBytePartsData);
+/// A [`DecimalByteParts`]-encoded Vortex array.
+pub type DecimalBytePartsArray = Array<DecimalByteParts>;
 
 impl ArrayHash for DecimalBytePartsData {
     fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -28,7 +28,6 @@ use vortex_array::require_patches;
 use vortex_array::require_validity;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::child_to_validity;
 use vortex_array::vtable::validity_to_child;
@@ -56,7 +55,8 @@ mod operations;
 mod rules;
 mod validity;
 
-vtable!(BitPacked, BitPacked, BitPackedData);
+/// A [`BitPacked`]-encoded Vortex array.
+pub type BitPackedArray = Array<BitPacked>;
 
 #[derive(Clone, prost::Message)]
 pub struct BitPackedMetadata {

--- a/encodings/fastlanes/src/delta/vtable/mod.rs
+++ b/encodings/fastlanes/src/delta/vtable/mod.rs
@@ -23,7 +23,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::PType;
 use vortex_array::match_each_unsigned_integer_ptype;
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -45,7 +44,8 @@ mod rules;
 mod slice;
 mod validity;
 
-vtable!(Delta, Delta, DeltaData);
+/// A [`Delta`]-encoded Vortex array.
+pub type DeltaArray = Array<Delta>;
 
 #[derive(Clone, prost::Message)]
 #[repr(C)]

--- a/encodings/fastlanes/src/for/vtable/mod.rs
+++ b/encodings/fastlanes/src/for/vtable/mod.rs
@@ -22,7 +22,6 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar::ScalarValue;
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTableFromChild;
 use vortex_error::VortexExpect;
@@ -45,7 +44,8 @@ mod rules;
 mod slice;
 mod validity;
 
-vtable!(FoR, FoR, FoRData);
+/// A [`FoR`]-encoded Vortex array.
+pub type FoRArray = Array<FoR>;
 
 impl ArrayHash for FoRData {
     fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -22,7 +22,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -43,7 +42,8 @@ mod operations;
 mod rules;
 mod validity;
 
-vtable!(RLE, RLE, RLEData);
+/// A [`RLE`]-encoded Vortex array.
+pub type RLEArray = Array<RLE>;
 
 #[derive(Clone, prost::Message)]
 pub struct RLEMetadata {

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -35,7 +35,6 @@ use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
 use vortex_array::vtable::child_to_validity;
@@ -55,7 +54,8 @@ use crate::canonical::fsst_decode_views;
 use crate::kernel::PARENT_KERNELS;
 use crate::rules::RULES;
 
-vtable!(FSST, FSST, FSSTData);
+/// A [`FSST`]-encoded Vortex array.
+pub type FSSTArray = Array<FSST>;
 
 #[derive(Clone, prost::Message)]
 pub struct FSSTMetadata {

--- a/encodings/parquet-variant/src/vtable.rs
+++ b/encodings/parquet-variant/src/vtable.rs
@@ -21,7 +21,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::child_to_validity;
 use vortex_array::vtable::validity_to_child;
@@ -63,7 +62,8 @@ struct ParquetVariantMetadataProto {
     pub value_nullable: bool,
 }
 
-vtable!(ParquetVariant, ParquetVariant, ParquetVariantData);
+/// A [`ParquetVariant`]-encoded Vortex array.
+pub type ParquetVariantArray = Array<ParquetVariant>;
 
 impl VTable for ParquetVariant {
     type ArrayData = ParquetVariantData;

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -39,7 +39,6 @@ use vortex_array::dtype::half;
 use vortex_array::scalar::Scalar;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
@@ -79,7 +78,8 @@ use crate::PcoPageInfo;
 
 const VALUES_PER_CHUNK: usize = pco::DEFAULT_MAX_PAGE_N;
 
-vtable!(Pco, Pco, PcoData);
+/// A [`Pco`]-encoded Vortex array.
+pub type PcoArray = Array<Pco>;
 
 impl ArrayHash for PcoData {
     fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -29,7 +29,6 @@ use vortex_array::search_sorted::SearchSorted;
 use vortex_array::search_sorted::SearchSortedSide;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
 use vortex_error::VortexExpect as _;
@@ -46,7 +45,8 @@ use crate::decompress_bool::runend_decode_bools;
 use crate::kernel::PARENT_KERNELS;
 use crate::rules::RULES;
 
-vtable!(RunEnd, RunEnd, RunEndData);
+/// A [`RunEnd`]-encoded Vortex array.
+pub type RunEndArray = Array<RunEnd>;
 
 #[derive(Clone, prost::Message)]
 pub struct RunEndMetadata {

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -33,7 +33,6 @@ use vortex_array::scalar::ScalarValue;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::stats::StatsSet;
 use vortex_array::validity::Validity;
-use vortex_array::vtable;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
@@ -49,7 +48,8 @@ use crate::compress::sequence_decompress;
 use crate::kernel::PARENT_KERNELS;
 use crate::rules::RULES;
 
-vtable!(Sequence, Sequence, SequenceData);
+/// A [`Sequence`]-encoded Vortex array.
+pub type SequenceArray = Array<Sequence>;
 
 #[derive(Clone, prost::Message)]
 pub struct SequenceMetadata {

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -32,7 +32,6 @@ use vortex_array::scalar::ScalarValue;
 use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
 use vortex_buffer::Buffer;
@@ -57,7 +56,8 @@ mod ops;
 mod rules;
 mod slice;
 
-vtable!(Sparse, Sparse, SparseData);
+/// A [`Sparse`]-encoded Vortex array.
+pub type SparseArray = Array<Sparse>;
 
 #[derive(Clone, prost::Message)]
 #[repr(C)]

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -21,7 +21,6 @@ use vortex_array::dtype::PType;
 use vortex_array::match_each_unsigned_integer_ptype;
 use vortex_array::scalar::Scalar;
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityChild;
@@ -39,7 +38,8 @@ use crate::kernel::PARENT_KERNELS;
 use crate::rules::RULES;
 use crate::zigzag_decode;
 
-vtable!(ZigZag, ZigZag, ZigZagData);
+/// A [`ZigZag`]-encoded Vortex array.
+pub type ZigZagArray = Array<ZigZag>;
 
 impl VTable for ZigZag {
     type ArrayData = ZigZagData;

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -34,7 +34,6 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar::Scalar;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
-use vortex_array::vtable;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
@@ -80,7 +79,8 @@ type ViewLen = u32;
 // We then insert these values to the correct position using a primitive array
 // constructor.
 
-vtable!(Zstd, Zstd, ZstdData);
+/// A [`Zstd`]-encoded Vortex array.
+pub type ZstdArray = Array<Zstd>;
 
 impl ArrayHash for ZstdData {
     fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -22,7 +22,6 @@ use vortex_array::dtype::DType;
 use vortex_array::scalar::Scalar;
 use vortex_array::serde::ArrayChildren;
 use vortex_array::session::ArraySessionExt;
-use vortex_array::vtable;
 use vortex_array::vtable::OperationsVTable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
@@ -36,7 +35,8 @@ use vortex_session::VortexSession;
 
 use crate::ZstdBuffersMetadata;
 
-vtable!(ZstdBuffers, ZstdBuffers, ZstdBuffersData);
+/// A [`ZstdBuffers`]-encoded Vortex array.
+pub type ZstdBuffersArray = Array<ZstdBuffers>;
 
 #[derive(Clone, Debug)]
 pub struct ZstdBuffers;

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -20948,8 +20948,6 @@ pub macro vortex_array::require_patches!
 
 pub macro vortex_array::require_validity!
 
-pub macro vortex_array::vtable!
-
 pub enum vortex_array::Canonical
 
 pub vortex_array::Canonical::Bool(vortex_array::arrays::BoolArray)

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -291,13 +291,11 @@ pub fn patches_child_name(idx: usize) -> &'static str {
     }
 }
 
-/// vtable! macro — generates IntoArray, From, and type alias for array types.
+/// vtable! macro — adds a deprecated `to_array()` helper on legacy array types.
 ///
-/// Three forms:
-/// - `vtable!(Foo)` — short for `vtable!(Foo, Foo)` (legacy form)
-/// - `vtable!(Foo, FooVT)` — legacy form where `FooArray` is the inner struct name
-/// - `vtable!(Foo, FooVT, FooData)` — new form where `FooData` is the inner struct,
-///   and `FooArray` is generated as a type alias for `Array<FooVT>`
+/// Two forms:
+/// - `vtable!(Foo)` — short for `vtable!(Foo, Foo)`
+/// - `vtable!(Foo, FooVT)` — where `FooArray` is the inner struct name
 #[macro_export]
 macro_rules! vtable {
     ($V:ident) => {
@@ -316,13 +314,6 @@ macro_rules! vtable {
                     self.clone().into_array()
                 }
             }
-        }
-    };
-    // New form: Data is the inner struct, FooArray is a type alias for Array<VT>.
-    ($Base:ident, $VT:ident, $Data:ident) => {
-        $crate::aliases::paste::paste! {
-            /// Type alias: `FooArray = Array<Foo>`.
-            pub type [<$Base Array>] = $crate::Array<$VT>;
         }
     };
 }

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -291,29 +291,3 @@ pub fn patches_child_name(idx: usize) -> &'static str {
     }
 }
 
-/// vtable! macro — adds a deprecated `to_array()` helper on legacy array types.
-///
-/// Two forms:
-/// - `vtable!(Foo)` — short for `vtable!(Foo, Foo)`
-/// - `vtable!(Foo, FooVT)` — where `FooArray` is the inner struct name
-#[macro_export]
-macro_rules! vtable {
-    ($V:ident) => {
-        $crate::vtable!($V, $V);
-    };
-    // Legacy form: FooArray is the inner struct name, no type alias generated.
-    ($Base:ident, $VT:ident) => {
-        $crate::aliases::paste::paste! {
-            impl [<$Base Array>] {
-                #[deprecated(note = "use `.into_array()` (owned) or `.clone().into_array()` (ref) to make clones explicit")]
-                pub fn to_array(&self) -> $crate::ArrayRef
-                where
-                    Self: Clone + $crate::IntoArray,
-                {
-                    use $crate::IntoArray;
-                    self.clone().into_array()
-                }
-            }
-        }
-    };
-}

--- a/vortex-array/src/array/vtable/mod.rs
+++ b/vortex-array/src/array/vtable/mod.rs
@@ -290,4 +290,3 @@ pub fn patches_child_name(idx: usize) -> &'static str {
         _ => vortex_panic!("patches child name index {idx} out of bounds"),
     }
 }
-

--- a/vortex-array/src/arrays/bool/vtable/mod.rs
+++ b/vortex-array/src/arrays/bool/vtable/mod.rs
@@ -26,7 +26,6 @@ use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 mod canonical;
 mod kernel;
 mod operations;
@@ -38,7 +37,8 @@ use crate::arrays::bool::compute::rules::RULES;
 use crate::hash::ArrayEq;
 use crate::hash::ArrayHash;
 
-vtable!(Bool, Bool, BoolData);
+/// A [`Bool`]-encoded Vortex array.
+pub type BoolArray = Array<Bool>;
 
 #[derive(prost::Message)]
 pub struct BoolMetadata {

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -39,11 +39,11 @@ use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::serde::ArrayChildren;
-use crate::vtable;
 mod canonical;
 mod operations;
 mod validity;
-vtable!(Chunked, Chunked, ChunkedData);
+/// A [`Chunked`]-encoded Vortex array.
+pub type ChunkedArray = Array<Chunked>;
 
 #[derive(Clone, Debug)]
 pub struct Chunked;

--- a/vortex-array/src/arrays/constant/vtable/mod.rs
+++ b/vortex-array/src/arrays/constant/vtable/mod.rs
@@ -41,12 +41,12 @@ use crate::scalar::DecimalValue;
 use crate::scalar::Scalar;
 use crate::scalar::ScalarValue;
 use crate::serde::ArrayChildren;
-use crate::vtable;
 pub(crate) mod canonical;
 mod operations;
 mod validity;
 
-vtable!(Constant, Constant, ConstantData);
+/// A [`Constant`]-encoded Vortex array.
+pub type ConstantArray = Array<Constant>;
 
 #[derive(Clone, Debug)]
 pub struct Constant;

--- a/vortex-array/src/arrays/decimal/vtable/mod.rs
+++ b/vortex-array/src/arrays/decimal/vtable/mod.rs
@@ -26,7 +26,6 @@ use crate::dtype::NativeDecimalType;
 use crate::match_each_decimal_value_type;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 mod kernel;
 mod operations;
 mod validity;
@@ -39,7 +38,8 @@ use crate::arrays::decimal::array::SLOT_NAMES;
 use crate::arrays::decimal::compute::rules::RULES;
 use crate::hash::ArrayEq;
 use crate::hash::ArrayHash;
-vtable!(Decimal, Decimal, DecimalData);
+/// A [`Decimal`]-encoded Vortex array.
+pub type DecimalArray = Array<Decimal>;
 
 // The type of the values can be determined by looking at the type info...right?
 #[derive(prost::Message)]

--- a/vortex-array/src/arrays/dict/vtable/mod.rs
+++ b/vortex-array/src/arrays/dict/vtable/mod.rs
@@ -42,12 +42,12 @@ use crate::executor::ExecutionResult;
 use crate::require_child;
 use crate::scalar::Scalar;
 use crate::serde::ArrayChildren;
-use crate::vtable;
 mod kernel;
 mod operations;
 mod validity;
 
-vtable!(Dict, Dict, DictData);
+/// A [`Dict`]-encoded Vortex array.
+pub type DictArray = Array<Dict>;
 
 #[derive(Clone, Debug)]
 pub struct Dict;

--- a/vortex-array/src/arrays/extension/vtable/mod.rs
+++ b/vortex-array/src/arrays/extension/vtable/mod.rs
@@ -33,9 +33,9 @@ use crate::arrays::extension::compute::rules::PARENT_RULES;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::serde::ArrayChildren;
-use crate::vtable;
 
-vtable!(Extension, Extension, ExtensionData);
+/// A [`Extension`]-encoded Vortex array.
+pub type ExtensionArray = Array<Extension>;
 
 impl ArrayHash for ExtensionData {
     fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -37,9 +37,9 @@ use crate::executor::ExecutionResult;
 use crate::scalar::Scalar;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 
-vtable!(Filter, Filter, FilterData);
+/// A [`Filter`]-encoded Vortex array.
+pub type FilterArray = Array<Filter>;
 
 #[derive(Clone, Debug)]
 pub struct Filter;

--- a/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/mod.rs
@@ -30,12 +30,12 @@ use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 mod kernel;
 mod operations;
 mod validity;
 
-vtable!(FixedSizeList, FixedSizeList, FixedSizeListData);
+/// A [`FixedSizeList`]-encoded Vortex array.
+pub type FixedSizeListArray = Array<FixedSizeList>;
 
 #[derive(Clone, Debug)]
 pub struct FixedSizeList;

--- a/vortex-array/src/arrays/list/vtable/mod.rs
+++ b/vortex-array/src/arrays/list/vtable/mod.rs
@@ -36,10 +36,10 @@ use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 mod operations;
 mod validity;
-vtable!(List, List, ListData);
+/// A [`List`]-encoded Vortex array.
+pub type ListArray = Array<List>;
 
 #[derive(Clone, prost::Message)]
 pub struct ListMetadata {

--- a/vortex-array/src/arrays/listview/vtable/mod.rs
+++ b/vortex-array/src/arrays/listview/vtable/mod.rs
@@ -34,10 +34,10 @@ use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 mod operations;
 mod validity;
-vtable!(ListView, ListView, ListViewData);
+/// A [`ListView`]-encoded Vortex array.
+pub type ListViewArray = Array<ListView>;
 
 #[derive(Clone, Debug)]
 pub struct ListView;

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -38,8 +38,8 @@ use crate::executor::ExecutionResult;
 use crate::scalar::Scalar;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
-vtable!(Masked, Masked, MaskedData);
+/// A [`Masked`]-encoded Vortex array.
+pub type MaskedArray = Array<Masked>;
 
 #[derive(Clone, Debug)]
 pub struct Masked;

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -27,11 +27,11 @@ use crate::dtype::DType;
 use crate::scalar::Scalar;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 
 pub(crate) mod compute;
 
-vtable!(Null, Null, NullData);
+/// A [`Null`]-encoded Vortex array.
+pub type NullArray = Array<Null>;
 
 impl ArrayHash for NullData {
     fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {

--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -46,9 +46,9 @@ use crate::dtype::NativePType;
 use crate::dtype::PType;
 use crate::match_each_native_ptype;
 use crate::serde::ArrayChildren;
-use crate::vtable;
 
-vtable!(Patched, Patched, PatchedData);
+/// A [`Patched`]-encoded Vortex array.
+pub type PatchedArray = Array<Patched>;
 
 #[derive(Clone, Debug)]
 pub struct Patched;

--- a/vortex-array/src/arrays/primitive/vtable/mod.rs
+++ b/vortex-array/src/arrays/primitive/vtable/mod.rs
@@ -19,7 +19,6 @@ use crate::dtype::DType;
 use crate::dtype::PType;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 mod kernel;
 mod operations;
 mod validity;
@@ -36,7 +35,8 @@ use crate::arrays::primitive::compute::rules::RULES;
 use crate::hash::ArrayEq;
 use crate::hash::ArrayHash;
 
-vtable!(Primitive, Primitive, PrimitiveData);
+/// A [`Primitive`]-encoded Vortex array.
+pub type PrimitiveArray = Array<Primitive>;
 
 impl ArrayHash for PrimitiveData {
     fn array_hash<H: Hasher>(&self, state: &mut H, precision: Precision) {

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -45,9 +45,9 @@ use crate::scalar_fn::ScalarFnRef;
 use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::VecExecutionArgs;
 use crate::serde::ArrayChildren;
-use crate::vtable;
 
-vtable!(ScalarFn, ScalarFnVTable, ScalarFnData);
+/// A [`ScalarFn`]-encoded Vortex array.
+pub type ScalarFnArray = Array<ScalarFnVTable>;
 
 #[derive(Clone, Debug)]
 pub struct ScalarFnVTable {

--- a/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/mod.rs
@@ -46,7 +46,7 @@ use crate::scalar_fn::ScalarFnVTableExt;
 use crate::scalar_fn::VecExecutionArgs;
 use crate::serde::ArrayChildren;
 
-/// A [`ScalarFn`]-encoded Vortex array.
+/// A [`ScalarFnVTable`]-encoded Vortex array.
 pub type ScalarFnArray = Array<ScalarFnVTable>;
 
 #[derive(Clone, Debug)]

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -28,9 +28,9 @@ use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::scalar::Scalar;
 use crate::validity::Validity;
-use crate::vtable;
 
-vtable!(Shared, Shared, SharedData);
+/// A [`Shared`]-encoded Vortex array.
+pub type SharedArray = Array<Shared>;
 
 // TODO(ngates): consider hooking Shared into the iterative execution model. Cache either the
 //  most executed, or after each iteration, and return a shared cache for each execution.

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -39,9 +39,9 @@ use crate::executor::ExecutionResult;
 use crate::scalar::Scalar;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 
-vtable!(Slice, Slice, SliceData);
+/// A [`Slice`]-encoded Vortex array.
+pub type SliceArray = Array<Slice>;
 
 #[derive(Clone, Debug)]
 pub struct Slice;

--- a/vortex-array/src/arrays/struct_/vtable/mod.rs
+++ b/vortex-array/src/arrays/struct_/vtable/mod.rs
@@ -29,7 +29,6 @@ use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 mod kernel;
 mod operations;
 mod validity;
@@ -37,7 +36,8 @@ mod validity;
 use crate::Precision;
 use crate::array::ArrayId;
 
-vtable!(Struct, Struct, StructData);
+/// A [`Struct`]-encoded Vortex array.
+pub type StructArray = Array<Struct>;
 
 impl ArrayHash for StructData {
     fn array_hash<H: Hasher>(&self, _state: &mut H, _precision: Precision) {}

--- a/vortex-array/src/arrays/varbin/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbin/vtable/mod.rs
@@ -28,7 +28,6 @@ use crate::dtype::Nullability;
 use crate::dtype::PType;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 mod canonical;
 mod kernel;
 mod operations;
@@ -43,7 +42,8 @@ use crate::arrays::varbin::compute::rules::PARENT_RULES;
 use crate::hash::ArrayEq;
 use crate::hash::ArrayHash;
 
-vtable!(VarBin, VarBin, VarBinData);
+/// A [`VarBin`]-encoded Vortex array.
+pub type VarBinArray = Array<VarBin>;
 
 #[derive(Clone, prost::Message)]
 pub struct VarBinMetadata {

--- a/vortex-array/src/arrays/varbinview/vtable/mod.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/mod.rs
@@ -33,11 +33,11 @@ use crate::hash::ArrayEq;
 use crate::hash::ArrayHash;
 use crate::serde::ArrayChildren;
 use crate::validity::Validity;
-use crate::vtable;
 mod kernel;
 mod operations;
 mod validity;
-vtable!(VarBinView, VarBinView, VarBinViewData);
+/// A [`VarBinView`]-encoded Vortex array.
+pub type VarBinViewArray = Array<VarBinView>;
 
 #[derive(Clone, Debug)]
 pub struct VarBinView;

--- a/vortex-array/src/arrays/variant/vtable/mod.rs
+++ b/vortex-array/src/arrays/variant/vtable/mod.rs
@@ -26,9 +26,9 @@ use crate::arrays::variant::VariantData;
 use crate::buffer::BufferHandle;
 use crate::dtype::DType;
 use crate::serde::ArrayChildren;
-use crate::vtable;
 
-vtable!(Variant, Variant, VariantData);
+/// A [`Variant`]-encoded Vortex array.
+pub type VariantArray = Array<Variant>;
 
 #[derive(Clone, Debug)]
 pub struct Variant;

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -19,7 +19,6 @@ use vortex::array::VTable;
 use vortex::array::ValidityVTable;
 use vortex::array::buffer::BufferHandle;
 use vortex::array::validity::Validity;
-use vortex::array::vtable;
 use vortex::dtype::DType;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
@@ -29,8 +28,6 @@ use vortex::scalar::Scalar;
 use vortex::session::VortexSession;
 
 use crate::arrays::py::PythonArray;
-
-vtable!(Python, PythonVTable);
 
 /// Wrapper struct encapsulating a Python encoding.
 #[derive(Debug, Clone)]

--- a/vortex-tensor/src/encodings/turboquant/vtable.rs
+++ b/vortex-tensor/src/encodings/turboquant/vtable.rs
@@ -23,7 +23,6 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::serde::ArrayChildren;
-use vortex_array::vtable;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityChild;
 use vortex_array::vtable::ValidityVTableFromChild;
@@ -106,7 +105,8 @@ impl TurboQuant {
     }
 }
 
-vtable!(TurboQuant, TurboQuant, TurboQuantData);
+/// A [`TurboQuant`]-encoded Vortex array.
+pub type TurboQuantArray = Array<TurboQuant>;
 
 impl ArrayHash for TurboQuantData {
     fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {


### PR DESCRIPTION
This is now unneeded