### PR TITLE
fix check for ArrayPlugin encoding ID on deserialize

### DIFF
--- a/encodings/fastlanes/src/bitpacking/plugin.rs
+++ b/encodings/fastlanes/src/bitpacking/plugin.rs
@@ -83,7 +83,7 @@ impl ArrayPlugin for BitPackedPatchedPlugin {
         Ok(patched.into_array())
     }
 
-    fn supported_encoding(&self, id: &ArrayId) -> bool {
+    fn is_supported_encoding(&self, id: &ArrayId) -> bool {
         id == &BitPacked::ID || id == &Patched.id()
     }
 }

--- a/encodings/fastlanes/src/bitpacking/plugin.rs
+++ b/encodings/fastlanes/src/bitpacking/plugin.rs
@@ -82,6 +82,10 @@ impl ArrayPlugin for BitPackedPatchedPlugin {
 
         Ok(patched.into_array())
     }
+
+    fn supported_encoding(&self, id: &ArrayId) -> bool {
+        id == &BitPacked::ID || id == &Patched.id()
+    }
 }
 
 #[cfg(test)]

--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -19412,6 +19412,8 @@ pub fn vortex_array::vtable::ArrayPlugin::deserialize(&self, dtype: &vortex_arra
 
 pub fn vortex_array::vtable::ArrayPlugin::id(&self) -> vortex_array::ArrayId
 
+pub fn vortex_array::vtable::ArrayPlugin::is_supported_encoding(&self, id: &vortex_array::ArrayId) -> bool
+
 pub fn vortex_array::vtable::ArrayPlugin::serialize(&self, array: &vortex_array::ArrayRef, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 impl<V: vortex_array::VTable> vortex_array::ArrayPlugin for V
@@ -19419,6 +19421,8 @@ impl<V: vortex_array::VTable> vortex_array::ArrayPlugin for V
 pub fn V::deserialize(&self, dtype: &vortex_array::dtype::DType, len: usize, metadata: &[u8], buffers: &[vortex_array::buffer::BufferHandle], children: &dyn vortex_array::serde::ArrayChildren, session: &vortex_session::VortexSession) -> core::result::Result<vortex_array::ArrayRef, vortex_error::VortexError>
 
 pub fn V::id(&self) -> arcref::ArcRef<str>
+
+pub fn V::is_supported_encoding(&self, id: &vortex_array::ArrayId) -> bool
 
 pub fn V::serialize(&self, array: &vortex_array::ArrayRef, session: &vortex_session::VortexSession) -> core::result::Result<core::option::Option<alloc::vec::Vec<u8>>, vortex_error::VortexError>
 
@@ -23056,6 +23060,10 @@ pub fn vortex_array::ArrayPlugin::id(&self) -> vortex_array::ArrayId
 
 pub fn vortex_array::ArrayPlugin::id(&self) -> vortex_array::ArrayId
 
+pub fn vortex_array::ArrayPlugin::is_supported_encoding(&self, id: &vortex_array::ArrayId) -> bool
+
+pub fn vortex_array::ArrayPlugin::is_supported_encoding(&self, id: &vortex_array::ArrayId) -> bool
+
 pub fn vortex_array::ArrayPlugin::serialize(&self, array: &vortex_array::ArrayRef, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
 
 pub fn vortex_array::ArrayPlugin::serialize(&self, array: &vortex_array::ArrayRef, session: &vortex_session::VortexSession) -> vortex_error::VortexResult<core::option::Option<alloc::vec::Vec<u8>>>
@@ -23071,6 +23079,10 @@ pub fn V::deserialize(&self, dtype: &vortex_array::dtype::DType, len: usize, met
 pub fn V::id(&self) -> arcref::ArcRef<str>
 
 pub fn V::id(&self) -> arcref::ArcRef<str>
+
+pub fn V::is_supported_encoding(&self, id: &vortex_array::ArrayId) -> bool
+
+pub fn V::is_supported_encoding(&self, id: &vortex_array::ArrayId) -> bool
 
 pub fn V::serialize(&self, array: &vortex_array::ArrayRef, session: &vortex_session::VortexSession) -> core::result::Result<core::option::Option<alloc::vec::Vec<u8>>, vortex_error::VortexError>
 

--- a/vortex-array/src/array/plugin.rs
+++ b/vortex-array/src/array/plugin.rs
@@ -27,6 +27,9 @@ pub type ArrayPluginRef = Arc<dyn ArrayPlugin>;
 /// [`deserialize`]: ArrayPlugin::deserialize
 pub trait ArrayPlugin: 'static + Send + Sync {
     /// Returns the ID for this array encoding.
+    ///
+    /// During serde, this is the key the registry uses to find
+    /// this plugin instance call the appropriate method on it.
     fn id(&self) -> ArrayId;
 
     /// Serialize the array metadata.
@@ -49,6 +52,14 @@ pub trait ArrayPlugin: 'static + Send + Sync {
         children: &dyn ArrayChildren,
         session: &VortexSession,
     ) -> VortexResult<ArrayRef>;
+
+    /// Can this plugin emit an array with the given encoding.
+    ///
+    /// By default, this is just the [ID][Self::id] of the plugin, but
+    /// can be overridden if this plugin instance supports reading/writing multiple arrays.
+    fn supported_encoding(&self, id: &ArrayId) -> bool {
+        self.id() == *id
+    }
 }
 
 impl std::fmt::Debug for dyn ArrayPlugin {

--- a/vortex-array/src/array/plugin.rs
+++ b/vortex-array/src/array/plugin.rs
@@ -57,7 +57,7 @@ pub trait ArrayPlugin: 'static + Send + Sync {
     ///
     /// By default, this is just the [ID][Self::id] of the plugin, but
     /// can be overridden if this plugin instance supports reading/writing multiple arrays.
-    fn supported_encoding(&self, id: &ArrayId) -> bool {
+    fn is_supported_encoding(&self, id: &ArrayId) -> bool {
         self.id() == *id
     }
 }

--- a/vortex-array/src/array/plugin.rs
+++ b/vortex-array/src/array/plugin.rs
@@ -29,7 +29,7 @@ pub trait ArrayPlugin: 'static + Send + Sync {
     /// Returns the ID for this array encoding.
     ///
     /// During serde, this is the key the registry uses to find
-    /// this plugin instance call the appropriate method on it.
+    /// this plugin instance and call the appropriate method on it.
     fn id(&self) -> ArrayId;
 
     /// Serialize the array metadata.

--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -369,7 +369,7 @@ impl SerializedArray {
         );
 
         assert!(
-            plugin.supported_encoding(&decoded.encoding_id()),
+            plugin.is_supported_encoding(&decoded.encoding_id()),
             "Array decoded from {} has incorrect encoding {}",
             encoding_id,
             decoded.encoding_id(),

--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -367,13 +367,6 @@ impl SerializedArray {
             decoded.dtype(),
             dtype,
         );
-        assert_eq!(
-            decoded.encoding_id(),
-            encoding_id,
-            "Array decoded from {} has incorrect encoding {}",
-            encoding_id,
-            decoded.encoding_id(),
-        );
 
         // Populate statistics from the serialized array.
         if let Some(stats) = self.flatbuffer().stats() {

--- a/vortex-array/src/serde.rs
+++ b/vortex-array/src/serde.rs
@@ -368,6 +368,13 @@ impl SerializedArray {
             dtype,
         );
 
+        assert!(
+            plugin.supported_encoding(&decoded.encoding_id()),
+            "Array decoded from {} has incorrect encoding {}",
+            encoding_id,
+            decoded.encoding_id(),
+        );
+
         // Populate statistics from the serialized array.
         if let Some(stats) = self.flatbuffer().stats() {
             decoded


### PR DESCRIPTION
## Summary

When deserializing an array encoded using the experimental patched encoding `ArrayPlugin`, reads can fail b/c of this assertion.

This adds a method `is_supported_encoding` that lets `ArrayPlugin` indicate support for multiple codecs, rather than just one. The default impl for the VTable is to just check the builtin supported encodings.

the BitPackPatched plugin reports support for both vortex.patched and fastlanes.bitpacked