### PR TITLE
perf: simplify bool take to always use direct bit access

### DIFF
--- a/vortex-array/src/arrays/bool/compute/take.rs
+++ b/vortex-array/src/arrays/bool/compute/take.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-use itertools::Itertools as _;
 use num_traits::AsPrimitive;
 use vortex_buffer::BitBuffer;
 use vortex_buffer::get_bit;
@@ -52,29 +51,13 @@ impl TakeExecute for Bool {
 }
 
 fn take_valid_indices<I: AsPrimitive<usize>>(bools: &BitBuffer, indices: &[I]) -> BitBuffer {
-    // For boolean arrays that roughly fit into a single page (at least, on Linux), it's worth
-    // the overhead to convert to a Vec<bool>.
-    if bools.len() <= 4096 {
-        let bools = bools.iter().collect_vec();
-        take_byte_bool(bools, indices)
-    } else {
-        take_bool_impl(bools, indices)
-    }
-}
-
-fn take_byte_bool<I: AsPrimitive<usize>>(bools: Vec<bool>, indices: &[I]) -> BitBuffer {
-    BitBuffer::collect_bool(indices.len(), |idx| {
-        bools[unsafe { indices.get_unchecked(idx).as_() }]
-    })
-}
-
-fn take_bool_impl<I: AsPrimitive<usize>>(bools: &BitBuffer, indices: &[I]) -> BitBuffer {
-    // We dereference to underlying buffer to avoid access cost on every index.
+    // Dereference to the underlying buffer once to avoid per-index overhead.
     let buffer = bools.inner().as_ref();
+    let offset = bools.offset();
     BitBuffer::collect_bool(indices.len(), |idx| {
-        // SAFETY: we can take from the indices unchecked since collect_bool just iterates len.
+        // SAFETY: collect_bool iterates exactly `indices.len()` times, so `idx` is in-bounds.
         let idx = unsafe { indices.get_unchecked(idx).as_() };
-        get_bit(buffer, bools.offset() + idx)
+        get_bit(buffer, offset + idx)
     })
 }
 


### PR DESCRIPTION
## Summary

- Remove the small-array special case in `take_valid_indices` that materialized a `Vec<bool>` (8× the memory of the bit buffer) for arrays ≤ 4096 bits.
- Unify into a single path using direct `get_bit` on the underlying buffer.
- Remove unused `take_byte_bool` / `take_bool_impl` helpers and `itertools` import.

## Profiling

Measured with `apmc stat` (hardware perf counters) and `xctrace` (CPU Profiler) on 11 representative ClickBench queries × 1 iteration, Vortex format only via `datafusion-bench`.

**xctrace** self-time as % of total running cycles:

| Function | Before | After | Δ |
|----------|--------|-------|---|
| `take_valid_indices` | 0.53% | 0.23% | **−57%** |

Before this change, `take_valid_indices` dispatched to two helpers: `take_byte_bool` (small arrays ≤ 4096 bits, via `Vec<bool>`) and `take_bool_impl` (large arrays, direct bit access). The 0.53% was the combined self-time across both paths. After this change there is a single unified `get_bit` path and the two helpers are gone.

Wall-clock impact is within noise on this query set (bool take is a small fraction of total work), but the per-function speedup is clear.