### PR TITLE
AllInvalid arrays have non empty distinct info

### DIFF
--- a/vortex-compressor/src/stats/float.rs
+++ b/vortex-compressor/src/stats/float.rs
@@ -179,7 +179,13 @@ where
             null_count: u32::try_from(array.len())?,
             value_count: 0,
             average_run_length: 0,
-            erased: TypedStats { distinct: None }.into(),
+            erased: TypedStats {
+                distinct: Some(DistinctInfo {
+                    distinct_values: HashSet::with_capacity_and_hasher(0, FxBuildHasher),
+                    distinct_count: 0,
+                }),
+            }
+            .into(),
         });
     }
 

--- a/vortex-compressor/src/stats/integer.rs
+++ b/vortex-compressor/src/stats/integer.rs
@@ -338,7 +338,12 @@ where
             erased: TypedStats {
                 min: T::max_value(),
                 max: T::min_value(),
-                distinct: None,
+                distinct: Some(DistinctInfo {
+                    distinct_values: HashMap::with_capacity_and_hasher(0, FxBuildHasher),
+                    distinct_count: 0,
+                    most_frequent_value: T::zero(),
+                    top_frequency: 0,
+                }),
             }
             .into(),
         });


### PR DESCRIPTION
This is required to handle cases where we are attempting to dict compress and
a sample ends up being all null

Signed-off-by: Robert Kruszewski <github@robertk.io>
