### PR TITLE
vortex-array: Attempt casting inner array to target for extensions

### DIFF
--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -17,7 +17,9 @@ impl CastReduce for Extension {
         dtype: &DType,
     ) -> vortex_error::VortexResult<Option<ArrayRef>> {
         if !array.dtype().eq_ignore_nullability(dtype) {
-            return Ok(None);
+            // Target is not the same extension type.
+            // Delegate to the storage array's cast.
+            return Ok(Some(array.storage_array().cast(dtype.clone())?));
         }
 
         let DType::Extension(ext_dtype) = dtype else {
@@ -51,9 +53,12 @@ mod tests {
     use super::*;
     use crate::IntoArray;
     use crate::arrays::PrimitiveArray;
+    use crate::assert_arrays_eq;
     use crate::builtins::ArrayBuiltins;
     use crate::compute::conformance::cast::test_cast_conformance;
+    use crate::dtype::DType;
     use crate::dtype::Nullability;
+    use crate::dtype::PType;
     use crate::extension::datetime::TimeUnit;
     use crate::extension::datetime::Timestamp;
 
@@ -106,6 +111,26 @@ mod tests {
                 .and_then(|a| a.to_canonical().map(|c| c.into_array()))
                 .is_err()
         );
+    }
+
+    #[test]
+    fn cast_timestamp_to_i64() -> vortex_error::VortexResult<()> {
+        let ext_dtype = Timestamp::new_with_tz(
+            TimeUnit::Nanoseconds,
+            Some("UTC".into()),
+            Nullability::NonNullable,
+        )
+        .erased();
+        let storage = buffer![1i64, 2, 3].into_array();
+        let arr = ExtensionArray::new(ext_dtype, storage).into_array();
+
+        let result = arr.cast(DType::Primitive(PType::I64, Nullability::NonNullable))?;
+        assert_eq!(
+            result.dtype(),
+            &DType::Primitive(PType::I64, Nullability::NonNullable)
+        );
+        assert_arrays_eq!(result, buffer![1i64, 2, 3].into_array());
+        Ok(())
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

Getting
```
No CastKernel to cast canonical array vortex.ext from vortex.timestamp[ns, tz=UTC](i64) to i64
```
When running a datafusion query like:
```
SELECT cast(timestamp as bigint) as timestamp from table;
```

Where the timestamp array is a utc timestamp type column.

Since the inner array of a timestamp array is int64 already, all we really need to do is try to attempt to cast the inner array of the extension type to the target type. That's exactly what this PR does.

## Testing

Added a unit test.