### PR TITLE
Allow inserting non-Default values to VortexSession

### DIFF
--- a/vortex-session/public-api.lock
+++ b/vortex-session/public-api.lock
@@ -114,6 +114,8 @@ pub fn vortex_session::VortexSession::empty() -> Self
 
 pub fn vortex_session::VortexSession::with<V: vortex_session::SessionVar + core::default::Default>(self) -> Self
 
+pub fn vortex_session::VortexSession::with_some<V: vortex_session::SessionVar>(self, var: V) -> Self
+
 impl core::clone::Clone for vortex_session::VortexSession
 
 pub fn vortex_session::VortexSession::clone(&self) -> vortex_session::VortexSession

--- a/vortex-session/src/lib.rs
+++ b/vortex-session/src/lib.rs
@@ -39,6 +39,15 @@ impl VortexSession {
     ///
     /// If a variable of that type already exists.
     pub fn with<V: SessionVar + Default>(self) -> Self {
+        self.with_some(V::default())
+    }
+
+    /// Inserts a new session variable of type `V`.
+    ///
+    /// # Panics
+    ///
+    /// If a variable of that type already exists.
+    pub fn with_some<V: SessionVar>(self, var: V) -> Self {
         match self.0.entry(TypeId::of::<V>()) {
             Entry::Occupied(_) => {
                 vortex_panic!(
@@ -47,7 +56,7 @@ impl VortexSession {
                 );
             }
             Entry::Vacant(e) => {
-                e.insert(Box::new(V::default()));
+                e.insert(Box::new(var));
             }
         }
         self


### PR DESCRIPTION
Previously there was no way to insert a non-default session var