### PR TITLE
chore[gpu]: trim Criterion CUDA benchmarks

### DIFF
--- a/vortex-cuda/benches/bitpacked_cuda.rs
+++ b/vortex-cuda/benches/bitpacked_cuda.rs
@@ -39,8 +39,7 @@ use crate::common::TimedLaunchStrategy;
 const N_ROWS: usize = 100_000_000;
 
 /// Patch frequencies to benchmark (as fractions)
-const PATCH_FREQUENCIES: &[(f64, &str)] =
-    &[(0.001, "0.1%"), (0.01, "1%"), (0.05, "5%"), (0.10, "10%")];
+const PATCH_FREQUENCIES: &[(f64, &str)] = &[(0.01, "1%"), (0.10, "10%")];
 
 /// Create a bit-packed array with the given bit width
 fn make_bitpacked_array<T>(bit_width: u8, len: usize) -> BitPackedArray
@@ -108,7 +107,6 @@ where
     T::Physical: DeviceRepr,
 {
     let mut group = c.benchmark_group(format!("bitunpack_cuda_{}", type_name));
-    group.sample_size(10);
 
     let array = make_bitpacked_array::<T>(bit_width, N_ROWS);
     let nbytes = N_ROWS * size_of::<T>();
@@ -153,7 +151,6 @@ where
     T::Physical: DeviceRepr,
 {
     let mut group = c.benchmark_group(format!("bitunpack_cuda_patched_{}", type_name));
-    group.sample_size(10);
 
     let nbytes = N_ROWS * size_of::<T>();
     group.throughput(Throughput::Bytes(nbytes as u64));
@@ -193,11 +190,15 @@ fn benchmark_bitunpack_with_patches(c: &mut Criterion) {
     benchmark_bitunpack_with_patches_typed::<u64>(c, "u64");
 }
 
-criterion::criterion_group!(
-    benches,
-    benchmark_bitunpack,
-    benchmark_bitunpack_with_patches
-);
+criterion::criterion_group! {
+    name = benches;
+    config = Criterion::default().without_plots()
+        .sample_size(10)
+        .warm_up_time(Duration::from_nanos(1))
+        .measurement_time(Duration::from_nanos(1))
+        .nresamples(10);
+    targets = benchmark_bitunpack, benchmark_bitunpack_with_patches
+}
 
 #[cuda_available]
 criterion::criterion_main!(benches);

--- a/vortex-cuda/benches/date_time_parts_cuda.rs
+++ b/vortex-cuda/benches/date_time_parts_cuda.rs
@@ -51,13 +51,8 @@ fn make_datetimeparts_array(len: usize, time_unit: TimeUnit) -> DateTimePartsArr
 
 fn benchmark_datetimeparts(c: &mut Criterion) {
     let mut group = c.benchmark_group("datetimeparts_cuda");
-    group.sample_size(10);
 
-    for (len, len_str) in [
-        (1_000_000usize, "1M"),
-        (10_000_000usize, "10M"),
-        (100_000_000usize, "100M"),
-    ] {
+    for (len, len_str) in [(10_000_000usize, "10M"), (100_000_000usize, "100M")] {
         group.throughput(Throughput::Bytes((len * size_of::<i64>()) as u64));
 
         let (time_unit, unit_str) = (TimeUnit::Milliseconds, "ms");
@@ -90,7 +85,15 @@ fn benchmark_datetimeparts(c: &mut Criterion) {
     group.finish();
 }
 
-criterion::criterion_group!(benches, benchmark_datetimeparts);
+criterion::criterion_group! {
+    name = benches;
+    config = Criterion::default().without_plots()
+        .sample_size(10)
+        .warm_up_time(Duration::from_nanos(1))
+        .measurement_time(Duration::from_nanos(1))
+        .nresamples(10);
+    targets = benchmark_datetimeparts
+}
 
 #[cuda_available]
 criterion::criterion_main!(benches);

--- a/vortex-cuda/benches/dict_cuda.rs
+++ b/vortex-cuda/benches/dict_cuda.rs
@@ -73,7 +73,6 @@ where
     <C as TryFrom<usize>>::Error: std::fmt::Debug,
 {
     let mut group = c.benchmark_group("dict_cuda");
-    group.sample_size(10);
 
     for (len, len_str) in BENCH_ARGS {
         // Throughput is based on output size (values read from dictionary)
@@ -156,7 +155,15 @@ fn benchmark_dict(c: &mut Criterion) {
     );
 }
 
-criterion::criterion_group!(benches, benchmark_dict);
+criterion::criterion_group! {
+    name = benches;
+    config = Criterion::default().without_plots()
+        .sample_size(10)
+        .warm_up_time(Duration::from_nanos(1))
+        .measurement_time(Duration::from_nanos(1))
+        .nresamples(10);
+    targets = benchmark_dict
+}
 
 #[cuda_available]
 criterion::criterion_main!(benches);

--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -49,11 +49,7 @@ use vortex_cuda::dynamic_dispatch::MaterializedPlan;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
 
-const BENCH_ARGS: &[(usize, &str)] = &[
-    (1_000_000, "1M"),
-    (10_000_000, "10M"),
-    (100_000_000, "100M"),
-];
+const BENCH_ARGS: &[(usize, &str)] = &[(10_000_000, "10M"), (100_000_000, "100M")];
 
 /// Launch the dynamic_dispatch kernel and return GPU-timed duration.
 ///
@@ -177,7 +173,6 @@ impl BenchRunner {
 // ---------------------------------------------------------------------------
 fn bench_for_bitpacked(c: &mut Criterion) {
     let mut group = c.benchmark_group("for_bitpacked_6bw");
-    group.sample_size(10);
 
     let bit_width: u8 = 6;
     let reference = 100_000u32;
@@ -224,7 +219,6 @@ fn bench_for_bitpacked(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 fn bench_dict_bp_codes(c: &mut Criterion) {
     let mut group = c.benchmark_group("dict_256vals_bp8bw_codes");
-    group.sample_size(10);
 
     let dict_size: usize = 256;
     let dict_bit_width: u8 = 8;
@@ -269,7 +263,6 @@ fn bench_dict_bp_codes(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 fn bench_runend(c: &mut Criterion) {
     let mut group = c.benchmark_group("runend_100runs");
-    group.sample_size(10);
 
     let num_runs: usize = 100;
 
@@ -313,7 +306,6 @@ fn bench_runend(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
     let mut group = c.benchmark_group("dict_64vals_bp6bw_codes_for_bp6bw_values");
-    group.sample_size(10);
 
     let dict_size: usize = 64;
     let dict_bit_width: u8 = 6;
@@ -367,7 +359,6 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 fn bench_alp_for_bitpacked(c: &mut Criterion) {
     let mut group = c.benchmark_group("alp_for_bp_6bw_f32");
-    group.sample_size(10);
 
     let exponents = Exponents { e: 2, f: 0 };
     let bit_width: u8 = 6;
@@ -428,7 +419,15 @@ fn benchmark_dynamic_dispatch(c: &mut Criterion) {
     bench_alp_for_bitpacked(c);
 }
 
-criterion::criterion_group!(benches, benchmark_dynamic_dispatch);
+criterion::criterion_group! {
+    name = benches;
+    config = Criterion::default().without_plots()
+        .sample_size(10)
+        .warm_up_time(Duration::from_nanos(1))
+        .measurement_time(Duration::from_nanos(1))
+        .nresamples(10);
+    targets = benchmark_dynamic_dispatch
+}
 
 #[cuda_available]
 criterion::criterion_main!(benches);

--- a/vortex-cuda/benches/filter_cuda.rs
+++ b/vortex-cuda/benches/filter_cuda.rs
@@ -32,7 +32,7 @@ use vortex_cuda::CudaSession;
 use vortex_cuda_macros::cuda_available;
 use vortex_cuda_macros::cuda_not_available;
 
-const BENCH_SIZES: &[(usize, &str)] = &[(1_000_000, "1M"), (10_000_000, "10M")];
+const BENCH_SIZES: &[(usize, &str)] = &[(10_000_000, "10M")];
 const SELECTIVITIES: &[(f64, &str)] = &[(0.1, "10%"), (0.5, "50%"), (0.9, "90%")];
 
 /// Creates input data of the given length.
@@ -142,7 +142,6 @@ where
         + 'static,
 {
     let mut group = c.benchmark_group(format!("filter_cuda_{type_name}"));
-    group.sample_size(10);
 
     for (len, len_label) in BENCH_SIZES {
         for (selectivity, sel_label) in SELECTIVITIES {
@@ -229,10 +228,17 @@ where
 fn benchmark_filter(c: &mut Criterion) {
     benchmark_filter_type::<i32>(c, "i32");
     benchmark_filter_type::<i64>(c, "i64");
-    benchmark_filter_type::<f64>(c, "f64");
 }
 
-criterion::criterion_group!(benches, benchmark_filter);
+criterion::criterion_group! {
+    name = benches;
+    config = Criterion::default().without_plots()
+        .sample_size(10)
+        .warm_up_time(Duration::from_nanos(1))
+        .measurement_time(Duration::from_nanos(1))
+        .nresamples(10);
+    targets = benchmark_filter
+}
 
 #[cuda_available]
 criterion::criterion_main!(benches);

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -71,7 +71,6 @@ where
     Scalar: From<T>,
 {
     let mut group = c.benchmark_group("for_cuda");
-    group.sample_size(10);
 
     for &(len, len_str) in BENCH_ARGS {
         group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
@@ -110,7 +109,6 @@ where
     Scalar: From<T>,
 {
     let mut group = c.benchmark_group("ffor_cuda");
-    group.sample_size(10);
 
     for &(len, len_str) in BENCH_ARGS {
         group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
@@ -159,7 +157,15 @@ fn benchmark_ffor(c: &mut Criterion) {
     benchmark_ffor_typed::<u64>(c, "u64");
 }
 
-criterion::criterion_group!(benches, benchmark_for, benchmark_ffor);
+criterion::criterion_group! {
+    name = benches;
+    config = Criterion::default().without_plots()
+        .sample_size(10)
+        .warm_up_time(Duration::from_nanos(1))
+        .measurement_time(Duration::from_nanos(1))
+        .nresamples(10);
+    targets = benchmark_for, benchmark_ffor
+}
 
 #[cuda_available]
 criterion::criterion_main!(benches);

--- a/vortex-cuda/benches/runend_cuda.rs
+++ b/vortex-cuda/benches/runend_cuda.rs
@@ -64,16 +64,11 @@ where
     T: NativePType + DeviceRepr + From<u8>,
 {
     let mut group = c.benchmark_group("runend_cuda");
-    group.sample_size(10);
 
-    for (len, len_str) in [
-        (1_000_000usize, "1M"),
-        (10_000_000usize, "10M"),
-        (100_000_000usize, "100M"),
-    ] {
+    for (len, len_str) in [(10_000_000usize, "10M"), (100_000_000usize, "100M")] {
         group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
 
-        for run_len in [10, 100, 1000, 10000, 100000] {
+        for run_len in [10, 1000, 100000] {
             let runend_array = make_runend_array_typed::<T>(len, run_len);
 
             group.bench_with_input(
@@ -114,7 +109,15 @@ fn benchmark_runend(c: &mut Criterion) {
     benchmark_runend_typed::<i32>(c, "i32");
 }
 
-criterion::criterion_group!(benches, benchmark_runend);
+criterion::criterion_group! {
+    name = benches;
+    config = Criterion::default().without_plots()
+        .sample_size(10)
+        .warm_up_time(Duration::from_nanos(1))
+        .measurement_time(Duration::from_nanos(1))
+        .nresamples(10);
+    targets = benchmark_runend
+}
 
 #[cuda_available]
 criterion::criterion_main!(benches);

--- a/vortex-cuda/benches/throughput_cuda.rs
+++ b/vortex-cuda/benches/throughput_cuda.rs
@@ -94,8 +94,6 @@ fn transfer_mix_timed(
 
 fn benchmark_transfer_throughput(c: &mut Criterion) {
     let mut group = c.benchmark_group("transfer_throughput_cuda");
-    group.sample_size(10);
-
     for &(input_bytes, output_bytes, label) in MIXES {
         let total_mem_bytes = input_bytes * 2 + output_bytes;
         group.throughput(Throughput::Bytes(total_mem_bytes as u64));
@@ -122,7 +120,15 @@ fn benchmark_transfer_throughput(c: &mut Criterion) {
     group.finish();
 }
 
-criterion::criterion_group!(benches, benchmark_transfer_throughput);
+criterion::criterion_group! {
+    name = benches;
+    config = Criterion::default().without_plots()
+        .sample_size(10)
+        .warm_up_time(Duration::from_nanos(1))
+        .measurement_time(Duration::from_nanos(1))
+        .nresamples(10);
+    targets = benchmark_transfer_throughput
+}
 
 #[cuda_available]
 criterion::criterion_main!(benches);

--- a/vortex-cuda/benches/transpose_patches.rs
+++ b/vortex-cuda/benches/transpose_patches.rs
@@ -66,7 +66,13 @@ fn benchmark_transpose(c: &mut Criterion) {
     );
 }
 
-criterion::criterion_group!(benches, benchmark_transpose);
+criterion::criterion_group! {
+    name = benches;
+    config = Criterion::default().without_plots()
+        .warm_up_time(Duration::from_nanos(1))
+        .nresamples(10);
+    targets = benchmark_transpose
+}
 
 #[cuda_available]
 criterion::criterion_main!(benches);

--- a/vortex-cuda/benches/zstd_cuda.rs
+++ b/vortex-cuda/benches/zstd_cuda.rs
@@ -118,7 +118,6 @@ async fn execute_zstd_kernel(
 /// Benchmark ZSTD CUDA decompression kernel performance
 fn benchmark_zstd_cuda_decompress(c: &mut Criterion) {
     let mut group = c.benchmark_group("ZSTD_cuda");
-    group.sample_size(10);
 
     for (num_strings, label) in BENCH_ARGS {
         let (zstd_array, uncompressed_size) =
@@ -162,7 +161,15 @@ fn benchmark_zstd_cuda_decompress(c: &mut Criterion) {
     group.finish();
 }
 
-criterion::criterion_group!(benches, benchmark_zstd_cuda_decompress);
+criterion::criterion_group! {
+    name = benches;
+    config = Criterion::default().without_plots()
+        .sample_size(10)
+        .warm_up_time(Duration::from_nanos(1))
+        .measurement_time(Duration::from_nanos(1))
+        .nresamples(10);
+    targets = benchmark_zstd_cuda_decompress
+}
 
 #[cuda_available]
 criterion::criterion_main!(benches);


### PR DESCRIPTION
CUDA Criterion benchmarks are a bottleneck right now in the workflow when iterating on GPU kernels. We therefore trim away the least relevant benchmarks and reduce the number of iterations being measured. Note that the benchmark results are unchanged regardless of the trimming down the warmup and iteration count.