### PR TITLE
Pull out `L2Denorm` from TurboQuant

### DIFF
--- a/vortex-tensor/public-api.lock
+++ b/vortex-tensor/public-api.lock
@@ -16,6 +16,8 @@ pub const vortex_tensor::encodings::turboquant::TurboQuant::MAX_CENTROIDS: usize
 
 pub const vortex_tensor::encodings::turboquant::TurboQuant::MIN_DIMENSION: u32
 
+pub unsafe fn vortex_tensor::encodings::turboquant::TurboQuant::new_array_unchecked(dtype: vortex_array::dtype::DType, codes: vortex_array::array::erased::ArrayRef, centroids: vortex_array::array::erased::ArrayRef, rotation_signs: vortex_array::array::erased::ArrayRef) -> vortex_tensor::encodings::turboquant::TurboQuantArray
+
 pub fn vortex_tensor::encodings::turboquant::TurboQuant::try_new_array(dtype: vortex_array::dtype::DType, codes: vortex_array::array::erased::ArrayRef, centroids: vortex_array::array::erased::ArrayRef, rotation_signs: vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_tensor::encodings::turboquant::TurboQuantArray>
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuant::validate_dtype(dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_tensor::vector::VectorMatcherMetadata>
@@ -175,6 +177,8 @@ pub fn T::codes(&self) -> &vortex_array::array::erased::ArrayRef
 pub fn T::rotation_signs(&self) -> &vortex_array::array::erased::ArrayRef
 
 pub fn vortex_tensor::encodings::turboquant::turboquant_encode(ext: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::extension::vtable::Extension>, config: &vortex_tensor::encodings::turboquant::TurboQuantConfig, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+
+pub unsafe fn vortex_tensor::encodings::turboquant::turboquant_encode_unchecked(ext: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::extension::vtable::Extension>, config: &vortex_tensor::encodings::turboquant::TurboQuantConfig, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub type vortex_tensor::encodings::turboquant::TurboQuantArray = vortex_array::array::typed::Array<vortex_tensor::encodings::turboquant::TurboQuant>
 
@@ -453,6 +457,8 @@ pub fn vortex_tensor::scalar_fns::l2_denorm::L2Denorm::is_null_sensitive(&self, 
 pub fn vortex_tensor::scalar_fns::l2_denorm::L2Denorm::return_dtype(&self, _options: &Self::Options, arg_dtypes: &[vortex_array::dtype::DType]) -> vortex_error::VortexResult<vortex_array::dtype::DType>
 
 pub fn vortex_tensor::scalar_fns::l2_denorm::L2Denorm::validity(&self, _options: &Self::Options, expression: &vortex_array::expr::expression::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::expression::Expression>>
+
+pub fn vortex_tensor::scalar_fns::l2_denorm::normalize_as_l2_denorm(options: &vortex_tensor::scalar_fns::ApproxOptions, input: vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::scalar_fn::vtable::ScalarFnArray>
 
 pub mod vortex_tensor::scalar_fns::l2_norm
 

--- a/vortex-tensor/public-api.lock
+++ b/vortex-tensor/public-api.lock
@@ -16,7 +16,7 @@ pub const vortex_tensor::encodings::turboquant::TurboQuant::MAX_CENTROIDS: usize
 
 pub const vortex_tensor::encodings::turboquant::TurboQuant::MIN_DIMENSION: u32
 
-pub fn vortex_tensor::encodings::turboquant::TurboQuant::try_new_array(dtype: vortex_array::dtype::DType, codes: vortex_array::array::erased::ArrayRef, norms: vortex_array::array::erased::ArrayRef, centroids: vortex_array::array::erased::ArrayRef, rotation_signs: vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_tensor::encodings::turboquant::TurboQuantArray>
+pub fn vortex_tensor::encodings::turboquant::TurboQuant::try_new_array(dtype: vortex_array::dtype::DType, codes: vortex_array::array::erased::ArrayRef, centroids: vortex_array::array::erased::ArrayRef, rotation_signs: vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_tensor::encodings::turboquant::TurboQuantArray>
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuant::validate_dtype(dtype: &vortex_array::dtype::DType) -> vortex_error::VortexResult<vortex_tensor::vector::VectorMatcherMetadata>
 
@@ -34,7 +34,7 @@ pub type vortex_tensor::encodings::turboquant::TurboQuant::ArrayData = vortex_te
 
 pub type vortex_tensor::encodings::turboquant::TurboQuant::OperationsVTable = vortex_tensor::encodings::turboquant::TurboQuant
 
-pub type vortex_tensor::encodings::turboquant::TurboQuant::ValidityVTable = vortex_array::array::vtable::validity::ValidityVTableFromChild
+pub type vortex_tensor::encodings::turboquant::TurboQuant::ValidityVTable = vortex_tensor::encodings::turboquant::TurboQuant
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuant::buffer(_array: vortex_array::array::view::ArrayView<'_, Self>, idx: usize) -> vortex_array::buffer::BufferHandle
 
@@ -62,9 +62,9 @@ impl vortex_array::array::vtable::operations::OperationsVTable<vortex_tensor::en
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuant::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_tensor::encodings::turboquant::TurboQuant>, index: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
-impl vortex_array::array::vtable::validity::ValidityChild<vortex_tensor::encodings::turboquant::TurboQuant> for vortex_tensor::encodings::turboquant::TurboQuant
+impl vortex_array::array::vtable::validity::ValidityVTable<vortex_tensor::encodings::turboquant::TurboQuant> for vortex_tensor::encodings::turboquant::TurboQuant
 
-pub fn vortex_tensor::encodings::turboquant::TurboQuant::validity_child(array: vortex_array::array::view::ArrayView<'_, vortex_tensor::encodings::turboquant::TurboQuant>) -> vortex_array::array::erased::ArrayRef
+pub fn vortex_tensor::encodings::turboquant::TurboQuant::validity(_array: vortex_array::array::view::ArrayView<'_, vortex_tensor::encodings::turboquant::TurboQuant>) -> vortex_error::VortexResult<vortex_array::validity::Validity>
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_tensor::encodings::turboquant::TurboQuant
 
@@ -110,7 +110,7 @@ pub fn vortex_tensor::encodings::turboquant::TurboQuantData::padded_dim(&self) -
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuantData::try_new(dimension: u32, bit_width: u8, num_rounds: u8) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_tensor::encodings::turboquant::TurboQuantData::validate(dtype: &vortex_array::dtype::DType, codes: &vortex_array::array::erased::ArrayRef, norms: &vortex_array::array::erased::ArrayRef, centroids: &vortex_array::array::erased::ArrayRef, rotation_signs: &vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<()>
+pub fn vortex_tensor::encodings::turboquant::TurboQuantData::validate(dtype: &vortex_array::dtype::DType, codes: &vortex_array::array::erased::ArrayRef, centroids: &vortex_array::array::erased::ArrayRef, rotation_signs: &vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<()>
 
 impl core::clone::Clone for vortex_tensor::encodings::turboquant::TurboQuantData
 
@@ -164,8 +164,6 @@ pub fn vortex_tensor::encodings::turboquant::TurboQuantArrayExt::centroids(&self
 
 pub fn vortex_tensor::encodings::turboquant::TurboQuantArrayExt::codes(&self) -> &vortex_array::array::erased::ArrayRef
 
-pub fn vortex_tensor::encodings::turboquant::TurboQuantArrayExt::norms(&self) -> &vortex_array::array::erased::ArrayRef
-
 pub fn vortex_tensor::encodings::turboquant::TurboQuantArrayExt::rotation_signs(&self) -> &vortex_array::array::erased::ArrayRef
 
 impl<T: vortex_array::array::typed::TypedArrayRef<vortex_tensor::encodings::turboquant::TurboQuant>> vortex_tensor::encodings::turboquant::TurboQuantArrayExt for T
@@ -173,8 +171,6 @@ impl<T: vortex_array::array::typed::TypedArrayRef<vortex_tensor::encodings::turb
 pub fn T::centroids(&self) -> &vortex_array::array::erased::ArrayRef
 
 pub fn T::codes(&self) -> &vortex_array::array::erased::ArrayRef
-
-pub fn T::norms(&self) -> &vortex_array::array::erased::ArrayRef
 
 pub fn T::rotation_signs(&self) -> &vortex_array::array::erased::ArrayRef
 

--- a/vortex-tensor/public-api.lock
+++ b/vortex-tensor/public-api.lock
@@ -430,7 +430,9 @@ impl vortex_tensor::scalar_fns::l2_denorm::L2Denorm
 
 pub fn vortex_tensor::scalar_fns::l2_denorm::L2Denorm::new(options: &vortex_tensor::scalar_fns::ApproxOptions) -> vortex_array::scalar_fn::typed::ScalarFn<vortex_tensor::scalar_fns::l2_denorm::L2Denorm>
 
-pub fn vortex_tensor::scalar_fns::l2_denorm::L2Denorm::try_new_array(options: &vortex_tensor::scalar_fns::ApproxOptions, normalized: vortex_array::array::erased::ArrayRef, norms: vortex_array::array::erased::ArrayRef, len: usize) -> vortex_error::VortexResult<vortex_array::arrays::scalar_fn::vtable::ScalarFnArray>
+pub unsafe fn vortex_tensor::scalar_fns::l2_denorm::L2Denorm::new_array_unchecked(options: &vortex_tensor::scalar_fns::ApproxOptions, normalized: vortex_array::array::erased::ArrayRef, norms: vortex_array::array::erased::ArrayRef, len: usize) -> vortex_error::VortexResult<vortex_array::arrays::scalar_fn::vtable::ScalarFnArray>
+
+pub fn vortex_tensor::scalar_fns::l2_denorm::L2Denorm::try_new_array(options: &vortex_tensor::scalar_fns::ApproxOptions, normalized: vortex_array::array::erased::ArrayRef, norms: vortex_array::array::erased::ArrayRef, len: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::scalar_fn::vtable::ScalarFnArray>
 
 impl core::clone::Clone for vortex_tensor::scalar_fns::l2_denorm::L2Denorm
 
@@ -459,6 +461,8 @@ pub fn vortex_tensor::scalar_fns::l2_denorm::L2Denorm::return_dtype(&self, _opti
 pub fn vortex_tensor::scalar_fns::l2_denorm::L2Denorm::validity(&self, _options: &Self::Options, expression: &vortex_array::expr::expression::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::expression::Expression>>
 
 pub fn vortex_tensor::scalar_fns::l2_denorm::normalize_as_l2_denorm(options: &vortex_tensor::scalar_fns::ApproxOptions, input: vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::scalar_fn::vtable::ScalarFnArray>
+
+pub fn vortex_tensor::scalar_fns::l2_denorm::validate_l2_normalized_rows(input: vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub mod vortex_tensor::scalar_fns::l2_norm
 

--- a/vortex-tensor/src/encodings/turboquant/array/data.rs
+++ b/vortex-tensor/src/encodings/turboquant/array/data.rs
@@ -19,12 +19,16 @@ use crate::encodings::turboquant::vtable::TurboQuant;
 /// TurboQuant array data.
 ///
 /// TurboQuant is a lossy vector quantization encoding for [`Vector`](crate::vector::Vector)
-/// extension arrays. It stores quantized coordinate codes and per-vector norms, along with shared
+/// extension arrays. It stores quantized coordinate codes for unit-norm vectors, along with shared
 /// codebook centroids and the parameters of the current structured rotation.
+///
+/// Norms should be stored externally in the [`L2Denorm`](crate::scalar_fns::l2_denorm::L2Denorm)
+/// `ScalarFnArray` wrapper.
 ///
 /// See the [module docs](crate::encodings::turboquant) for algorithmic details.
 ///
-/// A degenerate TurboQuant array has zero rows and `bit_width == 0`, with all slots empty.
+/// Note that degenerate TurboQuant arrays have zero rows and `bit_width == 0`, with all slots
+/// empty.
 #[derive(Clone, Debug)]
 pub struct TurboQuantData {
     /// The vector dimension `d`, cached from the `FixedSizeList` storage dtype's list size.
@@ -95,7 +99,6 @@ impl TurboQuantData {
     pub fn validate(
         dtype: &DType,
         codes: &ArrayRef,
-        norms: &ArrayRef,
         centroids: &ArrayRef,
         rotation_signs: &ArrayRef,
     ) -> VortexResult<()> {
@@ -103,8 +106,14 @@ impl TurboQuantData {
         let dimension = vector_metadata.dimensions();
         let padded_dim = dimension.next_power_of_two();
 
+        // TurboQuant arrays are always non-nullable. Nullability should be handled by the external
+        // L2Denorm ScalarFnArray wrapper.
+        vortex_ensure!(
+            !dtype.is_nullable(),
+            "TurboQuant dtype must be non-nullable, got {dtype}",
+        );
+
         // Codes must be a non-nullable FixedSizeList<u8> with list_size == padded_dim.
-        // Null vectors are represented by all-zero codes since validity lives in the norms array.
         let expected_codes_dtype = DType::FixedSizeList(
             Arc::new(DType::Primitive(PType::U8, Nullability::NonNullable)),
             padded_dim,
@@ -114,23 +123,6 @@ impl TurboQuantData {
             *codes.dtype(),
             expected_codes_dtype,
             "codes dtype does not match expected {expected_codes_dtype}",
-        );
-
-        let num_rows = codes.len();
-        vortex_ensure_eq!(
-            norms.len(),
-            num_rows,
-            "norms length must match codes length",
-        );
-
-        // Norms dtype must match the element ptype of the Vector, with the parent's nullability.
-        // Norms carry the validity of the entire TurboQuant array.
-        let element_ptype = vector_metadata.element_ptype();
-        let expected_norms_dtype = DType::Primitive(element_ptype, dtype.nullability());
-        vortex_ensure_eq!(
-            *norms.dtype(),
-            expected_norms_dtype,
-            "norms dtype does not match expected {expected_norms_dtype}",
         );
 
         // Centroids are always f32 regardless of element type.
@@ -154,6 +146,7 @@ impl TurboQuantData {
             "rotation_signs dtype does not match expected {expected_signs_dtype}",
         );
         // Degenerate (empty) case: all children must be empty, and bit_width is 0.
+        let num_rows = codes.len();
         if num_rows == 0 {
             vortex_ensure!(
                 centroids.is_empty(),
@@ -198,13 +191,11 @@ impl TurboQuantData {
 
     pub(crate) fn make_slots(
         codes: ArrayRef,
-        norms: ArrayRef,
         centroids: ArrayRef,
         rotation_signs: ArrayRef,
     ) -> Vec<Option<ArrayRef>> {
         let mut slots = vec![None; Slot::COUNT];
         slots[Slot::Codes as usize] = Some(codes);
-        slots[Slot::Norms as usize] = Some(norms);
         slots[Slot::Centroids as usize] = Some(centroids);
         slots[Slot::RotationSigns as usize] = Some(rotation_signs);
         slots
@@ -240,12 +231,6 @@ pub trait TurboQuantArrayExt: TypedArrayRef<TurboQuant> {
         self.as_ref().slots()[Slot::Codes as usize]
             .as_ref()
             .vortex_expect("TurboQuantArray codes slot")
-    }
-
-    fn norms(&self) -> &ArrayRef {
-        self.as_ref().slots()[Slot::Norms as usize]
-            .as_ref()
-            .vortex_expect("TurboQuantArray norms slot")
     }
 
     fn centroids(&self) -> &ArrayRef {

--- a/vortex-tensor/src/encodings/turboquant/array/slots.rs
+++ b/vortex-tensor/src/encodings/turboquant/array/slots.rs
@@ -2,22 +2,26 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 /// Slot positions for TurboQuantArray children.
+///
+/// Norms are not stored in the TurboQuantArray. They live in the external [`L2Denorm`]
+/// ScalarFnArray wrapper returned by [`turboquant_encode`].
+///
+/// [`L2Denorm`]: crate::scalar_fns::l2_denorm::L2Denorm
+/// [`turboquant_encode`]: crate::encodings::turboquant::turboquant_encode
 #[repr(usize)]
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum Slot {
     Codes = 0,
-    Norms = 1,
-    Centroids = 2,
-    RotationSigns = 3,
+    Centroids = 1,
+    RotationSigns = 2,
 }
 
 impl Slot {
-    pub(crate) const COUNT: usize = 4;
+    pub(crate) const COUNT: usize = 3;
 
     pub(crate) fn name(self) -> &'static str {
         match self {
             Self::Codes => "codes",
-            Self::Norms => "norms",
             Self::Centroids => "centroids",
             Self::RotationSigns => "rotation_signs",
         }
@@ -26,9 +30,8 @@ impl Slot {
     pub(crate) fn from_index(idx: usize) -> Self {
         match idx {
             0 => Self::Codes,
-            1 => Self::Norms,
-            2 => Self::Centroids,
-            3 => Self::RotationSigns,
+            1 => Self::Centroids,
+            2 => Self::RotationSigns,
             _ => vortex_error::vortex_panic!("invalid slot index {idx}"),
         }
     }

--- a/vortex-tensor/src/encodings/turboquant/compute/slice.rs
+++ b/vortex-tensor/src/encodings/turboquant/compute/slice.rs
@@ -17,14 +17,12 @@ impl SliceReduce for TurboQuant {
         array: ArrayView<'_, TurboQuant>,
         range: Range<usize>,
     ) -> VortexResult<Option<ArrayRef>> {
-        let sliced_codes = array.codes().slice(range.clone())?;
-        let sliced_norms = array.norms().slice(range)?;
+        let sliced_codes = array.codes().slice(range)?;
 
         Ok(Some(
             TurboQuant::try_new_array(
                 array.dtype().clone(),
                 sliced_codes,
-                sliced_norms,
                 array.centroids().clone(),
                 array.rotation_signs().clone(),
             )?

--- a/vortex-tensor/src/encodings/turboquant/compute/take.rs
+++ b/vortex-tensor/src/encodings/turboquant/compute/take.rs
@@ -19,13 +19,11 @@ impl TakeExecute for TurboQuant {
     ) -> VortexResult<Option<ArrayRef>> {
         // FSL children handle per-row take natively.
         let taken_codes = array.codes().take(indices.clone())?;
-        let taken_norms = array.norms().take(indices.clone())?;
 
         Ok(Some(
             TurboQuant::try_new_array(
                 array.dtype().clone(),
                 taken_codes,
-                taken_norms,
                 array.centroids().clone(),
                 array.rotation_signs().clone(),
             )?

--- a/vortex-tensor/src/encodings/turboquant/mod.rs
+++ b/vortex-tensor/src/encodings/turboquant/mod.rs
@@ -17,6 +17,20 @@
 //! TurboQuant minimizes mean-squared reconstruction error (1-8 bits per coordinate)
 //! using MSE-optimal scalar quantization on coordinates of a rotated unit vector.
 //!
+//! The `TurboQuantArray` stores only the quantized unit-norm vector data (codes, centroids,
+//! rotation signs). Per-vector L2 norms are stored separately in an [`L2Denorm`] ScalarFnArray
+//! wrapper. The [`turboquant_encode`] function returns this wrapper:
+//!
+//! ```text
+//! ScalarFnArray(L2Denorm, [TurboQuantArray, norms])
+//! ```
+//!
+//! When executed, the TQ array decompresses to unit-norm vectors, and the [`L2Denorm`] function
+//! lazily re-applies the stored norms to reconstruct the original magnitudes.
+//!
+//! [`L2Denorm`]: crate::scalar_fns::l2_denorm::L2Denorm
+//! [`turboquant_encode`]: crate::encodings::turboquant::turboquant_encode
+//!
 //! The TurboQuant paper analyzes a full random orthogonal rotation. The current Vortex
 //! implementation instead uses a fixed 3-round Walsh-Hadamard-based structured transform with
 //! random sign diagonals. This is a practical approximation chosen for encode/decode efficiency,
@@ -48,9 +62,10 @@
 //! # Compression ratios
 //!
 //! Each vector is stored as `padded_dim * bit_width / 8` bytes of quantized codes plus one stored
-//! norm. In the current implementation, that norm uses the vector's element float type, not a
-//! separate fixed storage precision. Non-power-of-2 dimensions are padded to the next power of 2
-//! for the structured rotation, which reduces the effective ratio for those dimensions.
+//! norm (in the [`L2Denorm`] wrapper). In the current implementation, that norm uses the vector's
+//! element float type, not a separate fixed storage precision. Non-power-of-2 dimensions are
+//! padded to the next power of 2 for the structured rotation, which reduces the effective ratio
+//! for those dimensions.
 //!
 //! The table below assumes f32 input, so the stored norm is 4 bytes.
 //!

--- a/vortex-tensor/src/encodings/turboquant/mod.rs
+++ b/vortex-tensor/src/encodings/turboquant/mod.rs
@@ -86,13 +86,17 @@
 //! use vortex_array::arrays::ExtensionArray;
 //! use vortex_array::arrays::FixedSizeListArray;
 //! use vortex_array::arrays::PrimitiveArray;
+//! use vortex_array::arrays::Extension;
+//! use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 //! use vortex_array::dtype::extension::ExtDType;
 //! use vortex_array::extension::EmptyMetadata;
 //! use vortex_array::validity::Validity;
 //! use vortex_buffer::BufferMut;
 //! use vortex_array::session::ArraySession;
 //! use vortex_session::VortexSession;
-//! use vortex_tensor::encodings::turboquant::{TurboQuantConfig, turboquant_encode};
+//! use vortex_tensor::encodings::turboquant::{TurboQuantConfig, turboquant_encode_unchecked};
+//! use vortex_tensor::scalar_fns::ApproxOptions;
+//! use vortex_tensor::scalar_fns::l2_denorm::normalize_as_l2_denorm;
 //! use vortex_tensor::vector::Vector;
 //!
 //! // Create a Vector extension array of 100 random 128-d vectors.
@@ -110,14 +114,23 @@
 //!     .unwrap().erased();
 //! let ext = ExtensionArray::new(ext_dtype, fsl.into_array());
 //!
-//! // Quantize at 2 bits per coordinate.
-//! let config = TurboQuantConfig { bit_width: 2, seed: Some(42), num_rounds: 3 };
+//! // Normalize, then quantize the normalized child at 2 bits per coordinate.
 //! let session = VortexSession::empty().with::<ArraySession>();
 //! let mut ctx = session.create_execution_ctx();
-//! let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx).unwrap();
+//! let l2_denorm = normalize_as_l2_denorm(
+//!     &ApproxOptions::Exact, ext.into_array(), &mut ctx,
+//! ).unwrap();
+//! let normalized = l2_denorm.child_at(0).clone();
+//!
+//! let normalized_ext = normalized.as_opt::<Extension>().unwrap();
+//! let config = TurboQuantConfig { bit_width: 2, seed: Some(42), num_rounds: 3 };
+//! // SAFETY: We just normalized the input.
+//! let tq = unsafe {
+//!     turboquant_encode_unchecked(normalized_ext, &config, &mut ctx).unwrap()
+//! };
 //!
 //! // Verify compression: 100 vectors x 128 dims x 4 bytes = 51200 bytes input.
-//! assert!(encoded.nbytes() < 51200);
+//! assert!(tq.nbytes() < 51200);
 //! ```
 
 mod array;
@@ -137,6 +150,7 @@ mod scheme;
 pub use scheme::TurboQuantScheme;
 pub use scheme::compress::TurboQuantConfig;
 pub use scheme::compress::turboquant_encode;
+pub use scheme::compress::turboquant_encode_unchecked;
 
 #[cfg(test)]
 mod tests;

--- a/vortex-tensor/src/encodings/turboquant/scheme/compress.rs
+++ b/vortex-tensor/src/encodings/turboquant/scheme/compress.rs
@@ -8,6 +8,7 @@
 //! externally by [`normalize_as_l2_denorm`](crate::scalar_fns::l2_denorm::normalize_as_l2_denorm),
 //! which the [`TurboQuantScheme`](super::TurboQuantScheme) calls before invoking this function.
 
+use num_traits::ToPrimitive;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
@@ -19,6 +20,7 @@ use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
+use vortex_array::match_each_float_ptype;
 use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
@@ -33,6 +35,13 @@ use crate::encodings::turboquant::array::centroids::find_nearest_centroid;
 use crate::encodings::turboquant::array::centroids::get_centroids;
 use crate::encodings::turboquant::array::rotation::RotationMatrix;
 use crate::encodings::turboquant::vtable::TurboQuantArray;
+use crate::scalar_fns::ApproxOptions;
+use crate::scalar_fns::l2_norm::L2Norm;
+use crate::vector::AnyVector;
+
+/// Tolerance for the unit-norm check in [`turboquant_encode`]. Each row's L2 norm must be within
+/// this distance of 1.0 (or be exactly 0.0 for zero vectors).
+const UNIT_NORM_TOLERANCE: f64 = 1e-10;
 
 /// Configuration for TurboQuant encoding.
 #[derive(Clone, Debug)]
@@ -99,8 +108,9 @@ struct QuantizationResult {
 
 /// Core quantization: rotate and quantize already-normalized rows.
 ///
-/// The input `fsl` must contain unit-norm vectors (already L2-normalized). The rotation and
-/// centroid lookup happen in f32.
+/// The input `fsl` must contain non-nullable, unit-norm vectors (already L2-normalized). Null
+/// vectors are not supported and must be zeroed out before reaching this function. The rotation
+/// and centroid lookup happen in f32.
 fn turboquant_quantize_core(
     fsl: &FixedSizeListArray,
     seed: u64,
@@ -186,7 +196,12 @@ fn build_turboquant(
 /// [`TurboQuantArray`].
 ///
 /// The input must be a non-nullable Vector extension array whose rows are already unit-norm.
-/// Normalization is handled externally (e.g. by [`normalize_as_l2_denorm`]).
+/// **Null vectors are not supported.** The caller must normalize and strip nullability before
+/// calling this function, for example via [`normalize_as_l2_denorm`].
+///
+/// This function validates that every row has L2 norm within `UNIT_NORM_TOLERANCE` of 1.0 (or is
+/// exactly 0.0). Use [`turboquant_encode_unchecked`] to skip this check when the caller has just
+/// performed normalization.
 ///
 /// The returned array is a plain [`TurboQuantArray`] that decompresses to unit-norm vectors.
 /// The caller is responsible for wrapping it in an [`L2Denorm`] ScalarFnArray if the original
@@ -200,13 +215,61 @@ pub fn turboquant_encode(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let ext_dtype = ext.dtype().clone();
-    let storage = ext.storage_array();
-    let fsl = storage.clone().execute::<FixedSizeListArray>(ctx)?;
 
     vortex_ensure!(
         !ext_dtype.is_nullable(),
         "TurboQuant input must be non-nullable (normalize first via L2Denorm), got {ext_dtype}",
     );
+
+    // Validate that all rows are unit-norm (or zero).
+    let num_rows = ext.as_ref().len();
+    if num_rows > 0 {
+        let norms_sfn =
+            L2Norm::try_new_array(&ApproxOptions::Exact, ext.as_ref().clone(), num_rows)?;
+        let norms: PrimitiveArray = norms_sfn.into_array().execute(ctx)?;
+
+        let element_ptype = ext_dtype
+            .as_extension()
+            .metadata::<AnyVector>()
+            .element_ptype();
+
+        match_each_float_ptype!(element_ptype, |T| {
+            for (i, &norm) in norms.as_slice::<T>().iter().enumerate() {
+                let norm_f64: f64 = ToPrimitive::to_f64(&norm).unwrap_or(f64::NAN);
+                vortex_ensure!(
+                    norm_f64 == 0.0 || (norm_f64 - 1.0).abs() < UNIT_NORM_TOLERANCE,
+                    "TurboQuant requires unit-norm input, but row {i} has L2 norm {norm_f64:.6} \
+                     (expected 1.0 or 0.0)",
+                );
+            }
+        });
+    }
+
+    // SAFETY: We just validated that the input is non-nullable and all rows are unit-norm.
+    unsafe { turboquant_encode_unchecked(ext, config, ctx) }
+}
+
+/// Encode a non-nullable, L2-normalized [`Vector`](crate::vector::Vector) extension array into a
+/// [`TurboQuantArray`], without validating the unit-norm precondition.
+///
+/// # Safety
+///
+/// The caller must ensure:
+///
+/// - The input dtype is non-nullable.
+/// - Every row is L2-normalized (unit norm) or is a zero vector.
+///
+/// Passing non-unit-norm vectors will not cause memory unsafety, but will produce silently
+/// incorrect quantization results.
+pub unsafe fn turboquant_encode_unchecked(
+    ext: ArrayView<Extension>,
+    config: &TurboQuantConfig,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let ext_dtype = ext.dtype().clone();
+    let storage = ext.storage_array();
+    let fsl = storage.clone().execute::<FixedSizeListArray>(ctx)?;
+
     vortex_ensure!(
         config.bit_width >= 1 && config.bit_width <= TurboQuant::MAX_BIT_WIDTH,
         "bit_width must be 1-{}, got {}",

--- a/vortex-tensor/src/encodings/turboquant/scheme/compress.rs
+++ b/vortex-tensor/src/encodings/turboquant/scheme/compress.rs
@@ -18,6 +18,7 @@ use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
+use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::match_each_float_ptype;
@@ -39,9 +40,20 @@ use crate::scalar_fns::ApproxOptions;
 use crate::scalar_fns::l2_norm::L2Norm;
 use crate::vector::AnyVector;
 
-/// Tolerance for the unit-norm check in [`turboquant_encode`]. Each row's L2 norm must be within
-/// this distance of 1.0 (or be exactly 0.0 for zero vectors).
-const UNIT_NORM_TOLERANCE: f64 = 1e-10;
+/// Returns the acceptable unit-norm drift for the given element precision.
+///
+/// The checked encode path validates the post-normalization storage values, so the tolerance has
+/// to account for quantization back into the vector element type.
+///
+/// These numbers are somewhat arbitrary and are derived from testing reasonable values.
+fn unit_norm_tolerance(element_ptype: PType) -> f64 {
+    match element_ptype {
+        PType::F16 => 2e-3,
+        PType::F32 => 1e-6,
+        PType::F64 => 1e-10,
+        _ => unreachable!("TurboQuant requires float elements, got {element_ptype:?}"),
+    }
+}
 
 /// Configuration for TurboQuant encoding.
 #[derive(Clone, Debug)]
@@ -165,7 +177,7 @@ fn turboquant_quantize_core(
 fn build_turboquant(
     num_rows: usize,
     core: QuantizationResult,
-    ext_dtype: &vortex_array::dtype::DType,
+    ext_dtype: &DType,
 ) -> VortexResult<TurboQuantArray> {
     let padded_dim = core.padded_dim;
     let padded_dim_u32 =
@@ -199,9 +211,9 @@ fn build_turboquant(
 /// **Null vectors are not supported.** The caller must normalize and strip nullability before
 /// calling this function, for example via [`normalize_as_l2_denorm`].
 ///
-/// This function validates that every row has L2 norm within `UNIT_NORM_TOLERANCE` of 1.0 (or is
-/// exactly 0.0). Use [`turboquant_encode_unchecked`] to skip this check when the caller has just
-/// performed normalization.
+/// This function validates that every row has L2 norm within a storage-precision-aware tolerance
+/// of 1.0 (or is exactly 0.0). Use [`turboquant_encode_unchecked`] to skip this check when the
+/// caller has just performed normalization.
 ///
 /// The returned array is a plain [`TurboQuantArray`] that decompresses to unit-norm vectors.
 /// The caller is responsible for wrapping it in an [`L2Denorm`] ScalarFnArray if the original
@@ -232,12 +244,13 @@ pub fn turboquant_encode(
             .as_extension()
             .metadata::<AnyVector>()
             .element_ptype();
+        let tolerance = unit_norm_tolerance(element_ptype);
 
         match_each_float_ptype!(element_ptype, |T| {
             for (i, &norm) in norms.as_slice::<T>().iter().enumerate() {
                 let norm_f64: f64 = ToPrimitive::to_f64(&norm).unwrap_or(f64::NAN);
                 vortex_ensure!(
-                    norm_f64 == 0.0 || (norm_f64 - 1.0).abs() < UNIT_NORM_TOLERANCE,
+                    norm_f64 == 0.0 || (norm_f64 - 1.0).abs() < tolerance,
                     "TurboQuant requires unit-norm input, but row {i} has L2 norm {norm_f64:.6} \
                      (expected 1.0 or 0.0)",
                 );

--- a/vortex-tensor/src/encodings/turboquant/scheme/compress.rs
+++ b/vortex-tensor/src/encodings/turboquant/scheme/compress.rs
@@ -2,8 +2,12 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 //! TurboQuant encoding (quantization) logic.
+//!
+//! The input to [`turboquant_encode`] must be a non-nullable [`Vector`](crate::vector::Vector)
+//! extension array whose rows are already L2-normalized (unit norm). Normalization is handled
+//! externally by [`normalize_as_l2_denorm`](crate::scalar_fns::l2_denorm::normalize_as_l2_denorm),
+//! which the [`TurboQuantScheme`](super::TurboQuantScheme) calls before invoking this function.
 
-use num_traits::ToPrimitive;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
@@ -13,10 +17,8 @@ use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
-use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
-use vortex_array::match_each_float_ptype;
 use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
@@ -31,8 +33,6 @@ use crate::encodings::turboquant::array::centroids::find_nearest_centroid;
 use crate::encodings::turboquant::array::centroids::get_centroids;
 use crate::encodings::turboquant::array::rotation::RotationMatrix;
 use crate::encodings::turboquant::vtable::TurboQuantArray;
-use crate::scalar_fns::ApproxOptions;
-use crate::scalar_fns::l2_norm::L2Norm;
 
 /// Configuration for TurboQuant encoding.
 #[derive(Clone, Debug)]
@@ -94,49 +94,23 @@ struct QuantizationResult {
     rotation: RotationMatrix,
     centroids: Vec<f32>,
     all_indices: BufferMut<u8>,
-    /// Native-precision norms (matching the Vector element type). Carries validity: null vectors
-    /// have null norms.
-    norms_array: ArrayRef,
     padded_dim: usize,
 }
 
-/// Core quantization: compute norms via [`L2Norm`], extract f32 elements, then
-/// normalize/rotate/quantize all rows.
+/// Core quantization: rotate and quantize already-normalized rows.
 ///
-/// Norms are computed in the native element precision via the [`L2Norm`] scalar function.
-/// The rotation and centroid lookup happen in f32. Null rows (per the input validity) produce
-/// all-zero codes.
+/// The input `fsl` must contain unit-norm vectors (already L2-normalized). The rotation and
+/// centroid lookup happen in f32.
 fn turboquant_quantize_core(
-    ext: ArrayView<Extension>,
     fsl: &FixedSizeListArray,
     seed: u64,
     bit_width: u8,
     num_rounds: u8,
-    validity: &Validity,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<QuantizationResult> {
     let dimension =
         usize::try_from(fsl.list_size()).vortex_expect("u32 FixedSizeList dimension fits in usize");
     let num_rows = fsl.len();
-
-    // Compute native-precision norms via the L2Norm scalar fn. L2Norm propagates validity from
-    // the input, so null vectors get null norms automatically.
-    let norms_sfn = L2Norm::try_new_array(&ApproxOptions::Exact, ext.as_ref().clone(), num_rows)?;
-    let norms_array: ArrayRef = norms_sfn.into_array().execute(ctx)?;
-    let norms_prim: PrimitiveArray = norms_array.clone().execute(ctx)?;
-
-    // Extract f32 norms for the internal quantization loop.
-    let f32_norms: Vec<f32> = match_each_float_ptype!(norms_prim.ptype(), |T| {
-        norms_prim
-            .as_slice::<T>()
-            .iter()
-            .map(|&v| {
-                // `ToPrimitive::to_f32` is infallible for all float types: f16 -> f32 is lossless,
-                // f32 is identity, and f64 -> f32 saturates to +-inf.
-                ToPrimitive::to_f32(&v).vortex_expect("float-to-f32 conversion is infallible")
-            })
-            .collect()
-    });
 
     let rotation = RotationMatrix::try_new(seed, dimension, num_rounds as usize)?;
     let padded_dim = rotation.padded_dim();
@@ -154,23 +128,12 @@ fn turboquant_quantize_core(
 
     let f32_slice = f32_elements.as_slice::<f32>();
     for row in 0..num_rows {
-        // Null vectors get all-zero codes.
-        if !validity.is_valid(row)? {
-            all_indices.extend(std::iter::repeat_n(0u8, padded_dim));
-            continue;
-        }
-
         let x = &f32_slice[row * dimension..(row + 1) * dimension];
-        let norm = f32_norms[row];
 
-        if norm > 0.0 {
-            let inv_norm = 1.0 / norm;
-            for (dst, &src) in padded[..dimension].iter_mut().zip(x.iter()) {
-                *dst = src * inv_norm;
-            }
-        } else {
-            padded[..dimension].fill(0.0);
-        }
+        // Zero-pad to the next power of 2.
+        padded[..dimension].copy_from_slice(x);
+        padded[dimension..].fill(0.0);
+
         rotation.rotate(&padded, &mut rotated);
 
         for j in 0..padded_dim {
@@ -182,18 +145,18 @@ fn turboquant_quantize_core(
         rotation,
         centroids,
         all_indices,
-        norms_array,
         padded_dim,
     })
 }
 
 /// Build a `TurboQuantArray` from quantization results.
+///
+/// The `ext_dtype` must be a non-nullable [`Vector`](crate::vector::Vector) extension dtype.
 fn build_turboquant(
-    fsl: &FixedSizeListArray,
+    num_rows: usize,
     core: QuantizationResult,
-    ext_dtype: DType,
+    ext_dtype: &vortex_array::dtype::DType,
 ) -> VortexResult<TurboQuantArray> {
-    let num_rows = fsl.len();
     let padded_dim = core.padded_dim;
     let padded_dim_u32 =
         u32::try_from(padded_dim).vortex_expect("padded_dim stays representable as u32");
@@ -216,19 +179,21 @@ fn build_turboquant(
 
     let rotation_signs = bitpack_rotation_signs(&core.rotation)?;
 
-    TurboQuant::try_new_array(
-        ext_dtype,
-        codes,
-        core.norms_array,
-        centroids_array,
-        rotation_signs,
-    )
+    TurboQuant::try_new_array(ext_dtype.clone(), codes, centroids_array, rotation_signs)
 }
 
-/// Encode a [`Vector`](crate::vector::Vector) extension array into a `TurboQuantArray`.
+/// Encode a non-nullable, L2-normalized [`Vector`](crate::vector::Vector) extension array into a
+/// [`TurboQuantArray`].
 ///
-/// Nullable inputs are supported: null vectors get all-zero codes and null norms. The validity
-/// of the resulting TurboQuant array is carried by the norms child.
+/// The input must be a non-nullable Vector extension array whose rows are already unit-norm.
+/// Normalization is handled externally (e.g. by [`normalize_as_l2_denorm`]).
+///
+/// The returned array is a plain [`TurboQuantArray`] that decompresses to unit-norm vectors.
+/// The caller is responsible for wrapping it in an [`L2Denorm`] ScalarFnArray if the original
+/// magnitudes need to be restored.
+///
+/// [`normalize_as_l2_denorm`]: crate::scalar_fns::l2_denorm::normalize_as_l2_denorm
+/// [`L2Denorm`]: crate::scalar_fns::l2_denorm::L2Denorm
 pub fn turboquant_encode(
     ext: ArrayView<Extension>,
     config: &TurboQuantConfig,
@@ -238,6 +203,10 @@ pub fn turboquant_encode(
     let storage = ext.storage_array();
     let fsl = storage.clone().execute::<FixedSizeListArray>(ctx)?;
 
+    vortex_ensure!(
+        !ext_dtype.is_nullable(),
+        "TurboQuant input must be non-nullable (normalize first via L2Denorm), got {ext_dtype}",
+    );
     vortex_ensure!(
         config.bit_width >= 1 && config.bit_width <= TurboQuant::MAX_BIT_WIDTH,
         "bit_width must be 1-{}, got {}",
@@ -260,13 +229,6 @@ pub fn turboquant_encode(
             0,
         )?;
 
-        // Norms dtype matches the element type and carries the parent's nullability.
-        let element_ptype = fsl.elements().dtype().as_ptype();
-        let norms_nullability = ext_dtype.nullability();
-        let empty_norms: ArrayRef = match_each_float_ptype!(element_ptype, |T| {
-            PrimitiveArray::empty::<T>(norms_nullability).into_array()
-        });
-
         let empty_centroids = PrimitiveArray::empty::<f32>(Nullability::NonNullable);
         let empty_signs = FixedSizeListArray::try_new(
             PrimitiveArray::empty::<u8>(Nullability::NonNullable).into_array(),
@@ -274,29 +236,21 @@ pub fn turboquant_encode(
             Validity::NonNullable,
             0,
         )?;
+
         return Ok(TurboQuant::try_new_array(
             ext_dtype,
             empty_codes.into_array(),
-            empty_norms,
             empty_centroids.into_array(),
             empty_signs.into_array(),
         )?
         .into_array());
     }
 
-    let validity = ext.as_ref().validity()?;
     let seed = config.seed.unwrap_or(42);
-    let core = turboquant_quantize_core(
-        ext,
-        &fsl,
-        seed,
-        config.bit_width,
-        config.num_rounds,
-        &validity,
-        ctx,
-    )?;
+    let num_rows = fsl.len();
+    let core = turboquant_quantize_core(&fsl, seed, config.bit_width, config.num_rounds, ctx)?;
 
-    Ok(build_turboquant(&fsl, core, ext_dtype)?.into_array())
+    Ok(build_turboquant(num_rows, core, &ext_dtype)?.into_array())
 }
 
 /// Export rotation signs as a `FixedSizeListArray` wrapping a 1-bit [`BitPackedArray`].

--- a/vortex-tensor/src/encodings/turboquant/scheme/compress.rs
+++ b/vortex-tensor/src/encodings/turboquant/scheme/compress.rs
@@ -8,7 +8,6 @@
 //! externally by [`normalize_as_l2_denorm`](crate::scalar_fns::l2_denorm::normalize_as_l2_denorm),
 //! which the [`TurboQuantScheme`](super::TurboQuantScheme) calls before invoking this function.
 
-use num_traits::ToPrimitive;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
@@ -21,7 +20,6 @@ use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
-use vortex_array::match_each_float_ptype;
 use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
@@ -36,24 +34,7 @@ use crate::encodings::turboquant::array::centroids::find_nearest_centroid;
 use crate::encodings::turboquant::array::centroids::get_centroids;
 use crate::encodings::turboquant::array::rotation::RotationMatrix;
 use crate::encodings::turboquant::vtable::TurboQuantArray;
-use crate::scalar_fns::ApproxOptions;
-use crate::scalar_fns::l2_norm::L2Norm;
-use crate::vector::AnyVector;
-
-/// Returns the acceptable unit-norm drift for the given element precision.
-///
-/// The checked encode path validates the post-normalization storage values, so the tolerance has
-/// to account for quantization back into the vector element type.
-///
-/// These numbers are somewhat arbitrary and are derived from testing reasonable values.
-fn unit_norm_tolerance(element_ptype: PType) -> f64 {
-    match element_ptype {
-        PType::F16 => 2e-3,
-        PType::F32 => 1e-6,
-        PType::F64 => 1e-10,
-        _ => unreachable!("TurboQuant requires float elements, got {element_ptype:?}"),
-    }
-}
+use crate::scalar_fns::l2_denorm::validate_l2_normalized_rows;
 
 /// Configuration for TurboQuant encoding.
 #[derive(Clone, Debug)]
@@ -211,9 +192,9 @@ fn build_turboquant(
 /// **Null vectors are not supported.** The caller must normalize and strip nullability before
 /// calling this function, for example via [`normalize_as_l2_denorm`].
 ///
-/// This function validates that every row has L2 norm within a storage-precision-aware tolerance
-/// of 1.0 (or is exactly 0.0). Use [`turboquant_encode_unchecked`] to skip this check when the
-/// caller has just performed normalization.
+/// This function validates that every row is L2-normalized (or is exactly 0.0). Use
+/// [`turboquant_encode_unchecked`] to skip this check when the caller has just performed
+/// normalization.
 ///
 /// The returned array is a plain [`TurboQuantArray`] that decompresses to unit-norm vectors.
 /// The caller is responsible for wrapping it in an [`L2Denorm`] ScalarFnArray if the original
@@ -233,30 +214,7 @@ pub fn turboquant_encode(
         "TurboQuant input must be non-nullable (normalize first via L2Denorm), got {ext_dtype}",
     );
 
-    // Validate that all rows are unit-norm (or zero).
-    let num_rows = ext.as_ref().len();
-    if num_rows > 0 {
-        let norms_sfn =
-            L2Norm::try_new_array(&ApproxOptions::Exact, ext.as_ref().clone(), num_rows)?;
-        let norms: PrimitiveArray = norms_sfn.into_array().execute(ctx)?;
-
-        let element_ptype = ext_dtype
-            .as_extension()
-            .metadata::<AnyVector>()
-            .element_ptype();
-        let tolerance = unit_norm_tolerance(element_ptype);
-
-        match_each_float_ptype!(element_ptype, |T| {
-            for (i, &norm) in norms.as_slice::<T>().iter().enumerate() {
-                let norm_f64: f64 = ToPrimitive::to_f64(&norm).unwrap_or(f64::NAN);
-                vortex_ensure!(
-                    norm_f64 == 0.0 || (norm_f64 - 1.0).abs() < tolerance,
-                    "TurboQuant requires unit-norm input, but row {i} has L2 norm {norm_f64:.6} \
-                     (expected 1.0 or 0.0)",
-                );
-            }
-        });
-    }
+    validate_l2_normalized_rows(ext.as_ref().clone(), ctx)?;
 
     // SAFETY: We just validated that the input is non-nullable and all rows are unit-norm.
     unsafe { turboquant_encode_unchecked(ext, config, ctx) }

--- a/vortex-tensor/src/encodings/turboquant/scheme/decompress.rs
+++ b/vortex-tensor/src/encodings/turboquant/scheme/decompress.rs
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 //! TurboQuant decoding (dequantization) logic.
+//!
+//! Decompression produces unit-norm vectors. The original magnitudes are restored externally
+//! by the [`L2Denorm`](crate::scalar_fns::l2_denorm::L2Denorm) ScalarFnArray wrapper.
 
 use num_traits::Float;
 use num_traits::FromPrimitive;
@@ -26,10 +29,12 @@ use crate::encodings::turboquant::array::rotation::RotationMatrix;
 use crate::encodings::turboquant::compute::float_from_f32;
 use crate::vector::AnyVector;
 
-/// Decompress a `TurboQuantArray` into a [`Vector`] extension array.
+/// Decompress a `TurboQuantArray` into a unit-norm [`Vector`] extension array.
 ///
-/// The returned array is an [`ExtensionArray`] with the original Vector dtype wrapping a
-/// `FixedSizeListArray` of the original vector element type.
+/// The returned array is an [`ExtensionArray`] with the (non-nullable) Vector dtype wrapping a
+/// `FixedSizeListArray` of the original vector element type. Each vector has unit L2 norm; the
+/// original magnitudes are restored by the [`L2Denorm`](crate::scalar_fns::l2_denorm::L2Denorm)
+/// ScalarFnArray wrapper.
 ///
 /// [`Vector`]: crate::vector::Vector
 pub fn execute_decompress(
@@ -38,19 +43,17 @@ pub fn execute_decompress(
 ) -> VortexResult<ArrayRef> {
     let dim = array.dimension() as usize;
     let padded_dim = array.padded_dim() as usize;
-    let num_rows = array.norms().len();
+    let num_rows = array.len();
     let ext_dtype = array.dtype().as_extension().clone();
     let element_ptype = ext_dtype.metadata::<AnyVector>().element_ptype();
 
     if num_rows == 0 {
-        let fsl_validity = Validity::from(ext_dtype.storage_dtype().nullability());
-
         match_each_float_ptype!(element_ptype, |T| {
             let elements = PrimitiveArray::empty::<T>(Nullability::NonNullable);
             let fsl = FixedSizeListArray::try_new(
                 elements.into_array(),
                 array.dimension(),
-                fsl_validity,
+                Validity::NonNullable,
                 0,
             )?;
 
@@ -85,38 +88,27 @@ pub fn execute_decompress(
         .execute::<PrimitiveArray>(ctx)?;
     let indices = codes_prim.as_slice::<u8>();
 
-    // Read norms in their native precision. Norms carry the validity of the array.
-    let norms_prim = array.norms().clone().execute::<PrimitiveArray>(ctx)?;
-    let output_validity = array.norms().validity()?;
-
-    // MSE decode: dequantize (f32) -> inverse rotate (f32) -> scale by norm -> cast to T.
+    // MSE decode: dequantize (f32) -> inverse rotate (f32) -> cast to T.
     // The rotation and centroid lookup always happen in f32. The final output is cast to the
-    // Vector's element type to match the original storage dtype.
+    // Vector's element type to match the original storage dtype. No norm scaling is applied here;
+    // that is handled by the external L2Denorm wrapper.
     match_each_float_ptype!(element_ptype, |T| {
-        decompress_typed::<T>(
-            &norms_prim,
-            centroids,
-            &rotation,
-            indices,
-            dim,
-            padded_dim,
-            num_rows,
+        decompress_typed::<T>(centroids, &rotation, indices, dim, padded_dim, num_rows).and_then(
+            |elements| {
+                let fsl = FixedSizeListArray::try_new(
+                    elements.into_array(),
+                    array.dimension(),
+                    Validity::NonNullable,
+                    num_rows,
+                )?;
+                Ok(ExtensionArray::new(ext_dtype, fsl.into_array()).into_array())
+            },
         )
-        .and_then(|elements| {
-            let fsl = FixedSizeListArray::try_new(
-                elements.into_array(),
-                array.dimension(),
-                output_validity,
-                num_rows,
-            )?;
-            Ok(ExtensionArray::new(ext_dtype, fsl.into_array()).into_array())
-        })
     })
 }
 
-/// Typed decompress: reads norms as `T`, dequantizes in f32, and produces output as `T`.
+/// Typed decompress: dequantizes in f32 and produces unit-norm output as `T`.
 fn decompress_typed<T: NativePType + Float + FromPrimitive>(
-    norms_prim: &PrimitiveArray,
     centroids: &[f32],
     rotation: &RotationMatrix,
     indices: &[u8],
@@ -124,15 +116,12 @@ fn decompress_typed<T: NativePType + Float + FromPrimitive>(
     padded_dim: usize,
     num_rows: usize,
 ) -> VortexResult<PrimitiveArray> {
-    let norms = norms_prim.as_slice::<T>();
-
     let mut output = BufferMut::<T>::with_capacity(num_rows * dim);
     let mut dequantized = vec![0.0f32; padded_dim];
     let mut unrotated = vec![0.0f32; padded_dim];
 
     for row in 0..num_rows {
         let row_indices = &indices[row * padded_dim..(row + 1) * padded_dim];
-        let norm = norms[row];
 
         for idx in 0..padded_dim {
             dequantized[idx] = centroids[row_indices[idx] as usize];
@@ -141,8 +130,7 @@ fn decompress_typed<T: NativePType + Float + FromPrimitive>(
         rotation.inverse_rotate(&dequantized, &mut unrotated);
 
         for idx in 0..dim {
-            let val = float_from_f32::<T>(unrotated[idx]) * norm;
-            output.push(val);
+            output.push(float_from_f32::<T>(unrotated[idx]));
         }
     }
 

--- a/vortex-tensor/src/encodings/turboquant/scheme/mod.rs
+++ b/vortex-tensor/src/encodings/turboquant/scheme/mod.rs
@@ -27,7 +27,7 @@ use vortex_error::VortexResult;
 
 use crate::encodings::turboquant::TurboQuant;
 use crate::encodings::turboquant::TurboQuantConfig;
-use crate::encodings::turboquant::turboquant_encode;
+use crate::encodings::turboquant::turboquant_encode_unchecked;
 use crate::scalar_fns::ApproxOptions;
 use crate::scalar_fns::l2_denorm::L2Denorm;
 use crate::scalar_fns::l2_denorm::normalize_as_l2_denorm;
@@ -112,7 +112,9 @@ impl Scheme for TurboQuantScheme {
             .as_opt::<Extension>()
             .vortex_expect("normalized child should be an Extension array");
         let config = TurboQuantConfig::default();
-        let tq = turboquant_encode(normalized_ext, &config, &mut ctx)?;
+        // SAFETY: We just normalized the input via `normalize_as_l2_denorm`, so all rows are
+        // guaranteed to be unit-norm (or zero for originally-null rows).
+        let tq = unsafe { turboquant_encode_unchecked(normalized_ext, &config, &mut ctx)? };
 
         // Reassemble L2Denorm(TurboQuant, norms).
         Ok(L2Denorm::try_new_array(&ApproxOptions::Exact, tq, norms, num_rows)?.into_array())

--- a/vortex-tensor/src/encodings/turboquant/scheme/mod.rs
+++ b/vortex-tensor/src/encodings/turboquant/scheme/mod.rs
@@ -2,10 +2,21 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 //! TurboQuant compression scheme and decompression.
+//!
+//! The scheme first normalizes the input via [`normalize_as_l2_denorm`], then encodes the
+//! normalized child via [`turboquant_encode`]. The result is:
+//!
+//! ```text
+//! ScalarFnArray(L2Denorm, [TurboQuantArray, norms])
+//! ```
+//!
+//! [`normalize_as_l2_denorm`]: crate::scalar_fns::l2_denorm::normalize_as_l2_denorm
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::IntoArray;
 use vortex_array::arrays::Extension;
+use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_compressor::CascadingCompressor;
 use vortex_compressor::ctx::CompressorContext;
 use vortex_compressor::estimate::CompressionEstimate;
@@ -17,6 +28,9 @@ use vortex_error::VortexResult;
 use crate::encodings::turboquant::TurboQuant;
 use crate::encodings::turboquant::TurboQuantConfig;
 use crate::encodings::turboquant::turboquant_encode;
+use crate::scalar_fns::ApproxOptions;
+use crate::scalar_fns::l2_denorm::L2Denorm;
+use crate::scalar_fns::l2_denorm::normalize_as_l2_denorm;
 
 pub(super) mod compress;
 pub(super) mod decompress;
@@ -84,8 +98,24 @@ impl Scheme for TurboQuantScheme {
             .as_opt::<Extension>()
             .vortex_expect("expected an extension array");
 
+        let mut ctx = compressor.execution_ctx();
+
+        // Normalize first: produces L2Denorm(normalized_vectors, norms).
+        let l2_denorm =
+            normalize_as_l2_denorm(&ApproxOptions::Exact, ext_array.as_ref().clone(), &mut ctx)?;
+        let normalized = l2_denorm.child_at(0).clone();
+        let norms = l2_denorm.child_at(1).clone();
+        let num_rows = l2_denorm.len();
+
+        // Quantize the normalized child.
+        let normalized_ext = normalized
+            .as_opt::<Extension>()
+            .vortex_expect("normalized child should be an Extension array");
         let config = TurboQuantConfig::default();
-        turboquant_encode(ext_array, &config, &mut compressor.execution_ctx())
+        let tq = turboquant_encode(normalized_ext, &config, &mut ctx)?;
+
+        // Reassemble L2Denorm(TurboQuant, norms).
+        Ok(L2Denorm::try_new_array(&ApproxOptions::Exact, tq, norms, num_rows)?.into_array())
     }
 }
 

--- a/vortex-tensor/src/encodings/turboquant/scheme/mod.rs
+++ b/vortex-tensor/src/encodings/turboquant/scheme/mod.rs
@@ -116,8 +116,12 @@ impl Scheme for TurboQuantScheme {
         // guaranteed to be unit-norm (or zero for originally-null rows).
         let tq = unsafe { turboquant_encode_unchecked(normalized_ext, &config, &mut ctx)? };
 
-        // Reassemble L2Denorm(TurboQuant, norms).
-        Ok(L2Denorm::try_new_array(&ApproxOptions::Exact, tq, norms, num_rows)?.into_array())
+        // SAFETY: TurboQuant is a lossy approximation of the normalized child, so we intentionally
+        // bypass the strict normalized-row validation when reattaching the stored norms.
+        Ok(
+            unsafe { L2Denorm::new_array_unchecked(&ApproxOptions::Exact, tq, norms, num_rows) }?
+                .into_array(),
+        )
     }
 }
 

--- a/vortex-tensor/src/encodings/turboquant/tests.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests.rs
@@ -14,8 +14,10 @@ use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::ScalarFnVTable;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
+use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::extension::ExtDType;
 use vortex_array::extension::EmptyMetadata;
@@ -31,6 +33,8 @@ use crate::encodings::turboquant::TurboQuantConfig;
 use crate::encodings::turboquant::array::rotation::RotationMatrix;
 use crate::encodings::turboquant::turboquant_encode;
 use crate::scalar_fns::ApproxOptions;
+use crate::scalar_fns::l2_denorm::L2Denorm;
+use crate::scalar_fns::l2_denorm::normalize_as_l2_denorm;
 use crate::scalar_fns::l2_norm::L2Norm;
 use crate::vector::Vector;
 
@@ -93,6 +97,38 @@ fn make_vector_ext(fsl: &FixedSizeListArray) -> ExtensionArray {
     ExtensionArray::new(ext_dtype, fsl.clone().into_array())
 }
 
+/// Full encode pipeline: normalize, then TQ-encode, then wrap in L2Denorm.
+///
+/// This mirrors what `TurboQuantScheme::compress()` does: normalize via `normalize_as_l2_denorm`,
+/// then quantize the normalized child via `turboquant_encode`, then reassemble.
+fn normalize_and_encode(
+    ext: &ExtensionArray,
+    config: &TurboQuantConfig,
+    ctx: &mut vortex_array::ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    let l2_denorm = normalize_as_l2_denorm(&ApproxOptions::Exact, ext.as_ref().clone(), ctx)?;
+    let normalized = l2_denorm.child_at(0).clone();
+    let norms = l2_denorm.child_at(1).clone();
+    let num_rows = l2_denorm.len();
+
+    let normalized_ext = normalized
+        .as_opt::<vortex_array::arrays::Extension>()
+        .expect("normalized child should be an Extension array");
+    let tq = turboquant_encode(normalized_ext, config, ctx)?;
+
+    Ok(L2Denorm::try_new_array(&ApproxOptions::Exact, tq, norms, num_rows)?.into_array())
+}
+
+/// Unwrap an L2Denorm ScalarFnArray into its TQ child and norms child.
+fn unwrap_l2denorm(encoded: &ArrayRef) -> (ArrayRef, ArrayRef) {
+    let sfn = encoded
+        .as_opt::<ScalarFnVTable>()
+        .expect("expected ScalarFnArray");
+    let tq_child = sfn.child_at(0).clone();
+    let norms_child = sfn.child_at(1).clone();
+    (tq_child, norms_child)
+}
+
 fn theoretical_mse_bound(bit_width: u8) -> f32 {
     let sqrt3_pi_over_2 = (3.0f32).sqrt() * std::f32::consts::PI / 2.0;
     sqrt3_pi_over_2 / (4.0f32).powi(bit_width as i32)
@@ -122,7 +158,7 @@ fn per_vector_normalized_mse(
     total / num_rows as f32
 }
 
-/// Encode and decode, returning (original, decoded) flat f32 slices.
+/// Normalize, encode, and decode, returning (original, decoded) flat f32 slices.
 fn encode_decode(
     fsl: &FixedSizeListArray,
     config: &TurboQuantConfig,
@@ -133,8 +169,7 @@ fn encode_decode(
         prim.as_slice::<f32>().to_vec()
     };
     let ext = make_vector_ext(fsl);
-    let config = config.clone();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
+    let encoded = normalize_and_encode(&ext, config, &mut ctx)?;
     let decoded_ext = encoded.execute::<ExtensionArray>(&mut ctx)?;
     let decoded_fsl = decoded_ext
         .storage_array()
@@ -152,13 +187,7 @@ fn encode_decode(
 
 fn empty_turboquant_parts(
     dim: u32,
-) -> VortexResult<(
-    vortex_array::dtype::DType,
-    ArrayRef,
-    ArrayRef,
-    ArrayRef,
-    ArrayRef,
-)> {
+) -> VortexResult<(vortex_array::dtype::DType, ArrayRef, ArrayRef, ArrayRef)> {
     let fsl = make_fsl(0, dim as usize, 42);
     let ext = make_vector_ext(&fsl);
 
@@ -169,7 +198,6 @@ fn empty_turboquant_parts(
         0,
     )?
     .into_array();
-    let norms = PrimitiveArray::empty::<f32>(ext.dtype().nullability()).into_array();
     let centroids = PrimitiveArray::empty::<f32>(Nullability::NonNullable).into_array();
     let rotation_signs = FixedSizeListArray::try_new(
         PrimitiveArray::empty::<u8>(Nullability::NonNullable).into_array(),
@@ -179,7 +207,13 @@ fn empty_turboquant_parts(
     )?
     .into_array();
 
-    Ok((ext.dtype().clone(), codes, norms, centroids, rotation_signs))
+    // TQ dtype is non-nullable.
+    Ok((
+        ext.dtype().as_nonnullable(),
+        codes,
+        centroids,
+        rotation_signs,
+    ))
 }
 
 // -----------------------------------------------------------------------
@@ -207,24 +241,11 @@ fn roundtrip(#[case] dim: usize, #[case] bit_width: u8) -> VortexResult<()> {
 }
 
 #[test]
-fn empty_try_new_rejects_invalid_norms_dtype() -> VortexResult<()> {
-    let (dtype, codes, _norms, centroids, rotation_signs) = empty_turboquant_parts(128)?;
-    let wrong_norms = PrimitiveArray::empty::<f64>(dtype.nullability()).into_array();
-
-    let err = TurboQuant::try_new_array(dtype, codes, wrong_norms, centroids, rotation_signs)
-        .unwrap_err();
-
-    assert!(err.to_string().contains("norms dtype does not match"));
-    Ok(())
-}
-
-#[test]
 fn empty_try_new_rejects_invalid_centroids_dtype() -> VortexResult<()> {
-    let (dtype, codes, norms, _centroids, rotation_signs) = empty_turboquant_parts(128)?;
+    let (dtype, codes, _centroids, rotation_signs) = empty_turboquant_parts(128)?;
     let wrong_centroids = PrimitiveArray::empty::<f64>(Nullability::NonNullable).into_array();
 
-    let err = TurboQuant::try_new_array(dtype, codes, norms, wrong_centroids, rotation_signs)
-        .unwrap_err();
+    let err = TurboQuant::try_new_array(dtype, codes, wrong_centroids, rotation_signs).unwrap_err();
 
     assert!(
         err.to_string()
@@ -235,11 +256,10 @@ fn empty_try_new_rejects_invalid_centroids_dtype() -> VortexResult<()> {
 
 #[test]
 fn empty_try_new_rejects_invalid_rotation_signs_dtype() -> VortexResult<()> {
-    let (dtype, codes, norms, centroids, _rotation_signs) = empty_turboquant_parts(128)?;
+    let (dtype, codes, centroids, _rotation_signs) = empty_turboquant_parts(128)?;
     let wrong_rotation_signs = PrimitiveArray::empty::<u8>(Nullability::NonNullable).into_array();
 
-    let err = TurboQuant::try_new_array(dtype, codes, norms, centroids, wrong_rotation_signs)
-        .unwrap_err();
+    let err = TurboQuant::try_new_array(dtype, codes, centroids, wrong_rotation_signs).unwrap_err();
 
     assert!(
         err.to_string()
@@ -353,7 +373,7 @@ fn roundtrip_edge_cases(#[case] num_rows: usize) -> VortexResult<()> {
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
     let decoded = encoded.execute::<ExtensionArray>(&mut ctx)?;
     assert_eq!(decoded.len(), num_rows);
     Ok(())
@@ -449,10 +469,11 @@ fn f64_input_encodes_successfully() -> VortexResult<()> {
     };
     // Verify encoding succeeds with f64 input (f64->f32 conversion).
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
-    let encoded = encoded.as_opt::<TurboQuant>().unwrap();
-    assert_eq!(encoded.norms().len(), num_rows);
-    assert_eq!(encoded.dimension() as usize, dim);
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
+    let (tq_child, norms_child) = unwrap_l2denorm(&encoded);
+    let tq = tq_child.as_opt::<TurboQuant>().unwrap();
+    assert_eq!(norms_child.len(), num_rows);
+    assert_eq!(tq.dimension() as usize, dim);
     Ok(())
 }
 
@@ -484,9 +505,10 @@ fn f16_input_encodes_successfully() -> VortexResult<()> {
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
-    let tq = encoded.as_opt::<TurboQuant>().unwrap();
-    assert_eq!(tq.norms().len(), num_rows);
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
+    let (tq_child, norms_child) = unwrap_l2denorm(&encoded);
+    let tq = tq_child.as_opt::<TurboQuant>().unwrap();
+    assert_eq!(norms_child.len(), num_rows);
     assert_eq!(tq.dimension() as usize, dim);
 
     // Verify roundtrip: decode and check reconstruction is reasonable.
@@ -514,17 +536,15 @@ fn stored_centroids_match_computed() -> VortexResult<()> {
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
-    let encoded = encoded.as_opt::<TurboQuant>().unwrap();
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
+    let (tq_child, _norms) = unwrap_l2denorm(&encoded);
+    let tq = tq_child.as_opt::<TurboQuant>().unwrap();
 
     let mut ctx = SESSION.create_execution_ctx();
-    let stored_centroids_prim = encoded
-        .centroids()
-        .clone()
-        .execute::<PrimitiveArray>(&mut ctx)?;
+    let stored_centroids_prim = tq.centroids().clone().execute::<PrimitiveArray>(&mut ctx)?;
     let stored = stored_centroids_prim.as_slice::<f32>();
 
-    let padded_dim = encoded.padded_dim();
+    let padded_dim = tq.padded_dim();
     let computed = crate::encodings::turboquant::array::centroids::get_centroids(padded_dim, 3)?;
 
     assert_eq!(stored.len(), computed.len());
@@ -545,15 +565,13 @@ fn stored_rotation_signs_produce_correct_decode() -> VortexResult<()> {
         num_rounds: 4,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
-    let encoded = encoded.as_opt::<TurboQuant>().unwrap();
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
+    let (tq_child, _norms) = unwrap_l2denorm(&encoded);
+    let tq = tq_child.as_opt::<TurboQuant>().unwrap();
 
-    // Decode via the stored-signs path (normal decode).
+    // Decode via the full L2Denorm path (TQ decompress + norm scaling).
     let mut ctx = SESSION.create_execution_ctx();
-    let decoded_ext = encoded
-        .array()
-        .clone()
-        .execute::<ExtensionArray>(&mut ctx)?;
+    let decoded_ext = encoded.execute::<ExtensionArray>(&mut ctx)?;
     let decoded_fsl = decoded_ext
         .storage_array()
         .clone()
@@ -567,7 +585,7 @@ fn stored_rotation_signs_produce_correct_decode() -> VortexResult<()> {
     // Verify stored signs match seed-derived signs.
     let rot_from_seed = RotationMatrix::try_new(123, 128, 4)?;
     let expected_u8 = rot_from_seed.export_inverse_signs_u8();
-    let stored_signs_fsl = encoded
+    let stored_signs_fsl = tq
         .rotation_signs()
         .clone()
         .execute::<FixedSizeListArray>(&mut ctx)?;
@@ -601,7 +619,7 @@ fn slice_preserves_data() -> VortexResult<()> {
         num_rounds: 4,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
 
     // Full decompress then slice.
     let mut ctx = SESSION.create_execution_ctx();
@@ -646,7 +664,7 @@ fn scalar_at_matches_decompress() -> VortexResult<()> {
         num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
 
     let full_decoded = encoded.clone().execute::<ExtensionArray>(&mut ctx)?;
 
@@ -668,11 +686,11 @@ fn l2_norm_readthrough() -> VortexResult<()> {
         num_rounds: 5,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
-    let tq = encoded.as_opt::<TurboQuant>().unwrap();
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
+    let (_tq_child, norms_child) = unwrap_l2denorm(&encoded);
 
     // Stored norms should match the actual L2 norms of the input.
-    let norms_prim = tq.norms().clone().execute::<PrimitiveArray>(&mut ctx)?;
+    let norms_prim = norms_child.execute::<PrimitiveArray>(&mut ctx)?;
     let stored_norms = norms_prim.as_slice::<f32>();
 
     let input_prim = fsl.elements().clone().execute::<PrimitiveArray>(&mut ctx)?;
@@ -700,8 +718,9 @@ fn cosine_similarity_quantized_accuracy() -> VortexResult<()> {
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
-    let tq = encoded.as_opt::<TurboQuant>().unwrap();
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
+    let (tq_child, norms_child) = unwrap_l2denorm(&encoded);
+    let tq = tq_child.as_opt::<TurboQuant>().unwrap();
 
     // Compute exact cosine similarity from original data.
     let input_prim = fsl.elements().clone().execute::<PrimitiveArray>(&mut ctx)?;
@@ -710,7 +729,7 @@ fn cosine_similarity_quantized_accuracy() -> VortexResult<()> {
     // Read quantized codes, norms, and centroids for approximate computation.
     let mut ctx = SESSION.create_execution_ctx();
     let pd = tq.padded_dim() as usize;
-    let norms_prim = tq.norms().clone().execute::<PrimitiveArray>(&mut ctx)?;
+    let norms_prim = norms_child.execute::<PrimitiveArray>(&mut ctx)?;
     let norms = norms_prim.as_slice::<f32>();
     let codes_fsl = tq.codes().clone().execute::<FixedSizeListArray>(&mut ctx)?;
     let codes_prim = codes_fsl
@@ -778,15 +797,16 @@ fn dot_product_quantized_accuracy() -> VortexResult<()> {
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
-    let tq = encoded.as_opt::<TurboQuant>().unwrap();
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
+    let (tq_child, norms_child) = unwrap_l2denorm(&encoded);
+    let tq = tq_child.as_opt::<TurboQuant>().unwrap();
 
     let input_prim = fsl.elements().clone().execute::<PrimitiveArray>(&mut ctx)?;
     let input_f32 = input_prim.as_slice::<f32>();
 
     let mut ctx = SESSION.create_execution_ctx();
     let pd = tq.padded_dim() as usize;
-    let norms_prim = tq.norms().clone().execute::<PrimitiveArray>(&mut ctx)?;
+    let norms_prim = norms_child.execute::<PrimitiveArray>(&mut ctx)?;
     let norms = norms_prim.as_slice::<f32>();
     let codes_fsl = tq.codes().clone().execute::<FixedSizeListArray>(&mut ctx)?;
     let codes_prim = codes_fsl
@@ -871,7 +891,7 @@ fn encoded_dtype_is_vector_extension() -> VortexResult<()> {
         num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
 
     // The encoded TurboQuant array should claim a Vector extension dtype.
     assert!(
@@ -906,7 +926,7 @@ fn nullable_vectors_roundtrip() -> VortexResult<()> {
         num_rounds: 4,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
 
     assert_eq!(encoded.len(), 10);
     assert!(encoded.dtype().is_nullable());
@@ -972,10 +992,10 @@ fn nullable_norms_match_validity() -> VortexResult<()> {
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
-    let tq = encoded.as_opt::<TurboQuant>().unwrap();
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
+    let (_tq_child, norms_child) = unwrap_l2denorm(&encoded);
 
-    let norms_validity = tq.norms().validity()?;
+    let norms_validity = norms_child.validity()?;
     for i in 0..5 {
         let expected = i % 2 == 0; // rows 0, 2, 4 are valid
         assert_eq!(
@@ -1000,7 +1020,7 @@ fn nullable_l2_norm_readthrough() -> VortexResult<()> {
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
 
     // Compute L2Norm on the encoded array.
     let norm_sfn = L2Norm::try_new_array(&ApproxOptions::Exact, encoded, 5)?;
@@ -1045,7 +1065,7 @@ fn nullable_slice_preserves_validity() -> VortexResult<()> {
         num_rounds: 2,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
 
     // Slice rows 1..6 -> [true, false, true, true, false].
     let sliced = encoded.slice(1..6)?;
@@ -1067,7 +1087,9 @@ fn nullable_slice_preserves_validity() -> VortexResult<()> {
 // Serde roundtrip tests
 // -----------------------------------------------------------------------
 
-/// Verify that a TurboQuant array survives serialize/deserialize.
+/// Verify that a TurboQuant array (extracted from the L2Denorm wrapper) survives
+/// serialize/deserialize. ScalarFnArray cannot be serialized yet, so we test the TQ child
+/// directly.
 #[test]
 fn serde_roundtrip() -> VortexResult<()> {
     use vortex_array::ArrayContext;
@@ -1088,14 +1110,15 @@ fn serde_roundtrip() -> VortexResult<()> {
         num_rounds: 5,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
+    let (tq_child, _norms) = unwrap_l2denorm(&encoded);
 
-    let dtype = encoded.dtype().clone();
-    let len = encoded.len();
+    let dtype = tq_child.dtype().clone();
+    let len = tq_child.len();
 
-    // Serialize.
+    // Serialize the TQ child.
     let array_ctx = ArrayContext::empty();
-    let serialized = encoded.serialize(&array_ctx, &SerializeOptions::default())?;
+    let serialized = tq_child.serialize(&array_ctx, &SerializeOptions::default())?;
 
     let mut concat = ByteBufferMut::empty();
     for buf in serialized {
@@ -1116,7 +1139,7 @@ fn serde_roundtrip() -> VortexResult<()> {
     )?;
 
     assert!(
-        decoded.array_eq(&encoded, Precision::Value),
+        decoded.array_eq(&tq_child, Precision::Value),
         "serde roundtrip did not preserve array equality"
     );
     Ok(())
@@ -1143,14 +1166,15 @@ fn serde_roundtrip_empty() -> VortexResult<()> {
         num_rounds: 3,
     };
     let mut ctx = SESSION.create_execution_ctx();
-    let encoded = turboquant_encode(ext.as_view(), &config, &mut ctx)?;
+    let encoded = normalize_and_encode(&ext, &config, &mut ctx)?;
     assert_eq!(encoded.len(), 0);
+    let (tq_child, _norms) = unwrap_l2denorm(&encoded);
 
-    let dtype = encoded.dtype().clone();
-    let len = encoded.len();
+    let dtype = tq_child.dtype().clone();
+    let len = tq_child.len();
 
     let array_ctx = ArrayContext::empty();
-    let serialized = encoded.serialize(&array_ctx, &SerializeOptions::default())?;
+    let serialized = tq_child.serialize(&array_ctx, &SerializeOptions::default())?;
 
     let mut concat = ByteBufferMut::empty();
     for buf in serialized {
@@ -1170,7 +1194,7 @@ fn serde_roundtrip_empty() -> VortexResult<()> {
     )?;
 
     assert!(
-        decoded.array_eq(&encoded, Precision::Value),
+        decoded.array_eq(&tq_child, Precision::Value),
         "serde roundtrip did not preserve array equality"
     );
     Ok(())

--- a/vortex-tensor/src/encodings/turboquant/tests.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests.rs
@@ -11,6 +11,7 @@ use rstest::rstest;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::Extension;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -24,6 +25,7 @@ use vortex_array::extension::EmptyMetadata;
 use vortex_array::session::ArraySession;
 use vortex_array::validity::Validity;
 use vortex_buffer::BufferMut;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_session::VortexSession;
 
@@ -32,6 +34,7 @@ use crate::encodings::turboquant::TurboQuantArrayExt;
 use crate::encodings::turboquant::TurboQuantConfig;
 use crate::encodings::turboquant::array::rotation::RotationMatrix;
 use crate::encodings::turboquant::turboquant_encode;
+use crate::encodings::turboquant::turboquant_encode_unchecked;
 use crate::scalar_fns::ApproxOptions;
 use crate::scalar_fns::l2_denorm::L2Denorm;
 use crate::scalar_fns::l2_denorm::normalize_as_l2_denorm;
@@ -100,7 +103,7 @@ fn make_vector_ext(fsl: &FixedSizeListArray) -> ExtensionArray {
 /// Full encode pipeline: normalize, then TQ-encode, then wrap in L2Denorm.
 ///
 /// This mirrors what `TurboQuantScheme::compress()` does: normalize via `normalize_as_l2_denorm`,
-/// then quantize the normalized child via `turboquant_encode`, then reassemble.
+/// then quantize the normalized child via `turboquant_encode_unchecked`, then reassemble.
 fn normalize_and_encode(
     ext: &ExtensionArray,
     config: &TurboQuantConfig,
@@ -112,9 +115,10 @@ fn normalize_and_encode(
     let num_rows = l2_denorm.len();
 
     let normalized_ext = normalized
-        .as_opt::<vortex_array::arrays::Extension>()
-        .expect("normalized child should be an Extension array");
-    let tq = turboquant_encode(normalized_ext, config, ctx)?;
+        .as_opt::<Extension>()
+        .vortex_expect("normalized child should be an Extension array");
+    // SAFETY: We just normalized the input via `normalize_as_l2_denorm`.
+    let tq = unsafe { turboquant_encode_unchecked(normalized_ext, config, ctx)? };
 
     Ok(L2Denorm::try_new_array(&ApproxOptions::Exact, tq, norms, num_rows)?.into_array())
 }

--- a/vortex-tensor/src/encodings/turboquant/tests.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests.rs
@@ -220,6 +220,17 @@ fn empty_turboquant_parts(
     ))
 }
 
+fn normalized_child(
+    ext: &ExtensionArray,
+    ctx: &mut vortex_array::ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    Ok(
+        normalize_as_l2_denorm(&ApproxOptions::Exact, ext.as_ref().clone(), ctx)?
+            .child_at(0)
+            .clone(),
+    )
+}
+
 // -----------------------------------------------------------------------
 // Roundtrip tests
 // -----------------------------------------------------------------------
@@ -397,6 +408,44 @@ fn rejects_dimension_below_128(#[case] dim: usize) {
     };
     let mut ctx = SESSION.create_execution_ctx();
     assert!(turboquant_encode(ext.as_view(), &config, &mut ctx).is_err());
+}
+
+#[test]
+fn checked_encode_accepts_normalized_f16_input() -> VortexResult<()> {
+    let num_rows = 10;
+    let dim = 128;
+    let mut rng = StdRng::seed_from_u64(99);
+    let normal = Normal::new(0.0f32, 1.0).unwrap();
+
+    let mut buf = BufferMut::<half::f16>::with_capacity(num_rows * dim);
+    for _ in 0..(num_rows * dim) {
+        buf.push(half::f16::from_f32(normal.sample(&mut rng)));
+    }
+    let elements = PrimitiveArray::new::<half::f16>(buf.freeze(), Validity::NonNullable);
+    let fsl = FixedSizeListArray::try_new(
+        elements.into_array(),
+        dim.try_into()
+            .expect("somehow got dimension greater than u32::MAX"),
+        Validity::NonNullable,
+        num_rows,
+    )?;
+
+    let ext = make_vector_ext(&fsl);
+    let config = TurboQuantConfig {
+        bit_width: 3,
+        seed: Some(42),
+        num_rounds: 3,
+    };
+
+    let mut ctx = SESSION.create_execution_ctx();
+    let normalized = normalized_child(&ext, &mut ctx)?;
+    let normalized_ext = normalized
+        .as_opt::<Extension>()
+        .vortex_expect("normalized child should be an Extension array");
+
+    let encoded = turboquant_encode(normalized_ext, &config, &mut ctx)?;
+    assert_eq!(encoded.len(), num_rows);
+    Ok(())
 }
 
 fn make_fsl_small(dim: usize) -> FixedSizeListArray {
@@ -1092,8 +1141,9 @@ fn nullable_slice_preserves_validity() -> VortexResult<()> {
 // -----------------------------------------------------------------------
 
 /// Verify that a TurboQuant array (extracted from the L2Denorm wrapper) survives
-/// serialize/deserialize. ScalarFnArray cannot be serialized yet, so we test the TQ child
-/// directly.
+/// serialize/deserialize.
+///
+/// TODO(connor): ScalarFnArray cannot be serialized yet, so we test the TQ child directly.
 #[test]
 fn serde_roundtrip() -> VortexResult<()> {
     use vortex_array::ArrayContext;

--- a/vortex-tensor/src/encodings/turboquant/tests.rs
+++ b/vortex-tensor/src/encodings/turboquant/tests.rs
@@ -120,7 +120,10 @@ fn normalize_and_encode(
     // SAFETY: We just normalized the input via `normalize_as_l2_denorm`.
     let tq = unsafe { turboquant_encode_unchecked(normalized_ext, config, ctx)? };
 
-    Ok(L2Denorm::try_new_array(&ApproxOptions::Exact, tq, norms, num_rows)?.into_array())
+    Ok(
+        unsafe { L2Denorm::new_array_unchecked(&ApproxOptions::Exact, tq, norms, num_rows) }?
+            .into_array(),
+    )
 }
 
 /// Unwrap an L2Denorm ScalarFnArray into its TQ child and norms child.

--- a/vortex-tensor/src/encodings/turboquant/vtable.rs
+++ b/vortex-tensor/src/encodings/turboquant/vtable.rs
@@ -26,6 +26,7 @@ use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
@@ -89,7 +90,8 @@ impl TurboQuant {
     /// Nullability is handled externally by the [`L2Denorm`](crate::scalar_fns::l2_denorm::L2Denorm)
     /// ScalarFnArray wrapper.
     ///
-    /// Internally calls [`TurboQuantData::validate`] and [`TurboQuantData::try_new`].
+    /// Internally calls [`TurboQuantData::validate`] and [`TurboQuantData::try_new`], then
+    /// delegates to [`new_array_unchecked`](Self::new_array_unchecked).
     pub fn try_new_array(
         dtype: DType,
         codes: ArrayRef,
@@ -98,25 +100,66 @@ impl TurboQuant {
     ) -> VortexResult<TurboQuantArray> {
         TurboQuantData::validate(&dtype, &codes, &centroids, &rotation_signs)?;
 
+        Ok(unsafe { Self::new_array_unchecked(dtype, codes, centroids, rotation_signs) })
+    }
+
+    /// Creates a new [`TurboQuantArray`] without validation.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure all invariants required by [`TurboQuantData::validate`] hold:
+    ///
+    /// - `dtype` is a non-nullable [`Vector`](crate::vector::Vector) extension type with
+    ///   dimension >= [`MIN_DIMENSION`](Self::MIN_DIMENSION).
+    /// - `codes` is a non-nullable `FixedSizeList<u8>` with `list_size == padded_dim`.
+    /// - `centroids` is a non-nullable `Primitive<f32>` with a power-of-2 length in
+    ///   `[2, MAX_CENTROIDS]` (or empty for degenerate arrays).
+    /// - `rotation_signs` is a non-nullable `FixedSizeList<u8>` with `list_size == padded_dim`.
+    ///
+    /// Violating these invariants may produce incorrect results during decompression or panics
+    /// during array access.
+    pub unsafe fn new_array_unchecked(
+        dtype: DType,
+        codes: ArrayRef,
+        centroids: ArrayRef,
+        rotation_signs: ArrayRef,
+    ) -> TurboQuantArray {
+        #[cfg(debug_assertions)]
+        TurboQuantData::validate(&dtype, &codes, &centroids, &rotation_signs)
+            .vortex_expect("[DEBUG ASSERTION]: TurboQuantData arrays are invalid");
+
         let len = codes.len();
-        let vector_metadata = TurboQuant::validate_dtype(&dtype)?;
+
+        let dimension = dtype
+            .as_extension_opt()
+            .and_then(|ext| ext.metadata_opt::<AnyVector>())
+            .map(|m| m.dimensions())
+            .unwrap_or(0);
 
         let bit_width = if centroids.is_empty() {
             0
         } else {
-            u8::try_from(centroids.len().trailing_zeros())
-                .map_err(|_| vortex_err!("centroids bit_width does not fit in u8"))?
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "bit_width is guaranteed <= 8"
+            )]
+            (centroids.len().trailing_zeros() as u8)
         };
 
-        // Derive num_rounds from the FSL rotation_signs length (0 for degenerate arrays).
-        let num_rounds = u8::try_from(rotation_signs.len())
-            .map_err(|_| vortex_err!("rotation_signs num_rounds does not fit in u8"))?;
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "num_rounds fits in u8 by the caller's invariants"
+        )]
+        let num_rounds = rotation_signs.len() as u8;
 
-        let data = TurboQuantData::try_new(vector_metadata.dimensions(), bit_width, num_rounds)?;
+        // SAFETY: The caller guarantees that dimension, bit_width, and num_rounds satisfy the
+        // invariants documented on `TurboQuantData::new_unchecked`.
+        let data = unsafe { TurboQuantData::new_unchecked(dimension, bit_width, num_rounds) };
         let parts = ArrayParts::new(TurboQuant, dtype, len, data)
             .with_slots(TurboQuantData::make_slots(codes, centroids, rotation_signs));
 
-        Array::try_from_parts(parts)
+        // SAFETY: The caller guarantees the parts are logically consistent.
+        unsafe { Array::from_parts_unchecked(parts) }
     }
 }
 

--- a/vortex-tensor/src/encodings/turboquant/vtable.rs
+++ b/vortex-tensor/src/encodings/turboquant/vtable.rs
@@ -26,6 +26,7 @@ use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
+#[cfg(debug_assertions)]
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;

--- a/vortex-tensor/src/encodings/turboquant/vtable.rs
+++ b/vortex-tensor/src/encodings/turboquant/vtable.rs
@@ -23,9 +23,9 @@ use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::serde::ArrayChildren;
+use vortex_array::validity::Validity;
 use vortex_array::vtable::VTable;
-use vortex_array::vtable::ValidityChild;
-use vortex_array::vtable::ValidityVTableFromChild;
+use vortex_array::vtable::ValidityVTable;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
@@ -33,7 +33,6 @@ use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 
-use crate::encodings::turboquant::TurboQuantArrayExt;
 use crate::encodings::turboquant::TurboQuantData;
 use crate::encodings::turboquant::array::slots::Slot;
 use crate::encodings::turboquant::compute::rules::PARENT_KERNELS;
@@ -86,17 +85,20 @@ impl TurboQuant {
 
     /// Creates a new [`TurboQuantArray`].
     ///
+    /// The `dtype` must be a non-nullable [`Vector`](crate::vector::Vector) extension type.
+    /// Nullability is handled externally by the [`L2Denorm`](crate::scalar_fns::l2_denorm::L2Denorm)
+    /// ScalarFnArray wrapper.
+    ///
     /// Internally calls [`TurboQuantData::validate`] and [`TurboQuantData::try_new`].
     pub fn try_new_array(
         dtype: DType,
         codes: ArrayRef,
-        norms: ArrayRef,
         centroids: ArrayRef,
         rotation_signs: ArrayRef,
     ) -> VortexResult<TurboQuantArray> {
-        TurboQuantData::validate(&dtype, &codes, &norms, &centroids, &rotation_signs)?;
+        TurboQuantData::validate(&dtype, &codes, &centroids, &rotation_signs)?;
 
-        let len = norms.len();
+        let len = codes.len();
         let vector_metadata = TurboQuant::validate_dtype(&dtype)?;
 
         let bit_width = if centroids.is_empty() {
@@ -111,9 +113,8 @@ impl TurboQuant {
             .map_err(|_| vortex_err!("rotation_signs num_rounds does not fit in u8"))?;
 
         let data = TurboQuantData::try_new(vector_metadata.dimensions(), bit_width, num_rounds)?;
-        let parts = ArrayParts::new(TurboQuant, dtype, len, data).with_slots(
-            TurboQuantData::make_slots(codes, norms, centroids, rotation_signs),
-        );
+        let parts = ArrayParts::new(TurboQuant, dtype, len, data)
+            .with_slots(TurboQuantData::make_slots(codes, centroids, rotation_signs));
 
         Array::try_from_parts(parts)
     }
@@ -125,7 +126,7 @@ pub type TurboQuantArray = Array<TurboQuant>;
 impl VTable for TurboQuant {
     type ArrayData = TurboQuantData;
     type OperationsVTable = TurboQuant;
-    type ValidityVTable = ValidityVTableFromChild;
+    type ValidityVTable = TurboQuant;
 
     fn id(&self) -> ArrayId {
         Self::ID
@@ -149,9 +150,6 @@ impl VTable for TurboQuant {
         let codes = slots[Slot::Codes as usize]
             .as_ref()
             .ok_or_else(|| vortex_err!("TurboQuantArray missing codes slot"))?;
-        let norms = slots[Slot::Norms as usize]
-            .as_ref()
-            .ok_or_else(|| vortex_err!("TurboQuantArray missing norms slot"))?;
         let centroids = slots[Slot::Centroids as usize]
             .as_ref()
             .ok_or_else(|| vortex_err!("TurboQuantArray missing centroids slot"))?;
@@ -160,12 +158,12 @@ impl VTable for TurboQuant {
             .ok_or_else(|| vortex_err!("TurboQuantArray missing rotation_signs slot"))?;
 
         vortex_ensure_eq!(
-            norms.len(),
+            codes.len(),
             len,
-            "TurboQuant norms length does not match outer length",
+            "TurboQuant codes length does not match outer length",
         );
 
-        TurboQuantData::validate(dtype, codes, norms, centroids, rotation_signs)?;
+        TurboQuantData::validate(dtype, codes, centroids, rotation_signs)?;
 
         vortex_ensure_eq!(data.dimension, Self::validate_dtype(dtype)?.dimensions());
 
@@ -234,24 +232,23 @@ impl VTable for TurboQuant {
             "num_rounds == 0 is only valid for empty arrays, got len={len}"
         );
 
-        // Validate and derive dimension and element ptype from the Vector extension dtype.
+        // Validate and derive dimension from the Vector extension dtype.
         let vector_metadata = TurboQuant::validate_dtype(dtype)?;
         let dimensions = vector_metadata.dimensions();
-        let element_ptype = vector_metadata.element_ptype();
+
+        // TurboQuant arrays are always non-nullable.
+        vortex_ensure!(
+            !dtype.is_nullable(),
+            "TurboQuant dtype must be non-nullable during deserialization"
+        );
 
         let padded_dim = dimensions.next_power_of_two();
 
-        // Get the codes array (indices into the codebook). Codes are always non-nullable;
-        // null vectors are represented by all-zero codes with a null norm.
+        // Get the codes array (indices into the codebook). Codes are always non-nullable.
         let codes_ptype = DType::Primitive(PType::U8, Nullability::NonNullable);
         let codes_dtype =
             DType::FixedSizeList(Arc::new(codes_ptype), padded_dim, Nullability::NonNullable);
         let codes_array = children.get(0, &codes_dtype, len)?;
-
-        // Get the L2 norms array. Norms carry the validity of the entire TurboQuant array:
-        // null vectors have null norms.
-        let norms_dtype = DType::Primitive(element_ptype, dtype.nullability());
-        let norms_array = children.get(1, &norms_dtype, len)?;
 
         // Get the centroids array (codebook).
         let num_centroids = if bit_width == 0 {
@@ -260,7 +257,7 @@ impl VTable for TurboQuant {
             1usize << bit_width
         };
         let centroids_dtype = DType::Primitive(PType::F32, Nullability::NonNullable);
-        let centroids = children.get(2, &centroids_dtype, num_centroids)?;
+        let centroids = children.get(1, &centroids_dtype, num_centroids)?;
 
         // Get the rotation signs array (FixedSizeList<u8> with list_size = padded_dim).
         let signs_len = if len == 0 { 0 } else { num_rounds as usize };
@@ -269,7 +266,7 @@ impl VTable for TurboQuant {
             padded_dim,
             Nullability::NonNullable,
         );
-        let rotation_signs = children.get(3, &signs_dtype, signs_len)?;
+        let rotation_signs = children.get(2, &signs_dtype, signs_len)?;
 
         Ok(ArrayParts::new(
             TurboQuant,
@@ -283,7 +280,6 @@ impl VTable for TurboQuant {
         )
         .with_slots(TurboQuantData::make_slots(
             codes_array,
-            norms_array,
             centroids,
             rotation_signs,
         )))
@@ -314,9 +310,11 @@ impl VTable for TurboQuant {
     }
 }
 
-impl ValidityChild<TurboQuant> for TurboQuant {
-    fn validity_child(array: ArrayView<'_, TurboQuant>) -> ArrayRef {
-        array.norms().clone()
+impl ValidityVTable<TurboQuant> for TurboQuant {
+    fn validity(_array: ArrayView<'_, TurboQuant>) -> VortexResult<Validity> {
+        // TurboQuant arrays are always non-nullable. This method is only called when the dtype is
+        // nullable, which should never happen for TQ arrays.
+        Ok(Validity::NonNullable)
     }
 }
 

--- a/vortex-tensor/src/encodings/turboquant/vtable.rs
+++ b/vortex-tensor/src/encodings/turboquant/vtable.rs
@@ -26,7 +26,6 @@ use vortex_array::serde::ArrayChildren;
 use vortex_array::validity::Validity;
 use vortex_array::vtable::VTable;
 use vortex_array::vtable::ValidityVTable;
-#[cfg(debug_assertions)]
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
@@ -133,9 +132,10 @@ impl TurboQuant {
 
         let dimension = dtype
             .as_extension_opt()
-            .and_then(|ext| ext.metadata_opt::<AnyVector>())
-            .map(|m| m.dimensions())
-            .unwrap_or(0);
+            .vortex_expect("we validated the dtype")
+            .metadata_opt::<AnyVector>()
+            .vortex_expect("we validated that this is a vector")
+            .dimensions();
 
         let bit_width = if centroids.is_empty() {
             0

--- a/vortex-tensor/src/scalar_fns/l2_denorm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_denorm.rs
@@ -200,9 +200,9 @@ impl ScalarFnVTable for L2Denorm {
 /// Builds an unexecuted [`L2Denorm`] expression by normalizing `input` and reattaching the exact
 /// norms as the norms child.
 ///
-/// The returned array is a lazy `L2Denorm(normalized, norms)` scalar function array.
-#[allow(dead_code, reason = "TODO(connor): Use this in a scheme")]
-fn normalize_as_l2_denorm(
+/// The returned array is a lazy `L2Denorm(normalized, norms)` scalar function array. The
+/// normalized child is a materialized extension array with unit-norm rows.
+pub(crate) fn normalize_as_l2_denorm(
     options: &ApproxOptions,
     input: ArrayRef,
     ctx: &mut ExecutionCtx,
@@ -216,8 +216,9 @@ fn normalize_as_l2_denorm(
     let norms: PrimitiveArray = norms_array.clone().execute(ctx)?;
 
     let input: ExtensionArray = input.execute(ctx)?;
-    let validity = input.as_ref().validity()?;
-    let normalized_dtype = input.dtype().clone();
+    // The normalized child is always non-nullable. Null rows become zero vectors (since their
+    // norm is zero), and nullability is tracked by the norms child in the L2Denorm wrapper.
+    let normalized_dtype = input.dtype().as_nonnullable();
     let flat = extract_flat_elements(input.storage_array(), tensor_flat_size, ctx)?;
 
     let normalized = match_each_float_ptype!(flat.ptype(), |T| {
@@ -239,7 +240,7 @@ fn normalize_as_l2_denorm(
             normalized_dtype,
             tensor_flat_size,
             row_count,
-            validity,
+            Validity::NonNullable,
             elements,
         )
     })?;

--- a/vortex-tensor/src/scalar_fns/l2_denorm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_denorm.rs
@@ -27,6 +27,7 @@ use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
+use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
@@ -200,9 +201,24 @@ impl ScalarFnVTable for L2Denorm {
 /// Builds an unexecuted [`L2Denorm`] expression by normalizing `input` and reattaching the exact
 /// norms as the norms child.
 ///
-/// The returned array is a lazy `L2Denorm(normalized, norms)` scalar function array. The
-/// normalized child is a materialized extension array with unit-norm rows.
-pub(crate) fn normalize_as_l2_denorm(
+/// The returned array is a lazy `L2Denorm(normalized, norms)` scalar function array.
+///
+/// # Normalized child
+///
+/// The normalized child is always **non-nullable** with [`Validity::NonNullable`]. Every non-null
+/// row with a positive L2 norm is divided by its norm to produce a unit-norm vector.
+///
+/// Rows that are null in the original input are **zeroed out** in the normalized output. This is
+/// necessary because null rows may have undefined (garbage) physical storage values, and we do not
+/// want to let those propagate into downstream encodings (like TurboQuant).
+///
+/// # Nullability
+///
+/// Nullability is tracked entirely by the norms child. Null input rows produce null norms via
+/// [`L2Norm`]'s validity propagation. When the [`L2Denorm`] wrapper is executed, its validity is
+/// `and(normalized_validity, norms_validity)`, which correctly identifies originally-null rows
+/// since the normalized child is all-valid and the norms child carries the original nulls.
+pub fn normalize_as_l2_denorm(
     options: &ApproxOptions,
     input: ArrayRef,
     ctx: &mut ExecutionCtx,
@@ -214,34 +230,40 @@ pub(crate) fn normalize_as_l2_denorm(
     let norms_sfn = L2Norm::try_new_array(options, input.clone(), row_count)?;
     let norms_array: ArrayRef = norms_sfn.into_array().execute(ctx)?;
     let norms: PrimitiveArray = norms_array.clone().execute(ctx)?;
+    let norms_validity = norms.validity()?;
 
     let input: ExtensionArray = input.execute(ctx)?;
-    // The normalized child is always non-nullable. Null rows become zero vectors (since their
-    // norm is zero), and nullability is tracked by the norms child in the L2Denorm wrapper.
     let normalized_dtype = input.dtype().as_nonnullable();
     let flat = extract_flat_elements(input.storage_array(), tensor_flat_size, ctx)?;
 
     let normalized = match_each_float_ptype!(flat.ptype(), |T| {
         let norm_values = norms.as_slice::<T>();
-        let elements: Buffer<T> = (0..row_count)
-            .flat_map(|i| {
-                let norm = norm_values[i];
-                flat.row::<T>(i).iter().map(move |&x| {
-                    if norm == T::zero() {
-                        T::zero()
-                    } else {
-                        x / norm
-                    }
-                })
-            })
-            .collect();
+
+        let total_elements = row_count * tensor_flat_size;
+        let mut elements = BufferMut::<T>::with_capacity(total_elements);
+        for i in 0..row_count {
+            let is_valid = norms_validity.is_valid(i)?;
+            let norm = norm_values[i];
+
+            // SAFETY: We allocated `row_count * tensor_flat_size` capacity and push exactly
+            // `tensor_flat_size` elements per row.
+
+            // Null rows must be explicitly zeroed out.
+            if !is_valid || norm == T::zero() {
+                unsafe { elements.push_n_unchecked(T::zero(), tensor_flat_size) };
+            } else {
+                for &x in flat.row::<T>(i) {
+                    unsafe { elements.push_unchecked(x / norm) };
+                }
+            }
+        }
 
         build_tensor_array(
             normalized_dtype,
             tensor_flat_size,
             row_count,
             Validity::NonNullable,
-            elements,
+            elements.freeze(),
         )
     })?;
 

--- a/vortex-tensor/src/scalar_fns/l2_denorm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_denorm.rs
@@ -5,6 +5,7 @@
 
 use std::fmt::Formatter;
 
+use num_traits::ToPrimitive;
 use num_traits::Zero;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
@@ -16,6 +17,7 @@ use vortex_array::arrays::ScalarFnArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
+use vortex_array::dtype::PType;
 use vortex_array::expr::Expression;
 use vortex_array::expr::and;
 use vortex_array::match_each_float_ptype;
@@ -31,6 +33,7 @@ use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
+use vortex_error::vortex_ensure;
 use vortex_error::vortex_ensure_eq;
 
 use crate::matcher::AnyTensor;
@@ -54,30 +57,104 @@ pub struct L2Denorm;
 impl L2Denorm {
     /// Creates a new [`ScalarFn`] wrapping the L2 denormalization operation with the given
     /// [`ApproxOptions`] controlling approximation behavior.
+    ///
+    /// This is a low-level scalar-function descriptor constructor. To build a semantically valid
+    /// [`L2Denorm`] array, prefer [`try_new_array`](Self::try_new_array).
     pub fn new(options: &ApproxOptions) -> ScalarFn<L2Denorm> {
         ScalarFn::new(L2Denorm, options.clone())
     }
 
-    /// Constructs a [`ScalarFnArray`] that lazily re-applies `norms` to `normalized`.
+    /// Constructs a validated [`ScalarFnArray`] that lazily re-applies `norms` to `normalized`.
+    ///
+    /// This is the correct constructor for [`L2Denorm`] arrays. In addition to the structural
+    /// checks performed by [`ScalarFnArray::try_new`], it validates that every valid row of the
+    /// `normalized` child has L2 norm `1.0` (or `0.0` for zero rows), within the tolerance implied
+    /// by the child element precision.
     ///
     /// # Errors
     ///
     /// Returns an error if the [`ScalarFnArray`] cannot be constructed (e.g. due to dtype
-    /// mismatches).
+    /// mismatches) or if the `normalized` child is not row-wise L2-normalized.
     pub fn try_new_array(
         options: &ApproxOptions,
         normalized: ArrayRef,
         norms: ArrayRef,
         len: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ScalarFnArray> {
-        // TODO(connor): Should figure out a way to do validation here instead of inside
-        // `return_dtype()` which this calls?
+        validate_l2_normalized_rows(normalized.clone(), ctx)?;
+
+        // SAFETY: We just validated that it is normalized.
+        unsafe { Self::new_array_unchecked(options, normalized, norms, len) }
+    }
+
+    /// Constructs an [`L2Denorm`] array without validating that the `normalized` child is actually
+    /// row-wise L2-normalized.
+    ///
+    /// This escape hatch is intended for advanced callers that already established, or
+    /// intentionally relax, the normalized-child invariant. Structural validation still runs via
+    /// [`ScalarFnArray::try_new`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the `normalized` child is semantically suitable for L2
+    /// denormalization, which typically means every valid row is unit-norm or zero. Violating this
+    /// invariant will not cause memory unsafety, but may produce incorrect results.
+    pub unsafe fn new_array_unchecked(
+        options: &ApproxOptions,
+        normalized: ArrayRef,
+        norms: ArrayRef,
+        len: usize,
+    ) -> VortexResult<ScalarFnArray> {
         ScalarFnArray::try_new(
             L2Denorm::new(options).erased(),
             vec![normalized, norms],
             len,
         )
     }
+}
+
+/// Returns the acceptable unit-norm drift for the given element precision.
+fn unit_norm_tolerance(element_ptype: PType) -> f64 {
+    match element_ptype {
+        PType::F16 => 2e-3,
+        PType::F32 => 2e-6,
+        PType::F64 => 1e-10,
+        _ => unreachable!("L2Denorm requires float elements, got {element_ptype:?}"),
+    }
+}
+
+/// Validates that every valid row of `input` is already L2-normalized.
+pub fn validate_l2_normalized_rows(input: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<()> {
+    let row_count = input.len();
+    if row_count == 0 {
+        return Ok(());
+    }
+
+    let tensor_match = validate_tensor_float_input(input.dtype())?;
+    let element_ptype = tensor_match.element_ptype();
+    let tolerance = unit_norm_tolerance(element_ptype);
+
+    let norms_sfn = L2Norm::try_new_array(&ApproxOptions::Exact, input, row_count)?;
+    let norms: PrimitiveArray = norms_sfn.into_array().execute(ctx)?;
+    let norms_validity = norms.validity()?;
+
+    match_each_float_ptype!(element_ptype, |T| {
+        for (i, &norm) in norms.as_slice::<T>().iter().enumerate() {
+            if !norms_validity.is_valid(i)? {
+                continue;
+            }
+
+            let norm_f64 = ToPrimitive::to_f64(&norm).unwrap_or(f64::NAN);
+            vortex_ensure!(
+                norm_f64 == 0.0 || (norm_f64 - 1.0).abs() <= tolerance,
+                "L2Denorm normalized child must have L2 norm 1.0 or 0.0, but row {i} has \
+                 {norm_f64:.6}",
+            );
+        }
+    });
+
+    Ok(())
 }
 
 impl ScalarFnVTable for L2Denorm {
@@ -268,7 +345,7 @@ pub fn normalize_as_l2_denorm(
     })?;
 
     // TODO(connor): Need to figure out a way to not run validation.
-    L2Denorm::try_new_array(options, normalized, norms_array, row_count)
+    L2Denorm::try_new_array(options, normalized, norms_array, row_count, ctx)
 }
 
 /// Rebuilds a tensor-like extension array from flat primitive elements.
@@ -307,15 +384,14 @@ mod tests {
     use vortex_array::arrays::FixedSizeListArray;
     use vortex_array::arrays::MaskedArray;
     use vortex_array::arrays::PrimitiveArray;
-    use vortex_array::arrays::ScalarFnArray;
     use vortex_array::arrays::extension::ExtensionArrayExt;
     use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
     use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::extension::ExtDType;
+    use vortex_array::extension::EmptyMetadata;
     use vortex_array::extension::datetime::Date;
     use vortex_array::extension::datetime::TimeUnit;
-    use vortex_array::scalar_fn::ScalarFn;
     use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
@@ -327,20 +403,22 @@ mod tests {
     use crate::scalar_fns::ApproxOptions;
     use crate::scalar_fns::l2_denorm::L2Denorm;
     use crate::scalar_fns::l2_denorm::normalize_as_l2_denorm;
+    use crate::scalar_fns::l2_denorm::validate_l2_normalized_rows;
     use crate::utils::test_helpers::assert_close;
     use crate::utils::test_helpers::constant_tensor_array;
     use crate::utils::test_helpers::constant_vector_array;
     use crate::utils::test_helpers::tensor_array;
     use crate::utils::test_helpers::vector_array;
+    use crate::vector::Vector;
 
     static SESSION: LazyLock<VortexSession> =
         LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
 
     /// Evaluates L2 denorm on a tensor/vector array and returns the executed array.
     fn eval_l2_denorm(normalized: ArrayRef, norms: ArrayRef, len: usize) -> VortexResult<ArrayRef> {
-        let scalar_fn = ScalarFn::new(L2Denorm, ApproxOptions::Exact).erased();
-        let result = ScalarFnArray::try_new(scalar_fn, vec![normalized, norms], len)?;
         let mut ctx = SESSION.create_execution_ctx();
+        let result =
+            L2Denorm::try_new_array(&ApproxOptions::Exact, normalized, norms, len, &mut ctx)?;
         result.into_array().execute(&mut ctx)
     }
 
@@ -363,6 +441,16 @@ mod tests {
         let ext_dtype =
             ExtDType::<Date>::try_new(TimeUnit::Days, storage.dtype().clone())?.erased();
         Ok(ExtensionArray::new(ext_dtype, storage).into_array())
+    }
+
+    fn f16_vector_array(dim: u32, elements: &[f32]) -> VortexResult<ArrayRef> {
+        let row_count = elements.len() / dim as usize;
+        let values: Vec<_> = elements.iter().copied().map(half::f16::from_f32).collect();
+        let elems: ArrayRef = Buffer::copy_from(values.as_slice()).into_array();
+        let fsl = FixedSizeListArray::new(elems, dim, Validity::NonNullable, row_count);
+
+        let ext_dtype = ExtDType::<Vector>::try_new(EmptyMetadata, fsl.dtype().clone())?.erased();
+        Ok(ExtensionArray::new(ext_dtype, fsl.into_array()).into_array())
     }
 
     fn tensor_snapshot(array: ArrayRef) -> VortexResult<(DType, Vec<bool>, Vec<f64>)> {
@@ -435,7 +523,8 @@ mod tests {
         let lhs = PrimitiveArray::from_iter([1.0f64, 2.0]).into_array();
         let rhs = PrimitiveArray::from_iter([1.0f64, 1.0]).into_array();
 
-        let result = L2Denorm::try_new_array(&ApproxOptions::Exact, lhs, rhs, 2);
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = L2Denorm::try_new_array(&ApproxOptions::Exact, lhs, rhs, 2, &mut ctx);
         assert!(result.is_err());
     }
 
@@ -444,7 +533,8 @@ mod tests {
         let lhs = non_tensor_extension_array()?;
         let rhs = PrimitiveArray::from_iter([1.0f64, 1.0]).into_array();
 
-        let result = L2Denorm::try_new_array(&ApproxOptions::Exact, lhs, rhs, 2);
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = L2Denorm::try_new_array(&ApproxOptions::Exact, lhs, rhs, 2, &mut ctx);
         assert!(result.is_err());
         Ok(())
     }
@@ -454,7 +544,8 @@ mod tests {
         let lhs = integer_tensor_array(&[2], &[1, 2, 3, 4])?;
         let rhs = PrimitiveArray::from_iter([1.0f64, 1.0]).into_array();
 
-        let result = L2Denorm::try_new_array(&ApproxOptions::Exact, lhs, rhs, 2);
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = L2Denorm::try_new_array(&ApproxOptions::Exact, lhs, rhs, 2, &mut ctx);
         assert!(result.is_err());
         Ok(())
     }
@@ -464,8 +555,49 @@ mod tests {
         let lhs = vector_array(2, &[1.0, 0.0, 0.0, 1.0])?;
         let rhs = PrimitiveArray::from_iter([1.0f32, 1.0]).into_array();
 
-        let result = L2Denorm::try_new_array(&ApproxOptions::Exact, lhs, rhs, 2);
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = L2Denorm::try_new_array(&ApproxOptions::Exact, lhs, rhs, 2, &mut ctx);
         assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn validate_l2_normalized_rows_accepts_normalized_f16_input() -> VortexResult<()> {
+        let input = f16_vector_array(2, &[3.0, 4.0, 0.0, 0.0])?;
+        let mut ctx = SESSION.create_execution_ctx();
+        let roundtrip = normalize_as_l2_denorm(&ApproxOptions::Exact, input, &mut ctx)?;
+        validate_l2_normalized_rows(roundtrip.child_at(0).clone(), &mut ctx)?;
+        Ok(())
+    }
+
+    #[test]
+    fn validate_l2_normalized_rows_rejects_unnormalized_input() -> VortexResult<()> {
+        let input = vector_array(2, &[3.0, 4.0, 1.0, 0.0])?;
+        let mut ctx = SESSION.create_execution_ctx();
+        let result = validate_l2_normalized_rows(input, &mut ctx);
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn l2_denorm_try_new_array_rejects_unnormalized_child() -> VortexResult<()> {
+        let normalized = vector_array(2, &[3.0, 4.0, 1.0, 0.0])?;
+        let norms = PrimitiveArray::from_iter([5.0f64, 1.0]).into_array();
+        let mut ctx = SESSION.create_execution_ctx();
+
+        let result = L2Denorm::try_new_array(&ApproxOptions::Exact, normalized, norms, 2, &mut ctx);
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn l2_denorm_new_array_unchecked_accepts_unnormalized_child() -> VortexResult<()> {
+        let normalized = vector_array(2, &[3.0, 4.0, 1.0, 0.0])?;
+        let norms = PrimitiveArray::from_iter([5.0f64, 1.0]).into_array();
+
+        let result =
+            unsafe { L2Denorm::new_array_unchecked(&ApproxOptions::Exact, normalized, norms, 2) };
+        assert!(result.is_ok());
         Ok(())
     }
 

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -12,7 +12,9 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::ScalarFnArray;
+use vortex_array::arrays::ScalarFnVTable as ScalarFnArrayVTable;
 use vortex_array::arrays::extension::ExtensionArrayExt;
+use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
@@ -29,10 +31,9 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure_eq;
 
-use crate::encodings::turboquant::TurboQuant;
-use crate::encodings::turboquant::TurboQuantArrayExt;
 use crate::matcher::AnyTensor;
 use crate::scalar_fns::ApproxOptions;
+use crate::scalar_fns::l2_denorm::L2Denorm;
 use crate::utils::extract_flat_elements;
 use crate::utils::validate_tensor_float_input;
 
@@ -121,15 +122,17 @@ impl ScalarFnVTable for L2Norm {
         let tensor_flat_size = tensor_match.list_size();
         let element_ptype = tensor_match.element_ptype();
 
-        // TODO(connor): TQ might not store norms in the future.
-        // TurboQuant stores exact precomputed norms, so no decompression needed.
-        if let Some(tq) = input_ref.as_opt::<TurboQuant>() {
-            let norms: PrimitiveArray = tq.norms().clone().execute(ctx)?;
+        // L2Norm(L2Denorm(normalized, norms)) == norms, since normalized vectors have unit norm
+        // and L2 norms are non-negative. This avoids decompressing the TQ child just to recompute
+        // norms that are already stored.
+        if let Some(sfn) = input_ref.as_opt::<ScalarFnArrayVTable>()
+            && sfn.scalar_fn().as_opt::<L2Denorm>().is_some()
+        {
+            let norms: PrimitiveArray = sfn.child_at(1).clone().execute(ctx)?;
 
-            // Assert that the norms dtype has the correct output dtype and nullability.
             vortex_ensure_eq!(
                 norms.dtype(),
-                &DType::Primitive(element_ptype, input_ref.dtype().nullability(),)
+                &DType::Primitive(element_ptype, input_ref.dtype().nullability())
             );
 
             return Ok(norms.into_array());

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -439,16 +439,20 @@ mod turboquant_benches {
     use rand::SeedableRng;
     use rand::rngs::StdRng;
     use vortex::array::IntoArray;
+    use vortex::array::arrays::Extension;
     use vortex::array::arrays::ExtensionArray;
     use vortex::array::arrays::FixedSizeListArray;
     use vortex::array::arrays::PrimitiveArray;
+    use vortex::array::arrays::scalar_fn::ScalarFnArrayExt;
     use vortex::array::dtype::extension::ExtDType;
     use vortex::array::extension::EmptyMetadata;
     use vortex::array::validity::Validity;
     use vortex_array::VortexSessionExecute;
     use vortex_buffer::BufferMut;
     use vortex_tensor::encodings::turboquant::TurboQuantConfig;
-    use vortex_tensor::encodings::turboquant::turboquant_encode;
+    use vortex_tensor::encodings::turboquant::turboquant_encode_unchecked;
+    use vortex_tensor::scalar_fns::ApproxOptions;
+    use vortex_tensor::scalar_fns::l2_denorm::normalize_as_l2_denorm;
     use vortex_tensor::vector::Vector;
 
     use super::SESSION;
@@ -492,18 +496,35 @@ mod turboquant_benches {
         }
     }
 
+    fn setup_normalized_vector_ext(dim: usize) -> ExtensionArray {
+        let ext = setup_vector_ext(dim);
+        let mut ctx = SESSION.create_execution_ctx();
+        let normalized = normalize_as_l2_denorm(&ApproxOptions::Exact, ext.into_array(), &mut ctx)
+            .unwrap()
+            .child_at(0)
+            .clone();
+        normalized.execute::<ExtensionArray>(&mut ctx).unwrap()
+    }
+
     macro_rules! turboquant_bench {
         (compress, $dim:literal, $bits:literal, $name:ident) => {
             paste! {
                 #[divan::bench(name = concat!("turboquant_compress_dim", stringify!($dim), "_", stringify!($bits), "bit"))]
                 fn $name(bencher: Bencher) {
-                    let ext = setup_vector_ext($dim);
+                    let normalized_ext = setup_normalized_vector_ext($dim);
                     let config = turboquant_config($bits);
                     with_byte_counter(bencher, (NUM_VECTORS * $dim * 4) as u64)
-                        .with_inputs(|| ext.clone())
+                        .with_inputs(|| normalized_ext.clone())
                         .bench_refs(|a| {
                             let mut ctx = SESSION.create_execution_ctx();
-                            turboquant_encode(a.as_view(), &config, &mut ctx).unwrap()
+                            let normalized = a
+                                .as_ref()
+                                .as_opt::<Extension>()
+                                .expect("normalized benchmark input should be an Extension array");
+                            // SAFETY: Benchmark inputs are normalized once up front so the timed
+                            // region measures only TurboQuant encoding.
+                            unsafe { turboquant_encode_unchecked(normalized, &config, &mut ctx) }
+                                .unwrap()
                         });
                 }
             }
@@ -512,10 +533,13 @@ mod turboquant_benches {
             paste! {
                 #[divan::bench(name = concat!("turboquant_decompress_dim", stringify!($dim), "_", stringify!($bits), "bit"))]
                 fn $name(bencher: Bencher) {
-                    let ext = setup_vector_ext($dim);
+                    let normalized_ext = setup_normalized_vector_ext($dim);
                     let config = turboquant_config($bits);
                     let mut ctx = SESSION.create_execution_ctx();
-                    let compressed = turboquant_encode(ext.as_view(), &config, &mut ctx).unwrap();
+                    let compressed = unsafe {
+                        turboquant_encode_unchecked(normalized_ext.as_view(), &config, &mut ctx)
+                    }
+                    .unwrap();
                     with_byte_counter(bencher, (NUM_VECTORS * $dim * 4) as u64)
                         .with_inputs(|| &compressed)
                         .bench_refs(|a| {


### PR DESCRIPTION
## Summary

Tracking issue: https://github.com/vortex-data/vortex/issues/7297

This is the first step in decomposing `TurboQuant` as 2 scalar fns on top of a dictionary.

We would like to (soon) decompose `TurboQuant` into a `Scheme` that roughly constructs the following array tree:

```
L2Denorm(
    norms,
    SorfTransform(
        rotation_signs,
        Dict(
            codes, (indices into centroids)
            values, (centroid book)
        ),
    ),
)
```

This is the outer layer.

## Testing

The logic is the same so existing tests suffice.