### PR TITLE
Dynamic WHT rounds in TurboQuant

### DIFF
--- a/vortex-tensor/public-api.lock
+++ b/vortex-tensor/public-api.lock
@@ -78,6 +78,8 @@ pub struct vortex_tensor::encodings::turboquant::TurboQuantConfig
 
 pub vortex_tensor::encodings::turboquant::TurboQuantConfig::bit_width: u8
 
+pub vortex_tensor::encodings::turboquant::TurboQuantConfig::num_rounds: u8
+
 pub vortex_tensor::encodings::turboquant::TurboQuantConfig::seed: core::option::Option<u64>
 
 impl core::clone::Clone for vortex_tensor::encodings::turboquant::TurboQuantConfig
@@ -100,11 +102,13 @@ pub fn vortex_tensor::encodings::turboquant::TurboQuantData::bit_width(&self) ->
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuantData::dimension(&self) -> u32
 
-pub unsafe fn vortex_tensor::encodings::turboquant::TurboQuantData::new_unchecked(dimension: u32, bit_width: u8) -> Self
+pub unsafe fn vortex_tensor::encodings::turboquant::TurboQuantData::new_unchecked(dimension: u32, bit_width: u8, num_rounds: u8) -> Self
+
+pub fn vortex_tensor::encodings::turboquant::TurboQuantData::num_rounds(&self) -> u8
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuantData::padded_dim(&self) -> u32
 
-pub fn vortex_tensor::encodings::turboquant::TurboQuantData::try_new(dimension: u32, bit_width: u8) -> vortex_error::VortexResult<Self>
+pub fn vortex_tensor::encodings::turboquant::TurboQuantData::try_new(dimension: u32, bit_width: u8, num_rounds: u8) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuantData::validate(dtype: &vortex_array::dtype::DType, codes: &vortex_array::array::erased::ArrayRef, norms: &vortex_array::array::erased::ArrayRef, centroids: &vortex_array::array::erased::ArrayRef, rotation_signs: &vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<()>
 
@@ -156,33 +160,21 @@ pub fn vortex_tensor::encodings::turboquant::TurboQuantScheme::scheme_name(&self
 
 pub trait vortex_tensor::encodings::turboquant::TurboQuantArrayExt: vortex_array::array::typed::TypedArrayRef<vortex_tensor::encodings::turboquant::TurboQuant>
 
-pub fn vortex_tensor::encodings::turboquant::TurboQuantArrayExt::bit_width(&self) -> u8
-
 pub fn vortex_tensor::encodings::turboquant::TurboQuantArrayExt::centroids(&self) -> &vortex_array::array::erased::ArrayRef
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuantArrayExt::codes(&self) -> &vortex_array::array::erased::ArrayRef
 
-pub fn vortex_tensor::encodings::turboquant::TurboQuantArrayExt::dimension(&self) -> u32
-
 pub fn vortex_tensor::encodings::turboquant::TurboQuantArrayExt::norms(&self) -> &vortex_array::array::erased::ArrayRef
-
-pub fn vortex_tensor::encodings::turboquant::TurboQuantArrayExt::padded_dim(&self) -> u32
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuantArrayExt::rotation_signs(&self) -> &vortex_array::array::erased::ArrayRef
 
 impl<T: vortex_array::array::typed::TypedArrayRef<vortex_tensor::encodings::turboquant::TurboQuant>> vortex_tensor::encodings::turboquant::TurboQuantArrayExt for T
 
-pub fn T::bit_width(&self) -> u8
-
 pub fn T::centroids(&self) -> &vortex_array::array::erased::ArrayRef
 
 pub fn T::codes(&self) -> &vortex_array::array::erased::ArrayRef
 
-pub fn T::dimension(&self) -> u32
-
 pub fn T::norms(&self) -> &vortex_array::array::erased::ArrayRef
-
-pub fn T::padded_dim(&self) -> u32
 
 pub fn T::rotation_signs(&self) -> &vortex_array::array::erased::ArrayRef
 

--- a/vortex-tensor/src/encodings/turboquant/array/data.rs
+++ b/vortex-tensor/src/encodings/turboquant/array/data.rs
@@ -123,41 +123,6 @@ impl TurboQuantData {
             "norms length must match codes length",
         );
 
-        // Degenerate (empty) case: all children must be empty, and bit_width is 0.
-        if num_rows == 0 {
-            vortex_ensure!(
-                centroids.is_empty(),
-                "degenerate TurboQuant must have empty centroids, got length {}",
-                centroids.len()
-            );
-            vortex_ensure!(
-                rotation_signs.is_empty(),
-                "degenerate TurboQuant must have empty rotation_signs, got length {}",
-                rotation_signs.len()
-            );
-            return Ok(());
-        }
-
-        // Non-degenerate: derive and validate bit_width from centroids.
-        let num_centroids = centroids.len();
-        vortex_ensure!(
-            num_centroids.is_power_of_two()
-                && (2..=TurboQuant::MAX_CENTROIDS).contains(&num_centroids),
-            "centroids length must be a power of 2 in [2, {}], got {num_centroids}",
-            TurboQuant::MAX_CENTROIDS
-        );
-
-        #[expect(
-            clippy::cast_possible_truncation,
-            reason = "Guaranteed to be [1,8] by the preceding power-of-2 and range checks."
-        )]
-        let bit_width = num_centroids.trailing_zeros() as u8;
-        vortex_ensure!(
-            (1..=TurboQuant::MAX_BIT_WIDTH).contains(&bit_width),
-            "derived bit_width must be 1-{}, got {bit_width}",
-            TurboQuant::MAX_BIT_WIDTH
-        );
-
         // Norms dtype must match the element ptype of the Vector, with the parent's nullability.
         // Norms carry the validity of the entire TurboQuant array.
         let element_ptype = vector_metadata.element_ptype();
@@ -188,9 +153,44 @@ impl TurboQuantData {
             expected_signs_dtype,
             "rotation_signs dtype does not match expected {expected_signs_dtype}",
         );
+        // Degenerate (empty) case: all children must be empty, and bit_width is 0.
+        if num_rows == 0 {
+            vortex_ensure!(
+                centroids.is_empty(),
+                "degenerate TurboQuant must have empty centroids, got length {}",
+                centroids.len()
+            );
+            vortex_ensure!(
+                rotation_signs.is_empty(),
+                "degenerate TurboQuant must have empty rotation_signs, got length {}",
+                rotation_signs.len()
+            );
+            return Ok(());
+        }
+
         vortex_ensure!(
             !rotation_signs.is_empty(),
             "rotation_signs must have at least 1 round"
+        );
+
+        // Non-degenerate: derive and validate bit_width from centroids.
+        let num_centroids = centroids.len();
+        vortex_ensure!(
+            num_centroids.is_power_of_two()
+                && (2..=TurboQuant::MAX_CENTROIDS).contains(&num_centroids),
+            "centroids length must be a power of 2 in [2, {}], got {num_centroids}",
+            TurboQuant::MAX_CENTROIDS
+        );
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "Guaranteed to be [1,8] by the preceding power-of-2 and range checks."
+        )]
+        let bit_width = num_centroids.trailing_zeros() as u8;
+        vortex_ensure!(
+            (1..=TurboQuant::MAX_BIT_WIDTH).contains(&bit_width),
+            "derived bit_width must be 1-{}, got {bit_width}",
+            TurboQuant::MAX_BIT_WIDTH
         );
 
         Ok(())

--- a/vortex-tensor/src/encodings/turboquant/array/data.rs
+++ b/vortex-tensor/src/encodings/turboquant/array/data.rs
@@ -36,6 +36,11 @@ pub struct TurboQuantData {
     ///
     /// This is 0 for degenerate empty arrays.
     pub(crate) bit_width: u8,
+
+    /// The number of sign-diagonal + WHT rounds in the structured rotation.
+    ///
+    /// This is 0 for degenerate empty arrays.
+    pub(crate) num_rounds: u8,
 }
 
 impl TurboQuantData {
@@ -46,7 +51,7 @@ impl TurboQuantData {
     /// Returns an error if:
     /// - `dimension` is less than [`MIN_DIMENSION`](TurboQuant::MIN_DIMENSION).
     /// - `bit_width` is greater than [`MAX_BIT_WIDTH`](TurboQuant::MAX_BIT_WIDTH).
-    pub fn try_new(dimension: u32, bit_width: u8) -> VortexResult<Self> {
+    pub fn try_new(dimension: u32, bit_width: u8, num_rounds: u8) -> VortexResult<Self> {
         vortex_ensure!(
             dimension >= TurboQuant::MIN_DIMENSION,
             "TurboQuant requires dimension >= {}, got {dimension}",
@@ -61,6 +66,7 @@ impl TurboQuantData {
         Ok(Self {
             dimension,
             bit_width,
+            num_rounds,
         })
     }
 
@@ -72,12 +78,14 @@ impl TurboQuantData {
     ///
     /// - `dimension` is >= [`MIN_DIMENSION`](TurboQuant::MIN_DIMENSION).
     /// - `bit_width` is in the range `[0, MAX_BIT_WIDTH]`.
+    /// - `num_rounds` is >= 1 (or 0 for degenerate empty arrays).
     ///
     /// Violating these invariants may produce incorrect results during decompression.
-    pub unsafe fn new_unchecked(dimension: u32, bit_width: u8) -> Self {
+    pub unsafe fn new_unchecked(dimension: u32, bit_width: u8, num_rounds: u8) -> Self {
         Self {
             dimension,
             bit_width,
+            num_rounds,
         }
     }
 
@@ -168,11 +176,21 @@ impl TurboQuantData {
             "centroids dtype must be non-nullable f32",
         );
 
-        // Rotation signs count must be 3 * padded_dim.
+        // Rotation signs must be a FixedSizeList<u8> with list_size == padded_dim. The FSL length
+        // is the number of rotation rounds.
+        let expected_signs_dtype = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::U8, Nullability::NonNullable)),
+            padded_dim,
+            Nullability::NonNullable,
+        );
         vortex_ensure_eq!(
-            rotation_signs.len(),
-            3 * padded_dim as usize,
-            "rotation_signs length does not match expected 3 * {padded_dim}",
+            *rotation_signs.dtype(),
+            expected_signs_dtype,
+            "rotation_signs dtype does not match expected {expected_signs_dtype}",
+        );
+        vortex_ensure!(
+            !rotation_signs.is_empty(),
+            "rotation_signs must have at least 1 round"
         );
 
         Ok(())
@@ -203,6 +221,11 @@ impl TurboQuantData {
         self.bit_width
     }
 
+    /// The number of sign-diagonal + WHT rounds in the structured rotation.
+    pub fn num_rounds(&self) -> u8 {
+        self.num_rounds
+    }
+
     /// Padded dimension (next power of 2 >= [`dimension`](Self::dimension)).
     ///
     /// The current Walsh-Hadamard-based structured rotation requires power-of-2 input, so
@@ -213,18 +236,6 @@ impl TurboQuantData {
 }
 
 pub trait TurboQuantArrayExt: TypedArrayRef<TurboQuant> {
-    fn dimension(&self) -> u32 {
-        std::ops::Deref::deref(self).dimension()
-    }
-
-    fn bit_width(&self) -> u8 {
-        std::ops::Deref::deref(self).bit_width()
-    }
-
-    fn padded_dim(&self) -> u32 {
-        std::ops::Deref::deref(self).padded_dim()
-    }
-
     fn codes(&self) -> &ArrayRef {
         self.as_ref().slots()[Slot::Codes as usize]
             .as_ref()

--- a/vortex-tensor/src/encodings/turboquant/array/rotation.rs
+++ b/vortex-tensor/src/encodings/turboquant/array/rotation.rs
@@ -37,26 +37,40 @@ const F32_SIGN_BIT: u32 = 0x8000_0000;
 
 /// A Walsh-Hadamard-based structured surrogate for a random orthogonal rotation.
 pub struct RotationMatrix {
-    /// XOR masks for each of the 3 diagonal matrices, each of length `padded_dim`. `0x00000000` =
-    /// multiply by +1 (no-op), `0x80000000` = multiply by -1 (flip sign bit).
-    sign_masks: [Vec<u32>; 3],
+    /// Flat XOR masks for all `num_rounds` diagonal matrices, total length `num_rounds * padded_dim`.
+    /// Indexed as `round * padded_dim + i`. `0x00000000` = multiply by +1 (no-op), `0x80000000` =
+    /// multiply by -1 (flip sign bit).
+    sign_masks: Vec<u32>,
+    /// The number of sign-diagonal + WHT rounds.
+    num_rounds: usize,
     /// The padded dimension (next power of 2 >= dimension).
     padded_dim: usize,
-    /// Normalization factor: 1/(padded_dim * sqrt(padded_dim)), applied once at the end.
+    /// Normalization factor: `padded_dim^(-num_rounds/2)`, applied once at the end.
     norm_factor: f32,
 }
 
 impl RotationMatrix {
     /// Create a new structured Walsh-Hadamard-based rotation from a deterministic seed.
-    pub fn try_new(seed: u64, dimension: usize) -> VortexResult<Self> {
+    pub fn try_new(seed: u64, dimension: usize, num_rounds: usize) -> VortexResult<Self> {
+        vortex_ensure!(num_rounds >= 1, "num_rounds must be >= 1, got {num_rounds}");
+
         let padded_dim = dimension.next_power_of_two();
         let mut rng = StdRng::seed_from_u64(seed);
 
-        let sign_masks = std::array::from_fn(|_| gen_random_sign_masks(&mut rng, padded_dim));
-        let norm_factor = 1.0 / (padded_dim as f32 * (padded_dim as f32).sqrt());
+        let mut sign_masks = Vec::with_capacity(num_rounds * padded_dim);
+        for _ in 0..num_rounds {
+            sign_masks.extend(gen_random_sign_masks(&mut rng, padded_dim));
+        }
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "Intentional f64 -> f32 truncation for normalization factor."
+        )]
+        let norm_factor = (padded_dim as f64).powf(-(num_rounds as f64) / 2.0) as f32;
 
         Ok(Self {
             sign_masks,
+            num_rounds,
             padded_dim,
             norm_factor,
         })
@@ -85,6 +99,11 @@ impl RotationMatrix {
         self.apply_inverse_srht(output);
     }
 
+    /// Returns the number of sign-diagonal + WHT rounds.
+    pub fn num_rounds(&self) -> usize {
+        self.num_rounds
+    }
+
     /// Returns the padded dimension (next power of 2 >= dim).
     ///
     /// All rotate/inverse_rotate buffers must be this length.
@@ -92,16 +111,13 @@ impl RotationMatrix {
         self.padded_dim
     }
 
-    /// Apply the structured rotation: `D₃ · H · D₂ · H · D₁ · H · x`, with normalization.
+    /// Apply the structured rotation: `D_k · H · ... · D₁ · H · x`, with normalization.
     fn apply_srht(&self, buf: &mut [f32]) {
-        apply_signs_xor(buf, &self.sign_masks[0]);
-        walsh_hadamard_transform(buf);
-
-        apply_signs_xor(buf, &self.sign_masks[1]);
-        walsh_hadamard_transform(buf);
-
-        apply_signs_xor(buf, &self.sign_masks[2]);
-        walsh_hadamard_transform(buf);
+        for round in 0..self.num_rounds {
+            let offset = round * self.padded_dim;
+            apply_signs_xor(buf, &self.sign_masks[offset..offset + self.padded_dim]);
+            walsh_hadamard_transform(buf);
+        }
 
         let norm = self.norm_factor;
         buf.iter_mut().for_each(|val| *val *= norm);
@@ -109,34 +125,33 @@ impl RotationMatrix {
 
     /// Apply the inverse structured rotation.
     ///
-    /// Forward is: norm · H · D₃ · H · D₂ · H · D₁
-    /// Inverse is: norm · D₁ · H · D₂ · H · D₃ · H
+    /// Forward is: `norm · H · D_k · H · ... · D₁ · H`.
+    /// Inverse is: `norm · D₁ · H · ... · D_k · H`.
     fn apply_inverse_srht(&self, buf: &mut [f32]) {
-        walsh_hadamard_transform(buf);
-        apply_signs_xor(buf, &self.sign_masks[2]);
-
-        walsh_hadamard_transform(buf);
-        apply_signs_xor(buf, &self.sign_masks[1]);
-
-        walsh_hadamard_transform(buf);
-        apply_signs_xor(buf, &self.sign_masks[0]);
+        for round in (0..self.num_rounds).rev() {
+            walsh_hadamard_transform(buf);
+            let offset = round * self.padded_dim;
+            apply_signs_xor(buf, &self.sign_masks[offset..offset + self.padded_dim]);
+        }
 
         let norm = self.norm_factor;
         buf.iter_mut().for_each(|val| *val *= norm);
     }
 
-    /// Export the 3 sign vectors as a flat `Vec<u8>` of 0/1 values in inverse application order
-    /// `[D₃ | D₂ | D₁]`.
+    /// Export the sign vectors as a flat `Vec<u8>` of 0/1 values in inverse application order
+    /// `[D_k | ... | D₁]`.
     ///
-    /// Convention: `1` = positive (+1), `0` = negative (-1). The output has length `3 * padded_dim`
-    /// and is suitable for bitpacking via FastLanes `bitpack_encode(..., 1, None)`.
+    /// Convention: `1` = positive (+1), `0` = negative (-1). The output has length
+    /// `num_rounds * padded_dim` and is suitable for bitpacking via FastLanes
+    /// `bitpack_encode(..., 1, None)`.
     pub fn export_inverse_signs_u8(&self) -> Vec<u8> {
-        let total = 3 * self.padded_dim;
+        let total = self.num_rounds * self.padded_dim;
         let mut out = Vec::with_capacity(total);
 
-        // Store in inverse order: sign_masks[2] (D₃), sign_masks[1] (D₂), sign_masks[0] (D₁)
-        for sign_idx in [2, 1, 0] {
-            for &mask in &self.sign_masks[sign_idx] {
+        // Store in inverse order: round k-1 first, then k-2, ..., then 0.
+        for round in (0..self.num_rounds).rev() {
+            let offset = round * self.padded_dim;
+            for &mask in &self.sign_masks[offset..offset + self.padded_dim] {
                 out.push(if mask == 0 { 1u8 } else { 0u8 });
             }
         }
@@ -145,36 +160,51 @@ impl RotationMatrix {
 
     /// Reconstruct a [`RotationMatrix`] from unpacked `u8` 0/1 values.
     ///
-    /// The input must have length `3 * padded_dim` with signs in inverse application order
-    /// `[D₃ | D₂ | D₁]` (as produced by [`export_inverse_signs_u8`]). Convention: `1` = positive,
-    /// `0` = negative.
+    /// The input must have length `num_rounds * padded_dim` with signs in inverse application
+    /// order `[D_k | ... | D₁]` (as produced by [`export_inverse_signs_u8`]). Convention:
+    /// `1` = positive, `0` = negative.
     ///
     /// This is the decode-time reconstruction path: FastLanes SIMD-unpacks the stored
     /// [`BitPackedArray`] into `&[u8]`, which is passed here.
-    pub fn from_u8_slice(signs_u8: &[u8], dimension: usize) -> VortexResult<Self> {
+    pub fn from_u8_slice(
+        signs_u8: &[u8],
+        dimension: usize,
+        num_rounds: usize,
+    ) -> VortexResult<Self> {
+        vortex_ensure!(num_rounds >= 1, "num_rounds must be >= 1, got {num_rounds}");
         let padded_dim = dimension.next_power_of_two();
         vortex_ensure!(
-            signs_u8.len() == 3 * padded_dim,
+            signs_u8.len() == num_rounds * padded_dim,
             "Expected {} sign bytes, got {}",
-            3 * padded_dim,
+            num_rounds * padded_dim,
             signs_u8.len()
         );
 
-        // Reconstruct in storage order (inverse): [D₃, D₂, D₁] → sign_masks[2], [1], [0]
-        let mut sign_masks: [Vec<u32>; 3] = std::array::from_fn(|_| Vec::with_capacity(padded_dim));
-
-        for (round, sign_idx) in [2, 1, 0].into_iter().enumerate() {
-            let offset = round * padded_dim;
-            sign_masks[sign_idx] = signs_u8[offset..offset + padded_dim]
-                .iter()
-                .map(|&v| if v != 0 { 0u32 } else { F32_SIGN_BIT })
-                .collect();
+        // The storage is in inverse application order: round k-1 first, then k-2, ..., 0.
+        // We reconstruct into forward order (round 0 at the start of the flat vec).
+        let mut sign_masks = vec![0u32; num_rounds * padded_dim];
+        for storage_idx in 0..num_rounds {
+            let round = num_rounds - 1 - storage_idx;
+            let src_offset = storage_idx * padded_dim;
+            let dst_offset = round * padded_dim;
+            for i in 0..padded_dim {
+                sign_masks[dst_offset + i] = if signs_u8[src_offset + i] != 0 {
+                    0u32
+                } else {
+                    F32_SIGN_BIT
+                };
+            }
         }
 
-        let norm_factor = 1.0 / (padded_dim as f32 * (padded_dim as f32).sqrt());
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "Intentional f64 -> f32 truncation for normalization factor."
+        )]
+        let norm_factor = (padded_dim as f64).powf(-(num_rounds as f64) / 2.0) as f32;
 
         Ok(Self {
             sign_masks,
+            num_rounds,
             padded_dim,
             norm_factor,
         })
@@ -255,8 +285,8 @@ mod tests {
 
     #[test]
     fn deterministic_from_seed() -> VortexResult<()> {
-        let r1 = RotationMatrix::try_new(42, 64)?;
-        let r2 = RotationMatrix::try_new(42, 64)?;
+        let r1 = RotationMatrix::try_new(42, 64, 3)?;
+        let r2 = RotationMatrix::try_new(42, 64, 3)?;
         let pd = r1.padded_dim();
 
         let mut input = vec![0.0f32; pd];
@@ -273,19 +303,22 @@ mod tests {
         Ok(())
     }
 
-    /// Verify roundtrip is exact to f32 precision across many dimensions,
+    /// Verify roundtrip is exact to f32 precision across many dimensions and round counts,
     /// including non-power-of-two dimensions that require padding.
     #[rstest]
-    #[case(32)]
-    #[case(64)]
-    #[case(100)]
-    #[case(128)]
-    #[case(256)]
-    #[case(512)]
-    #[case(768)]
-    #[case(1024)]
-    fn roundtrip_exact(#[case] dim: usize) -> VortexResult<()> {
-        let rot = RotationMatrix::try_new(42, dim)?;
+    #[case(32, 3)]
+    #[case(64, 3)]
+    #[case(100, 3)]
+    #[case(128, 1)]
+    #[case(128, 2)]
+    #[case(128, 3)]
+    #[case(128, 5)]
+    #[case(256, 3)]
+    #[case(512, 3)]
+    #[case(768, 3)]
+    #[case(1024, 3)]
+    fn roundtrip_exact(#[case] dim: usize, #[case] num_rounds: usize) -> VortexResult<()> {
+        let rot = RotationMatrix::try_new(42, dim, num_rounds)?;
         let padded_dim = rot.padded_dim();
 
         let mut input = vec![0.0f32; padded_dim];
@@ -309,17 +342,19 @@ mod tests {
         // SRHT roundtrip should be exact up to f32 precision (~1e-6).
         assert!(
             rel_err < 1e-5,
-            "roundtrip relative error too large for dim={dim}: {rel_err:.2e}"
+            "roundtrip relative error too large for dim={dim}, rounds={num_rounds}: {rel_err:.2e}"
         );
         Ok(())
     }
 
-    /// Verify norm preservation across dimensions.
+    /// Verify norm preservation across dimensions and round counts.
     #[rstest]
-    #[case(128)]
-    #[case(768)]
-    fn preserves_norm(#[case] dim: usize) -> VortexResult<()> {
-        let rot = RotationMatrix::try_new(7, dim)?;
+    #[case(128, 1)]
+    #[case(128, 3)]
+    #[case(128, 5)]
+    #[case(768, 3)]
+    fn preserves_norm(#[case] dim: usize, #[case] num_rounds: usize) -> VortexResult<()> {
+        let rot = RotationMatrix::try_new(7, dim, num_rounds)?;
         let padded_dim = rot.padded_dim();
 
         let mut input = vec![0.0f32; padded_dim];
@@ -342,17 +377,22 @@ mod tests {
         Ok(())
     }
 
-    /// Verify that export → from_u8_slice produces identical rotation output.
+    /// Verify that export -> [`from_u8_slice`] produces identical rotation output.
     #[rstest]
-    #[case(64)]
-    #[case(128)]
-    #[case(768)]
-    fn sign_export_import_roundtrip(#[case] dim: usize) -> VortexResult<()> {
-        let rot = RotationMatrix::try_new(42, dim)?;
+    #[case(64, 3)]
+    #[case(128, 1)]
+    #[case(128, 3)]
+    #[case(128, 5)]
+    #[case(768, 3)]
+    fn sign_export_import_roundtrip(
+        #[case] dim: usize,
+        #[case] num_rounds: usize,
+    ) -> VortexResult<()> {
+        let rot = RotationMatrix::try_new(42, dim, num_rounds)?;
         let padded_dim = rot.padded_dim();
 
         let signs_u8 = rot.export_inverse_signs_u8();
-        let rot2 = RotationMatrix::from_u8_slice(&signs_u8, dim)?;
+        let rot2 = RotationMatrix::from_u8_slice(&signs_u8, dim, num_rounds)?;
 
         let mut input = vec![0.0f32; padded_dim];
         for i in 0..dim {

--- a/vortex-tensor/src/encodings/turboquant/array/rotation.rs
+++ b/vortex-tensor/src/encodings/turboquant/array/rotation.rs
@@ -6,20 +6,25 @@
 //! The TurboQuant paper analyzes a full random orthogonal rotation. The current implementation
 //! uses a cheaper structured Walsh-Hadamard-based surrogate instead of a dense d x d matrix.
 //!
-//! Concretely, this applies three rounds of random sign diagonals interleaved with the
-//! Walsh-Hadamard Transform: D3 * H * D2 * H * D1 * H, followed by normalization. This is a
-//! SORF-style structured approximation to a random orthogonal matrix, chosen for O(d log d)
+//! Concretely, this applies three rounds of random sign diagonals interleaved with the Fast
+//! Walsh-Hadamard Transform (FWHT): `D3 * H * D2 * H * D1 * H`, followed by normalization. This is
+//! a SORF-style structured approximation to a random orthogonal matrix, chosen for O(d log d)
 //! encode/decode cost and compact serialized parameters.
 //!
-//! For dimensions that are not powers of 2, the input is zero-padded to the
-//! next power of 2 before the transform and truncated afterward.
+//! The FWHT exploits the Kronecker product structure of the Hadamard matrix (`H_n = H_2 (x) H_2
+//! (x) ... (x) H_2`, with `log2(n)` factors) to compute the matrix-vector product in O(n log n)
+//! time using only in-place 2-element butterfly operations. No row of the full n x n Hadamard
+//! matrix is ever materialized.
+//!
+//! For dimensions that are not powers of 2, the input is zero-padded to the next power of 2 before
+//! the transform and truncated afterward.
 //!
 //! # Sign representation
 //!
-//! Signs are stored internally as `u32` XOR masks: `0x00000000` for +1 (no-op)
-//! and `0x80000000` for -1 (flip IEEE 754 sign bit). The sign application
-//! function uses integer XOR instead of floating-point multiply, which avoids
-//! FP dependency chains and auto-vectorizes into `vpxor`/`veor`.
+//! Signs are stored internally as `u32` XOR masks: `0x00000000` for +1 (no-op) and `0x80000000` for
+//! -1 (flip IEEE 754 sign bit). The sign application function uses integer XOR instead of
+//! floating-point multiply, which avoids FP dependency chains and auto-vectorizes into
+//! `vpxor`/`veor`.
 
 use rand::RngExt;
 use rand::SeedableRng;
@@ -32,8 +37,8 @@ const F32_SIGN_BIT: u32 = 0x8000_0000;
 
 /// A Walsh-Hadamard-based structured surrogate for a random orthogonal rotation.
 pub struct RotationMatrix {
-    /// XOR masks for each of the 3 diagonal matrices, each of length `padded_dim`.
-    /// `0x00000000` = multiply by +1 (no-op), `0x80000000` = multiply by -1 (flip sign bit).
+    /// XOR masks for each of the 3 diagonal matrices, each of length `padded_dim`. `0x00000000` =
+    /// multiply by +1 (no-op), `0x80000000` = multiply by -1 (flip sign bit).
     sign_masks: [Vec<u32>; 3],
     /// The padded dimension (next power of 2 >= dimension).
     padded_dim: usize,
@@ -59,8 +64,8 @@ impl RotationMatrix {
 
     /// Apply forward rotation: `output = R(input)`.
     ///
-    /// Both `input` and `output` must have length `padded_dim()`. The caller
-    /// is responsible for zero-padding input beyond `dim` positions.
+    /// Both `input` and `output` must have length [`padded_dim()`](Self::padded_dim). The caller is
+    /// responsible for zero-padding input beyond `dim` positions.
     pub fn rotate(&self, input: &[f32], output: &mut [f32]) {
         debug_assert_eq!(input.len(), self.padded_dim);
         debug_assert_eq!(output.len(), self.padded_dim);
@@ -120,12 +125,11 @@ impl RotationMatrix {
         buf.iter_mut().for_each(|val| *val *= norm);
     }
 
-    /// Export the 3 sign vectors as a flat `Vec<u8>` of 0/1 values in inverse
-    /// application order `[D₃ | D₂ | D₁]`.
+    /// Export the 3 sign vectors as a flat `Vec<u8>` of 0/1 values in inverse application order
+    /// `[D₃ | D₂ | D₁]`.
     ///
-    /// Convention: `1` = positive (+1), `0` = negative (-1).
-    /// The output has length `3 * padded_dim` and is suitable for bitpacking
-    /// via FastLanes `bitpack_encode(..., 1, None)`.
+    /// Convention: `1` = positive (+1), `0` = negative (-1). The output has length `3 * padded_dim`
+    /// and is suitable for bitpacking via FastLanes `bitpack_encode(..., 1, None)`.
     pub fn export_inverse_signs_u8(&self) -> Vec<u8> {
         let total = 3 * self.padded_dim;
         let mut out = Vec::with_capacity(total);
@@ -139,14 +143,14 @@ impl RotationMatrix {
         out
     }
 
-    /// Reconstruct a `RotationMatrix` from unpacked `u8` 0/1 values.
+    /// Reconstruct a [`RotationMatrix`] from unpacked `u8` 0/1 values.
     ///
-    /// The input must have length `3 * padded_dim` with signs in inverse
-    /// application order `[D₃ | D₂ | D₁]` (as produced by [`export_inverse_signs_u8`]).
-    /// Convention: `1` = positive, `0` = negative.
+    /// The input must have length `3 * padded_dim` with signs in inverse application order
+    /// `[D₃ | D₂ | D₁]` (as produced by [`export_inverse_signs_u8`]). Convention: `1` = positive,
+    /// `0` = negative.
     ///
-    /// This is the decode-time reconstruction path: FastLanes SIMD-unpacks the
-    /// stored `BitPackedArray` into `&[u8]`, which is passed here.
+    /// This is the decode-time reconstruction path: FastLanes SIMD-unpacks the stored
+    /// [`BitPackedArray`] into `&[u8]`, which is passed here.
     pub fn from_u8_slice(signs_u8: &[u8], dimension: usize) -> VortexResult<Self> {
         let padded_dim = dimension.next_power_of_two();
         vortex_ensure!(
@@ -192,8 +196,8 @@ fn gen_random_sign_masks(rng: &mut StdRng, len: usize) -> Vec<u32> {
 
 /// Apply sign masks via XOR on the IEEE 754 sign bit.
 ///
-/// This is branchless and auto-vectorizes into `vpxor` (x86) / `veor` (ARM).
-/// Equivalent to multiplying each element by ±1.0, but avoids FP dependency chains.
+/// This is branchless and auto-vectorizes into `vpxor` (x86) / `veor` (ARM). Equivalent to
+/// multiplying each element by +/-1.0, but avoids FP dependency chains.
 #[inline]
 fn apply_signs_xor(buf: &mut [f32], masks: &[u32]) {
     for (val, &mask) in buf.iter_mut().zip(masks.iter()) {
@@ -201,13 +205,14 @@ fn apply_signs_xor(buf: &mut [f32], masks: &[u32]) {
     }
 }
 
-/// In-place Walsh-Hadamard Transform (unnormalized, iterative).
+/// In-place Fast Walsh-Hadamard Transform (FWHT), unnormalized and iterative.
 ///
-/// Input length must be a power of 2. Runs in O(n log n).
+/// Input length must be a power of 2. Runs in O(n log n) via `log2(n)` stages of `n / 2`
+/// [`butterfly`] operations each. See the [module-level docs](self) for why this avoids
+/// materializing the full Hadamard matrix.
 ///
-/// Uses a fixed-size chunk strategy: for each stage, the buffer is processed
-/// in `CHUNK`-element blocks with a compile-time-known butterfly function.
-/// This lets LLVM unroll and auto-vectorize the butterfly into NEON/AVX SIMD.
+/// The chunk-based iteration gives LLVM enough structure to auto-vectorize each butterfly call
+/// into NEON/AVX SIMD instructions.
 fn walsh_hadamard_transform(buf: &mut [f32]) {
     let len = buf.len();
     debug_assert!(len.is_power_of_two());
@@ -225,9 +230,11 @@ fn walsh_hadamard_transform(buf: &mut [f32]) {
     }
 }
 
-/// Butterfly: `lo[i], hi[i] = lo[i] + hi[i], lo[i] - hi[i]`.
+/// Butterfly: `(lo[i], hi[i]) -> (lo[i] + hi[i], lo[i] - hi[i])`.
 ///
-/// Separate function so LLVM can see the slice lengths match and auto-vectorize.
+/// This is multiplication by the 2x2 Hadamard kernel `H_2 = [[1, 1], [1, -1]]` on each element
+/// pair. Factored into a separate function so LLVM can see the slice lengths match and
+/// auto-vectorize.
 #[inline(always)]
 fn butterfly(lo: &mut [f32], hi: &mut [f32]) {
     debug_assert_eq!(lo.len(), hi.len());

--- a/vortex-tensor/src/encodings/turboquant/array/scheme.rs
+++ b/vortex-tensor/src/encodings/turboquant/array/scheme.rs
@@ -96,11 +96,11 @@ fn estimate_compression_ratio(bits_per_element: u8, dimensions: u32, num_vectors
         + (config.bit_width as usize) * padded_dim; // MSE codes
 
     // Shared overhead: codebook centroids (2^bit_width f32 values) and
-    // rotation signs (3 * padded_dim bits).
+    // rotation signs (num_rounds * padded_dim bits).
     let num_centroids = 1usize << config.bit_width;
     debug_assert!(num_centroids <= TurboQuant::MAX_CENTROIDS);
     let overhead_bits = num_centroids * 32 // centroids are always f32
-        + 3 * padded_dim; // rotation signs, 1 bit each
+        + config.num_rounds as usize * padded_dim; // rotation signs, 1 bit each
 
     let compressed_size_bits = compressed_bits_per_vector * num_vectors + overhead_bits;
 

--- a/vortex-tensor/src/encodings/turboquant/compress.rs
+++ b/vortex-tensor/src/encodings/turboquant/compress.rs
@@ -41,6 +41,8 @@ pub struct TurboQuantConfig {
     pub bit_width: u8,
     /// Optional seed for the rotation matrix. If None, the default seed is used.
     pub seed: Option<u64>,
+    /// Number of sign-diagonal + WHT rounds in the structured rotation (default 3).
+    pub num_rounds: u8,
 }
 
 impl Default for TurboQuantConfig {
@@ -48,6 +50,7 @@ impl Default for TurboQuantConfig {
         Self {
             bit_width: TurboQuant::MAX_BIT_WIDTH,
             seed: Some(42),
+            num_rounds: 3,
         }
     }
 }
@@ -108,6 +111,7 @@ fn turboquant_quantize_core(
     fsl: &FixedSizeListArray,
     seed: u64,
     bit_width: u8,
+    num_rounds: u8,
     validity: &Validity,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<QuantizationResult> {
@@ -134,7 +138,7 @@ fn turboquant_quantize_core(
             .collect()
     });
 
-    let rotation = RotationMatrix::try_new(seed, dimension)?;
+    let rotation = RotationMatrix::try_new(seed, dimension, num_rounds as usize)?;
     let padded_dim = rotation.padded_dim();
     let padded_dim_u32 =
         u32::try_from(padded_dim).vortex_expect("padded_dim stays representable as u32");
@@ -264,7 +268,12 @@ pub fn turboquant_encode(
         });
 
         let empty_centroids = PrimitiveArray::empty::<f32>(Nullability::NonNullable);
-        let empty_signs = PrimitiveArray::empty::<u8>(Nullability::NonNullable);
+        let empty_signs = FixedSizeListArray::try_new(
+            PrimitiveArray::empty::<u8>(Nullability::NonNullable).into_array(),
+            padded_dim,
+            Validity::NonNullable,
+            0,
+        )?;
         return Ok(TurboQuant::try_new_array(
             ext_dtype,
             empty_codes.into_array(),
@@ -277,20 +286,39 @@ pub fn turboquant_encode(
 
     let validity = ext.as_ref().validity()?;
     let seed = config.seed.unwrap_or(42);
-    let core = turboquant_quantize_core(ext, &fsl, seed, config.bit_width, &validity, ctx)?;
+    let core = turboquant_quantize_core(
+        ext,
+        &fsl,
+        seed,
+        config.bit_width,
+        config.num_rounds,
+        &validity,
+        ctx,
+    )?;
 
     Ok(build_turboquant(&fsl, core, ext_dtype)?.into_array())
 }
 
-/// Export rotation signs as a 1-bit `BitPackedArray` for efficient storage.
+/// Export rotation signs as a `FixedSizeListArray` wrapping a 1-bit [`BitPackedArray`].
 ///
-/// The rotation matrix's 3 x padded_dim sign values are exported as 0/1 u8
-/// values in inverse application order, then bitpacked to 1 bit per sign.
-/// On decode, FastLanes SIMD-unpacks back to `&[u8]` of 0/1 values.
+/// The rotation matrix's `num_rounds * padded_dim` sign values are exported as 0/1 u8 values in
+/// inverse application order, bitpacked to 1 bit per sign, then wrapped in a
+/// `FixedSizeListArray` with `list_size = padded_dim` and `len = num_rounds`.
 fn bitpack_rotation_signs(rotation: &RotationMatrix) -> VortexResult<ArrayRef> {
     let signs_u8 = rotation.export_inverse_signs_u8();
+    let num_rounds = rotation.num_rounds();
+    let padded_dim = u32::try_from(rotation.padded_dim()).vortex_expect("padded_dim fits in u32");
+
     let mut buf = BufferMut::<u8>::with_capacity(signs_u8.len());
     buf.extend_from_slice(&signs_u8);
     let prim = PrimitiveArray::new::<u8>(buf.freeze(), Validity::NonNullable);
-    Ok(bitpack_encode(&prim, 1, None)?.into_array())
+    let bitpacked = bitpack_encode(&prim, 1, None)?;
+
+    let fsl = FixedSizeListArray::try_new(
+        bitpacked.into_array(),
+        padded_dim,
+        Validity::NonNullable,
+        num_rounds,
+    )?;
+    Ok(fsl.into_array())
 }

--- a/vortex-tensor/src/encodings/turboquant/decompress.rs
+++ b/vortex-tensor/src/encodings/turboquant/decompress.rs
@@ -62,14 +62,20 @@ pub fn execute_decompress(
     let centroids_prim = array.centroids().clone().execute::<PrimitiveArray>(ctx)?;
     let centroids = centroids_prim.as_slice::<f32>();
 
-    // FastLanes SIMD-unpacks the 1-bit bitpacked rotation signs into u8 0/1 values, then we expand
-    // to u32 XOR masks once (amortized over all rows). This enables branchless XOR-based sign
-    // application in the per-row structured-rotation hot loop.
-    let signs_prim = array
+    // The rotation signs are stored as a FixedSizeListArray wrapping bitpacked u8 values.
+    // We unwrap to the flat elements, then FastLanes SIMD-unpacks the 1-bit values into u8 0/1.
+    // These are expanded to u32 XOR masks once (amortized over all rows), enabling branchless
+    // XOR-based sign application in the per-row structured-rotation hot loop.
+    let num_rounds = array.num_rounds() as usize;
+    let signs_fsl = array
         .rotation_signs()
         .clone()
+        .execute::<FixedSizeListArray>(ctx)?;
+    let signs_prim = signs_fsl
+        .elements()
+        .clone()
         .execute::<PrimitiveArray>(ctx)?;
-    let rotation = RotationMatrix::from_u8_slice(signs_prim.as_slice::<u8>(), dim)?;
+    let rotation = RotationMatrix::from_u8_slice(signs_prim.as_slice::<u8>(), dim, num_rounds)?;
 
     // Unpack codes from FixedSizeListArray -> flat u8 elements.
     let codes_fsl = array.codes().clone().execute::<FixedSizeListArray>(ctx)?;

--- a/vortex-tensor/src/encodings/turboquant/metadata.rs
+++ b/vortex-tensor/src/encodings/turboquant/metadata.rs
@@ -16,13 +16,18 @@ pub(super) struct TurboQuantMetadata {
     /// The number of bits per coordinate, which must be <= [`TurboQuant::MAX_BIT_WIDTH`].
     #[prost(uint32, required, tag = "1")]
     bit_width: u32,
+
+    /// The number of sign-diagonal + WHT rounds in the structured rotation.
+    #[prost(uint32, required, tag = "2")]
+    num_rounds: u32,
 }
 
 impl TurboQuantMetadata {
-    /// Creates metadata for the given bit width.
-    pub(super) fn new(bit_width: u8) -> Self {
+    /// Creates metadata for the given bit width and number of rotation rounds.
+    pub(super) fn new(bit_width: u8, num_rounds: u8) -> Self {
         Self {
             bit_width: u32::from(bit_width),
+            num_rounds: u32::from(num_rounds),
         }
     }
 
@@ -42,6 +47,18 @@ impl TurboQuantMetadata {
 
         Ok(bit_width)
     }
+
+    /// Returns the validated number of rotation rounds.
+    ///
+    /// Returns 0 for degenerate (empty) arrays, which is validated at a higher level.
+    pub(super) fn num_rounds(&self) -> VortexResult<u8> {
+        u8::try_from(self.num_rounds).map_err(|_| {
+            vortex_err!(
+                "TurboQuant num_rounds must fit into u8, got {}",
+                self.num_rounds
+            )
+        })
+    }
 }
 
 #[cfg(test)]
@@ -53,15 +70,19 @@ mod tests {
     use super::TurboQuantMetadata;
 
     #[rstest]
-    #[case(0)]
-    #[case(3)]
-    #[case(8)]
-    fn protobuf_metadata_roundtrip(#[case] bit_width: u8) -> VortexResult<()> {
-        let bytes = TurboQuantMetadata::new(bit_width).encode_to_vec();
-        assert_eq!(
-            TurboQuantMetadata::decode(bytes.as_slice())?.bit_width()?,
-            bit_width
-        );
+    #[case(0, 0)]
+    #[case(0, 3)]
+    #[case(3, 1)]
+    #[case(8, 3)]
+    #[case(8, 5)]
+    fn protobuf_metadata_roundtrip(
+        #[case] bit_width: u8,
+        #[case] num_rounds: u8,
+    ) -> VortexResult<()> {
+        let bytes = TurboQuantMetadata::new(bit_width, num_rounds).encode_to_vec();
+        let decoded = TurboQuantMetadata::decode(bytes.as_slice())?;
+        assert_eq!(decoded.bit_width()?, bit_width);
+        assert_eq!(decoded.num_rounds()?, num_rounds);
 
         Ok(())
     }

--- a/vortex-tensor/src/encodings/turboquant/mod.rs
+++ b/vortex-tensor/src/encodings/turboquant/mod.rs
@@ -96,7 +96,7 @@
 //! let ext = ExtensionArray::new(ext_dtype, fsl.into_array());
 //!
 //! // Quantize at 2 bits per coordinate.
-//! let config = TurboQuantConfig { bit_width: 2, seed: Some(42) };
+//! let config = TurboQuantConfig { bit_width: 2, seed: Some(42), num_rounds: 3 };
 //! let session = VortexSession::empty().with::<ArraySession>();
 //! let mut ctx = session.create_execution_ctx();
 //! let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx).unwrap();

--- a/vortex-tensor/src/encodings/turboquant/tests.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests.rs
@@ -8,6 +8,7 @@ use rand::rngs::StdRng;
 use rand_distr::Distribution;
 use rand_distr::Normal;
 use rstest::rstest;
+use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ExtensionArray;
@@ -15,6 +16,7 @@ use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
+use vortex_array::dtype::Nullability;
 use vortex_array::dtype::extension::ExtDType;
 use vortex_array::extension::EmptyMetadata;
 use vortex_array::session::ArraySession;
@@ -148,6 +150,38 @@ fn encode_decode(
     Ok((original, decoded_elements))
 }
 
+fn empty_turboquant_parts(
+    dim: u32,
+) -> VortexResult<(
+    vortex_array::dtype::DType,
+    ArrayRef,
+    ArrayRef,
+    ArrayRef,
+    ArrayRef,
+)> {
+    let fsl = make_fsl(0, dim as usize, 42);
+    let ext = make_vector_ext(&fsl);
+
+    let codes = FixedSizeListArray::try_new(
+        PrimitiveArray::empty::<u8>(Nullability::NonNullable).into_array(),
+        dim,
+        Validity::NonNullable,
+        0,
+    )?
+    .into_array();
+    let norms = PrimitiveArray::empty::<f32>(ext.dtype().nullability()).into_array();
+    let centroids = PrimitiveArray::empty::<f32>(Nullability::NonNullable).into_array();
+    let rotation_signs = FixedSizeListArray::try_new(
+        PrimitiveArray::empty::<u8>(Nullability::NonNullable).into_array(),
+        dim,
+        Validity::NonNullable,
+        0,
+    )?
+    .into_array();
+
+    Ok((ext.dtype().clone(), codes, norms, centroids, rotation_signs))
+}
+
 // -----------------------------------------------------------------------
 // Roundtrip tests
 // -----------------------------------------------------------------------
@@ -169,6 +203,48 @@ fn roundtrip(#[case] dim: usize, #[case] bit_width: u8) -> VortexResult<()> {
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
     assert_eq!(decoded.len(), original.len());
+    Ok(())
+}
+
+#[test]
+fn empty_try_new_rejects_invalid_norms_dtype() -> VortexResult<()> {
+    let (dtype, codes, _norms, centroids, rotation_signs) = empty_turboquant_parts(128)?;
+    let wrong_norms = PrimitiveArray::empty::<f64>(dtype.nullability()).into_array();
+
+    let err = TurboQuant::try_new_array(dtype, codes, wrong_norms, centroids, rotation_signs)
+        .unwrap_err();
+
+    assert!(err.to_string().contains("norms dtype does not match"));
+    Ok(())
+}
+
+#[test]
+fn empty_try_new_rejects_invalid_centroids_dtype() -> VortexResult<()> {
+    let (dtype, codes, norms, _centroids, rotation_signs) = empty_turboquant_parts(128)?;
+    let wrong_centroids = PrimitiveArray::empty::<f64>(Nullability::NonNullable).into_array();
+
+    let err = TurboQuant::try_new_array(dtype, codes, norms, wrong_centroids, rotation_signs)
+        .unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("centroids dtype must be non-nullable f32")
+    );
+    Ok(())
+}
+
+#[test]
+fn empty_try_new_rejects_invalid_rotation_signs_dtype() -> VortexResult<()> {
+    let (dtype, codes, norms, centroids, _rotation_signs) = empty_turboquant_parts(128)?;
+    let wrong_rotation_signs = PrimitiveArray::empty::<u8>(Nullability::NonNullable).into_array();
+
+    let err = TurboQuant::try_new_array(dtype, codes, norms, centroids, wrong_rotation_signs)
+        .unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("rotation_signs dtype does not match")
+    );
     Ok(())
 }
 

--- a/vortex-tensor/src/encodings/turboquant/tests.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests.rs
@@ -165,6 +165,7 @@ fn roundtrip(#[case] dim: usize, #[case] bit_width: u8) -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width,
         seed: Some(123),
+        num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
     assert_eq!(decoded.len(), original.len());
@@ -188,6 +189,7 @@ fn mse_within_theoretical_bound(#[case] dim: usize, #[case] bit_width: u8) -> Vo
     let config = TurboQuantConfig {
         bit_width,
         seed: Some(123),
+        num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
 
@@ -214,6 +216,7 @@ fn high_bitwidth_mse_is_small(#[case] dim: usize, #[case] bit_width: u8) -> Vort
     let config_4bit = TurboQuantConfig {
         bit_width: 4,
         seed: Some(123),
+        num_rounds: 3,
     };
     let (original_4, decoded_4) = encode_decode(&fsl, &config_4bit)?;
     let mse_4bit = per_vector_normalized_mse(&original_4, &decoded_4, dim, num_rows);
@@ -221,6 +224,7 @@ fn high_bitwidth_mse_is_small(#[case] dim: usize, #[case] bit_width: u8) -> Vort
     let config = TurboQuantConfig {
         bit_width,
         seed: Some(123),
+        num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
     let mse = per_vector_normalized_mse(&original, &decoded, dim, num_rows);
@@ -244,6 +248,7 @@ fn mse_decreases_with_bits() -> VortexResult<()> {
         let config = TurboQuantConfig {
             bit_width,
             seed: Some(123),
+            num_rounds: 3,
         };
         let (original, decoded) = encode_decode(&fsl, &config)?;
         let mse = per_vector_normalized_mse(&original, &decoded, dim, num_rows);
@@ -269,6 +274,7 @@ fn roundtrip_edge_cases(#[case] num_rows: usize) -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 2,
         seed: Some(123),
+        num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -287,6 +293,7 @@ fn rejects_dimension_below_128(#[case] dim: usize) {
     let config = TurboQuantConfig {
         bit_width: 2,
         seed: Some(0),
+        num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
     assert!(turboquant_encode(ext.as_view(), &config, &mut ctx).is_err());
@@ -326,6 +333,7 @@ fn all_zero_vectors_roundtrip() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(42),
+        num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
     // All-zero vectors should decode to all-zero (norm=0 -> 0 * anything = 0).
@@ -361,6 +369,7 @@ fn f64_input_encodes_successfully() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(42),
+        num_rounds: 3,
     };
     // Verify encoding succeeds with f64 input (f64->f32 conversion).
     let mut ctx = SESSION.create_execution_ctx();
@@ -396,6 +405,7 @@ fn f16_input_encodes_successfully() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(42),
+        num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -425,6 +435,7 @@ fn stored_centroids_match_computed() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(123),
+        num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -455,6 +466,7 @@ fn stored_rotation_signs_produce_correct_decode() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(123),
+        num_rounds: 4,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -477,10 +489,14 @@ fn stored_rotation_signs_produce_correct_decode() -> VortexResult<()> {
     let decoded_slice = decoded.as_slice::<f32>();
 
     // Verify stored signs match seed-derived signs.
-    let rot_from_seed = RotationMatrix::try_new(123, 128)?;
+    let rot_from_seed = RotationMatrix::try_new(123, 128, 4)?;
     let expected_u8 = rot_from_seed.export_inverse_signs_u8();
-    let stored_signs = encoded
+    let stored_signs_fsl = encoded
         .rotation_signs()
+        .clone()
+        .execute::<FixedSizeListArray>(&mut ctx)?;
+    let stored_signs = stored_signs_fsl
+        .elements()
         .clone()
         .execute::<PrimitiveArray>(&mut ctx)?;
     let stored_u8 = stored_signs.as_slice::<u8>();
@@ -506,6 +522,7 @@ fn slice_preserves_data() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(123),
+        num_rounds: 4,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -550,6 +567,7 @@ fn scalar_at_matches_decompress() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(123),
+        num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -571,6 +589,7 @@ fn l2_norm_readthrough() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(123),
+        num_rounds: 5,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -602,6 +621,7 @@ fn cosine_similarity_quantized_accuracy() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 4,
         seed: Some(123),
+        num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -679,6 +699,7 @@ fn dot_product_quantized_accuracy() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 8,
         seed: Some(123),
+        num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -748,6 +769,7 @@ fn large_dimension_roundtrip(#[case] dim: usize, #[case] bit_width: u8) -> Vorte
     let config = TurboQuantConfig {
         bit_width,
         seed: Some(123),
+        num_rounds: 3,
     };
     let (original, decoded) = encode_decode(&fsl, &config)?;
     assert_eq!(decoded.len(), original.len());
@@ -770,6 +792,7 @@ fn encoded_dtype_is_vector_extension() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(123),
+        num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -804,6 +827,7 @@ fn nullable_vectors_roundtrip() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(123),
+        num_rounds: 4,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -869,6 +893,7 @@ fn nullable_norms_match_validity() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 2,
         seed: Some(123),
+        num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -896,6 +921,7 @@ fn nullable_l2_norm_readthrough() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(123),
+        num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -940,6 +966,7 @@ fn nullable_slice_preserves_validity() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(123),
+        num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -982,6 +1009,7 @@ fn serde_roundtrip() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 3,
         seed: Some(123),
+        num_rounds: 5,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
@@ -1036,6 +1064,7 @@ fn serde_roundtrip_empty() -> VortexResult<()> {
     let config = TurboQuantConfig {
         bit_width: 2,
         seed: Some(123),
+        num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
     let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;

--- a/vortex-tensor/src/encodings/turboquant/vtable.rs
+++ b/vortex-tensor/src/encodings/turboquant/vtable.rs
@@ -105,7 +105,12 @@ impl TurboQuant {
             u8::try_from(centroids.len().trailing_zeros())
                 .map_err(|_| vortex_err!("centroids bit_width does not fit in u8"))?
         };
-        let data = TurboQuantData::try_new(vector_metadata.dimensions(), bit_width)?;
+
+        // Derive num_rounds from the FSL rotation_signs length (0 for degenerate arrays).
+        let num_rounds = u8::try_from(rotation_signs.len())
+            .map_err(|_| vortex_err!("rotation_signs num_rounds does not fit in u8"))?;
+
+        let data = TurboQuantData::try_new(vector_metadata.dimensions(), bit_width, num_rounds)?;
         let parts = ArrayParts::new(TurboQuant, dtype, len, data).with_slots(
             TurboQuantData::make_slots(codes, norms, centroids, rotation_signs),
         );
@@ -176,6 +181,15 @@ impl VTable for TurboQuant {
             "TurboQuant bit_width does not match centroids slot",
         );
 
+        // Verify num_rounds matches the rotation_signs FSL length.
+        let expected_num_rounds = u8::try_from(rotation_signs.len())
+            .map_err(|_| vortex_err!("rotation_signs num_rounds does not fit in u8"))?;
+        vortex_ensure_eq!(
+            data.num_rounds,
+            expected_num_rounds,
+            "TurboQuant num_rounds does not match rotation_signs slot",
+        );
+
         Ok(())
     }
 
@@ -193,7 +207,7 @@ impl VTable for TurboQuant {
 
     fn serialize(array: ArrayView<'_, Self>) -> VortexResult<Option<Vec<u8>>> {
         Ok(Some(
-            TurboQuantMetadata::new(array.bit_width).encode_to_vec(),
+            TurboQuantMetadata::new(array.bit_width, array.num_rounds).encode_to_vec(),
         ))
     }
 
@@ -208,12 +222,16 @@ impl VTable for TurboQuant {
     ) -> VortexResult<ArrayParts<Self>> {
         let metadata = TurboQuantMetadata::decode(metadata)?;
         let bit_width = metadata.bit_width()?;
+        let num_rounds = metadata.num_rounds()?;
 
-        // bit_width == 0 is only valid for degenerate (empty) arrays. A non-empty array with
-        // bit_width == 0 would have zero centroids while codes reference centroid indices.
+        // bit_width == 0 and num_rounds == 0 are only valid for degenerate (empty) arrays.
         vortex_ensure!(
             bit_width > 0 || len == 0,
             "bit_width == 0 is only valid for empty arrays, got len={len}"
+        );
+        vortex_ensure!(
+            num_rounds > 0 || len == 0,
+            "num_rounds == 0 is only valid for empty arrays, got len={len}"
         );
 
         // Validate and derive dimension and element ptype from the Vector extension dtype.
@@ -244,9 +262,13 @@ impl VTable for TurboQuant {
         let centroids_dtype = DType::Primitive(PType::F32, Nullability::NonNullable);
         let centroids = children.get(2, &centroids_dtype, num_centroids)?;
 
-        // Get the rotation array.
-        let signs_len = if len == 0 { 0 } else { 3 * padded_dim as usize };
-        let signs_dtype = DType::Primitive(PType::U8, Nullability::NonNullable);
+        // Get the rotation signs array (FixedSizeList<u8> with list_size = padded_dim).
+        let signs_len = if len == 0 { 0 } else { num_rounds as usize };
+        let signs_dtype = DType::FixedSizeList(
+            Arc::new(DType::Primitive(PType::U8, Nullability::NonNullable)),
+            padded_dim,
+            Nullability::NonNullable,
+        );
         let rotation_signs = children.get(3, &signs_dtype, signs_len)?;
 
         Ok(ArrayParts::new(
@@ -256,6 +278,7 @@ impl VTable for TurboQuant {
             TurboQuantData {
                 dimension: dimensions,
                 bit_width,
+                num_rounds,
             },
         )
         .with_slots(TurboQuantData::make_slots(
@@ -301,11 +324,14 @@ impl ArrayHash for TurboQuantData {
     fn array_hash<H: Hasher>(&self, state: &mut H, _precision: Precision) {
         self.dimension.hash(state);
         self.bit_width.hash(state);
+        self.num_rounds.hash(state);
     }
 }
 
 impl ArrayEq for TurboQuantData {
     fn array_eq(&self, other: &Self, _precision: Precision) -> bool {
-        self.dimension == other.dimension && self.bit_width == other.bit_width
+        self.dimension == other.dimension
+            && self.bit_width == other.bit_width
+            && self.num_rounds == other.num_rounds
     }
 }

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -488,6 +488,7 @@ mod turboquant_benches {
         TurboQuantConfig {
             bit_width,
             seed: Some(123),
+            num_rounds: 3,
         }
     }
 


### PR DESCRIPTION
## Summary

Tracking issue: https://github.com/vortex-data/vortex/issues/7297

Adds the ability to have a dynamic number of rounds of FWHT rounds for the SORF algorithm. Previously, this was just hardcoded to 3.

Also fixes a small validation bug.

## Testing

Existing tests suffice, and then added some regression tests for the validation bug.