### PR TITLE
Add a dedicated CI build profile

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Build binary
         shell: bash
         env:
-          RUSTFLAGS: "-C target-cpu=native -C force-frame-pointers=yes"
+          RUSTFLAGS: "-C target-cpu=native"
         run: |
           cargo build --package ${{ matrix.benchmark.id }} --profile release_debug ${{ matrix.benchmark.build_args }}
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Build binary
         shell: bash
         env:
-          RUSTFLAGS: "-C target-cpu=native -C force-frame-pointers=yes"
+          RUSTFLAGS: "-C target-cpu=native"
         run: |
           cargo build --bin ${{ matrix.benchmark.id }} --profile release_debug ${{ matrix.benchmark.build_args }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -924,7 +924,7 @@ jobs:
         run: |
           cd vortex-ffi
           mkdir build
-          cmake -Bbuild
+          cmake -Bbuild -DRUST_BUILD_PROFILE=ci
           cmake --build build -j $(nproc)
           ctest --test-dir build -j $(nproc)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -822,7 +822,7 @@ jobs:
           command: "cargo test --profile ci -p vortex-sqllogictest --test sqllogictests --no-run"
 
   wasm-integration:
-    name: "wasm-integration"
+    name: "WASM integration smoke test"
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       # PyRight needs the project for type information, so use uv run
       - name: Python Lint - PyRight
         env:
-          MATURIN_PEP517_ARGS: "--profile dev"
+          MATURIN_PEP517_ARGS: "--profile ci"
         run: |
           uv sync --all-packages
           uv run basedpyright vortex-python
@@ -82,7 +82,7 @@ jobs:
     timeout-minutes: 40
     env:
       RUST_LOG: "info,uv=debug"
-      MATURIN_PEP517_ARGS: "--profile dev"
+      MATURIN_PEP517_ARGS: "--profile ci"
     steps:
       - uses: runs-on/action@v2
         if: github.repository == 'vortex-data/vortex'
@@ -171,9 +171,9 @@ jobs:
       - uses: ./.github/actions/setup-prebuild
       - name: Docs
         run: |
-          RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
+          RUSTDOCFLAGS="-D warnings" cargo doc --profile ci --no-deps
           # nextest doesn't support doc tests, so we run it here
-          cargo test --doc --workspace --all-features --exclude vortex-cxx --exclude vortex-jni --exclude vortex-ffi --exclude xtask --no-fail-fast
+          cargo test --profile ci --doc --workspace --all-features --exclude vortex-cxx --exclude vortex-jni --exclude vortex-ffi --exclude xtask --no-fail-fast
 
   build-rust:
     name: "Rust build (${{matrix.config.name}})"
@@ -203,7 +203,7 @@ jobs:
             runner: amd64-medium
             target: wasm32-unknown-unknown
             env:
-              rustflags: "RUSTFLAGS='-A warnings --cfg getrandom_backend=\"wasm_js\"'"
+              rustflags: "RUSTFLAGS='-A warnings'"
             args: "--target wasm32-unknown-unknown --exclude vortex --exclude vortex-cuda --exclude vortex-cub --exclude vortex-nvcomp --exclude vortex-datafusion --exclude vortex-duckdb --exclude vortex-tui --exclude vortex-zstd --exclude vortex-test-e2e-cuda --exclude vortex-sqllogictest"
     steps:
       - uses: runs-on/action@v2
@@ -217,7 +217,7 @@ jobs:
         run: rustup target add wasm32-unknown-unknown
       - uses: ./.github/actions/check-rebuild
         with:
-          command: "${{matrix.config.env.rustflags}} cargo hack build --locked ${{matrix.config.args}} --ignore-private"
+          command: "${{matrix.config.env.rustflags}} cargo hack build --profile ci --locked ${{matrix.config.args}} --ignore-private"
       - name: "Make sure no files changed after build"
         run: |
           git status --porcelain
@@ -258,13 +258,13 @@ jobs:
       - name: Rust Lint - Format
         run: cargo +$NIGHTLY_TOOLCHAIN fmt --all --check
       - name: Rustc check
-        run: RUSTFLAGS="-D warnings" cargo check --locked --all-features --all-targets
+        run: RUSTFLAGS="-D warnings" cargo check --profile ci --locked --all-features --all-targets
       - name: Rustc check (release)
         run: RUSTFLAGS="-D warnings" cargo check --locked --all-features --all-targets --release
       - name: Rust Lint - Clippy All Features
-        run: cargo clippy --locked --all-features --all-targets -- -D warnings
+        run: cargo clippy --profile ci --locked --all-features --all-targets -- -D warnings
       - name: Rust Lint - Clippy Default Features
-        run: cargo clippy --locked --all-targets -- -D warnings
+        run: cargo clippy --profile ci --locked --all-targets -- -D warnings
 
   cpp-lint:
     name: "C/C++ (lint)"
@@ -296,7 +296,7 @@ jobs:
       - name: Rust Lint - Clippy No Default Features
         shell: bash
         run: |
-          cargo hack --no-dev-deps --ignore-private clippy --no-default-features -- -D warnings
+          cargo hack --no-dev-deps --ignore-private clippy --profile ci --no-default-features -- -D warnings
 
   public-api:
     name: "Public API lock files"
@@ -315,7 +315,7 @@ jobs:
       - name: Install nightly for public-api
         run: rustup toolchain install $NIGHTLY_TOOLCHAIN
       - name: Regenerate public API lock files
-        run: cargo +$NIGHTLY_TOOLCHAIN xtask public-api
+        run: cargo +$NIGHTLY_TOOLCHAIN run --profile ci -p xtask -- public-api
       - name: Verify lock files are up to date
         run: |
           if ! git diff --quiet '**/public-api.lock'; then
@@ -524,12 +524,12 @@ jobs:
       - uses: ./.github/actions/check-rebuild
         with:
           command: >-
-            cargo build --locked --all-features --all-targets
+            cargo build --profile ci --locked --all-features --all-targets
             -p vortex-cuda -p vortex-cub -p vortex-nvcomp
             -p gpu-scan-cli -p vortex-test-e2e-cuda
       - name: Clippy CUDA crates
         run: |
-          cargo clippy --locked --all-features --all-targets \
+          cargo clippy --profile ci --locked --all-features --all-targets \
             -p vortex-cuda \
             -p vortex-cub \
             -p vortex-nvcomp \
@@ -564,6 +564,7 @@ jobs:
           FLAT_LAYOUT_INLINE_ARRAY_NODE: true
         run: |
           cargo nextest run \
+            --cargo-profile ci \
             --locked \
             -p vortex-file \
             -p vortex-cuda \
@@ -607,11 +608,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build tests
-        run: cargo test --locked -p vortex-cuda --all-features --target x86_64-unknown-linux-gnu --no-run
+        run: cargo test --profile ci --locked -p vortex-cuda --all-features --target x86_64-unknown-linux-gnu --no-run
       - name: "CUDA - ${{ matrix.sanitizer }}"
         env:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER: "compute-sanitizer ${{ matrix.runner_flags }}"
-        run: cargo test --locked -p vortex-cuda --all-features --target x86_64-unknown-linux-gnu
+        run: cargo test --profile ci --locked -p vortex-cuda --all-features --target x86_64-unknown-linux-gnu
 
   cuda-test-cudf:
     if: github.repository == 'vortex-data/vortex'
@@ -632,12 +633,12 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build cudf test library
-        run: cargo build --locked -p vortex-test-e2e-cuda --target x86_64-unknown-linux-gnu
+        run: cargo build --profile ci --locked -p vortex-test-e2e-cuda --target x86_64-unknown-linux-gnu
       - name: Download and run cudf-test-harness
         run: |
           curl -fsSL https://github.com/vortex-data/cudf-test-harness/releases/latest/download/cudf-test-harness-x86_64.tar.gz | tar -xz
           cd cudf-test-harness-x86_64
-          compute-sanitizer --tool memcheck --error-exitcode 1 ./cudf-test-harness check $GITHUB_WORKSPACE/target/x86_64-unknown-linux-gnu/debug/libvortex_test_e2e_cuda.so
+          compute-sanitizer --tool memcheck --error-exitcode 1 ./cudf-test-harness check $GITHUB_WORKSPACE/target/x86_64-unknown-linux-gnu/ci/libvortex_test_e2e_cuda.so
 
   rust-test-other:
     name: "Rust tests (${{ matrix.os }})"
@@ -664,14 +665,12 @@ jobs:
       - name: Setup (Windows)
         if: matrix.os == 'windows-x64'
         run: |
-          $flags = '-C debuginfo=0'
-          echo "RUSTFLAGS=$flags" >> $env:GITHUB_ENV
           echo "C:\rust\cargo\bin" >> $env:GITHUB_PATH
       - uses: ./.github/actions/setup-prebuild
       - name: Rust Tests (Windows)
         if: matrix.os == 'windows-x64'
         run: |
-          cargo nextest run --locked --workspace --all-features --no-fail-fast `
+          cargo nextest run --cargo-profile ci --locked --workspace --all-features --no-fail-fast `
             --exclude vortex-bench --exclude vortex-python --exclude vortex-duckdb `
             --exclude vortex-fuzz --exclude vortex-cuda --exclude vortex-nvcomp `
             --exclude vortex-cub --exclude vortex-test-e2e-cuda --exclude duckdb-bench `
@@ -681,11 +680,11 @@ jobs:
       - name: Rust Tests (Other)
         if: matrix.os != 'windows-x64'
         run: |
-          cargo nextest run --locked --workspace --all-features --no-fail-fast --exclude vortex-bench --exclude xtask --exclude vortex-sqllogictest
+          cargo nextest run --cargo-profile ci --locked --workspace --all-features --no-fail-fast --exclude vortex-bench --exclude xtask --exclude vortex-sqllogictest
       - uses: ./.github/actions/check-rebuild
         if: matrix.os != 'windows-x64'
         with:
-          command: "cargo test --locked --workspace --all-features --no-run --exclude vortex-bench --exclude xtask --exclude vortex-sqllogictest"
+          command: "cargo test --profile ci --locked --workspace --all-features --no-run --exclude vortex-bench --exclude xtask --exclude vortex-sqllogictest"
 
       - name: Alert incident.io
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/develop'
@@ -799,7 +798,7 @@ jobs:
           vortex-cxx/examples/build/hello-vortex vortex-cxx/examples/goldenfiles/example.vortex
       - uses: ./.github/actions/check-rebuild
         with:
-          command: "cargo build --locked -p vortex-cxx --lib"
+          command: "cargo build --profile ci --locked -p vortex-cxx --lib"
 
   sqllogic-test:
     name: "SQL logic tests"
@@ -817,10 +816,10 @@ jobs:
       - name: Run sqllogictest tests
         run: |
           ./vortex-sqllogictest/slt/tpch/generate_data.sh
-          cargo test -p vortex-sqllogictest --test sqllogictests
+          cargo test --profile ci -p vortex-sqllogictest --test sqllogictests
       - uses: ./.github/actions/check-rebuild
         with:
-          command: "cargo test -p vortex-sqllogictest --test sqllogictests --no-run"
+          command: "cargo test --profile ci -p vortex-sqllogictest --test sqllogictests --no-run"
 
   wasm-integration:
     name: "wasm-integration"
@@ -837,9 +836,9 @@ jobs:
         run: |
           curl https://get.wasmer.io -sSfL | sh
           echo "$HOME/.wasmer/bin" >> $GITHUB_PATH
-      - run: cargo build --target wasm32-wasip1
+      - run: cargo build --profile ci --target wasm32-wasip1
         working-directory: ./wasm-test
-      - run: wasmer run ./target/wasm32-wasip1/debug/wasm-test.wasm
+      - run: wasmer run ./target/wasm32-wasip1/ci/wasm-test.wasm
         working-directory: ./wasm-test
 
   miri:
@@ -883,11 +882,11 @@ jobs:
         run: rustup toolchain install $NIGHTLY_TOOLCHAIN
       - name: "regenerate all .fbs/.proto Rust code"
         run: |
-          cargo xtask generate-fbs
-          cargo xtask generate-proto
+          cargo run --profile ci -p xtask -- generate-fbs
+          cargo run --profile ci -p xtask -- generate-proto
       - name: "regenerate FFI header file"
         run: |
-          cargo +$NIGHTLY_TOOLCHAIN build -p vortex-ffi
+          cargo +$NIGHTLY_TOOLCHAIN build --profile ci -p vortex-ffi
       - name: "Make sure no files changed after regenerating"
         run: |
           git status --porcelain
@@ -920,7 +919,7 @@ jobs:
       - uses: ./.github/actions/setup-prebuild
       - name: "regenerate FFI header file"
         run: |
-          cargo +$NIGHTLY_TOOLCHAIN build -p vortex-ffi
+          cargo +$NIGHTLY_TOOLCHAIN build --profile ci -p vortex-ffi
       - name: Build and run C++ unit tests
         run: |
           cd vortex-ffi
@@ -954,7 +953,7 @@ jobs:
           targets: ${{ matrix.target.target }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           enable-sccache: "false"
-      - run: cargo build --package vortex-jni
+      - run: cargo build --profile ci --package vortex-jni
 
   compat-check:
     name: "Compat check"

--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Build binaries
         shell: bash
         env:
-          RUSTFLAGS: "-C target-cpu=native -C force-frame-pointers=yes"
+          RUSTFLAGS: "-C target-cpu=native"
         run: |
           packages="--bin data-gen --bin datafusion-bench --bin duckdb-bench"
           if [ "${{ matrix.build_lance }}" = "true" ]; then

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -388,7 +388,7 @@ inherits = "dev"
 debug = "line-tables-only"
 incremental = false
 
-# This rule only applies to all dependencies that are not members of the workspace.
+# This rule only applies to dependencies that are not members of the workspace.
 [profile.ci.package."*"]
 debug = false
 debug-assertions = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -382,3 +382,15 @@ lto = false
 [profile.bench_assert]
 debug-assertions = true
 inherits = "bench"
+
+[profile.ci]
+inherits = "dev"
+debug = "line-tables-only"
+incremental = false
+
+# This rule only applies to all dependencies that are not members of the workspace.
+[profile.ci.package."*"]
+debug = false
+debug-assertions = false
+strip = "debuginfo"
+incremental = false

--- a/vortex-ffi/CMakeLists.txt
+++ b/vortex-ffi/CMakeLists.txt
@@ -13,6 +13,7 @@ option(BUILD_TESTS "Build tests" OFF)
 
 set(SANITIZER "" CACHE STRING "Build with sanitizers")
 set(TARGET_TRIPLE "" CACHE STRING "Rust target triple for FFI library")
+set(RUST_BUILD_PROFILE "" CACHE STRING "Cargo profile name for the Rust FFI library")
 
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
@@ -46,12 +47,14 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL "Debug" AND
     message(FATAL_ERROR "vortex-ffi can only be built in Release, Debug, or RelWithDebInfo mode")
 endif()
 
-if (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    set(CMAKE_BUILD_TYPE_LOWER "release_debug")
-else()
-    string(TOLOWER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_LOWER)
+if (RUST_BUILD_PROFILE STREQUAL "")
+    if (CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+        set(RUST_BUILD_PROFILE "release_debug")
+    else()
+        string(TOLOWER ${CMAKE_BUILD_TYPE} RUST_BUILD_PROFILE)
+    endif()
 endif()
-set(LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../target/${TARGET_TRIPLE}/${CMAKE_BUILD_TYPE_LOWER}")
+set(LIBRARY_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../target/${TARGET_TRIPLE}/${RUST_BUILD_PROFILE}")
 
 if(WIN32)
     set(LIBRARY_PATH "${LIBRARY_DIR}/libvortex_ffi.lib")

--- a/wasm-test/Cargo.toml
+++ b/wasm-test/Cargo.toml
@@ -9,8 +9,10 @@ publish = false
 edition = "2024"
 rust-version = "1.86"
 
-#[lib]
-#crate-type = ["cdylib"]
-
 [dependencies]
 vortex = { path = "../vortex", default-features = false }
+
+[profile.ci]
+inherits = "dev"
+debug = "line-tables-only"
+incremental = false


### PR DESCRIPTION
## Summary

@gatesn pointed out to me that we disable incremental builds pretty selectively, and reading through the CI code we have many partial configuration that can be applied more widely.
I've attempted to unify all of them into a ci-specific build profile, and removed some flags that we pass twice (once in CI, and another already in `.cargo/config.toml`) 
