### PR TITLE
fix: maturin never logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           || 'ubuntu-latest' }}
     timeout-minutes: 40
     env:
-      RUST_LOG: "info,maturin=warn,uv=debug"
+      RUST_LOG: "info,maturin=off,uv=debug"
       MATURIN_PEP517_ARGS: "--profile ci"
     steps:
       - uses: runs-on/action@v2


### PR DESCRIPTION
Maturin logs on stdout non-deterministically race with maturin printing the wheel path (which also goes to stdout). If the wheel path is not last, the `Pytest - Vortex` step fails.
