### PR TITLE
bump rand to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7518,9 +7518,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -7598,7 +7598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -7627,7 +7627,7 @@ dependencies = [
  "clap",
  "indicatif",
  "lance-bench",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_distr 0.6.0",
  "tokio",
  "vortex-bench",
@@ -10069,7 +10069,7 @@ dependencies = [
  "mimalloc",
  "parquet 58.0.0",
  "paste",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_distr 0.6.0",
  "serde_json",
  "tokio",
@@ -10114,7 +10114,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-traits",
  "prost 0.14.3",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rstest",
  "rustc-hash",
  "vortex-array",
@@ -10165,7 +10165,7 @@ dependencies = [
  "pin-project-lite",
  "primitive-types",
  "prost 0.14.3",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_distr 0.6.0",
  "rstest",
  "rstest_reuse",
@@ -10222,7 +10222,7 @@ dependencies = [
  "noodles-vcf",
  "parking_lot",
  "parquet 58.0.0",
- "rand 0.10.0",
+ "rand 0.10.1",
  "regex",
  "reqwest 0.12.28",
  "serde",
@@ -10252,7 +10252,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-traits",
  "pco",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rstest",
  "rustc-hash",
  "test-with",
@@ -10341,7 +10341,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-traits",
  "parking_lot",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rstest",
  "rustc-hash",
  "tracing",
@@ -10534,7 +10534,7 @@ dependencies = [
  "lending-iterator",
  "num-traits",
  "prost 0.14.3",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rstest",
  "vortex-alp",
  "vortex-array",
@@ -10627,7 +10627,7 @@ dependencies = [
  "codspeed-divan-compat",
  "fsst-rs",
  "prost 0.14.3",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rstest",
  "vortex-array",
  "vortex-buffer",
@@ -10883,7 +10883,7 @@ dependencies = [
  "itertools 0.14.0",
  "num-traits",
  "prost 0.14.3",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rstest",
  "vortex-array",
  "vortex-buffer",
@@ -10980,7 +10980,7 @@ dependencies = [
  "mimalloc",
  "num-traits",
  "prost 0.14.3",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_distr 0.6.0",
  "rstest",
  "vortex-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ pyo3-bytes = "0.6"
 pyo3-log = "0.13.0"
 pyo3-object_store = "0.9.0"
 quote = "1.0.44"
-rand = "0.10.0"
+rand = "0.10.1"
 rand_distr = "0.6"
 ratatui = { version = "0.30", default-features = false }
 regex = "1.11.0"


### PR DESCRIPTION
## Summary

Bumps `rand` to `0.10.1`.

- https://rustsec.org/advisories/RUSTSEC-2026-0097
- https://github.com/rust-random/rand/pull/1763

## Testing

N/A