### PR TITLE
add BtrBlocksCompressorBuilder::empty()

### DIFF
--- a/vortex-btrblocks/public-api.lock
+++ b/vortex-btrblocks/public-api.lock
@@ -682,6 +682,8 @@ impl vortex_btrblocks::BtrBlocksCompressorBuilder
 
 pub fn vortex_btrblocks::BtrBlocksCompressorBuilder::build(self) -> vortex_btrblocks::BtrBlocksCompressor
 
+pub fn vortex_btrblocks::BtrBlocksCompressorBuilder::empty() -> Self
+
 pub fn vortex_btrblocks::BtrBlocksCompressorBuilder::exclude_schemes(self, ids: impl core::iter::traits::collect::IntoIterator<Item = vortex_compressor::scheme::SchemeId>) -> Self
 
 pub fn vortex_btrblocks::BtrBlocksCompressorBuilder::only_cuda_compatible(self) -> Self

--- a/vortex-btrblocks/src/builder.rs
+++ b/vortex-btrblocks/src/builder.rs
@@ -97,6 +97,15 @@ impl Default for BtrBlocksCompressorBuilder {
 }
 
 impl BtrBlocksCompressorBuilder {
+    /// Creates a builder with no schemes registered.
+    ///
+    /// Useful when the caller wants explicit, scheme-by-scheme control over the compressor.
+    pub fn empty() -> Self {
+        Self {
+            schemes: Vec::new(),
+        }
+    }
+
     /// Adds an external compression scheme not in [`ALL_SCHEMES`].
     ///
     /// This allows encoding crates outside of `vortex-btrblocks` to register their own schemes
@@ -186,5 +195,22 @@ impl BtrBlocksCompressorBuilder {
     /// Builds the configured [`BtrBlocksCompressor`].
     pub fn build(self) -> BtrBlocksCompressor {
         BtrBlocksCompressor(CascadingCompressor::new(self.schemes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_starts_with_no_schemes() {
+        let builder = BtrBlocksCompressorBuilder::empty();
+        assert!(builder.schemes.is_empty());
+    }
+
+    #[test]
+    fn default_includes_all_schemes() {
+        let builder = BtrBlocksCompressorBuilder::default();
+        assert_eq!(builder.schemes.len(), ALL_SCHEMES.len());
     }
 }


### PR DESCRIPTION
## Summary

This will be helpful for testing and benchmarking when we specifically do not want to run any compression.

## API Changes

Adds the new `empty` method to the builder.

## Testing

N/A