### PR TITLE
Remove more scalar_at from sparse arrays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10881,6 +10881,7 @@ dependencies = [
 name = "vortex-sparse"
 version = "0.1.0"
 dependencies = [
+ "codspeed-divan-compat",
  "itertools 0.14.0",
  "num-traits",
  "prost 0.14.3",

--- a/encodings/sparse/Cargo.toml
+++ b/encodings/sparse/Cargo.toml
@@ -27,6 +27,11 @@ vortex-mask = { workspace = true }
 vortex-session = { workspace = true }
 
 [dev-dependencies]
+divan = { workspace = true }
 itertools = { workspace = true }
 rstest = { workspace = true }
 vortex-array = { workspace = true, features = ["_test-harness"] }
+
+[[bench]]
+name = "sparse_canonical"
+harness = false

--- a/encodings/sparse/benches/sparse_canonical.rs
+++ b/encodings/sparse/benches/sparse_canonical.rs
@@ -7,7 +7,10 @@ use std::sync::Arc;
 
 use divan::Bencher;
 use vortex_array::ArrayRef;
+use vortex_array::Canonical;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::ListViewArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -25,16 +28,14 @@ fn main() {
 
 const LIST_ARGS: &[(usize, usize, usize)] = &[
     // len, patch_stride, list_size
-    (10_000, 7, 8),
-    (50_000, 7, 8),
-    (50_000, 11, 16),
+    (4_096, 7, 8),
+    (8_192, 17, 16),
 ];
 
 const FIXED_SIZE_LIST_ARGS: &[(usize, usize, u32)] = &[
     // len, patch_stride, list_size
-    (10_000, 7, 8),
-    (50_000, 7, 8),
-    (50_000, 11, 16),
+    (4_096, 7, 8),
+    (8_192, 17, 16),
 ];
 
 fn make_sparse_list(len: usize, patch_stride: usize, list_size: usize) -> ArrayRef {
@@ -92,11 +93,11 @@ fn canonicalize_sparse_list(
     let sparse = make_sparse_list(len, patch_stride, list_size);
 
     bencher
-        .with_inputs(|| sparse.clone())
-        .bench_values(|array| {
+        .with_inputs(|| (sparse.clone(), LEGACY_SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
             divan::black_box(
                 array
-                    .to_canonical()
+                    .execute::<Canonical>(&mut ctx)
                     .vortex_expect("sparse list canonicalization"),
             )
         });
@@ -110,11 +111,11 @@ fn canonicalize_sparse_fixed_size_list(
     let sparse = make_sparse_fixed_size_list(len, patch_stride, list_size);
 
     bencher
-        .with_inputs(|| sparse.clone())
-        .bench_values(|array| {
+        .with_inputs(|| (sparse.clone(), LEGACY_SESSION.create_execution_ctx()))
+        .bench_values(|(array, mut ctx)| {
             divan::black_box(
                 array
-                    .to_canonical()
+                    .execute::<Canonical>(&mut ctx)
                     .vortex_expect("sparse fixed-size-list canonicalization"),
             )
         });

--- a/encodings/sparse/benches/sparse_canonical.rs
+++ b/encodings/sparse/benches/sparse_canonical.rs
@@ -73,7 +73,7 @@ fn make_sparse_fixed_size_list(len: usize, patch_stride: usize, list_size: u32) 
         FixedSizeListArray::new(patch_elements, list_size, Validity::NonNullable, n_patches)
             .into_array();
 
-    let fill_value = Scalar::list(
+    let fill_value = Scalar::fixed_size_list(
         Arc::new(I32.into()),
         (0..list_size as i32).map(Scalar::from).collect(),
         NonNullable,

--- a/encodings/sparse/benches/sparse_canonical.rs
+++ b/encodings/sparse/benches/sparse_canonical.rs
@@ -94,7 +94,11 @@ fn canonicalize_sparse_list(
     bencher
         .with_inputs(|| sparse.clone())
         .bench_values(|array| {
-            divan::black_box(array.to_canonical().vortex_expect("sparse list canonicalization"))
+            divan::black_box(
+                array
+                    .to_canonical()
+                    .vortex_expect("sparse list canonicalization"),
+            )
         });
 }
 

--- a/encodings/sparse/benches/sparse_canonical.rs
+++ b/encodings/sparse/benches/sparse_canonical.rs
@@ -28,14 +28,14 @@ fn main() {
 
 const LIST_ARGS: &[(usize, usize, usize)] = &[
     // len, patch_stride, list_size
-    (4_096, 7, 8),
-    (8_192, 17, 16),
+    (512, 7, 4),
+    (1_024, 17, 8),
 ];
 
 const FIXED_SIZE_LIST_ARGS: &[(usize, usize, u32)] = &[
     // len, patch_stride, list_size
-    (4_096, 7, 8),
-    (8_192, 17, 16),
+    (512, 7, 4),
+    (1_024, 17, 8),
 ];
 
 fn make_sparse_list(len: usize, patch_stride: usize, list_size: usize) -> ArrayRef {

--- a/encodings/sparse/benches/sparse_canonical.rs
+++ b/encodings/sparse/benches/sparse_canonical.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright the Vortex contributors
+
+#![expect(clippy::cast_possible_truncation)]
+
+use std::sync::Arc;
+
+use divan::Bencher;
+use vortex_array::ArrayRef;
+use vortex_array::IntoArray;
+use vortex_array::arrays::FixedSizeListArray;
+use vortex_array::arrays::ListViewArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::dtype::Nullability::NonNullable;
+use vortex_array::dtype::PType::I32;
+use vortex_array::scalar::Scalar;
+use vortex_array::validity::Validity;
+use vortex_buffer::Buffer;
+use vortex_error::VortexExpect;
+use vortex_sparse::Sparse;
+
+fn main() {
+    divan::main();
+}
+
+const LIST_ARGS: &[(usize, usize, usize)] = &[
+    // len, patch_stride, list_size
+    (10_000, 7, 8),
+    (50_000, 7, 8),
+    (50_000, 11, 16),
+];
+
+const FIXED_SIZE_LIST_ARGS: &[(usize, usize, u32)] = &[
+    // len, patch_stride, list_size
+    (10_000, 7, 8),
+    (50_000, 7, 8),
+    (50_000, 11, 16),
+];
+
+fn make_sparse_list(len: usize, patch_stride: usize, list_size: usize) -> ArrayRef {
+    let patch_indices: Buffer<u32> = (0..len).step_by(patch_stride).map(|i| i as u32).collect();
+    let n_patches = patch_indices.len();
+
+    let patch_elements = PrimitiveArray::from_iter(0..(n_patches * list_size) as i32).into_array();
+    let patch_offsets: Buffer<u32> = (0..n_patches).map(|i| (i * list_size) as u32).collect();
+    let patch_sizes: Buffer<u32> = std::iter::repeat_n(list_size as u32, n_patches).collect();
+    let patch_values = ListViewArray::new(
+        patch_elements,
+        patch_offsets.into_array(),
+        patch_sizes.into_array(),
+        Validity::NonNullable,
+    )
+    .into_array();
+
+    let fill_value = Scalar::list(
+        Arc::new(I32.into()),
+        (0..list_size as i32).map(Scalar::from).collect(),
+        NonNullable,
+    );
+
+    Sparse::try_new(patch_indices.into_array(), patch_values, len, fill_value)
+        .vortex_expect("sparse list input should be valid")
+        .into_array()
+}
+
+fn make_sparse_fixed_size_list(len: usize, patch_stride: usize, list_size: u32) -> ArrayRef {
+    let patch_indices: Buffer<u32> = (0..len).step_by(patch_stride).map(|i| i as u32).collect();
+    let n_patches = patch_indices.len();
+
+    let patch_elements =
+        PrimitiveArray::from_iter(0..(n_patches * list_size as usize) as i32).into_array();
+    let patch_values =
+        FixedSizeListArray::new(patch_elements, list_size, Validity::NonNullable, n_patches)
+            .into_array();
+
+    let fill_value = Scalar::list(
+        Arc::new(I32.into()),
+        (0..list_size as i32).map(Scalar::from).collect(),
+        NonNullable,
+    );
+
+    Sparse::try_new(patch_indices.into_array(), patch_values, len, fill_value)
+        .vortex_expect("sparse fixed-size-list input should be valid")
+        .into_array()
+}
+
+#[divan::bench(args = LIST_ARGS)]
+fn canonicalize_sparse_list(
+    bencher: Bencher,
+    (len, patch_stride, list_size): (usize, usize, usize),
+) {
+    let sparse = make_sparse_list(len, patch_stride, list_size);
+
+    bencher
+        .with_inputs(|| sparse.clone())
+        .bench_values(|array| {
+            divan::black_box(array.to_canonical().vortex_expect("sparse list canonicalization"))
+        });
+}
+
+#[divan::bench(args = FIXED_SIZE_LIST_ARGS)]
+fn canonicalize_sparse_fixed_size_list(
+    bencher: Bencher,
+    (len, patch_stride, list_size): (usize, usize, u32),
+) {
+    let sparse = make_sparse_fixed_size_list(len, patch_stride, list_size);
+
+    bencher
+        .with_inputs(|| sparse.clone())
+        .bench_values(|array| {
+            divan::black_box(
+                array
+                    .to_canonical()
+                    .vortex_expect("sparse fixed-size-list canonicalization"),
+            )
+        });
+}

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -22,6 +22,7 @@ use vortex_array::arrays::varbinview::build_views::BinaryView;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::builders::ArrayBuilder;
 use vortex_array::builders::DecimalBuilder;
+use vortex_array::builders::FixedSizeListBuilder;
 use vortex_array::builders::ListViewBuilder;
 use vortex_array::builders::builder_with_capacity;
 use vortex_array::dtype::DType;
@@ -38,7 +39,6 @@ use vortex_array::match_each_native_ptype;
 use vortex_array::match_smallest_offset_type;
 use vortex_array::patches::Patches;
 use vortex_array::scalar::DecimalScalar;
-use vortex_array::scalar::ListScalar;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar::StructScalar;
 use vortex_array::validity::Validity;
@@ -142,26 +142,21 @@ fn execute_sparse_lists(
         .values()
         .clone()
         .execute::<ListViewArray>(ctx)?;
-    let fill_value = array.fill_scalar().as_list();
+    let fill_scalar = array.fill_scalar().clone();
 
     let n_filled = array.len() - resolved_patches.num_patches();
-    let total_canonical_values = values.elements().len() + fill_value.len() * n_filled;
-
-    let validity = {
-        let arr = array.as_array();
-        Validity::from_mask(arr.validity()?.execute_mask(arr.len(), ctx)?, nullability)
-    };
+    let total_canonical_values = values.elements().len() + fill_scalar.as_list().len() * n_filled;
 
     Ok(match_each_integer_ptype!(indices.ptype(), |I| {
         match_smallest_offset_type!(total_canonical_values, |O| {
             execute_sparse_lists_inner::<I, O>(
                 indices.as_slice(),
                 values,
-                fill_value,
+                fill_scalar,
                 values_dtype,
                 array.len(),
                 total_canonical_values,
-                validity,
+                nullability,
                 ctx,
             )
         })
@@ -172,57 +167,55 @@ fn execute_sparse_lists(
 fn execute_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
     patch_indices: &[I],
     patch_values: ListViewArray,
-    fill_value: ListScalar,
+    fill_scalar: Scalar,
     values_dtype: Arc<DType>,
     len: usize,
     total_canonical_values: usize,
-    validity: Validity,
+    nullability: Nullability,
     ctx: &mut ExecutionCtx,
 ) -> ArrayRef {
     // Create the builder with appropriate types. It is easy to just use the same type for both
     // `offsets` and `sizes` since we have no other constraints.
     let mut builder = ListViewBuilder::<O, O>::with_capacity(
         values_dtype,
-        validity.nullability(),
+        nullability,
         total_canonical_values,
         len,
     );
+    let fill_elements = list_scalar_elements_array(&fill_scalar);
     let patch_values_validity = patch_values
         .listview_validity()
-        .execute_mask(len, ctx)
+        .execute_mask(patch_values.len(), ctx)
         .vortex_expect("sparse list validity mask failed to execute");
 
-    let mut patch_idx = 0;
+    let mut next_index = 0;
 
-    // Loop over the patch indices and set them to the corresponding scalar values. For positions
-    // that are not patched, use the fill value.
-    for position in 0..len {
-        let position_is_patched = patch_idx < patch_indices.len()
-            && patch_indices[patch_idx]
-                .to_usize()
-                .vortex_expect("patch index must fit in usize")
-                == position;
+    for (patch_idx, sparse_idx) in patch_indices.iter().enumerate() {
+        let sparse_idx = sparse_idx
+            .to_usize()
+            .vortex_expect("patch index must fit in usize");
 
-        if position_is_patched {
-            if patch_values_validity.value(patch_idx) {
-                // Bulk-append the list value to avoid per-element scalar_at.
-                let patch_list = patch_values
-                    .list_elements_at(patch_idx)
-                    .vortex_expect("list_elements_at");
-                builder
-                    .append_array_as_list(&patch_list)
-                    .vortex_expect("Failed to append sparse value");
-            } else {
-                builder.append_null();
-            }
-            patch_idx += 1;
-        } else {
-            // Set with the fill value.
+        append_list_fill(
+            &mut builder,
+            fill_elements.as_ref(),
+            sparse_idx - next_index,
+        );
+
+        if patch_values_validity.value(patch_idx) {
+            let patch_list = patch_values
+                .list_elements_at(patch_idx)
+                .vortex_expect("list_elements_at");
             builder
-                .append_value(fill_value)
-                .vortex_expect("Failed to append fill value");
+                .append_array_as_list(&patch_list)
+                .vortex_expect("Failed to append sparse value");
+        } else {
+            builder.append_null();
         }
+
+        next_index = sparse_idx + 1;
     }
+
+    append_list_fill(&mut builder, fill_elements.as_ref(), len - next_index);
 
     builder.finish()
 }
@@ -242,20 +235,15 @@ fn execute_sparse_fixed_size_list(
         .values()
         .clone()
         .execute::<FixedSizeListArray>(ctx)?;
-    let fill_value = array.fill_scalar().as_list();
-
-    let validity = {
-        let arr = array.as_array();
-        Validity::from_mask(arr.validity()?.execute_mask(arr.len(), ctx)?, nullability)
-    };
+    let fill_scalar = array.fill_scalar().clone();
 
     Ok(match_each_integer_ptype!(indices.ptype(), |I| {
         execute_sparse_fixed_size_list_inner::<I>(
             indices.as_slice(),
             values,
-            fill_value,
+            fill_scalar,
             array.len(),
-            validity,
+            nullability,
             ctx,
         )
         .into_array()
@@ -271,16 +259,23 @@ fn execute_sparse_fixed_size_list(
 fn execute_sparse_fixed_size_list_inner<I: IntegerPType>(
     indices: &[I],
     values: FixedSizeListArray,
-    fill_value: ListScalar,
+    fill_scalar: Scalar,
     array_len: usize,
-    validity: Validity,
+    nullability: Nullability,
     ctx: &mut ExecutionCtx,
 ) -> FixedSizeListArray {
     let list_size = values.list_size();
-    let element_dtype = values.elements().dtype();
-    let total_elements = array_len * list_size as usize;
-    let mut builder = builder_with_capacity(element_dtype, total_elements);
-    let fill_elements = fill_value.elements();
+    let element_dtype = values
+        .dtype()
+        .as_fixed_size_list_element_opt()
+        .vortex_expect("sparse fixed-size-list values must have fixed-size-list dtype");
+    let mut builder = FixedSizeListBuilder::with_capacity(
+        Arc::clone(element_dtype),
+        list_size,
+        nullability,
+        array_len,
+    );
+    let fill_elements = list_scalar_elements_array(&fill_scalar);
     let values_validity = values
         .validity()
         .vortex_expect("sparse fixed-size-list validity should be derivable")
@@ -294,10 +289,9 @@ fn execute_sparse_fixed_size_list_inner<I: IntegerPType>(
 
     for (patch_idx, sparse_idx) in indices.enumerate() {
         // Fill gap before this patch with fill values.
-        append_n_lists(
-            &mut *builder,
-            fill_elements.as_deref(),
-            list_size,
+        append_fixed_size_list_fill(
+            &mut builder,
+            fill_elements.as_ref(),
             sparse_idx - next_index,
         );
 
@@ -306,48 +300,64 @@ fn execute_sparse_fixed_size_list_inner<I: IntegerPType>(
             let patch_list = values
                 .fixed_size_list_elements_at(patch_idx)
                 .vortex_expect("fixed_size_list_elements_at");
-            builder.extend_from_array(&patch_list);
+            builder
+                .append_array_as_list(&patch_list)
+                .vortex_expect("Failed to append sparse fixed-size-list value");
         } else {
-            builder.append_defaults(list_size as usize);
+            builder.append_null();
         }
 
         next_index = sparse_idx + 1;
     }
 
     // Fill remaining positions after last patch.
-    append_n_lists(
-        &mut *builder,
-        fill_elements.as_deref(),
-        list_size,
-        array_len - next_index,
-    );
+    append_fixed_size_list_fill(&mut builder, fill_elements.as_ref(), array_len - next_index);
 
-    let elements = builder.finish();
-
-    // SAFETY: elements.len() == array_len * list_size, validity length matches array_len.
-    unsafe { FixedSizeListArray::new_unchecked(elements, list_size, validity, array_len) }
+    builder.finish_into_fixed_size_list()
 }
 
-/// Append `count` copies of a fixed-size list to the builder.
-///
-/// If `fill_elements` is `Some`, appends those elements `count` times.
-/// If `fill_elements` is `None` (null fill), appends `list_size` default elements `count` times.
-fn append_n_lists(
-    builder: &mut dyn ArrayBuilder,
-    fill_elements: Option<&[Scalar]>,
-    list_size: u32,
+fn list_scalar_elements_array(scalar: &Scalar) -> Option<ArrayRef> {
+    let list = scalar.as_list();
+    list.elements().map(|elements| {
+        let mut builder = builder_with_capacity(list.element_dtype(), elements.len());
+        for element in elements {
+            builder
+                .append_scalar(&element)
+                .vortex_expect("list element scalar was invalid");
+        }
+        builder.finish()
+    })
+}
+
+fn append_list_fill<O: IntegerPType, S: IntegerPType>(
+    builder: &mut ListViewBuilder<O, S>,
+    fill_elements: Option<&ArrayRef>,
     count: usize,
 ) {
-    for _ in 0..count {
-        if let Some(fill_elems) = fill_elements {
-            for elem in fill_elems {
-                builder
-                    .append_scalar(elem)
-                    .vortex_expect("element dtype must match");
-            }
-        } else {
-            builder.append_defaults(list_size as usize);
+    if let Some(fill_elements) = fill_elements {
+        for _ in 0..count {
+            builder
+                .append_array_as_list(fill_elements)
+                .vortex_expect("Failed to append sparse fill value");
         }
+    } else {
+        builder.append_nulls(count);
+    }
+}
+
+fn append_fixed_size_list_fill(
+    builder: &mut FixedSizeListBuilder,
+    fill_elements: Option<&ArrayRef>,
+    count: usize,
+) {
+    if let Some(fill_elements) = fill_elements {
+        for _ in 0..count {
+            builder
+                .append_array_as_list(fill_elements)
+                .vortex_expect("Failed to append sparse fixed-size-list fill value");
+        }
+    } else {
+        builder.append_nulls(count);
     }
 }
 

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -187,6 +187,10 @@ fn execute_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
         total_canonical_values,
         len,
     );
+    let patch_values_validity = patch_values
+        .listview_validity()
+        .execute_mask(len, ctx)
+        .vortex_expect("sparse list validity mask failed to execute");
 
     let mut patch_idx = 0;
 
@@ -200,15 +204,17 @@ fn execute_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
                 == position;
 
         if position_is_patched {
-            // Set with the patch value.
-            builder
-                .append_value(
-                    patch_values
-                        .execute_scalar(patch_idx, ctx)
-                        .vortex_expect("scalar_at")
-                        .as_list(),
-                )
-                .vortex_expect("Failed to append sparse value");
+            if patch_values_validity.value(patch_idx) {
+                // Bulk-append the list value to avoid per-element scalar_at.
+                let patch_list = patch_values
+                    .list_elements_at(patch_idx)
+                    .vortex_expect("list_elements_at");
+                builder
+                    .append_array_as_list(&patch_list)
+                    .vortex_expect("Failed to append sparse value");
+            } else {
+                builder.append_null();
+            }
             patch_idx += 1;
         } else {
             // Set with the fill value.
@@ -275,6 +281,11 @@ fn execute_sparse_fixed_size_list_inner<I: IntegerPType>(
     let total_elements = array_len * list_size as usize;
     let mut builder = builder_with_capacity(element_dtype, total_elements);
     let fill_elements = fill_value.elements();
+    let values_validity = values
+        .validity()
+        .vortex_expect("sparse fixed-size-list validity should be derivable")
+        .execute_mask(values.len(), ctx)
+        .vortex_expect("sparse fixed-size-list validity mask failed to execute");
 
     let mut next_index = 0;
     let indices = indices
@@ -291,20 +302,11 @@ fn execute_sparse_fixed_size_list_inner<I: IntegerPType>(
         );
 
         // Append the patch value, handling null patches by appending defaults.
-        if values
-            .validity()
-            .vortex_expect("sparse fixed-size-list validity should be derivable")
-            .is_valid(patch_idx)
-            .vortex_expect("is_valid")
-        {
+        if values_validity.value(patch_idx) {
             let patch_list = values
                 .fixed_size_list_elements_at(patch_idx)
                 .vortex_expect("fixed_size_list_elements_at");
-            for i in 0..list_size as usize {
-                builder
-                    .append_scalar(&patch_list.execute_scalar(i, ctx).vortex_expect("scalar_at"))
-                    .vortex_expect("element dtype must match");
-            }
+            builder.extend_from_array(&patch_list);
         } else {
             builder.append_defaults(list_size as usize);
         }

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -39,6 +39,7 @@ use vortex_array::match_each_native_ptype;
 use vortex_array::match_smallest_offset_type;
 use vortex_array::patches::Patches;
 use vortex_array::scalar::DecimalScalar;
+use vortex_array::scalar::ListScalar;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar::StructScalar;
 use vortex_array::validity::Validity;
@@ -142,10 +143,10 @@ fn execute_sparse_lists(
         .values()
         .clone()
         .execute::<ListViewArray>(ctx)?;
-    let fill_scalar = array.fill_scalar().clone();
+    let fill_scalar = array.fill_scalar().as_list();
 
     let n_filled = array.len() - resolved_patches.num_patches();
-    let total_canonical_values = values.elements().len() + fill_scalar.as_list().len() * n_filled;
+    let total_canonical_values = values.elements().len() + fill_scalar.len() * n_filled;
 
     Ok(match_each_integer_ptype!(indices.ptype(), |I| {
         match_smallest_offset_type!(total_canonical_values, |O| {
@@ -167,7 +168,7 @@ fn execute_sparse_lists(
 fn execute_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
     patch_indices: &[I],
     patch_values: ListViewArray,
-    fill_scalar: Scalar,
+    fill_scalar: ListScalar,
     values_dtype: Arc<DType>,
     len: usize,
     total_canonical_values: usize,
@@ -182,7 +183,7 @@ fn execute_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
         total_canonical_values,
         len,
     );
-    let fill_elements = list_scalar_elements_array(&fill_scalar);
+    let fill_elements = list_scalar_elements_array(fill_scalar);
     let patch_values_validity = patch_values
         .listview_validity()
         .execute_mask(patch_values.len(), ctx)
@@ -235,7 +236,7 @@ fn execute_sparse_fixed_size_list(
         .values()
         .clone()
         .execute::<FixedSizeListArray>(ctx)?;
-    let fill_scalar = array.fill_scalar().clone();
+    let fill_scalar = array.fill_scalar().as_list();
 
     Ok(match_each_integer_ptype!(indices.ptype(), |I| {
         execute_sparse_fixed_size_list_inner::<I>(
@@ -259,7 +260,7 @@ fn execute_sparse_fixed_size_list(
 fn execute_sparse_fixed_size_list_inner<I: IntegerPType>(
     indices: &[I],
     values: FixedSizeListArray,
-    fill_scalar: Scalar,
+    fill_scalar: ListScalar,
     array_len: usize,
     nullability: Nullability,
     ctx: &mut ExecutionCtx,
@@ -275,7 +276,7 @@ fn execute_sparse_fixed_size_list_inner<I: IntegerPType>(
         nullability,
         array_len,
     );
-    let fill_elements = list_scalar_elements_array(&fill_scalar);
+    let fill_elements = list_scalar_elements_array(fill_scalar);
     let values_validity = values
         .validity()
         .vortex_expect("sparse fixed-size-list validity should be derivable")
@@ -316,8 +317,7 @@ fn execute_sparse_fixed_size_list_inner<I: IntegerPType>(
     builder.finish_into_fixed_size_list()
 }
 
-fn list_scalar_elements_array(scalar: &Scalar) -> Option<ArrayRef> {
-    let list = scalar.as_list();
+fn list_scalar_elements_array(list: ListScalar) -> Option<ArrayRef> {
     list.elements().map(|elements| {
         let mut builder = builder_with_capacity(list.element_dtype(), elements.len());
         for element in elements {


### PR DESCRIPTION
| Benchmark case | Before (mean) | After (mean) | Speedup |
|---|---:|---:|---:|
| `extend_from_array_non_zctl_overlapping (1000, 8)` | `1.413 ms` | `80.71 us` | `17.5x` |
| `extend_from_array_non_zctl_overlapping (1000, 32)` | `2.586 ms` | `83.67 us` | `30.9x` |
| `extend_from_array_non_zctl_overlapping (10000, 8)` | `9.708 ms` | `560.3 us` | `17.3x` |
| `extend_from_array_zctl (1000, 8)` | `1.116 ms` | `14.31 us` | `78.0x` |
| `extend_from_array_zctl (1000, 64)` | `5.511 ms` | `38.68 us` | `142.5x` |
| `extend_from_array_zctl (10000, 8)` | `11.01 ms` | `108.4 us` | `101.6x` |

Before = commit `d72bf9b93` (pre-fix), After = commit `c4ad4e2ad` (the ListViewBuilder scalar-at removal fix).