### PR TITLE
support multiple globs in DuckDB and MultiFileDataSource

### DIFF
--- a/benchmarks/datafusion-bench/src/main.rs
+++ b/benchmarks/datafusion-bench/src/main.rs
@@ -317,8 +317,7 @@ async fn register_v2_tables<B: Benchmark + ?Sized>(
         };
 
         let multi_ds = MultiFileDataSource::new(SESSION.clone())
-            .with_filesystem(fs)
-            .with_glob(glob_pattern)
+            .with_glob(glob_pattern, Some(fs))
             .build()
             .await?;
 

--- a/vortex-duckdb/cpp/table_function.cpp
+++ b/vortex-duckdb/cpp/table_function.cpp
@@ -383,6 +383,8 @@ extern "C" duckdb_state duckdb_vx_tfunc_register(duckdb_database ffi_db, const d
         auto &system_catalog = Catalog::GetSystemCatalog(*db);
         auto data = CatalogTransaction::GetSystemTransaction(*db);
         CreateTableFunctionInfo tf_info(tf);
+        // Allow registering multiple overloads with the same name but different parameter types.
+        tf_info.on_conflict = OnCreateConflict::ALTER_ON_CONFLICT;
         system_catalog.CreateFunction(data, tf_info);
     } catch (...) {
         return DuckDBError;

--- a/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
+++ b/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
@@ -351,6 +351,40 @@ fn test_vortex_scan_multiple_files() {
 }
 
 #[test]
+fn test_vortex_scan_multiple_globs() {
+    // Test scanning multiple directories using a list of glob patterns.
+    let (tempdir1, tempdir2, _file1, _file2, _file3) = RUNTIME.block_on(async {
+        let tempdir1 = tempfile::tempdir().unwrap();
+        let tempdir2 = tempfile::tempdir().unwrap();
+
+        let file1 = write_vortex_file_to_dir(tempdir1.path(), "numbers", buffer![1i32, 2, 3]).await;
+        let file2 = write_vortex_file_to_dir(tempdir1.path(), "numbers", buffer![4i32, 5, 6]).await;
+        let file3 =
+            write_vortex_file_to_dir(tempdir2.path(), "numbers", buffer![7i32, 8, 9, 10]).await;
+
+        (tempdir1, tempdir2, file1, file2, file3)
+    });
+
+    // Create glob patterns for each directory.
+    let glob_pattern1 = format!("{}/*.vortex", tempdir1.path().display());
+    let glob_pattern2 = format!("{}/*.vortex", tempdir2.path().display());
+
+    // Scan files from both directories using a list of globs.
+    let conn = database_connection();
+    let result = conn
+        .query(&format!(
+            "SELECT SUM(numbers) FROM read_vortex(['{glob_pattern1}', '{glob_pattern2}'])"
+        ))
+        .unwrap();
+    let chunk = result.into_iter().next().unwrap();
+    let vec = chunk.get_vector(0);
+    let total_sum = vec.as_slice_with_len::<i64>(chunk.len().as_())[0];
+
+    // 1+2+3 + 4+5+6 + 7+8+9+10 = 55
+    assert_eq!(total_sum, 55);
+}
+
+#[test]
 fn test_vortex_scan_over_http() {
     let file = RUNTIME.block_on(async {
         let strings = VarBinArray::from(vec!["a", "b", "c"]);

--- a/vortex-duckdb/src/lib.rs
+++ b/vortex-duckdb/src/lib.rs
@@ -21,6 +21,7 @@ use crate::duckdb::DatabaseRef;
 use crate::duckdb::LogicalType;
 use crate::duckdb::Value;
 use crate::multi_file::VortexMultiFileScan;
+use crate::multi_file::VortexMultiFileScanList;
 
 mod convert;
 mod datasource;
@@ -56,6 +57,9 @@ pub fn initialize(db: &DatabaseRef) -> VortexResult<()> {
     )?;
     db.register_table_function::<VortexMultiFileScan>(c"vortex_scan")?;
     db.register_table_function::<VortexMultiFileScan>(c"read_vortex")?;
+    // Register list overloads for multi-glob scanning (e.g., read_vortex(['a.vortex', 'b.vortex']))
+    db.register_table_function::<VortexMultiFileScanList>(c"vortex_scan")?;
+    db.register_table_function::<VortexMultiFileScanList>(c"read_vortex")?;
     db.register_copy_function::<VortexCopyFunction>(c"vortex", c"vortex")
 }
 

--- a/vortex-duckdb/src/multi_file.rs
+++ b/vortex-duckdb/src/multi_file.rs
@@ -5,8 +5,10 @@ use std::path::Path;
 use std::path::absolute;
 use std::sync::Arc;
 
+use itertools::Itertools;
 use url::Url;
 use vortex::error::VortexResult;
+use vortex::error::vortex_bail;
 use vortex::error::vortex_err;
 use vortex::file::multi::MultiFileDataSource;
 use vortex::io::runtime::BlockingRuntime;
@@ -17,6 +19,7 @@ use crate::SESSION;
 use crate::datasource::DataSourceTableFunction;
 use crate::duckdb::BindInputRef;
 use crate::duckdb::ClientContextRef;
+use crate::duckdb::ExtractedValue;
 use crate::duckdb::LogicalType;
 use crate::filesystem::resolve_filesystem;
 
@@ -60,34 +63,92 @@ fn normalize_path(path: std::path::PathBuf) -> std::path::PathBuf {
 #[derive(Debug)]
 pub struct VortexMultiFileScan;
 
+/// Variant of [`VortexMultiFileScan`] that accepts a list of globs.
+///
+/// This is registered as a separate overload to handle `read_vortex(['a.vortex', 'b.vortex'])`.
+#[derive(Debug)]
+pub struct VortexMultiFileScanList;
+
 impl DataSourceTableFunction for VortexMultiFileScan {
     fn parameters() -> Vec<LogicalType> {
         vec![LogicalType::varchar()]
     }
 
     fn bind(ctx: &ClientContextRef, input: &BindInputRef) -> VortexResult<DataSourceRef> {
-        let glob_url_parameter = input
-            .get_parameter(0)
-            .ok_or_else(|| vortex_err!("Missing file glob parameter"))?;
-
-        // Parse the URL and separate the base URL (keep scheme, host, etc.) from the path.
-        let glob_url_string = glob_url_parameter.as_string();
-        let glob_url_str = glob_url_string.as_str();
-        let glob_url = parse_glob_url(glob_url_str)?;
-
-        let mut base_url = glob_url.clone();
-        base_url.set_path("");
-
-        let fs = resolve_filesystem(&base_url, ctx)?;
-
-        RUNTIME.block_on(async {
-            let builder = MultiFileDataSource::new(SESSION.clone())
-                .with_filesystem(fs)
-                .with_glob(glob_url.path());
-            let ds = builder.build().await?;
-            VortexResult::Ok(Arc::new(ds) as DataSourceRef)
-        })
+        bind_multi_file_scan(ctx, input)
     }
+}
+
+impl DataSourceTableFunction for VortexMultiFileScanList {
+    fn parameters() -> Vec<LogicalType> {
+        vec![
+            LogicalType::list_type(LogicalType::varchar())
+                .unwrap_or_else(|_| unreachable!("creating list<varchar> type should not fail")),
+        ]
+    }
+
+    fn bind(ctx: &ClientContextRef, input: &BindInputRef) -> VortexResult<DataSourceRef> {
+        bind_multi_file_scan(ctx, input)
+    }
+}
+
+/// Shared bind logic for both single-glob and multi-glob variants.
+fn bind_multi_file_scan(
+    ctx: &ClientContextRef,
+    input: &BindInputRef,
+) -> VortexResult<DataSourceRef> {
+    let glob_url_parameter = input
+        .get_parameter(0)
+        .ok_or_else(|| vortex_err!("Missing file glob parameter"))?;
+
+    // The input to the table function can either be a single glob, or a List of glob patterns.
+    let glob_strings: Vec<String> = match glob_url_parameter.extract() {
+        ExtractedValue::Varchar(glob) => {
+            vec![glob.to_string()]
+        }
+        ExtractedValue::List(globs) => globs
+            .into_iter()
+            .map(|glob| {
+                let ExtractedValue::Varchar(string) = glob.extract() else {
+                    vortex_bail!("list element must be Varchar type")
+                };
+
+                Ok(string.to_string())
+            })
+            .try_collect()?,
+        _ => vortex_bail!("Invalid argument to read_vortex table function"),
+    };
+
+    // Parse each glob URL and resolve its filesystem.
+    // Group globs by their base URL to avoid resolving the same filesystem multiple times.
+    let mut glob_urls: Vec<Url> = Vec::with_capacity(glob_strings.len());
+    for glob_str in &glob_strings {
+        glob_urls.push(parse_glob_url(glob_str)?);
+    }
+
+    RUNTIME.block_on(async {
+        let mut builder = MultiFileDataSource::new(SESSION.clone());
+
+        // Track the current base URL to avoid redundant filesystem resolution.
+        let mut current_base_url: Option<Url> = None;
+
+        for glob_url in &glob_urls {
+            let mut base_url = glob_url.clone();
+            base_url.set_path("");
+
+            // Only resolve a new filesystem if the base URL changed.
+            if current_base_url.as_ref() != Some(&base_url) {
+                let fs = resolve_filesystem(&base_url, ctx)?;
+                builder = builder.with_filesystem(fs);
+                current_base_url = Some(base_url);
+            }
+
+            builder = builder.with_glob(glob_url.path());
+        }
+
+        let ds = builder.build().await?;
+        Ok(Arc::new(ds) as DataSourceRef)
+    })
 }
 
 #[cfg(test)]

--- a/vortex-duckdb/src/multi_file.rs
+++ b/vortex-duckdb/src/multi_file.rs
@@ -129,21 +129,12 @@ fn bind_multi_file_scan(
     RUNTIME.block_on(async {
         let mut builder = MultiFileDataSource::new(SESSION.clone());
 
-        // Track the current base URL to avoid redundant filesystem resolution.
-        let mut current_base_url: Option<Url> = None;
-
         for glob_url in &glob_urls {
             let mut base_url = glob_url.clone();
             base_url.set_path("");
 
-            // Only resolve a new filesystem if the base URL changed.
-            if current_base_url.as_ref() != Some(&base_url) {
-                let fs = resolve_filesystem(&base_url, ctx)?;
-                builder = builder.with_filesystem(fs);
-                current_base_url = Some(base_url);
-            }
-
-            builder = builder.with_glob(glob_url.path());
+            let fs = resolve_filesystem(&base_url, ctx)?;
+            builder = builder.with_glob(glob_url.path(), Some(fs));
         }
 
         let ds = builder.build().await?;

--- a/vortex-duckdb/src/multi_file.rs
+++ b/vortex-duckdb/src/multi_file.rs
@@ -11,8 +11,10 @@ use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
 use vortex::error::vortex_err;
 use vortex::file::multi::MultiFileDataSource;
+use vortex::io::filesystem::FileSystemRef;
 use vortex::io::runtime::BlockingRuntime;
 use vortex::scan::DataSourceRef;
+use vortex_utils::aliases::hash_map::HashMap;
 
 use crate::RUNTIME;
 use crate::SESSION;
@@ -120,10 +122,20 @@ fn bind_multi_file_scan(
     };
 
     // Parse each glob URL and resolve its filesystem.
-    // Group globs by their base URL to avoid resolving the same filesystem multiple times.
     let mut glob_urls: Vec<Url> = Vec::with_capacity(glob_strings.len());
     for glob_str in &glob_strings {
         glob_urls.push(parse_glob_url(glob_str)?);
+    }
+
+    // Cache filesystems by base URL to avoid resolving the same filesystem multiple times.
+    let mut fs_cache: HashMap<Url, FileSystemRef> = HashMap::new();
+    for glob_url in &glob_urls {
+        let mut base_url = glob_url.clone();
+        base_url.set_path("");
+        if !fs_cache.contains_key(&base_url) {
+            let fs = resolve_filesystem(&base_url, ctx)?;
+            fs_cache.insert(base_url, fs);
+        }
     }
 
     RUNTIME.block_on(async {
@@ -132,8 +144,10 @@ fn bind_multi_file_scan(
         for glob_url in &glob_urls {
             let mut base_url = glob_url.clone();
             base_url.set_path("");
-
-            let fs = resolve_filesystem(&base_url, ctx)?;
+            let fs = fs_cache
+                .get(&base_url)
+                .map(Arc::clone)
+                .unwrap_or_else(|| unreachable!("fs should be cached for all base URLs"));
             builder = builder.with_glob(glob_url.path(), Some(fs));
         }
 

--- a/vortex-file/public-api.lock
+++ b/vortex-file/public-api.lock
@@ -10,9 +10,7 @@ pub async fn vortex_file::multi::MultiFileDataSource::build(self) -> vortex_erro
 
 pub fn vortex_file::multi::MultiFileDataSource::new(session: vortex_session::VortexSession) -> Self
 
-pub fn vortex_file::multi::MultiFileDataSource::with_filesystem(self, fs: vortex_io::filesystem::FileSystemRef) -> Self
-
-pub fn vortex_file::multi::MultiFileDataSource::with_glob(self, glob: impl core::convert::Into<alloc::string::String>) -> Self
+pub fn vortex_file::multi::MultiFileDataSource::with_glob(self, glob: impl core::convert::Into<alloc::string::String>, fs: core::option::Option<vortex_io::filesystem::FileSystemRef>) -> Self
 
 pub fn vortex_file::multi::MultiFileDataSource::with_open_options(self, f: impl core::ops::function::Fn(vortex_file::VortexOpenOptions) -> vortex_file::VortexOpenOptions + core::marker::Send + core::marker::Sync + 'static) -> Self
 

--- a/vortex-file/src/multi/mod.rs
+++ b/vortex-file/src/multi/mod.rs
@@ -28,43 +28,35 @@ use crate::v2::FileStatsLayoutReader;
 /// A builder that discovers multiple Vortex files from glob patterns and constructs a
 /// [`MultiLayoutDataSource`] to scan them as a single data source.
 ///
-/// The primary interface is [`Self::with_glob`], which accepts a glob
-/// pattern. For non-local filesystems (S3, GCS, etc.), callers must provide a
-/// [`FileSystemRef`] via [`Self::with_filesystem`] before calling [`Self::with_glob`].
-///
-/// Multiple globs can be added, each potentially using a different filesystem by calling
-/// [`Self::with_filesystem`] before each [`Self::with_glob`] call.
+/// The primary interface is [`Self::with_glob`], which accepts a glob pattern and an optional
+/// filesystem. For non-local filesystems (S3, GCS, etc.), callers must provide a [`FileSystemRef`].
+/// For local files, pass `None` and a local filesystem will be created automatically.
 ///
 /// # Examples
 ///
 /// ```ignore
 /// // Local files — filesystem is auto-created:
 /// let ds = MultiFileDataSource::new(session)
-///     .with_glob("/data/warehouse/*.vortex")
+///     .with_glob("/data/warehouse/*.vortex", None)
 ///     .build()
 ///     .await?;
 ///
 /// // S3 — caller provides the filesystem:
 /// let ds = MultiFileDataSource::new(session)
-///     .with_filesystem(s3_fs)
-///     .with_glob("prefix/*.vortex")
+///     .with_glob("prefix/*.vortex", Some(s3_fs))
 ///     .build()
 ///     .await?;
 ///
 /// // Mixed filesystems — multiple globs with different filesystems:
 /// let ds = MultiFileDataSource::new(session)
-///     .with_filesystem(s3_fs)
-///     .with_glob("bucket-a/*.vortex")
-///     .with_glob("bucket-b/*.vortex")
-///     .with_filesystem(gcs_fs)
-///     .with_glob("gcs-bucket/*.vortex")
+///     .with_glob("bucket-a/*.vortex", Some(s3_fs.clone()))
+///     .with_glob("bucket-b/*.vortex", Some(s3_fs))
+///     .with_glob("gcs-bucket/*.vortex", Some(gcs_fs))
 ///     .build()
 ///     .await?;
 /// ```
 pub struct MultiFileDataSource {
     session: VortexSession,
-    /// The current filesystem to use for subsequent globs.
-    current_fs: Option<FileSystemRef>,
     /// List of (glob, optional filesystem) pairs to resolve.
     /// When the filesystem is None, a local filesystem will be created in build().
     glob_sources: Vec<(String, Option<FileSystemRef>)>,
@@ -76,7 +68,6 @@ impl MultiFileDataSource {
     pub fn new(session: VortexSession) -> Self {
         Self {
             session,
-            current_fs: None,
             glob_sources: Vec::new(),
             open_options_fn: Arc::new(|opts| opts),
         }
@@ -84,22 +75,11 @@ impl MultiFileDataSource {
 
     /// Add a path glob for file discovery.
     ///
-    /// This path should be relative to the filesystem's base URL. If no filesystem has been
-    /// set via [`Self::with_filesystem`], a local filesystem will be created automatically
-    /// when [`Self::build`] is called.
-    pub fn with_glob(mut self, glob: impl Into<String>) -> Self {
+    /// The glob path should be relative to the filesystem's base URL. Pass `None` for the
+    /// filesystem to use the local filesystem (auto-created in [`Self::build`]).
+    pub fn with_glob(mut self, glob: impl Into<String>, fs: Option<FileSystemRef>) -> Self {
         let glob_str = glob.into().trim_start_matches('/').to_string();
-        self.glob_sources.push((glob_str, self.current_fs.clone()));
-        self
-    }
-
-    /// Set the filesystem to use for subsequent globs.
-    ///
-    /// This filesystem will be used for all globs added via [`Self::with_glob`] until
-    /// a new filesystem is set. For `file://` or bare path URLs, a local filesystem
-    /// is created automatically if none is provided.
-    pub fn with_filesystem(mut self, fs: FileSystemRef) -> Self {
-        self.current_fs = Some(fs);
+        self.glob_sources.push((glob_str, fs));
         self
     }
 

--- a/vortex-file/src/multi/mod.rs
+++ b/vortex-file/src/multi/mod.rs
@@ -13,7 +13,6 @@ use session::MultiFileSessionExt;
 use tracing::debug;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
-use vortex_error::vortex_err;
 use vortex_io::filesystem::FileListing;
 use vortex_io::filesystem::FileSystemRef;
 use vortex_layout::LayoutReaderRef;
@@ -26,12 +25,15 @@ use crate::OpenOptionsSessionExt;
 use crate::VortexOpenOptions;
 use crate::v2::FileStatsLayoutReader;
 
-/// A builder that discovers multiple Vortex files from a glob pattern and constructs a
+/// A builder that discovers multiple Vortex files from glob patterns and constructs a
 /// [`MultiLayoutDataSource`] to scan them as a single data source.
 ///
 /// The primary interface is [`Self::with_glob`], which accepts a glob
-/// pattern (optionally prefixed with `file://`). For non-local filesystems (S3, GCS, etc.),
-/// callers must also provide a [`FileSystemRef`] via [`Self::with_filesystem`]).
+/// pattern. For non-local filesystems (S3, GCS, etc.), callers must provide a
+/// [`FileSystemRef`] via [`Self::with_filesystem`] before calling [`Self::with_glob`].
+///
+/// Multiple globs can be added, each potentially using a different filesystem by calling
+/// [`Self::with_filesystem`] before each [`Self::with_glob`] call.
 ///
 /// # Examples
 ///
@@ -48,11 +50,24 @@ use crate::v2::FileStatsLayoutReader;
 ///     .with_glob("prefix/*.vortex")
 ///     .build()
 ///     .await?;
+///
+/// // Mixed filesystems — multiple globs with different filesystems:
+/// let ds = MultiFileDataSource::new(session)
+///     .with_filesystem(s3_fs)
+///     .with_glob("bucket-a/*.vortex")
+///     .with_glob("bucket-b/*.vortex")
+///     .with_filesystem(gcs_fs)
+///     .with_glob("gcs-bucket/*.vortex")
+///     .build()
+///     .await?;
 /// ```
 pub struct MultiFileDataSource {
     session: VortexSession,
-    fs: Option<FileSystemRef>,
-    glob: Option<String>,
+    /// The current filesystem to use for subsequent globs.
+    current_fs: Option<FileSystemRef>,
+    /// List of (glob, optional filesystem) pairs to resolve.
+    /// When the filesystem is None, a local filesystem will be created in build().
+    glob_sources: Vec<(String, Option<FileSystemRef>)>,
     open_options_fn: Arc<dyn Fn(VortexOpenOptions) -> VortexOpenOptions + Send + Sync>,
 }
 
@@ -61,26 +76,30 @@ impl MultiFileDataSource {
     pub fn new(session: VortexSession) -> Self {
         Self {
             session,
-            fs: None,
-            glob: None,
+            current_fs: None,
+            glob_sources: Vec::new(),
             open_options_fn: Arc::new(|opts| opts),
         }
     }
 
-    /// Set the path glob for file discovery.
+    /// Add a path glob for file discovery.
     ///
-    /// This path should be relative to the filesystem's base URL.
+    /// This path should be relative to the filesystem's base URL. If no filesystem has been
+    /// set via [`Self::with_filesystem`], a local filesystem will be created automatically
+    /// when [`Self::build`] is called.
     pub fn with_glob(mut self, glob: impl Into<String>) -> Self {
-        self.glob = Some(glob.into().trim_start_matches("/").to_string());
+        let glob_str = glob.into().trim_start_matches('/').to_string();
+        self.glob_sources.push((glob_str, self.current_fs.clone()));
         self
     }
 
-    /// Set the filesystem to use for file discovery and reading.
+    /// Set the filesystem to use for subsequent globs.
     ///
-    /// Required for non-local URLs (S3, GCS, etc.). For `file://` or bare path URLs,
-    /// a local filesystem is created automatically if none is provided.
+    /// This filesystem will be used for all globs added via [`Self::with_glob`] until
+    /// a new filesystem is set. For `file://` or bare path URLs, a local filesystem
+    /// is created automatically if none is provided.
     pub fn with_filesystem(mut self, fs: FileSystemRef) -> Self {
-        self.fs = Some(fs);
+        self.current_fs = Some(fs);
         self
     }
 
@@ -99,36 +118,63 @@ impl MultiFileDataSource {
     ///
     /// Discovers files via glob, opens the first file eagerly to determine the schema,
     /// and creates lazy factories for the remaining files.
-    pub async fn build(mut self) -> VortexResult<impl DataSource> {
-        let glob = self
-            .glob
-            .take()
-            .ok_or_else(|| vortex_err!("MultiFileDataSource requires a glob URL"))?;
-
-        let fs = match self.fs {
-            Some(fs) => fs,
-            None => create_local_filesystem(&self.session)?,
-        };
-        let files: Vec<FileListing> = fs.glob(&glob)?.try_collect().await?;
-
-        if files.is_empty() {
-            vortex_bail!("No files matched the glob pattern '{}'", glob);
+    pub async fn build(self) -> VortexResult<impl DataSource> {
+        if self.glob_sources.is_empty() {
+            vortex_bail!("MultiFileDataSource requires at least one glob pattern");
         }
 
-        let file_count = files.len();
-        debug!(file_count, glob = %glob, "discovered files");
+        // Create local filesystem lazily if needed (only if any glob lacks a filesystem).
+        let local_fs: Option<FileSystemRef> = self
+            .glob_sources
+            .iter()
+            .any(|(_, fs)| fs.is_none())
+            .then(|| create_local_filesystem(&self.session))
+            .transpose()?;
+
+        // Collect files from all glob sources.
+        let mut all_files: Vec<(FileListing, FileSystemRef)> = Vec::new();
+        for (glob, maybe_fs) in &self.glob_sources {
+            // Use the provided filesystem, or fall back to the local filesystem.
+            // We know local_fs is Some when maybe_fs is None (by construction above).
+            let fs = maybe_fs
+                .as_ref()
+                .or(local_fs.as_ref())
+                .map(Arc::clone)
+                .unwrap_or_else(|| {
+                    unreachable!("local_fs is set when any glob lacks a filesystem")
+                });
+            let files: Vec<FileListing> = fs.glob(glob)?.try_collect().await?;
+            for file in files {
+                all_files.push((file, Arc::clone(&fs)));
+            }
+        }
+
+        if all_files.is_empty() {
+            let globs: Vec<_> = self.glob_sources.iter().map(|(g, _)| g.as_str()).collect();
+            vortex_bail!("No files matched the glob pattern(s): {:?}", globs);
+        }
+
+        let file_count = all_files.len();
+        let globs: Vec<_> = self.glob_sources.iter().map(|(g, _)| g.as_str()).collect();
+        debug!(file_count, glob = ?globs, "discovered files");
 
         // Open first file eagerly for dtype.
-        let first_file =
-            open_file(&fs, &files[0], &self.session, self.open_options_fn.as_ref()).await?;
+        let (first_file_listing, first_fs) = &all_files[0];
+        let first_file = open_file(
+            first_fs,
+            first_file_listing,
+            &self.session,
+            self.open_options_fn.as_ref(),
+        )
+        .await?;
         let first_reader = layout_reader_with_stats(&first_file)?;
 
-        let factories: Vec<Arc<dyn LayoutReaderFactory>> = files[1..]
+        let factories: Vec<Arc<dyn LayoutReaderFactory>> = all_files[1..]
             .iter()
-            .map(|f| {
+            .map(|(file, fs)| {
                 Arc::new(VortexFileReaderFactory {
-                    fs: Arc::clone(&fs),
-                    file: f.clone(),
+                    fs: Arc::clone(fs),
+                    file: file.clone(),
                     session: self.session.clone(),
                     open_options_fn: Arc::clone(&self.open_options_fn),
                 }) as Arc<dyn LayoutReaderFactory>


### PR DESCRIPTION
## Summary

Adds support for multiple globs in DuckDB, similar to Parquet,

E.g. instead of `read_vortex('*.vortex')` now you can also do `read_vortex(['s3://bucket1/path/*.vortex', '/a/b/*.vortex'])`

Note that multiple file systems are supported in a single scan.

This is implemented and wired through into the underlying Rust MultiFileDataSource.

## Testing

We add new DuckDB e2e tests for multi-glob

Couldn't figure out a great way to test multiple file systems, just multiple globs