### PR TITLE
binstall for vortex-tui

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,59 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runs-on: macos-latest
+            archive: tgz
+          - target: x86_64-apple-darwin
+            runs-on: macos-15-intel
+            archive: tgz
+          - target: aarch64-unknown-linux-gnu
+            runs-on: ubuntu-24.04-arm
+            archive: tgz
+          - target: x86_64-unknown-linux-gnu
+            runs-on: ubuntu-24.04
+            archive: tgz
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          targets: ${{ matrix.target }}
+          enable-sccache: "false"
+
+      - name: Build release binary
+        run: cargo build --release --package vortex-tui --bin vx --target ${{ matrix.target }}
+
+      - name: Create archive (tgz)
+        if: matrix.archive == 'tgz'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar -czvf ../../../vx-${{ matrix.target }}.tar.gz vx
+
+      - name: Create archive (zip)
+        if: matrix.archive == 'zip'
+        run: |
+          cd target/${{ matrix.target }}/release
+          zip ../../../vx-${{ matrix.target }}.zip vx.exe
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v2
+        with:
+          files: vx-${{ matrix.target }}.${{ matrix.archive == 'tgz' && 'tar.gz' || 'zip' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build ${{ matrix.target }}
@@ -52,8 +55,6 @@ jobs:
           zip ../../../vx-${{ matrix.target }}.zip vx.exe
 
       - name: Upload release asset
-        uses: softprops/action-gh-release@v2
-        with:
-          files: vx-${{ matrix.target }}.${{ matrix.archive == 'tgz' && 'tar.gz' || 'zip' }}
+        run: gh release upload "${{ github.event.release.tag_name }}" vx-${{ matrix.target }}.${{ matrix.archive == 'tgz' && 'tar.gz' || 'zip' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -86,11 +86,14 @@ uv add vortex-data
 For browsing the structure of Vortex files, you can use the `vx` command-line tool.
 
 ```bash
-# Install latest release
-cargo install vortex-tui --locked
+# Install pre-built binary (fast, recommended)
+cargo binstall vortex-tui
 
 # Or build from source
-cargo install --path vortex-tui --locked
+cargo install vortex-tui --locked
+
+# Or run via Python without installing
+uvx --from vortex-data vx --help
 
 # Usage
 vx browse <file>

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -7,6 +7,13 @@ the terminal.
 
 ::::{tab-set}
 
+:::{tab-item} Binstall (recommended)
+```bash
+cargo binstall vortex-tui
+```
+Downloads a pre-built binary. Requires [cargo-binstall](https://github.com/cargo-bins/cargo-binstall).
+:::
+
 :::{tab-item} pip
 ```bash
 pip install vortex-data
@@ -14,10 +21,18 @@ pip install vortex-data
 This also installs the Python library. See the [Python quickstart](python.rst) for library usage.
 :::
 
+:::{tab-item} uvx
+```bash
+uvx --from vortex-data vx --help
+```
+Runs the CLI without installing. Requires [uv](https://docs.astral.sh/uv/).
+:::
+
 :::{tab-item} Cargo
 ```bash
 cargo install vortex-tui
 ```
+Builds from source. This can be slow due to the large dependency tree.
 :::
 
 ::::

--- a/vortex-tui/Cargo.toml
+++ b/vortex-tui/Cargo.toml
@@ -90,5 +90,13 @@ web-sys = { version = "0.3.81", features = [
     "Window",
 ] }
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ version }/vx-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.'cfg(target_os = "windows")']
+pkg-fmt = "zip"
+
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

Adds support for downloading via `cargo binstall` for the `vx` CLI tool.

This is more targeted at folks in the Rust community who have a Rust toolchain but might not be as familiar with Python toolchains.

Updates documentation to reference both install pathways (`cargo binstall` and `uvx`) from our README and getting started docs