### PR TITLE
Don't re-run benchmarks nightly

### DIFF
--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -23,33 +23,8 @@ jobs:
     with:
       mode: "develop"
       machine_type: ${{ matrix.machine_type.instance_name }}
-      # datafusion:vortex uses a lot of memory
       benchmark_matrix: |
         [
-          {
-            "id": "clickbench-nvme",
-            "subcommand": "clickbench",
-            "name": "Clickbench on NVME",
-            "targets": "datafusion:parquet,datafusion:vortex,datafusion:vortex-compact,datafusion:lance,duckdb:parquet,duckdb:vortex,duckdb:vortex-compact,duckdb:duckdb",
-            "build_lance": true
-          },
-          {
-            "id": "tpch-nvme",
-            "subcommand": "tpch",
-            "name": "TPC-H on NVME",
-            "targets": "datafusion:parquet,datafusion:vortex,datafusion:lance,duckdb:parquet,duckdb:vortex,duckdb:duckdb",
-            "scale_factor": "10.0",
-            "build_lance": true
-          },
-          {
-            "id": "tpch-s3",
-            "subcommand": "tpch",
-            "name": "TPC-H on S3",
-            "local_dir": "vortex-bench/data/tpch/10.0",
-            "remote_storage": "s3://vortex-ci-benchmark-datasets/${{github.ref_name}}/${{github.run_id}}/tpch/10.0/",
-            "targets": "datafusion:parquet,datafusion:vortex,duckdb:parquet,duckdb:vortex",
-            "scale_factor": "10.0"
-          },
           {
             "id": "tpch-nvme",
             "subcommand": "tpch",
@@ -74,6 +49,3 @@ jobs:
         machine_type:
           - id: x86
             instance_name: c6id.8xlarge
-# TODO(joe): support other arch
-#          - id: arm64
-#            instance_name: c6gd.8xlarge


### PR DESCRIPTION
We currently run some of the same benchmarks both nightly and per-commit, which pollutes the data file, which causes [failures](https://github.com/vortex-data/vortex/actions/runs/24129409553/job/70402005592) when comparing runs like in and is also just wasteful.

```
  File "/home/runner/_work/vortex/vortex/scripts/compare-benchmark-jsons.py", line 629, in <module>
    main()
  File "/home/runner/_work/vortex/vortex/scripts/compare-benchmark-jsons.py", line 516, in main
    statistical_analysis = build_statistical_analysis(df3, threshold_pct)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/_work/vortex/vortex/scripts/compare-benchmark-jsons.py", line 300, in build_statistical_analysis
    log_ratio_table = detail_df.pivot(index="query", columns="combo", values="log_ratio")
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/uv/environments-v2/compare-benchmark-jsons-6c3240f590b6fe2d/lib/python3.11/site-packages/pandas/core/frame.py", line 10974, in pivot
    return pivot(self, index=index, columns=columns, values=values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/uv/environments-v2/compare-benchmark-jsons-6c3240f590b6fe2d/lib/python3.11/site-packages/pandas/core/reshape/pivot.py", line 910, in pivot
    result = cast("DataFrame", indexed.unstack(columns_listlike))  # type: ignore[arg-type]
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/uv/environments-v2/compare-benchmark-jsons-6c3240f590b6fe2d/lib/python3.11/site-packages/pandas/core/series.py", line 4501, in unstack
    return unstack(self, level, fill_value, sort)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/uv/environments-v2/compare-benchmark-jsons-6c3240f590b6fe2d/lib/python3.11/site-packages/pandas/core/reshape/reshape.py", line 596, in unstack
    unstacker = _Unstacker(
                ^^^^^^^^^^^
  File "/home/runner/.cache/uv/environments-v2/compare-benchmark-jsons-6c3240f590b6fe2d/lib/python3.11/site-packages/pandas/core/reshape/reshape.py", line 176, in __init__
    self._make_selectors()
  File "/home/runner/.cache/uv/environments-v2/compare-benchmark-jsons-6c3240f590b6fe2d/lib/python3.11/site-packages/pandas/core/reshape/reshape.py", line 232, in _make_selectors
    raise ValueError("Index contains duplicate entries, cannot reshape")
ValueError: Index contains duplicate entries, cannot reshape
```