### PR TITLE
Update locked rustls-webpki to address sec advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8233,9 +8233,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -15,9 +15,6 @@ feature-depth = 1
 ignore = [
     # Paste is no longer maintained because its essentially "finished".
     "RUSTSEC-2024-0436",
-    # rustls-pemfile is a hard requirement from object_store crate.
-    # need to wait for them to release, see https://github.com/apache/arrow-rs-object-store/pull/565
-    "RUSTSEC-2025-0134",
 ]
 
 [licenses]


### PR DESCRIPTION
# Summary

Addresses a couple of recent security advisories by updating the lockfile