### PR TITLE
fix(ci): restore vortex-compact file size tracking for PR clickbench

### DIFF
--- a/.github/workflows/sql-benchmarks.yml
+++ b/.github/workflows/sql-benchmarks.yml
@@ -20,7 +20,8 @@ on:
               "id": "clickbench-nvme",
               "subcommand": "clickbench",
               "name": "Clickbench on NVME",
-              "targets": "datafusion:parquet,datafusion:vortex,duckdb:parquet,duckdb:vortex,duckdb:duckdb"
+              "targets": "datafusion:parquet,datafusion:vortex,duckdb:parquet,duckdb:vortex,duckdb:duckdb",
+              "extra_data_formats": "vortex-compact"
             },
             {
               "id": "tpch-nvme",


### PR DESCRIPTION
## Summary
- The matrix consolidation in #7448 dropped `extra_data_formats: "vortex-compact"` from the clickbench default matrix entry
- This meant PR clickbench no longer generates vortex-compact data, so file size comparisons in PR comments lost vortex-compact coverage
- Restores the field so `data-gen` produces vortex-compact files for file size tracking without adding it as a benchmark target on PRs