### PR TITLE
perf: remove `ExecutionCtx` from `OperationsVTable::scalar_at`

### DIFF
--- a/encodings/alp/public-api.lock
+++ b/encodings/alp/public-api.lock
@@ -56,7 +56,7 @@ pub fn vortex_alp::ALP::validate(&self, data: &vortex_alp::ALPData, dtype: &vort
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_alp::ALP> for vortex_alp::ALP
 
-pub fn vortex_alp::ALP::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_alp::ALP>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_alp::ALP::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_alp::ALP>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityChild<vortex_alp::ALP> for vortex_alp::ALP
 
@@ -194,7 +194,7 @@ pub fn vortex_alp::ALPRD::validate(&self, data: &vortex_alp::ALPRDData, dtype: &
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_alp::ALPRD> for vortex_alp::ALPRD
 
-pub fn vortex_alp::ALPRD::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_alp::ALPRD>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_alp::ALPRD::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_alp::ALPRD>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityChild<vortex_alp::ALPRD> for vortex_alp::ALPRD
 

--- a/encodings/alp/src/alp/ops.rs
+++ b/encodings/alp/src/alp/ops.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayView;
-use vortex_array::ExecutionCtx;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexExpect;
@@ -15,11 +14,7 @@ use crate::ALPFloat;
 use crate::match_each_alp_float_ptype;
 
 impl OperationsVTable<ALP> for ALP {
-    fn scalar_at(
-        array: ArrayView<'_, ALP>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, ALP>, index: usize) -> VortexResult<Scalar> {
         if let Some(patches) = array.patches()
             && let Some(patch) = patches.get_patched(index)?
         {

--- a/encodings/alp/src/alp_rd/ops.rs
+++ b/encodings/alp/src/alp_rd/ops.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayView;
-use vortex_array::ExecutionCtx;
 use vortex_array::dtype::PType;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
@@ -13,11 +12,7 @@ use crate::ALPRD;
 use crate::ALPRDArrayExt;
 
 impl OperationsVTable<ALPRD> for ALPRD {
-    fn scalar_at(
-        array: ArrayView<'_, ALPRD>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, ALPRD>, index: usize) -> VortexResult<Scalar> {
         // The left value can either be a direct value, or an exception.
         // The exceptions array represents exception positions with non-null values.
         let maybe_patched_value = match array.left_parts_patches() {

--- a/encodings/bytebool/public-api.lock
+++ b/encodings/bytebool/public-api.lock
@@ -52,7 +52,7 @@ pub fn vortex_bytebool::ByteBool::validate(&self, data: &Self::ArrayData, dtype:
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_bytebool::ByteBool> for vortex_bytebool::ByteBool
 
-pub fn vortex_bytebool::ByteBool::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_bytebool::ByteBool>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_bytebool::ByteBool::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_bytebool::ByteBool>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityVTable<vortex_bytebool::ByteBool> for vortex_bytebool::ByteBool
 

--- a/encodings/bytebool/src/array.rs
+++ b/encodings/bytebool/src/array.rs
@@ -319,11 +319,7 @@ impl ValidityVTable<ByteBool> for ByteBool {
 }
 
 impl OperationsVTable<ByteBool> for ByteBool {
-    fn scalar_at(
-        array: ArrayView<'_, ByteBool>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, ByteBool>, index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::bool(
             array.buffer.as_host()[index] == 1,
             array.dtype().nullability(),

--- a/encodings/datetime-parts/public-api.lock
+++ b/encodings/datetime-parts/public-api.lock
@@ -50,7 +50,7 @@ pub fn vortex_datetime_parts::DateTimeParts::validate(&self, _data: &Self::Array
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_datetime_parts::DateTimeParts> for vortex_datetime_parts::DateTimeParts
 
-pub fn vortex_datetime_parts::DateTimeParts::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_datetime_parts::DateTimeParts>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_datetime_parts::DateTimeParts::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_datetime_parts::DateTimeParts>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityChild<vortex_datetime_parts::DateTimeParts> for vortex_datetime_parts::DateTimeParts
 

--- a/encodings/datetime-parts/src/ops.rs
+++ b/encodings/datetime-parts/src/ops.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayView;
-use vortex_array::ExecutionCtx;
 use vortex_array::dtype::DType;
 use vortex_array::extension::datetime::Timestamp;
 use vortex_array::scalar::Scalar;
@@ -17,11 +16,7 @@ use crate::timestamp;
 use crate::timestamp::TimestampParts;
 
 impl OperationsVTable<DateTimeParts> for DateTimeParts {
-    fn scalar_at(
-        array: ArrayView<'_, DateTimeParts>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, DateTimeParts>, index: usize) -> VortexResult<Scalar> {
         let DType::Extension(ext) = array.dtype().clone() else {
             vortex_panic!(
                 "DateTimePartsArray must have extension dtype, found {}",

--- a/encodings/decimal-byte-parts/public-api.lock
+++ b/encodings/decimal-byte-parts/public-api.lock
@@ -48,7 +48,7 @@ pub fn vortex_decimal_byte_parts::DecimalByteParts::validate(&self, _data: &Self
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_decimal_byte_parts::DecimalByteParts> for vortex_decimal_byte_parts::DecimalByteParts
 
-pub fn vortex_decimal_byte_parts::DecimalByteParts::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_decimal_byte_parts::DecimalByteParts>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_decimal_byte_parts::DecimalByteParts::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_decimal_byte_parts::DecimalByteParts>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityChild<vortex_decimal_byte_parts::DecimalByteParts> for vortex_decimal_byte_parts::DecimalByteParts
 

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/mod.rs
@@ -300,11 +300,7 @@ fn to_canonical_decimal(
 }
 
 impl OperationsVTable<DecimalByteParts> for DecimalByteParts {
-    fn scalar_at(
-        array: ArrayView<'_, DecimalByteParts>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, DecimalByteParts>, index: usize) -> VortexResult<Scalar> {
         // TODO(joe): support parts len != 1
         let scalar = array.msp().scalar_at(index)?;
 

--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -170,7 +170,7 @@ pub fn vortex_fastlanes::BitPacked::validate(&self, data: &Self::ArrayData, dtyp
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_fastlanes::BitPacked> for vortex_fastlanes::BitPacked
 
-pub fn vortex_fastlanes::BitPacked::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_fastlanes::BitPacked>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fastlanes::BitPacked::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_fastlanes::BitPacked>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityVTable<vortex_fastlanes::BitPacked> for vortex_fastlanes::BitPacked
 
@@ -324,7 +324,7 @@ pub fn vortex_fastlanes::Delta::validate(&self, data: &Self::ArrayData, dtype: &
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_fastlanes::Delta> for vortex_fastlanes::Delta
 
-pub fn vortex_fastlanes::Delta::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_fastlanes::Delta>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fastlanes::Delta::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_fastlanes::Delta>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityVTable<vortex_fastlanes::Delta> for vortex_fastlanes::Delta
 
@@ -414,7 +414,7 @@ pub fn vortex_fastlanes::FoR::validate(&self, data: &Self::ArrayData, dtype: &vo
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_fastlanes::FoR> for vortex_fastlanes::FoR
 
-pub fn vortex_fastlanes::FoR::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_fastlanes::FoR>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fastlanes::FoR::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_fastlanes::FoR>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityChild<vortex_fastlanes::FoR> for vortex_fastlanes::FoR
 
@@ -522,7 +522,7 @@ pub fn vortex_fastlanes::RLE::validate(&self, data: &Self::ArrayData, dtype: &vo
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_fastlanes::RLE> for vortex_fastlanes::RLE
 
-pub fn vortex_fastlanes::RLE::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_fastlanes::RLE>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fastlanes::RLE::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_fastlanes::RLE>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityVTable<vortex_fastlanes::RLE> for vortex_fastlanes::RLE
 

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayView;
-use vortex_array::ExecutionCtx;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexResult;
@@ -11,11 +10,7 @@ use crate::BitPacked;
 use crate::bitpack_decompress;
 use crate::bitpacking::array::BitPackedArrayExt;
 impl OperationsVTable<BitPacked> for BitPacked {
-    fn scalar_at(
-        array: ArrayView<'_, BitPacked>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, BitPacked>, index: usize) -> VortexResult<Scalar> {
         Ok(
             if let Some(patches) = array.patches()
                 && let Some(patch) = patches.get_patched(index)?

--- a/encodings/fastlanes/src/delta/vtable/operations.rs
+++ b/encodings/fastlanes/src/delta/vtable/operations.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayView;
-use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::ToCanonical;
 use vortex_array::scalar::Scalar;
@@ -11,11 +10,7 @@ use vortex_error::VortexResult;
 
 use super::Delta;
 impl OperationsVTable<Delta> for Delta {
-    fn scalar_at(
-        array: ArrayView<'_, Delta>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Delta>, index: usize) -> VortexResult<Scalar> {
         let decompressed = array.array().slice(index..index + 1)?.to_primitive();
         decompressed.into_array().scalar_at(0)
     }

--- a/encodings/fastlanes/src/for/vtable/operations.rs
+++ b/encodings/fastlanes/src/for/vtable/operations.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayView;
-use vortex_array::ExecutionCtx;
 use vortex_array::match_each_integer_ptype;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
@@ -12,11 +11,7 @@ use vortex_error::VortexResult;
 use super::FoR;
 use crate::r#for::array::FoRArrayExt;
 impl OperationsVTable<FoR> for FoR {
-    fn scalar_at(
-        array: ArrayView<'_, FoR>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, FoR>, index: usize) -> VortexResult<Scalar> {
         let encoded_pvalue = array.encoded().scalar_at(index)?;
         let encoded_pvalue = encoded_pvalue.as_primitive();
         let reference = array.reference_scalar();

--- a/encodings/fastlanes/src/rle/vtable/operations.rs
+++ b/encodings/fastlanes/src/rle/vtable/operations.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayView;
-use vortex_array::ExecutionCtx;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexExpect;
@@ -13,11 +12,7 @@ use crate::FL_CHUNK_SIZE;
 use crate::rle::RLEArrayExt;
 
 impl OperationsVTable<RLE> for RLE {
-    fn scalar_at(
-        array: ArrayView<'_, RLE>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, RLE>, index: usize) -> VortexResult<Scalar> {
         let offset_in_chunk = array.offset();
         let chunk_relative_idx = array.indices().scalar_at(offset_in_chunk + index)?;
 

--- a/encodings/fsst/public-api.lock
+++ b/encodings/fsst/public-api.lock
@@ -50,7 +50,7 @@ pub fn vortex_fsst::FSST::validate(&self, data: &Self::ArrayData, dtype: &vortex
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_fsst::FSST> for vortex_fsst::FSST
 
-pub fn vortex_fsst::FSST::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_fsst::FSST>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_fsst::FSST::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_fsst::FSST>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityVTable<vortex_fsst::FSST> for vortex_fsst::FSST
 

--- a/encodings/fsst/src/ops.rs
+++ b/encodings/fsst/src/ops.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayView;
-use vortex_array::ExecutionCtx;
 use vortex_array::arrays::varbin::varbin_scalar;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
@@ -14,11 +13,7 @@ use crate::FSST;
 use crate::FSSTArrayExt;
 
 impl OperationsVTable<FSST> for FSST {
-    fn scalar_at(
-        array: ArrayView<'_, FSST>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, FSST>, index: usize) -> VortexResult<Scalar> {
         let compressed = array.codes().scalar_at(index)?;
         let binary_datum = compressed.as_binary().value().vortex_expect("non-null");
 

--- a/encodings/parquet-variant/src/operations.rs
+++ b/encodings/parquet-variant/src/operations.rs
@@ -7,7 +7,6 @@ use chrono::Timelike;
 use parquet_variant::Variant as PqVariant;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
-use vortex_array::ExecutionCtx;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::DecimalDType;
 use vortex_array::dtype::FieldName;
@@ -38,11 +37,7 @@ impl OperationsVTable<ParquetVariant> for ParquetVariant {
     /// | non-NULL | NULL        | Un-shredded: decode from metadata + value bytes       |
     /// | NULL     | non-NULL    | Perfectly shredded: use typed_value directly           |
     /// | non-NULL | non-NULL    | Partially shredded object (typed_value takes priority) |
-    fn scalar_at(
-        array: ArrayView<'_, ParquetVariant>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, ParquetVariant>, index: usize) -> VortexResult<Scalar> {
         if array.validity()?.is_null(index)? {
             return Ok(Scalar::null(DType::Variant(Nullability::Nullable)));
         }

--- a/encodings/pco/public-api.lock
+++ b/encodings/pco/public-api.lock
@@ -46,7 +46,7 @@ pub fn vortex_pco::Pco::validate(&self, data: &vortex_pco::PcoData, dtype: &vort
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_pco::Pco> for vortex_pco::Pco
 
-pub fn vortex_pco::Pco::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_pco::Pco>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_pco::Pco::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_pco::Pco>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityVTable<vortex_pco::Pco> for vortex_pco::Pco
 

--- a/encodings/pco/public-api.lock
+++ b/encodings/pco/public-api.lock
@@ -86,7 +86,7 @@ pub struct vortex_pco::PcoData
 
 impl vortex_pco::PcoData
 
-pub fn vortex_pco::PcoData::decompress(&self, unsliced_validity: &vortex_array::validity::Validity, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::primitive::vtable::PrimitiveArray>
+pub fn vortex_pco::PcoData::decompress(&self, unsliced_validity: &vortex_array::validity::Validity, unsliced_mask: &vortex_mask::Mask) -> vortex_error::VortexResult<vortex_array::arrays::primitive::vtable::PrimitiveArray>
 
 pub fn vortex_pco::PcoData::from_array(array: vortex_array::array::erased::ArrayRef, level: usize, nums_per_page: usize) -> vortex_error::VortexResult<Self>
 

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -626,11 +626,7 @@ impl ValidityVTable<Pco> for Pco {
 }
 
 impl OperationsVTable<Pco> for Pco {
-    fn scalar_at(
-        array: ArrayView<'_, Pco>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Pco>, index: usize) -> VortexResult<Scalar> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let unsliced_validity = child_to_validity(&array.slots()[0], array.dtype().nullability());
         array

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -28,10 +28,8 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::Precision;
 use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
@@ -54,6 +52,7 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
+use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
 use crate::PcoChunkInfo;
@@ -219,10 +218,11 @@ impl VTable for Pco {
     fn execute(array: Array<Self>, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult> {
         let unsliced_validity =
             child_to_validity(&array.as_ref().slots()[0], array.dtype().nullability());
+        let unsliced_mask = unsliced_validity.execute_mask(array.data().unsliced_n_rows(), ctx)?;
         Ok(ExecutionResult::done(
             array
                 .data()
-                .decompress(&unsliced_validity, ctx)?
+                .decompress(&unsliced_validity, &unsliced_mask)?
                 .into_array(),
         ))
     }
@@ -491,7 +491,7 @@ impl PcoData {
     pub fn decompress(
         &self,
         unsliced_validity: &Validity,
-        ctx: &mut ExecutionCtx,
+        unsliced_mask: &Mask,
     ) -> VortexResult<PrimitiveArray> {
         // To start, we figure out which chunks and pages we need to decompress, and with
         // what value offset into the first such page.
@@ -499,7 +499,7 @@ impl PcoData {
         let values_byte_buffer = match_number_enum!(
             number_type,
             NumberType<T> => {
-              self.decompress_values_typed::<T>(unsliced_validity, ctx)?
+              self.decompress_values_typed::<T>(unsliced_mask)?
             }
         );
 
@@ -511,15 +511,10 @@ impl PcoData {
         ))
     }
 
-    fn decompress_values_typed<T: Number>(
-        &self,
-        unsliced_validity: &Validity,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<ByteBuffer> {
+    fn decompress_values_typed<T: Number>(&self, unsliced_mask: &Mask) -> VortexResult<ByteBuffer> {
         // To start, we figure out what range of values we need to decompress.
-        let slice_value_indices = unsliced_validity
-            .execute_mask(self.unsliced_n_rows, ctx)?
-            .valid_counts_for_indices(&[self.slice_start, self.slice_stop]);
+        let slice_value_indices =
+            unsliced_mask.valid_counts_for_indices(&[self.slice_start, self.slice_stop]);
         let slice_value_start = slice_value_indices[0];
         let slice_value_stop = slice_value_indices[1];
         let slice_n_values = slice_value_stop - slice_value_start;
@@ -627,11 +622,11 @@ impl ValidityVTable<Pco> for Pco {
 
 impl OperationsVTable<Pco> for Pco {
     fn scalar_at(array: ArrayView<'_, Pco>, index: usize) -> VortexResult<Scalar> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let unsliced_validity = child_to_validity(&array.slots()[0], array.dtype().nullability());
+        let unsliced_mask = unsliced_validity.to_mask(array.unsliced_n_rows());
         array
             ._slice(index, index + 1)
-            .decompress(&unsliced_validity, &mut ctx)?
+            .decompress(&unsliced_validity, &unsliced_mask)?
             .into_array()
             .scalar_at(0)
     }

--- a/encodings/pco/src/test.rs
+++ b/encodings/pco/src/test.rs
@@ -49,12 +49,14 @@ fn test_compress_decompress() {
     assert!(compressed.pages.len() < array.into_array().nbytes() as usize);
 
     // check full decompression works
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let unsliced_validity = child_to_validity(
         &compressed.as_ref().slots()[0],
         compressed.dtype().nullability(),
     );
-    let decompressed = compressed.decompress(&unsliced_validity, &mut ctx).unwrap();
+    let unsliced_mask = unsliced_validity.to_mask(compressed.unsliced_n_rows());
+    let decompressed = compressed
+        .decompress(&unsliced_validity, &unsliced_mask)
+        .unwrap();
     assert_arrays_eq!(decompressed, PrimitiveArray::from_iter(data));
 
     // check slicing works
@@ -76,12 +78,14 @@ fn test_compress_decompress_small() {
     let expected = array.into_array();
     assert_arrays_eq!(compressed, expected);
 
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let unsliced_validity = child_to_validity(
         &compressed.as_ref().slots()[0],
         compressed.dtype().nullability(),
     );
-    let decompressed = compressed.decompress(&unsliced_validity, &mut ctx).unwrap();
+    let unsliced_mask = unsliced_validity.to_mask(compressed.unsliced_n_rows());
+    let decompressed = compressed
+        .decompress(&unsliced_validity, &unsliced_mask)
+        .unwrap();
     assert_arrays_eq!(decompressed, expected);
 }
 
@@ -90,12 +94,14 @@ fn test_empty() {
     let data: Vec<i32> = vec![];
     let array = PrimitiveArray::from_iter(data.clone());
     let compressed = Pco::from_primitive(array.as_view(), 3, 100).unwrap();
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let unsliced_validity = child_to_validity(
         &compressed.as_ref().slots()[0],
         compressed.dtype().nullability(),
     );
-    let primitive = compressed.decompress(&unsliced_validity, &mut ctx).unwrap();
+    let unsliced_mask = unsliced_validity.to_mask(compressed.unsliced_n_rows());
+    let primitive = compressed
+        .decompress(&unsliced_validity, &unsliced_mask)
+        .unwrap();
     assert_arrays_eq!(primitive, PrimitiveArray::from_iter(data));
 }
 

--- a/encodings/runend/public-api.lock
+++ b/encodings/runend/public-api.lock
@@ -72,7 +72,7 @@ pub fn vortex_runend::RunEnd::validate(&self, data: &Self::ArrayData, dtype: &vo
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_runend::RunEnd> for vortex_runend::RunEnd
 
-pub fn vortex_runend::RunEnd::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_runend::RunEnd>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_runend::RunEnd::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_runend::RunEnd>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityVTable<vortex_runend::RunEnd> for vortex_runend::RunEnd
 

--- a/encodings/runend/src/ops.rs
+++ b/encodings/runend/src/ops.rs
@@ -3,7 +3,6 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
-use vortex_array::ExecutionCtx;
 use vortex_array::scalar::PValue;
 use vortex_array::scalar::Scalar;
 use vortex_array::search_sorted::SearchResult;
@@ -16,11 +15,7 @@ use crate::RunEnd;
 use crate::array::RunEndArrayExt;
 
 impl OperationsVTable<RunEnd> for RunEnd {
-    fn scalar_at(
-        array: ArrayView<'_, RunEnd>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, RunEnd>, index: usize) -> VortexResult<Scalar> {
         array.values().scalar_at(array.find_physical_index(index)?)
     }
 }

--- a/encodings/sequence/public-api.lock
+++ b/encodings/sequence/public-api.lock
@@ -50,7 +50,7 @@ pub fn vortex_sequence::Sequence::validate(&self, data: &Self::ArrayData, dtype:
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_sequence::Sequence> for vortex_sequence::Sequence
 
-pub fn vortex_sequence::Sequence::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_sequence::Sequence>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_sequence::Sequence::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_sequence::Sequence>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityVTable<vortex_sequence::Sequence> for vortex_sequence::Sequence
 

--- a/encodings/sequence/src/array.rs
+++ b/encodings/sequence/src/array.rs
@@ -347,11 +347,7 @@ impl VTable for Sequence {
 }
 
 impl OperationsVTable<Sequence> for Sequence {
-    fn scalar_at(
-        array: ArrayView<'_, Sequence>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Sequence>, index: usize) -> VortexResult<Scalar> {
         Scalar::try_new(
             array.dtype().clone(),
             Some(ScalarValue::Primitive(array.index_value(index))),

--- a/encodings/sparse/public-api.lock
+++ b/encodings/sparse/public-api.lock
@@ -52,7 +52,7 @@ pub fn vortex_sparse::Sparse::validate(&self, data: &Self::ArrayData, dtype: &vo
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_sparse::Sparse> for vortex_sparse::Sparse
 
-pub fn vortex_sparse::Sparse::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_sparse::Sparse>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_sparse::Sparse::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_sparse::Sparse>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityVTable<vortex_sparse::Sparse> for vortex_sparse::Sparse
 

--- a/encodings/sparse/src/ops.rs
+++ b/encodings/sparse/src/ops.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayView;
-use vortex_array::ExecutionCtx;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexResult;
@@ -10,11 +9,7 @@ use vortex_error::VortexResult;
 use crate::Sparse;
 
 impl OperationsVTable<Sparse> for Sparse {
-    fn scalar_at(
-        array: ArrayView<'_, Sparse>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Sparse>, index: usize) -> VortexResult<Scalar> {
         Ok(array
             .patches()
             .get_patched(index)?

--- a/encodings/zigzag/public-api.lock
+++ b/encodings/zigzag/public-api.lock
@@ -48,7 +48,7 @@ pub fn vortex_zigzag::ZigZag::validate(&self, _data: &Self::ArrayData, dtype: &v
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_zigzag::ZigZag> for vortex_zigzag::ZigZag
 
-pub fn vortex_zigzag::ZigZag::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_zigzag::ZigZag>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_zigzag::ZigZag::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_zigzag::ZigZag>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityChild<vortex_zigzag::ZigZag> for vortex_zigzag::ZigZag
 

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -237,11 +237,7 @@ impl Default for ZigZagData {
 }
 
 impl OperationsVTable<ZigZag> for ZigZag {
-    fn scalar_at(
-        array: ArrayView<'_, ZigZag>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, ZigZag>, index: usize) -> VortexResult<Scalar> {
         let scalar = array.encoded().scalar_at(index)?;
         if scalar.is_null() {
             return scalar.primitive_reinterpret_cast(ZigZagArrayExt::ptype(&array));

--- a/encodings/zstd/public-api.lock
+++ b/encodings/zstd/public-api.lock
@@ -54,7 +54,7 @@ pub fn vortex_zstd::Zstd::validate(&self, data: &Self::ArrayData, dtype: &vortex
 
 impl vortex_array::array::vtable::operations::OperationsVTable<vortex_zstd::Zstd> for vortex_zstd::Zstd
 
-pub fn vortex_zstd::Zstd::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_zstd::Zstd>, index: usize, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_zstd::Zstd::scalar_at(array: vortex_array::array::view::ArrayView<'_, vortex_zstd::Zstd>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::array::vtable::validity::ValidityVTable<vortex_zstd::Zstd> for vortex_zstd::Zstd
 

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -1020,11 +1020,7 @@ impl ValidityVTable<Zstd> for Zstd {
 }
 
 impl OperationsVTable<Zstd> for Zstd {
-    fn scalar_at(
-        array: ArrayView<'_, Zstd>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Zstd>, index: usize) -> VortexResult<Scalar> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let unsliced_validity = child_to_validity(&array.slots()[0], array.dtype().nullability());
         let sliced = array.data().with_slice(index, index + 1);

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -21,10 +21,8 @@ use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::Precision;
 use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -54,6 +52,7 @@ use vortex_error::vortex_ensure;
 use vortex_error::vortex_err;
 use vortex_error::vortex_panic;
 use vortex_mask::AllOr;
+use vortex_mask::Mask;
 use vortex_session::VortexSession;
 
 use crate::ZstdFrameMetadata;
@@ -233,9 +232,10 @@ impl VTable for Zstd {
     fn execute(array: Array<Self>, ctx: &mut ExecutionCtx) -> VortexResult<ExecutionResult> {
         let unsliced_validity =
             child_to_validity(&array.as_ref().slots()[0], array.dtype().nullability());
+        let unsliced_mask = unsliced_validity.execute_mask(array.data().unsliced_n_rows(), ctx)?;
         array
             .data()
-            .decompress(array.dtype(), &unsliced_validity, ctx)?
+            .decompress(array.dtype(), &unsliced_validity, &unsliced_mask)?
             .execute::<ArrayRef>(ctx)
             .map(ExecutionResult::done)
     }
@@ -309,9 +309,10 @@ impl Zstd {
     pub fn decompress(array: &ZstdArray, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
         let unsliced_validity =
             child_to_validity(&array.as_ref().slots()[0], array.dtype().nullability());
+        let unsliced_mask = unsliced_validity.execute_mask(array.data().unsliced_n_rows(), ctx)?;
         array
             .data()
-            .decompress(array.dtype(), &unsliced_validity, ctx)
+            .decompress(array.dtype(), &unsliced_validity, &unsliced_mask)
     }
 }
 
@@ -809,15 +810,14 @@ impl ZstdData {
         &self,
         dtype: &DType,
         unsliced_validity: &Validity,
-        ctx: &mut ExecutionCtx,
+        unsliced_mask: &Mask,
     ) -> VortexResult<ArrayRef> {
         // To start, we figure out which frames we need to decompress, and with
         // what row offset into the first such frame.
         let byte_width = Self::byte_width(dtype);
         let slice_n_rows = self.slice_stop - self.slice_start;
-        let slice_value_indices = unsliced_validity
-            .execute_mask(self.unsliced_n_rows, ctx)?
-            .valid_counts_for_indices(&[self.slice_start, self.slice_stop]);
+        let slice_value_indices =
+            unsliced_mask.valid_counts_for_indices(&[self.slice_start, self.slice_stop]);
 
         let slice_value_idx_start = slice_value_indices[0];
         let slice_value_idx_stop = slice_value_indices[1];
@@ -922,7 +922,10 @@ impl ZstdData {
                 Ok(primitive.into_array())
             }
             DType::Binary(_) | DType::Utf8(_) => {
-                match slice_validity.execute_mask(slice_n_rows, ctx)?.indices() {
+                match unsliced_mask
+                    .slice(self.slice_start..self.slice_stop)
+                    .indices()
+                {
                     AllOr::All => {
                         let (buffers, all_views) = reconstruct_views(&decompressed, MAX_BUFFER_LEN);
                         let valid_views = all_views.slice(
@@ -1021,11 +1024,11 @@ impl ValidityVTable<Zstd> for Zstd {
 
 impl OperationsVTable<Zstd> for Zstd {
     fn scalar_at(array: ArrayView<'_, Zstd>, index: usize) -> VortexResult<Scalar> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let unsliced_validity = child_to_validity(&array.slots()[0], array.dtype().nullability());
+        let unsliced_mask = unsliced_validity.to_mask(array.data().unsliced_n_rows());
         let sliced = array.data().with_slice(index, index + 1);
         sliced
-            .decompress(array.dtype(), &unsliced_validity, &mut ctx)?
+            .decompress(array.dtype(), &unsliced_validity, &unsliced_mask)?
             .scalar_at(0)
     }
 }

--- a/encodings/zstd/src/zstd_buffers.rs
+++ b/encodings/zstd/src/zstd_buffers.rs
@@ -453,11 +453,7 @@ impl VTable for ZstdBuffers {
 }
 
 impl OperationsVTable<ZstdBuffers> for ZstdBuffers {
-    fn scalar_at(
-        array: ArrayView<'_, ZstdBuffers>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, ZstdBuffers>, index: usize) -> VortexResult<Scalar> {
         // TODO(os): maybe we should not support scalar_at, it is really slow, and adding a cache
         // layer here is weird. Valid use of zstd buffers array would be by executing it first into
         // canonical

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -1142,7 +1142,7 @@ pub fn vortex_array::arrays::Bool::fmt(&self, f: &mut core::fmt::Formatter<'_>) 
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Bool> for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::Bool::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Bool>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Bool::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Bool>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Bool
 
@@ -1320,7 +1320,7 @@ pub fn vortex_array::arrays::Chunked::fmt(&self, f: &mut core::fmt::Formatter<'_
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::Chunked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Chunked>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Chunked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Chunked>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Chunked
 
@@ -1488,7 +1488,7 @@ pub fn vortex_array::arrays::Constant::fmt(&self, f: &mut core::fmt::Formatter<'
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::Constant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Constant>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Constant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Constant>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Constant
 
@@ -1672,7 +1672,7 @@ pub fn vortex_array::arrays::Decimal::fmt(&self, f: &mut core::fmt::Formatter<'_
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Decimal> for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::Decimal::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Decimal>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Decimal::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Decimal>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Decimal
 
@@ -1892,7 +1892,7 @@ pub fn vortex_array::arrays::dict::Dict::fmt(&self, f: &mut core::fmt::Formatter
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::dict::Dict>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::dict::Dict>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::dict::Dict
 
@@ -1988,7 +1988,7 @@ pub fn vortex_array::arrays::dict::Dict::fmt(&self, f: &mut core::fmt::Formatter
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::dict::Dict>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::dict::Dict>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::dict::Dict
 
@@ -2326,7 +2326,7 @@ pub fn vortex_array::arrays::Extension::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::Extension::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Extension>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Extension::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Extension>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Extension
 
@@ -2456,7 +2456,7 @@ pub fn vortex_array::arrays::Filter::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::Filter::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Filter>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Filter::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Filter>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Filter
 
@@ -2648,7 +2648,7 @@ pub fn vortex_array::arrays::FixedSizeList::fmt(&self, f: &mut core::fmt::Format
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::FixedSizeList> for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::FixedSizeList>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::FixedSizeList>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::FixedSizeList
 
@@ -2796,7 +2796,7 @@ pub fn vortex_array::arrays::List::fmt(&self, f: &mut core::fmt::Formatter<'_>) 
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::List> for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::List::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::List>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::List::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::List>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::List
 
@@ -2980,7 +2980,7 @@ pub fn vortex_array::arrays::ListView::fmt(&self, f: &mut core::fmt::Formatter<'
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::ListView> for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::ListView>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::ListView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::ListView>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::ListView
 
@@ -3164,7 +3164,7 @@ pub fn vortex_array::arrays::Masked::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Masked> for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::Masked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Masked>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Masked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Masked>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Masked
 
@@ -3294,7 +3294,7 @@ pub fn vortex_array::arrays::null::Null::fmt(&self, f: &mut core::fmt::Formatter
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::Null::scalar_at(_array: vortex_array::ArrayView<'_, vortex_array::arrays::null::Null>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::null::Null::scalar_at(_array: vortex_array::ArrayView<'_, vortex_array::arrays::null::Null>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::null::Null
 
@@ -3380,7 +3380,7 @@ pub fn vortex_array::arrays::patched::Patched::fmt(&self, f: &mut core::fmt::For
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::patched::Patched> for vortex_array::arrays::patched::Patched
 
-pub fn vortex_array::arrays::patched::Patched::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::patched::Patched>, index: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::patched::Patched::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::patched::Patched>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::patched::Patched
 
@@ -3670,7 +3670,7 @@ pub fn vortex_array::arrays::Primitive::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Primitive> for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::Primitive::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Primitive>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Primitive::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Primitive>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Primitive
 
@@ -3962,7 +3962,7 @@ pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::fmt(&self, f: &mut core:
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::scalar_fn::ScalarFnVTable>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::scalar_fn::ScalarFnVTable>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
@@ -4076,7 +4076,7 @@ pub fn vortex_array::arrays::Shared::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
 
-pub fn vortex_array::arrays::Shared::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Shared>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Shared::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Shared>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Shared
 
@@ -4192,7 +4192,7 @@ pub fn vortex_array::arrays::slice::Slice::fmt(&self, f: &mut core::fmt::Formatt
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::slice::Slice::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::slice::Slice>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::slice::Slice::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::slice::Slice>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::slice::Slice
 
@@ -4422,7 +4422,7 @@ pub fn vortex_array::arrays::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::Struct::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Struct>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Struct::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Struct>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Struct
 
@@ -4586,7 +4586,7 @@ pub fn vortex_array::arrays::VarBin::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::VarBin> for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBin::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBin>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBin::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBin>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::VarBin
 
@@ -4956,7 +4956,7 @@ pub fn vortex_array::arrays::VarBinView::fmt(&self, f: &mut core::fmt::Formatter
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::VarBinView> for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBinView>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBinView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBinView>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::VarBinView
 
@@ -5146,7 +5146,7 @@ pub fn vortex_array::arrays::Variant::fmt(&self, f: &mut core::fmt::Formatter<'_
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Variant> for vortex_array::arrays::Variant
 
-pub fn vortex_array::arrays::Variant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Variant>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Variant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Variant>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Variant
 
@@ -5218,7 +5218,7 @@ pub fn vortex_array::arrays::Bool::fmt(&self, f: &mut core::fmt::Formatter<'_>) 
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Bool> for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::Bool::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Bool>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Bool::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Bool>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Bool
 
@@ -5310,7 +5310,7 @@ pub fn vortex_array::arrays::Chunked::fmt(&self, f: &mut core::fmt::Formatter<'_
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::Chunked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Chunked>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Chunked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Chunked>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Chunked
 
@@ -5404,7 +5404,7 @@ pub fn vortex_array::arrays::Constant::fmt(&self, f: &mut core::fmt::Formatter<'
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::Constant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Constant>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Constant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Constant>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Constant
 
@@ -5494,7 +5494,7 @@ pub fn vortex_array::arrays::Decimal::fmt(&self, f: &mut core::fmt::Formatter<'_
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Decimal> for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::Decimal::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Decimal>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Decimal::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Decimal>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Decimal
 
@@ -5586,7 +5586,7 @@ pub fn vortex_array::arrays::dict::Dict::fmt(&self, f: &mut core::fmt::Formatter
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::dict::Dict>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::dict::Dict>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::dict::Dict
 
@@ -5680,7 +5680,7 @@ pub fn vortex_array::arrays::Extension::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::Extension::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Extension>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Extension::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Extension>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Extension
 
@@ -5766,7 +5766,7 @@ pub fn vortex_array::arrays::Filter::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::Filter::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Filter>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Filter::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Filter>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Filter
 
@@ -5828,7 +5828,7 @@ pub fn vortex_array::arrays::FixedSizeList::fmt(&self, f: &mut core::fmt::Format
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::FixedSizeList> for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::FixedSizeList>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::FixedSizeList>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::FixedSizeList
 
@@ -5906,7 +5906,7 @@ pub fn vortex_array::arrays::List::fmt(&self, f: &mut core::fmt::Formatter<'_>) 
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::List> for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::List::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::List>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::List::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::List>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::List
 
@@ -5988,7 +5988,7 @@ pub fn vortex_array::arrays::ListView::fmt(&self, f: &mut core::fmt::Formatter<'
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::ListView> for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::ListView>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::ListView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::ListView>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::ListView
 
@@ -6066,7 +6066,7 @@ pub fn vortex_array::arrays::Masked::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Masked> for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::Masked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Masked>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Masked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Masked>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Masked
 
@@ -6148,7 +6148,7 @@ pub fn vortex_array::arrays::null::Null::fmt(&self, f: &mut core::fmt::Formatter
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::Null::scalar_at(_array: vortex_array::ArrayView<'_, vortex_array::arrays::null::Null>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::null::Null::scalar_at(_array: vortex_array::ArrayView<'_, vortex_array::arrays::null::Null>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::null::Null
 
@@ -6230,7 +6230,7 @@ pub fn vortex_array::arrays::patched::Patched::fmt(&self, f: &mut core::fmt::For
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::patched::Patched> for vortex_array::arrays::patched::Patched
 
-pub fn vortex_array::arrays::patched::Patched::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::patched::Patched>, index: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::patched::Patched::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::patched::Patched>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::patched::Patched
 
@@ -6308,7 +6308,7 @@ pub fn vortex_array::arrays::Primitive::fmt(&self, f: &mut core::fmt::Formatter<
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Primitive> for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::Primitive::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Primitive>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Primitive::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Primitive>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Primitive
 
@@ -6396,7 +6396,7 @@ pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::fmt(&self, f: &mut core:
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::scalar_fn::ScalarFnVTable>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::scalar_fn::ScalarFnVTable>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
@@ -6458,7 +6458,7 @@ pub fn vortex_array::arrays::Shared::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
 
-pub fn vortex_array::arrays::Shared::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Shared>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Shared::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Shared>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Shared
 
@@ -6520,7 +6520,7 @@ pub fn vortex_array::arrays::slice::Slice::fmt(&self, f: &mut core::fmt::Formatt
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::slice::Slice::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::slice::Slice>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::slice::Slice::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::slice::Slice>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::slice::Slice
 
@@ -6586,7 +6586,7 @@ pub fn vortex_array::arrays::Struct::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::Struct::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Struct>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Struct::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Struct>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Struct
 
@@ -6672,7 +6672,7 @@ pub fn vortex_array::arrays::VarBin::fmt(&self, f: &mut core::fmt::Formatter<'_>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::VarBin> for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBin::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBin>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBin::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBin>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::VarBin
 
@@ -6758,7 +6758,7 @@ pub fn vortex_array::arrays::VarBinView::fmt(&self, f: &mut core::fmt::Formatter
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::VarBinView> for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBinView>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBinView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBinView>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::VarBinView
 
@@ -6840,7 +6840,7 @@ pub fn vortex_array::arrays::Variant::fmt(&self, f: &mut core::fmt::Formatter<'_
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Variant> for vortex_array::arrays::Variant
 
-pub fn vortex_array::arrays::Variant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Variant>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Variant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Variant>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::VTable for vortex_array::arrays::Variant
 
@@ -19392,7 +19392,7 @@ pub struct vortex_array::vtable::NotSupported
 
 impl<V: vortex_array::VTable> vortex_array::OperationsVTable<V> for vortex_array::NotSupported
 
-pub fn vortex_array::NotSupported::scalar_at(array: vortex_array::ArrayView<'_, V>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::NotSupported::scalar_at(array: vortex_array::ArrayView<'_, V>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub struct vortex_array::vtable::ValidityVTableFromChild
 
@@ -20304,95 +20304,95 @@ pub fn vortex_array::arrays::slice::Slice::validate(&self, data: &Self::ArrayDat
 
 pub trait vortex_array::vtable::OperationsVTable<V: vortex_array::VTable>
 
-pub fn vortex_array::vtable::OperationsVTable::scalar_at(array: vortex_array::ArrayView<'_, V>, index: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::vtable::OperationsVTable::scalar_at(array: vortex_array::ArrayView<'_, V>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Bool> for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::Bool::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Bool>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Bool::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Bool>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::Chunked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Chunked>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Chunked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Chunked>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::Constant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Constant>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Constant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Constant>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Decimal> for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::Decimal::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Decimal>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Decimal::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Decimal>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::Extension::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Extension>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Extension::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Extension>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::Filter::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Filter>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Filter::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Filter>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::FixedSizeList> for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::FixedSizeList>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::FixedSizeList>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::List> for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::List::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::List>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::List::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::List>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::ListView> for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::ListView>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::ListView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::ListView>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Masked> for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::Masked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Masked>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Masked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Masked>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Primitive> for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::Primitive::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Primitive>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Primitive::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Primitive>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
 
-pub fn vortex_array::arrays::Shared::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Shared>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Shared::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Shared>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::Struct::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Struct>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Struct::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Struct>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::VarBin> for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBin::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBin>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBin::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBin>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::VarBinView> for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBinView>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBinView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBinView>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Variant> for vortex_array::arrays::Variant
 
-pub fn vortex_array::arrays::Variant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Variant>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Variant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Variant>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::dict::Dict>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::dict::Dict>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::Null::scalar_at(_array: vortex_array::ArrayView<'_, vortex_array::arrays::null::Null>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::null::Null::scalar_at(_array: vortex_array::ArrayView<'_, vortex_array::arrays::null::Null>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::patched::Patched> for vortex_array::arrays::patched::Patched
 
-pub fn vortex_array::arrays::patched::Patched::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::patched::Patched>, index: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::patched::Patched::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::patched::Patched>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::scalar_fn::ScalarFnVTable>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::scalar_fn::ScalarFnVTable>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::slice::Slice::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::slice::Slice>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::slice::Slice::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::slice::Slice>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl<V: vortex_array::VTable> vortex_array::OperationsVTable<V> for vortex_array::NotSupported
 
-pub fn vortex_array::NotSupported::scalar_at(array: vortex_array::ArrayView<'_, V>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::NotSupported::scalar_at(array: vortex_array::ArrayView<'_, V>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub trait vortex_array::vtable::VTable: 'static + core::clone::Clone + core::marker::Sized + core::marker::Send + core::marker::Sync + core::fmt::Debug
 
@@ -22760,7 +22760,7 @@ pub struct vortex_array::NotSupported
 
 impl<V: vortex_array::VTable> vortex_array::OperationsVTable<V> for vortex_array::NotSupported
 
-pub fn vortex_array::NotSupported::scalar_at(array: vortex_array::ArrayView<'_, V>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::NotSupported::scalar_at(array: vortex_array::ArrayView<'_, V>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub struct vortex_array::ProstMetadata<M>(pub M)
 
@@ -24138,95 +24138,95 @@ pub fn vortex_array::Array<V>::into_array(self) -> vortex_array::ArrayRef
 
 pub trait vortex_array::OperationsVTable<V: vortex_array::VTable>
 
-pub fn vortex_array::OperationsVTable::scalar_at(array: vortex_array::ArrayView<'_, V>, index: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::OperationsVTable::scalar_at(array: vortex_array::ArrayView<'_, V>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Bool> for vortex_array::arrays::Bool
 
-pub fn vortex_array::arrays::Bool::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Bool>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Bool::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Bool>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Chunked> for vortex_array::arrays::Chunked
 
-pub fn vortex_array::arrays::Chunked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Chunked>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Chunked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Chunked>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Constant> for vortex_array::arrays::Constant
 
-pub fn vortex_array::arrays::Constant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Constant>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Constant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Constant>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Decimal> for vortex_array::arrays::Decimal
 
-pub fn vortex_array::arrays::Decimal::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Decimal>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Decimal::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Decimal>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Extension> for vortex_array::arrays::Extension
 
-pub fn vortex_array::arrays::Extension::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Extension>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Extension::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Extension>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Filter> for vortex_array::arrays::Filter
 
-pub fn vortex_array::arrays::Filter::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Filter>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Filter::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Filter>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::FixedSizeList> for vortex_array::arrays::FixedSizeList
 
-pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::FixedSizeList>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::FixedSizeList::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::FixedSizeList>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::List> for vortex_array::arrays::List
 
-pub fn vortex_array::arrays::List::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::List>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::List::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::List>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::ListView> for vortex_array::arrays::ListView
 
-pub fn vortex_array::arrays::ListView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::ListView>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::ListView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::ListView>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Masked> for vortex_array::arrays::Masked
 
-pub fn vortex_array::arrays::Masked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Masked>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Masked::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Masked>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Primitive> for vortex_array::arrays::Primitive
 
-pub fn vortex_array::arrays::Primitive::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Primitive>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Primitive::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Primitive>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Shared> for vortex_array::arrays::Shared
 
-pub fn vortex_array::arrays::Shared::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Shared>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Shared::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Shared>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Struct> for vortex_array::arrays::Struct
 
-pub fn vortex_array::arrays::Struct::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Struct>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Struct::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Struct>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::VarBin> for vortex_array::arrays::VarBin
 
-pub fn vortex_array::arrays::VarBin::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBin>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBin::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBin>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::VarBinView> for vortex_array::arrays::VarBinView
 
-pub fn vortex_array::arrays::VarBinView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBinView>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::VarBinView::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::VarBinView>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::Variant> for vortex_array::arrays::Variant
 
-pub fn vortex_array::arrays::Variant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Variant>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::Variant::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::Variant>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::dict::Dict> for vortex_array::arrays::dict::Dict
 
-pub fn vortex_array::arrays::dict::Dict::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::dict::Dict>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::dict::Dict::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::dict::Dict>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::null::Null> for vortex_array::arrays::null::Null
 
-pub fn vortex_array::arrays::null::Null::scalar_at(_array: vortex_array::ArrayView<'_, vortex_array::arrays::null::Null>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::null::Null::scalar_at(_array: vortex_array::ArrayView<'_, vortex_array::arrays::null::Null>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::patched::Patched> for vortex_array::arrays::patched::Patched
 
-pub fn vortex_array::arrays::patched::Patched::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::patched::Patched>, index: usize, ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::patched::Patched::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::patched::Patched>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::scalar_fn::ScalarFnVTable> for vortex_array::arrays::scalar_fn::ScalarFnVTable
 
-pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::scalar_fn::ScalarFnVTable>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::scalar_fn::ScalarFnVTable::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::scalar_fn::ScalarFnVTable>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl vortex_array::OperationsVTable<vortex_array::arrays::slice::Slice> for vortex_array::arrays::slice::Slice
 
-pub fn vortex_array::arrays::slice::Slice::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::slice::Slice>, index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::arrays::slice::Slice::scalar_at(array: vortex_array::ArrayView<'_, vortex_array::arrays::slice::Slice>, index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 impl<V: vortex_array::VTable> vortex_array::OperationsVTable<V> for vortex_array::NotSupported
 
-pub fn vortex_array::NotSupported::scalar_at(array: vortex_array::ArrayView<'_, V>, _index: usize, _ctx: &mut vortex_array::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
+pub fn vortex_array::NotSupported::scalar_at(array: vortex_array::ArrayView<'_, V>, _index: usize) -> vortex_error::VortexResult<vortex_array::scalar::Scalar>
 
 pub trait vortex_array::SerializeMetadata
 

--- a/vortex-array/src/array/mod.rs
+++ b/vortex-array/src/array/mod.rs
@@ -17,8 +17,6 @@ use vortex_error::vortex_panic;
 use vortex_session::VortexSession;
 
 use crate::ExecutionCtx;
-use crate::LEGACY_SESSION;
-use crate::VortexSessionExecute;
 use crate::buffer::BufferHandle;
 use crate::builders::ArrayBuilder;
 use crate::dtype::DType;
@@ -220,11 +218,7 @@ impl<V: VTable> DynArray for ArrayInner<V> {
 
     fn scalar_at(&self, this: &ArrayRef, index: usize) -> VortexResult<Scalar> {
         let view = unsafe { ArrayView::new_unchecked(this, &self.data) };
-        <V::OperationsVTable as OperationsVTable<V>>::scalar_at(
-            view,
-            index,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
+        <V::OperationsVTable as OperationsVTable<V>>::scalar_at(view, index)
     }
 
     fn validity(&self, this: &ArrayRef) -> VortexResult<Validity> {

--- a/vortex-array/src/array/vtable/operations.rs
+++ b/vortex-array/src/array/vtable/operations.rs
@@ -4,7 +4,6 @@
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::VTable;
 use crate::scalar::Scalar;
@@ -17,19 +16,11 @@ pub trait OperationsVTable<V: VTable> {
     ///
     /// Bounds-checking has already been performed by the time this function is called,
     /// and the index is guaranteed to be non-null.
-    fn scalar_at(
-        array: ArrayView<'_, V>,
-        index: usize,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar>;
+    fn scalar_at(array: ArrayView<'_, V>, index: usize) -> VortexResult<Scalar>;
 }
 
 impl<V: VTable> OperationsVTable<V> for NotSupported {
-    fn scalar_at(
-        array: ArrayView<'_, V>,
-        _index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, V>, _index: usize) -> VortexResult<Scalar> {
         vortex_bail!(
             "Legacy scalar_at operation is not supported for {} arrays",
             array.encoding_id()

--- a/vortex-array/src/arrays/bool/vtable/operations.rs
+++ b/vortex-array/src/arrays/bool/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::Bool;
@@ -11,11 +10,7 @@ use crate::arrays::bool::BoolArrayExt;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Bool> for Bool {
-    fn scalar_at(
-        array: ArrayView<'_, Bool>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Bool>, index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::bool(
             array.to_bit_buffer().value(index),
             array.dtype().nullability(),

--- a/vortex-array/src/arrays/chunked/vtable/operations.rs
+++ b/vortex-array/src/arrays/chunked/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::Chunked;
@@ -11,11 +10,7 @@ use crate::arrays::chunked::ChunkedArrayExt;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Chunked> for Chunked {
-    fn scalar_at(
-        array: ArrayView<'_, Chunked>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Chunked>, index: usize) -> VortexResult<Scalar> {
         let (chunk_index, chunk_offset) = array.find_chunk_idx(index)?;
         array.chunk(chunk_index).scalar_at(chunk_offset)
     }

--- a/vortex-array/src/arrays/constant/vtable/operations.rs
+++ b/vortex-array/src/arrays/constant/vtable/operations.rs
@@ -3,18 +3,13 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::Constant;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Constant> for Constant {
-    fn scalar_at(
-        array: ArrayView<'_, Constant>,
-        _index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Constant>, _index: usize) -> VortexResult<Scalar> {
         Ok(array.scalar.clone())
     }
 }

--- a/vortex-array/src/arrays/decimal/vtable/operations.rs
+++ b/vortex-array/src/arrays/decimal/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::Decimal;
@@ -12,11 +11,7 @@ use crate::scalar::DecimalValue;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Decimal> for Decimal {
-    fn scalar_at(
-        array: ArrayView<'_, Decimal>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Decimal>, index: usize) -> VortexResult<Scalar> {
         Ok(match_each_decimal_value_type!(array.values_type(), |D| {
             Scalar::decimal(
                 DecimalValue::from(array.buffer::<D>()[index]),

--- a/vortex-array/src/arrays/dict/vtable/operations.rs
+++ b/vortex-array/src/arrays/dict/vtable/operations.rs
@@ -5,18 +5,13 @@ use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
 use super::Dict;
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::dict::DictArraySlotsExt;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Dict> for Dict {
-    fn scalar_at(
-        array: ArrayView<'_, Dict>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Dict>, index: usize) -> VortexResult<Scalar> {
         let Some(dict_index) = array
             .codes()
             .scalar_at(index)?

--- a/vortex-array/src/arrays/extension/vtable/operations.rs
+++ b/vortex-array/src/arrays/extension/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::Extension;
@@ -11,11 +10,7 @@ use crate::arrays::extension::ExtensionArrayExt;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Extension> for Extension {
-    fn scalar_at(
-        array: ArrayView<'_, Extension>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Extension>, index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::extension_ref(
             array.ext_dtype().clone(),
             array.storage_array().scalar_at(index)?,

--- a/vortex-array/src/arrays/filter/vtable.rs
+++ b/vortex-array/src/arrays/filter/vtable.rs
@@ -178,11 +178,7 @@ impl VTable for Filter {
     }
 }
 impl OperationsVTable<Filter> for Filter {
-    fn scalar_at(
-        array: ArrayView<'_, Filter>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Filter>, index: usize) -> VortexResult<Scalar> {
         let rank_idx = array.mask.rank(index);
         array.child().scalar_at(rank_idx)
     }

--- a/vortex-array/src/arrays/fixed_size_list/vtable/operations.rs
+++ b/vortex-array/src/arrays/fixed_size_list/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::FixedSizeList;
@@ -11,11 +10,7 @@ use crate::arrays::fixed_size_list::FixedSizeListArrayExt;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<FixedSizeList> for FixedSizeList {
-    fn scalar_at(
-        array: ArrayView<'_, FixedSizeList>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, FixedSizeList>, index: usize) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
         let list = array.fixed_size_list_elements_at(index)?;
         let children_elements: Vec<Scalar> = (0..list.len())

--- a/vortex-array/src/arrays/list/vtable/operations.rs
+++ b/vortex-array/src/arrays/list/vtable/operations.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::List;
@@ -13,11 +12,7 @@ use crate::arrays::list::ListArrayExt;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<List> for List {
-    fn scalar_at(
-        array: ArrayView<'_, List>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, List>, index: usize) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
         let elems = array.list_elements_at(index)?;
         let scalars: Vec<Scalar> = (0..elems.len())

--- a/vortex-array/src/arrays/listview/vtable/operations.rs
+++ b/vortex-array/src/arrays/listview/vtable/operations.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::ListView;
@@ -13,11 +12,7 @@ use crate::arrays::listview::ListViewArrayExt;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<ListView> for ListView {
-    fn scalar_at(
-        array: ArrayView<'_, ListView>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, ListView>, index: usize) -> VortexResult<Scalar> {
         // By the preconditions we know that the list scalar is not null.
         let list = array.list_elements_at(index)?;
         let children: Vec<Scalar> = (0..list.len())

--- a/vortex-array/src/arrays/masked/vtable/operations.rs
+++ b/vortex-array/src/arrays/masked/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::Masked;
@@ -11,11 +10,7 @@ use crate::arrays::masked::MaskedArrayExt;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Masked> for Masked {
-    fn scalar_at(
-        array: ArrayView<'_, Masked>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Masked>, index: usize) -> VortexResult<Scalar> {
         // Invalid indices are handled by the entrypoint function.
         Ok(array.child().scalar_at(index)?.into_nullable())
     }

--- a/vortex-array/src/arrays/null/mod.rs
+++ b/vortex-array/src/arrays/null/mod.rs
@@ -152,11 +152,7 @@ impl Array<Null> {
 }
 
 impl OperationsVTable<Null> for Null {
-    fn scalar_at(
-        _array: ArrayView<'_, Null>,
-        _index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(_array: ArrayView<'_, Null>, _index: usize) -> VortexResult<Scalar> {
         Ok(Scalar::null(DType::Null))
     }
 }

--- a/vortex-array/src/arrays/patched/vtable/operations.rs
+++ b/vortex-array/src/arrays/patched/vtable/operations.rs
@@ -3,15 +3,12 @@
 
 use vortex_error::VortexResult;
 
-use crate::LEGACY_SESSION;
-use crate::VortexSessionExecute as _;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::patched::Patched;
 use crate::arrays::patched::PatchedArrayExt;
 use crate::arrays::patched::PatchedArraySlotsExt;
-use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Patched> for Patched {
@@ -28,14 +25,18 @@ impl OperationsVTable<Patched> for Patched {
 
         let range = array.lane_range(chunk, lane)?;
 
-        // Get the range of indices corresponding to the lane, potentially decoding them to avoid
-        // the overhead of repeated scalar_at calls.
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        let patch_indices = array
+        // patch_indices is always Primitive after execution (enforced by require_child! in
+        // Patched::execute), and PrimitiveArray::slice returns a PrimitiveArray directly.
+        let patch_indices: PrimitiveArray = array
             .patch_indices()
             .slice(range.clone())?
-            .optimize()?
-            .execute::<PrimitiveArray>(&mut ctx)?;
+            .try_downcast()
+            .map_err(|arr| {
+                vortex_error::vortex_err!(
+                    "Expected PrimitiveArray for patch_indices, got {}",
+                    arr.encoding_id()
+                )
+            })?;
 
         // NOTE: we do linear scan as lane has <= 32 patches, binary search would likely
         //  be slower.

--- a/vortex-array/src/arrays/patched/vtable/operations.rs
+++ b/vortex-array/src/arrays/patched/vtable/operations.rs
@@ -3,7 +3,8 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
+use crate::LEGACY_SESSION;
+use crate::VortexSessionExecute as _;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::PrimitiveArray;
@@ -14,11 +15,7 @@ use crate::optimizer::ArrayOptimizer;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Patched> for Patched {
-    fn scalar_at(
-        array: ArrayView<'_, Patched>,
-        index: usize,
-        ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Patched>, index: usize) -> VortexResult<Scalar> {
         let chunk = (index + array.offset()) / 1024;
 
         #[expect(
@@ -33,11 +30,12 @@ impl OperationsVTable<Patched> for Patched {
 
         // Get the range of indices corresponding to the lane, potentially decoding them to avoid
         // the overhead of repeated scalar_at calls.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patch_indices = array
             .patch_indices()
             .slice(range.clone())?
             .optimize()?
-            .execute::<PrimitiveArray>(ctx)?;
+            .execute::<PrimitiveArray>(&mut ctx)?;
 
         // NOTE: we do linear scan as lane has <= 32 patches, binary search would likely
         //  be slower.

--- a/vortex-array/src/arrays/primitive/vtable/operations.rs
+++ b/vortex-array/src/arrays/primitive/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::Primitive;
@@ -11,11 +10,7 @@ use crate::match_each_native_ptype;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Primitive> for Primitive {
-    fn scalar_at(
-        array: ArrayView<'_, Primitive>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Primitive>, index: usize) -> VortexResult<Scalar> {
         Ok(match_each_native_ptype!(array.ptype(), |T| {
             Scalar::primitive(array.as_slice::<T>()[index], array.dtype().nullability())
         }))

--- a/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
@@ -17,11 +16,7 @@ use crate::scalar::Scalar;
 use crate::scalar_fn::VecExecutionArgs;
 
 impl OperationsVTable<ScalarFnVTable> for ScalarFnVTable {
-    fn scalar_at(
-        array: ArrayView<'_, ScalarFnVTable>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, ScalarFnVTable>, index: usize) -> VortexResult<Scalar> {
         let inputs: Vec<_> = array
             .children()
             .iter()

--- a/vortex-array/src/arrays/shared/vtable.rs
+++ b/vortex-array/src/arrays/shared/vtable.rs
@@ -118,11 +118,7 @@ impl VTable for Shared {
     }
 }
 impl OperationsVTable<Shared> for Shared {
-    fn scalar_at(
-        array: ArrayView<'_, Shared>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Shared>, index: usize) -> VortexResult<Scalar> {
         array.current_array_ref().scalar_at(index)
     }
 }

--- a/vortex-array/src/arrays/slice/vtable.rs
+++ b/vortex-array/src/arrays/slice/vtable.rs
@@ -163,11 +163,7 @@ impl VTable for Slice {
     }
 }
 impl OperationsVTable<Slice> for Slice {
-    fn scalar_at(
-        array: ArrayView<'_, Slice>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Slice>, index: usize) -> VortexResult<Scalar> {
         array.child().scalar_at(array.range.start + index)
     }
 }

--- a/vortex-array/src/arrays/struct_/vtable/operations.rs
+++ b/vortex-array/src/arrays/struct_/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::Struct;
@@ -11,11 +10,7 @@ use crate::arrays::struct_::StructArrayExt;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Struct> for Struct {
-    fn scalar_at(
-        array: ArrayView<'_, Struct>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Struct>, index: usize) -> VortexResult<Scalar> {
         let field_scalars: VortexResult<Vec<Scalar>> = array
             .iter_unmasked_fields()
             .map(|field| field.scalar_at(index))

--- a/vortex-array/src/arrays/varbin/vtable/operations.rs
+++ b/vortex-array/src/arrays/varbin/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::VarBin;
@@ -12,11 +11,7 @@ use crate::arrays::varbin::varbin_scalar;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<VarBin> for VarBin {
-    fn scalar_at(
-        array: ArrayView<'_, VarBin>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, VarBin>, index: usize) -> VortexResult<Scalar> {
         Ok(varbin_scalar(array.bytes_at(index), array.dtype()))
     }
 }

--- a/vortex-array/src/arrays/varbinview/vtable/operations.rs
+++ b/vortex-array/src/arrays/varbinview/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::VarBinView;
@@ -11,11 +10,7 @@ use crate::arrays::varbin::varbin_scalar;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<VarBinView> for VarBinView {
-    fn scalar_at(
-        array: ArrayView<'_, VarBinView>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, VarBinView>, index: usize) -> VortexResult<Scalar> {
         Ok(varbin_scalar(array.bytes_at(index), array.dtype()))
     }
 }

--- a/vortex-array/src/arrays/variant/vtable/operations.rs
+++ b/vortex-array/src/arrays/variant/vtable/operations.rs
@@ -3,7 +3,6 @@
 
 use vortex_error::VortexResult;
 
-use crate::ExecutionCtx;
 use crate::array::ArrayView;
 use crate::array::OperationsVTable;
 use crate::arrays::Variant;
@@ -11,11 +10,7 @@ use crate::arrays::variant::VariantArrayExt;
 use crate::scalar::Scalar;
 
 impl OperationsVTable<Variant> for Variant {
-    fn scalar_at(
-        array: ArrayView<'_, Variant>,
-        index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(array: ArrayView<'_, Variant>, index: usize) -> VortexResult<Scalar> {
         array.child().scalar_at(index)
     }
 }

--- a/vortex-python/src/arrays/py/vtable.rs
+++ b/vortex-python/src/arrays/py/vtable.rs
@@ -124,11 +124,7 @@ impl VTable for PythonVTable {
 }
 
 impl OperationsVTable<PythonVTable> for PythonVTable {
-    fn scalar_at(
-        _array: ArrayView<'_, PythonVTable>,
-        _index: usize,
-        _ctx: &mut ExecutionCtx,
-    ) -> VortexResult<Scalar> {
+    fn scalar_at(_array: ArrayView<'_, PythonVTable>, _index: usize) -> VortexResult<Scalar> {
         todo!()
     }
 }


### PR DESCRIPTION
## Summary

- Removes all usages of `ExecutionCtx` in `scalar_at`

## Profiling

Profiled with [apmc](https://github.com/nickhrsims/apmc). ClickBench, Vortex format, Apple Silicon M4 Max, 3 iterations:

| Metric | Before | After | Delta |
|---|---|---|---|
| Cycles | 1,973.5B | 1,942.6B | **-1.6%** |
| Instructions | 4,730.2B | 4,722.5B | -0.16% |
| IPC | 2.40 | 2.43 | **+1.25%** |
| Wall clock | 43.09s | 41.92s | **-2.7%** |
| Dispatch stalls | 593.7B | 573.9B | **-3.3%** |
| L1D cache misses | 80.7B | 80.6B | ~0% |
| Branch mispredicts | 11.2B | 11.2B | ~0% |