### PR TITLE
fix[vortex-array]: avoid unnecessary checks in check_listview_constant

### DIFF
--- a/vortex-array/src/aggregate_fn/fns/is_constant/list.rs
+++ b/vortex-array/src/aggregate_fn/fns/is_constant/list.rs
@@ -4,6 +4,7 @@
 use vortex_error::VortexResult;
 
 use super::arrays_value_equal;
+use super::is_constant;
 use crate::ExecutionCtx;
 use crate::arrays::ListViewArray;
 use crate::arrays::listview::ListViewArrayExt;
@@ -20,16 +21,24 @@ pub(super) fn check_listview_constant(
         return Ok(true);
     }
 
-    let first_size = l.size_at(0);
-    let first_elements = l.list_elements_at(0)?;
+    if !is_constant(l.sizes(), ctx)? {
+        // If sizes aren't all equal, can't be constant.
+        return Ok(false);
+    }
 
+    let first_size = l.size_at(0);
+    if first_size == 0 {
+        return Ok(true);
+    }
+
+    if is_constant(l.offsets(), ctx)? {
+        // If all offsets are identical, every list references the same slice.
+        return Ok(true);
+    }
+
+    // Check each list individually, this can be expensive.
+    let first_elements = l.list_elements_at(0)?;
     for i in 1..l.len() {
-        if l.size_at(i) != first_size {
-            return Ok(false);
-        }
-        if first_size == 0 {
-            continue;
-        }
         let current_elements = l.list_elements_at(i)?;
         if !arrays_value_equal(&first_elements, &current_elements, ctx)? {
             return Ok(false);


### PR DESCRIPTION
## Summary

ListView sizes are checked on each element iteration. This can cause unecessary calls to arrays_value_equal if most but not all sizes are equal. This commit pulls up some fast checks we can do before executing the expensive arrays_value_equal loop. Concretely, only execute the loop if all sizes are equal *and* non-zero *and* offsets are not all equal, since the inverse is trivially constant.

[Profile link here, we're seeing that this check is expensive](https://pprof.me/39a57fd47bacf99f6669aa6ba5beed31/?profile_filters=p%3Ahide_libc%3AHide%2520libc%2Cp%3Ahide_tokio_frames%3AHide%2520Tokio%2520Frames%2Cp%3Ahide_rust_futures%3AHide%2520Rust%2520Futures%2520Infrastructure%2Cp%3Ahide_rust_panic_backtrace%3AHide%2520Rust%2520Panic%2520Backtrace%2520Infrastructure)

<!--
Thank you for submitting a pull request! We appreciate your time and effort.

Please make sure to provide enough information so that we can review your pull
request. The Summary and Testing sections below contain guidance on what to
include.
-->

<!--
If this PR is related to a tracked effort, please link to the relevant issue
here (e.g., `Closes: #123`). Otherwise, feel free to ignore / delete this.

In this section, please:

1. Explain the rationale for this change.
2. Summarize the changes included in this PR.

A general rule of thumb is that larger PRs should have larger summaries. If
there are a lot of changes, please help us review the code by explaining what
was changed and why.

If there is an issue or discussion attached, there is no need to duplicate all
the details, but clarity is always preferred over brevity.
-->

Closes: #000

<!--
## API Changes

Uncomment this section if there are any user-facing changes.

Consider whether the change affects users in one of the following ways:

1. Breaks public APIs in some way.
2. Changes the underlying behavior of one of the engine integrations.
3. Should some documentation be updated to reflect this change?

If a public API is changed in a breaking manner, make sure to add the
appropriate label. You can run `./scripts/public-api.sh` locally to see if there
are any public API changes (and this also runs in our CI).
-->

## Testing

<!--
Please describe how this change was tested. Here are some common categories for
testing in Vortex:

1. Verifying existing behavior is maintained.
2. Verifying new behavior and functionality works correctly.
3. Serialization compatibility (backwards and forwards) should be maintained or
   explicitly broken.
-->
