### PR TITLE
TurboQuant `InnerProduct` optimizations

### DIFF
--- a/vortex-tensor/benches/similarity_search.rs
+++ b/vortex-tensor/benches/similarity_search.rs
@@ -33,7 +33,7 @@ use common::generate_random_vectors;
 static GLOBAL: MiMalloc = MiMalloc;
 
 /// Number of vectors in the benchmark dataset.
-const NUM_ROWS: usize = 10_000;
+const NUM_ROWS: usize = 100_000;
 
 /// Dimensionality of each vector. Must be `>= vortex_tensor::encodings::turboquant::MIN_DIMENSION`
 /// (128) for the TurboQuant variant to work.

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -250,6 +250,7 @@ impl CosineSimilarity {
 
         let dot_arr = InnerProduct::try_new_array(normalized, plain_ref.clone(), len)?;
         let norm_arr = L2Norm::try_new_array(plain_ref.clone(), len)?;
+
         let dot: PrimitiveArray = dot_arr.into_array().execute(ctx)?;
         let plain_norm: PrimitiveArray = norm_arr.into_array().execute(ctx)?;
 

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -5,19 +5,27 @@
 
 use std::fmt::Formatter;
 
+use num_traits::Float;
 use num_traits::Zero;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Constant;
+use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::Extension;
+use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::ScalarFnArray;
+use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::scalar_fn::ExactScalarFn;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
+use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
 use vortex_array::expr::Expression;
 use vortex_array::expr::and;
 use vortex_array::match_each_float_ptype;
+use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::Arity;
 use vortex_array::scalar_fn::ChildName;
 use vortex_array::scalar_fn::EmptyOptions;
@@ -27,12 +35,15 @@ use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 
+use crate::matcher::AnyTensor;
 use crate::scalar_fns::inner_product::InnerProduct;
 use crate::scalar_fns::l2_denorm::L2Denorm;
 use crate::scalar_fns::l2_norm::L2Norm;
+use crate::utils::extract_flat_elements;
 use crate::utils::extract_l2_denorm_children;
 use crate::utils::validate_tensor_float_input;
 
@@ -132,6 +143,16 @@ impl ScalarFnVTable for CosineSimilarity {
         let mut lhs_ref = args.get(0)?;
         let mut rhs_ref = args.get(1)?;
         let len = args.row_count();
+
+        // If either side is a constant tensor-like extension array, eagerly normalize the single
+        // stored row and re-wrap it as an `L2Denorm` whose children are both [`ConstantArray`]s.
+        // The L2Denorm fast path below then picks it up.
+        if let Some(wrapped) = try_wrap_constant_as_l2_denorm(&lhs_ref, len, ctx)? {
+            lhs_ref = wrapped;
+        }
+        if let Some(wrapped) = try_wrap_constant_as_l2_denorm(&rhs_ref, len, ctx)? {
+            rhs_ref = wrapped;
+        }
 
         // Check if any of our children have be already normalized.
         {
@@ -249,9 +270,9 @@ impl CosineSimilarity {
         let (normalized, _) = extract_l2_denorm_children(denorm_ref);
 
         let dot_arr = InnerProduct::try_new_array(normalized, plain_ref.clone(), len)?;
-        let norm_arr = L2Norm::try_new_array(plain_ref.clone(), len)?;
-
         let dot: PrimitiveArray = dot_arr.into_array().execute(ctx)?;
+
+        let norm_arr = L2Norm::try_new_array(plain_ref.clone(), len)?;
         let plain_norm: PrimitiveArray = norm_arr.into_array().execute(ctx)?;
 
         // TODO(connor): Ideally we would have a `SafeDiv` binary numeric operation.
@@ -273,6 +294,90 @@ impl CosineSimilarity {
             Ok(unsafe { PrimitiveArray::new_unchecked(buffer, validity) }.into_array())
         })
     }
+}
+
+/// If `input` is a tensor-like [`ExtensionArray`] whose storage is a [`ConstantArray`] with a
+/// non-null fixed-size-list scalar, eagerly normalize the single stored row and return an
+/// equivalent [`L2Denorm`]-wrapped constant array whose normalized and norms children are both
+/// [`ConstantArray`]s.
+///
+/// Returns `Ok(None)` when `input` is not an extension array, when its storage is not a
+/// [`ConstantArray`], or when the constant scalar is null. In those cases, the caller falls
+/// through to the standard cosine-similarity path.
+fn try_wrap_constant_as_l2_denorm(
+    input: &ArrayRef,
+    len: usize,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Option<ArrayRef>> {
+    // The input must be an extension array whose storage is a constant array with a non-null
+    // scalar value. Any other shape falls through so the standard path handles it.
+    let Some(ext) = input.as_opt::<Extension>() else {
+        return Ok(None);
+    };
+    let storage = ext.storage_array();
+    let Some(const_storage) = storage.as_opt::<Constant>() else {
+        return Ok(None);
+    };
+    if const_storage.scalar().is_null() {
+        return Ok(None);
+    }
+
+    // `return_dtype` has already validated this is an `AnyTensor` extension dtype.
+    let tensor_match = input
+        .dtype()
+        .as_extension()
+        .metadata_opt::<AnyTensor>()
+        .vortex_expect("return_dtype validated input has AnyTensor metadata");
+    let list_size = tensor_match.list_size();
+    let original_nullability = input.dtype().nullability();
+    let ext_dtype = input.dtype().as_extension().clone();
+    let storage_fsl_nullability = storage.dtype().nullability();
+
+    // `extract_flat_elements` already takes the stride-0 single-row path for `Constant` storage,
+    // so this is cheap and does not expand the constant to the full column length.
+    let flat = extract_flat_elements(storage, list_size, ctx)?;
+
+    // TODO(connor): This is ugly because we do not have `ScalarValue::Array` still.
+    let (normalized_fsl_scalar, norms_scalar) = match_each_float_ptype!(flat.ptype(), |T| {
+        let row = flat.row::<T>(0);
+
+        let mut sum_sq = T::zero();
+        for &x in row {
+            sum_sq += x * x;
+        }
+        let norm_t: T = sum_sq.sqrt();
+
+        // Zero-norm rows must be stored as all-zeros so [`L2Denorm`]'s unit-norm-or-zero
+        // invariant holds. This mirrors `normalize_as_l2_denorm` in `l2_denorm.rs`.
+        let element_dtype = DType::Primitive(T::PTYPE, Nullability::NonNullable);
+        let children: Vec<Scalar> = if norm_t == T::zero() {
+            (0..list_size)
+                .map(|_| Scalar::zero_value(&element_dtype))
+                .collect()
+        } else {
+            row.iter()
+                .map(|&v| Scalar::primitive(v / norm_t, Nullability::NonNullable))
+                .collect()
+        };
+
+        // The rebuilt FSL scalar preserves the original storage FSL's nullability so the
+        // resulting `ExtensionArray::new` call accepts the same extension dtype.
+        let fsl_scalar = Scalar::fixed_size_list(element_dtype, children, storage_fsl_nullability);
+        let norms_scalar = Scalar::primitive(norm_t, original_nullability);
+        (fsl_scalar, norms_scalar)
+    });
+
+    // Rebuild the normalized side as a constant-backed extension array with the original dtype.
+    let normalized_storage = ConstantArray::new(normalized_fsl_scalar, len).into_array();
+    let normalized_ext = ExtensionArray::new(ext_dtype, normalized_storage).into_array();
+
+    // Build the norms side as a constant primitive array.
+    let norms_array = ConstantArray::new(norms_scalar, len).into_array();
+
+    // SAFETY: Each row of `normalized_ext` is either `v / ||v||` (unit norm within floating point
+    // tolerance) or all zeros when `||v|| == 0`. Stored norms are non-negative by construction.
+    let wrapped = unsafe { L2Denorm::new_array_unchecked(normalized_ext, norms_array, len)? };
+    Ok(Some(wrapped.into_array()))
 }
 
 #[cfg(test)]
@@ -574,6 +679,108 @@ mod tests {
         assert!(prim.is_valid(0)?);
         assert!(!prim.is_valid(1)?);
         assert_close(&[prim.as_slice::<f64>()[0]], &[1.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn constant_lhs_matches_plain_tensor() -> VortexResult<()> {
+        // The constant query `[1, 2, 2]` has norm 3, so its normalized form is `[1/3, 2/3, 2/3]`.
+        // Expected cosine similarity against each row is `dot([1, 2, 2], row) / (3 * ||row||)`.
+        let lhs = constant_tensor_array(&[3], &[1.0, 2.0, 2.0], 4)?;
+        let rhs = tensor_array(
+            &[3],
+            &[
+                1.0, 0.0, 0.0, // dot=1, ||rhs||=1, expected=1/3
+                1.0, 2.0, 2.0, // dot=9, ||rhs||=3, expected=1
+                0.0, 0.0, 1.0, // dot=2, ||rhs||=1, expected=2/3
+                2.0, 1.0, 2.0, // dot=8, ||rhs||=3, expected=8/9
+            ],
+        )?;
+        assert_close(
+            &eval_cosine_similarity(lhs, rhs, 4)?,
+            &[1.0 / 3.0, 1.0, 2.0 / 3.0, 8.0 / 9.0],
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn constant_rhs_matches_plain_tensor() -> VortexResult<()> {
+        // Mirror of `constant_lhs_matches_plain_tensor` with the constant on the right.
+        let lhs = tensor_array(
+            &[3],
+            &[
+                1.0, 0.0, 0.0, //
+                1.0, 2.0, 2.0, //
+                0.0, 0.0, 1.0, //
+                2.0, 1.0, 2.0, //
+            ],
+        )?;
+        let rhs = constant_tensor_array(&[3], &[1.0, 2.0, 2.0], 4)?;
+        assert_close(
+            &eval_cosine_similarity(lhs, rhs, 4)?,
+            &[1.0 / 3.0, 1.0, 2.0 / 3.0, 8.0 / 9.0],
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn both_constant_tensors() -> VortexResult<()> {
+        // `[1, 0, 0]` vs `[1, 1, 0]`. dot=1, ||lhs||=1, ||rhs||=sqrt(2), expected=1/sqrt(2).
+        let lhs = constant_tensor_array(&[3], &[1.0, 0.0, 0.0], 3)?;
+        let rhs = constant_tensor_array(&[3], &[1.0, 1.0, 0.0], 3)?;
+        let expected = 1.0 / 2.0_f64.sqrt();
+        assert_close(
+            &eval_cosine_similarity(lhs, rhs, 3)?,
+            &[expected, expected, expected],
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn constant_zero_norm_query() -> VortexResult<()> {
+        // A zero-norm constant query must produce `0.0` for every row via the zero-norm guard in
+        // `execute_one_denorm` and `execute_both_denorm`.
+        let lhs = constant_tensor_array(&[3], &[0.0, 0.0, 0.0], 3)?;
+        let rhs = tensor_array(
+            &[3],
+            &[
+                1.0, 2.0, 3.0, //
+                4.0, 5.0, 6.0, //
+                7.0, 8.0, 9.0, //
+            ],
+        )?;
+        assert_close(&eval_cosine_similarity(lhs, rhs, 3)?, &[0.0, 0.0, 0.0]);
+        Ok(())
+    }
+
+    #[test]
+    fn constant_self_similarity_nonunit() -> VortexResult<()> {
+        // A non-unit constant query compared to itself must produce `1.0`. This exercises the
+        // helper's division: after normalization, both sides must be exactly unit so the
+        // L2Denorm fast path's inner product yields 1.
+        let lhs = constant_tensor_array(&[3], &[3.0, 4.0, 0.0], 5)?;
+        let rhs = constant_tensor_array(&[3], &[3.0, 4.0, 0.0], 5)?;
+        assert_close(&eval_cosine_similarity(lhs, rhs, 5)?, &[1.0; 5]);
+        Ok(())
+    }
+
+    #[test]
+    fn vector_constant_matches_plain() -> VortexResult<()> {
+        // Exercise the `Vector` extension variant through the new pre-pass.
+        let lhs = constant_vector_array(&[1.0, 2.0, 2.0], 4)?;
+        let rhs = vector_array(
+            3,
+            &[
+                1.0, 0.0, 0.0, //
+                1.0, 2.0, 2.0, //
+                0.0, 0.0, 1.0, //
+                2.0, 1.0, 2.0, //
+            ],
+        )?;
+        assert_close(
+            &eval_cosine_similarity(lhs, rhs, 4)?,
+            &[1.0 / 3.0, 1.0, 2.0 / 3.0, 8.0 / 9.0],
+        );
         Ok(())
     }
 }

--- a/vortex-tensor/src/scalar_fns/cosine_similarity.rs
+++ b/vortex-tensor/src/scalar_fns/cosine_similarity.rs
@@ -5,27 +5,19 @@
 
 use std::fmt::Formatter;
 
-use num_traits::Float;
 use num_traits::Zero;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::arrays::Constant;
-use vortex_array::arrays::ConstantArray;
-use vortex_array::arrays::Extension;
-use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::ScalarFnArray;
-use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::scalar_fn::ExactScalarFn;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
-use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
 use vortex_array::expr::Expression;
 use vortex_array::expr::and;
 use vortex_array::match_each_float_ptype;
-use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::Arity;
 use vortex_array::scalar_fn::ChildName;
 use vortex_array::scalar_fn::EmptyOptions;
@@ -35,15 +27,13 @@ use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
-use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 
-use crate::matcher::AnyTensor;
 use crate::scalar_fns::inner_product::InnerProduct;
 use crate::scalar_fns::l2_denorm::L2Denorm;
+use crate::scalar_fns::l2_denorm::try_build_constant_l2_denorm;
 use crate::scalar_fns::l2_norm::L2Norm;
-use crate::utils::extract_flat_elements;
 use crate::utils::extract_l2_denorm_children;
 use crate::utils::validate_tensor_float_input;
 
@@ -147,11 +137,15 @@ impl ScalarFnVTable for CosineSimilarity {
         // If either side is a constant tensor-like extension array, eagerly normalize the single
         // stored row and re-wrap it as an `L2Denorm` whose children are both [`ConstantArray`]s.
         // The L2Denorm fast path below then picks it up.
-        if let Some(wrapped) = try_wrap_constant_as_l2_denorm(&lhs_ref, len, ctx)? {
-            lhs_ref = wrapped;
+        if let Some(lhs_constant) =
+            try_build_constant_l2_denorm(&lhs_ref, len, ctx)?.map(|sfn| sfn.into_array())
+        {
+            lhs_ref = lhs_constant;
         }
-        if let Some(wrapped) = try_wrap_constant_as_l2_denorm(&rhs_ref, len, ctx)? {
-            rhs_ref = wrapped;
+        if let Some(rhs_constant) =
+            try_build_constant_l2_denorm(&rhs_ref, len, ctx)?.map(|sfn| sfn.into_array())
+        {
+            rhs_ref = rhs_constant;
         }
 
         // Check if any of our children have be already normalized.
@@ -294,90 +288,6 @@ impl CosineSimilarity {
             Ok(unsafe { PrimitiveArray::new_unchecked(buffer, validity) }.into_array())
         })
     }
-}
-
-/// If `input` is a tensor-like [`ExtensionArray`] whose storage is a [`ConstantArray`] with a
-/// non-null fixed-size-list scalar, eagerly normalize the single stored row and return an
-/// equivalent [`L2Denorm`]-wrapped constant array whose normalized and norms children are both
-/// [`ConstantArray`]s.
-///
-/// Returns `Ok(None)` when `input` is not an extension array, when its storage is not a
-/// [`ConstantArray`], or when the constant scalar is null. In those cases, the caller falls
-/// through to the standard cosine-similarity path.
-fn try_wrap_constant_as_l2_denorm(
-    input: &ArrayRef,
-    len: usize,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<Option<ArrayRef>> {
-    // The input must be an extension array whose storage is a constant array with a non-null
-    // scalar value. Any other shape falls through so the standard path handles it.
-    let Some(ext) = input.as_opt::<Extension>() else {
-        return Ok(None);
-    };
-    let storage = ext.storage_array();
-    let Some(const_storage) = storage.as_opt::<Constant>() else {
-        return Ok(None);
-    };
-    if const_storage.scalar().is_null() {
-        return Ok(None);
-    }
-
-    // `return_dtype` has already validated this is an `AnyTensor` extension dtype.
-    let tensor_match = input
-        .dtype()
-        .as_extension()
-        .metadata_opt::<AnyTensor>()
-        .vortex_expect("return_dtype validated input has AnyTensor metadata");
-    let list_size = tensor_match.list_size();
-    let original_nullability = input.dtype().nullability();
-    let ext_dtype = input.dtype().as_extension().clone();
-    let storage_fsl_nullability = storage.dtype().nullability();
-
-    // `extract_flat_elements` already takes the stride-0 single-row path for `Constant` storage,
-    // so this is cheap and does not expand the constant to the full column length.
-    let flat = extract_flat_elements(storage, list_size, ctx)?;
-
-    // TODO(connor): This is ugly because we do not have `ScalarValue::Array` still.
-    let (normalized_fsl_scalar, norms_scalar) = match_each_float_ptype!(flat.ptype(), |T| {
-        let row = flat.row::<T>(0);
-
-        let mut sum_sq = T::zero();
-        for &x in row {
-            sum_sq += x * x;
-        }
-        let norm_t: T = sum_sq.sqrt();
-
-        // Zero-norm rows must be stored as all-zeros so [`L2Denorm`]'s unit-norm-or-zero
-        // invariant holds. This mirrors `normalize_as_l2_denorm` in `l2_denorm.rs`.
-        let element_dtype = DType::Primitive(T::PTYPE, Nullability::NonNullable);
-        let children: Vec<Scalar> = if norm_t == T::zero() {
-            (0..list_size)
-                .map(|_| Scalar::zero_value(&element_dtype))
-                .collect()
-        } else {
-            row.iter()
-                .map(|&v| Scalar::primitive(v / norm_t, Nullability::NonNullable))
-                .collect()
-        };
-
-        // The rebuilt FSL scalar preserves the original storage FSL's nullability so the
-        // resulting `ExtensionArray::new` call accepts the same extension dtype.
-        let fsl_scalar = Scalar::fixed_size_list(element_dtype, children, storage_fsl_nullability);
-        let norms_scalar = Scalar::primitive(norm_t, original_nullability);
-        (fsl_scalar, norms_scalar)
-    });
-
-    // Rebuild the normalized side as a constant-backed extension array with the original dtype.
-    let normalized_storage = ConstantArray::new(normalized_fsl_scalar, len).into_array();
-    let normalized_ext = ExtensionArray::new(ext_dtype, normalized_storage).into_array();
-
-    // Build the norms side as a constant primitive array.
-    let norms_array = ConstantArray::new(norms_scalar, len).into_array();
-
-    // SAFETY: Each row of `normalized_ext` is either `v / ||v||` (unit norm within floating point
-    // tolerance) or all zeros when `||v|| == 0`. Stored norms are non-negative by construction.
-    let wrapped = unsafe { L2Denorm::new_array_unchecked(normalized_ext, norms_array, len)? };
-    Ok(Some(wrapped.into_array()))
 }
 
 #[cfg(test)]

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -46,7 +46,6 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 
-use crate::encodings::turboquant::MAX_CENTROIDS;
 use crate::matcher::AnyTensor;
 use crate::scalar_fns::l2_denorm::L2Denorm;
 use crate::scalar_fns::sorf_transform::SorfMatrix;
@@ -424,9 +423,8 @@ impl InnerProduct {
         Ok(Some(rewritten))
     }
 
-    /// Fast path when one side is an extension whose storage is `FSL(Dict(u8, f32))` with
-    /// at most `MAX_CENTROIDS` values, and the other side is a constant-backed tensor
-    /// extension with an F32 element ptype.
+    /// Fast path when one side is an extension whose storage is `FSL(Dict(u8, f32))` and
+    /// the other side is a constant-backed tensor extension with an F32 element ptype.
     ///
     /// Computes each row's inner product as
     ///   `out[i] = sum_{j in 0..padded_dim} q[j] * values[codes[i * padded_dim + j] as usize]`
@@ -434,8 +432,7 @@ impl InnerProduct {
     /// `P[j, k] = q[j] * values[k]` (size `padded_dim * num_centroids * 4B`, ~1 MiB for the
     /// common 1024/256 case) was tried and measured ~10% *slower* on the
     /// `similarity_search` bench because the 1 KiB `values` table stays in L1 across all
-    /// rows, while the 1 MiB product table does not. See the plan file for the math
-    /// justifying both forms.
+    /// rows, while the 1 MiB product table does not.
     ///
     /// Returns `Ok(None)` when the pattern doesn't match; the caller should fall through to
     /// the standard path.
@@ -485,18 +482,15 @@ impl InnerProduct {
         let codes_prim: PrimitiveArray = dict.codes().clone().execute(ctx)?;
         let values_prim: PrimitiveArray = dict.values().clone().execute(ctx)?;
 
-        // Gate: u8 codes, f32 centroids, and at most 256 centroids.
+        // Gate: u8 codes and f32 centroids.
         if codes_prim.ptype() != PType::U8 {
             // TODO(connor): support wider code widths (u16, u32). TurboQuant only emits u8
             // codes today, so this is the only path we need for now.
             return Ok(None);
         }
         if values_prim.ptype() != PType::F32 {
-            // TODO(connor): the product-table path only supports f32 centroids. SorfTransform
+            // TODO(connor): direct-lookup path only supports f32 centroids. SorfTransform
             // forces f32 anyway, so this is the only shape we need for now.
-            return Ok(None);
-        }
-        if values_prim.len() > MAX_CENTROIDS {
             return Ok(None);
         }
 
@@ -796,6 +790,7 @@ mod tests {
     mod case_1_and_2 {
         use std::sync::LazyLock;
 
+        use rstest::rstest;
         use vortex_array::ArrayRef;
         use vortex_array::IntoArray;
         use vortex_array::VortexSessionExecute;
@@ -1164,10 +1159,11 @@ mod tests {
             Ok(())
         }
 
-        /// Case 2: dict with more than 256 values falls through to the standard path but
-        /// still produces the correct result.
+        /// Case 2: dict with `u16` codes (and hence more than 256 values) falls through to
+        /// the standard path but still produces the correct result. The direct-lookup path
+        /// only handles `u8` codes today.
         #[test]
-        fn case2_more_than_256_values_falls_through() -> VortexResult<()> {
+        fn case2_u16_codes_falls_through() -> VortexResult<()> {
             let list_size: u32 = 4;
             let num_rows = 3usize;
             let num_values = 300usize;
@@ -1298,6 +1294,297 @@ mod tests {
 
             let actual = eval_ip_f32(sorf, const_rhs, num_rows)?;
             assert_close_f32(&actual, &expected, 1e-3);
+            Ok(())
+        }
+
+        // ---- Additional correctness / stress tests (all with loose tolerances) ----
+
+        /// A tiny in-place xorshift64 PRNG so these tests don't depend on `rand`. Producing
+        /// deterministic pseudo-random f32 values lets the correctness checks exercise
+        /// realistic data instead of smooth sin/cos patterns.
+        struct XorShift64(u64);
+
+        impl XorShift64 {
+            fn new(seed: u64) -> Self {
+                // Any nonzero seed is fine; xorshift fixed-points at 0.
+                Self(seed.wrapping_add(0x9E37_79B9_7F4A_7C15))
+            }
+
+            fn next_u64(&mut self) -> u64 {
+                let mut x = self.0;
+                x ^= x << 13;
+                x ^= x >> 7;
+                x ^= x << 17;
+                self.0 = x;
+                x
+            }
+
+            /// Uniform f32 in `[-1.0, 1.0)`.
+            fn next_f32(&mut self) -> f32 {
+                // Top 24 bits -> mantissa in [0, 1), then shift to [-1, 1).
+                let bits = (self.next_u64() >> 40) as u32; // 24 bits
+                (bits as f32) / (1u32 << 24) as f32 * 2.0 - 1.0
+            }
+        }
+
+        /// Case 2 stress: u8-coded dict with 200 centroids (formerly blocked by the
+        /// `values.len() <= 256` gate). The direct-lookup path must now handle it.
+        #[test]
+        fn case2_large_u8_codebook_direct_lookup() -> VortexResult<()> {
+            let list_size: u32 = 16;
+            let num_rows = 20usize;
+            let num_centroids = 200usize;
+            assert!(num_centroids > 8 && num_centroids <= 256);
+
+            let mut rng = XorShift64::new(0xDEAD_BEEF);
+            let values: Vec<f32> = (0..num_centroids).map(|_| rng.next_f32()).collect();
+            let codes: Vec<u8> = (0..num_rows * list_size as usize)
+                .map(|_| (rng.next_u64() % num_centroids as u64) as u8)
+                .collect();
+
+            let dict_lhs = dict_vector_f32(list_size, &codes, &values)?;
+            let query: Vec<f32> = (0..list_size).map(|_| rng.next_f32()).collect();
+            let const_rhs = constant_vector_f32(&query, num_rows)?;
+
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|row| {
+                    let mut acc = 0.0f32;
+                    for j in 0..list_size as usize {
+                        let k = codes[row * list_size as usize + j] as usize;
+                        acc += query[j] * values[k];
+                    }
+                    acc
+                })
+                .collect();
+
+            let actual = eval_ip_f32(dict_lhs, const_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-4);
+            Ok(())
+        }
+
+        /// Parameterized sweep over the full `InnerProduct(SorfTransform(Vector[FSL(Dict)]),
+        /// ConstantArray)` tree, exercising the case 1 + case 2 chain for a realistic mix
+        /// of dimensions, row counts, seeds, and number of SORF rounds. Tolerance is
+        /// deliberately loose because the rewrite introduces an f32-domain rotation that
+        /// accumulates a small numerical drift versus a naive decode.
+        #[rstest]
+        #[case::small_no_pad(128, 11, 1, 1)]
+        #[case::small_no_pad_rounds3(128, 23, 1_234, 3)]
+        #[case::small_padded(100, 17, 42, 3)]
+        #[case::mid_padded(200, 13, 2024, 3)]
+        #[case::mid_power_of_two(256, 31, 7, 3)]
+        #[case::larger_padded(300, 9, 99, 3)]
+        #[case::max_rounds(128, 5, 31_415, 5)]
+        fn case1_sorf_random_sweep(
+            #[case] dim: u32,
+            #[case] num_rows: usize,
+            #[case] seed: u64,
+            #[case] num_rounds: u8,
+        ) -> VortexResult<()> {
+            let (sorf, codes, values, padded_dim) =
+                build_sorf_with_dict_child(dim, num_rows, seed, num_rounds)?;
+
+            // Use a pseudo-random query with both positive and negative entries so the sum
+            // has cancellation.
+            let mut rng = XorShift64::new(seed ^ 0xABCD_1234);
+            let query: Vec<f32> = (0..dim).map(|_| rng.next_f32()).collect();
+            let const_rhs = constant_vector_f32(&query, num_rows)?;
+
+            let decoded = decode_sorf_dict(
+                &codes,
+                &values,
+                padded_dim,
+                dim as usize,
+                num_rows,
+                seed,
+                num_rounds,
+            )?;
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|i| naive_dot(&decoded[i * dim as usize..(i + 1) * dim as usize], &query))
+                .collect();
+
+            // Loose tolerance: the sorf transform works in f32 with a k-round butterfly, so
+            // the rewrite path and the decoded path accumulate slightly different rounding
+            // even though the math is equivalent in exact arithmetic.
+            let actual = eval_ip_f32(sorf, const_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-2);
+            Ok(())
+        }
+
+        /// Parameterized sweep over plain `Vector[FSL(Dict(u8, f32))]` + constant query,
+        /// without SorfTransform in the mix. This directly exercises case 2 across a
+        /// variety of list sizes, num_rows, and codebook sizes including large ones that
+        /// the old `<= 256` gate would have rejected.
+        #[rstest]
+        #[case::small(4, 7, 8)]
+        #[case::medium(16, 50, 64)]
+        #[case::larger(32, 100, 150)]
+        #[case::very_large_codebook(8, 25, 250)]
+        fn case2_random_sweep(
+            #[case] list_size: u32,
+            #[case] num_rows: usize,
+            #[case] num_centroids: usize,
+        ) -> VortexResult<()> {
+            let mut rng = XorShift64::new((list_size as u64) * 31 + num_rows as u64);
+            let values: Vec<f32> = (0..num_centroids).map(|_| rng.next_f32()).collect();
+            assert!(num_centroids <= 256, "u8 codes cap at 256 centroids");
+            let codes: Vec<u8> = (0..num_rows * list_size as usize)
+                .map(|_| (rng.next_u64() % num_centroids as u64) as u8)
+                .collect();
+
+            let dict_lhs = dict_vector_f32(list_size, &codes, &values)?;
+            let query: Vec<f32> = (0..list_size).map(|_| rng.next_f32()).collect();
+            let const_rhs = constant_vector_f32(&query, num_rows)?;
+
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|row| {
+                    let mut acc = 0.0f32;
+                    for j in 0..list_size as usize {
+                        let k = codes[row * list_size as usize + j] as usize;
+                        acc += query[j] * values[k];
+                    }
+                    acc
+                })
+                .collect();
+
+            // Tight tolerance here because no SorfTransform rotation is involved — the
+            // arithmetic should agree bit-for-bit up to float reassociation.
+            let actual = eval_ip_f32(dict_lhs, const_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-4);
+            Ok(())
+        }
+
+        /// End-to-end regression: for a plausible vector-search configuration (SORF rounds
+        /// = 3, dim = 128, num_rows = 64, u8 codes, 64 centroids), the fast-path result
+        /// must track a fully naive computation within 1e-2.
+        #[test]
+        fn end_to_end_dim128_rows64_bit6_regression() -> VortexResult<()> {
+            let dim: u32 = 128;
+            let num_rows = 64usize;
+            let seed = 0xFACE_F00D;
+            let num_rounds = 3u8;
+
+            // Use 64 centroids (6 bits), a typical TurboQuant configuration.
+            let num_centroids = 64usize;
+            let padded_dim = (dim as usize).next_power_of_two();
+            let mut rng = XorShift64::new(seed);
+            let values: Vec<f32> = (0..num_centroids).map(|_| rng.next_f32()).collect();
+            let codes: Vec<u8> = (0..num_rows * padded_dim)
+                .map(|_| (rng.next_u64() % num_centroids as u64) as u8)
+                .collect();
+
+            let padded_vector = dict_vector_f32(padded_dim as u32, &codes, &values)?;
+            let sorf_options = SorfOptions {
+                seed,
+                num_rounds,
+                dimension: dim,
+                element_ptype: PType::F32,
+            };
+            let sorf =
+                SorfTransform::try_new_array(&sorf_options, padded_vector, num_rows)?.into_array();
+
+            let query: Vec<f32> = (0..dim).map(|_| rng.next_f32()).collect();
+            let const_rhs = constant_vector_f32(&query, num_rows)?;
+
+            let decoded = decode_sorf_dict(
+                &codes,
+                &values,
+                padded_dim,
+                dim as usize,
+                num_rows,
+                seed,
+                num_rounds,
+            )?;
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|i| naive_dot(&decoded[i * dim as usize..(i + 1) * dim as usize], &query))
+                .collect();
+
+            let actual = eval_ip_f32(sorf, const_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-2);
+
+            // Also verify the max relative error is small. The SORF rotation does not
+            // amplify error, so both measures should be bounded.
+            for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+                let denom = e.abs().max(1.0);
+                let rel = (a - e).abs() / denom;
+                assert!(
+                    rel < 1e-3,
+                    "row {i}: rel err {rel} too large (a={a}, e={e})"
+                );
+            }
+            Ok(())
+        }
+
+        /// Case 1 + Case 2 end-to-end with varying `num_rounds`. The rotation becomes
+        /// progressively more chaotic as rounds increase, so this catches any off-by-one
+        /// bug in the round-indexing that would not show up in the 3-round default.
+        #[rstest]
+        #[case(1)]
+        #[case(2)]
+        #[case(3)]
+        #[case(4)]
+        #[case(5)]
+        fn case1_various_num_rounds(#[case] num_rounds: u8) -> VortexResult<()> {
+            let dim: u32 = 128;
+            let num_rows = 8usize;
+            let seed = 0x1234_5678;
+
+            let (sorf, codes, values, padded_dim) =
+                build_sorf_with_dict_child(dim, num_rows, seed, num_rounds)?;
+
+            let mut rng = XorShift64::new(seed ^ (num_rounds as u64));
+            let query: Vec<f32> = (0..dim).map(|_| rng.next_f32()).collect();
+            let const_rhs = constant_vector_f32(&query, num_rows)?;
+
+            let decoded = decode_sorf_dict(
+                &codes,
+                &values,
+                padded_dim,
+                dim as usize,
+                num_rows,
+                seed,
+                num_rounds,
+            )?;
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|i| naive_dot(&decoded[i * dim as usize..(i + 1) * dim as usize], &query))
+                .collect();
+
+            let actual = eval_ip_f32(sorf, const_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-2);
+            Ok(())
+        }
+
+        /// Swap LHS and RHS on the full tree to prove the side-detection and the scalar
+        /// argument-order handling are symmetric for both cases simultaneously.
+        #[test]
+        fn end_to_end_constant_lhs_sorf_rhs_mirrored() -> VortexResult<()> {
+            let dim: u32 = 256;
+            let num_rows = 12usize;
+            let seed = 0xBEEF_CAFE;
+            let num_rounds = 3u8;
+
+            let (sorf, codes, values, padded_dim) =
+                build_sorf_with_dict_child(dim, num_rows, seed, num_rounds)?;
+
+            let mut rng = XorShift64::new(seed);
+            let query: Vec<f32> = (0..dim).map(|_| rng.next_f32()).collect();
+            let const_lhs = constant_vector_f32(&query, num_rows)?;
+
+            let decoded = decode_sorf_dict(
+                &codes,
+                &values,
+                padded_dim,
+                dim as usize,
+                num_rows,
+                seed,
+                num_rounds,
+            )?;
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|i| naive_dot(&decoded[i * dim as usize..(i + 1) * dim as usize], &query))
+                .collect();
+
+            let actual = eval_ip_f32(const_lhs, sorf, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-2);
             Ok(())
         }
     }

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -184,8 +184,9 @@ impl ScalarFnVTable for InnerProduct {
             return Ok(rewritten);
         }
 
-        // Reduction case 2: `InnerProduct(Vector[FSL(Dict(u8, f32<=256))], const)` is
-        // computed by precomputing a product table and gather-summing over the codes.
+        // Reduction case 2: `InnerProduct(Vector[FSL(Dict(u8, f32))], const)` is computed by
+        // gather-summing `q[j] * values[codes[j] as usize]` per row, reading the codebook
+        // directly instead of decoding the column into dense vectors.
         if let Some(result) = self.try_execute_dict_constant(&lhs_ref, &rhs_ref, len, ctx)? {
             return Ok(result);
         }
@@ -330,17 +331,14 @@ impl InnerProduct {
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         // Identify which side is the SorfTransform, if any.
-        let (sorf_ref, const_ref) = if lhs_ref.is::<ExactScalarFn<SorfTransform>>() {
-            (lhs_ref, rhs_ref)
-        } else if rhs_ref.is::<ExactScalarFn<SorfTransform>>() {
-            (rhs_ref, lhs_ref)
-        } else {
-            return Ok(None);
-        };
-
-        let sorf_view = sorf_ref
-            .as_opt::<ExactScalarFn<SorfTransform>>()
-            .vortex_expect("just checked via `is`");
+        let (sorf_view, const_ref) =
+            if let Some(view) = lhs_ref.as_opt::<ExactScalarFn<SorfTransform>>() {
+                (view, rhs_ref)
+            } else if let Some(view) = rhs_ref.as_opt::<ExactScalarFn<SorfTransform>>() {
+                (view, lhs_ref)
+            } else {
+                return Ok(None);
+            };
 
         // TODO(connor): pull-through is only sound for F32 because SorfTransform applies an
         // `f32 -> element_ptype` cast at the end of its execute. For F16/F64 the rewrite
@@ -443,17 +441,38 @@ impl InnerProduct {
         len: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        // Identify which side is `Extension[FSL[Dict]]`, with a non-canonicalizing peek.
-        let (dict_ref, const_ref) = if is_dict_fsl_extension(lhs_ref) {
-            (lhs_ref, rhs_ref)
-        } else if is_dict_fsl_extension(rhs_ref) {
-            (rhs_ref, lhs_ref)
-        } else {
+        // Try each orientation. The oriented helper navigates each side exactly once, so
+        // the only redundant work here is the failed navigation of the first side when the
+        // dict happens to be on the right.
+        if let Some(result) = self.try_execute_dict_constant_oriented(lhs_ref, rhs_ref, len, ctx)? {
+            return Ok(Some(result));
+        }
+        self.try_execute_dict_constant_oriented(rhs_ref, lhs_ref, len, ctx)
+    }
+
+    /// Orientation-specific helper for [`Self::try_execute_dict_constant`]. `dict_candidate`
+    /// is tried as `Extension[FSL[Dict]]`; `const_candidate` is tried as a constant-backed
+    /// tensor extension. Returns `Ok(None)` if either navigation fails or any gate rejects.
+    fn try_execute_dict_constant_oriented(
+        &self,
+        dict_candidate: &ArrayRef,
+        const_candidate: &ArrayRef,
+        len: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        // Navigate the dict side.
+        let Some(dict_ext) = dict_candidate.as_opt::<Extension>() else {
+            return Ok(None);
+        };
+        let Some(fsl) = dict_ext.storage_array().as_opt::<FixedSizeList>() else {
+            return Ok(None);
+        };
+        let Some(dict) = fsl.elements().as_opt::<Dict>() else {
             return Ok(None);
         };
 
-        // Detect the constant-backed extension on the other side.
-        let Some(const_ext) = const_ref.as_opt::<Extension>() else {
+        // Navigate the constant side and require its scalar be non-null.
+        let Some(const_ext) = const_candidate.as_opt::<Extension>() else {
             return Ok(None);
         };
         let const_storage = const_ext.storage_array();
@@ -464,21 +483,8 @@ impl InnerProduct {
             return Ok(None);
         }
 
-        // Navigate into the dict side. We already verified the shape via the peek.
-        let dict_ext = dict_ref
-            .as_opt::<Extension>()
-            .vortex_expect("peek guaranteed Extension");
-        let fsl = dict_ext
-            .storage_array()
-            .as_opt::<FixedSizeList>()
-            .vortex_expect("peek guaranteed FixedSizeList");
-        let dict = fsl
-            .elements()
-            .as_opt::<Dict>()
-            .vortex_expect("peek guaranteed Dict");
-
         // Canonicalize codes and values. Codes may be e.g. BitPacked; executing is cheaper
-        // than falling through to the naive path (which would also canonicalize).
+        // than falling through to the standard path (which would also canonicalize).
         let codes_prim: PrimitiveArray = dict.codes().clone().execute(ctx)?;
         let values_prim: PrimitiveArray = dict.values().clone().execute(ctx)?;
 
@@ -505,9 +511,11 @@ impl InnerProduct {
 
         // Combine the input validities up front; the per-row arithmetic may write garbage
         // into null rows but the validity mask hides it (matching the standard path).
-        let validity = dict_ref.validity()?.and(const_ref.validity()?)?;
+        let validity = dict_candidate
+            .validity()?
+            .and(const_candidate.validity()?)?;
 
-        // Fast path for the empty case: skip the product-table allocation entirely.
+        // Fast path for the empty case: skip allocating and touching the codes buffer.
         if len == 0 {
             let empty = PrimitiveArray::empty::<f32>(validity.nullability());
             return Ok(Some(empty.into_array()));
@@ -519,8 +527,8 @@ impl InnerProduct {
         let values: &[f32] = values_prim.as_slice::<f32>();
         debug_assert_eq!(codes.len(), len * padded_dim);
 
-        // Direct codebook lookup: `acc += q[j] * values[codes[j]]`. See the benchmark
-        // comment below for why this beats an explicit product table here.
+        // Direct codebook lookup in the hot loop. See the function doc comment for why this
+        // beats an explicit product table here.
         let mut out = BufferMut::<f32>::with_capacity(len);
         for row in 0..len {
             let row_codes = &codes[row * padded_dim..(row + 1) * padded_dim];
@@ -536,19 +544,6 @@ impl InnerProduct {
         let result = unsafe { PrimitiveArray::new_unchecked(out.freeze(), validity) }.into_array();
         Ok(Some(result))
     }
-}
-
-/// Non-canonicalizing shape peek: returns `true` iff `arr` is an `Extension` whose storage
-/// is a `FixedSizeList` whose elements are a `Dict`. Used to pick the dict side of an
-/// `InnerProduct` without doing any execution work.
-fn is_dict_fsl_extension(arr: &ArrayRef) -> bool {
-    let Some(ext) = arr.as_opt::<Extension>() else {
-        return false;
-    };
-    let Some(fsl) = ext.storage_array().as_opt::<FixedSizeList>() else {
-        return false;
-    };
-    fsl.elements().as_opt::<Dict>().is_some()
 }
 
 /// Computes the inner product (dot product) of two equal-length float slices.
@@ -781,13 +776,13 @@ mod tests {
         Ok(())
     }
 
-    // ---- Case 1 (SorfTransform + Constant) and Case 2 (Dict + Constant) tests ----
+    // ---- Tests for the `SorfTransform + constant` and `Dict + constant` fast paths ----
 
     #[allow(
         clippy::cast_possible_truncation,
         reason = "tests build small fixtures with deterministic in-range indices"
     )]
-    mod case_1_and_2 {
+    mod constant_query_optimizations {
         use std::sync::LazyLock;
 
         use rstest::rstest;
@@ -809,7 +804,6 @@ mod tests {
         use vortex_array::session::ArraySession;
         use vortex_array::validity::Validity;
         use vortex_buffer::Buffer;
-        use vortex_buffer::BufferMut;
         use vortex_error::VortexResult;
         use vortex_session::VortexSession;
 
@@ -852,16 +846,12 @@ mod tests {
         /// TurboQuant produces as the SorfTransform child.
         fn dict_vector_f32(list_size: u32, codes: &[u8], values: &[f32]) -> VortexResult<ArrayRef> {
             let num_rows = codes.len() / list_size as usize;
-            let codes_arr = {
-                let mut buf = BufferMut::<u8>::with_capacity(codes.len());
-                buf.extend_from_slice(codes);
-                PrimitiveArray::new::<u8>(buf.freeze(), Validity::NonNullable).into_array()
-            };
-            let values_arr = {
-                let mut buf = BufferMut::<f32>::with_capacity(values.len());
-                buf.extend_from_slice(values);
-                PrimitiveArray::new::<f32>(buf.freeze(), Validity::NonNullable).into_array()
-            };
+            let codes_arr =
+                PrimitiveArray::new::<u8>(Buffer::copy_from(codes), Validity::NonNullable)
+                    .into_array();
+            let values_arr =
+                PrimitiveArray::new::<f32>(Buffer::copy_from(values), Validity::NonNullable)
+                    .into_array();
             let dict = DictArray::try_new(codes_arr, values_arr)?;
             let fsl = FixedSizeListArray::try_new(
                 dict.into_array(),
@@ -896,7 +886,7 @@ mod tests {
 
         /// Build a SorfTransform ScalarFnArray whose child is a `Vector<padded_dim, f32>`
         /// wrapping `FSL(Dict(codes, values))`. Returns `(sorf_array, codes, values,
-        /// padded_dim, dim)`.
+        /// padded_dim)`.
         fn build_sorf_with_dict_child(
             dim: u32,
             num_rows: usize,
@@ -955,19 +945,16 @@ mod tests {
 
         // ---- Case 1: SorfTransform + Constant pull-through ----
 
-        /// Case 1: SorfTransform on LHS, constant query on RHS, `dim < padded_dim`.
+        /// Case 1: SorfTransform on LHS, constant query on RHS, with `dim < padded_dim`
+        /// so the zero-padding branch is exercised.
         #[test]
         fn case1_sorf_lhs_constant_rhs_padded_gt_dim() -> VortexResult<()> {
-            let dim: u32 = 128;
-            let padded_dim = (dim as usize).next_power_of_two();
-            assert_eq!(padded_dim, 128); // degenerate case for this dim, handled by next test
-            // Bump dim to exercise padding explicitly.
             let dim: u32 = 100;
-            let padded_dim = (dim as usize).next_power_of_two();
-            assert!(padded_dim > dim as usize);
             let num_rows = 7usize;
             let seed = 42u64;
             let num_rounds = 3u8;
+            let padded_dim = (dim as usize).next_power_of_two();
+            assert!(padded_dim > dim as usize, "test must exercise padding");
 
             let (sorf_lhs, codes, values, padded_dim_computed) =
                 build_sorf_with_dict_child(dim, num_rows, seed, num_rounds)?;
@@ -1095,7 +1082,7 @@ mod tests {
             Ok(())
         }
 
-        // ---- Case 2: Dict + Constant product-table path ----
+        // ---- Case 2: Dict + Constant direct-lookup path ----
 
         /// Case 2: Vector[FSL[Dict(u8, f32)]] on LHS, constant query on RHS.
         #[test]
@@ -1169,18 +1156,16 @@ mod tests {
             let num_values = 300usize;
             let values: Vec<f32> = (0..num_values).map(|i| i as f32 * 0.01).collect();
             // Codes must be u16 because 300 > 255. dict_vector_f32 only supports u8 so we
-            // need a u16-coded dict here.
-            let mut codes_u16_buf = BufferMut::<u16>::with_capacity(num_rows * 4);
-            for i in 0..(num_rows * 4) {
-                codes_u16_buf.push((i % num_values) as u16);
-            }
+            // build the dict by hand here.
+            let codes_u16: Vec<u16> = (0..(num_rows * 4))
+                .map(|i| (i % num_values) as u16)
+                .collect();
             let codes_arr =
-                PrimitiveArray::new::<u16>(codes_u16_buf.freeze(), Validity::NonNullable)
+                PrimitiveArray::new::<u16>(Buffer::copy_from(codes_u16), Validity::NonNullable)
                     .into_array();
-            let mut values_buf = BufferMut::<f32>::with_capacity(values.len());
-            values_buf.extend_from_slice(&values);
             let values_arr =
-                PrimitiveArray::new::<f32>(values_buf.freeze(), Validity::NonNullable).into_array();
+                PrimitiveArray::new::<f32>(Buffer::copy_from(&values), Validity::NonNullable)
+                    .into_array();
             let dict = DictArray::try_new(codes_arr, values_arr)?;
             let fsl = FixedSizeListArray::try_new(
                 dict.into_array(),
@@ -1241,7 +1226,7 @@ mod tests {
         }
 
         /// Case 2: empty `len == 0` fast path returns an empty primitive array without
-        /// allocating a product table.
+        /// touching the codes buffer.
         #[test]
         fn case2_empty_len_zero() -> VortexResult<()> {
             let list_size: u32 = 4;

--- a/vortex-tensor/src/scalar_fns/inner_product.rs
+++ b/vortex-tensor/src/scalar_fns/inner_product.rs
@@ -4,22 +4,34 @@
 //! Inner product expression for tensor-like types.
 
 use std::fmt::Formatter;
+use std::sync::Arc;
 
 use num_traits::Float;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Constant;
+use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::Dict;
+use vortex_array::arrays::Extension;
 use vortex_array::arrays::ExtensionArray;
+use vortex_array::arrays::FixedSizeList;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::ScalarFnArray;
+use vortex_array::arrays::dict::DictArraySlotsExt;
 use vortex_array::arrays::extension::ExtensionArrayExt;
+use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
 use vortex_array::arrays::scalar_fn::ExactScalarFn;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
+use vortex_array::dtype::PType;
+use vortex_array::dtype::extension::ExtDType;
 use vortex_array::expr::Expression;
 use vortex_array::expr::and;
+use vortex_array::extension::EmptyMetadata;
 use vortex_array::match_each_float_ptype;
+use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::Arity;
 use vortex_array::scalar_fn::ChildName;
 use vortex_array::scalar_fn::EmptyOptions;
@@ -28,15 +40,20 @@ use vortex_array::scalar_fn::ScalarFn;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
 use vortex_buffer::Buffer;
+use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 
+use crate::encodings::turboquant::MAX_CENTROIDS;
 use crate::matcher::AnyTensor;
 use crate::scalar_fns::l2_denorm::L2Denorm;
+use crate::scalar_fns::sorf_transform::SorfMatrix;
+use crate::scalar_fns::sorf_transform::SorfTransform;
 use crate::utils::extract_flat_elements;
 use crate::utils::extract_l2_denorm_children;
+use crate::vector::Vector;
 
 /// Inner product (dot product) between two columns.
 ///
@@ -161,6 +178,19 @@ impl ScalarFnVTable for InnerProduct {
             }
         }
 
+        // Reduction case 1: `InnerProduct(SorfTransform(x), const)` rewrites to
+        // `InnerProduct(x, forward_rotate(zero_pad(const)))`. Re-executes recursively so
+        // case 2 can fire on the rewritten tree.
+        if let Some(rewritten) = self.try_execute_sorf_constant(&lhs_ref, &rhs_ref, len, ctx)? {
+            return Ok(rewritten);
+        }
+
+        // Reduction case 2: `InnerProduct(Vector[FSL(Dict(u8, f32<=256))], const)` is
+        // computed by precomputing a product table and gather-summing over the codes.
+        if let Some(result) = self.try_execute_dict_constant(&lhs_ref, &rhs_ref, len, ctx)? {
+            return Ok(result);
+        }
+
         // Compute combined validity.
         let validity = lhs_ref.validity()?.and(rhs_ref.validity()?)?;
 
@@ -275,6 +305,256 @@ impl InnerProduct {
             Ok(unsafe { PrimitiveArray::new_unchecked(buffer, validity) }.into_array())
         })
     }
+
+    /// Fast path when one side is `ExactScalarFn<SorfTransform>` and the other side is a
+    /// constant-backed tensor-like extension. Rewrites to
+    /// `InnerProduct(sorf_child, forward_rotate(zero_pad(const_query)))` because SORF is
+    /// orthogonal, so `<T(R^{-1} x), c> = <x, R · zero_pad(c)>` where `T` is the truncation
+    /// from `padded_dim` to `dim` applied by `SorfTransform` and `R` is the SORF forward
+    /// matrix. See the proof in the crate-level docs and in the plan file.
+    ///
+    /// Returns `Ok(None)` if neither side matches or when `element_ptype` is not `F32`. The
+    /// caller is expected to fall through to the standard path in that case.
+    ///
+    /// # TODO(connor):
+    ///
+    /// This rewrite is only sound for `PType::F32` because `SorfTransform` applies an
+    /// `f32 -> element_ptype` cast at the end of its execute (see `sorf_transform/vtable.rs`
+    /// line ~218). For F16/F64 the cast changes the inner product's rounding and would
+    /// change the semantics of the rewrite. Until we push the cast through `InnerProduct`,
+    /// this path only fires for F32.
+    fn try_execute_sorf_constant(
+        &self,
+        lhs_ref: &ArrayRef,
+        rhs_ref: &ArrayRef,
+        len: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        // Identify which side is the SorfTransform, if any.
+        let (sorf_ref, const_ref) = if lhs_ref.is::<ExactScalarFn<SorfTransform>>() {
+            (lhs_ref, rhs_ref)
+        } else if rhs_ref.is::<ExactScalarFn<SorfTransform>>() {
+            (rhs_ref, lhs_ref)
+        } else {
+            return Ok(None);
+        };
+
+        let sorf_view = sorf_ref
+            .as_opt::<ExactScalarFn<SorfTransform>>()
+            .vortex_expect("just checked via `is`");
+
+        // TODO(connor): pull-through is only sound for F32 because SorfTransform applies an
+        // `f32 -> element_ptype` cast at the end of its execute. For F16/F64 the rewrite
+        // would change the inner product's rounding semantics. Fall through so the standard
+        // path (which does the cast before inner product) handles it.
+        if sorf_view.options.element_ptype != PType::F32 {
+            return Ok(None);
+        }
+
+        // The other side must be a constant-backed tensor-like extension whose scalar is
+        // non-null.
+        let Some(const_ext) = const_ref.as_opt::<Extension>() else {
+            return Ok(None);
+        };
+        let const_storage = const_ext.storage_array();
+        let Some(const_backing) = const_storage.as_opt::<Constant>() else {
+            return Ok(None);
+        };
+        if const_backing.scalar().is_null() {
+            return Ok(None);
+        }
+
+        let dim = sorf_view.options.dimension as usize;
+        let num_rounds = sorf_view.options.num_rounds as usize;
+        let seed = sorf_view.options.seed;
+        let padded_dim = dim.next_power_of_two();
+
+        // Extract the single stored row of the constant via the stride-0 short-circuit.
+        let flat = extract_flat_elements(const_storage, dim, ctx)?;
+        if flat.ptype() != PType::F32 {
+            // TODO(connor): as above, f16/f64 are not supported by this rewrite yet. The
+            // standard path handles them correctly.
+            return Ok(None);
+        }
+
+        // Zero-pad the query from `dim` to `padded_dim` and forward-rotate.
+        let mut padded_query = vec![0.0f32; padded_dim];
+        padded_query[..dim].copy_from_slice(flat.row::<f32>(0));
+
+        let rotation = SorfMatrix::try_new(seed, dim, num_rounds)?;
+        let mut rotated_query = vec![0.0f32; padded_dim];
+        rotation.rotate(&padded_query, &mut rotated_query);
+
+        // Build the rewritten constant as a `Vector<padded_dim, f32>` extension wrapping a
+        // `ConstantArray` of length `len`. We reuse the original storage FSL nullability so
+        // the new extension dtype stays consistent with whatever the original tree expected.
+        let storage_fsl_nullability = const_storage.dtype().nullability();
+        let element_dtype = DType::Primitive(PType::F32, Nullability::NonNullable);
+        let children: Vec<Scalar> = rotated_query
+            .into_iter()
+            .map(|v| Scalar::primitive(v, Nullability::NonNullable))
+            .collect();
+        let fsl_scalar =
+            Scalar::fixed_size_list(element_dtype.clone(), children, storage_fsl_nullability);
+        let new_storage = ConstantArray::new(fsl_scalar, len).into_array();
+
+        // Build a fresh `Vector<padded_dim, f32>` extension dtype. We cannot reuse the
+        // original extension dtype because that one has `dim`, not `padded_dim`.
+        let padded_dim_u32 = u32::try_from(padded_dim).vortex_expect("padded_dim fits u32");
+        let new_fsl_dtype = DType::FixedSizeList(
+            Arc::new(element_dtype),
+            padded_dim_u32,
+            storage_fsl_nullability,
+        );
+        let new_ext_dtype = ExtDType::<Vector>::try_new(EmptyMetadata, new_fsl_dtype)?.erased();
+        let new_constant = ExtensionArray::new(new_ext_dtype, new_storage).into_array();
+
+        // Extract the SorfTransform child (the already-padded Vector<padded_dim, f32>).
+        let sorf_child = sorf_view
+            .nth_child(0)
+            .vortex_expect("SorfTransform must have exactly one child");
+
+        // Recursively execute the rewritten inner product. This allows case 2 to fire on
+        // the rewritten tree if the sorf child is `Vector[FSL(Dict)]`. Termination is
+        // guaranteed because the rewrite strictly removes a `SorfTransform` scalar-fn node
+        // from the tree and SORFs cannot be nested.
+        let rewritten = InnerProduct::try_new_array(sorf_child, new_constant, len)?
+            .into_array()
+            .execute(ctx)?;
+        Ok(Some(rewritten))
+    }
+
+    /// Fast path when one side is an extension whose storage is `FSL(Dict(u8, f32))` with
+    /// at most `MAX_CENTROIDS` values, and the other side is a constant-backed tensor
+    /// extension with an F32 element ptype.
+    ///
+    /// Computes each row's inner product as
+    ///   `out[i] = sum_{j in 0..padded_dim} q[j] * values[codes[i * padded_dim + j] as usize]`
+    /// using a direct codebook lookup in the hot loop. An explicit product table
+    /// `P[j, k] = q[j] * values[k]` (size `padded_dim * num_centroids * 4B`, ~1 MiB for the
+    /// common 1024/256 case) was tried and measured ~10% *slower* on the
+    /// `similarity_search` bench because the 1 KiB `values` table stays in L1 across all
+    /// rows, while the 1 MiB product table does not. See the plan file for the math
+    /// justifying both forms.
+    ///
+    /// Returns `Ok(None)` when the pattern doesn't match; the caller should fall through to
+    /// the standard path.
+    fn try_execute_dict_constant(
+        &self,
+        lhs_ref: &ArrayRef,
+        rhs_ref: &ArrayRef,
+        len: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Option<ArrayRef>> {
+        // Identify which side is `Extension[FSL[Dict]]`, with a non-canonicalizing peek.
+        let (dict_ref, const_ref) = if is_dict_fsl_extension(lhs_ref) {
+            (lhs_ref, rhs_ref)
+        } else if is_dict_fsl_extension(rhs_ref) {
+            (rhs_ref, lhs_ref)
+        } else {
+            return Ok(None);
+        };
+
+        // Detect the constant-backed extension on the other side.
+        let Some(const_ext) = const_ref.as_opt::<Extension>() else {
+            return Ok(None);
+        };
+        let const_storage = const_ext.storage_array();
+        let Some(const_backing) = const_storage.as_opt::<Constant>() else {
+            return Ok(None);
+        };
+        if const_backing.scalar().is_null() {
+            return Ok(None);
+        }
+
+        // Navigate into the dict side. We already verified the shape via the peek.
+        let dict_ext = dict_ref
+            .as_opt::<Extension>()
+            .vortex_expect("peek guaranteed Extension");
+        let fsl = dict_ext
+            .storage_array()
+            .as_opt::<FixedSizeList>()
+            .vortex_expect("peek guaranteed FixedSizeList");
+        let dict = fsl
+            .elements()
+            .as_opt::<Dict>()
+            .vortex_expect("peek guaranteed Dict");
+
+        // Canonicalize codes and values. Codes may be e.g. BitPacked; executing is cheaper
+        // than falling through to the naive path (which would also canonicalize).
+        let codes_prim: PrimitiveArray = dict.codes().clone().execute(ctx)?;
+        let values_prim: PrimitiveArray = dict.values().clone().execute(ctx)?;
+
+        // Gate: u8 codes, f32 centroids, and at most 256 centroids.
+        if codes_prim.ptype() != PType::U8 {
+            // TODO(connor): support wider code widths (u16, u32). TurboQuant only emits u8
+            // codes today, so this is the only path we need for now.
+            return Ok(None);
+        }
+        if values_prim.ptype() != PType::F32 {
+            // TODO(connor): the product-table path only supports f32 centroids. SorfTransform
+            // forces f32 anyway, so this is the only shape we need for now.
+            return Ok(None);
+        }
+        if values_prim.len() > MAX_CENTROIDS {
+            return Ok(None);
+        }
+
+        let padded_dim = usize::try_from(fsl.list_size()).vortex_expect("fsl list_size fits usize");
+
+        let flat = extract_flat_elements(const_storage, padded_dim, ctx)?;
+        if flat.ptype() != PType::F32 {
+            // TODO(connor): case 2 is f32-only. For f16/f64 we fall through to the standard
+            // path, which computes the inner product with the correct element type.
+            return Ok(None);
+        }
+
+        // Combine the input validities up front; the per-row arithmetic may write garbage
+        // into null rows but the validity mask hides it (matching the standard path).
+        let validity = dict_ref.validity()?.and(const_ref.validity()?)?;
+
+        // Fast path for the empty case: skip the product-table allocation entirely.
+        if len == 0 {
+            let empty = PrimitiveArray::empty::<f32>(validity.nullability());
+            return Ok(Some(empty.into_array()));
+        }
+
+        let q: &[f32] = flat.row::<f32>(0);
+        debug_assert_eq!(q.len(), padded_dim);
+        let codes: &[u8] = codes_prim.as_slice::<u8>();
+        let values: &[f32] = values_prim.as_slice::<f32>();
+        debug_assert_eq!(codes.len(), len * padded_dim);
+
+        // Direct codebook lookup: `acc += q[j] * values[codes[j]]`. See the benchmark
+        // comment below for why this beats an explicit product table here.
+        let mut out = BufferMut::<f32>::with_capacity(len);
+        for row in 0..len {
+            let row_codes = &codes[row * padded_dim..(row + 1) * padded_dim];
+            let mut acc = 0.0f32;
+            for j in 0..padded_dim {
+                acc += q[j] * values[row_codes[j] as usize];
+            }
+            // SAFETY: we reserved `len` slots above and push exactly once per row.
+            unsafe { out.push_unchecked(acc) };
+        }
+
+        // SAFETY: the buffer length equals `len`, which matches the validity length.
+        let result = unsafe { PrimitiveArray::new_unchecked(out.freeze(), validity) }.into_array();
+        Ok(Some(result))
+    }
+}
+
+/// Non-canonicalizing shape peek: returns `true` iff `arr` is an `Extension` whose storage
+/// is a `FixedSizeList` whose elements are a `Dict`. Used to pick the dict side of an
+/// `InnerProduct` without doing any execution work.
+fn is_dict_fsl_extension(arr: &ArrayRef) -> bool {
+    let Some(ext) = arr.as_opt::<Extension>() else {
+        return false;
+    };
+    let Some(fsl) = ext.storage_array().as_opt::<FixedSizeList>() else {
+        return false;
+    };
+    fsl.elements().as_opt::<Dict>().is_some()
 }
 
 /// Computes the inner product (dot product) of two equal-length float slices.
@@ -505,5 +785,520 @@ mod tests {
         assert!(!prim.is_valid(1)?);
         assert_close(&[prim.as_slice::<f64>()[0]], &[25.0]);
         Ok(())
+    }
+
+    // ---- Case 1 (SorfTransform + Constant) and Case 2 (Dict + Constant) tests ----
+
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "tests build small fixtures with deterministic in-range indices"
+    )]
+    mod case_1_and_2 {
+        use std::sync::LazyLock;
+
+        use vortex_array::ArrayRef;
+        use vortex_array::IntoArray;
+        use vortex_array::VortexSessionExecute;
+        use vortex_array::arrays::ConstantArray;
+        use vortex_array::arrays::ExtensionArray;
+        use vortex_array::arrays::FixedSizeListArray;
+        use vortex_array::arrays::PrimitiveArray;
+        use vortex_array::arrays::ScalarFnArray;
+        use vortex_array::arrays::dict::DictArray;
+        use vortex_array::dtype::DType;
+        use vortex_array::dtype::Nullability;
+        use vortex_array::dtype::PType;
+        use vortex_array::dtype::extension::ExtDType;
+        use vortex_array::extension::EmptyMetadata;
+        use vortex_array::scalar::Scalar;
+        use vortex_array::session::ArraySession;
+        use vortex_array::validity::Validity;
+        use vortex_buffer::Buffer;
+        use vortex_buffer::BufferMut;
+        use vortex_error::VortexResult;
+        use vortex_session::VortexSession;
+
+        use crate::scalar_fns::inner_product::InnerProduct;
+        use crate::scalar_fns::sorf_transform::SorfMatrix;
+        use crate::scalar_fns::sorf_transform::SorfOptions;
+        use crate::scalar_fns::sorf_transform::SorfTransform;
+        use crate::vector::Vector;
+
+        static SESSION: LazyLock<VortexSession> =
+            LazyLock::new(|| VortexSession::empty().with::<ArraySession>());
+
+        /// Compact f32 Vector<dim> extension over a column-major `elements` slice.
+        fn vector_f32(dim: u32, elements: &[f32]) -> VortexResult<ArrayRef> {
+            let row_count = elements.len() / dim as usize;
+            let elems: ArrayRef = Buffer::copy_from(elements).into_array();
+            let fsl = FixedSizeListArray::new(elems, dim, Validity::NonNullable, row_count);
+            let ext_dtype =
+                ExtDType::<Vector>::try_new(EmptyMetadata, fsl.dtype().clone())?.erased();
+            Ok(ExtensionArray::new(ext_dtype, fsl.into_array()).into_array())
+        }
+
+        /// Compact constant-backed f32 Vector<dim> extension with a single stored row.
+        fn constant_vector_f32(elements: &[f32], len: usize) -> VortexResult<ArrayRef> {
+            let element_dtype = DType::Primitive(PType::F32, Nullability::NonNullable);
+            let children: Vec<Scalar> = elements
+                .iter()
+                .map(|&v| Scalar::primitive(v, Nullability::NonNullable))
+                .collect();
+            let storage_scalar =
+                Scalar::fixed_size_list(element_dtype, children, Nullability::NonNullable);
+            let storage = ConstantArray::new(storage_scalar, len).into_array();
+            let ext_dtype =
+                ExtDType::<Vector>::try_new(EmptyMetadata, storage.dtype().clone())?.erased();
+            Ok(ExtensionArray::new(ext_dtype, storage).into_array())
+        }
+
+        /// Build an `ExtensionArray<Vector<list_size, f32>>` whose storage is
+        /// `FSL(DictArray(codes: u8, values: f32))`. This mirrors the shape that
+        /// TurboQuant produces as the SorfTransform child.
+        fn dict_vector_f32(list_size: u32, codes: &[u8], values: &[f32]) -> VortexResult<ArrayRef> {
+            let num_rows = codes.len() / list_size as usize;
+            let codes_arr = {
+                let mut buf = BufferMut::<u8>::with_capacity(codes.len());
+                buf.extend_from_slice(codes);
+                PrimitiveArray::new::<u8>(buf.freeze(), Validity::NonNullable).into_array()
+            };
+            let values_arr = {
+                let mut buf = BufferMut::<f32>::with_capacity(values.len());
+                buf.extend_from_slice(values);
+                PrimitiveArray::new::<f32>(buf.freeze(), Validity::NonNullable).into_array()
+            };
+            let dict = DictArray::try_new(codes_arr, values_arr)?;
+            let fsl = FixedSizeListArray::try_new(
+                dict.into_array(),
+                list_size,
+                Validity::NonNullable,
+                num_rows,
+            )?;
+            let ext_dtype =
+                ExtDType::<Vector>::try_new(EmptyMetadata, fsl.dtype().clone())?.erased();
+            Ok(ExtensionArray::new(ext_dtype, fsl.into_array()).into_array())
+        }
+
+        /// Execute an inner product and return the flat `f32` results.
+        fn eval_ip_f32(lhs: ArrayRef, rhs: ArrayRef, len: usize) -> VortexResult<Vec<f32>> {
+            let scalar_fn = InnerProduct::new().erased();
+            let result = ScalarFnArray::try_new(scalar_fn, vec![lhs, rhs], len)?;
+            let mut ctx = SESSION.create_execution_ctx();
+            let prim: PrimitiveArray = result.into_array().execute(&mut ctx)?;
+            Ok(prim.as_slice::<f32>().to_vec())
+        }
+
+        fn assert_close_f32(actual: &[f32], expected: &[f32], tol: f32) {
+            assert_eq!(actual.len(), expected.len(), "length mismatch");
+            for (i, (a, e)) in actual.iter().zip(expected).enumerate() {
+                assert!(
+                    (a - e).abs() < tol,
+                    "row {i}: got {a}, expected {e} (diff = {})",
+                    (a - e).abs()
+                );
+            }
+        }
+
+        /// Build a SorfTransform ScalarFnArray whose child is a `Vector<padded_dim, f32>`
+        /// wrapping `FSL(Dict(codes, values))`. Returns `(sorf_array, codes, values,
+        /// padded_dim, dim)`.
+        fn build_sorf_with_dict_child(
+            dim: u32,
+            num_rows: usize,
+            seed: u64,
+            num_rounds: u8,
+        ) -> VortexResult<(ArrayRef, Vec<u8>, Vec<f32>, usize)> {
+            let padded_dim = (dim as usize).next_power_of_two();
+            // Small hand-picked codebook of 8 f32 centroids.
+            let values: Vec<f32> = vec![-1.5, -1.0, -0.5, -0.1, 0.1, 0.5, 1.0, 1.5];
+            // Deterministic codes in 0..values.len() covering every position.
+            let codes: Vec<u8> = (0..num_rows * padded_dim)
+                .map(|i| (i as u8) % (values.len() as u8))
+                .collect();
+
+            let padded_vector = dict_vector_f32(padded_dim as u32, &codes, &values)?;
+            let sorf_options = SorfOptions {
+                seed,
+                num_rounds,
+                dimension: dim,
+                element_ptype: PType::F32,
+            };
+            let sorf =
+                SorfTransform::try_new_array(&sorf_options, padded_vector, num_rows)?.into_array();
+            Ok((sorf, codes, values, padded_dim))
+        }
+
+        /// Decode a SorfTransform-wrapped dict-vector to a flat `Vec<f32>` of `num_rows *
+        /// dim` post-rotation, post-truncation values. This is the ground truth against
+        /// which we compare the fast-path result.
+        fn decode_sorf_dict(
+            codes: &[u8],
+            values: &[f32],
+            padded_dim: usize,
+            dim: usize,
+            num_rows: usize,
+            seed: u64,
+            num_rounds: u8,
+        ) -> VortexResult<Vec<f32>> {
+            let rotation = SorfMatrix::try_new(seed, dim, num_rounds as usize)?;
+            let mut padded = vec![0.0f32; padded_dim];
+            let mut rotated = vec![0.0f32; padded_dim];
+            let mut out = Vec::with_capacity(num_rows * dim);
+            for row in 0..num_rows {
+                for j in 0..padded_dim {
+                    padded[j] = values[codes[row * padded_dim + j] as usize];
+                }
+                rotation.inverse_rotate(&padded, &mut rotated);
+                out.extend_from_slice(&rotated[..dim]);
+            }
+            Ok(out)
+        }
+
+        fn naive_dot(a: &[f32], b: &[f32]) -> f32 {
+            a.iter().zip(b.iter()).map(|(&x, &y)| x * y).sum()
+        }
+
+        // ---- Case 1: SorfTransform + Constant pull-through ----
+
+        /// Case 1: SorfTransform on LHS, constant query on RHS, `dim < padded_dim`.
+        #[test]
+        fn case1_sorf_lhs_constant_rhs_padded_gt_dim() -> VortexResult<()> {
+            let dim: u32 = 128;
+            let padded_dim = (dim as usize).next_power_of_two();
+            assert_eq!(padded_dim, 128); // degenerate case for this dim, handled by next test
+            // Bump dim to exercise padding explicitly.
+            let dim: u32 = 100;
+            let padded_dim = (dim as usize).next_power_of_two();
+            assert!(padded_dim > dim as usize);
+            let num_rows = 7usize;
+            let seed = 42u64;
+            let num_rounds = 3u8;
+
+            let (sorf_lhs, codes, values, padded_dim_computed) =
+                build_sorf_with_dict_child(dim, num_rows, seed, num_rounds)?;
+            assert_eq!(padded_dim_computed, padded_dim);
+
+            // Query has `dim` elements.
+            let query_elems: Vec<f32> = (0..dim).map(|i| (i as f32 * 0.1).sin()).collect();
+            let const_rhs = constant_vector_f32(&query_elems, num_rows)?;
+
+            // Ground truth: decode LHS to plain f32 vectors, dot each with the query.
+            let decoded = decode_sorf_dict(
+                &codes,
+                &values,
+                padded_dim,
+                dim as usize,
+                num_rows,
+                seed,
+                num_rounds,
+            )?;
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|i| {
+                    naive_dot(
+                        &decoded[i * dim as usize..(i + 1) * dim as usize],
+                        &query_elems,
+                    )
+                })
+                .collect();
+
+            let actual = eval_ip_f32(sorf_lhs, const_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-3);
+            Ok(())
+        }
+
+        /// Case 1: SorfTransform on RHS, constant query on LHS (mirrored).
+        #[test]
+        fn case1_constant_lhs_sorf_rhs_mirrored() -> VortexResult<()> {
+            let dim: u32 = 100;
+            let num_rows = 5usize;
+            let seed = 7u64;
+            let num_rounds = 3u8;
+
+            let (sorf, codes, values, padded_dim) =
+                build_sorf_with_dict_child(dim, num_rows, seed, num_rounds)?;
+
+            let query_elems: Vec<f32> = (0..dim).map(|i| (i as f32 * 0.2).cos()).collect();
+            let const_lhs = constant_vector_f32(&query_elems, num_rows)?;
+
+            let decoded = decode_sorf_dict(
+                &codes,
+                &values,
+                padded_dim,
+                dim as usize,
+                num_rows,
+                seed,
+                num_rounds,
+            )?;
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|i| {
+                    naive_dot(
+                        &decoded[i * dim as usize..(i + 1) * dim as usize],
+                        &query_elems,
+                    )
+                })
+                .collect();
+
+            let actual = eval_ip_f32(const_lhs, sorf, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-3);
+            Ok(())
+        }
+
+        /// Case 1: `dim == padded_dim` (power-of-two, no zero padding).
+        #[test]
+        fn case1_padded_equals_dim() -> VortexResult<()> {
+            let dim: u32 = 128;
+            let num_rows = 4usize;
+            let seed = 11u64;
+            let num_rounds = 3u8;
+
+            let (sorf, codes, values, padded_dim) =
+                build_sorf_with_dict_child(dim, num_rows, seed, num_rounds)?;
+            assert_eq!(padded_dim, dim as usize);
+
+            let query_elems: Vec<f32> = (0..dim).map(|i| i as f32 * 0.01 - 0.5).collect();
+            let const_rhs = constant_vector_f32(&query_elems, num_rows)?;
+
+            let decoded = decode_sorf_dict(
+                &codes,
+                &values,
+                padded_dim,
+                dim as usize,
+                num_rows,
+                seed,
+                num_rounds,
+            )?;
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|i| {
+                    naive_dot(
+                        &decoded[i * dim as usize..(i + 1) * dim as usize],
+                        &query_elems,
+                    )
+                })
+                .collect();
+
+            let actual = eval_ip_f32(sorf, const_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-3);
+            Ok(())
+        }
+
+        /// Case 1: empty `len == 0`. The fast path should handle this without exploding.
+        #[test]
+        fn case1_empty_len_zero() -> VortexResult<()> {
+            let dim: u32 = 100;
+            let num_rows = 0usize;
+            let seed = 42u64;
+            let num_rounds = 3u8;
+
+            let (sorf, _codes, _values, _padded_dim) =
+                build_sorf_with_dict_child(dim, num_rows, seed, num_rounds)?;
+
+            let query_elems: Vec<f32> = vec![0.0; dim as usize];
+            let const_rhs = constant_vector_f32(&query_elems, num_rows)?;
+
+            let actual = eval_ip_f32(sorf, const_rhs, num_rows)?;
+            assert_eq!(actual.len(), 0);
+            Ok(())
+        }
+
+        // ---- Case 2: Dict + Constant product-table path ----
+
+        /// Case 2: Vector[FSL[Dict(u8, f32)]] on LHS, constant query on RHS.
+        #[test]
+        fn case2_dict_lhs_constant_rhs_matches_naive() -> VortexResult<()> {
+            let list_size: u32 = 8;
+            let num_rows = 10usize;
+            // 8 centroids, tiny table.
+            let values: Vec<f32> = vec![-1.0, -0.5, -0.25, -0.1, 0.1, 0.25, 0.5, 1.0];
+            // Deterministic codes.
+            let codes: Vec<u8> = (0..num_rows * list_size as usize)
+                .map(|i| (i as u8) % (values.len() as u8))
+                .collect();
+            let dict_lhs = dict_vector_f32(list_size, &codes, &values)?;
+
+            let query: Vec<f32> = (0..list_size).map(|i| (i as f32 + 1.0) * 0.3).collect();
+            let const_rhs = constant_vector_f32(&query, num_rows)?;
+
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|row| {
+                    let mut acc = 0.0f32;
+                    for j in 0..list_size as usize {
+                        let k = codes[row * list_size as usize + j] as usize;
+                        acc += query[j] * values[k];
+                    }
+                    acc
+                })
+                .collect();
+
+            let actual = eval_ip_f32(dict_lhs, const_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-5);
+            Ok(())
+        }
+
+        /// Case 2: constant query on LHS, dict column on RHS (mirrored).
+        #[test]
+        fn case2_constant_lhs_dict_rhs_mirrored() -> VortexResult<()> {
+            let list_size: u32 = 4;
+            let num_rows = 6usize;
+            let values: Vec<f32> = vec![0.1, 0.4, 0.7, 1.0];
+            let codes: Vec<u8> = (0..num_rows * list_size as usize)
+                .map(|i| ((i * 3) as u8) % (values.len() as u8))
+                .collect();
+            let dict_rhs = dict_vector_f32(list_size, &codes, &values)?;
+
+            let query: Vec<f32> = vec![0.5, -1.0, 2.5, -0.25];
+            let const_lhs = constant_vector_f32(&query, num_rows)?;
+
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|row| {
+                    let mut acc = 0.0f32;
+                    for j in 0..list_size as usize {
+                        let k = codes[row * list_size as usize + j] as usize;
+                        acc += query[j] * values[k];
+                    }
+                    acc
+                })
+                .collect();
+
+            let actual = eval_ip_f32(const_lhs, dict_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-5);
+            Ok(())
+        }
+
+        /// Case 2: dict with more than 256 values falls through to the standard path but
+        /// still produces the correct result.
+        #[test]
+        fn case2_more_than_256_values_falls_through() -> VortexResult<()> {
+            let list_size: u32 = 4;
+            let num_rows = 3usize;
+            let num_values = 300usize;
+            let values: Vec<f32> = (0..num_values).map(|i| i as f32 * 0.01).collect();
+            // Codes must be u16 because 300 > 255. dict_vector_f32 only supports u8 so we
+            // need a u16-coded dict here.
+            let mut codes_u16_buf = BufferMut::<u16>::with_capacity(num_rows * 4);
+            for i in 0..(num_rows * 4) {
+                codes_u16_buf.push((i % num_values) as u16);
+            }
+            let codes_arr =
+                PrimitiveArray::new::<u16>(codes_u16_buf.freeze(), Validity::NonNullable)
+                    .into_array();
+            let mut values_buf = BufferMut::<f32>::with_capacity(values.len());
+            values_buf.extend_from_slice(&values);
+            let values_arr =
+                PrimitiveArray::new::<f32>(values_buf.freeze(), Validity::NonNullable).into_array();
+            let dict = DictArray::try_new(codes_arr, values_arr)?;
+            let fsl = FixedSizeListArray::try_new(
+                dict.into_array(),
+                list_size,
+                Validity::NonNullable,
+                num_rows,
+            )?;
+            let ext_dtype =
+                ExtDType::<Vector>::try_new(EmptyMetadata, fsl.dtype().clone())?.erased();
+            let dict_lhs = ExtensionArray::new(ext_dtype, fsl.into_array()).into_array();
+
+            let query: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0];
+            let const_rhs = constant_vector_f32(&query, num_rows)?;
+
+            // Build expected by decoding by hand.
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|row| {
+                    let mut acc = 0.0f32;
+                    for j in 0..4 {
+                        let code = (row * 4 + j) % num_values;
+                        acc += query[j] * values[code];
+                    }
+                    acc
+                })
+                .collect();
+
+            let actual = eval_ip_f32(dict_lhs, const_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-5);
+            Ok(())
+        }
+
+        /// Case 2: plain (non-dict) FSL with a constant RHS falls through to the standard
+        /// path and produces the correct result.
+        #[test]
+        fn case2_plain_fsl_falls_through() -> VortexResult<()> {
+            let dim: u32 = 4;
+            let num_rows = 3usize;
+            let lhs_elems: Vec<f32> = (0..num_rows * dim as usize)
+                .map(|i| i as f32 * 0.25)
+                .collect();
+            let plain_lhs = vector_f32(dim, &lhs_elems)?;
+
+            let query: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0];
+            let const_rhs = constant_vector_f32(&query, num_rows)?;
+
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|row| {
+                    naive_dot(
+                        &lhs_elems[row * dim as usize..(row + 1) * dim as usize],
+                        &query,
+                    )
+                })
+                .collect();
+
+            let actual = eval_ip_f32(plain_lhs, const_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-5);
+            Ok(())
+        }
+
+        /// Case 2: empty `len == 0` fast path returns an empty primitive array without
+        /// allocating a product table.
+        #[test]
+        fn case2_empty_len_zero() -> VortexResult<()> {
+            let list_size: u32 = 4;
+            let num_rows = 0usize;
+            let values: Vec<f32> = vec![0.0, 1.0, 2.0, 3.0];
+            let codes: Vec<u8> = Vec::new();
+            let dict_lhs = dict_vector_f32(list_size, &codes, &values)?;
+
+            let query: Vec<f32> = vec![0.0; 4];
+            let const_rhs = constant_vector_f32(&query, num_rows)?;
+
+            let actual = eval_ip_f32(dict_lhs, const_rhs, num_rows)?;
+            assert_eq!(actual.len(), 0);
+            Ok(())
+        }
+
+        /// Case 1 + Case 2 end-to-end: the SorfTransform-wrapped dict column hits Case 1
+        /// then Case 2 via recursive execution.
+        #[test]
+        fn end_to_end_sorf_plus_dict_cosine_path() -> VortexResult<()> {
+            let dim: u32 = 100;
+            let num_rows = 9usize;
+            let seed = 99u64;
+            let num_rounds = 3u8;
+
+            let (sorf, codes, values, padded_dim) =
+                build_sorf_with_dict_child(dim, num_rows, seed, num_rounds)?;
+
+            let query_elems: Vec<f32> = (0..dim).map(|i| ((i as f32) * 0.15).sin() * 0.4).collect();
+            let const_rhs = constant_vector_f32(&query_elems, num_rows)?;
+
+            // Ground truth via full decode + naive dot.
+            let decoded = decode_sorf_dict(
+                &codes,
+                &values,
+                padded_dim,
+                dim as usize,
+                num_rows,
+                seed,
+                num_rounds,
+            )?;
+            let expected: Vec<f32> = (0..num_rows)
+                .map(|i| {
+                    naive_dot(
+                        &decoded[i * dim as usize..(i + 1) * dim as usize],
+                        &query_elems,
+                    )
+                })
+                .collect();
+
+            let actual = eval_ip_f32(sorf, const_rhs, num_rows)?;
+            assert_close_f32(&actual, &expected, 1e-3);
+            Ok(())
+        }
     }
 }

--- a/vortex-tensor/src/scalar_fns/l2_denorm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_denorm.rs
@@ -10,17 +10,23 @@ use num_traits::Zero;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
+use vortex_array::arrays::Constant;
+use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::ScalarFnArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
+use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
+use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::PType;
 use vortex_array::expr::Expression;
 use vortex_array::expr::and;
 use vortex_array::match_each_float_ptype;
+use vortex_array::scalar::Scalar;
+use vortex_array::scalar::ScalarValue;
 use vortex_array::scalar_fn::Arity;
 use vortex_array::scalar_fn::ChildName;
 use vortex_array::scalar_fn::EmptyOptions;
@@ -28,6 +34,7 @@ use vortex_array::scalar_fn::ExecutionArgs;
 use vortex_array::scalar_fn::ScalarFn;
 use vortex_array::scalar_fn::ScalarFnId;
 use vortex_array::scalar_fn::ScalarFnVTable;
+use vortex_array::scalar_fn::fns::operators::Operator;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
@@ -183,8 +190,31 @@ impl ScalarFnVTable for L2Denorm {
         args: &dyn ExecutionArgs,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
-        let normalized: ExtensionArray = args.get(0)?.execute(ctx)?;
-        let norms: PrimitiveArray = args.get(1)?.execute(ctx)?;
+        let normalized_ref = args.get(0)?;
+        let norms_ref = args.get(1)?;
+        let output_dtype = normalized_ref
+            .dtype()
+            .union_nullability(norms_ref.dtype().nullability());
+        let validity = normalized_ref.validity()?.and(norms_ref.validity()?)?;
+
+        if let Some(const_norms) = norms_ref.as_opt::<Constant>() {
+            let norm_scalar = const_norms.scalar();
+            vortex_ensure!(norm_scalar.dtype().is_float());
+
+            if let Some(norm_value) = norm_scalar.value() {
+                return execute_l2_denorm_constant_norms(
+                    normalized_ref,
+                    norm_scalar,
+                    norm_value,
+                    output_dtype,
+                    validity,
+                    ctx,
+                );
+            }
+        }
+
+        let normalized: ExtensionArray = normalized_ref.execute(ctx)?;
+        let norms: PrimitiveArray = norms_ref.execute(ctx)?;
         let row_count = args.row_count();
 
         let tensor_match = normalized
@@ -194,10 +224,6 @@ impl ScalarFnVTable for L2Denorm {
             .vortex_expect("we already validated this in `return_dtype`");
         let tensor_flat_size = tensor_match.list_size();
 
-        let validity = normalized.as_ref().validity()?.and(norms.validity()?)?;
-        let output_dtype = normalized
-            .dtype()
-            .union_nullability(norms.dtype().nullability());
         let flat = extract_flat_elements(normalized.storage_array(), tensor_flat_size, ctx)?;
 
         // TODO(connor): Theoretically we could model this as a multiplication between the
@@ -243,6 +269,57 @@ impl ScalarFnVTable for L2Denorm {
     }
 }
 
+/// Optimized execution when the norms array is constant.
+fn execute_l2_denorm_constant_norms(
+    normalized_ref: ArrayRef,
+    norm_scalar: &Scalar,
+    norm_value: &ScalarValue,
+    output_dtype: DType,
+    new_validity: Validity,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
+    // If the norms are all equal to 1 then we don't need to do anything.
+    let err = norm_value
+        .as_primitive()
+        .as_f64()
+        .vortex_expect("we know that this is a float, so it must fit in f64")
+        - 1.0f64;
+
+    let tolerance = unit_norm_tolerance(norm_scalar.dtype().as_ptype());
+    if err.abs() < tolerance {
+        return Ok(normalized_ref);
+    }
+
+    // Even if the norms are not all 1, if they are all the same then we can multiply
+    // the entire elements array by the same number.
+    let normalized: ExtensionArray = normalized_ref.execute(ctx)?;
+
+    // TODO(connor): If the storage array is constant then this is inefficient, but that is rare.
+    let storage_fsl: FixedSizeListArray = normalized.storage_array().clone().execute(ctx)?;
+
+    // Replace the elements array with an array that multiplies it by the constant
+    // norms array (with length multiplied by the dimensions of the vectors).
+    let const_array =
+        ConstantArray::new(norm_scalar.clone(), storage_fsl.elements().len()).into_array();
+    let mult_elements = storage_fsl
+        .elements()
+        .clone()
+        .binary(const_array, Operator::Mul)?;
+
+    // SAFETY: We just updated the elements of the array with a scalar fn, so all
+    // invariants still hold.
+    let new_fsl = unsafe {
+        FixedSizeListArray::new_unchecked(
+            mult_elements,
+            storage_fsl.list_size(),
+            new_validity,
+            storage_fsl.len(),
+        )
+    };
+
+    Ok(ExtensionArray::new(output_dtype.as_extension().clone(), new_fsl.into_array()).into_array())
+}
+
 /// Builds an unexecuted [`L2Denorm`] expression by normalizing `input` and reattaching the exact
 /// norms as the norms child.
 ///
@@ -274,17 +351,19 @@ pub fn normalize_as_l2_denorm(
     let tensor_match = validate_tensor_float_input(input.dtype())?;
     let tensor_flat_size = tensor_match.list_size();
 
+    // Calculate the norms of the vectors.
     let norms_sfn = L2Norm::try_new_array(input.clone(), row_count)?;
     let norms_array: ArrayRef = norms_sfn.into_array().execute(ctx)?;
-    let norms: PrimitiveArray = norms_array.clone().execute(ctx)?;
-    let norms_validity = norms.validity()?;
+    let primitive_norms: PrimitiveArray = norms_array.clone().execute(ctx)?;
+    let norms_validity = primitive_norms.validity()?;
 
     let input: ExtensionArray = input.execute(ctx)?;
     let normalized_dtype = input.dtype().as_nonnullable();
     let flat = extract_flat_elements(input.storage_array(), tensor_flat_size, ctx)?;
 
+    // Normalize all of the vectors.
     let normalized = match_each_float_ptype!(flat.ptype(), |T| {
-        let norm_values = norms.as_slice::<T>();
+        let norm_values = primitive_norms.as_slice::<T>();
 
         let total_elements = row_count * tensor_flat_size;
         let mut elements = BufferMut::<T>::with_capacity(total_elements);
@@ -305,6 +384,8 @@ pub fn normalize_as_l2_denorm(
             }
         }
 
+        // Since L2Denorm's validity is the `and` of its child validities, we can make the
+        // normalized array non-nullable.
         build_tensor_array(
             normalized_dtype,
             tensor_flat_size,
@@ -463,6 +544,7 @@ mod tests {
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::ConstantArray;
     use vortex_array::arrays::ExtensionArray;
     use vortex_array::arrays::FixedSizeListArray;
     use vortex_array::arrays::MaskedArray;
@@ -471,10 +553,12 @@ mod tests {
     use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
     use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
     use vortex_array::dtype::DType;
+    use vortex_array::dtype::Nullability;
     use vortex_array::dtype::extension::ExtDType;
     use vortex_array::extension::EmptyMetadata;
     use vortex_array::extension::datetime::Date;
     use vortex_array::extension::datetime::TimeUnit;
+    use vortex_array::scalar::Scalar;
     use vortex_array::session::ArraySession;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
@@ -759,6 +843,61 @@ mod tests {
 
         assert_close(&elements.as_slice::<f64>()[..2], &[0.0, 0.0]);
         assert_tensor_arrays_eq(actual, input)?;
+        Ok(())
+    }
+
+    /// Builds a non-nullable constant f64 norms array of length `len`.
+    fn constant_f64_norms(value: f64, len: usize) -> ArrayRef {
+        ConstantArray::new(Scalar::primitive(value, Nullability::NonNullable), len).into_array()
+    }
+
+    #[test]
+    fn l2_denorm_constant_unit_norms_is_noop() -> VortexResult<()> {
+        // Every stored norm is exactly 1.0, so the constant fast path must short-circuit and
+        // return the normalized child unchanged.
+        let normalized = vector_array(3, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0])?;
+        let norms = constant_f64_norms(1.0, 2);
+
+        let actual = eval_l2_denorm(normalized.clone(), norms, 2)?;
+        assert_tensor_arrays_eq(actual, normalized)?;
+        Ok(())
+    }
+
+    #[test]
+    fn l2_denorm_constant_near_unit_norms_is_noop() -> VortexResult<()> {
+        // A norm that differs from 1.0 by less than the f64 unit-norm tolerance must still
+        // hit the fast path and return the normalized child unchanged.
+        let normalized = vector_array(3, &[1.0, 0.0, 0.0, 0.0, 1.0, 0.0])?;
+        let norms = constant_f64_norms(1.0 + 1e-12, 2);
+
+        let actual = eval_l2_denorm(normalized.clone(), norms, 2)?;
+        assert_tensor_arrays_eq(actual, normalized)?;
+        Ok(())
+    }
+
+    #[test]
+    fn l2_denorm_constant_nonunit_norms_scales_vectors() -> VortexResult<()> {
+        // A constant norm that is not 1.0 must scale every element of every row by the same
+        // factor via the backing elements multiplication path.
+        let normalized = vector_array(3, &[0.6, 0.8, 0.0, 1.0, 0.0, 0.0])?;
+        let norms = constant_f64_norms(5.0, 2);
+
+        let actual = eval_l2_denorm(normalized, norms, 2)?;
+        let expected = vector_array(3, &[3.0, 4.0, 0.0, 5.0, 0.0, 0.0])?;
+        assert_tensor_arrays_eq(actual, expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn l2_denorm_constant_nonunit_norms_scales_fixed_shape_tensors() -> VortexResult<()> {
+        // The same constant-scaling fast path must also cover multi-dimensional fixed-shape
+        // tensors, where the backing elements buffer spans more than one slot per row.
+        let normalized = tensor_array(&[2, 2], &[0.5, 0.5, 0.5, 0.5, 1.0, 0.0, 0.0, 0.0])?;
+        let norms = constant_f64_norms(4.0, 2);
+
+        let actual = eval_l2_denorm(normalized, norms, 2)?;
+        let expected = tensor_array(&[2, 2], &[2.0, 2.0, 2.0, 2.0, 4.0, 0.0, 0.0, 0.0])?;
+        assert_tensor_arrays_eq(actual, expected)?;
         Ok(())
     }
 }

--- a/vortex-tensor/src/scalar_fns/l2_denorm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_denorm.rs
@@ -5,6 +5,7 @@
 
 use std::fmt::Formatter;
 
+use num_traits::Float;
 use num_traits::ToPrimitive;
 use num_traits::Zero;
 use vortex_array::ArrayRef;
@@ -12,6 +13,7 @@ use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::Extension;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -21,6 +23,7 @@ use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
+use vortex_array::dtype::Nullability;
 use vortex_array::dtype::PType;
 use vortex_array::expr::Expression;
 use vortex_array::expr::and;
@@ -293,8 +296,6 @@ fn execute_l2_denorm_constant_norms(
     // Even if the norms are not all 1, if they are all the same then we can multiply
     // the entire elements array by the same number.
     let normalized: ExtensionArray = normalized_ref.execute(ctx)?;
-
-    // TODO(connor): If the storage array is constant then this is inefficient, but that is rare.
     let storage_fsl: FixedSizeListArray = normalized.storage_array().clone().execute(ctx)?;
 
     // Replace the elements array with an array that multiplies it by the constant
@@ -351,6 +352,12 @@ pub fn normalize_as_l2_denorm(
     let tensor_match = validate_tensor_float_input(input.dtype())?;
     let tensor_flat_size = tensor_match.list_size();
 
+    // Constant fast path: if the input is a constant-backed extension, normalize the single
+    // stored row once and return an `L2Denorm` whose children are both `ConstantArray`s.
+    if let Some(wrapped) = try_build_constant_l2_denorm(&input, row_count, ctx)? {
+        return Ok(wrapped);
+    }
+
     // Calculate the norms of the vectors.
     let norms_sfn = L2Norm::try_new_array(input.clone(), row_count)?;
     let norms_array: ArrayRef = norms_sfn.into_array().execute(ctx)?;
@@ -404,6 +411,90 @@ pub fn normalize_as_l2_denorm(
     // - Null rows are zeroed out above to avoid propagating arbitrary physical storage values into
     //   downstream lossy encodings.
     unsafe { L2Denorm::new_array_unchecked(normalized, norms_array, row_count) }
+}
+
+/// Attempts to build an [`L2Denorm`] whose two children are both [`ConstantArray`]s by eagerly
+/// normalizing `input`'s single stored row.
+///
+/// Returns `Ok(None)` when `input` is not a tensor-like extension array whose storage is a
+/// [`ConstantArray`] with a non-null fixed-size-list scalar.
+///
+/// When `input` matches, the returned [`ScalarFnArray`] is equivalent to [`normalize_as_l2_denorm`]
+/// but runs in `O(list_size)` time instead of `O(row_count * list_size)`.
+///
+/// This is helpful in some of the reduction steps for cosine similarity execution into inner
+/// product execution.
+pub(crate) fn try_build_constant_l2_denorm(
+    input: &ArrayRef,
+    len: usize,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Option<ScalarFnArray>> {
+    let Some(ext) = input.as_opt::<Extension>() else {
+        return Ok(None);
+    };
+    let storage = ext.storage_array();
+    let Some(const_storage) = storage.as_opt::<Constant>() else {
+        return Ok(None);
+    };
+    if const_storage.scalar().is_null() {
+        return Ok(None);
+    }
+
+    // The caller is expected to have already validated that `input` is an `AnyTensor`
+    // extension dtype.
+    let tensor_match = input
+        .dtype()
+        .as_extension()
+        .metadata_opt::<AnyTensor>()
+        .vortex_expect("caller validated input has AnyTensor metadata");
+    let list_size = tensor_match.list_size();
+    let original_nullability = input.dtype().nullability();
+    let ext_dtype = input.dtype().as_extension().clone();
+    let storage_fsl_nullability = storage.dtype().nullability();
+
+    // `extract_flat_elements` takes the stride-0 single-row path for `Constant` storage, so
+    // this is cheap and does not expand the constant to the full column length.
+    let flat = extract_flat_elements(storage, list_size, ctx)?;
+
+    let (normalized_fsl_scalar, norms_scalar) = match_each_float_ptype!(flat.ptype(), |T| {
+        let row = flat.row::<T>(0);
+
+        let mut sum_sq = T::zero();
+        for &x in row {
+            sum_sq += x * x;
+        }
+        let norm_t: T = sum_sq.sqrt();
+
+        // Zero-norm rows must be stored as all-zeros so [`L2Denorm`]'s unit-norm-or-zero
+        // invariant holds. This mirrors the per-row logic in `normalize_as_l2_denorm`.
+        let element_dtype = DType::Primitive(T::PTYPE, Nullability::NonNullable);
+        let children: Vec<Scalar> = if norm_t == T::zero() {
+            (0..list_size)
+                .map(|_| Scalar::zero_value(&element_dtype))
+                .collect()
+        } else {
+            row.iter()
+                .map(|&v| Scalar::primitive(v / norm_t, Nullability::NonNullable))
+                .collect()
+        };
+
+        // The rebuilt FSL scalar preserves the original storage FSL's nullability so the
+        // resulting `ExtensionArray::new` call accepts the same extension dtype.
+        let fsl_scalar = Scalar::fixed_size_list(element_dtype, children, storage_fsl_nullability);
+        let norms_scalar = Scalar::primitive(norm_t, original_nullability);
+        (fsl_scalar, norms_scalar)
+    });
+
+    let normalized_storage = ConstantArray::new(normalized_fsl_scalar, len).into_array();
+    let normalized_ext = ExtensionArray::new(ext_dtype, normalized_storage).into_array();
+    let norms_array = ConstantArray::new(norms_scalar, len).into_array();
+
+    // SAFETY: Each row of `normalized_ext` is either `v / ||v||` (unit norm within floating
+    // point tolerance) or all zeros when `||v|| == 0`. Stored norms are non-negative by
+    // construction (`sqrt`). These are exactly the invariants required by
+    // [`L2Denorm::new_array_unchecked`].
+    let wrapped = unsafe { L2Denorm::new_array_unchecked(normalized_ext, norms_array, len)? };
+    Ok(Some(wrapped))
 }
 
 /// Rebuilds a tensor-like extension array from flat primitive elements.
@@ -485,8 +576,6 @@ fn validate_l2_normalized_rows_impl(
     let normalized: ExtensionArray = normalized.clone().execute(ctx)?;
     let normalized_validity = normalized.as_ref().validity()?;
 
-    // TODO(connor): This is wrong, if we know that the normalized array is constant then we can
-    // just check that the scalar in normalized and then we are done.
     let flat = extract_flat_elements(normalized.storage_array(), tensor_flat_size, ctx)?;
     let norms = norms
         .map(|norms| norms.clone().execute::<PrimitiveArray>(ctx))
@@ -547,7 +636,9 @@ mod tests {
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::Constant;
     use vortex_array::arrays::ConstantArray;
+    use vortex_array::arrays::Extension;
     use vortex_array::arrays::ExtensionArray;
     use vortex_array::arrays::FixedSizeListArray;
     use vortex_array::arrays::MaskedArray;
@@ -831,6 +922,44 @@ mod tests {
         let actual = roundtrip.into_array().execute(&mut ctx)?;
 
         assert_tensor_arrays_eq(actual, input)?;
+        Ok(())
+    }
+
+    #[test]
+    fn normalize_as_l2_denorm_constant_input_has_constant_children() -> VortexResult<()> {
+        // The constant fast path in `normalize_as_l2_denorm` must produce an `L2Denorm` whose
+        // normalized storage and norms child are both still `ConstantArray`s. This is what
+        // allows downstream ops (cosine similarity, inner product) to short-circuit.
+        let input = constant_vector_array(&[3.0, 4.0], 16)?;
+        let mut ctx = SESSION.create_execution_ctx();
+        let roundtrip = normalize_as_l2_denorm(input, &mut ctx)?;
+
+        // The normalized child must be an extension array whose storage is still constant.
+        let normalized = roundtrip.child_at(0).clone();
+        let normalized_ext = normalized
+            .as_opt::<Extension>()
+            .expect("normalized child should be an Extension array");
+        assert!(
+            normalized_ext
+                .storage_array()
+                .as_opt::<Constant>()
+                .is_some(),
+            "normalized storage should stay constant after the fast path"
+        );
+
+        // The norms child must itself be a ConstantArray with the exact precomputed norm.
+        let norms = roundtrip.child_at(1).clone();
+        let norms_const = norms
+            .as_opt::<Constant>()
+            .expect("norms child should be a ConstantArray");
+        assert_close(
+            &[norms_const
+                .scalar()
+                .as_primitive()
+                .typed_value::<f64>()
+                .expect("norms scalar")],
+            &[5.0],
+        );
         Ok(())
     }
 

--- a/vortex-tensor/src/scalar_fns/l2_denorm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_denorm.rs
@@ -484,6 +484,9 @@ fn validate_l2_normalized_rows_impl(
 
     let normalized: ExtensionArray = normalized.clone().execute(ctx)?;
     let normalized_validity = normalized.as_ref().validity()?;
+
+    // TODO(connor): This is wrong, if we know that the normalized array is constant then we can
+    // just check that the scalar in normalized and then we are done.
     let flat = extract_flat_elements(normalized.storage_array(), tensor_flat_size, ctx)?;
     let norms = norms
         .map(|norms| norms.clone().execute::<PrimitiveArray>(ctx))

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -12,9 +12,8 @@ use vortex_array::IntoArray;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::ScalarFnArray;
-use vortex_array::arrays::ScalarFnVTable as ScalarFnArrayVTable;
 use vortex_array::arrays::extension::ExtensionArrayExt;
-use vortex_array::arrays::scalar_fn::ScalarFnArrayExt;
+use vortex_array::arrays::scalar_fn::ExactScalarFn;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
 use vortex_array::dtype::Nullability;
@@ -125,17 +124,17 @@ impl ScalarFnVTable for L2Norm {
         // L2Norm(L2Denorm(normalized, norms)) is defined to read back the authoritative stored
         // norms. Exact callers of lossy encodings like TurboQuant opt into that storage semantics
         // instead of forcing a decode-and-recompute path here.
-        if let Some(sfn) = input_ref.as_opt::<ScalarFnArrayVTable>()
-            && sfn.scalar_fn().as_opt::<L2Denorm>().is_some()
-        {
-            let norms: PrimitiveArray = sfn.child_at(1).clone().execute(ctx)?;
+        if let Some(sfn) = input_ref.as_opt::<ExactScalarFn<L2Denorm>>() {
+            let norms = sfn
+                .nth_child(1)
+                .vortex_expect("L2Denom must have at 2 children");
 
             vortex_ensure_eq!(
                 norms.dtype(),
                 &DType::Primitive(element_ptype, input_ref.dtype().nullability())
             );
 
-            return Ok(norms.into_array());
+            return Ok(norms);
         }
 
         let input: ExtensionArray = input_ref.execute(ctx)?;

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -141,6 +141,8 @@ impl ScalarFnVTable for L2Norm {
         let validity = input.as_ref().validity()?;
 
         let storage = input.storage_array();
+        // TODO(connor): This is wrong, if the storage array is `Constant` then we can return a
+        // `ConstantArray` directly here.
         let flat = extract_flat_elements(storage, tensor_flat_size, ctx)?;
 
         match_each_float_ptype!(flat.ptype(), |T| {

--- a/vortex-tensor/src/scalar_fns/l2_norm.rs
+++ b/vortex-tensor/src/scalar_fns/l2_norm.rs
@@ -141,8 +141,6 @@ impl ScalarFnVTable for L2Norm {
         let validity = input.as_ref().validity()?;
 
         let storage = input.storage_array();
-        // TODO(connor): This is wrong, if the storage array is `Constant` then we can return a
-        // `ConstantArray` directly here.
         let flat = extract_flat_elements(storage, tensor_flat_size, ctx)?;
 
         match_each_float_ptype!(flat.ptype(), |T| {

--- a/vortex-tensor/src/utils.rs
+++ b/vortex-tensor/src/utils.rs
@@ -103,6 +103,8 @@ impl FlatElements {
     }
 }
 
+// TODO(connor): Usage of this function is sometimes incorrect / not performant.
+// Make sure to fix them.
 /// Extracts the flat primitive elements from a tensor storage array (FixedSizeList).
 ///
 /// When the input is a [`ConstantArray`] (e.g., a literal query vector), only a single row is


### PR DESCRIPTION
_Stacked on top of https://github.com/vortex-data/vortex/pull/7394._

## Summary

Tracking issue: https://github.com/vortex-data/vortex/issues/7297

Implements the final pushdown / reduction rules needed to make the TurboQuant quantization scheme make sense.

TODO

## Testing

More tests 