### PR TITLE
chore: unify ci timeouts to 4 tiers

### DIFF
--- a/.github/workflows/approvals.yml
+++ b/.github/workflows/approvals.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check-approvals:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check required approvals
         uses: actions/github-script@450193c5abd4cdb17ba9f3ffcfe8f635c4bb6c2a

--- a/.github/workflows/bench-dispatch.yml
+++ b/.github/workflows/bench-dispatch.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   remove-bench-label:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 10
     if: github.event.label.name == 'action/benchmark'
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1
@@ -34,7 +34,7 @@ jobs:
 
   remove-sql-label:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 10
     if: github.event.label.name == 'action/benchmark-sql'
     steps:
       - uses: actions-ecosystem/action-remove-labels@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,14 +28,14 @@ env:
 jobs:
   lint-toml:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: spiraldb/actions/.github/actions/lint-toml@0.18.5
 
   validate-workflow-yaml:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: Validate YAML file
@@ -52,7 +52,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=python-lint', github.run_id)
           || 'ubuntu-latest' }}
-    timeout-minutes: 40
+    timeout-minutes: 10
     steps:
       - uses: runs-on/action@v2
         if: github.repository == 'vortex-data/vortex'
@@ -79,7 +79,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64-pre-v2/tag=python-test', github.run_id)
           || 'ubuntu-latest' }}
-    timeout-minutes: 40
+    timeout-minutes: 30
     env:
       RUST_LOG: "info,maturin=off,uv=debug"
       MATURIN_PEP517_ARGS: "--profile ci"
@@ -117,7 +117,7 @@ jobs:
   python-wheel-build:
     name: "Python (wheel build)"
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Rust Dependency Cache
@@ -157,7 +157,7 @@ jobs:
 
   rust-docs:
     name: "Rust (docs)"
-    timeout-minutes: 40
+    timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-small/image=ubuntu24-full-x64-pre-v2/tag=rust-docs', github.run_id)
@@ -177,7 +177,7 @@ jobs:
 
   build-rust:
     name: "Rust build (${{matrix.config.name}})"
-    timeout-minutes: 40
+    timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner={1}/image=ubuntu24-full-x64-pre-v2/tag={2}', github.run_id, matrix.config.runner, matrix.config.name)
@@ -225,7 +225,7 @@ jobs:
 
   check-min-deps:
     name: "Check build with minimal dependencies"
-    timeout-minutes: 40
+    timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=rust-min-deps', github.run_id)
@@ -241,7 +241,7 @@ jobs:
 
   rust-lint:
     name: "Rust (lint)"
-    timeout-minutes: 40
+    timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-large/image=ubuntu24-full-x64-pre-v2/tag=rust-lint', github.run_id)
@@ -282,7 +282,7 @@ jobs:
 
   rust-lint-no-default:
     name: "Rust (lint, no default)"
-    timeout-minutes: 40
+    timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=rust-lint-no-default', github.run_id)
@@ -301,7 +301,7 @@ jobs:
 
   public-api:
     name: "Public API lock files"
-    timeout-minutes: 40
+    timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-xsmall/image=ubuntu24-full-x64-pre-v2/tag=public-api', github.run_id)
@@ -335,7 +335,7 @@ jobs:
 
   rust-coverage:
     name: "Rust tests (coverage) (${{ matrix.suite }})"
-    timeout-minutes: 40
+    timeout-minutes: 30
     permissions:
       id-token: write
     strategy:
@@ -398,7 +398,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/pool=amd64-medium-pre-v2/tag=rust-test-sanitizer', github.run_id)
           || 'ubuntu-latest' }}
-    timeout-minutes: 40
+    timeout-minutes: 30
     env:
       ASAN_OPTIONS: "symbolize=1:check_initialization_order=1:detect_leaks=1:leak_check_at_exit=1"
       LSAN_OPTIONS: "report_objects=1"
@@ -459,7 +459,7 @@ jobs:
           - sanitizer: tsan
             sanitizer_flags: "-Zsanitizer=thread"
     name: "Rust/C++ FFI tests (${{ matrix.sanitizer }})"
-    timeout-minutes: 40
+    timeout-minutes: 30
     env:
       ASAN_OPTIONS: "symbolize=1:check_initialization_order=1:detect_leaks=1:leak_check_at_exit=1"
       LSAN_OPTIONS: "report_objects=1"
@@ -511,7 +511,7 @@ jobs:
   cuda-build-lint:
     if: github.repository == 'vortex-data/vortex'
     name: "CUDA build & lint"
-    timeout-minutes: 40
+    timeout-minutes: 30
     runs-on: runs-on=${{ github.run_id }}/runner=gpu/tag=cuda-build
     steps:
       - uses: runs-on/action@v2
@@ -642,7 +642,7 @@ jobs:
 
   rust-test-other:
     name: "Rust tests (${{ matrix.os }})"
-    timeout-minutes: 40
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -700,7 +700,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/pool=amd64-medium-pre-v2/tag=java', github.run_id)
           || 'ubuntu-latest' }}
-    timeout-minutes: 40
+    timeout-minutes: 30
     steps:
       - uses: runs-on/action@v2
         if: github.repository == 'vortex-data/vortex'
@@ -724,7 +724,7 @@ jobs:
           - { shard: 7, name: "Encodings 4", packages: "vortex-sparse vortex-zigzag vortex-zstd" }
           - { shard: 8, name: "Storage formats", packages: "vortex-flatbuffers vortex-proto vortex-btrblocks" }
     name: "Benchmark with Codspeed (Shard #${{ matrix.shard }})"
-    timeout-minutes: 40
+    timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=bench-codspeed-{1}', github.run_id, matrix.shard)
@@ -757,7 +757,7 @@ jobs:
   license-check-and-audit-check:
     name: License Check and Audit Check
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 30
     strategy:
       matrix:
         checks:
@@ -773,7 +773,7 @@ jobs:
 
   cxx-test:
     name: "C++ build"
-    timeout-minutes: 40
+    timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=cxx-build', github.run_id)
@@ -806,6 +806,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=sql-logic-test', github.run_id)
           || 'ubuntu-latest' }}
+    timeout-minutes: 30
     steps:
       - uses: runs-on/action@v2
         if: github.repository == 'vortex-data/vortex'
@@ -824,7 +825,7 @@ jobs:
   wasm-integration:
     name: "WASM integration smoke test"
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-rust
@@ -847,7 +848,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=rust-miri', github.run_id)
           || 'ubuntu-latest' }}
-    timeout-minutes: 40
+    timeout-minutes: 30
     env:
       MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-symbolic-alignment-check -Zmiri-disable-isolation -Zmiri-env-forward=RUST_BACKTRACE
       RUSTFLAGS: "-A warnings"
@@ -870,7 +871,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=generated-files', github.run_id)
           || 'ubuntu-latest' }}
-    timeout-minutes: 40
+    timeout-minutes: 30
     steps:
       - uses: runs-on/action@v2
         if: github.repository == 'vortex-data/vortex'
@@ -932,7 +933,7 @@ jobs:
     runs-on: ${{ matrix.target.runs-on }}
     container:
       image: "ubuntu:20.04"
-    timeout-minutes: 40
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -963,7 +964,7 @@ jobs:
 
   rust-publish-dry-run:
     name: "Rust publish dry-run"
-    timeout-minutes: 40
+    timeout-minutes: 30
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-xsmall/image=ubuntu24-full-x64-pre-v2/tag=rust-publish-dry-run', github.run_id)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -23,6 +23,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/close-fixed-fuzzer-issues.yml
+++ b/.github/workflows/close-fixed-fuzzer-issues.yml
@@ -29,7 +29,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=arm64-medium/disk=large/tag=fuzzer-cleanup-{1}', github.run_id, matrix.target)
           || 'ubuntu-latest' }}
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: runs-on/action@v2
         if: github.repository == 'vortex-data/vortex'

--- a/.github/workflows/compat-gen-upload.yml
+++ b/.github/workflows/compat-gen-upload.yml
@@ -27,6 +27,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=compat-gen-dry-run', github.run_id)
           || 'ubuntu-latest' }}
+    timeout-minutes: 30
     permissions:
       id-token: write
       contents: read
@@ -77,6 +78,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=compat-gen-upload', github.run_id)
           || 'ubuntu-latest' }}
+    timeout-minutes: 30
     environment: compat-upload
     permissions:
       id-token: write

--- a/.github/workflows/compat-validation.yml
+++ b/.github/workflows/compat-validation.yml
@@ -27,7 +27,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=amd64-medium/image=ubuntu24-full-x64-pre-v2/tag=compat-validation', github.run_id)
           || 'ubuntu-latest' }}
-    timeout-minutes: 120
+    timeout-minutes: 30
     steps:
       - uses: runs-on/action@v2
         if: github.repository == 'vortex-data/vortex'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-rust

--- a/.github/workflows/fuzz-coverage.yml
+++ b/.github/workflows/fuzz-coverage.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         fuzz_target: [array_ops, file_io, compress_roundtrip]
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=arm64-medium/disk=large', github.run_id)

--- a/.github/workflows/fuzzer-fix-automation.yml
+++ b/.github/workflows/fuzzer-fix-automation.yml
@@ -32,7 +32,7 @@ jobs:
       github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
 
     permissions:
       contents: write

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,6 +13,7 @@ jobs:
   check_changelog_label:
     name: Validate Changelog Label
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       pull-requests: read  # Grant permission to read PR information
     steps:

--- a/.github/workflows/minimize_fuzz_corpus_workflow.yml
+++ b/.github/workflows/minimize_fuzz_corpus_workflow.yml
@@ -43,6 +43,7 @@ jobs:
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner=arm64-medium/disk=large/tag={1}-minimize', github.run_id, inputs.fuzz_target)
           || 'ubuntu-latest' }}
+    timeout-minutes: 240
     steps:
       - name: Bail if not on develop
         if: github.ref != 'refs/heads/develop'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -84,6 +84,7 @@ jobs:
 
   prepare-java-macos:
     runs-on: "macos-latest"
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
         with:
@@ -108,7 +109,7 @@ jobs:
     runs-on: ${{ matrix.target.runs-on }}
     container:
       image: "ubuntu:20.04"
-    timeout-minutes: 120
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -140,5 +141,6 @@ jobs:
   prepare-all:
     needs: [prepare-python, prepare-java-macos, prepare-java-linux]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - run: echo "All packages built successfully"

--- a/.github/workflows/publish-benchmarks-website.yml
+++ b/.github/workflows/publish-benchmarks-website.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
   publish-rust:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 30
     needs: [package]
     steps:
       - uses: actions/checkout@v6
@@ -49,7 +49,7 @@ jobs:
   publish-python:
     needs: [package]
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 30
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
       deployments: write
@@ -76,7 +76,7 @@ jobs:
   publish-java:
     needs: [package]
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 30
     env:
       # Picked up by gradle-git-version
       GIT_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,6 +25,7 @@ jobs:
       # write permission is required to create a github release
       contents: write
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: release-drafter/release-drafter@v7.1.1
         with:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   reuse-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - name: REUSE Compliance Check

--- a/.github/workflows/run-fuzzer.yml
+++ b/.github/workflows/run-fuzzer.yml
@@ -65,7 +65,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_FUZZ_SECRET_ACCESS_KEY }}
       AWS_REGION: "us-east-1"
       AWS_ENDPOINT_URL: "https://01e9655179bbec953276890b183039bc.r2.cloudflarestorage.com"
-    timeout-minutes: 230  # almost 4 hours
+    timeout-minutes: 240  # 4 hours
     runs-on: >-
       ${{ github.repository == 'vortex-data/vortex'
           && format('runs-on={0}/runner={1}/disk=large/tag={2}-fuzz', github.run_id, inputs.runner, inputs.fuzz_name || inputs.fuzz_target)

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -16,6 +16,7 @@ jobs:
   spelling:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout Actions Repository
         uses: actions/checkout@v6

--- a/.github/workflows/wasm-fuzz.yml
+++ b/.github/workflows/wasm-fuzz.yml
@@ -23,7 +23,7 @@ jobs:
   wasm-fuzz:
     name: "Build & Fuzz WASM"
     runs-on: ubuntu-latest
-    timeout-minutes: 270
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v6
 
@@ -63,7 +63,7 @@ jobs:
           # Capture exit code - wasmfuzz exits with error on crash
           set +e
           wasmfuzz fuzz \
-            --timeout=4h \
+            --timeout=3h30m \
             --cores 2 \
             --dir corpus-wasm/ \
             target/wasm32-wasip1/release/array_ops_wasm.wasm

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -22,6 +22,7 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       pull-requests: read
     outputs:


### PR DESCRIPTION
Audit all GitHub Actions workflow timeouts against actual run durations and consolidate to 4 consistent tiers:

- 10 min: quick utility jobs (labels, lints, deploys, reports)
- 30 min: standard CI build/test/lint, docs build
- 120 min: heavy compute (benchmarks, packaging, publishing, fuzz-coverage)
- 240 min: marathon fuzz runs and corpus minimization

Notably, fuzz-coverage was hitting its old 60-min timeout and getting cancelled on most runs — bumping to 120 fixes that.

### Timeout tiers

| Tier | Timeout | Purpose | Safety margin |
|------|---------|---------|---------------|
| ⚡ | **10 min** | Quick utility jobs (labels, lints, deploys, reports) | ~100×+ over typical |
| 🔨 | **30 min** | Standard CI build/test/lint, docs, packaging, publishing | ~5× over slowest job in tier |
| 🏋️ | **120 min** | Heavy compute (benchmarks, python packaging, fuzz-coverage) | ~2× over slowest job in tier |
| 🔬 | **240 min** | Marathon fuzz runs and corpus minimization | Matches libfuzzer/wasmfuzz time configs |

### Per-job breakdown

#### ⚡ Tier 1 — 10 min

| Workflow | Job | Previous timeout | Max observed duration |
|----------|-----|-----------------|----------------------|
| `approvals.yml` | `check-approvals` | ❌ none (6h default) | < 1 min |
| `bench-dispatch.yml` | `remove-bench-label` | 2 min | < 1 min |
| `bench-dispatch.yml` | `remove-sql-label` | 2 min | < 1 min |
| `bench.yml` | `commit-metadata` | 10 min | < 1 min |
| `ci.yml` | `lint-toml` | 40 min | ~9 sec |
| `ci.yml` | `validate-workflow-yaml` | 40 min | ~8 sec |
| `ci.yml` | `python-lint` | 40 min | ~39 sec |
| `ci.yml` | `cpp-lint` | 10 min | ~8 sec |
| `ci.yml` | `ffi-c-test` | 10 min | ~49 sec |
| `docs.yml` | `deploy` | 10 min | ~31 sec |
| `labels.yml` | `check_changelog_label` | ❌ none | < 1 min |
| `package.yml` | `prepare-all` | ❌ none | < 1 min |
| `publish-benchmarks-website.yml` | `publish` | ❌ none | < 1 min |
| `release-drafter.yml` | `update_release_draft` | ❌ none | < 1 min |
| `report-fuzz-crash.yml` | `report` | 10 min | < 1 min |
| `reuse.yml` | `reuse-check` | ❌ none | < 1 min |
| `stale.yml` | `close-issues` | 10 min | < 1 min |
| `typos.yml` | `spelling` | ❌ none | < 1 min |
| `web.yml` | `changes` | ❌ none | < 1 min |
| `web.yml` | `deploy` | 10 min | < 1 min |

#### 🔨 Tier 2 — 30 min

| Workflow | Job | Previous timeout | Max observed duration |
|----------|-----|-----------------|----------------------|
| `ci.yml` | `python-test` | 40 min | ~2 min 10 sec |
| `ci.yml` | `python-wheel-build` | 40 min | ~2 min 44 sec |
| `ci.yml` | `rust-docs` | 40 min | ~2 min 20 sec |
| `ci.yml` | `build-rust` (all matrix entries) | 40 min | ~2 min 18 sec |
| `ci.yml` | `check-min-deps` | 40 min | ~1 min 23 sec |
| `ci.yml` | `rust-lint` | 40 min | ~2 min 22 sec |
| `ci.yml` | `rust-lint-no-default` | 40 min | ~1 min 35 sec |
| `ci.yml` | `public-api` | 40 min | ~1 min 17 sec |
| `ci.yml` | `rust-coverage` | 40 min | ~4 min 47 sec |
| `ci.yml` | `rust-test-sanitizer` | 40 min | ~3 min 19 sec |
| `ci.yml` | `rust-ffi-test-sanitizer` | 40 min | ~1 min 16 sec |
| `ci.yml` | `cuda-build-lint` | 40 min | ~3 min 9 sec |
| `ci.yml` | `cuda-test` | 30 min | ~3 min 32 sec |
| `ci.yml` | `cuda-test-sanitizer` | 30 min | ~3 min 14 sec |
| `ci.yml` | `cuda-test-cudf` | 30 min | ~2 min |
| `ci.yml` | `rust-test-other` (windows/arm64) | 40 min | ~5 min 58 sec |
| `ci.yml` | `build-java` | 40 min | ~2 min 24 sec |
| `ci.yml` | `bench-codspeed` (all shards) | 40 min | ~2 min 37 sec |
| `ci.yml` | `license-check-and-audit-check` | 40 min | ~57 sec |
| `ci.yml` | `cxx-test` | 40 min | ~1 min 28 sec |
| `ci.yml` | `sqllogic-test` | ❌ none (6h default) | ~1 min 38 sec |
| `ci.yml` | `wasm-integration` | 40 min | ~2 min 16 sec |
| `ci.yml` | `miri` | 40 min | ~1 min 44 sec |
| `ci.yml` | `generated-files` | 40 min | ~45 sec |
| `ci.yml` | `check-java-publish-build` | 40 min | ~2 min 47 sec |
| `ci.yml` | `rust-publish-dry-run` | 40 min | ~36 sec |
| `close-fixed-fuzzer-issues.yml` | `close-fixed` | 60 min | ~2 min |
| `compat-gen-upload.yml` | `dry-run` | ❌ none | ~3 min |
| `compat-gen-upload.yml` | `upload` | ❌ none | ~1 min 18 sec |
| `compat-validation.yml` | `compat-test` | 120 min | ~3 min 20 sec |
| `docs.yml` | `build` | 120 min | ~15 min |
| `package.yml` | `prepare-java-macos` | ❌ none | ~6 min |
| `package.yml` | `prepare-java-linux` | 120 min | ~6 min 22 sec |
| `publish.yml` | `publish-rust` | 120 min | ~1 min 37 sec |
| `publish.yml` | `publish-python` | 120 min | ~34 sec |
| `publish.yml` | `publish-java` | 120 min | ~10 min 12 sec |
| `web.yml` | `check` | 30 min | ~3 min |
| `web.yml` | `build` | 30 min | ~3 min |

#### 🏋️ Tier 3 — 120 min

| Workflow | Job | Previous timeout | Max observed duration |
|----------|-----|-----------------|----------------------|
| `bench-pr.yml` | `bench` | 120 min | ~42 min |
| `bench.yml` | `bench` | 120 min | ~42 min |
| `claude.yml` | `claude` | ❌ none | variable (AI agent) |
| `fuzz-coverage.yml` | `coverage` | 60 min ⚠️ | **~60 min (was hitting timeout!)** |
| `fuzzer-fix-automation.yml` | `attempt-fix` | 90 min | ~30 min |
| `package.yml` | `prepare-python` | 120 min | ~40 min |
| `release-binaries.yml` | `build` | 120 min | ~40 min |
| `sql-benchmarks.yml` | `bench` | 120 min | ~60 min (nightly SF=100) |

#### 🔬 Tier 4 — 240 min

| Workflow | Job | Previous timeout | Max observed duration |
|----------|-----|-----------------|----------------------|
| `run-fuzzer.yml` | `fuzz` | 230 min | ~50 min (libfuzzer `max_total_time=2700s`) |
| `wasm-fuzz.yml` | `wasm-fuzz` | 270 min | up to 3h30m (wasmfuzz `--timeout=3h30m`) |
| `minimize_fuzz_corpus_workflow.yml` | `minimize` | ❌ none (6h default) | variable |

Also lowered wasmfuzz `--timeout` from `4h` to `3h30m` so the fuzz step itself fits within 240 min with ~30 min headroom for build/setup/teardown.

### Notable fixes

- **`fuzz-coverage` was silently broken**: the old 60-min timeout was being hit on 4 out of 5 recent runs (all cancelled at ~61 min). Bumping to 120 min fixes this.
- **14 jobs had no timeout at all**, defaulting to the GitHub Actions 6-hour maximum. All now have explicit timeouts.
- **`sqllogic-test`** in CI had no timeout — now set to 30 min.