### PR TITLE
Correct rust version channel

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -58,7 +58,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: vortex-web/package-lock.json
       - run: npm ci
-      - run: npm run wasm
+      - env:
+          RUSTFLAGS: --cfg getrandom_backend\"unsupported"
+          run: npm run wasm
       - run: npm run format:check
       - run: npm run lint
       - run: npm run typecheck

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ keywords = ["vortex"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/spiraldb/vortex"
-rust-version = "1.90"
+rust-version = "1.90.0"
 version = "0.1.0"
 
 [workspace.dependencies]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.90"
+channel = "1.90.0"
 components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/vortex-web/crate/Cargo.toml
+++ b/vortex-web/crate/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vortex-web-wasm"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.90"
+rust-version = "1.90.0"
 license = "Apache-2.0"
 description = "WASM bindings for the Vortex web explorer"
 publish = false


### PR DESCRIPTION
I had noticed when setting up machines for benchmarking that 1.90 isn't actually
a valid rust version and changing it to 1.90.0 was required to make it work

Signed-off-by: Robert Kruszewski <github@robertk.io>
