### PR TITLE
perf: inline and simplify BinaryView::make_view

### DIFF
--- a/vortex-array/src/arrays/varbinview/view.rs
+++ b/vortex-array/src/arrays/varbinview/view.rs
@@ -10,7 +10,6 @@ use std::ops::Range;
 
 use static_assertions::assert_eq_align;
 use static_assertions::assert_eq_size;
-use vortex_error::VortexExpect;
 
 /// A view over a variable-length binary value.
 ///
@@ -46,17 +45,6 @@ pub struct Inlined {
 }
 
 impl Inlined {
-    /// Creates a new inlined representation from the provided value of constant size.
-    fn new<const N: usize>(value: &[u8]) -> Self {
-        debug_assert_eq!(value.len(), N);
-        let mut inlined = Self {
-            size: N.try_into().vortex_expect("inlined size must fit in u32"),
-            data: [0u8; BinaryView::MAX_INLINED_SIZE],
-        };
-        inlined.data[..N].copy_from_slice(&value[..N]);
-        inlined
-    }
-
     /// Returns the full inlined value.
     #[inline]
     pub fn value(&self) -> &[u8] {
@@ -108,59 +96,29 @@ impl BinaryView {
     ///
     /// Adapted from arrow-rs <https://github.com/apache/arrow-rs/blob/f4fde769ab6e1a9b75f890b7f8b47bc22800830b/arrow-array/src/builder/generic_bytes_view_builder.rs#L524>
     /// Explicitly enumerating inlined view produces code that avoids calling generic `ptr::copy_non_interleave` that's slower than explicit stores
-    #[inline(never)]
+    #[inline]
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "BinaryView sizes are bounded to u32::MAX by the format"
+    )]
     pub fn make_view(value: &[u8], block: u32, offset: u32) -> Self {
-        match value.len() {
-            0 => Self {
-                inlined: Inlined::new::<0>(value),
-            },
-            1 => Self {
-                inlined: Inlined::new::<1>(value),
-            },
-            2 => Self {
-                inlined: Inlined::new::<2>(value),
-            },
-            3 => Self {
-                inlined: Inlined::new::<3>(value),
-            },
-            4 => Self {
-                inlined: Inlined::new::<4>(value),
-            },
-            5 => Self {
-                inlined: Inlined::new::<5>(value),
-            },
-            6 => Self {
-                inlined: Inlined::new::<6>(value),
-            },
-            7 => Self {
-                inlined: Inlined::new::<7>(value),
-            },
-            8 => Self {
-                inlined: Inlined::new::<8>(value),
-            },
-            9 => Self {
-                inlined: Inlined::new::<9>(value),
-            },
-            10 => Self {
-                inlined: Inlined::new::<10>(value),
-            },
-            11 => Self {
-                inlined: Inlined::new::<11>(value),
-            },
-            12 => Self {
-                inlined: Inlined::new::<12>(value),
-            },
-            _ => Self {
+        let len = value.len();
+        if len <= Self::MAX_INLINED_SIZE {
+            let mut inlined = Inlined {
+                size: len as u32,
+                data: [0u8; Self::MAX_INLINED_SIZE],
+            };
+            inlined.data[..len].copy_from_slice(value);
+            Self { inlined }
+        } else {
+            Self {
                 _ref: Ref {
-                    size: u32::try_from(value.len()).vortex_expect("value length must fit in u32"),
-                    prefix: value[0..4]
-                        .try_into()
-                        .ok()
-                        .vortex_expect("prefix must be exactly 4 bytes"),
+                    size: len as u32,
+                    prefix: [value[0], value[1], value[2], value[3]],
                     buffer_index: block,
                     offset,
                 },
-            },
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Remove `#[inline(never)]` from `BinaryView::make_view` and replace the 13-arm match (one per inlined size 0–12) with a single `if len <= MAX_INLINED_SIZE` branch.
- Remove now-unused `Inlined::new` const-generic helper and `vortex_error::VortexExpect` import.

## Profiling (ClickBench, Vortex format, Apple Silicon)

**apmc stat** (hardware counters, 11 representative queries × 3 iterations):

| Metric | Baseline | After | Δ |
|--------|----------|-------|---|
| Cycles | 762.1B | 755.4B | **−0.9%** |
| Instructions | 1,450.4B | 1,440.6B | −0.7% |
| IPC | 1.90 | 1.91 | +0.5% |
| Frontend stall slots | 1,080.0B | 1,029.3B | **−4.7%** |

**xctrace** (CPU Profiler): `BinaryView::make_view` no longer appears as a self-time leaf — fully inlined by LLVM. Previously 0.44% of total cycles.