### PR TITLE
Ignore dead_code warnings on scalar bit transpose code

### DIFF
--- a/encodings/fastlanes/src/bit_transpose/scalar.rs
+++ b/encodings/fastlanes/src/bit_transpose/scalar.rs
@@ -12,6 +12,7 @@ use crate::bit_transpose::TRANSPOSE_8X8;
 /// This version uses 64-bit gather + parallel bit operations instead of
 /// extracting bits one by one. Typically 5-10x faster than the basic scalar version.
 #[inline(never)]
+#[allow(dead_code)]
 pub fn transpose_bits_scalar(input: &[u8; 128], output: &mut [u8; 128]) {
     // Helper to perform 8x8 bit transpose on a u64 (each byte becomes a row)
     fn transpose_8x8(mut x: u64) -> u64 {
@@ -84,6 +85,7 @@ pub fn transpose_bits_scalar(input: &[u8; 128], output: &mut [u8; 128]) {
 
 /// Fast scalar untranspose using the 8x8 bit matrix transpose algorithm.
 #[inline(never)]
+#[allow(dead_code)]
 pub fn untranspose_bits_scalar(input: &[u8; 128], output: &mut [u8; 128]) {
     fn transpose_8x8(mut x: u64) -> u64 {
         let t = (x ^ (x >> 7)) & TRANSPOSE_2X2;


### PR DESCRIPTION
Likely we shouldn't use expect here but we also don't test on architectures
where this wouldn't be dead code

Signed-off-by: Robert Kruszewski <github@robertk.io>
