### PR TITLE
AVX2 take handles indices that are equal to the index type max value

### DIFF
--- a/vortex-array/src/arrays/primitive/compute/take/avx2.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/avx2.rs
@@ -14,6 +14,7 @@ use std::arch::x86_64::_mm_setzero_si128;
 use std::arch::x86_64::_mm_shuffle_epi32;
 use std::arch::x86_64::_mm_storeu_si128;
 use std::arch::x86_64::_mm_unpacklo_epi64;
+use std::arch::x86_64::_mm256_andnot_si256;
 use std::arch::x86_64::_mm256_cmpgt_epi32;
 use std::arch::x86_64::_mm256_cmpgt_epi64;
 use std::arch::x86_64::_mm256_cvtepu8_epi32;

--- a/vortex-array/src/arrays/primitive/compute/take/avx2.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/avx2.rs
@@ -135,6 +135,10 @@ unsafe fn take_avx2<V: NativePType, I: UnsignedPType>(buffer: &[V], indices: &[I
         }};
     }
 
+    if buffer.is_empty() {
+        return Buffer::zeroed(indices.len());
+    }
+
     match (I::PTYPE, V::PTYPE) {
         // Int value types. Only 32 and 64 bit types are supported.
         (PType::U8, PType::I32) => dispatch_avx2!(u8, i32),

--- a/vortex-array/src/arrays/primitive/compute/take/avx2.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/avx2.rs
@@ -592,7 +592,7 @@ mod avx2_tests {
     #[test]
     fn test_avx2_take_last_valid_index_u16() {
         let values: Vec<i64> = (0..(65535 + 1)).collect();
-        let indices: Vec<u8> = vec![65535; 20];
+        let indices: Vec<u16> = vec![65535; 20];
 
         let result = unsafe { take_avx2(&values, &indices) };
         assert_eq!(&vec![65535; indices.len()], result.as_slice());

--- a/vortex-array/src/arrays/primitive/compute/take/avx2.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/avx2.rs
@@ -201,7 +201,7 @@ macro_rules! impl_gather {
             impl_gather!(single; $idx, $value, load: $load, extend: $extend, splat: $splat, zero_vec: $zero_vec, mask_indices: $mask_indices, mask_cvt: |$mask_var| $mask_cvt, gather: $masked_gather, store: $store, WIDTH = $WIDTH, STRIDE = $STRIDE);
         )*
     };
-    (single; $idx:ty, $value:ty, load: $load:ident, extend: $extend:ident, splat: $splat:ident, zero_vec: $zero_vec:ident, mask_indices: $mask_indices:ident, mask_equal: $mask_equal:ident, mask_cvt: |$mask_var:ident| $mask_cvt:block, gather: $masked_gather:ident, store: $store:ident, WIDTH = $WIDTH:literal, STRIDE = $STRIDE:literal) => {
+    (single; $idx:ty, $value:ty, load: $load:ident, extend: $extend:ident, splat: $splat:ident, zero_vec: $zero_vec:ident, mask_indices: $mask_indices:ident, mask_cvt: |$mask_var:ident| $mask_cvt:block, gather: $masked_gather:ident, store: $store:ident, WIDTH = $WIDTH:literal, STRIDE = $STRIDE:literal) => {
             impl GatherFn<$idx, $value> for AVX2Gather {
                 const WIDTH: usize = $WIDTH;
                 const STRIDE: usize = $STRIDE;
@@ -222,7 +222,7 @@ macro_rules! impl_gather {
                     // Create a vec of the max idx.
                     let max_idx_vec = unsafe { $splat(max_idx as _) };
                     // Create a mask for valid indices (where the max_idx > provided index).
-                    let invalid_mask = unsafe { _mm256_or_si256($mask_indices(max_idx_vec, indices_vec), $mask_equal(max_idx_vec, indices_vec)) };
+                    let invalid_mask = unsafe { _mm256_andnot_si256($mask_indices(indices_vec, max_idx_vec), $splat(-1)) };
                     let invalid_mask = {
                         let $mask_var = invalid_mask;
                         $mask_cvt
@@ -249,7 +249,6 @@ impl_gather!(u8,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
-        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -261,7 +260,6 @@ impl_gather!(u8,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
-        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -275,7 +273,6 @@ impl_gather!(u8,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
-        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -287,7 +284,6 @@ impl_gather!(u8,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
-        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -304,7 +300,6 @@ impl_gather!(u16,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
-        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -316,7 +311,6 @@ impl_gather!(u16,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
-        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -330,7 +324,6 @@ impl_gather!(u16,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
-        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -342,7 +335,6 @@ impl_gather!(u16,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
-        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -359,7 +351,6 @@ impl_gather!(u32,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
-        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -371,7 +362,6 @@ impl_gather!(u32,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
-        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -385,7 +375,6 @@ impl_gather!(u32,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
-        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -397,7 +386,6 @@ impl_gather!(u32,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
-        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -413,7 +401,6 @@ impl_gather!(u64,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm_setzero_si128,
         mask_indices: _mm256_cmpgt_epi64,
-        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |m| {
             unsafe {
                 let lo_bits = _mm256_extracti128_si256::<0>(m);    // lower half
@@ -433,7 +420,6 @@ impl_gather!(u64,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm_setzero_si128,
         mask_indices: _mm256_cmpgt_epi64,
-        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |m| {
             unsafe {
                 let lo_bits = _mm256_extracti128_si256::<0>(m);    // lower half
@@ -455,7 +441,6 @@ impl_gather!(u64,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
-        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -467,7 +452,6 @@ impl_gather!(u64,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
-        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -533,8 +517,6 @@ where
 #[cfg_attr(miri, ignore)]
 #[cfg(target_arch = "x86_64")]
 mod avx2_tests {
-    use rstest::rstest;
-
     use super::*;
 
     macro_rules! test_cases {

--- a/vortex-array/src/arrays/primitive/compute/take/avx2.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/avx2.rs
@@ -118,7 +118,6 @@ where
 /// # Safety
 ///
 /// The caller must ensure the `avx2` feature is enabled.
-#[allow(dead_code, unused_variables, reason = "TODO(connor): Implement this")]
 #[target_feature(enable = "avx2")]
 #[doc(hidden)]
 unsafe fn take_avx2<V: NativePType, I: UnsignedPType>(buffer: &[V], indices: &[I]) -> Buffer<V> {
@@ -202,7 +201,7 @@ macro_rules! impl_gather {
             impl_gather!(single; $idx, $value, load: $load, extend: $extend, splat: $splat, zero_vec: $zero_vec, mask_indices: $mask_indices, mask_cvt: |$mask_var| $mask_cvt, gather: $masked_gather, store: $store, WIDTH = $WIDTH, STRIDE = $STRIDE);
         )*
     };
-    (single; $idx:ty, $value:ty, load: $load:ident, extend: $extend:ident, splat: $splat:ident, zero_vec: $zero_vec:ident, mask_indices: $mask_indices:ident, mask_cvt: |$mask_var:ident| $mask_cvt:block, gather: $masked_gather:ident, store: $store:ident, WIDTH = $WIDTH:literal, STRIDE = $STRIDE:literal) => {
+    (single; $idx:ty, $value:ty, load: $load:ident, extend: $extend:ident, splat: $splat:ident, zero_vec: $zero_vec:ident, mask_indices: $mask_indices:ident, mask_equal: $mask_equal:ident, mask_cvt: |$mask_var:ident| $mask_cvt:block, gather: $masked_gather:ident, store: $store:ident, WIDTH = $WIDTH:literal, STRIDE = $STRIDE:literal) => {
             impl GatherFn<$idx, $value> for AVX2Gather {
                 const WIDTH: usize = $WIDTH;
                 const STRIDE: usize = $STRIDE;
@@ -223,7 +222,7 @@ macro_rules! impl_gather {
                     // Create a vec of the max idx.
                     let max_idx_vec = unsafe { $splat(max_idx as _) };
                     // Create a mask for valid indices (where the max_idx > provided index).
-                    let invalid_mask = unsafe { $mask_indices(max_idx_vec, indices_vec) };
+                    let invalid_mask = unsafe { _mm256_or_si256($mask_indices(max_idx_vec, indices_vec), $mask_equal(max_idx_vec, indices_vec)) };
                     let invalid_mask = {
                         let $mask_var = invalid_mask;
                         $mask_cvt
@@ -250,6 +249,7 @@ impl_gather!(u8,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
+        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -261,6 +261,7 @@ impl_gather!(u8,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
+        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -274,6 +275,7 @@ impl_gather!(u8,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
+        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -285,6 +287,7 @@ impl_gather!(u8,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
+        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -301,6 +304,7 @@ impl_gather!(u16,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
+        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -312,6 +316,7 @@ impl_gather!(u16,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
+        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -325,6 +330,7 @@ impl_gather!(u16,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
+        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -336,6 +342,7 @@ impl_gather!(u16,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
+        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -352,6 +359,7 @@ impl_gather!(u32,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
+        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -363,6 +371,7 @@ impl_gather!(u32,
         splat: _mm256_set1_epi32,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi32,
+        mask_equal: _mm256_cmpeq_epi32,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i32gather_epi32,
         store: _mm256_storeu_si256,
@@ -376,6 +385,7 @@ impl_gather!(u32,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
+        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -387,6 +397,7 @@ impl_gather!(u32,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
+        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -402,6 +413,7 @@ impl_gather!(u64,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm_setzero_si128,
         mask_indices: _mm256_cmpgt_epi64,
+        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |m| {
             unsafe {
                 let lo_bits = _mm256_extracti128_si256::<0>(m);    // lower half
@@ -421,6 +433,7 @@ impl_gather!(u64,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm_setzero_si128,
         mask_indices: _mm256_cmpgt_epi64,
+        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |m| {
             unsafe {
                 let lo_bits = _mm256_extracti128_si256::<0>(m);    // lower half
@@ -442,6 +455,7 @@ impl_gather!(u64,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
+        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -453,6 +467,7 @@ impl_gather!(u64,
         splat: _mm256_set1_epi64x,
         zero_vec: _mm256_setzero_si256,
         mask_indices: _mm256_cmpgt_epi64,
+        mask_equal: _mm256_cmpeq_epi64,
         mask_cvt: |x| { x },
         gather: _mm256_mask_i64gather_epi64,
         store: _mm256_storeu_si256,
@@ -518,6 +533,8 @@ where
 #[cfg_attr(miri, ignore)]
 #[cfg(target_arch = "x86_64")]
 mod avx2_tests {
+    use rstest::rstest;
+
     use super::*;
 
     macro_rules! test_cases {
@@ -579,4 +596,22 @@ mod avx2_tests {
         index_type => u64,
         value_types => u32, i32, u64, i64, f32, f64
     );
+
+    #[test]
+    fn test_avx2_take_last_valid_index_u8() {
+        let values: Vec<i64> = (0..(255 + 1)).collect();
+        let indices: Vec<u8> = vec![255; 20];
+
+        let result = unsafe { take_avx2(&values, &indices) };
+        assert_eq!(&vec![255; indices.len()], result.as_slice());
+    }
+
+    #[test]
+    fn test_avx2_take_last_valid_index_u16() {
+        let values: Vec<i64> = (0..(65535 + 1)).collect();
+        let indices: Vec<u8> = vec![65535; 20];
+
+        let result = unsafe { take_avx2(&values, &indices) };
+        assert_eq!(&vec![65535; indices.len()], result.as_slice());
+    }
 }


### PR DESCRIPTION
The in the avx2 take code correctly states that we need to fitler out values
greater than but then it also filters out values that are equal, this fixes the
edge case for values that are equal to the max index value

Signed-off-by: Robert Kruszewski <github@robertk.io>
