### PR TITLE
feat[gpu]: dyn dispatch patches infrastructure

### DIFF
--- a/vortex-cuda/kernels/src/dynamic_dispatch.cu
+++ b/vortex-cuda/kernels/src/dynamic_dispatch.cu
@@ -195,9 +195,7 @@ template <typename T>
 __device__ inline GPUPatches unpack_source_patches(uint64_t patches_ptr,
                                                     uint32_t stage_len,
                                                     uint32_t element_offset) {
-    if (patches_ptr == 0) {
-        return { nullptr, nullptr, nullptr };
-    }
+    static_assert((sizeof(T) & (sizeof(T) - 1)) == 0, "sizeof(T) must be a power of two");
     uint8_t *base = reinterpret_cast<uint8_t *>(patches_ptr);
     constexpr uint32_t FL_CHUNK = 1024;
     constexpr uint32_t N_LANES = (sizeof(T) < 8) ? 32 : 16;

--- a/vortex-cuda/kernels/src/dynamic_dispatch.cu
+++ b/vortex-cuda/kernels/src/dynamic_dispatch.cu
@@ -192,9 +192,8 @@ __device__ inline void bitunpack(const T *__restrict packed,
 /// The packed layout is: [lane_offsets (uint32 × lo_count)] [indices (uint16 × num_patches)]
 /// [values (T × num_patches, aligned)].  Returns null pointers when patches_ptr == 0.
 template <typename T>
-__device__ inline GPUPatches unpack_source_patches(uint64_t patches_ptr,
-                                                    uint32_t stage_len,
-                                                    uint32_t element_offset) {
+__device__ inline GPUPatches
+unpack_source_patches(uint64_t patches_ptr, uint32_t stage_len, uint32_t element_offset) {
     static_assert((sizeof(T) & (sizeof(T) - 1)) == 0, "sizeof(T) must be a power of two");
     uint8_t *base = reinterpret_cast<uint8_t *>(patches_ptr);
     constexpr uint32_t FL_CHUNK = 1024;
@@ -208,17 +207,17 @@ __device__ inline GPUPatches unpack_source_patches(uint64_t patches_ptr,
     uint32_t values_byte_start = indices_byte_start + num_patches * sizeof(uint16_t);
     values_byte_start = (values_byte_start + sizeof(T) - 1) & ~(sizeof(T) - 1);
     void *values = base + values_byte_start;
-    return { lane_offsets, indices, values };
+    return {lane_offsets, indices, values};
 }
 
 /// Apply source patches for a single FL chunk (used in the output stage).
 /// Overwrites patched positions in `scratch` and issues __syncthreads().
 template <typename T>
 __device__ inline void apply_source_patches_chunk(uint64_t patches_ptr,
-                                                   T *__restrict scratch,
-                                                   uint32_t stage_len,
-                                                   uint32_t element_offset,
-                                                   uint32_t fl_chunk) {
+                                                  T *__restrict scratch,
+                                                  uint32_t stage_len,
+                                                  uint32_t element_offset,
+                                                  uint32_t fl_chunk) {
     const GPUPatches patches = unpack_source_patches<T>(patches_ptr, stage_len, element_offset);
     constexpr uint32_t N_LANES = (sizeof(T) < 8) ? 32 : 16;
     for (uint32_t lane = threadIdx.x; lane < N_LANES; lane += blockDim.x) {
@@ -236,9 +235,9 @@ __device__ inline void apply_source_patches_chunk(uint64_t patches_ptr,
 /// Overwrites patched positions in `smem_out` and issues __syncthreads().
 template <typename T>
 __device__ inline void apply_source_patches_all(uint64_t patches_ptr,
-                                                 T *__restrict smem_out,
-                                                 uint32_t stage_len,
-                                                 uint32_t element_offset) {
+                                                T *__restrict smem_out,
+                                                uint32_t stage_len,
+                                                uint32_t element_offset) {
     const GPUPatches patches = unpack_source_patches<T>(patches_ptr, stage_len, element_offset);
     constexpr uint32_t FL_CHUNK = 1024;
     constexpr uint32_t N_LANES = (sizeof(T) < 8) ? 32 : 16;
@@ -397,8 +396,11 @@ __device__ void execute_output_stage(T *__restrict output,
             if (stage.patches_ptr != 0) {
                 const uint32_t fl_chunk = static_cast<uint32_t>(
                     (block_start + elem_idx + src.params.bitunpack.element_offset) / 1024);
-                apply_source_patches_chunk<T>(stage.patches_ptr, scratch,
-                                              stage.len, src.params.bitunpack.element_offset, fl_chunk);
+                apply_source_patches_chunk<T>(stage.patches_ptr,
+                                              scratch,
+                                              stage.len,
+                                              src.params.bitunpack.element_offset,
+                                              fl_chunk);
             }
         } else {
             chunk_len = block_len;
@@ -482,7 +484,8 @@ __device__ void execute_input_stage(const Stage &stage, char *__restrict smem) {
 
         // Merge source patches into the decoded smem region.
         if (stage.patches_ptr != 0) {
-            apply_source_patches_all<T>(stage.patches_ptr, raw_smem,
+            apply_source_patches_all<T>(stage.patches_ptr,
+                                        raw_smem,
                                         stage.len,
                                         src.params.bitunpack.element_offset);
         }

--- a/vortex-cuda/kernels/src/dynamic_dispatch.cu
+++ b/vortex-cuda/kernels/src/dynamic_dispatch.cu
@@ -52,6 +52,7 @@
 
 #include "bit_unpack.cuh"
 #include "dynamic_dispatch.h"
+#include "patches.cuh"
 #include "types.cuh"
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -181,6 +182,82 @@ __device__ inline void bitunpack(const T *__restrict packed,
             bit_unpack_lane<T>(src_chunk, chunk_dst, 0, lane, bw);
         }
     }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Source-patch helpers
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Reconstruct a GPUPatches struct from a packed device pointer.
+/// The packed layout is: [lane_offsets (uint32 × lo_count)] [indices (uint16 × num_patches)]
+/// [values (T × num_patches, aligned)].  Returns null pointers when patches_ptr == 0.
+template <typename T>
+__device__ inline GPUPatches unpack_source_patches(uint64_t patches_ptr,
+                                                    uint32_t stage_len,
+                                                    uint32_t element_offset) {
+    if (patches_ptr == 0) {
+        return { nullptr, nullptr, nullptr };
+    }
+    uint8_t *base = reinterpret_cast<uint8_t *>(patches_ptr);
+    constexpr uint32_t FL_CHUNK = 1024;
+    constexpr uint32_t N_LANES = (sizeof(T) < 8) ? 32 : 16;
+    const uint32_t n_chunks = (stage_len + (element_offset % FL_CHUNK) + FL_CHUNK - 1) / FL_CHUNK;
+    const uint32_t lo_count = n_chunks * N_LANES + 1;
+    uint32_t *lane_offsets = reinterpret_cast<uint32_t *>(base);
+    const uint32_t num_patches = lane_offsets[lo_count - 1];
+    const uint32_t indices_byte_start = lo_count * sizeof(uint32_t);
+    uint16_t *indices = reinterpret_cast<uint16_t *>(base + indices_byte_start);
+    uint32_t values_byte_start = indices_byte_start + num_patches * sizeof(uint16_t);
+    values_byte_start = (values_byte_start + sizeof(T) - 1) & ~(sizeof(T) - 1);
+    void *values = base + values_byte_start;
+    return { lane_offsets, indices, values };
+}
+
+/// Apply source patches for a single FL chunk (used in the output stage).
+/// Overwrites patched positions in `scratch` and issues __syncthreads().
+template <typename T>
+__device__ inline void apply_source_patches_chunk(uint64_t patches_ptr,
+                                                   T *__restrict scratch,
+                                                   uint32_t stage_len,
+                                                   uint32_t element_offset,
+                                                   uint32_t fl_chunk) {
+    const GPUPatches patches = unpack_source_patches<T>(patches_ptr, stage_len, element_offset);
+    constexpr uint32_t N_LANES = (sizeof(T) < 8) ? 32 : 16;
+    for (uint32_t lane = threadIdx.x; lane < N_LANES; lane += blockDim.x) {
+        PatchesCursor<T> cursor(patches, fl_chunk, lane, N_LANES);
+        auto p = cursor.next();
+        while (p.index != 1024) {
+            scratch[p.index] = p.value;
+            p = cursor.next();
+        }
+    }
+    __syncthreads();
+}
+
+/// Apply source patches for all FL chunks (used in the input stage).
+/// Overwrites patched positions in `smem_out` and issues __syncthreads().
+template <typename T>
+__device__ inline void apply_source_patches_all(uint64_t patches_ptr,
+                                                 T *__restrict smem_out,
+                                                 uint32_t stage_len,
+                                                 uint32_t element_offset) {
+    const GPUPatches patches = unpack_source_patches<T>(patches_ptr, stage_len, element_offset);
+    constexpr uint32_t FL_CHUNK = 1024;
+    constexpr uint32_t N_LANES = (sizeof(T) < 8) ? 32 : 16;
+    const uint32_t first_chunk = element_offset / FL_CHUNK;
+    const uint32_t n_chunks = (stage_len + (element_offset % FL_CHUNK) + FL_CHUNK - 1) / FL_CHUNK;
+    for (uint32_t c = 0; c < n_chunks; ++c) {
+        T *chunk_base = smem_out + c * FL_CHUNK;
+        for (uint32_t lane = threadIdx.x; lane < N_LANES; lane += blockDim.x) {
+            PatchesCursor<T> cursor(patches, first_chunk + c, lane, N_LANES);
+            auto p = cursor.next();
+            while (p.index != 1024) {
+                chunk_base[p.index] = p.value;
+                p = cursor.next();
+            }
+        }
+    }
+    __syncthreads();
 }
 
 /// Read N values from a source op into `out`.
@@ -317,6 +394,14 @@ __device__ void execute_output_stage(T *__restrict output,
             smem_src = scratch + align;
             // Write barrier: all threads finished bitunpack, safe to read from scratch.
             __syncthreads();
+
+            // Merge source patches for this FL chunk into smem scratch.
+            if (stage.patches_ptr != 0) {
+                const uint32_t fl_chunk = static_cast<uint32_t>(
+                    (block_start + elem_idx + src.params.bitunpack.element_offset) / 1024);
+                apply_source_patches_chunk<T>(stage.patches_ptr, scratch,
+                                              stage.len, src.params.bitunpack.element_offset, fl_chunk);
+            }
         } else {
             chunk_len = block_len;
         }
@@ -391,11 +476,20 @@ __device__ void execute_input_stage(const Stage &stage, char *__restrict smem) {
     const auto &src = stage.source;
 
     if (src.op_code == SourceOp::BITUNPACK) {
+        T *raw_smem = smem_out;
         bitunpack<T>(reinterpret_cast<const T *>(stage.input_ptr), smem_out, 0, stage.len, src);
-        smem_out += src.params.bitunpack.element_offset % SMEM_TILE_SIZE;
         // Write barrier: cooperative bitunpack finished, safe to read
         // decoded elements in the scalar-op loop below.
         __syncthreads();
+
+        // Merge source patches into the decoded smem region.
+        if (stage.patches_ptr != 0) {
+            apply_source_patches_all<T>(stage.patches_ptr, raw_smem,
+                                        stage.len,
+                                        src.params.bitunpack.element_offset);
+        }
+
+        smem_out += src.params.bitunpack.element_offset % SMEM_TILE_SIZE;
 
         if (stage.num_scalar_ops > 0) {
             for (uint32_t i = threadIdx.x; i < stage.len; i += blockDim.x) {

--- a/vortex-cuda/kernels/src/dynamic_dispatch.h
+++ b/vortex-cuda/kernels/src/dynamic_dispatch.h
@@ -227,7 +227,7 @@ struct Stage {
     uint16_t smem_byte_offset;         // byte offset within dynamic shared memory
     enum PTypeTag source_ptype;        // PType produced by the source op
     uint8_t num_scalar_ops;            // number of scalar ops
-    struct SourceOp source;            // source decode op (packed, align 1)
+    struct SourceOp source;            // source decode op
 };
 
 /// Parse a single stage from the packed plan byte buffer and advance the cursor.

--- a/vortex-cuda/kernels/src/dynamic_dispatch.h
+++ b/vortex-cuda/kernels/src/dynamic_dispatch.h
@@ -188,8 +188,8 @@ struct ScalarOp {
 /// `smem_byte_offset` is a byte offset into the dynamic shared memory
 /// pool so that stages with different element widths can coexist.
 struct PackedStage {
-    uint64_t input_ptr;        // global memory pointer to this stage's encoded input
-    uint64_t patches_ptr;      // device ptr to packed source patches (0 = none)
+    uint64_t input_ptr;   // global memory pointer to this stage's encoded input
+    uint64_t patches_ptr; // device ptr to packed source patches (0 = none)
     struct SourceOp source;
     uint32_t len;              // number of elements this stage produces
     uint16_t smem_byte_offset; // byte offset within dynamic shared memory for output

--- a/vortex-cuda/kernels/src/dynamic_dispatch.h
+++ b/vortex-cuda/kernels/src/dynamic_dispatch.h
@@ -195,6 +195,7 @@ struct PackedStage {
     struct SourceOp source;
     uint8_t num_scalar_ops;
     enum PTypeTag source_ptype; // PType produced by the source op
+    uint64_t patches_ptr;       // device ptr to packed source patches (0 = none)
 };
 
 /// Header for the packed plan byte buffer.
@@ -227,6 +228,7 @@ struct Stage {
     struct SourceOp source;            // source decode op
     uint8_t num_scalar_ops;            // number of scalar ops
     const struct ScalarOp *scalar_ops; // scalar decode ops
+    uint64_t patches_ptr;              // device ptr to packed source patches (0 = none)
 };
 
 /// Parse a single stage from the packed plan byte buffer and advance the cursor.
@@ -249,6 +251,7 @@ __device__ inline Stage parse_stage(const uint8_t *&cursor) {
         .source = packed_stage->source,
         .num_scalar_ops = packed_stage->num_scalar_ops,
         .scalar_ops = ops,
+        .patches_ptr = packed_stage->patches_ptr,
     };
 }
 

--- a/vortex-cuda/kernels/src/dynamic_dispatch.h
+++ b/vortex-cuda/kernels/src/dynamic_dispatch.h
@@ -107,7 +107,7 @@ union SourceParams {
     /// Unpack FastLanes bit-packed data.
     struct BitunpackParams {
         uint8_t bit_width;
-        uint32_t element_offset; // Sub-byte offset
+        uint16_t element_offset; // Sub-block offset (0..1023)
     } bitunpack;
 
     /// Copy from global to shared memory.
@@ -120,10 +120,10 @@ union SourceParams {
     /// The smem offsets are byte offsets so that ends and values can have
     /// different element widths.
     struct RunEndParams {
-        uint32_t ends_smem_byte_offset;   // byte offset to decoded ends in smem
-        uint32_t values_smem_byte_offset; // byte offset to decoded values in smem
-        uint64_t num_runs;
-        uint64_t offset; // slice offset into the run-end encoded array
+        uint16_t ends_smem_byte_offset;   // byte offset to decoded ends in smem
+        uint16_t values_smem_byte_offset; // byte offset to decoded values in smem
+        uint32_t num_runs;
+        uint32_t offset; // slice offset into the run-end encoded array
     } runend;
 
     /// Generate a linear sequence: `value[i] = base + i * multiplier`.
@@ -134,8 +134,8 @@ union SourceParams {
 };
 
 struct SourceOp {
-    enum SourceOpCode { BITUNPACK, LOAD, RUNEND, SEQUENCE } op_code;
     union SourceParams params;
+    enum SourceOpCode : uint8_t { BITUNPACK, LOAD, RUNEND, SEQUENCE } op_code;
 };
 
 /// Scalar ops: element-wise transforms in registers.
@@ -166,17 +166,17 @@ union ScalarParams {
     /// `output_ptype` (on the enclosing ScalarOp) to determine the values'
     /// element type.
     struct DictParams {
-        uint32_t values_smem_byte_offset; // byte offset to decoded dict values in smem
+        uint16_t values_smem_byte_offset; // byte offset to decoded dict values in smem
     } dict;
 };
 
 struct ScalarOp {
-    enum ScalarOpCode { FOR, ZIGZAG, ALP, DICT } op_code;
+    union ScalarParams params;
+    enum ScalarOpCode : uint8_t { FOR, ZIGZAG, ALP, DICT } op_code;
     /// The PType this op produces. For type-preserving ops (FOR, ZIGZAG)
     /// this equals the input PType. For type-changing ops (ALP, DICT) this
     /// is the new output PType.
     enum PTypeTag output_ptype;
-    union ScalarParams params;
 };
 
 /// Packed stage header, followed by `num_scalar_ops` inline ScalarOps.
@@ -189,13 +189,12 @@ struct ScalarOp {
 /// pool so that stages with different element widths can coexist.
 struct PackedStage {
     uint64_t input_ptr;        // global memory pointer to this stage's encoded input
-    uint32_t smem_byte_offset; // byte offset within dynamic shared memory for output
-    uint32_t len;              // number of elements this stage produces
-
+    uint64_t patches_ptr;      // device ptr to packed source patches (0 = none)
     struct SourceOp source;
+    uint32_t len;              // number of elements this stage produces
+    uint16_t smem_byte_offset; // byte offset within dynamic shared memory for output
     uint8_t num_scalar_ops;
     enum PTypeTag source_ptype; // PType produced by the source op
-    uint64_t patches_ptr;       // device ptr to packed source patches (0 = none)
 };
 
 /// Header for the packed plan byte buffer.
@@ -222,13 +221,13 @@ struct __attribute__((aligned(8))) PlanHeader {
 /// `output_ptype` (or `source_ptype` if there are no scalar ops).
 struct Stage {
     uint64_t input_ptr;                // encoded input in global memory
-    uint32_t smem_byte_offset;         // byte offset within dynamic shared memory
-    uint32_t len;                      // elements produced
-    enum PTypeTag source_ptype;        // PType produced by the source op
-    struct SourceOp source;            // source decode op
-    uint8_t num_scalar_ops;            // number of scalar ops
-    const struct ScalarOp *scalar_ops; // scalar decode ops
+    const struct ScalarOp *scalar_ops; // pointer into packed plan buffer
     uint64_t patches_ptr;              // device ptr to packed source patches (0 = none)
+    uint32_t len;                      // elements produced
+    uint16_t smem_byte_offset;         // byte offset within dynamic shared memory
+    enum PTypeTag source_ptype;        // PType produced by the source op
+    uint8_t num_scalar_ops;            // number of scalar ops
+    struct SourceOp source;            // source decode op (packed, align 1)
 };
 
 /// Parse a single stage from the packed plan byte buffer and advance the cursor.
@@ -245,13 +244,13 @@ __device__ inline Stage parse_stage(const uint8_t *&cursor) {
 
     return Stage {
         .input_ptr = packed_stage->input_ptr,
-        .smem_byte_offset = packed_stage->smem_byte_offset,
-        .len = packed_stage->len,
-        .source_ptype = packed_stage->source_ptype,
-        .source = packed_stage->source,
-        .num_scalar_ops = packed_stage->num_scalar_ops,
         .scalar_ops = ops,
         .patches_ptr = packed_stage->patches_ptr,
+        .len = packed_stage->len,
+        .smem_byte_offset = packed_stage->smem_byte_offset,
+        .source_ptype = packed_stage->source_ptype,
+        .num_scalar_ops = packed_stage->num_scalar_ops,
+        .source = packed_stage->source,
     };
 }
 

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -520,6 +520,7 @@ mod tests {
     use vortex::encodings::alp::alp_encode;
     use vortex::encodings::fastlanes::BitPacked;
     use vortex::encodings::fastlanes::BitPackedArray;
+    use vortex::encodings::fastlanes::BitPackedArrayExt;
     use vortex::encodings::fastlanes::FoR;
     use vortex::encodings::fastlanes::FoRArrayExt;
     use vortex::encodings::runend::RunEnd;
@@ -783,6 +784,69 @@ mod tests {
         let bp = bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let plan = dispatch_plan(&bp.into_array(), &cuda_ctx)?;
+
+        let actual =
+            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[crate::test]
+    fn test_bitpacked_with_patches() -> VortexResult<()> {
+        let bit_width: u8 = 6;
+        let len = 3000;
+        let max_val = (1u32 << bit_width) - 1;
+        // Most values fit in bit_width bits, but every 100th is an exception.
+        let expected: Vec<u32> = (0..len)
+            .map(|i| {
+                if i % 100 == 0 {
+                    max_val + 1 + (i as u32 % 1000)
+                } else {
+                    (i as u32) % (max_val + 1)
+                }
+            })
+            .collect();
+
+        let prim = PrimitiveArray::new(Buffer::from(expected.clone()), NonNullable);
+        let bp = BitPacked::encode(&prim.into_array(), bit_width)?;
+        assert!(bp.patches().is_some(), "expected patches to be present");
+
+        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let plan = dispatch_plan(&bp.into_array(), &cuda_ctx)?;
+
+        let actual =
+            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[crate::test]
+    fn test_for_bitpacked_with_patches() -> VortexResult<()> {
+        let bit_width: u8 = 6;
+        let len = 3000;
+        let reference = 100_000u32;
+        let max_val = (1u32 << bit_width) - 1;
+        // Residuals: most fit in bit_width, every 50th is an exception.
+        let residuals: Vec<u32> = (0..len)
+            .map(|i| {
+                if i % 50 == 0 {
+                    max_val + 1 + (i as u32 % 500)
+                } else {
+                    (i as u32) % (max_val + 1)
+                }
+            })
+            .collect();
+        let expected: Vec<u32> = residuals.iter().map(|&v| v + reference).collect();
+
+        let prim = PrimitiveArray::new(Buffer::from(residuals), NonNullable);
+        let bp = BitPacked::encode(&prim.into_array(), bit_width)?;
+        assert!(bp.patches().is_some(), "expected patches to be present");
+        let for_arr = FoR::try_new(bp.into_array(), Scalar::from(reference))?;
+
+        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
+        let plan = dispatch_plan(&for_arr.into_array(), &cuda_ctx)?;
 
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -520,7 +520,6 @@ mod tests {
     use vortex::encodings::alp::alp_encode;
     use vortex::encodings::fastlanes::BitPacked;
     use vortex::encodings::fastlanes::BitPackedArray;
-    use vortex::encodings::fastlanes::BitPackedArrayExt;
     use vortex::encodings::fastlanes::FoR;
     use vortex::encodings::fastlanes::FoRArrayExt;
     use vortex::encodings::runend::RunEnd;
@@ -784,69 +783,6 @@ mod tests {
         let bp = bitpacked_array_u32(bit_width, len);
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let plan = dispatch_plan(&bp.into_array(), &cuda_ctx)?;
-
-        let actual =
-            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
-        assert_eq!(actual, expected);
-
-        Ok(())
-    }
-
-    #[crate::test]
-    fn test_bitpacked_with_patches() -> VortexResult<()> {
-        let bit_width: u8 = 6;
-        let len = 3000;
-        let max_val = (1u32 << bit_width) - 1;
-        // Most values fit in bit_width bits, but every 100th is an exception.
-        let expected: Vec<u32> = (0..len)
-            .map(|i| {
-                if i % 100 == 0 {
-                    max_val + 1 + (i as u32 % 1000)
-                } else {
-                    (i as u32) % (max_val + 1)
-                }
-            })
-            .collect();
-
-        let prim = PrimitiveArray::new(Buffer::from(expected.clone()), NonNullable);
-        let bp = BitPacked::encode(&prim.into_array(), bit_width)?;
-        assert!(bp.patches().is_some(), "expected patches to be present");
-
-        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&bp.into_array(), &cuda_ctx)?;
-
-        let actual =
-            run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;
-        assert_eq!(actual, expected);
-
-        Ok(())
-    }
-
-    #[crate::test]
-    fn test_for_bitpacked_with_patches() -> VortexResult<()> {
-        let bit_width: u8 = 6;
-        let len = 3000;
-        let reference = 100_000u32;
-        let max_val = (1u32 << bit_width) - 1;
-        // Residuals: most fit in bit_width, every 50th is an exception.
-        let residuals: Vec<u32> = (0..len)
-            .map(|i| {
-                if i % 50 == 0 {
-                    max_val + 1 + (i as u32 % 500)
-                } else {
-                    (i as u32) % (max_val + 1)
-                }
-            })
-            .collect();
-        let expected: Vec<u32> = residuals.iter().map(|&v| v + reference).collect();
-
-        let prim = PrimitiveArray::new(Buffer::from(residuals), NonNullable);
-        let bp = BitPacked::encode(&prim.into_array(), bit_width)?;
-        assert!(bp.patches().is_some(), "expected patches to be present");
-        let for_arr = FoR::try_new(bp.into_array(), Scalar::from(reference))?;
-
-        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
-        let plan = dispatch_plan(&for_arr.into_array(), &cuda_ctx)?;
 
         let actual =
             run_dynamic_dispatch_plan(&cuda_ctx, len, &plan.dispatch_plan, plan.shared_mem_bytes)?;

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -111,7 +111,7 @@ pub struct MaterializedStage {
     /// Device pointer to the input buffer for this stage.
     pub input_ptr: u64,
     /// Byte offset into shared memory where this stage's data is stored.
-    pub smem_byte_offset: u32,
+    pub smem_byte_offset: u16,
     /// Number of elements in this stage.
     pub len: u32,
     /// PType tag for the source op's output type.
@@ -127,7 +127,7 @@ pub struct MaterializedStage {
 impl MaterializedStage {
     pub fn new(
         input_ptr: u64,
-        smem_byte_offset: u32,
+        smem_byte_offset: u16,
         len: u32,
         source_ptype: PTypeTag,
         source: SourceOp,
@@ -152,7 +152,7 @@ impl MaterializedStage {
 #[derive(Clone)]
 pub struct ParsedStage {
     pub input_ptr: u64,
-    pub smem_byte_offset: u32,
+    pub smem_byte_offset: u16,
     pub len: u32,
     pub source_ptype: PTypeTag,
     pub source: SourceOp,
@@ -316,7 +316,7 @@ impl SourceOp {
             params: SourceParams {
                 bitunpack: SourceParams_BitunpackParams {
                     bit_width,
-                    element_offset: u32::from(element_offset),
+                    element_offset,
                 },
             },
         }
@@ -339,10 +339,10 @@ impl SourceOp {
     /// * `num_runs` - number of runs (length of ends/values)
     /// * `offset` - logical offset for sliced arrays
     pub fn runend(
-        ends_smem_byte_offset: u32,
-        values_smem_byte_offset: u32,
-        num_runs: u64,
-        offset: u64,
+        ends_smem_byte_offset: u16,
+        values_smem_byte_offset: u16,
+        num_runs: u32,
+        offset: u32,
     ) -> Self {
         Self {
             op_code: SourceOp_SourceOpCode_RUNEND,
@@ -404,7 +404,7 @@ impl ScalarOp {
 
     /// Dictionary gather: use current value as index into decoded values
     /// in shared memory (populated by an earlier input stage).
-    pub fn dict(values_smem_byte_offset: u32, output_ptype: PTypeTag) -> Self {
+    pub fn dict(values_smem_byte_offset: u16, output_ptype: PTypeTag) -> Self {
         Self {
             op_code: ScalarOp_ScalarOpCode_DICT,
             output_ptype,
@@ -604,7 +604,7 @@ mod tests {
     fn test_plan_structure() {
         // Stage 0: input dict values (BP→FoR), 256 u32 elements → smem bytes [0..1024)
         // Stage 1: output codes (BP→FoR→DICT), 1024 elements, gather from smem byte 0
-        let values_smem_bytes: u32 = 256 * 4; // 256 u32 elements × 4 bytes
+        let values_smem_bytes: u16 = 256 * 4; // 256 u32 elements × 4 bytes
         let plan = CudaDispatchPlan::new(
             [
                 MaterializedStage::new(

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -1059,7 +1059,7 @@ mod tests {
         let array = dict.into_array();
 
         // Mixed-width Dict (u8 codes, u32 values): both are Primitive, so
-        // walk_mixed_width_child grabs the codes buffer directly as a LOAD
+        // walk_child grabs the codes buffer directly as a LOAD
         // source. No pending subtrees → Fused.
         let plan = DispatchPlan::new(&array)?;
         assert!(
@@ -1091,7 +1091,7 @@ mod tests {
         let array = dict.into_array();
 
         // Mixed-width Dict (u16 codes, u32 values): both are Primitive, so
-        // walk_mixed_width_child grabs the codes buffer directly as a LOAD
+        // walk_child grabs the codes buffer directly as a LOAD
         // source. No pending subtrees → Fused.
         let plan = DispatchPlan::new(&array)?;
         assert!(

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -120,6 +120,8 @@ pub struct MaterializedStage {
     pub source: SourceOp,
     /// Chain of element-wise scalar operations applied after the source (e.g. frame-of-reference, zigzag, ALP).
     pub scalar_ops: Vec<ScalarOp>,
+    /// Device pointer to packed source patches (0 = no patches).
+    pub patches_ptr: u64,
 }
 
 impl MaterializedStage {
@@ -130,6 +132,7 @@ impl MaterializedStage {
         source_ptype: PTypeTag,
         source: SourceOp,
         scalar_ops: &[ScalarOp],
+        patches_ptr: u64,
     ) -> Self {
         Self {
             input_ptr,
@@ -138,6 +141,7 @@ impl MaterializedStage {
             source_ptype,
             source,
             scalar_ops: scalar_ops.to_vec(),
+            patches_ptr,
         }
     }
 }
@@ -154,6 +158,8 @@ pub struct ParsedStage {
     pub source: SourceOp,
     pub num_scalar_ops: u8,
     pub scalar_ops: Vec<ScalarOp>,
+    /// Device pointer to packed source patches (0 = no patches).
+    pub patches_ptr: u64,
 }
 
 /// A dispatch plan serialized as a packed byte buffer.
@@ -220,6 +226,7 @@ impl CudaDispatchPlan {
                 source: stage.source,
                 num_scalar_ops: stage.scalar_ops.len() as u8,
                 source_ptype: stage.source_ptype,
+                patches_ptr: stage.patches_ptr,
             };
             buffer.extend_from_slice(&as_bytes(&packed_stage));
             for op in &stage.scalar_ops {
@@ -291,6 +298,7 @@ impl CudaDispatchPlan {
             source: ps.source,
             num_scalar_ops: ps.num_scalar_ops,
             scalar_ops,
+            patches_ptr: ps.patches_ptr,
         }
     }
 }
@@ -580,6 +588,7 @@ mod tests {
                 PTypeTag_PTYPE_U32,
                 SourceOp::bitunpack(bit_width, 0),
                 &scalar_ops,
+                0,
             )],
             PTypeTag_PTYPE_U32,
         );
@@ -605,6 +614,7 @@ mod tests {
                     PTypeTag_PTYPE_U32,
                     SourceOp::bitunpack(4, 0),
                     &[ScalarOp::frame_of_ref(10, PTypeTag_PTYPE_U32)],
+                    0,
                 ),
                 MaterializedStage::new(
                     0xBBBB,
@@ -616,6 +626,7 @@ mod tests {
                         ScalarOp::frame_of_ref(42, PTypeTag_PTYPE_U32),
                         ScalarOp::dict(0, PTypeTag_PTYPE_U32),
                     ],
+                    0,
                 ),
             ],
             PTypeTag_PTYPE_U32,
@@ -688,6 +699,7 @@ mod tests {
                     ScalarOp::zigzag(PTypeTag_PTYPE_U32),
                     ScalarOp::alp(alp_f, alp_e),
                 ],
+                0,
             )],
             PTypeTag_PTYPE_U32,
         );
@@ -1792,6 +1804,7 @@ mod tests {
                 PTypeTag_PTYPE_I8,
                 SourceOp::load(),
                 &[],
+                0,
             )],
             PTypeTag_PTYPE_U32,
         );
@@ -1823,6 +1836,7 @@ mod tests {
                 PTypeTag_PTYPE_I16,
                 SourceOp::load(),
                 &[],
+                0,
             )],
             PTypeTag_PTYPE_U32,
         );

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -144,7 +144,7 @@ impl Stage {
     }
 }
 
-type SmemByteOffset = u32;
+type SmemByteOffset = u16;
 type OutputLen = u32;
 
 /// A dispatch plan before device materialization.
@@ -304,7 +304,7 @@ impl FusedPlan {
         let mut pending_subtrees: Vec<ArrayRef> = Vec::new();
         let mut plan = Self {
             stages: Vec::new(),
-            smem_byte_cursor: 0u32,
+            smem_byte_cursor: 0,
             source_buffers: Vec::new(),
             output_elem_bytes,
             output_ptype,
@@ -320,7 +320,7 @@ impl FusedPlan {
 
     /// Dynamic shared memory bytes passed to the CUDA launch config.
     fn dynamic_shared_mem_bytes(&self) -> u32 {
-        self.smem_byte_cursor + SMEM_TILE_SIZE * self.output_elem_bytes
+        u32::from(self.smem_byte_cursor) + SMEM_TILE_SIZE * self.output_elem_bytes
     }
 
     /// Total shared memory (fixed + dynamic) for limit checking.
@@ -642,9 +642,12 @@ impl FusedPlan {
 
         let values_ptype = PType::try_from(values.dtype())?;
 
-        let values_len = values.len() as u32;
+        let values_len: u32 = values
+            .len()
+            .try_into()
+            .map_err(|_| vortex_err!("Dict values length {} exceeds u32::MAX", values.len()))?;
         let values_spec = self.walk_child(values, pending_subtrees)?;
-        let values_smem_byte_offset = self.push_smem_stage(values_spec, values_len);
+        let values_smem_byte_offset = self.push_smem_stage(values_spec, values_len)?;
 
         let mut pipeline = self.walk_child(codes, pending_subtrees)?;
         // DICT scalar op: pass byte offset directly (C ABI uses byte offsets).
@@ -672,17 +675,26 @@ impl FusedPlan {
         pending_subtrees: &mut Vec<ArrayRef>,
     ) -> VortexResult<Stage> {
         let re = array.as_::<RunEnd>();
-        let offset = re.offset() as u64;
+        let offset: u32 = re
+            .offset()
+            .try_into()
+            .map_err(|_| vortex_err!("RunEnd offset {} exceeds u32::MAX", re.offset()))?;
         let ends = re.ends().clone();
         let values = re.values().clone();
-        let num_runs = ends.len() as u32;
-        let num_values = values.len() as u32;
+        let num_runs: u32 = ends
+            .len()
+            .try_into()
+            .map_err(|_| vortex_err!("RunEnd num_runs {} exceeds u32::MAX", ends.len()))?;
+        let num_values: u32 = values
+            .len()
+            .try_into()
+            .map_err(|_| vortex_err!("RunEnd num_values {} exceeds u32::MAX", values.len()))?;
 
         let ends_spec = self.walk_child(ends, pending_subtrees)?;
-        let ends_smem_byte_offset = self.push_smem_stage(ends_spec, num_runs);
+        let ends_smem_byte_offset = self.push_smem_stage(ends_spec, num_runs)?;
 
         let values_spec = self.walk_child(values, pending_subtrees)?;
-        let values_smem_byte_offset = self.push_smem_stage(values_spec, num_values);
+        let values_smem_byte_offset = self.push_smem_stage(values_spec, num_values)?;
 
         // Pass byte offsets and PTypeTags directly — the C ABI now uses
         // byte offsets and per-field ptype tags for cross-stage references.
@@ -690,7 +702,7 @@ impl FusedPlan {
             SourceOp::runend(
                 ends_smem_byte_offset,
                 values_smem_byte_offset,
-                num_runs as u64,
+                num_runs,
                 offset,
             ),
             None,
@@ -706,7 +718,7 @@ impl FusedPlan {
     /// type-changing scalar ops (e.g. dict values with FoR→ALP), the final
     /// smem footprint is `len × final_ptype_byte_width`. If there are no
     /// scalar ops, the source_ptype determines the width.
-    fn push_smem_stage(&mut self, spec: Stage, len: u32) -> u32 {
+    fn push_smem_stage(&mut self, spec: Stage, len: u32) -> VortexResult<SmemByteOffset> {
         let smem_byte_offset = self.smem_byte_cursor;
         // The kernel's execute_input_stage<T> always writes T-wide elements
         // into smem (reinterpret_cast<T*>), so we must allocate at least
@@ -720,8 +732,12 @@ impl FusedPlan {
         let final_elem_bytes = tag_to_ptype(final_ptype).byte_width() as u32;
         let elem_bytes = final_elem_bytes.max(self.output_elem_bytes);
         let stage_bytes = len * elem_bytes;
+        let new_cursor = u32::from(self.smem_byte_cursor) + stage_bytes;
+        if new_cursor > u16::MAX as u32 {
+            vortex_bail!("shared memory byte offset {new_cursor} exceeds u16::MAX (65535)");
+        }
         self.stages.push((spec, smem_byte_offset, len));
-        self.smem_byte_cursor += stage_bytes;
-        smem_byte_offset
+        self.smem_byte_cursor = new_cursor as u16;
+        Ok(smem_byte_offset)
     }
 }

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -73,7 +73,7 @@ fn is_dyn_dispatch_compatible(array: &ArrayRef) -> bool {
         return arr.patches().is_none() && arr.dtype().as_ptype() == PType::F32;
     }
     if id == BitPacked::ID {
-        return true;
+        return array.as_::<BitPacked>().patches().is_none();
     }
     if id == Dict::ID {
         let arr = array.as_::<Dict>();

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -33,6 +33,7 @@ use vortex::encodings::zigzag::ZigZagArrayExt;
 use vortex::error::VortexResult;
 use vortex::error::vortex_bail;
 use vortex::error::vortex_err;
+use vortex_array::patches::Patches;
 
 use super::CudaDispatchPlan;
 use super::MaterializedStage;
@@ -44,6 +45,7 @@ use super::ptype_to_tag;
 use super::tag_to_ptype;
 use crate::CudaBufferExt;
 use crate::CudaExecutionCtx;
+use crate::kernel::pack_patches_for_fused;
 
 /// A plan whose source buffers have been copied to the device, ready for kernel launch.
 pub struct MaterializedPlan {
@@ -71,7 +73,7 @@ fn is_dyn_dispatch_compatible(array: &ArrayRef) -> bool {
         return arr.patches().is_none() && arr.dtype().as_ptype() == PType::F32;
     }
     if id == BitPacked::ID {
-        return array.as_::<BitPacked>().patches().is_none();
+        return true;
     }
     if id == Dict::ID {
         let arr = array.as_::<Dict>();
@@ -126,6 +128,8 @@ struct Stage {
     source_buffer_index: Option<usize>,
     /// PType tag for the source op's output type.
     source_ptype: PTypeTag,
+    /// Source patches (e.g. BitPacked exceptions) with element_offset.
+    patches: Option<(Patches, u32)>,
 }
 
 impl Stage {
@@ -135,6 +139,7 @@ impl Stage {
             scalar_ops: vec![],
             source_buffer_index,
             source_ptype,
+            patches: None,
         }
     }
 }
@@ -363,13 +368,26 @@ impl FusedPlan {
             }
         };
 
+        // Pack per-stage patches into device buffers.
+        let mut patches_ptrs: Vec<u64> = Vec::new();
+        for (stage, ..) in &self.stages {
+            if let Some((patches, element_offset)) = &stage.patches {
+                let (ptr, handle) = pack_patches_for_fused(patches, *element_offset as usize, ctx)?;
+                patches_ptrs.push(ptr);
+                device_buffers.push(handle);
+            } else {
+                patches_ptrs.push(0);
+            }
+        }
+
         // Byte offsets are passed directly to the C ABI — the kernel now
         // indexes shared memory by byte offset and casts to the correct type
         // using source_ptype / output_ptype.
         let stages: Vec<MaterializedStage> = self
             .stages
             .iter()
-            .map(|(stage, smem_byte_offset, len)| {
+            .enumerate()
+            .map(|(i, (stage, smem_byte_offset, len))| {
                 MaterializedStage::new(
                     resolve_ptr(stage),
                     *smem_byte_offset,
@@ -377,6 +395,7 @@ impl FusedPlan {
                     stage.source_ptype,
                     stage.source,
                     &stage.scalar_ops,
+                    patches_ptrs[i],
                 )
             })
             .collect();
@@ -408,6 +427,31 @@ impl FusedPlan {
         self.materialize(ctx)
     }
 
+    /// Record an unfusable subtree as a deferred LOAD source.
+    ///
+    /// Reserves a placeholder slot in `source_buffers` (filled at materialize
+    /// time) and pushes the array onto `pending_subtrees`.
+    fn push_pending(
+        &mut self,
+        array: ArrayRef,
+        pending_subtrees: &mut Vec<ArrayRef>,
+    ) -> VortexResult<Stage> {
+        let ptype = PType::try_from(array.dtype()).map_err(|_| {
+            vortex_err!(
+                "unfusable subtree has non-primitive dtype {:?}, cannot partially fuse",
+                array.dtype()
+            )
+        })?;
+        let buf_idx = self.source_buffers.len();
+        self.source_buffers.push(None);
+        pending_subtrees.push(array);
+        Ok(Stage::new(
+            SourceOp::load(),
+            Some(buf_idx),
+            ptype_to_tag(ptype),
+        ))
+    }
+
     /// Walk the encoding tree, producing a [`Stage`] for the root.
     fn walk(
         &mut self,
@@ -415,22 +459,7 @@ impl FusedPlan {
         pending_subtrees: &mut Vec<ArrayRef>,
     ) -> VortexResult<Stage> {
         if !is_dyn_dispatch_compatible(&array) {
-            // Subtree can't be fused — record it as a deferred LOAD source.
-            // Bail if dtype is non-primitive (can't become a LOAD stage).
-            let ptype = PType::try_from(array.dtype()).map_err(|_| {
-                vortex_err!(
-                    "unfusable subtree has non-primitive dtype {:?}, cannot partially fuse",
-                    array.dtype()
-                )
-            })?;
-            let buf_idx = self.source_buffers.len();
-            self.source_buffers.push(None); // placeholder, filled at materialize time
-            pending_subtrees.push(array);
-            return Ok(Stage::new(
-                SourceOp::load(),
-                Some(buf_idx),
-                ptype_to_tag(ptype),
-            ));
+            return self.push_pending(array, pending_subtrees);
         }
 
         let id = array.encoding_id();
@@ -496,21 +525,20 @@ impl FusedPlan {
 
     fn walk_bitpacked(&mut self, array: ArrayRef) -> VortexResult<Stage> {
         let bp = array.as_::<BitPacked>();
-
-        if bp.patches().is_some() {
-            vortex_bail!("Dynamic dispatch does not support BitPackedArray with patches");
-        }
+        let element_offset = bp.offset();
 
         let source_ptype = ptype_to_tag(PType::try_from(bp.dtype()).map_err(|_| {
             vortex_err!("BitPacked must have primitive dtype, got {:?}", bp.dtype())
         })?);
         let buf_index = self.source_buffers.len();
         self.source_buffers.push(Some(bp.packed().clone()));
-        Ok(Stage::new(
-            SourceOp::bitunpack(bp.bit_width(), bp.offset()),
+        let mut stage = Stage::new(
+            SourceOp::bitunpack(bp.bit_width(), element_offset),
             Some(buf_index),
             source_ptype,
-        ))
+        );
+        stage.patches = bp.patches().map(|p| (p, u32::from(element_offset)));
+        Ok(stage)
     }
 
     fn walk_for(
@@ -585,29 +613,22 @@ impl FusedPlan {
         Ok(pipeline)
     }
 
-    /// Handle a child array whose element width differs from the output type.
+    /// Walk a child array, falling back to `push_pending` when its element
+    /// width differs from the output type and the encoding is not `Primitive`.
     ///
-    /// If the child is a `Primitive`, its buffer is grabbed directly as a LOAD
-    /// source — no separate kernel launch needed, since `load_element<T>()`
-    /// handles the widening in-kernel. Otherwise, the child is recorded as a
-    /// pending subtree for separate execution.
-    fn walk_mixed_width_child(
+    /// `Primitive` children are always handled directly (just grab the buffer)
+    /// because `load_element<T>()` handles widening in-kernel.
+    fn walk_child(
         &mut self,
-        child: ArrayRef,
+        array: ArrayRef,
         pending_subtrees: &mut Vec<ArrayRef>,
     ) -> VortexResult<Stage> {
-        let ptype = PType::try_from(child.dtype())?;
-        if child.encoding_id() == Primitive::ID {
-            return self.walk_primitive(child);
+        let ptype = PType::try_from(array.dtype())?;
+        let elem_bytes = ptype.byte_width() as u32;
+        if elem_bytes != self.output_elem_bytes && array.encoding_id() != Primitive::ID {
+            return self.push_pending(array, pending_subtrees);
         }
-        let buf_idx = self.source_buffers.len();
-        self.source_buffers.push(None);
-        pending_subtrees.push(child);
-        Ok(Stage::new(
-            SourceOp::load(),
-            Some(buf_idx),
-            ptype_to_tag(ptype),
-        ))
+        self.walk(array, pending_subtrees)
     }
 
     fn walk_dict(
@@ -620,28 +641,12 @@ impl FusedPlan {
         let codes = dict.codes().clone();
 
         let values_ptype = PType::try_from(values.dtype())?;
-        let values_elem_bytes = values_ptype.byte_width() as u32;
-        let codes_ptype = PType::try_from(codes.dtype())?;
-        let codes_elem_bytes = codes_ptype.byte_width() as u32;
 
-        // If values have a different width than the output type, they
-        // can't be fused into the same kernel instantiation. Primitives
-        // are handled directly (just grab the buffer); other encodings
-        // become pending subtrees executed by a separate kernel.
         let values_len = values.len() as u32;
-        let values_spec = if values_elem_bytes != self.output_elem_bytes {
-            self.walk_mixed_width_child(values, pending_subtrees)?
-        } else {
-            self.walk(values, pending_subtrees)?
-        };
+        let values_spec = self.walk_child(values, pending_subtrees)?;
         let values_smem_byte_offset = self.push_smem_stage(values_spec, values_len);
 
-        // Same for codes.
-        let mut pipeline = if codes_elem_bytes != self.output_elem_bytes {
-            self.walk_mixed_width_child(codes, pending_subtrees)?
-        } else {
-            self.walk(codes, pending_subtrees)?
-        };
+        let mut pipeline = self.walk_child(codes, pending_subtrees)?;
         // DICT scalar op: pass byte offset directly (C ABI uses byte offsets).
         // output_ptype is the values' ptype — DICT transforms codes → values.
         pipeline.scalar_ops.push(ScalarOp::dict(
@@ -673,26 +678,10 @@ impl FusedPlan {
         let num_runs = ends.len() as u32;
         let num_values = values.len() as u32;
 
-        let ends_ptype = PType::try_from(ends.dtype())?;
-        let ends_elem_bytes = ends_ptype.byte_width() as u32;
-        let values_ptype = PType::try_from(values.dtype())?;
-        let values_elem_bytes = values_ptype.byte_width() as u32;
-
-        // If ends or values have a different width than the output type,
-        // they can't be fused into the same kernel instantiation.
-        // Primitives are handled directly; others become pending subtrees.
-        let ends_spec = if ends_elem_bytes != self.output_elem_bytes {
-            self.walk_mixed_width_child(ends, pending_subtrees)?
-        } else {
-            self.walk(ends, pending_subtrees)?
-        };
+        let ends_spec = self.walk_child(ends, pending_subtrees)?;
         let ends_smem_byte_offset = self.push_smem_stage(ends_spec, num_runs);
 
-        let values_spec = if values_elem_bytes != self.output_elem_bytes {
-            self.walk_mixed_width_child(values, pending_subtrees)?
-        } else {
-            self.walk(values, pending_subtrees)?
-        };
+        let values_spec = self.walk_child(values, pending_subtrees)?;
         let values_smem_byte_offset = self.push_smem_stage(values_spec, num_values);
 
         // Pass byte offsets and PTypeTags directly — the C ABI now uses

--- a/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
+++ b/vortex-cuda/src/dynamic_dispatch/plan_builder.rs
@@ -490,10 +490,10 @@ impl FusedPlan {
         }
     }
 
-    /// SliceArray → resolve the slice via reduce/execute rules.
+    /// SliceArray → resolve the slice via `reduce_parent`.
     ///
     /// When the plan builder encounters a `SliceArray`, it resolves the slice
-    /// by invoking the child's `reduce_parent`, `execute_parent`.
+    /// by invoking the child's `reduce_parent`.
     fn walk_slice(
         &mut self,
         array: ArrayRef,
@@ -696,7 +696,7 @@ impl FusedPlan {
         let values_spec = self.walk_child(values, pending_subtrees)?;
         let values_smem_byte_offset = self.push_smem_stage(values_spec, num_values)?;
 
-        // Pass byte offsets and PTypeTags directly — the C ABI now uses
+        // Pass byte offsets and PTypeTags directly — the C ABI uses
         // byte offsets and per-field ptype tags for cross-stage references.
         Ok(Stage::new(
             SourceOp::runend(

--- a/vortex-cuda/src/kernel/mod.rs
+++ b/vortex-cuda/src/kernel/mod.rs
@@ -34,6 +34,7 @@ pub use encodings::ZstdKernelPrep;
 pub use encodings::zstd_kernel_prepare;
 pub(crate) use encodings::*;
 pub(crate) use filter::FilterExecutor;
+pub(crate) use patches::types::pack_patches_for_fused;
 pub use patches::types::transpose_patches;
 pub(crate) use slice::SliceExecutor;
 

--- a/vortex-cuda/src/kernel/patches/types.rs
+++ b/vortex-cuda/src/kernel/patches/types.rs
@@ -5,17 +5,22 @@
 //! patching enables fully parallel GPU execution, as outlined by Hepkema et al. in
 //! "G-ALP: Rethinking Light-weight Encodings for GPUs" <https://doi.org/10.1145/3736227.3736242>
 
+use std::mem::size_of_val;
+
 use vortex::array::Canonical;
 use vortex::array::buffer::BufferHandle;
 use vortex::array::dtype::IntegerPType;
 use vortex::array::dtype::NativePType;
+use vortex::buffer::Alignment;
 use vortex::buffer::Buffer;
 use vortex::buffer::BufferMut;
+use vortex::buffer::ByteBufferMut;
 use vortex_array::match_each_native_ptype;
 use vortex_array::match_each_unsigned_integer_ptype;
 use vortex_array::patches::Patches;
 use vortex_error::VortexResult;
 
+use crate::CudaBufferExt;
 use crate::CudaExecutionCtx;
 
 /// A set of device-resident patches that live in the GPU.
@@ -120,6 +125,83 @@ impl<V: Copy> HostPatches<V> {
             values: values_handle,
         })
     }
+}
+
+/// Pack transposed patches into a single contiguous device buffer.
+///
+/// Layout: `[lane_offsets (u32) | indices (u16) | padding | values (V)]`
+///
+/// Returns `(device_ptr, BufferHandle)` where the handle must be kept alive.
+#[allow(clippy::cognitive_complexity)]
+pub fn pack_patches_for_fused(
+    patches: &Patches,
+    element_offset: usize,
+    ctx: &CudaExecutionCtx,
+) -> VortexResult<(u64, BufferHandle)> {
+    let array_len = patches.array_len();
+    let offset = patches.offset();
+
+    let indices = patches.indices().to_canonical()?.into_primitive();
+    let values = patches.values().to_canonical()?.into_primitive();
+
+    let indices_ptype = indices.ptype();
+    let values_ptype = values.ptype();
+
+    let indices_host = indices.buffer_handle().to_host_sync();
+    let values_host = values.buffer_handle().to_host_sync();
+
+    match_each_unsigned_integer_ptype!(indices_ptype, |I| {
+        match_each_native_ptype!(values_ptype, |V| {
+            let idx_buf: Buffer<I> = Buffer::from_byte_buffer(indices_host);
+            let val_buf: Buffer<V> = Buffer::from_byte_buffer(values_host);
+
+            let host = transpose(
+                idx_buf.as_slice(),
+                val_buf.as_slice(),
+                offset + element_offset,
+                array_len,
+            );
+
+            // Pack [lane_offsets | indices | padding | values] into one contiguous buffer.
+            let lo_bytes = host.lane_offsets.as_slice();
+            let idx_bytes = host.indices.as_slice();
+            let val_bytes = host.values.as_slice();
+
+            let lo_byte_len = size_of_val(lo_bytes);
+            let idx_byte_len = size_of_val(idx_bytes);
+            let pre_pad = lo_byte_len + idx_byte_len;
+            let val_align = size_of::<V>().max(1);
+            let padded = pre_pad.next_multiple_of(val_align);
+            let pad_len = padded - pre_pad;
+            let val_byte_len = size_of_val(val_bytes);
+            let total = padded + val_byte_len;
+
+            let mut buf = ByteBufferMut::with_capacity_aligned(total, Alignment::of::<u32>());
+            // SAFETY: we are writing repr(C) numeric slices as raw bytes.
+            unsafe {
+                buf.extend_from_slice(std::slice::from_raw_parts(
+                    lo_bytes.as_ptr().cast::<u8>(),
+                    lo_byte_len,
+                ));
+                buf.extend_from_slice(std::slice::from_raw_parts(
+                    idx_bytes.as_ptr().cast::<u8>(),
+                    idx_byte_len,
+                ));
+            }
+            buf.extend_from_slice(&vec![0u8; pad_len]);
+            unsafe {
+                buf.extend_from_slice(std::slice::from_raw_parts(
+                    val_bytes.as_ptr().cast::<u8>(),
+                    val_byte_len,
+                ));
+            }
+
+            let handle = BufferHandle::new_host(buf.freeze());
+            let device_handle = ctx.ensure_on_device_sync(handle)?;
+            let ptr = device_handle.cuda_device_ptr()?;
+            Ok((ptr, device_handle))
+        })
+    })
 }
 
 /// Transpose a set of patches from the default sorted layout into the data parallel layout.

--- a/vortex-cuda/src/kernel/patches/types.rs
+++ b/vortex-cuda/src/kernel/patches/types.rs
@@ -170,7 +170,7 @@ pub fn pack_patches_for_fused(
             let lo_byte_len = size_of_val(lo_bytes);
             let idx_byte_len = size_of_val(idx_bytes);
             let pre_pad = lo_byte_len + idx_byte_len;
-            let val_align = size_of::<V>().max(1);
+            let val_align = size_of::<V>();
             let padded = pre_pad.next_multiple_of(val_align);
             let pad_len = padded - pre_pad;
             let val_byte_len = size_of_val(val_bytes);


### PR DESCRIPTION
Adds patches infra for dyn dispatch, without applying them to bitpacking and alp yet. As part of that, the types used in dyn dispatch are trimmed down in size. This is to not reduce warp occupancy on the SMs due to allocating more registers on the GPU.