### PR TITLE
Renovate can create unlimited prs during morning monday hours, limit overall renovate prs to 20

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,8 @@
   },
   "autoApprove": true,
   "automergeStrategy": "squash",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 20,
   "rebaseWhen": "conflicted",
   "cloneSubmodules": true,
   "platformAutomerge": true,


### PR DESCRIPTION
Essentially these 3 settings combined mean that we will only ever create
8 renovate prs per week

1. schedule:earlyMondays (line 14) — only runs "before 4am on Monday" (UTC). Renovate has a ~4 hour window, period. Anything not created in that window waits another week.
2. prHourlyLimit: 2 — inherited from config:recommended. Max 2 new PRs per hour, so the early-Monday window caps out at roughly 8 PRs per run.
3. prConcurrentLimit: 10 — also from config:recommended. Once 10 Renovate PRs are open, no new ones open until some are merged/closed.

This pr uncappes the concurrent pr opening on Mondays, however, still keeps
a limit of 20 open renovate prs

Signed-off-by: Robert Kruszewski <github@robertk.io>
