### PR TITLE
Add `tracing` support to the compressor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10458,6 +10458,7 @@ dependencies = [
  "rstest",
  "rustc-hash",
  "tracing",
+ "tracing-subscriber",
  "vortex-array",
  "vortex-buffer",
  "vortex-error",

--- a/benchmarks/compress-bench/src/main.rs
+++ b/benchmarks/compress-bench/src/main.rs
@@ -15,6 +15,7 @@ use regex::Regex;
 use vortex::utils::aliases::hash_map::HashMap;
 use vortex_bench::Engine;
 use vortex_bench::Format;
+use vortex_bench::LogFormat;
 use vortex_bench::Target;
 use vortex_bench::compress::CompressMeasurements;
 use vortex_bench::compress::CompressOp;
@@ -39,7 +40,7 @@ use vortex_bench::public_bi::PBIDataset::CMSprovider;
 use vortex_bench::public_bi::PBIDataset::Euro2016;
 use vortex_bench::public_bi::PBIDataset::Food;
 use vortex_bench::public_bi::PBIDataset::HashTags;
-use vortex_bench::setup_logging_and_tracing;
+use vortex_bench::setup_logging_and_tracing_with_format;
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
@@ -69,13 +70,17 @@ struct Args {
     output_path: Option<PathBuf>,
     #[arg(long)]
     tracing: bool,
+    /// Format for the primary stderr log sink. `text` is the default human-readable format;
+    /// `json` emits one JSON object per event, suitable for piping into `jq`.
+    #[arg(long, value_enum, default_value_t = LogFormat::Text)]
+    log_format: LogFormat,
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
-    setup_logging_and_tracing(args.verbose, args.tracing)?;
+    setup_logging_and_tracing_with_format(args.verbose, args.tracing, args.log_format)?;
 
     run_compress(
         args.iterations,

--- a/vortex-bench/Cargo.toml
+++ b/vortex-bench/Cargo.toml
@@ -61,6 +61,7 @@ tracing = { workspace = true }
 tracing-perfetto = { workspace = true }
 tracing-subscriber = { workspace = true, features = [
     "env-filter",
+    "json",
     "tracing-log",
 ] }
 url = { workspace = true }

--- a/vortex-bench/src/bin/data-gen.rs
+++ b/vortex-bench/src/bin/data-gen.rs
@@ -17,12 +17,13 @@ use vortex_bench::Benchmark;
 use vortex_bench::BenchmarkArg;
 use vortex_bench::CompactionStrategy;
 use vortex_bench::Format;
+use vortex_bench::LogFormat;
 use vortex_bench::Opt;
 use vortex_bench::Opts;
 use vortex_bench::conversions::convert_parquet_directory_to_vortex;
 use vortex_bench::create_benchmark;
 use vortex_bench::generate_duckdb_registration_sql;
-use vortex_bench::setup_logging_and_tracing;
+use vortex_bench::setup_logging_and_tracing_with_format;
 
 #[derive(Parser)]
 #[command(name = "bench-data-gen")]
@@ -37,6 +38,11 @@ struct Args {
     #[arg(long)]
     tracing: bool,
 
+    /// Format for the primary stderr log sink. `text` is the default human-readable format;
+    /// `json` emits one JSON object per event, suitable for piping into `jq`.
+    #[arg(long, value_enum, default_value_t = LogFormat::Text)]
+    log_format: LogFormat,
+
     #[arg(long, value_delimiter = ',', value_parser = value_parser!(Format))]
     formats: Vec<Format>,
 
@@ -49,7 +55,7 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let opts = Opts::from(args.options);
 
-    setup_logging_and_tracing(args.verbose, args.tracing)?;
+    setup_logging_and_tracing_with_format(args.verbose, args.tracing, args.log_format)?;
 
     let benchmark = create_benchmark(args.benchmark, &opts)?;
 

--- a/vortex-bench/src/utils/logging.rs
+++ b/vortex-bench/src/utils/logging.rs
@@ -4,34 +4,77 @@
 use std::fs::File;
 use std::io::IsTerminal;
 
+use clap::ValueEnum;
 use tracing::level_filters::LevelFilter;
 use tracing_perfetto::PerfettoLayer;
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Layer;
 use tracing_subscriber::prelude::*;
 
-/// Initialize logging/tracing for a benchmark
-pub fn setup_logging_and_tracing(verbose: bool, tracing: bool) -> anyhow::Result<()> {
+/// Format for the primary stderr log sink.
+///
+/// `Text` is the default human-readable formatter matching the historical behavior of this crate.
+/// `Json` emits one newline-delimited JSON object per event, suitable for piping into `jq` or a log
+/// aggregator.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum LogFormat {
+    #[default]
+    Text,
+    Json,
+}
+
+/// Initialize logging/tracing for a benchmark, hardcoding [`LogFormat::Text`].
+///
+/// See [`setup_logging_and_tracing_with_format`] if you want to select JSON
+/// output from a CLI flag.
+pub fn setup_logging_and_tracing(verbose: bool, perfetto: bool) -> anyhow::Result<()> {
+    setup_logging_and_tracing_with_format(verbose, perfetto, LogFormat::Text)
+}
+
+/// Initialize logging/tracing for a benchmark with an explicit stderr format.
+///
+/// - `verbose`: when `RUST_LOG` is unset, raises the default filter from `INFO` to `TRACE`. Has no
+///   effect when `RUST_LOG` is set (the env var wins).
+/// - `perfetto`: when `true`, additionally attaches a [`tracing_perfetto::PerfettoLayer`] that
+///   writes span begin/end events to `trace.json` in the current directory. Intended to be loaded
+///   into the Perfetto UI for flamegraph visualization.
+/// - `format`: controls the primary stderr sink's formatting. See [`LogFormat`].
+pub fn setup_logging_and_tracing_with_format(
+    verbose: bool,
+    perfetto: bool,
+    format: LogFormat,
+) -> anyhow::Result<()> {
     let filter = default_env_filter(verbose);
 
-    let fmt_layer = tracing_subscriber::fmt::layer()
-        .with_writer(std::io::stderr)
-        .with_level(true)
-        .with_file(true)
-        .with_line_number(true)
-        .with_ansi(std::io::stderr().is_terminal());
+    let perfetto_layer = perfetto
+        .then(|| {
+            Ok::<_, anyhow::Error>(
+                PerfettoLayer::new(File::create("trace.json")?).with_debug_annotations(true),
+            )
+        })
+        .transpose()?;
+
+    // `fmt::layer()` and `fmt::layer().json()` produce different concrete types,
+    // so erase each to a `dyn Layer` via `.boxed()` and keep the registry uniform.
+    let fmt_layer: Box<dyn Layer<_> + Send + Sync> = match format {
+        LogFormat::Text => tracing_subscriber::fmt::layer()
+            .with_writer(std::io::stderr)
+            .with_level(true)
+            .with_file(true)
+            .with_line_number(true)
+            .with_ansi(std::io::stderr().is_terminal())
+            .boxed(),
+        LogFormat::Json => tracing_subscriber::fmt::layer()
+            .json()
+            .with_writer(std::io::stderr)
+            .with_current_span(true)
+            .with_span_list(true)
+            .boxed(),
+    };
 
     tracing_subscriber::registry()
         .with(filter)
-        .with(
-            tracing
-                .then(|| {
-                    Ok::<_, anyhow::Error>(
-                        PerfettoLayer::new(File::create("trace.json")?)
-                            .with_debug_annotations(true),
-                    )
-                })
-                .transpose()?,
-        )
+        .with(perfetto_layer)
         .with(fmt_layer)
         .init();
 

--- a/vortex-btrblocks/src/schemes/integer.rs
+++ b/vortex-btrblocks/src/schemes/integer.rs
@@ -307,8 +307,6 @@ impl Scheme for ZigZagScheme {
 
         let compressed = compressor.compress_child(&encoded.into_array(), &ctx, self.id(), 0)?;
 
-        tracing::debug!("zigzag output: {}", compressed.encoding_id());
-
         Ok(ZigZag::try_new(compressed)?.into_array())
     }
 }

--- a/vortex-compressor/Cargo.toml
+++ b/vortex-compressor/Cargo.toml
@@ -19,7 +19,7 @@ num-traits = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
 rustc-hash = { workspace = true }
-tracing = { workspace = true }
+tracing = { workspace = true, features = ["std", "attributes"] }
 vortex-array = { workspace = true }
 vortex-buffer = { workspace = true }
 vortex-error = { workspace = true }
@@ -29,6 +29,7 @@ vortex-utils = { workspace = true }
 [dev-dependencies]
 divan = { workspace = true }
 rstest = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 vortex-array = { workspace = true, features = ["_test-harness"] }
 
 [lints]

--- a/vortex-compressor/src/compressor.rs
+++ b/vortex-compressor/src/compressor.rs
@@ -1093,7 +1093,7 @@ mod tests {
     }
 
     #[test]
-    fn zero_byte_sample_beats_any_finite_ratio() -> VortexResult<()> {
+    fn zero_byte_sample_loses_to_finite_ratio() -> VortexResult<()> {
         let compressor = CascadingCompressor::new(vec![&HugeRatioScheme, &ZeroBytesSamplingScheme]);
         let schemes: [&'static dyn Scheme; 2] = [&HugeRatioScheme, &ZeroBytesSamplingScheme];
         let mut data = estimate_test_data();
@@ -1103,14 +1103,14 @@ mod tests {
 
         assert!(matches!(
             winner,
-            Some((scheme, WinnerEstimate::Score(EstimateScore::ZeroBytes)))
-                if scheme.id() == ZeroBytesSamplingScheme.id()
+            Some((scheme, WinnerEstimate::Score(EstimateScore::FiniteCompression(100.0))))
+                if scheme.id() == HugeRatioScheme.id()
         ));
         Ok(())
     }
 
     #[test]
-    fn finite_ratio_does_not_displace_zero_byte_sample() -> VortexResult<()> {
+    fn finite_ratio_displaces_zero_byte_sample() -> VortexResult<()> {
         let compressor = CascadingCompressor::new(vec![&ZeroBytesSamplingScheme, &HugeRatioScheme]);
         let schemes: [&'static dyn Scheme; 2] = [&ZeroBytesSamplingScheme, &HugeRatioScheme];
         let mut data = estimate_test_data();
@@ -1120,9 +1120,22 @@ mod tests {
 
         assert!(matches!(
             winner,
-            Some((scheme, WinnerEstimate::Score(EstimateScore::ZeroBytes)))
-                if scheme.id() == ZeroBytesSamplingScheme.id()
+            Some((scheme, WinnerEstimate::Score(EstimateScore::FiniteCompression(100.0))))
+                if scheme.id() == HugeRatioScheme.id()
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn zero_byte_sample_alone_selects_no_scheme() -> VortexResult<()> {
+        let compressor = CascadingCompressor::new(vec![&ZeroBytesSamplingScheme]);
+        let schemes: [&'static dyn Scheme; 1] = [&ZeroBytesSamplingScheme];
+        let mut data = estimate_test_data();
+
+        let winner =
+            compressor.choose_best_scheme(&schemes, &mut data, CompressorContext::new())?;
+
+        assert!(winner.is_none());
         Ok(())
     }
 
@@ -1220,7 +1233,7 @@ mod tests {
     }
 
     #[test]
-    fn zero_byte_results_omit_ratio_fields() {
+    fn zero_byte_sample_result_omits_ratio_fields_and_selects_no_scheme() {
         let compressor = CascadingCompressor::new(vec![&ZeroBytesSamplingScheme]);
         let array = test_integer_array();
 
@@ -1235,12 +1248,12 @@ mod tests {
         );
         assert!(!sample_event.fields.contains_key("sampled_ratio"));
 
-        let result_event = find_event(&events, TARGET_TRACE, "scheme.compress_result");
-        assert_eq!(
-            result_event.fields.get("after_nbytes").map(String::as_str),
-            Some("0")
-        );
-        assert!(!result_event.fields.contains_key("estimated_ratio"));
-        assert!(!result_event.fields.contains_key("actual_ratio"));
+        assert!(!events.iter().any(|event| {
+            event.target == TARGET_TRACE
+                && event
+                    .fields
+                    .get("message")
+                    .is_some_and(|value| value == "scheme.compress_result")
+        }));
     }
 }

--- a/vortex-compressor/src/compressor.rs
+++ b/vortex-compressor/src/compressor.rs
@@ -39,9 +39,11 @@ use crate::builtins::IntDictScheme;
 use crate::ctx::CompressorContext;
 use crate::estimate::CompressionEstimate;
 use crate::estimate::DeferredEstimate;
+use crate::estimate::EstimateScore;
 use crate::estimate::EstimateVerdict;
+use crate::estimate::WinnerEstimate;
 use crate::estimate::estimate_compression_ratio_with_sampling;
-use crate::estimate::is_better_ratio;
+use crate::estimate::is_better_score;
 use crate::scheme::ChildSelection;
 use crate::scheme::DescendantExclusion;
 use crate::scheme::Scheme;
@@ -49,11 +51,10 @@ use crate::scheme::SchemeExt;
 use crate::scheme::SchemeId;
 use crate::stats::ArrayAndStats;
 use crate::stats::GenerateStatsOptions;
+use crate::trace;
 
-/// The implicit root scheme ID for the compressor's own cascading (e.g. list offset compression).
-///
-/// This is the **only** [`SchemeId`] that is not auto-provided via [`SchemeExt`].
-const ROOT_SCHEME_ID: SchemeId = SchemeId {
+/// Synthetic scheme ID used for the compressor's own root-level cascading.
+pub(crate) const ROOT_SCHEME_ID: SchemeId = SchemeId {
     name: "vortex.compressor.root",
 };
 
@@ -63,15 +64,6 @@ mod root_list_children {
     pub const OFFSETS: usize = 1;
     /// ListView sizes child.
     pub const SIZES: usize = 2;
-}
-
-/// The winning estimate for a scheme after all deferred work has been resolved.
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum WinnerEstimate {
-    /// The scheme must be used immediately.
-    AlwaysUse,
-    /// The scheme won by numeric compression ratio.
-    Ratio(f64),
 }
 
 /// The main compressor type implementing cascading adaptive compression.
@@ -136,22 +128,27 @@ impl CascadingCompressor {
     ///
     /// Returns an error if canonicalization or compression fails.
     pub fn compress(&self, array: &ArrayRef) -> VortexResult<ArrayRef> {
+        let before_nbytes = array.nbytes();
+        let span = trace::compress_span(array.len(), array.dtype(), before_nbytes);
+        let _enter = span.enter();
+
         let canonical = array
             .clone()
             .execute::<CanonicalValidity>(&mut self.execution_ctx())?
             .0;
-
-        // Compact it, removing any wasted space before we attempt to compress it.
         let compact = canonical.compact()?;
+        let compressed = self.compress_canonical(compact, CompressorContext::new())?;
 
-        self.compress_canonical(compact, CompressorContext::new())
+        trace::record_compress_outcome(&span, before_nbytes, compressed.nbytes());
+
+        Ok(compressed)
     }
 
     /// Compresses a child array produced by a cascading scheme.
     ///
-    /// If the cascade budget is exhausted, the canonical array is returned as-is. Otherwise,
-    /// the child context is created by descending and recording the parent scheme + child
-    /// index, and compression proceeds normally.
+    /// If the cascade budget is exhausted, the canonical array is returned as-is. Otherwise, the
+    /// child context is created by descending and recording the parent scheme + child index, and
+    /// compression proceeds normally.
     ///
     /// # Errors
     ///
@@ -164,6 +161,7 @@ impl CascadingCompressor {
         child_index: usize,
     ) -> VortexResult<ArrayRef> {
         if parent_ctx.finished_cascading() {
+            trace::cascade_exhausted(parent_id, child_index);
             return Ok(child.clone());
         }
 
@@ -276,17 +274,16 @@ impl CascadingCompressor {
     /// The main scheme-selection entry point for a single leaf array.
     ///
     /// Filters allowed schemes by [`matches`] and exclusion rules, merges their [`stats_options`]
-    /// into a single [`GenerateStatsOptions`], then delegates to [`choose_scheme`] to pick the
-    /// winner by estimated compression ratio.
+    /// into a single [`GenerateStatsOptions`], and picks the winner by estimated compression
+    /// ratio.
     ///
-    /// If a winner is found and its compressed output is actually smaller, that output is returned.
-    /// Otherwise, the original array is returned unchanged.
+    /// If a winner is found and its compressed output is actually smaller, that output is
+    /// returned. Otherwise, the original array is returned unchanged.
     ///
     /// Empty and all-null arrays are short-circuited before any scheme evaluation.
     ///
     /// [`matches`]: Scheme::matches
     /// [`stats_options`]: Scheme::stats_options
-    /// [`choose_scheme`]: Self::choose_scheme
     fn choose_and_compress(
         &self,
         canonical: Canonical,
@@ -301,15 +298,10 @@ impl CascadingCompressor {
 
         let array: ArrayRef = canonical.into();
 
-        // If there are no schemes that we can compress into, then just return it uncompressed.
-        if eligible_schemes.is_empty() {
+        if eligible_schemes.is_empty() || array.is_empty() {
             return Ok(array);
         }
 
-        // Nothing to compress if empty or all-null.
-        if array.is_empty() {
-            return Ok(array);
-        }
         if array.all_invalid(&mut self.execution_ctx())? {
             return Ok(
                 ConstantArray::new(Scalar::null(array.dtype().clone()), array.len()).into_array(),
@@ -327,35 +319,51 @@ impl CascadingCompressor {
 
         let mut data = ArrayAndStats::new(array, merged_opts);
 
-        // TODO(connor): Add tracing support for logging the winner estimate.
-        if let Some((winner, _winner_estimate)) =
+        let Some((winner, winner_estimate)) =
             self.choose_best_scheme(&eligible_schemes, &mut data, ctx.clone())?
-        {
-            // Sampling and estimation chose a scheme, so let's compress the whole array with it.
-            let compressed = winner.compress(self, &mut data, ctx)?;
+        else {
+            return Ok(data.into_array());
+        };
 
-            // TODO(connor): Add a tracing warning here if compression with the chosen scheme
-            // failed, since there was likely more we could have done while choosing schemes.
-
-            // Only choose the compressed array if it is smaller than the canonical one.
-            if compressed.nbytes() < before_nbytes {
-                // TODO(connor): Add a tracing warning here too.
-                return Ok(compressed);
+        // Run the winning scheme's `compress`. On failure, emit an ERROR event carrying the
+        // scheme name and cascade history before propagating.
+        let error_ctx = trace::enabled_error_context(&ctx);
+        let compressed = match winner.compress(self, &mut data, ctx) {
+            Ok(compressed) => compressed,
+            Err(err) => {
+                // NB: this is the only way we can tell which scheme panicked / bailed on their
+                // data, especially for third-party schemes where the error site may not carry any
+                // compressor context.
+                trace::scheme_compress_failed(winner.id(), before_nbytes, error_ctx.as_ref(), &err);
+                return Err(err);
             }
+        };
 
-            // TODO(connor): HACK TO SUPPORT L2 DENORMALIZATION!!!
-            if compressed.is::<AnyScalarFn>() {
-                return Ok(compressed);
-            }
+        let after_nbytes = compressed.nbytes();
+        let actual_ratio = (after_nbytes != 0).then(|| before_nbytes as f64 / after_nbytes as f64);
+
+        // TODO(connor): HACK TO SUPPORT L2 DENORMALIZATION!!!
+        let accepted = after_nbytes < before_nbytes || compressed.is::<AnyScalarFn>();
+
+        trace::scheme_compress_result(
+            winner.id(),
+            before_nbytes,
+            after_nbytes,
+            winner_estimate.trace_ratio(),
+            actual_ratio,
+            accepted,
+        );
+
+        if accepted {
+            Ok(compressed)
+        } else {
+            Ok(data.into_array())
         }
-
-        // No scheme improved on the original.
-        Ok(data.into_array())
     }
 
-    /// Calls [`expected_compression_ratio`] on each candidate and returns the winning scheme and
-    /// resolved winner estimate, or `None` if no scheme exceeds 1.0. Ties are broken by
-    /// registration order (earlier in the list wins).
+    /// Calls [`expected_compression_ratio`] on each candidate and returns the winning scheme along
+    /// with its resolved winner estimate, or `None` if no scheme beats the canonical encoding.
+    /// Ties are broken by registration order (earlier in the list wins).
     ///
     /// [`expected_compression_ratio`]: Scheme::expected_compression_ratio
     fn choose_best_scheme(
@@ -364,65 +372,43 @@ impl CascadingCompressor {
         data: &mut ArrayAndStats,
         ctx: CompressorContext,
     ) -> VortexResult<Option<(&'static dyn Scheme, WinnerEstimate)>> {
-        let mut best: Option<(&'static dyn Scheme, f64)> = None;
+        let mut best: Option<(&'static dyn Scheme, EstimateScore)> = None;
 
-        // TODO(connor): Might want to use an `im` data structure inside of `ctx` if the clones here
-        // are expensive.
+        // TODO(connor): Rather than computing the deferred estimates eagerly, it would be better to
+        // look at all quick estimates and see if it makes sense to sample at all.
         for &scheme in schemes {
-            let estimate = scheme.expected_compression_ratio(data, ctx.clone());
-
-            // TODO(connor): Rather than computing the deferred estimates eagerly, it would be
-            // better to look at all quick estimates and see if it makes sense to sample at all.
-            match estimate {
-                CompressionEstimate::Verdict(verdict) => {
-                    if let Some(winner_estimate) =
-                        Self::check_and_update_estimate_verdict(&mut best, scheme, verdict)
-                    {
-                        return Ok(Some((scheme, winner_estimate)));
-                    }
-                }
+            let verdict = match scheme.expected_compression_ratio(data, ctx.clone()) {
+                CompressionEstimate::Verdict(verdict) => verdict,
                 CompressionEstimate::Deferred(DeferredEstimate::Sample) => {
-                    let sample_ratio = estimate_compression_ratio_with_sampling(
+                    let score = estimate_compression_ratio_with_sampling(
                         scheme,
                         self,
                         data.array(),
                         ctx.clone(),
                     )?;
-
-                    if is_better_ratio(sample_ratio, &best) {
-                        best = Some((scheme, sample_ratio));
+                    if is_better_score(score, &best) {
+                        best = Some((scheme, score));
                     }
+                    continue;
                 }
-                CompressionEstimate::Deferred(DeferredEstimate::Callback(estimate_callback)) => {
-                    let verdict = estimate_callback(self, data, ctx.clone())?;
-                    if let Some(winner_estimate) =
-                        Self::check_and_update_estimate_verdict(&mut best, scheme, verdict)
-                    {
-                        return Ok(Some((scheme, winner_estimate)));
+                CompressionEstimate::Deferred(DeferredEstimate::Callback(callback)) => {
+                    callback(self, data, ctx.clone())?
+                }
+            };
+
+            match verdict {
+                EstimateVerdict::Skip => {}
+                EstimateVerdict::AlwaysUse => return Ok(Some((scheme, WinnerEstimate::AlwaysUse))),
+                EstimateVerdict::Ratio(ratio) => {
+                    let score = EstimateScore::Finite(ratio);
+                    if is_better_score(score, &best) {
+                        best = Some((scheme, score));
                     }
                 }
             }
         }
 
-        Ok(best.map(|(scheme, ratio)| (scheme, WinnerEstimate::Ratio(ratio))))
-    }
-
-    /// Updates `best` from a terminal estimate verdict.
-    fn check_and_update_estimate_verdict(
-        best: &mut Option<(&'static dyn Scheme, f64)>,
-        scheme: &'static dyn Scheme,
-        verdict: EstimateVerdict,
-    ) -> Option<WinnerEstimate> {
-        match verdict {
-            EstimateVerdict::Skip => None,
-            EstimateVerdict::AlwaysUse => Some(WinnerEstimate::AlwaysUse),
-            EstimateVerdict::Ratio(ratio) => {
-                if is_better_ratio(ratio, &*best) {
-                    *best = Some((scheme, ratio));
-                }
-                None
-            }
-        }
+        Ok(best.map(|(scheme, score)| (scheme, WinnerEstimate::Score(score))))
     }
 
     // TODO(connor): Lots of room for optimization here.
@@ -544,10 +530,21 @@ impl CascadingCompressor {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use tracing::Event;
+    use tracing::Subscriber;
+    use tracing::field::Field;
+    use tracing::field::Visit;
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::layer::Context;
+    use tracing_subscriber::prelude::*;
     use vortex_array::ArrayRef;
     use vortex_array::Canonical;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::Constant;
+    use vortex_array::arrays::NullArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
@@ -559,8 +556,11 @@ mod tests {
     use crate::ctx::CompressorContext;
     use crate::estimate::CompressionEstimate;
     use crate::estimate::DeferredEstimate;
+    use crate::estimate::EstimateScore;
     use crate::estimate::EstimateVerdict;
+    use crate::estimate::WinnerEstimate;
     use crate::scheme::SchemeExt;
+    use crate::trace::TARGET_TRACE;
 
     fn compressor() -> CascadingCompressor {
         CascadingCompressor::new(vec![&IntDictScheme, &FloatDictScheme, &StringDictScheme])
@@ -573,6 +573,98 @@ mod tests {
 
     fn matches_integer_primitive(canonical: &Canonical) -> bool {
         matches!(canonical, Canonical::Primitive(primitive) if primitive.ptype().is_int())
+    }
+
+    fn test_integer_array() -> ArrayRef {
+        PrimitiveArray::new(buffer![1i32, 2, 3, 4], Validity::NonNullable).into_array()
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct RecordedEvent {
+        target: String,
+        fields: BTreeMap<String, String>,
+    }
+
+    #[derive(Default)]
+    struct EventVisitor {
+        fields: BTreeMap<String, String>,
+    }
+
+    impl Visit for EventVisitor {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            self.fields
+                .insert(field.name().to_owned(), format!("{value:?}"));
+        }
+
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.fields
+                .insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.fields
+                .insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_bool(&mut self, field: &Field, value: bool) {
+            self.fields
+                .insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields
+                .insert(field.name().to_owned(), value.to_owned());
+        }
+    }
+
+    struct RecordingLayer {
+        events: Arc<Mutex<Vec<RecordedEvent>>>,
+    }
+
+    impl RecordingLayer {
+        fn new(events: Arc<Mutex<Vec<RecordedEvent>>>) -> Self {
+            Self { events }
+        }
+    }
+
+    impl<S> Layer<S> for RecordingLayer
+    where
+        S: Subscriber,
+    {
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = EventVisitor::default();
+            event.record(&mut visitor);
+            self.events.lock().push(RecordedEvent {
+                target: event.metadata().target().to_owned(),
+                fields: visitor.fields,
+            });
+        }
+    }
+
+    fn record_events<T>(f: impl FnOnce() -> T) -> (T, Vec<RecordedEvent>) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let subscriber =
+            tracing_subscriber::registry().with(RecordingLayer::new(Arc::clone(&events)));
+        let result = tracing::subscriber::with_default(subscriber, f);
+        let recorded = events.lock().clone();
+        (result, recorded)
+    }
+
+    fn find_event<'a>(
+        events: &'a [RecordedEvent],
+        target: &str,
+        message: &str,
+    ) -> &'a RecordedEvent {
+        events
+            .iter()
+            .find(|event| {
+                event.target == target
+                    && event
+                        .fields
+                        .get("message")
+                        .is_some_and(|value| value == message)
+            })
+            .expect("expected event not found")
     }
 
     #[derive(Debug)]
@@ -731,6 +823,156 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct HugeRatioScheme;
+
+    impl Scheme for HugeRatioScheme {
+        fn scheme_name(&self) -> &'static str {
+            "test.huge_ratio"
+        }
+
+        fn matches(&self, canonical: &Canonical) -> bool {
+            matches_integer_primitive(canonical)
+        }
+
+        fn expected_compression_ratio(
+            &self,
+            _data: &mut ArrayAndStats,
+            _ctx: CompressorContext,
+        ) -> CompressionEstimate {
+            CompressionEstimate::Verdict(EstimateVerdict::Ratio(100.0))
+        }
+
+        fn compress(
+            &self,
+            _compressor: &CascadingCompressor,
+            _data: &mut ArrayAndStats,
+            _ctx: CompressorContext,
+        ) -> VortexResult<ArrayRef> {
+            unreachable!("test helper should never be selected for compression")
+        }
+    }
+
+    #[derive(Debug)]
+    struct ZeroBytesSamplingScheme;
+
+    impl Scheme for ZeroBytesSamplingScheme {
+        fn scheme_name(&self) -> &'static str {
+            "test.zero_bytes_sampling"
+        }
+
+        fn matches(&self, canonical: &Canonical) -> bool {
+            matches_integer_primitive(canonical)
+        }
+
+        fn expected_compression_ratio(
+            &self,
+            _data: &mut ArrayAndStats,
+            _ctx: CompressorContext,
+        ) -> CompressionEstimate {
+            CompressionEstimate::Deferred(DeferredEstimate::Sample)
+        }
+
+        fn compress(
+            &self,
+            _compressor: &CascadingCompressor,
+            data: &mut ArrayAndStats,
+            _ctx: CompressorContext,
+        ) -> VortexResult<ArrayRef> {
+            Ok(NullArray::new(data.array().len()).into_array())
+        }
+    }
+
+    #[derive(Debug)]
+    struct NestedFailureParentScheme;
+
+    impl Scheme for NestedFailureParentScheme {
+        fn scheme_name(&self) -> &'static str {
+            "test.nested_failure_parent"
+        }
+
+        fn matches(&self, canonical: &Canonical) -> bool {
+            matches_integer_primitive(canonical)
+        }
+
+        fn expected_compression_ratio(
+            &self,
+            _data: &mut ArrayAndStats,
+            _ctx: CompressorContext,
+        ) -> CompressionEstimate {
+            CompressionEstimate::Verdict(EstimateVerdict::AlwaysUse)
+        }
+
+        fn compress(
+            &self,
+            compressor: &CascadingCompressor,
+            data: &mut ArrayAndStats,
+            ctx: CompressorContext,
+        ) -> VortexResult<ArrayRef> {
+            compressor.compress_child(data.array(), &ctx, self.id(), 1)
+        }
+    }
+
+    #[derive(Debug)]
+    struct NestedFailureLeafScheme;
+
+    impl Scheme for NestedFailureLeafScheme {
+        fn scheme_name(&self) -> &'static str {
+            "test.nested_failure_leaf"
+        }
+
+        fn matches(&self, canonical: &Canonical) -> bool {
+            matches_integer_primitive(canonical)
+        }
+
+        fn expected_compression_ratio(
+            &self,
+            _data: &mut ArrayAndStats,
+            _ctx: CompressorContext,
+        ) -> CompressionEstimate {
+            CompressionEstimate::Verdict(EstimateVerdict::AlwaysUse)
+        }
+
+        fn compress(
+            &self,
+            _compressor: &CascadingCompressor,
+            _data: &mut ArrayAndStats,
+            _ctx: CompressorContext,
+        ) -> VortexResult<ArrayRef> {
+            vortex_error::vortex_bail!("nested failure")
+        }
+    }
+
+    #[derive(Debug)]
+    struct SamplingFailureScheme;
+
+    impl Scheme for SamplingFailureScheme {
+        fn scheme_name(&self) -> &'static str {
+            "test.sampling_failure"
+        }
+
+        fn matches(&self, canonical: &Canonical) -> bool {
+            matches_integer_primitive(canonical)
+        }
+
+        fn expected_compression_ratio(
+            &self,
+            _data: &mut ArrayAndStats,
+            _ctx: CompressorContext,
+        ) -> CompressionEstimate {
+            CompressionEstimate::Deferred(DeferredEstimate::Sample)
+        }
+
+        fn compress(
+            &self,
+            _compressor: &CascadingCompressor,
+            _data: &mut ArrayAndStats,
+            _ctx: CompressorContext,
+        ) -> VortexResult<ArrayRef> {
+            vortex_error::vortex_bail!("sample failure")
+        }
+    }
+
     #[test]
     fn test_self_exclusion() {
         let c = compressor();
@@ -827,7 +1069,7 @@ mod tests {
 
         assert!(matches!(
             winner,
-            Some((scheme, WinnerEstimate::Ratio(2.0)))
+            Some((scheme, WinnerEstimate::Score(EstimateScore::Finite(2.0))))
                 if scheme.id() == DirectRatioScheme.id()
         ));
         Ok(())
@@ -844,8 +1086,25 @@ mod tests {
 
         assert!(matches!(
             winner,
-            Some((scheme, WinnerEstimate::Ratio(3.0)))
+            Some((scheme, WinnerEstimate::Score(EstimateScore::Finite(3.0))))
                 if scheme.id() == CallbackRatioScheme.id()
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn zero_byte_sample_beats_any_finite_ratio() -> VortexResult<()> {
+        let compressor = CascadingCompressor::new(vec![&HugeRatioScheme, &ZeroBytesSamplingScheme]);
+        let schemes: [&'static dyn Scheme; 2] = [&HugeRatioScheme, &ZeroBytesSamplingScheme];
+        let mut data = estimate_test_data();
+
+        let winner =
+            compressor.choose_best_scheme(&schemes, &mut data, CompressorContext::new())?;
+
+        assert!(matches!(
+            winner,
+            Some((scheme, WinnerEstimate::Score(EstimateScore::ZeroBytes)))
+                if scheme.id() == ZeroBytesSamplingScheme.id()
         ));
         Ok(())
     }
@@ -890,9 +1149,81 @@ mod tests {
 
         // Before the fix this panicked with:
         //   "this must be present since `DictScheme` declared that we need distinct values"
-        let ratio =
+        let score =
             estimate_compression_ratio_with_sampling(&FloatDictScheme, &compressor, &array, ctx)?;
-        assert!(ratio.is_finite());
+        assert!(matches!(score, EstimateScore::Finite(ratio) if ratio.is_finite()));
         Ok(())
+    }
+
+    #[test]
+    fn compress_failure_event_includes_cascade_path_and_depth() {
+        let compressor =
+            CascadingCompressor::new(vec![&NestedFailureParentScheme, &NestedFailureLeafScheme]);
+        let array = test_integer_array();
+
+        let (result, events) = record_events(|| compressor.compress(&array));
+
+        assert!(result.is_err());
+        let event = find_event(&events, TARGET_TRACE, "scheme.compress_failed");
+        assert_eq!(
+            event.fields.get("scheme").map(String::as_str),
+            Some("test.nested_failure_leaf")
+        );
+        assert_eq!(
+            event.fields.get("cascade_path").map(String::as_str),
+            Some("test.nested_failure_parent[1]")
+        );
+        assert_eq!(
+            event.fields.get("cascade_depth").map(String::as_str),
+            Some("1")
+        );
+    }
+
+    #[test]
+    fn sample_failure_event_includes_cascade_path_and_depth() {
+        let compressor = CascadingCompressor::new(vec![&SamplingFailureScheme]);
+        let array = test_integer_array();
+
+        let (result, events) = record_events(|| compressor.compress(&array));
+
+        assert!(result.is_err());
+        let event = find_event(&events, TARGET_TRACE, "sample.compress_failed");
+        assert_eq!(
+            event.fields.get("scheme").map(String::as_str),
+            Some("test.sampling_failure")
+        );
+        assert_eq!(
+            event.fields.get("cascade_path").map(String::as_str),
+            Some("root")
+        );
+        assert_eq!(
+            event.fields.get("cascade_depth").map(String::as_str),
+            Some("0")
+        );
+    }
+
+    #[test]
+    fn zero_byte_results_omit_ratio_fields() {
+        let compressor = CascadingCompressor::new(vec![&ZeroBytesSamplingScheme]);
+        let array = test_integer_array();
+
+        let (result, events) = record_events(|| compressor.compress(&array));
+
+        assert!(result.is_ok());
+
+        let sample_event = find_event(&events, TARGET_TRACE, "sample.result");
+        assert_eq!(
+            sample_event.fields.get("sampled_after").map(String::as_str),
+            Some("0")
+        );
+        assert!(!sample_event.fields.contains_key("sampled_ratio"));
+
+        let result_event = find_event(&events, TARGET_TRACE, "scheme.compress_result");
+        assert_eq!(
+            result_event.fields.get("after_nbytes").map(String::as_str),
+            Some("0")
+        );
+        assert!(!result_event.fields.contains_key("estimated_ratio"));
+        assert!(!result_event.fields.contains_key("actual_ratio"));
     }
 }

--- a/vortex-compressor/src/compressor.rs
+++ b/vortex-compressor/src/compressor.rs
@@ -400,7 +400,7 @@ impl CascadingCompressor {
                 EstimateVerdict::Skip => {}
                 EstimateVerdict::AlwaysUse => return Ok(Some((scheme, WinnerEstimate::AlwaysUse))),
                 EstimateVerdict::Ratio(ratio) => {
-                    let score = EstimateScore::Finite(ratio);
+                    let score = EstimateScore::FiniteCompression(ratio);
                     if is_better_score(score, &best) {
                         best = Some((scheme, score));
                     }
@@ -1069,7 +1069,7 @@ mod tests {
 
         assert!(matches!(
             winner,
-            Some((scheme, WinnerEstimate::Score(EstimateScore::Finite(2.0))))
+            Some((scheme, WinnerEstimate::Score(EstimateScore::FiniteCompression(2.0))))
                 if scheme.id() == DirectRatioScheme.id()
         ));
         Ok(())
@@ -1086,7 +1086,7 @@ mod tests {
 
         assert!(matches!(
             winner,
-            Some((scheme, WinnerEstimate::Score(EstimateScore::Finite(3.0))))
+            Some((scheme, WinnerEstimate::Score(EstimateScore::FiniteCompression(3.0))))
                 if scheme.id() == CallbackRatioScheme.id()
         ));
         Ok(())
@@ -1096,6 +1096,23 @@ mod tests {
     fn zero_byte_sample_beats_any_finite_ratio() -> VortexResult<()> {
         let compressor = CascadingCompressor::new(vec![&HugeRatioScheme, &ZeroBytesSamplingScheme]);
         let schemes: [&'static dyn Scheme; 2] = [&HugeRatioScheme, &ZeroBytesSamplingScheme];
+        let mut data = estimate_test_data();
+
+        let winner =
+            compressor.choose_best_scheme(&schemes, &mut data, CompressorContext::new())?;
+
+        assert!(matches!(
+            winner,
+            Some((scheme, WinnerEstimate::Score(EstimateScore::ZeroBytes)))
+                if scheme.id() == ZeroBytesSamplingScheme.id()
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn finite_ratio_does_not_displace_zero_byte_sample() -> VortexResult<()> {
+        let compressor = CascadingCompressor::new(vec![&ZeroBytesSamplingScheme, &HugeRatioScheme]);
+        let schemes: [&'static dyn Scheme; 2] = [&ZeroBytesSamplingScheme, &HugeRatioScheme];
         let mut data = estimate_test_data();
 
         let winner =
@@ -1151,7 +1168,7 @@ mod tests {
         //   "this must be present since `DictScheme` declared that we need distinct values"
         let score =
             estimate_compression_ratio_with_sampling(&FloatDictScheme, &compressor, &array, ctx)?;
-        assert!(matches!(score, EstimateScore::Finite(ratio) if ratio.is_finite()));
+        assert!(matches!(score, EstimateScore::FiniteCompression(ratio) if ratio.is_finite()));
         Ok(())
     }
 

--- a/vortex-compressor/src/ctx.rs
+++ b/vortex-compressor/src/ctx.rs
@@ -3,8 +3,11 @@
 
 //! Compression context for recursive compression.
 
+use std::fmt;
+
 use vortex_error::VortexExpect;
 
+use crate::compressor::ROOT_SCHEME_ID;
 use crate::scheme::SchemeId;
 use crate::stats::GenerateStatsOptions;
 
@@ -73,6 +76,16 @@ impl CompressorContext {
         &self.cascade_history
     }
 
+    /// Returns a display wrapper for the current cascade ancestry.
+    pub(crate) fn cascade_path(&self) -> impl fmt::Display + '_ {
+        CascadePath(&self.cascade_history)
+    }
+
+    /// Returns the current cascade ancestry depth.
+    pub(crate) fn cascade_depth(&self) -> usize {
+        self.cascade_history.len()
+    }
+
     /// Whether cascading is exhausted (no further cascade levels allowed).
     ///
     /// This should only be used in the implementation of a [`Scheme`](crate::scheme::Scheme) if the
@@ -111,5 +124,30 @@ impl CompressorContext {
             .vortex_expect("cannot descend: cascade depth exhausted");
         self.cascade_history.push((id, child_index));
         self
+    }
+}
+
+/// Display wrapper for a cascade ancestry path.
+struct CascadePath<'a>(&'a [(SchemeId, usize)]);
+
+impl fmt::Display for CascadePath<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0.is_empty() {
+            return f.write_str("root");
+        }
+
+        for (index, (scheme_id, child_index)) in self.0.iter().enumerate() {
+            if index > 0 {
+                f.write_str(" > ")?;
+            }
+
+            if *scheme_id == ROOT_SCHEME_ID {
+                write!(f, "root[{child_index}]")?;
+            } else {
+                write!(f, "{scheme_id}[{child_index}]")?;
+            }
+        }
+
+        Ok(())
     }
 }

--- a/vortex-compressor/src/estimate.rs
+++ b/vortex-compressor/src/estimate.rs
@@ -93,9 +93,10 @@ pub(super) enum EstimateScore {
     FiniteCompression(f64),
     /// Trial compression produced a 0-byte output.
     ///
-    /// This is treated as an unbounded score for scheme selection, but has no finite trace ratio.
-    /// Final full-array compression still has to pass the normal before/after acceptance check, so
-    /// a zero-byte sample can choose a scheme but cannot force a larger output to be returned.
+    /// This has no finite trace ratio and is not eligible for scheme selection.
+    ///
+    /// TODO(connor): A zero-byte sample usually means the sampler happened to hit an all-null
+    /// sample. Improve this logic so we can distinguish real zero-byte wins from sampling artifacts.
     ZeroBytes,
 }
 
@@ -123,16 +124,15 @@ impl EstimateScore {
             Self::FiniteCompression(ratio) => {
                 ratio.is_finite() && !ratio.is_subnormal() && ratio > 1.0
             }
-            Self::ZeroBytes => true,
+            Self::ZeroBytes => false,
         }
     }
 
     /// Returns whether this estimate beats another valid estimate.
     fn beats(self, other: Self) -> bool {
         match (self, other) {
-            (Self::ZeroBytes, Self::FiniteCompression(_)) => true,
-            (Self::ZeroBytes, Self::ZeroBytes) => false,
-            (Self::FiniteCompression(_), Self::ZeroBytes) => false,
+            (Self::ZeroBytes, _) => false,
+            (Self::FiniteCompression(_), Self::ZeroBytes) => true,
             (Self::FiniteCompression(ratio), Self::FiniteCompression(best_ratio)) => {
                 ratio > best_ratio
             }

--- a/vortex-compressor/src/estimate.rs
+++ b/vortex-compressor/src/estimate.rs
@@ -16,7 +16,9 @@ use crate::sample::SAMPLE_SIZE;
 use crate::sample::sample;
 use crate::sample::sample_count_approx_one_percent;
 use crate::scheme::Scheme;
+use crate::scheme::SchemeExt;
 use crate::stats::ArrayAndStats;
+use crate::trace;
 
 /// Closure type for [`DeferredEstimate::Callback`].
 ///
@@ -84,10 +86,72 @@ pub enum DeferredEstimate {
     Callback(Box<EstimateFn>),
 }
 
-/// Returns `true` if `ratio` is a valid compression ratio (> 1.0, finite, not subnormal) that
-/// beats the current best.
-pub(super) fn is_better_ratio(ratio: f64, best: &Option<(&'static dyn Scheme, f64)>) -> bool {
-    ratio.is_finite() && !ratio.is_subnormal() && ratio > 1.0 && best.is_none_or(|(_, r)| ratio > r)
+/// Ranked estimate used for comparing non-terminal compression candidates.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum EstimateScore {
+    /// A finite compression ratio.
+    Finite(f64),
+    /// Trial compression produced a 0-byte output.
+    ZeroBytes,
+}
+
+impl EstimateScore {
+    /// Converts measured sample sizes into a ranked estimate.
+    pub(super) fn from_sample_sizes(before_nbytes: u64, after_nbytes: u64) -> Self {
+        if after_nbytes == 0 {
+            Self::ZeroBytes
+        } else {
+            Self::Finite(before_nbytes as f64 / after_nbytes as f64)
+        }
+    }
+
+    /// Returns the traceable numeric ratio, omitting the zero-byte special case.
+    pub(super) fn trace_ratio(self) -> Option<f64> {
+        match self {
+            Self::Finite(ratio) => Some(ratio),
+            Self::ZeroBytes => None,
+        }
+    }
+}
+
+/// Winner estimate carried from scheme selection into result tracing.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum WinnerEstimate {
+    /// The scheme must be used immediately.
+    AlwaysUse,
+    /// The scheme won by a ranked estimate.
+    Score(EstimateScore),
+}
+
+impl WinnerEstimate {
+    /// Returns the traceable numeric ratio for the winning estimate.
+    pub(super) fn trace_ratio(self) -> Option<f64> {
+        match self {
+            Self::AlwaysUse => None,
+            Self::Score(score) => score.trace_ratio(),
+        }
+    }
+}
+
+/// Returns `true` if `score` beats the current best estimate.
+pub(super) fn is_better_score(
+    score: EstimateScore,
+    best: &Option<(&'static dyn Scheme, EstimateScore)>,
+) -> bool {
+    match score {
+        EstimateScore::ZeroBytes => {
+            best.is_none_or(|(_, best_score)| !matches!(best_score, EstimateScore::ZeroBytes))
+        }
+        EstimateScore::Finite(ratio) => {
+            ratio.is_finite()
+                && !ratio.is_subnormal()
+                && ratio > 1.0
+                && best.is_none_or(|(_, best_score)| match best_score {
+                    EstimateScore::Finite(best_ratio) => ratio > best_ratio,
+                    EstimateScore::ZeroBytes => false,
+                })
+        }
+    }
 }
 
 /// Estimates compression ratio by compressing a ~1% sample of the data.
@@ -103,19 +167,11 @@ pub(super) fn estimate_compression_ratio_with_sampling<S: Scheme + ?Sized>(
     compressor: &CascadingCompressor,
     array: &ArrayRef,
     ctx: CompressorContext,
-) -> VortexResult<f64> {
+) -> VortexResult<EstimateScore> {
     let sample_array = if ctx.is_sample() {
         array.clone()
     } else {
-        let source_len = array.len();
-        let sample_count = sample_count_approx_one_percent(source_len);
-
-        tracing::trace!(
-            "Sampling {} values out of {}",
-            SAMPLE_SIZE as u64 * sample_count as u64,
-            source_len
-        );
-
+        let sample_count = sample_count_approx_one_percent(array.len());
         // `ArrayAndStats` expects a canonical array (so that it can easily compute lazy stats).
         let canonical: Canonical =
             sample(array, SAMPLE_SIZE, sample_count).execute(&mut compressor.execution_ctx())?;
@@ -123,26 +179,27 @@ pub(super) fn estimate_compression_ratio_with_sampling<S: Scheme + ?Sized>(
     };
 
     let mut sample_data = ArrayAndStats::new(sample_array, scheme.stats_options());
+    let error_ctx = trace::enabled_error_context(&ctx);
     let sample_ctx = ctx.with_sampling();
 
-    let after = scheme
-        .compress(compressor, &mut sample_data, sample_ctx)?
-        .nbytes();
+    let compressed = match scheme.compress(compressor, &mut sample_data, sample_ctx) {
+        Ok(compressed) => compressed,
+        Err(err) => {
+            trace::sample_compress_failed(scheme.id(), error_ctx.as_ref(), &err);
+            return Err(err);
+        }
+    };
+
+    let after = compressed.nbytes();
     let before = sample_data.array().nbytes();
 
-    // TODO(connor): Issue https://github.com/vortex-data/vortex/issues/7268.
-    // if after == 0 {
-    //     tracing::warn!(
-    //         scheme = %scheme.id(),
-    //         "sample compressed to 0 bytes, which should only happen for constant arrays",
-    //     );
-    // }
+    let score = EstimateScore::from_sample_sizes(before, after);
 
-    let ratio = before as f64 / after as f64;
+    // Single DEBUG event per sampled scheme. Downstream tooling can join this with the eventual
+    // `scheme.compress_result` on the same scheme to compute sample-vs-full divergence.
+    trace::sample_result(scheme.id(), before, after, score.trace_ratio());
 
-    tracing::debug!("estimate_compression_ratio_with_sampling(compressor={scheme:#?}) = {ratio}",);
-
-    Ok(ratio)
+    Ok(score)
 }
 
 impl fmt::Debug for DeferredEstimate {

--- a/vortex-compressor/src/estimate.rs
+++ b/vortex-compressor/src/estimate.rs
@@ -89,9 +89,13 @@ pub enum DeferredEstimate {
 /// Ranked estimate used for comparing non-terminal compression candidates.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(super) enum EstimateScore {
-    /// A finite compression ratio.
-    Finite(f64),
+    /// A finite compression ratio. Higher means a smaller amount of data, so it is better.
+    FiniteCompression(f64),
     /// Trial compression produced a 0-byte output.
+    ///
+    /// This is treated as an unbounded score for scheme selection, but has no finite trace ratio.
+    /// Final full-array compression still has to pass the normal before/after acceptance check, so
+    /// a zero-byte sample can choose a scheme but cannot force a larger output to be returned.
     ZeroBytes,
 }
 
@@ -101,15 +105,37 @@ impl EstimateScore {
         if after_nbytes == 0 {
             Self::ZeroBytes
         } else {
-            Self::Finite(before_nbytes as f64 / after_nbytes as f64)
+            Self::FiniteCompression(before_nbytes as f64 / after_nbytes as f64)
         }
     }
 
     /// Returns the traceable numeric ratio, omitting the zero-byte special case.
     pub(super) fn trace_ratio(self) -> Option<f64> {
         match self {
-            Self::Finite(ratio) => Some(ratio),
+            Self::FiniteCompression(ratio) => Some(ratio),
             Self::ZeroBytes => None,
+        }
+    }
+
+    /// Returns whether this estimate is eligible to compete.
+    fn is_valid(self) -> bool {
+        match self {
+            Self::FiniteCompression(ratio) => {
+                ratio.is_finite() && !ratio.is_subnormal() && ratio > 1.0
+            }
+            Self::ZeroBytes => true,
+        }
+    }
+
+    /// Returns whether this estimate beats another valid estimate.
+    fn beats(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::ZeroBytes, Self::FiniteCompression(_)) => true,
+            (Self::ZeroBytes, Self::ZeroBytes) => false,
+            (Self::FiniteCompression(_), Self::ZeroBytes) => false,
+            (Self::FiniteCompression(ratio), Self::FiniteCompression(best_ratio)) => {
+                ratio > best_ratio
+            }
         }
     }
 }
@@ -138,20 +164,7 @@ pub(super) fn is_better_score(
     score: EstimateScore,
     best: &Option<(&'static dyn Scheme, EstimateScore)>,
 ) -> bool {
-    match score {
-        EstimateScore::ZeroBytes => {
-            best.is_none_or(|(_, best_score)| !matches!(best_score, EstimateScore::ZeroBytes))
-        }
-        EstimateScore::Finite(ratio) => {
-            ratio.is_finite()
-                && !ratio.is_subnormal()
-                && ratio > 1.0
-                && best.is_none_or(|(_, best_score)| match best_score {
-                    EstimateScore::Finite(best_ratio) => ratio > best_ratio,
-                    EstimateScore::ZeroBytes => false,
-                })
-        }
-    }
+    score.is_valid() && best.is_none_or(|(_, best_score)| score.beats(best_score))
 }
 
 /// Estimates compression ratio by compressing a ~1% sample of the data.

--- a/vortex-compressor/src/lib.rs
+++ b/vortex-compressor/src/lib.rs
@@ -15,6 +15,26 @@
 //!
 //! This crate contains no encoding dependencies. Batteries-included compressors are provided by
 //! downstream crates like `vortex-btrblocks`, which register different encodings to the compressor.
+//!
+//! # Observability
+//!
+//! The compressor emits a small set of `tracing` events on a single target so you can see what
+//! it's doing without attaching a profiler.
+//!
+//! For example, set `RUST_LOG=vortex_compressor::encode=debug` to see one line per leaf compression
+//! decision. The `vortex_compressor::encode` target carries the main decision events
+//! (`scheme.compress_result`, `sample.result`, and both `*.compress_failed`) plus the coarse
+//! top-level `compress` span and `cascade_exhausted` event.
+//!
+//! The primary event is `scheme.compress_result`, which carries `scheme`, `before_nbytes`,
+//! `after_nbytes`, `estimated_ratio` (absent when the scheme returned `AlwaysUse` or sampled to 0
+//! bytes), `actual_ratio` (absent when the compressed output is 0 bytes), and `accepted`.
+//!
+//! Failure events additionally carry `cascade_path` and `cascade_depth`, so nested compression
+//! errors can be tied back to the ancestor branch that triggered them.
+//!
+//! From those fields you can derive per-scheme savings, rejection counts, and estimator accuracy
+//! with a short `jq` query.
 
 pub mod builtins;
 pub mod ctx;
@@ -25,4 +45,5 @@ pub mod stats;
 mod sample;
 
 mod compressor;
+mod trace;
 pub use compressor::CascadingCompressor;

--- a/vortex-compressor/src/scheme.rs
+++ b/vortex-compressor/src/scheme.rs
@@ -20,10 +20,10 @@ use crate::stats::GenerateStatsOptions;
 
 /// Unique identifier for a compression scheme.
 ///
-/// The only way to obtain a [`SchemeId`] is through [`SchemeExt::id()`], which is
-/// auto-implemented for all [`Scheme`] types. There is no public constructor.
+/// The only way to obtain a [`SchemeId`] is through [`SchemeExt::id()`], which is auto-implemented
+/// for all [`Scheme`] types. There is no public constructor.
 ///
-/// The only exception to this is for `ROOT_SCHEME_ID` in `compressor.rs`.
+/// The only exception to this is for the compressor's synthetic `ROOT_SCHEME_ID`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SchemeId {
     /// Only constructable within `vortex-compressor`.

--- a/vortex-compressor/src/trace.rs
+++ b/vortex-compressor/src/trace.rs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+//! Internal tracing helpers for compressor observability.
+
+use std::fmt;
+
+use crate::ctx::CompressorContext;
+use crate::scheme::SchemeId;
+
+/// Shared tracing target for compressor decisions and coarse cascade structure.
+pub(super) const TARGET_TRACE: &str = "vortex_compressor::encode";
+
+/// Builds the top-level compression span.
+#[inline]
+pub(super) fn compress_span(
+    len: usize,
+    dtype: &impl fmt::Display,
+    before_nbytes: u64,
+) -> tracing::Span {
+    tracing::debug_span!(
+        target: TARGET_TRACE,
+        "compress",
+        len,
+        dtype = %dtype,
+        before_nbytes,
+        after_nbytes = tracing::field::Empty,
+        ratio = tracing::field::Empty,
+    )
+}
+
+/// Records the final output size and, when finite, the top-level compression ratio.
+#[inline]
+pub(super) fn record_compress_outcome(span: &tracing::Span, before_nbytes: u64, after_nbytes: u64) {
+    span.record("after_nbytes", after_nbytes);
+    if after_nbytes != 0 {
+        span.record("ratio", before_nbytes as f64 / after_nbytes as f64);
+    }
+}
+
+/// Emits the MAX_CASCADE short-circuit event.
+#[inline]
+pub(super) fn cascade_exhausted(parent: SchemeId, child_index: usize) {
+    tracing::debug!(
+        target: TARGET_TRACE,
+        parent = %parent,
+        child_index,
+        "cascade_exhausted",
+    );
+}
+
+/// Captures the context needed for error tracing only when ERROR logs are enabled.
+#[inline]
+pub(super) fn enabled_error_context(ctx: &CompressorContext) -> Option<CompressorContext> {
+    tracing::enabled!(target: TARGET_TRACE, tracing::Level::ERROR).then(|| ctx.clone())
+}
+
+/// Emits a compression-failure event for a winning scheme.
+#[inline]
+pub(super) fn scheme_compress_failed(
+    scheme: SchemeId,
+    before_nbytes: u64,
+    ctx: Option<&CompressorContext>,
+    err: &impl fmt::Display,
+) {
+    if let Some(ctx) = ctx {
+        tracing::error!(
+            target: TARGET_TRACE,
+            scheme = %scheme,
+            before_nbytes,
+            cascade_path = %ctx.cascade_path(),
+            cascade_depth = ctx.cascade_depth(),
+            error = %err,
+            "scheme.compress_failed",
+        );
+    }
+}
+
+/// Emits the leaf compression result event.
+#[inline]
+#[allow(
+    clippy::cognitive_complexity,
+    reason = "tracing sometimes triggers this"
+)]
+pub(super) fn scheme_compress_result(
+    scheme: SchemeId,
+    before_nbytes: u64,
+    after_nbytes: u64,
+    estimated_ratio: Option<f64>,
+    actual_ratio: Option<f64>,
+    accepted: bool,
+) {
+    match (estimated_ratio, actual_ratio) {
+        (Some(estimated_ratio), Some(actual_ratio)) => {
+            tracing::debug!(
+                target: TARGET_TRACE,
+                scheme = %scheme,
+                before_nbytes,
+                after_nbytes,
+                estimated_ratio,
+                actual_ratio,
+                accepted,
+                "scheme.compress_result",
+            );
+        }
+        (Some(estimated_ratio), None) => {
+            tracing::debug!(
+                target: TARGET_TRACE,
+                scheme = %scheme,
+                before_nbytes,
+                after_nbytes,
+                estimated_ratio,
+                accepted,
+                "scheme.compress_result",
+            );
+        }
+        (None, Some(actual_ratio)) => {
+            tracing::debug!(
+                target: TARGET_TRACE,
+                scheme = %scheme,
+                before_nbytes,
+                after_nbytes,
+                actual_ratio,
+                accepted,
+                "scheme.compress_result",
+            );
+        }
+        (None, None) => {
+            tracing::debug!(
+                target: TARGET_TRACE,
+                scheme = %scheme,
+                before_nbytes,
+                after_nbytes,
+                accepted,
+                "scheme.compress_result",
+            );
+        }
+    }
+}
+
+/// Emits a sampling-failure event.
+#[inline]
+pub(super) fn sample_compress_failed(
+    scheme: SchemeId,
+    ctx: Option<&CompressorContext>,
+    err: &impl fmt::Display,
+) {
+    if let Some(ctx) = ctx {
+        tracing::error!(
+            target: TARGET_TRACE,
+            scheme = %scheme,
+            cascade_path = %ctx.cascade_path(),
+            cascade_depth = ctx.cascade_depth(),
+            error = %err,
+            "sample.compress_failed",
+        );
+    }
+}
+
+/// Emits the sampling result event.
+#[inline]
+pub(super) fn sample_result(
+    scheme: SchemeId,
+    sampled_before: u64,
+    sampled_after: u64,
+    sampled_ratio: Option<f64>,
+) {
+    if let Some(sampled_ratio) = sampled_ratio {
+        tracing::debug!(
+            target: TARGET_TRACE,
+            scheme = %scheme,
+            sampled_before,
+            sampled_after,
+            sampled_ratio,
+            "sample.result",
+        );
+    } else {
+        tracing::debug!(
+            target: TARGET_TRACE,
+            scheme = %scheme,
+            sampled_before,
+            sampled_after,
+            "sample.result",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Tracking issue: https://github.com/vortex-data/vortex/issues/7216

We have very little observability into the compressor. When we are debugging, we don't really have any idea of what schemes the compressor is trying, how good or how bad estimates are, how reliable sampling is, how the cascading paths look, etc.

This change adds structured `tracing` support to `vortex-compressor`. The compressor now emits a top-level `compress` span and decision/debug events on the `vortex_compressor::encode` target, so a normal tracing subscriber can see what the compressor sampled, selected, accepted/rejected, and where nested failures happened.

The `scheme.compress_result` event reports `scheme`, `before_nbytes`, `after_nbytes`, `estimated_ratio` when available, `actual_ratio` when available, and `accepted`. Sampling is recorded through `sample.result`; compression failures are recorded through `scheme.compress_failed` / `sample.compress_failed` with `cascade_path` and `cascade_depth`. Zero-byte outputs intentionally omit ratio fields instead of logging infinities.

This also adds JSON formatting to the benchmark logging setup via `--log-format json`, which makes `data-gen` / `compress-bench` output usable as JSONL. One useful workflow is to generate TPC-H data with compressor logs enabled and use `jq` to find over-optimistic estimates that were rejected.

<details>
<summary>Example jq query for rejected over-estimates</summary>

```fish
set LOG data-gen.jsonl

jq -R -s -r '
  def rows: split("\n") | map(fromjson? // empty);
  def r:
    if type == "number" then ((. * 1000 | round) / 1000)
    else .
    end;

  ([
    "estimated_over_actual",
    "scheme",
    "estimated_ratio",
    "actual_ratio",
    "before_nbytes",
    "after_nbytes",
    "extra_bytes",
    "span_dtype",
    "span_len"
  ] | @tsv),
  (
    rows
    | map(select(.target == "vortex_compressor::encode"))
    | map(select(.fields.message == "scheme.compress_result"))
    | map(select(.fields.accepted == false))
    | map(select(.fields.estimated_ratio != null and .fields.actual_ratio != null))
    | map(select(.fields.estimated_ratio > .fields.actual_ratio))
    | map(.fields as $f | {
        scheme: $f.scheme,
        estimated_ratio: $f.estimated_ratio,
        actual_ratio: $f.actual_ratio,
        estimated_over_actual: ($f.estimated_ratio / $f.actual_ratio),
        before_nbytes: $f.before_nbytes,
        after_nbytes: $f.after_nbytes,
        extra_bytes: ($f.after_nbytes - $f.before_nbytes),
        span_dtype: (.span.dtype // ""),
        span_len: (.span.len // "")
      })
    | sort_by(.estimated_over_actual) | reverse
    | .[:50][]
    | [
        (.estimated_over_actual | r),
        .scheme,
        (.estimated_ratio | r),
        (.actual_ratio | r),
        .before_nbytes,
        .after_nbytes,
        .extra_bytes,
        .span_dtype,
        .span_len
      ]
    | @tsv
  )
' $LOG
```

```
estimated_over_actual	scheme	estimated_ratio	actual_ratio	before_nbytes	after_nbytes	extra_bytes	span_dtype	span_len
512	vortex.int.for	1.6	0.003	2	640	638	utf8?	2
512	vortex.int.for	2.667	0.005	2	384	382	utf8?	2
512	vortex.int.for	5.333	0.01	8	768	760	decimal(15,2)?	2
512	vortex.int.for	4.571	0.009	8	896	888	decimal(15,2)?	2
512	vortex.int.for	4	0.008	8	1024	1016	decimal(15,2)?	2
512	vortex.int.for	1.6	0.003	2	640	638	utf8?	2
512	vortex.int.for	8	0.016	2	128	126	utf8?	2
512	vortex.int.for	2.56	0.005	16	3200	3184	i64?	2
512	vortex.int.for	5.818	0.011	16	1408	1392	i64?	2
256	vortex.int.for	2	0.008	4	512	508	utf8	4
256	vortex.int.for	2	0.008	4	512	508	utf8	4
256	vortex.int.for	2	0.008	4	512	508	utf8	8192
256	vortex.int.for	2	0.008	4	512	508	utf8	8192
256	vortex.int.for	2	0.008	4	512	508	utf8	8192
256	vortex.int.for	2	0.008	4	512	508	utf8	8192
256	vortex.int.for	2	0.008	4	512	508	utf8	8192
256	vortex.int.for	2	0.008	4	512	508	utf8	8192
204.8	vortex.int.for	4	0.02	5	256	251	utf8	5
204.8	vortex.int.for	4	0.02	5	256	251	utf8	8192
204.8	vortex.int.for	4	0.02	5	256	251	utf8	8192
204.8	vortex.int.for	2.667	0.013	5	384	379	utf8	5
204.8	vortex.int.for	2.667	0.013	5	384	379	utf8	5
146.286	vortex.int.for	1.333	0.009	7	768	761	utf8?	19
146.286	vortex.int.for	1.333	0.009	7	768	761	utf8?	19
128	vortex.int.for	2	0.016	8	512	504	utf8?	98
128	vortex.int.for	2	0.016	8	512	504	utf8?	98
113.778	vortex.int.for	1.6	0.014	18	1280	1262	i32?	184
113.778	vortex.int.for	1.6	0.014	18	1280	1262	i32?	184
113.778	vortex.int.for	32	0.281	36	128	92	i32?	184
113.778	vortex.int.for	32	0.281	36	128	92	i32?	184
64	vortex.int.for	2	0.031	16	512	496	utf8?	98
64	vortex.int.for	2	0.031	16	512	496	utf8?	98
64	vortex.int.for	2	0.031	16	512	496	utf8?	98
64	vortex.int.for	2	0.031	16	512	496	utf8?	98
53.895	vortex.int.for	1.6	0.03	19	640	621	utf8?	19
53.895	vortex.int.for	3.2	0.059	76	1280	1204	decimal(15,2)?	19
53.895	vortex.int.for	2.909	0.054	76	1408	1332	decimal(15,2)?	19
53.895	vortex.int.for	1.6	0.03	19	640	621	utf8?	19
53.895	vortex.int.for	1.6	0.03	19	640	621	utf8?	19
53.895	vortex.int.for	32	0.594	76	128	52	i32?	184
53.895	vortex.int.for	32	0.594	76	128	52	i32?	184
53.895	vortex.int.for	4	0.074	76	1024	948	decimal(15,2)?	19
51.2	vortex.int.for	2	0.039	20	512	492	utf8?	98
51.2	vortex.int.for	2	0.039	20	512	492	utf8?	98
51.2	vortex.int.for	2	0.039	20	512	492	utf8?	98
51.2	vortex.int.for	2	0.039	20	512	492	utf8?	98
51.2	vortex.int.for	2	0.039	20	512	492	utf8?	98
51.2	vortex.int.for	2	0.039	20	512	492	utf8?	98
40.96	vortex.int.for	2	0.049	25	512	487	utf8?	25
40.96	vortex.int.for	2	0.049	25	512	487	utf8?	25
```

</details>

## Testing

Some basic tracing tests (that was claude-generated).