### PR TITLE
Unify id creation for ScalarFns and rename is_null to vortex.is_null

### DIFF
--- a/vortex-array/src/scalar_fn/fns/dynamic.rs
+++ b/vortex-array/src/scalar_fn/fns/dynamic.rs
@@ -46,7 +46,7 @@ impl ScalarFnVTable for DynamicComparison {
     type Options = DynamicComparisonExpr;
 
     fn id(&self) -> ScalarFnId {
-        ScalarFnId::new_ref("vortex.dynamic")
+        ScalarFnId::from("vortex.dynamic")
     }
 
     fn arity(&self, _options: &Self::Options) -> Arity {

--- a/vortex-array/src/scalar_fn/fns/is_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_null.rs
@@ -34,7 +34,7 @@ impl ScalarFnVTable for IsNull {
     type Options = EmptyOptions;
 
     fn id(&self) -> ScalarFnId {
-        ScalarFnId::new_ref("is_null")
+        ScalarFnId::from("vortex.is_null")
     }
 
     fn serialize(&self, _instance: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/scalar_fn/fns/literal.rs
+++ b/vortex-array/src/scalar_fn/fns/literal.rs
@@ -38,7 +38,7 @@ impl ScalarFnVTable for Literal {
     type Options = Scalar;
 
     fn id(&self) -> ScalarFnId {
-        ScalarFnId::new_ref("vortex.literal")
+        ScalarFnId::from("vortex.literal")
     }
 
     fn serialize(&self, instance: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/scalar_fn/fns/merge.rs
+++ b/vortex-array/src/scalar_fn/fns/merge.rs
@@ -51,7 +51,7 @@ impl ScalarFnVTable for Merge {
     type Options = DuplicateHandling;
 
     fn id(&self) -> ScalarFnId {
-        ScalarFnId::new_ref("vortex.merge")
+        ScalarFnId::from("vortex.merge")
     }
 
     fn serialize(&self, instance: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/scalar_fn/fns/pack.rs
+++ b/vortex-array/src/scalar_fn/fns/pack.rs
@@ -54,7 +54,7 @@ impl ScalarFnVTable for Pack {
     type Options = PackOptions;
 
     fn id(&self) -> ScalarFnId {
-        ScalarFnId::new_ref("vortex.pack")
+        ScalarFnId::from("vortex.pack")
     }
 
     fn serialize(&self, instance: &Self::Options) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-array/src/scalar_fn/fns/select.rs
+++ b/vortex-array/src/scalar_fn/fns/select.rs
@@ -48,7 +48,7 @@ impl ScalarFnVTable for Select {
     type Options = FieldSelection;
 
     fn id(&self) -> ScalarFnId {
-        ScalarFnId::new_ref("vortex.select")
+        ScalarFnId::from("vortex.select")
     }
 
     fn serialize(&self, instance: &FieldSelection) -> VortexResult<Option<Vec<u8>>> {

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -77,7 +77,7 @@ impl ScalarFnVTable for CosineSimilarity {
     type Options = ApproxOptions;
 
     fn id(&self) -> ScalarFnId {
-        ScalarFnId::new_ref("vortex.tensor.cosine_similarity")
+        ScalarFnId::from("vortex.tensor.cosine_similarity")
     }
 
     fn arity(&self, _options: &Self::Options) -> Arity {

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -79,7 +79,7 @@ impl ScalarFnVTable for InnerProduct {
     type Options = ApproxOptions;
 
     fn id(&self) -> ScalarFnId {
-        ScalarFnId::new_ref("vortex.tensor.inner_product")
+        ScalarFnId::from("vortex.tensor.inner_product")
     }
 
     fn arity(&self, _options: &Self::Options) -> Arity {

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -72,7 +72,7 @@ impl ScalarFnVTable for L2Norm {
     type Options = ApproxOptions;
 
     fn id(&self) -> ScalarFnId {
-        ScalarFnId::new_ref("vortex.tensor.l2_norm")
+        ScalarFnId::from("vortex.tensor.l2_norm")
     }
 
     fn arity(&self, _options: &Self::Options) -> Arity {


### PR DESCRIPTION
Use ScalarFnId::from instead of new_ref and rename is_null fn to vortex.is_null

Signed-off-by: Robert Kruszewski <github@robertk.io>
