### PR TITLE
chore: dedup formats in sql engine runner

### DIFF
--- a/vortex-bench/src/runner.rs
+++ b/vortex-bench/src/runner.rs
@@ -13,6 +13,7 @@ use std::time::Instant;
 
 use indicatif::ProgressBar;
 use vortex::error::vortex_panic;
+use vortex::utils::aliases::hash_set::HashSet;
 
 use crate::Benchmark;
 use crate::BenchmarkDataset;
@@ -67,6 +68,7 @@ pub struct SqlBenchmarkRunner {
     benchmark_dataset: BenchmarkDataset,
     storage: String,
     expected_row_counts: Option<Vec<usize>>,
+    /// Deduplicated, preserving insertion order.
     formats: Vec<Format>,
     memory_tracker: Option<BenchmarkMemoryTracker>,
     hide_progress_bar: bool,
@@ -79,10 +81,12 @@ impl SqlBenchmarkRunner {
     pub fn new<B: Benchmark + ?Sized>(
         benchmark: &B,
         engine: Engine,
-        formats: Vec<Format>,
+        formats: impl IntoIterator<Item = Format>,
         track_memory: bool,
         hide_progress_bar: bool,
     ) -> anyhow::Result<Self> {
+        let mut seen = HashSet::new();
+        let formats: Vec<Format> = formats.into_iter().filter(|f| seen.insert(*f)).collect();
         let storage = url_scheme_to_storage(benchmark.data_url())?;
 
         let memory_tracker = track_memory.then(BenchmarkMemoryTracker::new);


### PR DESCRIPTION
Dedup formats in SQL engine runner to prevent benchmarking the same format multiple times, as passed on the CLI. Keeps the insertion order.