### PR TITLE
perf: `Arc::ptr_eq` short-circuit to DType eq comparisons

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -9758,7 +9758,7 @@ pub fn vortex_array::dtype::FieldName::cmp(&self, other: &vortex_array::dtype::F
 
 impl core::cmp::PartialEq for vortex_array::dtype::FieldName
 
-pub fn vortex_array::dtype::FieldName::eq(&self, other: &vortex_array::dtype::FieldName) -> bool
+pub fn vortex_array::dtype::FieldName::eq(&self, other: &Self) -> bool
 
 impl core::cmp::PartialEq<&alloc::string::String> for vortex_array::dtype::FieldName
 
@@ -9832,8 +9832,6 @@ impl core::hash::Hash for vortex_array::dtype::FieldName
 
 pub fn vortex_array::dtype::FieldName::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
 
-impl core::marker::StructuralPartialEq for vortex_array::dtype::FieldName
-
 pub struct vortex_array::dtype::FieldNames(_)
 
 impl vortex_array::dtype::FieldNames
@@ -9858,7 +9856,7 @@ impl core::cmp::Eq for vortex_array::dtype::FieldNames
 
 impl core::cmp::PartialEq for vortex_array::dtype::FieldNames
 
-pub fn vortex_array::dtype::FieldNames::eq(&self, other: &vortex_array::dtype::FieldNames) -> bool
+pub fn vortex_array::dtype::FieldNames::eq(&self, other: &Self) -> bool
 
 impl core::cmp::PartialEq<&[&str]> for &vortex_array::dtype::FieldNames
 
@@ -9927,8 +9925,6 @@ pub type vortex_array::dtype::FieldNames::IntoIter = vortex_array::dtype::FieldN
 pub type vortex_array::dtype::FieldNames::Item = vortex_array::dtype::FieldName
 
 pub fn vortex_array::dtype::FieldNames::into_iter(self) -> Self::IntoIter
-
-impl core::marker::StructuralPartialEq for vortex_array::dtype::FieldNames
 
 impl core::ops::index::Index<usize> for vortex_array::dtype::FieldNames
 
@@ -10170,7 +10166,7 @@ impl core::cmp::Eq for vortex_array::dtype::StructFields
 
 impl core::cmp::PartialEq for vortex_array::dtype::StructFields
 
-pub fn vortex_array::dtype::StructFields::eq(&self, other: &vortex_array::dtype::StructFields) -> bool
+pub fn vortex_array::dtype::StructFields::eq(&self, other: &Self) -> bool
 
 impl core::default::Default for vortex_array::dtype::StructFields
 
@@ -10187,8 +10183,6 @@ pub fn vortex_array::dtype::StructFields::fmt(&self, f: &mut core::fmt::Formatte
 impl core::hash::Hash for vortex_array::dtype::StructFields
 
 pub fn vortex_array::dtype::StructFields::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-
-impl core::marker::StructuralPartialEq for vortex_array::dtype::StructFields
 
 impl vortex_array::dtype::arrow::FromArrowType<&arrow_schema::fields::Fields> for vortex_array::dtype::StructFields
 

--- a/vortex-array/src/dtype/field_names.rs
+++ b/vortex-array/src/dtype/field_names.rs
@@ -10,8 +10,15 @@ use itertools::Itertools;
 use vortex_utils::aliases::StringEscape;
 
 /// A name for a field in a struct.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, Eq, PartialOrd, Ord, Hash)]
+#[allow(clippy::derived_hash_with_manual_eq)] // manual PartialEq adds Arc::ptr_eq fast path only
 pub struct FieldName(Arc<str>);
+
+impl PartialEq for FieldName {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0) || *self.0 == *other.0
+    }
+}
 
 impl FieldName {
     /// Returns a reference to the inner string
@@ -139,9 +146,16 @@ impl From<FieldName> for Arc<str> {
 }
 
 /// An ordered list of field names in a struct.
-#[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
+#[derive(Clone, Eq, Debug, Default, Hash)]
+#[allow(clippy::derived_hash_with_manual_eq)] // manual PartialEq adds Arc::ptr_eq fast path only
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FieldNames(Arc<[FieldName]>);
+
+impl PartialEq for FieldNames {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0) || *self.0 == *other.0
+    }
+}
 
 impl fmt::Display for FieldNames {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/vortex-array/src/dtype/struct_.rs
+++ b/vortex-array/src/dtype/struct_.rs
@@ -138,8 +138,15 @@ impl FieldDTypeInner {
 /// // Accessing a field by name will yield the first
 /// assert_eq!(fields.field("int_col").unwrap(), DType::Primitive(PType::I32, Nullability::Nullable));
 /// ```
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Eq, Hash)]
+#[allow(clippy::derived_hash_with_manual_eq)] // manual PartialEq adds Arc::ptr_eq fast path only
 pub struct StructFields(Arc<StructFieldsInner>);
+
+impl PartialEq for StructFields {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0) || self.0 == other.0
+    }
+}
 
 impl std::fmt::Debug for StructFields {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
FieldName, FieldNames, and StructFields all wrap Arc types but their derived PartialEq always dereferences through the Arc to compare contents. Since DTypes are frequently cloned (every slice, filter, execute copies the DType), the cloned Arcs share pointers - making pointer equality a reliable fast path.

DataFusion ClickBench full-suite [apmc](https://github.com/0ax1/apmc) measurement for vortex, averaged over two runs:
  - Cycles: -5.7% (861B → 812B) — fewer total CPU cycles
  - IPC: +5.8% (1.88 → 1.99) — more instructions per cycle
  - MAP_STALL: -5.5% (360B → 340B) — less CPU stalls waiting on memory