### PR TITLE
Use an unsafe trait to reinterpret packed struct references as bytes

### DIFF
--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -86,21 +86,25 @@ pub fn tag_to_ptype(tag: PTypeTag) -> PType {
     }
 }
 
-/// Serialize a `#[repr(C)]` struct to a byte vector for the packed plan.
+/// Reinterpret a reference to a packed type as a raw bytes slice.
 ///
-/// Copies field data into a pre-zeroed buffer so padding holes are
-/// deterministically zero, avoiding UB from reading uninitialised bytes.
-fn as_bytes<T: Sized>(val: &T) -> Vec<u8> {
-    let n = size_of::<T>();
-    let mut buf = vec![0u8; n];
-    // SAFETY: T is a bindgen-generated #[repr(C)] struct with only
-    // integer/float/enum fields. We overwrite the zeroed buffer with
-    // the struct's bytes; padding holes keep their zero value.
-    unsafe {
-        std::ptr::copy_nonoverlapping(std::ptr::addr_of!(*val).cast::<u8>(), buf.as_mut_ptr(), n);
+/// # Safety
+///
+/// The caller must ensure `T` is a `#[repr(C)]` type whose layout is
+/// compatible with the C ABI.  All the types we serialise (`PlanHeader`,
+/// `PackedStage`, `ScalarOp`) are bindgen-generated `#[repr(C)]` structs.
+/// Padding bytes may be uninitialised on the Rust side, but the C reader
+/// never inspects them, so the values are irrelevant.
+unsafe trait AsPackedBytes: Sized {
+    /// Reinterpret a `&T` as a byte slice for serialization into the packed plan.
+    fn as_packed_bytes(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(std::ptr::addr_of!(*self).cast(), size_of::<Self>()) }
     }
-    buf
 }
+
+unsafe impl AsPackedBytes for PlanHeader {}
+unsafe impl AsPackedBytes for PackedStage {}
+unsafe impl AsPackedBytes for ScalarOp {}
 
 /// A stage used to build a [`CudaDispatchPlan`] on the host side.
 ///
@@ -210,7 +214,7 @@ impl CudaDispatchPlan {
             output_ptype,
             plan_size_bytes: total_size as u16,
         };
-        buffer.extend_from_slice(&as_bytes(&header));
+        buffer.extend_from_slice(header.as_packed_bytes());
 
         for stage in &stages {
             let packed_stage = PackedStage {
@@ -221,9 +225,9 @@ impl CudaDispatchPlan {
                 num_scalar_ops: stage.scalar_ops.len() as u8,
                 source_ptype: stage.source_ptype,
             };
-            buffer.extend_from_slice(&as_bytes(&packed_stage));
+            buffer.extend_from_slice(packed_stage.as_packed_bytes());
             for op in &stage.scalar_ops {
-                buffer.extend_from_slice(&as_bytes(op));
+                buffer.extend_from_slice(op.as_packed_bytes());
             }
         }
 


### PR DESCRIPTION
## Summary

This is a cosmetic change to make it clearer what is happening when re-interpreting references as raw bytes to serialize plans, making it harder to mis-use by making it a more specific trait.