### PR TITLE
Remove getrandom feature flag overrides

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,9 +3,6 @@ rustflags = [
     "-C", "force-frame-pointers=yes",
 ]
 
-[target.wasm32-unknown-unknown]
-rustflags = ['--cfg', 'getrandom_backend="wasm_js"', '-C', 'target-feature=+atomics']
-
 [alias]
 xtask = "run -p xtask --"
 vx = "run -p vortex-tui --"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
             runner: amd64-medium
             target: wasm32-unknown-unknown
             env:
-              rustflags: "RUSTFLAGS='-A warnings'"
+              rustflags: "RUSTFLAGS='-A warnings --cfg getrandom_backend=\"unsupported\"'"
             args: "--target wasm32-unknown-unknown --exclude vortex --exclude vortex-cuda --exclude vortex-cub --exclude vortex-nvcomp --exclude vortex-datafusion --exclude vortex-duckdb --exclude vortex-tui --exclude vortex-zstd --exclude vortex-test-e2e-cuda --exclude vortex-sqllogictest"
     steps:
       - uses: runs-on/action@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10129,7 +10129,6 @@ dependencies = [
  "enum-iterator",
  "flatbuffers",
  "futures",
- "getrandom 0.4.2",
  "goldenfile",
  "half",
  "humansize",
@@ -10228,7 +10227,6 @@ name = "vortex-btrblocks"
 version = "0.1.0"
 dependencies = [
  "codspeed-divan-compat",
- "getrandom 0.4.2",
  "itertools 0.14.0",
  "num-traits",
  "pco",
@@ -10553,7 +10551,6 @@ dependencies = [
  "bytes",
  "flatbuffers",
  "futures",
- "getrandom 0.4.2",
  "itertools 0.14.0",
  "kanal",
  "moka",
@@ -10563,7 +10560,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
- "uuid",
  "vortex-alp",
  "vortex-array",
  "vortex-btrblocks",
@@ -10653,7 +10649,6 @@ dependencies = [
  "bytes",
  "custom-labels",
  "futures",
- "getrandom 0.4.2",
  "glob",
  "handle",
  "itertools 0.14.0",
@@ -10770,7 +10765,6 @@ dependencies = [
 name = "vortex-metrics"
 version = "0.1.0"
 dependencies = [
- "getrandom 0.4.2",
  "parking_lot",
  "sketches-ddsketch 0.4.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,11 +302,6 @@ vortex-duckdb = { path = "./vortex-duckdb", default-features = false }
 vortex-test-e2e-cuda = { path = "./vortex-test/e2e-cuda", default-features = false }
 vortex-tui = { path = "./vortex-tui" }
 
-[workspace.dependencies.getrandom_v03]
-features = ["wasm_js"]
-package = "getrandom"
-version = "0.4.0"
-
 [workspace.lints.rust]
 let_underscore_drop = "deny"
 macro_use_extern_crate = "deny"

--- a/encodings/parquet-variant/Cargo.toml
+++ b/encodings/parquet-variant/Cargo.toml
@@ -36,5 +36,3 @@ vortex-session = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }
 
-[package.metadata.cargo-machete]
-ignored = ["getrandom_v03"]

--- a/encodings/pco/Cargo.toml
+++ b/encodings/pco/Cargo.toml
@@ -29,5 +29,3 @@ vortex-session = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }
 
-[package.metadata.cargo-machete]
-ignored = ["getrandom_v03"]

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -38,7 +38,6 @@ cudarc = { workspace = true, optional = true }
 enum-iterator = { workspace = true }
 flatbuffers = { workspace = true }
 futures = { workspace = true, features = ["alloc", "async-await", "std"] }
-getrandom_v03 = { workspace = true }
 goldenfile = { workspace = true, optional = true }
 half = { workspace = true, features = ["num-traits"] }
 humansize = { workspace = true }
@@ -185,5 +184,3 @@ harness = false
 name = "listview_rebuild"
 harness = false
 
-[package.metadata.cargo-machete]
-ignored = ["getrandom_v03"]

--- a/vortex-array/Cargo.toml
+++ b/vortex-array/Cargo.toml
@@ -183,4 +183,3 @@ harness = false
 [[bench]]
 name = "listview_rebuild"
 harness = false
-

--- a/vortex-btrblocks/Cargo.toml
+++ b/vortex-btrblocks/Cargo.toml
@@ -63,4 +63,3 @@ test = false
 name = "compress_listview"
 harness = false
 test = false
-

--- a/vortex-btrblocks/Cargo.toml
+++ b/vortex-btrblocks/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
-getrandom_v03 = { workspace = true }
 itertools = { workspace = true }
 num-traits = { workspace = true }
 pco = { workspace = true, optional = true }
@@ -65,5 +64,3 @@ name = "compress_listview"
 harness = false
 test = false
 
-[package.metadata.cargo-machete]
-ignored = ["getrandom_v03"]

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -82,4 +82,3 @@ unstable_encodings = [
     "vortex-zstd?/unstable_encodings",
     "vortex-btrblocks/unstable_encodings",
 ]
-

--- a/vortex-file/Cargo.toml
+++ b/vortex-file/Cargo.toml
@@ -21,7 +21,6 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 flatbuffers = { workspace = true }
 futures = { workspace = true, features = ["std", "async-await"] }
-getrandom_v03 = { workspace = true }                              # Needed to pickup the "wasm_js" feature for wasm targets from the workspace configuration
 itertools = { workspace = true }
 kanal = { workspace = true }
 moka = { workspace = true, features = ["sync"] }
@@ -31,7 +30,6 @@ parking_lot = { workspace = true }
 pin-project-lite = { workspace = true }
 tokio = { workspace = true, features = ["rt"], optional = true }
 tracing = { workspace = true }
-uuid = { workspace = true }                                       # Needed to pickup the "js" feature for wasm targets from the workspace configuration
 vortex-alp = { workspace = true }
 vortex-array = { workspace = true }
 vortex-btrblocks = { workspace = true }
@@ -85,5 +83,3 @@ unstable_encodings = [
     "vortex-btrblocks/unstable_encodings",
 ]
 
-[package.metadata.cargo-machete]
-ignored = ["getrandom_v03", "uuid"]

--- a/vortex-io/Cargo.toml
+++ b/vortex-io/Cargo.toml
@@ -22,7 +22,6 @@ async-stream = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 futures = { workspace = true, features = ["std", "executor"] }
-getrandom_v03 = { workspace = true } # Needed to pickup the "wasm_js" feature for wasm targets from the workspace configuration
 glob = { workspace = true }
 handle = "1.0.2"
 kanal = { workspace = true }
@@ -68,5 +67,3 @@ tokio = ["tokio/fs", "tokio/rt-multi-thread"]
 [lints]
 workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["getrandom_v03"]

--- a/vortex-io/Cargo.toml
+++ b/vortex-io/Cargo.toml
@@ -66,4 +66,3 @@ tokio = ["tokio/fs", "tokio/rt-multi-thread"]
 
 [lints]
 workspace = true
-

--- a/vortex-metrics/Cargo.toml
+++ b/vortex-metrics/Cargo.toml
@@ -19,4 +19,3 @@ sketches-ddsketch = { workspace = true }
 
 [lints]
 workspace = true
-

--- a/vortex-metrics/Cargo.toml
+++ b/vortex-metrics/Cargo.toml
@@ -14,12 +14,9 @@ rust-version = { workspace = true }
 version = { workspace = true }
 
 [dependencies]
-getrandom_v03 = { workspace = true }
 parking_lot = { workspace = true }
 sketches-ddsketch = { workspace = true }
 
 [lints]
 workspace = true
 
-[package.metadata.cargo-machete]
-ignored = ["getrandom_v03"]


### PR DESCRIPTION
These have been required at some point in our codebase to get getrandom v0.2 and
v0.3 to coexsit in wasm setup. However, the world has moved from getrandom v0.2
and override situation is not as complicated anymore. It seems we can wholesale
remove these overrides that we kept around for way too long.

fix #7382

Signed-off-by: Robert Kruszewski <github@robertk.io>
