### PR TITLE
perf: `Arc::ptr_eq` short-circuit for List & FixedSizeList DType eq

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -9166,7 +9166,7 @@ impl core::cmp::Eq for vortex_array::dtype::DType
 
 impl core::cmp::PartialEq for vortex_array::dtype::DType
 
-pub fn vortex_array::dtype::DType::eq(&self, other: &vortex_array::dtype::DType) -> bool
+pub fn vortex_array::dtype::DType::eq(&self, other: &Self) -> bool
 
 impl core::convert::From<vortex_array::dtype::DType> for vortex_array::dtype::FieldDType
 
@@ -9215,8 +9215,6 @@ pub fn vortex_array::dtype::DType::fmt(&self, f: &mut core::fmt::Formatter<'_>) 
 impl core::hash::Hash for vortex_array::dtype::DType
 
 pub fn vortex_array::dtype::DType::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
-
-impl core::marker::StructuralPartialEq for vortex_array::dtype::DType
 
 impl vortex_array::dtype::arrow::FromArrowType<&arrow_schema::field::Field> for vortex_array::dtype::DType
 

--- a/vortex-array/src/dtype/mod.rs
+++ b/vortex-array/src/dtype/mod.rs
@@ -50,7 +50,8 @@ use std::sync::Arc;
 ///
 /// [`I32`]: PType::I32
 /// [`NonNullable`]: Nullability::NonNullable
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Eq, Hash)]
+#[allow(clippy::derived_hash_with_manual_eq)] // manual PartialEq adds Arc::ptr_eq fast path only
 pub enum DType {
     /// A logical null type.
     ///
@@ -104,6 +105,42 @@ pub enum DType {
 
     /// Variant type.
     Variant(Nullability),
+}
+
+impl PartialEq for DType {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Null, Self::Null) => true,
+            (Self::Bool(a), Self::Bool(b)) => a == b,
+            (Self::Primitive(pa, na), Self::Primitive(pb, nb)) => pa == pb && na == nb,
+            (Self::Decimal(da, na), Self::Decimal(db, nb)) => da == db && na == nb,
+            (Self::Utf8(a), Self::Utf8(b)) => a == b,
+            (Self::Binary(a), Self::Binary(b)) => a == b,
+            (Self::List(da, na), Self::List(db, nb)) => {
+                na == nb && (Arc::ptr_eq(da, db) || da == db)
+            }
+            (Self::FixedSizeList(da, sa, na), Self::FixedSizeList(db, sb, nb)) => {
+                sa == sb && na == nb && (Arc::ptr_eq(da, db) || da == db)
+            }
+            // StructFields handles its own Arc::ptr_eq in its PartialEq impl.
+            (Self::Struct(a, na), Self::Struct(b, nb)) => na == nb && a == b,
+            (Self::Extension(a), Self::Extension(b)) => a == b,
+            (Self::Variant(a), Self::Variant(b)) => a == b,
+            // Every variant is listed in the first position so that adding a new
+            // variant produces a non-exhaustive match compile error.
+            (Self::Null, _)
+            | (Self::Bool(_), _)
+            | (Self::Primitive(..), _)
+            | (Self::Decimal(..), _)
+            | (Self::Utf8(_), _)
+            | (Self::Binary(_), _)
+            | (Self::List(..), _)
+            | (Self::FixedSizeList(..), _)
+            | (Self::Struct(..), _)
+            | (Self::Extension(_), _)
+            | (Self::Variant(_), _) => false,
+        }
+    }
 }
 
 pub use bigint::*;


### PR DESCRIPTION
Extend the `Arc::ptr_eq` fast-path from #7398 to cover the remaining Arc-containing DType variants. List and FixedSizeList hold a bare `Arc<DType>` in the enum variant, so the shortcut is applied in `DType`'s manual `PartialEq` impl. `StructFields` already handles its own `Arc::ptr_eq` internally.

The mismatch arms enumerate every variant in the first position so that adding a new DType variant produces a non-exhaustive match compile error.

DuckDB StatPopGen full-suite [apmc](https://github.com/0ax1/apmc) measurement for vortex, averaged over two runs:
  - Cycles: -5.4% (5.97B → 5.65B)
  - Instructions: -15.3% (15.5B → 13.1B)
  - L1D_CACHE_MISS_LD: -0.8% (56.2M → 55.7M)
  - MAP_STALL: -0.2% (1.35B → 1.34B)