### PR TITLE
chore: remove deprecated compute functions from vortex-array

### DIFF
--- a/vortex-array/src/aggregate_fn/fns/sum/bool.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/bool.rs
@@ -52,10 +52,11 @@ mod tests {
 
     #[test]
     fn sum_bool_all_true() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr: BoolArray = [true, true, true].into_iter().collect();
         let result = sum(
             &arr.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(3));
         Ok(())
@@ -63,10 +64,11 @@ mod tests {
 
     #[test]
     fn sum_bool_mixed() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr: BoolArray = [true, false, true, false, true].into_iter().collect();
         let result = sum(
             &arr.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(3));
         Ok(())
@@ -74,10 +76,11 @@ mod tests {
 
     #[test]
     fn sum_bool_all_false() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr: BoolArray = [false, false, false].into_iter().collect();
         let result = sum(
             &arr.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(0));
         Ok(())
@@ -85,10 +88,11 @@ mod tests {
 
     #[test]
     fn sum_bool_with_nulls() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = BoolArray::from_iter([Some(true), None, Some(true), Some(false)]);
         let result = sum(
             &arr.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(2));
         Ok(())
@@ -96,10 +100,11 @@ mod tests {
 
     #[test]
     fn sum_bool_all_null() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = BoolArray::from_iter([None::<bool>, None, None]);
         let result = sum(
             &arr.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(0));
         Ok(())
@@ -143,8 +148,9 @@ mod tests {
 
     #[test]
     fn sum_boolean_from_iter() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = BoolArray::from_iter([true, false, false, true]).into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().as_::<i32>(), Some(2));
         Ok(())
     }

--- a/vortex-array/src/aggregate_fn/fns/sum/constant.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/constant.rs
@@ -108,55 +108,62 @@ mod tests {
 
     #[test]
     fn sum_constant_unsigned() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = ConstantArray::new(5u64, 10).into_array();
-        let result = sum(&array, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&array, &mut ctx)?;
         assert_eq!(result, 50u64.into());
         Ok(())
     }
 
     #[test]
     fn sum_constant_signed() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = ConstantArray::new(-5i64, 10).into_array();
-        let result = sum(&array, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&array, &mut ctx)?;
         assert_eq!(result, (-50i64).into());
         Ok(())
     }
 
     #[test]
     fn sum_constant_nullable_value() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = ConstantArray::new(Scalar::null(DType::Primitive(PType::U32, Nullable)), 10)
             .into_array();
-        let result = sum(&array, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&array, &mut ctx)?;
         assert_eq!(result, Scalar::primitive(0u64, Nullable));
         Ok(())
     }
 
     #[test]
     fn sum_constant_bool_false() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = ConstantArray::new(false, 10).into_array();
-        let result = sum(&array, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&array, &mut ctx)?;
         assert_eq!(result, 0u64.into());
         Ok(())
     }
 
     #[test]
     fn sum_constant_bool_true() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = ConstantArray::new(true, 10).into_array();
-        let result = sum(&array, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&array, &mut ctx)?;
         assert_eq!(result, 10u64.into());
         Ok(())
     }
 
     #[test]
     fn sum_constant_bool_null() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = ConstantArray::new(Scalar::null(DType::Bool(Nullable)), 10).into_array();
-        let result = sum(&array, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&array, &mut ctx)?;
         assert_eq!(result, Scalar::primitive(0u64, Nullable));
         Ok(())
     }
 
     #[test]
     fn sum_constant_decimal() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(10, 2);
         let array = ConstantArray::new(
             Scalar::decimal(
@@ -168,7 +175,7 @@ mod tests {
         )
         .into_array();
 
-        let result = sum(&array, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&array, &mut ctx)?;
 
         assert_eq!(
             result.as_decimal().decimal_value(),
@@ -180,11 +187,12 @@ mod tests {
 
     #[test]
     fn sum_constant_decimal_null() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(10, 2);
         let array = ConstantArray::new(Scalar::null(DType::Decimal(decimal_dtype, Nullable)), 10)
             .into_array();
 
-        let result = sum(&array, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&array, &mut ctx)?;
         assert_eq!(
             result,
             Scalar::decimal(
@@ -198,6 +206,7 @@ mod tests {
 
     #[test]
     fn sum_constant_decimal_large_value() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(10, 2);
         let array = ConstantArray::new(
             Scalar::decimal(
@@ -209,7 +218,7 @@ mod tests {
         )
         .into_array();
 
-        let result = sum(&array, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&array, &mut ctx)?;
         assert_eq!(
             result.as_decimal().decimal_value(),
             Some(DecimalValue::I256(i256::from_i128(99_999_999_900)))

--- a/vortex-array/src/aggregate_fn/fns/sum/decimal.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/decimal.rs
@@ -131,6 +131,7 @@ mod tests {
 
     #[test]
     fn sum_decimal_basic() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal = DecimalArray::new(
             buffer![100i32, 200i32, 300i32],
             DecimalDType::new(4, 2),
@@ -139,7 +140,7 @@ mod tests {
 
         let result = sum(
             &decimal.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
 
         let expected = Scalar::try_new(
@@ -153,6 +154,7 @@ mod tests {
 
     #[test]
     fn sum_decimal_with_nulls() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal = DecimalArray::new(
             buffer![100i32, 200i32, 300i32, 400i32],
             DecimalDType::new(4, 2),
@@ -161,7 +163,7 @@ mod tests {
 
         let result = sum(
             &decimal.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
 
         let expected = Scalar::try_new(
@@ -175,6 +177,7 @@ mod tests {
 
     #[test]
     fn sum_decimal_negative_values() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal = DecimalArray::new(
             buffer![100i32, -200i32, 300i32, -50i32],
             DecimalDType::new(4, 2),
@@ -183,7 +186,7 @@ mod tests {
 
         let result = sum(
             &decimal.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
 
         let expected = Scalar::try_new(
@@ -197,6 +200,7 @@ mod tests {
 
     #[test]
     fn sum_decimal_near_i32_max() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let near_max = i32::MAX - 1000;
         let decimal = DecimalArray::new(
             buffer![near_max, 500i32, 400i32],
@@ -206,7 +210,7 @@ mod tests {
 
         let result = sum(
             &decimal.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
 
         let expected_sum = near_max as i64 + 500 + 400;
@@ -221,6 +225,7 @@ mod tests {
 
     #[test]
     fn sum_decimal_large_i64_values() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let large_val = i64::MAX / 4;
         let decimal = DecimalArray::new(
             buffer![large_val, large_val, large_val, large_val + 1],
@@ -230,7 +235,7 @@ mod tests {
 
         let result = sum(
             &decimal.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
 
         let expected_sum = (large_val as i128) * 4 + 1;
@@ -245,6 +250,7 @@ mod tests {
 
     #[test]
     fn sum_decimal_preserves_scale() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal = DecimalArray::new(
             buffer![12345i32, 67890i32, 11111i32],
             DecimalDType::new(6, 4),
@@ -253,7 +259,7 @@ mod tests {
 
         let result = sum(
             &decimal.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
 
         let expected = Scalar::try_new(
@@ -267,12 +273,13 @@ mod tests {
 
     #[test]
     fn sum_decimal_single_value() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal =
             DecimalArray::new(buffer![42i32], DecimalDType::new(3, 1), Validity::AllValid);
 
         let result = sum(
             &decimal.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
 
         let expected = Scalar::try_new(
@@ -286,6 +293,7 @@ mod tests {
 
     #[test]
     fn sum_decimal_all_nulls_except_one() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal = DecimalArray::new(
             buffer![100i32, 200i32, 300i32, 400i32],
             DecimalDType::new(4, 2),
@@ -294,7 +302,7 @@ mod tests {
 
         let result = sum(
             &decimal.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
 
         let expected = Scalar::try_new(
@@ -308,6 +316,7 @@ mod tests {
 
     #[test]
     fn sum_decimal_overflow_detection() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let max_val = i128::MAX / 2;
         let decimal = DecimalArray::new(
             buffer![max_val, max_val, max_val],
@@ -317,7 +326,7 @@ mod tests {
 
         let result = sum(
             &decimal.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
 
         let expected_sum =
@@ -333,6 +342,7 @@ mod tests {
 
     #[test]
     fn sum_decimal_i256_overflow() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(76, 0);
         let decimal = DecimalArray::new(
             buffer![i256::MAX, i256::MAX, i256::MAX],
@@ -343,7 +353,7 @@ mod tests {
         assert_eq!(
             sum(
                 &decimal.into_array(),
-                &mut LEGACY_SESSION.create_execution_ctx()
+                &mut ctx
             )
             .vortex_expect("operation should succeed in test"),
             Scalar::null(DType::Decimal(decimal_dtype, Nullable))

--- a/vortex-array/src/aggregate_fn/fns/sum/mod.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/mod.rs
@@ -477,6 +477,7 @@ mod tests {
 
     #[test]
     fn sum_stats() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = ChunkedArray::try_new(
             vec![
                 PrimitiveArray::from_iter([1, 1, 1]).into_array(),
@@ -489,7 +490,7 @@ mod tests {
         // compute sum with accumulator to populate stats
         sum_with_accumulator(&array, &Scalar::primitive(2i64, Nullable))?;
 
-        let sum_without_acc = sum(&array, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let sum_without_acc = sum(&array, &mut ctx)?;
         assert_eq!(sum_without_acc, Scalar::primitive(9i64, Nullable));
         Ok(())
     }
@@ -512,8 +513,9 @@ mod tests {
     // Grouped sum tests
 
     fn run_grouped_sum(groups: &ArrayRef, elem_dtype: &DType) -> VortexResult<ArrayRef> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut acc = GroupedAccumulator::try_new(Sum, EmptyOptions, elem_dtype.clone())?;
-        acc.accumulate_list(groups, &mut LEGACY_SESSION.create_execution_ctx())?;
+        acc.accumulate_list(groups, &mut ctx)?;
         acc.finish()
     }
 
@@ -620,6 +622,7 @@ mod tests {
 
     #[test]
     fn sum_chunked_floats_with_nulls() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let chunk1 =
             PrimitiveArray::from_option_iter(vec![Some(1.5f64), None, Some(3.2), Some(4.8)]);
         let chunk2 = PrimitiveArray::from_option_iter(vec![Some(2.1f64), Some(5.7), None]);
@@ -636,7 +639,7 @@ mod tests {
 
         let result = sum(
             &chunked.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         assert_eq!(result.as_primitive().as_::<f64>(), Some(20.8));
         Ok(())
@@ -644,13 +647,14 @@ mod tests {
 
     #[test]
     fn sum_chunked_floats_all_nulls_is_zero() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let chunk1 = PrimitiveArray::from_option_iter::<f32, _>(vec![None, None, None]);
         let chunk2 = PrimitiveArray::from_option_iter::<f32, _>(vec![None, None]);
         let dtype = chunk1.dtype().clone();
         let chunked = ChunkedArray::try_new(vec![chunk1.into_array(), chunk2.into_array()], dtype)?;
         let result = sum(
             &chunked.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         assert_eq!(result, Scalar::primitive(0f64, Nullable));
         Ok(())
@@ -658,6 +662,7 @@ mod tests {
 
     #[test]
     fn sum_chunked_floats_empty_chunks() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let chunk1 = PrimitiveArray::from_option_iter(vec![Some(10.5f64), Some(20.3)]);
         let chunk2 = ConstantArray::new(Scalar::primitive(0f64, Nullable), 0);
         let chunk3 = PrimitiveArray::from_option_iter(vec![Some(5.2f64)]);
@@ -673,7 +678,7 @@ mod tests {
 
         let result = sum(
             &chunked.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         assert_eq!(result.as_primitive().as_::<f64>(), Some(36.0));
         Ok(())
@@ -681,6 +686,7 @@ mod tests {
 
     #[test]
     fn sum_chunked_int_almost_all_null() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let chunk1 = PrimitiveArray::from_option_iter::<u32, _>(vec![Some(1)]);
         let chunk2 = PrimitiveArray::from_option_iter::<u32, _>(vec![None]);
         let dtype = chunk1.dtype().clone();
@@ -688,7 +694,7 @@ mod tests {
 
         let result = sum(
             &chunked.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         assert_eq!(result.as_primitive().as_::<u64>(), Some(1));
         Ok(())
@@ -696,6 +702,7 @@ mod tests {
 
     #[test]
     fn sum_chunked_decimals() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(10, 2);
         let chunk1 = DecimalArray::new(
             buffer![100i32, 100i32, 100i32, 100i32, 100i32],
@@ -720,7 +727,7 @@ mod tests {
 
         let result = sum(
             &chunked.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         let decimal_result = result.as_decimal();
         assert_eq!(
@@ -732,6 +739,7 @@ mod tests {
 
     #[test]
     fn sum_chunked_decimals_with_nulls() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(10, 2);
         let chunk1 = DecimalArray::new(
             buffer![100i32, 100i32, 100i32],
@@ -756,7 +764,7 @@ mod tests {
 
         let result = sum(
             &chunked.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         let decimal_result = result.as_decimal();
         assert_eq!(
@@ -768,6 +776,7 @@ mod tests {
 
     #[test]
     fn sum_chunked_decimals_large() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(3, 0);
         let chunk1 = ConstantArray::new(
             Scalar::decimal(
@@ -790,7 +799,7 @@ mod tests {
 
         let result = sum(
             &chunked.into_array(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         let decimal_result = result.as_decimal();
         assert_eq!(

--- a/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
+++ b/vortex-array/src/aggregate_fn/fns/sum/primitive.rs
@@ -139,65 +139,73 @@ mod tests {
 
     #[test]
     fn sum_i32() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::new(buffer![1i32, 2, 3, 4], Validity::NonNullable).into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().typed_value::<i64>(), Some(10));
         Ok(())
     }
 
     #[test]
     fn sum_u8() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::new(buffer![10u8, 20, 30], Validity::NonNullable).into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().typed_value::<u64>(), Some(60));
         Ok(())
     }
 
     #[test]
     fn sum_f64() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr =
             PrimitiveArray::new(buffer![1.5f64, 2.5, 3.0], Validity::NonNullable).into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(7.0));
         Ok(())
     }
 
     #[test]
     fn sum_with_nulls() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::from_option_iter([Some(2i32), None, Some(4)]).into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().typed_value::<i64>(), Some(6));
         Ok(())
     }
 
     #[test]
     fn sum_all_null() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::from_option_iter([None::<i32>, None, None]).into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().typed_value::<i64>(), Some(0));
         Ok(())
     }
 
     #[test]
     fn sum_all_invalid_float() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::from_option_iter::<f32, _>([None, None, None]).into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result, Scalar::primitive(0f64, Nullable));
         Ok(())
     }
 
     #[test]
     fn sum_buffer_i32() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = buffer![1, 1, 1, 1].into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().as_::<i32>(), Some(4));
         Ok(())
     }
 
     #[test]
     fn sum_buffer_f64() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = buffer![1., 1., 1., 1.].into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().as_::<f32>(), Some(4.));
         Ok(())
     }
@@ -222,51 +230,56 @@ mod tests {
 
     #[test]
     fn sum_f64_with_nan() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::new(
             buffer![1.0f64, f64::NAN, 2.0, f64::NAN, 3.0],
             Validity::NonNullable,
         )
         .into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(6.0));
         Ok(())
     }
 
     #[test]
     fn sum_f32_with_nan() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr =
             PrimitiveArray::new(buffer![1.0f32, f32::NAN, 4.0], Validity::NonNullable).into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(5.0));
         Ok(())
     }
 
     #[test]
     fn sum_f64_with_nan_and_nulls() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::from_option_iter([Some(1.0f64), None, Some(f64::NAN), Some(3.0)])
             .into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(4.0));
         Ok(())
     }
 
     #[test]
     fn sum_all_nan() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr =
             PrimitiveArray::new(buffer![f64::NAN, f64::NAN], Validity::NonNullable).into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert_eq!(result.as_primitive().typed_value::<f64>(), Some(0.0));
         Ok(())
     }
 
     #[test]
     fn sum_f64_with_infinity() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let batch = PrimitiveArray::new(
             buffer![1.0f64, f64::INFINITY, f64::NEG_INFINITY, 2.0],
             Validity::NonNullable,
         )
         .into_array();
-        let acc = sum(&batch, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let acc = sum(&batch, &mut ctx)?;
         // INFINITY + NEG_INFINITY = NaN, which is treated as saturated
         assert!(acc.as_primitive().typed_value::<f64>().unwrap().is_nan());
 
@@ -275,28 +288,30 @@ mod tests {
             EmptyOptions,
             DType::Primitive(PType::F64, Nullability::NonNullable),
         )?;
-        acc.accumulate(&batch, &mut LEGACY_SESSION.create_execution_ctx())?;
+        acc.accumulate(&batch, &mut ctx)?;
         assert!(acc.is_saturated());
         Ok(())
     }
 
     #[test]
     fn sum_checked_overflow() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::new(buffer![i64::MAX, 1i64], Validity::NonNullable).into_array();
-        let result = sum(&arr, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let result = sum(&arr, &mut ctx)?;
         assert!(result.is_null());
         Ok(())
     }
 
     #[test]
     fn sum_checked_overflow_is_saturated() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DType::Primitive(PType::I64, Nullability::NonNullable);
         let mut acc = Accumulator::try_new(Sum, EmptyOptions, dtype)?;
         assert!(!acc.is_saturated());
 
         let batch =
             PrimitiveArray::new(buffer![i64::MAX, 1i64], Validity::NonNullable).into_array();
-        acc.accumulate(&batch, &mut LEGACY_SESSION.create_execution_ctx())?;
+        acc.accumulate(&batch, &mut ctx)?;
         assert!(acc.is_saturated());
 
         // finish resets state, clearing saturation

--- a/vortex-array/src/array/erased.rs
+++ b/vortex-array/src/array/erased.rs
@@ -211,7 +211,8 @@ impl ArrayRef {
         efficient execution when fetching multiple scalars from the same array."
     )]
     pub fn scalar_at(&self, index: usize) -> VortexResult<Scalar> {
-        self.execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        self.execute_scalar(index, &mut ctx)
     }
 
     /// Execute the array to extract a scalar at the given index.
@@ -303,7 +304,8 @@ impl ArrayRef {
     /// Returns the canonical representation of the array.
     #[deprecated(note = "use `array.execute::<Canonical>(ctx)` instead")]
     pub fn into_canonical(self) -> VortexResult<Canonical> {
-        self.execute(&mut LEGACY_SESSION.create_execution_ctx())
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        self.execute(&mut ctx)
     }
 
     /// Returns the canonical representation of the array.

--- a/vortex-array/src/array/typed.rs
+++ b/vortex-array/src/array/typed.rs
@@ -352,8 +352,9 @@ impl<V: VTable> Array<V> {
         efficient execution when fetching multiple scalars from the same array."
     )]
     pub fn scalar_at(&self, index: usize) -> VortexResult<crate::scalar::Scalar> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.inner
-            .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(index, &mut ctx)
     }
 
     /// Execute the array to extract a scalar at the given index.

--- a/vortex-array/src/arrays/arbitrary.rs
+++ b/vortex-array/src/arrays/arbitrary.rs
@@ -13,8 +13,8 @@ use vortex_error::VortexExpect;
 
 use crate::ArrayRef;
 use crate::IntoArray;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
+use crate::LEGACY_SESSION;
+use crate::VortexSessionExecute;
 use crate::arrays::BoolArray;
 use crate::arrays::ChunkedArray;
 use crate::arrays::NullArray;
@@ -107,9 +107,10 @@ fn random_array_chunk(
             PType::I32 => random_primitive::<i32>(u, *n, chunk_len),
             PType::I64 => random_primitive::<i64>(u, *n, chunk_len),
             PType::F16 => {
-                #[expect(deprecated)]
+                let mut ctx = LEGACY_SESSION.create_execution_ctx();
                 let prim = random_primitive::<u16>(u, *n, chunk_len)?
-                    .to_primitive()
+                    .execute::<PrimitiveArray>(&mut ctx)
+                    .vortex_expect("to_primitive failed")
                     .reinterpret_cast(PType::F16)
                     .into_array();
                 Ok(prim)

--- a/vortex-array/src/arrays/assertions.rs
+++ b/vortex-array/src/arrays/assertions.rs
@@ -56,10 +56,9 @@ macro_rules! assert_nth_scalar {
         use $crate::LEGACY_SESSION;
         use $crate::VortexSessionExecute as _;
         let arr_ref: $crate::ArrayRef = $crate::IntoArray::into_array($arr.clone());
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         assert_eq!(
-            arr_ref
-                .execute_scalar($n, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap(),
+            arr_ref.execute_scalar($n, &mut ctx).unwrap(),
             $expected.try_into().unwrap()
         );
     }};
@@ -79,16 +78,13 @@ macro_rules! assert_nth_scalar_is_null {
         use $crate::LEGACY_SESSION;
         use $crate::VortexSessionExecute as _;
         let arr_ref: $crate::ArrayRef = $crate::IntoArray::into_array($arr.clone());
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let scalar_val = arr_ref.execute_scalar($n, &mut ctx).unwrap();
         assert!(
-            arr_ref
-                .execute_scalar($n, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-                .is_null(),
+            scalar_val.is_null(),
             "expected scalar at index {} to be null, but was {:?}",
             $n,
-            arr_ref
-                .execute_scalar($n, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
+            scalar_val
         );
     }};
 }
@@ -131,7 +127,8 @@ macro_rules! assert_arrays_eq {
 #[track_caller]
 #[expect(clippy::panic)]
 pub fn assert_arrays_eq_impl(left: &ArrayRef, right: &ArrayRef) {
-    let executed = execute_to_canonical(left.clone(), &mut LEGACY_SESSION.create_execution_ctx());
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let executed = execute_to_canonical(left.clone(), &mut ctx);
 
     let left_right = find_mismatched_indices(left, right);
     let executed_right = find_mismatched_indices(&executed, right);

--- a/vortex-array/src/arrays/bool/array.rs
+++ b/vortex-array/src/arrays/bool/array.rs
@@ -369,9 +369,10 @@ mod tests {
 
     #[test]
     fn bool_array() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = BoolArray::from_iter([true, false, true]);
         let scalar = bool::try_from(
-            &arr.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            &arr.execute_scalar(0, &mut ctx)
                 .unwrap(),
         )
         .unwrap();
@@ -380,18 +381,19 @@ mod tests {
 
     #[test]
     fn test_all_some_iter() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = BoolArray::from_iter([Some(true), Some(false)]);
 
         assert!(matches!(arr.validity(), Ok(Validity::AllValid)));
 
         let scalar = bool::try_from(
-            &arr.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            &arr.execute_scalar(0, &mut ctx)
                 .unwrap(),
         )
         .unwrap();
         assert!(scalar);
         let scalar = bool::try_from(
-            &arr.execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            &arr.execute_scalar(1, &mut ctx)
                 .unwrap(),
         )
         .unwrap();
@@ -400,42 +402,44 @@ mod tests {
 
     #[test]
     fn test_bool_from_iter() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = BoolArray::from_iter([Some(true), Some(true), None, Some(false), None]);
 
         let scalar = bool::try_from(
-            &arr.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            &arr.execute_scalar(0, &mut ctx)
                 .unwrap(),
         )
         .unwrap();
         assert!(scalar);
 
         let scalar = bool::try_from(
-            &arr.execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            &arr.execute_scalar(1, &mut ctx)
                 .unwrap(),
         )
         .unwrap();
         assert!(scalar);
 
         let scalar = arr
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap();
         assert!(scalar.is_null());
 
         let scalar = bool::try_from(
-            &arr.execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+            &arr.execute_scalar(3, &mut ctx)
                 .unwrap(),
         )
         .unwrap();
         assert!(!scalar);
 
         let scalar = arr
-            .execute_scalar(4, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(4, &mut ctx)
             .unwrap();
         assert!(scalar.is_null());
     }
 
     #[test]
     fn patch_sliced_bools() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = BoolArray::from(BitBuffer::new_set(12));
         let sliced = arr.slice(4..12).unwrap();
         assert_arrays_eq!(sliced, BoolArray::from_iter([true; 8]));
@@ -459,7 +463,7 @@ mod tests {
         )
         .unwrap();
         let arr = arr
-            .patch(&patches, &mut LEGACY_SESSION.create_execution_ctx())
+            .patch(&patches, &mut ctx)
             .unwrap();
         // After patching index 4 to false: indices 1-3 and 5-11 are true, index 0 and 4 are false
         let expected_patched: Vec<bool> = (0..12).map(|i| (1..12).contains(&i) && i != 4).collect();
@@ -478,6 +482,7 @@ mod tests {
 
     #[test]
     fn patch_bools_owned() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = BoolArray::from(BitBuffer::new_set(16));
         let buf_ptr = arr.to_bit_buffer().inner().as_ptr();
 
@@ -490,7 +495,7 @@ mod tests {
         )
         .unwrap();
         let arr = arr
-            .patch(&patches, &mut LEGACY_SESSION.create_execution_ctx())
+            .patch(&patches, &mut ctx)
             .unwrap();
         // Verify buffer was reused in place
         assert_eq!(arr.to_bit_buffer().inner().as_ptr(), buf_ptr);

--- a/vortex-array/src/arrays/bool/test_harness.rs
+++ b/vortex-array/src/arrays/bool/test_harness.rs
@@ -11,11 +11,12 @@ use crate::arrays::bool::BoolArrayExt;
 
 impl BoolArray {
     pub fn opt_bool_vec(&self) -> Vec<Option<bool>> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.validity()
             .vortex_expect("failed to get validity")
             .to_mask(
                 self.as_ref().len(),
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .vortex_expect("Failed to compute validity mask")
             .to_bit_buffer()
@@ -26,11 +27,12 @@ impl BoolArray {
     }
 
     pub fn bool_vec(&self) -> Vec<bool> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.validity()
             .vortex_expect("failed to get validity")
             .to_mask(
                 self.as_ref().len(),
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .vortex_expect("Failed to compute validity mask")
             .to_bit_buffer()

--- a/vortex-array/src/arrays/chunked/array.rs
+++ b/vortex-array/src/arrays/chunked/array.rs
@@ -352,6 +352,7 @@ mod test {
 
     #[test]
     fn test_empty_chunks_all_valid() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create chunks where some are empty but all non-empty chunks have all valid values
         let chunks = vec![
             PrimitiveArray::new(buffer![1u64, 2, 3], Validity::AllValid).into_array(),
@@ -366,13 +367,13 @@ mod test {
         // Should be all_valid since all non-empty chunks are all_valid
         assert!(
             chunked
-                .all_valid(&mut LEGACY_SESSION.create_execution_ctx())
+                .all_valid(&mut ctx)
                 .unwrap()
         );
         assert!(
             !chunked
                 .into_array()
-                .all_invalid(&mut LEGACY_SESSION.create_execution_ctx())
+                .all_invalid(&mut ctx)
                 .unwrap()
         );
 
@@ -381,6 +382,7 @@ mod test {
 
     #[test]
     fn test_empty_chunks_all_invalid() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create chunks where some are empty but all non-empty chunks have all invalid values
         let chunks = vec![
             PrimitiveArray::new(buffer![1u64, 2], Validity::AllInvalid).into_array(),
@@ -395,13 +397,13 @@ mod test {
         // Should be all_invalid since all non-empty chunks are all_invalid
         assert!(
             !chunked
-                .all_valid(&mut LEGACY_SESSION.create_execution_ctx())
+                .all_valid(&mut ctx)
                 .unwrap()
         );
         assert!(
             chunked
                 .into_array()
-                .all_invalid(&mut LEGACY_SESSION.create_execution_ctx())
+                .all_invalid(&mut ctx)
                 .unwrap()
         );
 
@@ -410,6 +412,7 @@ mod test {
 
     #[test]
     fn test_empty_chunks_mixed_validity() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create chunks with mixed validity including empty chunks
         let chunks = vec![
             PrimitiveArray::new(buffer![1u64, 2], Validity::AllValid).into_array(),
@@ -424,13 +427,13 @@ mod test {
         // Should be neither all_valid nor all_invalid
         assert!(
             !chunked
-                .all_valid(&mut LEGACY_SESSION.create_execution_ctx())
+                .all_valid(&mut ctx)
                 .unwrap()
         );
         assert!(
             !chunked
                 .into_array()
-                .all_invalid(&mut LEGACY_SESSION.create_execution_ctx())
+                .all_invalid(&mut ctx)
                 .unwrap()
         );
 

--- a/vortex-array/src/arrays/chunked/array.rs
+++ b/vortex-array/src/arrays/chunked/array.rs
@@ -16,7 +16,10 @@ use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::IntoArray;
+use crate::LEGACY_SESSION;
+use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayParts;
 use crate::array::TypedArrayRef;
@@ -184,6 +187,7 @@ impl Array<Chunked> {
         let mut chunks_to_combine = Vec::new();
         let mut new_chunk_n_bytes = 0;
         let mut new_chunk_n_elements = 0;
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         for chunk in self.iter_chunks() {
             let n_bytes = chunk.nbytes();
             let n_elements = chunk.len();
@@ -192,14 +196,14 @@ impl Array<Chunked> {
                 || new_chunk_n_elements + n_elements > target_rowsize)
                 && !chunks_to_combine.is_empty()
             {
-                #[expect(deprecated)]
-                let canonical = unsafe {
-                    Array::<Chunked>::new_unchecked(chunks_to_combine, self.dtype().clone())
-                }
-                .into_array()
-                .to_canonical()?
-                .into_array();
-                new_chunks.push(canonical);
+                new_chunks.push(
+                    unsafe {
+                        Array::<Chunked>::new_unchecked(chunks_to_combine, self.dtype().clone())
+                    }
+                    .into_array()
+                    .execute::<Canonical>(&mut ctx)?
+                    .into_array(),
+                );
 
                 new_chunk_n_bytes = 0;
                 new_chunk_n_elements = 0;
@@ -216,13 +220,12 @@ impl Array<Chunked> {
         }
 
         if !chunks_to_combine.is_empty() {
-            #[expect(deprecated)]
-            let canonical =
+            new_chunks.push(
                 unsafe { Array::<Chunked>::new_unchecked(chunks_to_combine, self.dtype().clone()) }
                     .into_array()
-                    .to_canonical()?
-                    .into_array();
-            new_chunks.push(canonical);
+                    .execute::<Canonical>(&mut ctx)?
+                    .into_array(),
+            );
         }
 
         unsafe { Ok(Self::new_unchecked(new_chunks, self.dtype().clone())) }

--- a/vortex-array/src/arrays/chunked/compute/zip.rs
+++ b/vortex-array/src/arrays/chunked/compute/zip.rs
@@ -65,6 +65,7 @@ mod tests {
 
     #[test]
     fn test_chunked_zip_aligns_across_boundaries() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let if_true = ChunkedArray::try_new(
             vec![
                 buffer![1i32, 2].into_array(),
@@ -94,7 +95,7 @@ mod tests {
         // One step of execution will push down the zip.
         let zipped = zipped
             .clone()
-            .execute::<ArrayRef>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<ArrayRef>(&mut ctx)
             .unwrap();
         let zipped = zipped
             .as_opt::<Chunked>()

--- a/vortex-array/src/arrays/chunked/tests.rs
+++ b/vortex-array/src/arrays/chunked/tests.rs
@@ -206,6 +206,7 @@ pub fn pack_nested_structs() {
 
 #[test]
 pub fn pack_nested_lists() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let l1 = ListArray::try_new(
         buffer![1, 2, 3, 4].into_array(),
         buffer![0, 3].into_array(),
@@ -232,17 +233,17 @@ pub fn pack_nested_lists() {
     let canon_values = chunked_list.unwrap().as_array().to_listview();
 
     assert_eq!(
-        l1.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        l1.execute_scalar(0, &mut ctx)
             .unwrap(),
         canon_values
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
     );
     assert_eq!(
-        l2.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        l2.execute_scalar(0, &mut ctx)
             .unwrap(),
         canon_values
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
     );
 }

--- a/vortex-array/src/arrays/chunked/tests.rs
+++ b/vortex-array/src/arrays/chunked/tests.rs
@@ -19,8 +19,6 @@ use crate::arrays::VarBinViewArray;
 use crate::arrays::chunked::ChunkedArrayExt;
 use crate::arrays::struct_::StructArrayExt;
 use crate::assert_arrays_eq;
-#[expect(deprecated)]
-use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::PType;

--- a/vortex-array/src/arrays/chunked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/chunked/vtable/canonical.rs
@@ -290,6 +290,7 @@ mod tests {
 
     #[test]
     pub fn pack_nested_lists() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let l1 = ListArray::try_new(
             buffer![1, 2, 3, 4].into_array(),
             buffer![0, 3].into_array(),
@@ -313,17 +314,17 @@ mod tests {
         let canon_values = chunked_list.unwrap().as_array().to_listview();
 
         assert_eq!(
-            l1.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            l1.execute_scalar(0, &mut ctx)
                 .unwrap(),
             canon_values
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap()
         );
         assert_eq!(
-            l2.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            l2.execute_scalar(0, &mut ctx)
                 .unwrap(),
             canon_values
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .unwrap()
         );
     }

--- a/vortex-array/src/arrays/chunked/vtable/mod.rs
+++ b/vortex-array/src/arrays/chunked/vtable/mod.rs
@@ -21,8 +21,6 @@ use crate::ExecutionCtx;
 use crate::ExecutionResult;
 use crate::IntoArray;
 use crate::Precision;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::array::Array;
 use crate::array::ArrayId;
 use crate::array::ArrayParts;

--- a/vortex-array/src/arrays/constant/compute/take.rs
+++ b/vortex-array/src/arrays/constant/compute/take.rs
@@ -85,6 +85,7 @@ mod tests {
 
     #[test]
     fn take_nullable_indices() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = ConstantArray::new(42, 10).into_array();
         let taken = array
             .take(
@@ -112,7 +113,7 @@ mod tests {
             taken
                 .validity()
                 .unwrap()
-                .to_mask(taken.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(taken.len(), &mut ctx)
                 .unwrap()
                 .indices(),
             AllOr::Some(valid_indices)
@@ -121,6 +122,7 @@ mod tests {
 
     #[test]
     fn take_all_valid_indices() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = ConstantArray::new(42, 10).into_array();
         let taken = array
             .take(PrimitiveArray::new(buffer![0, 5, 7], Validity::AllValid).into_array())
@@ -138,7 +140,7 @@ mod tests {
             taken
                 .validity()
                 .unwrap()
-                .to_mask(taken.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(taken.len(), &mut ctx)
                 .unwrap()
                 .indices(),
             AllOr::All

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -322,6 +322,7 @@ mod tests {
     use vortex_error::VortexExpect;
     use vortex_error::VortexResult;
 
+    use crate::Canonical;
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
@@ -377,8 +378,10 @@ mod tests {
                 &mut LEGACY_SESSION.create_execution_ctx(),
             )
             .unwrap();
-        #[expect(deprecated)]
-        let canonical = const_array.to_canonical()?.into_array();
+        let canonical = const_array
+            .clone()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .into_array();
         let canonical_stats = canonical.statistics();
 
         let stats_ref = stats.as_typed_ref(canonical.dtype());

--- a/vortex-array/src/arrays/constant/vtable/canonical.rs
+++ b/vortex-array/src/arrays/constant/vtable/canonical.rs
@@ -347,13 +347,14 @@ mod tests {
 
     #[test]
     fn test_canonicalize_null() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let const_null = ConstantArray::new(Scalar::null(DType::Null), 42);
         #[expect(deprecated)]
         let actual = const_null.as_array().to_null();
         assert_eq!(actual.len(), 42);
         assert_eq!(
             actual
-                .execute_scalar(33, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(33, &mut ctx)
                 .unwrap(),
             Scalar::null(DType::Null)
         );
@@ -369,18 +370,19 @@ mod tests {
 
     #[test]
     fn test_canonicalize_propagates_stats() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let scalar = Scalar::bool(true, Nullability::NonNullable);
         let const_array = ConstantArray::new(scalar, 4).into_array();
         let stats = const_array
             .statistics()
             .compute_all(
                 &all::<Stat>().collect_vec(),
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap();
         let canonical = const_array
             .clone()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .execute::<Canonical>(&mut ctx)?
             .into_array();
         let canonical_stats = canonical.statistics();
 
@@ -401,6 +403,7 @@ mod tests {
 
     #[test]
     fn test_canonicalize_scalar_values() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let f16_value = f16::from_f32(5.722046e-6);
         let f16_scalar = Scalar::primitive(f16_value, Nullability::NonNullable);
 
@@ -412,7 +415,7 @@ mod tests {
         // Verify the scalar value is preserved through canonicalization
         assert_eq!(
             canonical_const
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             f16_scalar
         );
@@ -498,6 +501,7 @@ mod tests {
 
     #[test]
     fn test_canonicalize_nullable_struct() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = ConstantArray::new(
             Scalar::null(DType::struct_(
                 [(
@@ -514,7 +518,7 @@ mod tests {
         assert_eq!(struct_array.len(), 3);
         assert_eq!(
             struct_array
-                .valid_count(&mut LEGACY_SESSION.create_execution_ctx())
+                .valid_count(&mut ctx)
                 .unwrap(),
             0
         );
@@ -635,6 +639,7 @@ mod tests {
 
     #[test]
     fn test_canonicalize_fixed_size_list_nested() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test with nested data types (list of strings).
         let fsl_scalar = Scalar::fixed_size_list(
             Arc::new(DType::Utf8(Nullability::NonNullable)),
@@ -654,25 +659,25 @@ mod tests {
         let elements = canonical.elements().to_varbinview();
         assert_eq!(
             elements
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             "hello".into()
         );
         assert_eq!(
             elements
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .unwrap(),
             "world".into()
         );
         assert_eq!(
             elements
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .unwrap(),
             "hello".into()
         );
         assert_eq!(
             elements
-                .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(3, &mut ctx)
                 .unwrap(),
             "world".into()
         );
@@ -701,6 +706,7 @@ mod tests {
 
     #[test]
     fn test_canonicalize_fixed_size_list_with_null_elements() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test FSL with nullable element type where some elements are null.
         let fsl_scalar = Scalar::fixed_size_list(
             Arc::new(DType::Primitive(PType::I32, Nullability::Nullable)),
@@ -725,19 +731,19 @@ mod tests {
         let elements = canonical.elements().to_primitive();
         assert_eq!(
             elements
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::from(100i32)
         );
         assert_eq!(
             elements
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .unwrap(),
             Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable))
         );
         assert_eq!(
             elements
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .unwrap(),
             Scalar::from(200i32)
         );
@@ -758,6 +764,7 @@ mod tests {
 
     #[test]
     fn test_canonicalize_fixed_size_list_large() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test with a large constant array.
         let fsl_scalar = Scalar::fixed_size_list(
             Arc::new(DType::Primitive(PType::U8, Nullability::NonNullable)),
@@ -787,31 +794,31 @@ mod tests {
             let base = i * 5;
             assert_eq!(
                 elements
-                    .execute_scalar(base, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(base, &mut ctx)
                     .unwrap(),
                 Scalar::from(1u8)
             );
             assert_eq!(
                 elements
-                    .execute_scalar(base + 1, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(base + 1, &mut ctx)
                     .unwrap(),
                 Scalar::from(2u8)
             );
             assert_eq!(
                 elements
-                    .execute_scalar(base + 2, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(base + 2, &mut ctx)
                     .unwrap(),
                 Scalar::from(3u8)
             );
             assert_eq!(
                 elements
-                    .execute_scalar(base + 3, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(base + 3, &mut ctx)
                     .unwrap(),
                 Scalar::from(4u8)
             );
             assert_eq!(
                 elements
-                    .execute_scalar(base + 4, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(base + 4, &mut ctx)
                     .unwrap(),
                 Scalar::from(5u8)
             );

--- a/vortex-array/src/arrays/decimal/compute/cast.rs
+++ b/vortex-array/src/arrays/decimal/compute/cast.rs
@@ -145,6 +145,7 @@ mod tests {
     use vortex_buffer::buffer;
 
     use super::upcast_decimal_values;
+    use crate::Canonical;
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
@@ -212,12 +213,14 @@ mod tests {
 
         // Attempt to cast to non-nullable should fail
         let non_nullable_dtype = DType::Decimal(decimal_dtype, Nullability::NonNullable);
-        #[expect(deprecated)]
         let result = array
             .into_array()
             .cast(non_nullable_dtype)
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()));
-        result.unwrap();
+            .and_then(|a| {
+                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                    .map(|c| c.into_array())
+            })
+            .unwrap();
     }
 
     #[test]
@@ -234,7 +237,10 @@ mod tests {
         let result = array
             .into_array()
             .cast(different_dtype)
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()));
+            .and_then(|a| {
+            a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .map(|c| c.into_array())
+        });
 
         assert!(result.is_err());
         assert!(
@@ -259,7 +265,10 @@ mod tests {
         let result = array
             .into_array()
             .cast(smaller_dtype)
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()));
+            .and_then(|a| {
+            a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .map(|c| c.into_array())
+        });
 
         assert!(result.is_err());
         assert!(
@@ -303,7 +312,10 @@ mod tests {
         let result = array
             .into_array()
             .cast(DType::Utf8(Nullability::NonNullable))
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()));
+            .and_then(|a| {
+            a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                .map(|c| c.into_array())
+        });
 
         assert!(result.is_err());
         assert!(

--- a/vortex-array/src/arrays/decimal/compute/cast.rs
+++ b/vortex-array/src/arrays/decimal/compute/cast.rs
@@ -206,6 +206,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Cannot cast array with invalid values to non-nullable type")]
     fn cast_nullable_with_nulls_to_non_nullable_fails() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(10, 2);
 
         // Create nullable array with nulls
@@ -213,11 +214,11 @@ mod tests {
 
         // Attempt to cast to non-nullable should fail
         let non_nullable_dtype = DType::Decimal(decimal_dtype, Nullability::NonNullable);
-        let result = array
+        array
             .into_array()
             .cast(non_nullable_dtype)
             .and_then(|a| {
-                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                a.execute::<Canonical>(&mut ctx)
                     .map(|c| c.into_array())
             })
             .unwrap();
@@ -225,6 +226,7 @@ mod tests {
 
     #[test]
     fn cast_different_scale_fails() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = DecimalArray::new(
             buffer![100i32],
             DecimalDType::new(10, 2),
@@ -233,12 +235,11 @@ mod tests {
 
         // Try to cast to different scale - not supported
         let different_dtype = DType::Decimal(DecimalDType::new(15, 3), Nullability::NonNullable);
-        #[expect(deprecated)]
         let result = array
             .into_array()
             .cast(different_dtype)
             .and_then(|a| {
-            a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            a.execute::<Canonical>(&mut ctx)
                 .map(|c| c.into_array())
         });
 
@@ -253,6 +254,7 @@ mod tests {
 
     #[test]
     fn cast_downcast_precision_fails() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = DecimalArray::new(
             buffer![100i64],
             DecimalDType::new(18, 2),
@@ -261,12 +263,11 @@ mod tests {
 
         // Try to downcast precision - not supported
         let smaller_dtype = DType::Decimal(DecimalDType::new(10, 2), Nullability::NonNullable);
-        #[expect(deprecated)]
         let result = array
             .into_array()
             .cast(smaller_dtype)
             .and_then(|a| {
-            a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            a.execute::<Canonical>(&mut ctx)
                 .map(|c| c.into_array())
         });
 
@@ -301,6 +302,7 @@ mod tests {
 
     #[test]
     fn cast_to_non_decimal_returns_err() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = DecimalArray::new(
             buffer![100i32],
             DecimalDType::new(10, 2),
@@ -308,12 +310,11 @@ mod tests {
         );
 
         // Try to cast to non-decimal type - should fail since no kernel can handle it
-        #[expect(deprecated)]
         let result = array
             .into_array()
             .cast(DType::Utf8(Nullability::NonNullable))
             .and_then(|a| {
-            a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            a.execute::<Canonical>(&mut ctx)
                 .map(|c| c.into_array())
         });
 
@@ -395,6 +396,7 @@ mod tests {
 
     #[test]
     fn upcast_decimal_values_with_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(10, 2);
         let array = DecimalArray::from_option_iter([Some(100i32), None, Some(300)], decimal_dtype);
 
@@ -411,7 +413,7 @@ mod tests {
             .unwrap()
             .to_mask(
                 casted.as_ref().len(),
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap();
         assert!(mask.value(0));

--- a/vortex-array/src/arrays/decimal/compute/fill_null.rs
+++ b/vortex-array/src/arrays/decimal/compute/fill_null.rs
@@ -104,6 +104,7 @@ mod tests {
 
     #[test]
     fn fill_null_leading_none() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(19, 2);
         let arr = DecimalArray::from_option_iter(
             [None, Some(800i128), None, Some(1000i128), None],
@@ -131,7 +132,7 @@ mod tests {
             p.as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(p.as_ref().len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(p.as_ref().len(), &mut ctx)
                 .unwrap()
                 .all_true()
         );

--- a/vortex-array/src/arrays/decimal/vtable/operations.rs
+++ b/vortex-array/src/arrays/decimal/vtable/operations.rs
@@ -73,6 +73,7 @@ mod tests {
 
     #[test]
     fn test_scalar_at() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = DecimalArray::new(
             buffer![100i128],
             DecimalDType::new(3, 2),
@@ -81,7 +82,7 @@ mod tests {
 
         assert_eq!(
             array
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::decimal(
                 DecimalValue::I128(100),

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -142,10 +142,11 @@ pub trait DictArrayExt: TypedArrayRef<Dict> + DictArraySlotsExt {
     }
 
     fn compute_referenced_values_mask(&self, referenced: bool) -> VortexResult<BitBuffer> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let codes = self.codes();
         let codes_validity = codes
             .validity()?
-            .to_mask(codes.len(), &mut LEGACY_SESSION.create_execution_ctx())?;
+            .to_mask(codes.len(), &mut ctx)?;
         #[expect(deprecated)]
         let codes_primitive = self.codes().to_primitive();
         let values_len = self.values().len();
@@ -289,6 +290,7 @@ mod test {
 
     #[test]
     fn nullable_codes_validity() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dict = DictArray::try_new(
             PrimitiveArray::new(
                 buffer![0u32, 1, 2, 2, 1],
@@ -304,7 +306,7 @@ mod test {
             .unwrap()
             .to_mask(
                 dict.as_ref().len(),
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap();
         let AllOr::Some(indices) = mask.indices() else {
@@ -315,6 +317,7 @@ mod test {
 
     #[test]
     fn nullable_values_validity() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dict = DictArray::try_new(
             buffer![0u32, 1, 2, 2, 1].into_array(),
             PrimitiveArray::new(
@@ -330,7 +333,7 @@ mod test {
             .unwrap()
             .to_mask(
                 dict.as_ref().len(),
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap();
         let AllOr::Some(indices) = mask.indices() else {
@@ -341,6 +344,7 @@ mod test {
 
     #[test]
     fn nullable_codes_and_values() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dict = DictArray::try_new(
             PrimitiveArray::new(
                 buffer![0u32, 1, 2, 2, 1],
@@ -360,7 +364,7 @@ mod test {
             .unwrap()
             .to_mask(
                 dict.as_ref().len(),
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap();
         let AllOr::Some(indices) = mask.indices() else {
@@ -371,6 +375,7 @@ mod test {
 
     #[test]
     fn nullable_codes_and_non_null_values() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dict = DictArray::try_new(
             PrimitiveArray::new(
                 buffer![0u32, 1, 2, 2, 1],
@@ -386,7 +391,7 @@ mod test {
             .unwrap()
             .to_mask(
                 dict.as_ref().len(),
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap();
         let AllOr::Some(indices) = mask.indices() else {
@@ -426,6 +431,7 @@ mod test {
 
     #[test]
     fn test_dict_array_from_primitive_chunks() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let len = 2;
         let chunk_count = 2;
         let array = make_dict_primitive_chunks::<u64, u64>(len, 2, chunk_count);
@@ -434,7 +440,7 @@ mod test {
             &DType::Primitive(PType::U64, NonNullable),
             len * chunk_count,
         );
-        array.append_to_builder(builder.as_mut(), &mut LEGACY_SESSION.create_execution_ctx())?;
+        array.append_to_builder(builder.as_mut(), &mut ctx)?;
 
         #[expect(deprecated)]
         let into_prim = array.to_primitive();

--- a/vortex-array/src/arrays/dict/array.rs
+++ b/vortex-array/src/arrays/dict/array.rs
@@ -13,8 +13,6 @@ use vortex_mask::AllOr;
 
 use crate::ArrayRef;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayParts;
@@ -273,8 +271,6 @@ mod test {
     use crate::ArrayRef;
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use crate::ToCanonical as _;
     use crate::VortexSessionExecute;
     use crate::arrays::ChunkedArray;
     use crate::arrays::DictArray;

--- a/vortex-array/src/arrays/dict/compute/fill_null.rs
+++ b/vortex-array/src/arrays/dict/compute/fill_null.rs
@@ -108,6 +108,7 @@ mod tests {
 
     #[test]
     fn nullable_codes_fill_in_values() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dict = DictArray::try_new(
             PrimitiveArray::new(
                 buffer![0u32, 1, 2],
@@ -127,7 +128,7 @@ mod tests {
         assert_arrays_eq!(filled_primitive, PrimitiveArray::from_iter([10, 20, 20]));
         assert!(
             filled_primitive
-                .all_valid(&mut LEGACY_SESSION.create_execution_ctx())
+                .all_valid(&mut ctx)
                 .unwrap()
         );
     }

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -100,6 +100,7 @@ mod tests {
 
     #[test]
     fn cast_different_ext_dtype() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let original_dtype =
             Timestamp::new(TimeUnit::Milliseconds, Nullability::NonNullable).erased();
         // Note NS here instead of MS
@@ -112,7 +113,7 @@ mod tests {
             arr.into_array()
                 .cast(DType::Extension(target_dtype))
                 .and_then(|a| {
-                    a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                    a.execute::<Canonical>(&mut ctx)
                         .map(|c| c.into_array())
                 })
                 .is_err()

--- a/vortex-array/src/arrays/extension/compute/cast.rs
+++ b/vortex-array/src/arrays/extension/compute/cast.rs
@@ -51,7 +51,10 @@ mod tests {
     use vortex_buffer::buffer;
 
     use super::*;
+    use crate::Canonical;
     use crate::IntoArray;
+    use crate::LEGACY_SESSION;
+    use crate::VortexSessionExecute;
     use crate::arrays::PrimitiveArray;
     use crate::assert_arrays_eq;
     use crate::builtins::ArrayBuiltins;
@@ -105,12 +108,15 @@ mod tests {
         let storage = buffer![1i64].into_array();
         let arr = ExtensionArray::new(original_dtype, storage);
 
-        #[expect(deprecated)]
-        let result = arr
-            .into_array()
-            .cast(DType::Extension(target_dtype))
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()));
-        assert!(result.is_err());
+        assert!(
+            arr.into_array()
+                .cast(DType::Extension(target_dtype))
+                .and_then(|a| {
+                    a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                        .map(|c| c.into_array())
+                })
+                .is_err()
+        );
     }
 
     #[test]

--- a/vortex-array/src/arrays/filter/execute/listview.rs
+++ b/vortex-array/src/arrays/filter/execute/listview.rs
@@ -301,6 +301,7 @@ mod test {
     #[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `filter`"]
     #[test]
     fn test_filter_extreme_offsets() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // ListView-specific: Test with very large offsets.
         let elements = PrimitiveArray::from_iter(0i32..10000).into_array();
 
@@ -331,7 +332,7 @@ mod test {
         let list0 = result_list.list_elements_at(0).unwrap();
         assert_eq!(
             list0
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap()
                 .as_primitive()
                 .as_::<i32>()
@@ -340,7 +341,7 @@ mod test {
         );
         assert_eq!(
             list0
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .unwrap()
                 .as_primitive()
                 .as_::<i32>()

--- a/vortex-array/src/arrays/fixed_size_list/tests/basic.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/basic.rs
@@ -18,6 +18,7 @@ use crate::validity::Validity;
 
 #[test]
 fn test_basic_fixed_size_list() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 4;
     let list_size = 3;
 
@@ -40,19 +41,19 @@ fn test_basic_fixed_size_list() {
     let first_list = fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(
         first_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         1i32.into()
     );
     assert_eq!(
         first_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         2i32.into()
     );
     assert_eq!(
         first_list
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap(),
         3i32.into()
     );
@@ -60,19 +61,19 @@ fn test_basic_fixed_size_list() {
     let second_list = fsl.fixed_size_list_elements_at(1).unwrap();
     assert_eq!(
         second_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         4i32.into()
     );
     assert_eq!(
         second_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         5i32.into()
     );
     assert_eq!(
         second_list
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap(),
         6i32.into()
     );
@@ -80,19 +81,19 @@ fn test_basic_fixed_size_list() {
     let third_list = fsl.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(
         third_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         7i32.into()
     );
     assert_eq!(
         third_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         8i32.into()
     );
     assert_eq!(
         third_list
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap(),
         9i32.into()
     );
@@ -100,19 +101,19 @@ fn test_basic_fixed_size_list() {
     let fourth_list = fsl.fixed_size_list_elements_at(3).unwrap();
     assert_eq!(
         fourth_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         10i32.into()
     );
     assert_eq!(
         fourth_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         11i32.into()
     );
     assert_eq!(
         fourth_list
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap(),
         12i32.into()
     );
@@ -120,6 +121,7 @@ fn test_basic_fixed_size_list() {
 
 #[test]
 fn test_scalar_at() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 2;
     let list_size = 3;
 
@@ -128,7 +130,7 @@ fn test_scalar_at() {
 
     // First list: [1, 2, 3].
     let first = fsl
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert_eq!(
         first,
@@ -143,26 +145,26 @@ fn test_scalar_at() {
     let first_list = fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(
         first_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         1i32.into()
     );
     assert_eq!(
         first_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         2i32.into()
     );
     assert_eq!(
         first_list
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap(),
         3i32.into()
     );
 
     // Second list: [4, 5, 6].
     let second = fsl
-        .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(1, &mut ctx)
         .unwrap();
     assert_eq!(
         second,
@@ -177,19 +179,19 @@ fn test_scalar_at() {
     let second_list = fsl.fixed_size_list_elements_at(1).unwrap();
     assert_eq!(
         second_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         4i32.into()
     );
     assert_eq!(
         second_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         5i32.into()
     );
     assert_eq!(
         second_list
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap(),
         6i32.into()
     );
@@ -197,6 +199,7 @@ fn test_scalar_at() {
 
 #[test]
 fn test_fixed_size_list_at() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 3;
     let list_size = 2;
 
@@ -208,13 +211,13 @@ fn test_fixed_size_list_at() {
     assert_eq!(first_list.len(), list_size as usize);
     assert_eq!(
         first_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         1.0f64.into()
     );
     assert_eq!(
         first_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         2.0f64.into()
     );
@@ -224,13 +227,13 @@ fn test_fixed_size_list_at() {
     assert_eq!(third_list.len(), list_size as usize);
     assert_eq!(
         third_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         5.0f64.into()
     );
     assert_eq!(
         third_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         6.0f64.into()
     );

--- a/vortex-array/src/arrays/fixed_size_list/tests/degenerate.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/degenerate.rs
@@ -44,6 +44,7 @@ fn test_fsl_size_0_length_0_non_nullable() {
 
 #[test]
 fn test_fsl_size_0_length_1_non_nullable() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 1;
     let list_size = 0;
 
@@ -57,7 +58,7 @@ fn test_fsl_size_0_length_1_non_nullable() {
 
     // Get the single empty list.
     let scalar = fsl
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(!scalar.is_null());
     assert_eq!(
@@ -72,6 +73,7 @@ fn test_fsl_size_0_length_1_non_nullable() {
 
 #[test]
 fn test_fsl_size_0_huge_length_non_nullable() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 1_000_000_000_000;
     let list_size = 0;
 
@@ -85,7 +87,7 @@ fn test_fsl_size_0_huge_length_non_nullable() {
 
     // Spot check a few lists.
     let scalar_first = fsl
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(!scalar_first.is_null());
     assert_eq!(
@@ -98,7 +100,7 @@ fn test_fsl_size_0_huge_length_non_nullable() {
     );
 
     let scalar_middle = fsl
-        .execute_scalar(500_000_000_000, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(500_000_000_000, &mut ctx)
         .unwrap();
     assert!(!scalar_middle.is_null());
     assert_eq!(
@@ -111,7 +113,7 @@ fn test_fsl_size_0_huge_length_non_nullable() {
     );
 
     let scalar_end = fsl
-        .execute_scalar(999_999_999_999, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(999_999_999_999, &mut ctx)
         .unwrap();
     assert!(!scalar_end.is_null());
     assert_eq!(
@@ -149,6 +151,7 @@ fn test_fsl_size_0_length_0_nullable() {
 
 #[test]
 fn test_fsl_size_0_length_1_nullable_valid() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 1;
     let list_size = 0;
 
@@ -163,7 +166,7 @@ fn test_fsl_size_0_length_1_nullable_valid() {
 
     // Get the single empty list (should be valid).
     let scalar = fsl
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(!scalar.is_null());
     assert_eq!(
@@ -174,6 +177,7 @@ fn test_fsl_size_0_length_1_nullable_valid() {
 
 #[test]
 fn test_fsl_size_0_length_1_nullable_null() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 1;
     let list_size = 0;
 
@@ -188,13 +192,14 @@ fn test_fsl_size_0_length_1_nullable_null() {
 
     // The single list should be null.
     let scalar = fsl
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(scalar.is_null());
 }
 
 #[test]
 fn test_fsl_size_0_length_10_nullable_mixed() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 10;
     let list_size = 0;
 
@@ -215,7 +220,7 @@ fn test_fsl_size_0_length_10_nullable_mixed() {
     ];
     for i in 0..len {
         let scalar = fsl
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .unwrap();
         if expected_valid[i] {
             assert!(!scalar.is_null());
@@ -235,6 +240,7 @@ fn test_fsl_size_0_length_10_nullable_mixed() {
 
 #[test]
 fn test_fsl_size_0_nullable_elements() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 5;
     let list_size = 0;
 
@@ -256,7 +262,7 @@ fn test_fsl_size_0_nullable_elements() {
     // All lists should be empty but valid.
     for i in 0..len {
         let scalar = fsl
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .unwrap();
         assert!(!scalar.is_null());
     }

--- a/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
@@ -30,6 +30,7 @@ use crate::validity::Validity;
 
 #[test]
 fn test_fsl_of_fsl_basic() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let outer_len = 2;
     let outer_list_size = 3;
     let inner_list_size = 2;
@@ -76,7 +77,7 @@ fn test_fsl_of_fsl_basic() {
     // The first outer list should contain 3 inner lists.
     // We can check by slicing and examining scalars.
     let first_scalar = outer_fsl
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(!first_scalar.is_null());
 
@@ -92,13 +93,13 @@ fn test_fsl_of_fsl_basic() {
         .unwrap();
     assert_eq!(
         inner_list_0
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         1i32.into()
     );
     assert_eq!(
         inner_list_0
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         2i32.into()
     );
@@ -111,13 +112,13 @@ fn test_fsl_of_fsl_basic() {
         .unwrap();
     assert_eq!(
         inner_list_1
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         3i32.into()
     );
     assert_eq!(
         inner_list_1
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         4i32.into()
     );
@@ -130,13 +131,13 @@ fn test_fsl_of_fsl_basic() {
         .unwrap();
     assert_eq!(
         inner_list_2
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         5i32.into()
     );
     assert_eq!(
         inner_list_2
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         6i32.into()
     );
@@ -152,13 +153,13 @@ fn test_fsl_of_fsl_basic() {
         .unwrap();
     assert_eq!(
         inner_list_0
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         7i32.into()
     );
     assert_eq!(
         inner_list_0
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         8i32.into()
     );
@@ -171,13 +172,13 @@ fn test_fsl_of_fsl_basic() {
         .unwrap();
     assert_eq!(
         inner_list_1
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         9i32.into()
     );
     assert_eq!(
         inner_list_1
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         10i32.into()
     );
@@ -190,13 +191,13 @@ fn test_fsl_of_fsl_basic() {
         .unwrap();
     assert_eq!(
         inner_list_2
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         11i32.into()
     );
     assert_eq!(
         inner_list_2
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         12i32.into()
     );
@@ -204,6 +205,7 @@ fn test_fsl_of_fsl_basic() {
 
 #[test]
 fn test_fsl_of_fsl_with_nulls() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let outer_len = 3;
     let outer_list_size = 2;
     let inner_list_size = 2;
@@ -246,7 +248,7 @@ fn test_fsl_of_fsl_with_nulls() {
     // First outer list is valid.
     assert!(
         !outer_fsl
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .is_null()
     );
@@ -254,7 +256,7 @@ fn test_fsl_of_fsl_with_nulls() {
     // Second outer list is null.
     assert!(
         outer_fsl
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .is_null()
     );
@@ -262,7 +264,7 @@ fn test_fsl_of_fsl_with_nulls() {
     // Third outer list is valid.
     assert!(
         !outer_fsl
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap()
             .is_null()
     );
@@ -270,6 +272,7 @@ fn test_fsl_of_fsl_with_nulls() {
 
 #[test]
 fn test_deeply_nested_fsl() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let _len = 2;
     let list_size = 2;
 
@@ -327,13 +330,13 @@ fn test_deeply_nested_fsl() {
         .unwrap();
     assert_eq!(
         level1_0_0
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         1i32.into()
     );
     assert_eq!(
         level1_0_0
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         2i32.into()
     );
@@ -345,13 +348,13 @@ fn test_deeply_nested_fsl() {
         .unwrap();
     assert_eq!(
         level1_0_1
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         3i32.into()
     );
     assert_eq!(
         level1_0_1
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         4i32.into()
     );
@@ -364,13 +367,13 @@ fn test_deeply_nested_fsl() {
         .unwrap();
     assert_eq!(
         level1_1_0
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         5i32.into()
     );
     assert_eq!(
         level1_1_0
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         6i32.into()
     );
@@ -382,13 +385,13 @@ fn test_deeply_nested_fsl() {
         .unwrap();
     assert_eq!(
         level1_1_1
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         7i32.into()
     );
     assert_eq!(
         level1_1_1
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         8i32.into()
     );

--- a/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/nested.rs
@@ -7,8 +7,6 @@ use vortex_buffer::buffer;
 
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::PrimitiveArray;

--- a/vortex-array/src/arrays/fixed_size_list/tests/nullability.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/nullability.rs
@@ -20,6 +20,7 @@ use crate::validity::Validity;
 
 #[test]
 fn test_nullable_fsl_with_nulls() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 4;
     let list_size = 2;
 
@@ -33,7 +34,7 @@ fn test_nullable_fsl_with_nulls() {
 
     // First list is valid: [1, 2].
     let first = fsl
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(!first.is_null());
     assert_eq!(
@@ -49,26 +50,26 @@ fn test_nullable_fsl_with_nulls() {
     let first_list = fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(
         first_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         1i32.into()
     );
     assert_eq!(
         first_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         2i32.into()
     );
 
     // Second list is null.
     let second = fsl
-        .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(1, &mut ctx)
         .unwrap();
     assert!(second.is_null());
 
     // Third list is valid: [5, 6].
     let third = fsl
-        .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(2, &mut ctx)
         .unwrap();
     assert!(!third.is_null());
     assert_eq!(
@@ -84,26 +85,27 @@ fn test_nullable_fsl_with_nulls() {
     let third_list = fsl.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(
         third_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         5i32.into()
     );
     assert_eq!(
         third_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         6i32.into()
     );
 
     // Fourth list is null.
     let fourth = fsl
-        .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(3, &mut ctx)
         .unwrap();
     assert!(fourth.is_null());
 }
 
 #[test]
 fn test_nullable_elements_non_nullable_lists() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 2;
     let list_size = 3;
 
@@ -123,7 +125,7 @@ fn test_nullable_elements_non_nullable_lists() {
 
     // First list: [Some(1), None, Some(3)].
     let first = fsl
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(!first.is_null());
     assert_eq!(
@@ -137,7 +139,7 @@ fn test_nullable_elements_non_nullable_lists() {
 
     // Second list: [Some(4), Some(5), None].
     let second = fsl
-        .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(1, &mut ctx)
         .unwrap();
     assert!(!second.is_null());
     assert_eq!(
@@ -152,6 +154,7 @@ fn test_nullable_elements_non_nullable_lists() {
 
 #[test]
 fn test_nullable_elements_and_nullable_lists() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 3;
     let list_size = 2;
 
@@ -165,7 +168,7 @@ fn test_nullable_elements_and_nullable_lists() {
 
     // First list is valid: [Some(10), None].
     let first = fsl
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(!first.is_null());
     assert_eq!(
@@ -181,26 +184,26 @@ fn test_nullable_elements_and_nullable_lists() {
     let first_list = fsl.fixed_size_list_elements_at(0).unwrap();
     assert_eq!(
         first_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         Some(10u16).into()
     );
     assert_eq!(
         first_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         None::<u16>.into()
     );
 
     // Second list is null (but elements would be [Some(20), Some(30)]).
     let second = fsl
-        .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(1, &mut ctx)
         .unwrap();
     assert!(second.is_null());
 
     // Third list is valid: [None, None].
     let third = fsl
-        .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(2, &mut ctx)
         .unwrap();
     assert!(!third.is_null());
     assert_eq!(
@@ -216,13 +219,13 @@ fn test_nullable_elements_and_nullable_lists() {
     let third_list = fsl.fixed_size_list_elements_at(2).unwrap();
     assert_eq!(
         third_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         None::<u16>.into()
     );
     assert_eq!(
         third_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         None::<u16>.into()
     );
@@ -230,6 +233,7 @@ fn test_nullable_elements_and_nullable_lists() {
 
 #[test]
 fn test_alternating_nulls() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 6;
     let list_size = 1;
 
@@ -243,7 +247,7 @@ fn test_alternating_nulls() {
     // Check alternating pattern.
     for i in 0..len {
         let scalar = fsl
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .unwrap();
         if i % 2 == 0 {
             assert!(!scalar.is_null());
@@ -264,6 +268,7 @@ fn test_alternating_nulls() {
 
 #[test]
 fn test_validity_types() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 4;
     let list_size = 2;
 
@@ -275,7 +280,7 @@ fn test_validity_types() {
         let fsl = FixedSizeListArray::new(elements.clone(), list_size, Validity::AllInvalid, len);
         for i in 0..len {
             assert!(
-                fsl.execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                fsl.execute_scalar(i, &mut ctx)
                     .unwrap()
                     .is_null()
             );
@@ -293,22 +298,22 @@ fn test_validity_types() {
         );
 
         assert!(
-            !fsl.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            !fsl.execute_scalar(0, &mut ctx)
                 .unwrap()
                 .is_null()
         );
         assert!(
-            !fsl.execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            !fsl.execute_scalar(1, &mut ctx)
                 .unwrap()
                 .is_null()
         );
         assert!(
-            fsl.execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            fsl.execute_scalar(2, &mut ctx)
                 .unwrap()
                 .is_null()
         );
         assert!(
-            !fsl.execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+            !fsl.execute_scalar(3, &mut ctx)
                 .unwrap()
                 .is_null()
         );
@@ -317,6 +322,7 @@ fn test_validity_types() {
 
 #[test]
 fn test_mixed_nullability_patterns() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = 5;
     let list_size = 2;
 
@@ -338,31 +344,31 @@ fn test_mixed_nullability_patterns() {
 
     // List 0: valid with [Some(1), None].
     let list0 = fsl
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(!list0.is_null());
 
     // List 1: null.
     let list1 = fsl
-        .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(1, &mut ctx)
         .unwrap();
     assert!(list1.is_null());
 
     // List 2: valid with [Some(5), Some(6)].
     let list2 = fsl
-        .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(2, &mut ctx)
         .unwrap();
     assert!(!list2.is_null());
 
     // List 3: valid with [Some(7), None].
     let list3 = fsl
-        .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(3, &mut ctx)
         .unwrap();
     assert!(!list3.is_null());
 
     // List 4: valid with [None, Some(10)].
     let list4 = fsl
-        .execute_scalar(4, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(4, &mut ctx)
         .unwrap();
     assert!(!list4.is_null());
 }

--- a/vortex-array/src/arrays/fixed_size_list/tests/take.rs
+++ b/vortex-array/src/arrays/fixed_size_list/tests/take.rs
@@ -82,6 +82,7 @@ fn test_take_degenerate_lists(
     #[case] expected_len: usize,
     #[case] expected_nulls: Vec<bool>,
 ) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Create a degenerate FSL array with list_size = 0.
     // This is a specific edge case for FSL where lists have no elements.
     let elements = PrimitiveArray::empty::<i32>(Nullability::NonNullable);
@@ -97,7 +98,7 @@ fn test_take_degenerate_lists(
     for (i, expected_null) in expected_nulls.iter().enumerate() {
         assert_eq!(
             result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .unwrap()
                 .is_null(),
             *expected_null
@@ -188,6 +189,7 @@ fn test_take_nullable_arrays_fsl_specific(
     #[case] indices: Vec<Option<u32>>,
     #[case] expected_nulls: Vec<bool>,
 ) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Build the nullable FSL array.
     let list_size = if let Some(Some(first)) = array_values.first() {
         u32::try_from(first.len()).unwrap()
@@ -231,7 +233,7 @@ fn test_take_nullable_arrays_fsl_specific(
     for (i, expected_null) in expected_nulls.iter().enumerate() {
         assert_eq!(
             result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .unwrap()
                 .is_null(),
             *expected_null

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -13,6 +13,7 @@ use vortex_error::vortex_ensure;
 use vortex_error::vortex_panic;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
@@ -327,9 +328,10 @@ pub trait ListArrayExt: TypedArrayRef<List> {
     fn reset_offsets(&self, recurse: bool) -> VortexResult<Array<List>> {
         let mut elements = self.sliced_elements()?;
         if recurse && elements.is_canonical() {
-            #[expect(deprecated)]
-            let compacted = elements.to_canonical()?.compact()?.into_array();
-            elements = compacted;
+            elements = elements
+                .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+                .compact()?
+                .into_array();
         } else if recurse && let Some(child_list_array) = elements.as_opt::<List>() {
             elements = child_list_array
                 .into_owned()

--- a/vortex-array/src/arrays/list/array.rs
+++ b/vortex-array/src/arrays/list/array.rs
@@ -290,6 +290,7 @@ pub trait ListArrayExt: TypedArrayRef<List> {
     }
 
     fn offset_at(&self, index: usize) -> VortexResult<usize> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         vortex_ensure!(
             index <= self.as_ref().len(),
             "Index {index} out of bounds 0..={}",
@@ -302,7 +303,7 @@ pub trait ListArrayExt: TypedArrayRef<List> {
             }))
         } else {
             self.offsets()
-                .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())?
+                .execute_scalar(index, &mut ctx)?
                 .as_primitive()
                 .as_::<usize>()
                 .ok_or_else(|| vortex_error::vortex_err!("offset value does not fit in usize"))
@@ -326,10 +327,11 @@ pub trait ListArrayExt: TypedArrayRef<List> {
     }
 
     fn reset_offsets(&self, recurse: bool) -> VortexResult<Array<List>> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut elements = self.sliced_elements()?;
         if recurse && elements.is_canonical() {
             elements = elements
-                .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+                .execute::<Canonical>(&mut ctx)?
                 .compact()?
                 .into_array();
         } else if recurse && let Some(child_list_array) = elements.as_opt::<List>() {
@@ -340,7 +342,7 @@ pub trait ListArrayExt: TypedArrayRef<List> {
         }
 
         let offsets = self.offsets();
-        let first_offset = offsets.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let first_offset = offsets.execute_scalar(0, &mut ctx)?;
         let adjusted_offsets = offsets.clone().binary(
             ConstantArray::new(first_offset, offsets.len()).into_array(),
             Operator::Sub,

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -78,6 +78,7 @@ mod tests {
 
     #[test]
     fn test_cast_to_wrong_type() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let list = ListArray::try_new(
             buffer![0i32, 2, 3, 4].into_array(),
             buffer![0, 2, 3].into_array(),
@@ -92,7 +93,7 @@ mod tests {
             .into_array()
             .cast(target_dtype)
             .and_then(|a| {
-                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                a.execute::<Canonical>(&mut ctx)
                     .map(|c| c.into_array())
             });
         assert!(result.is_err());
@@ -100,6 +101,7 @@ mod tests {
 
     #[test]
     fn test_cant_cast_nulls_to_non_null() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test that if list has nulls, the conversion will fail
 
         // Nulls in the list itself
@@ -119,7 +121,7 @@ mod tests {
             .into_array()
             .cast(target_dtype)
             .and_then(|a| {
-                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                a.execute::<Canonical>(&mut ctx)
                     .map(|c| c.into_array())
             });
         assert!(result.is_err());
@@ -139,7 +141,7 @@ mod tests {
         );
 
         let result = list.into_array().cast(target_dtype).and_then(|a| {
-            a.execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            a.execute::<RecursiveCanonical>(&mut ctx)
                 .map(|c| c.0.into_array())
         });
         assert!(result.is_err());

--- a/vortex-array/src/arrays/list/compute/cast.rs
+++ b/vortex-array/src/arrays/list/compute/cast.rs
@@ -37,6 +37,7 @@ mod tests {
     use rstest::rstest;
     use vortex_buffer::buffer;
 
+    use crate::Canonical;
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::RecursiveCanonical;
@@ -87,11 +88,13 @@ mod tests {
         let target_dtype = DType::Primitive(PType::U64, Nullability::NonNullable);
         // can't cast list to u64
 
-        let result = list.into_array().cast(target_dtype).and_then(|a| {
-            #[expect(deprecated)]
-            let canonical = a.to_canonical().map(|c| c.into_array());
-            canonical
-        });
+        let result = list
+            .into_array()
+            .cast(target_dtype)
+            .and_then(|a| {
+                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                    .map(|c| c.into_array())
+            });
         assert!(result.is_err());
     }
 
@@ -112,11 +115,13 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = list.into_array().cast(target_dtype).and_then(|a| {
-            #[expect(deprecated)]
-            let canonical = a.to_canonical().map(|c| c.into_array());
-            canonical
-        });
+        let result = list
+            .into_array()
+            .cast(target_dtype)
+            .and_then(|a| {
+                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                    .map(|c| c.into_array())
+            });
         assert!(result.is_err());
 
         // Nulls in list element array — the inner cast error is deferred until

--- a/vortex-array/src/arrays/list/compute/take.rs
+++ b/vortex-array/src/arrays/list/compute/take.rs
@@ -215,6 +215,7 @@ mod test {
 
     #[test]
     fn nullable_take() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let list = ListArray::try_new(
             buffer![0i32, 5, 3, 4].into_array(),
             buffer![0, 2, 3, 4, 4].into_array(),
@@ -245,12 +246,12 @@ mod test {
 
         assert!(
             result
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(0, &mut ctx)
                 .unwrap()
         );
         assert_eq!(
             result
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::list(
                 Arc::clone(&element_dtype),
@@ -261,18 +262,18 @@ mod test {
 
         assert!(
             result
-                .is_invalid(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_invalid(1, &mut ctx)
                 .unwrap()
         );
 
         assert!(
             result
-                .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(2, &mut ctx)
                 .unwrap()
         );
         assert_eq!(
             result
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .unwrap(),
             Scalar::list(
                 Arc::clone(&element_dtype),
@@ -283,12 +284,12 @@ mod test {
 
         assert!(
             result
-                .is_valid(3, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(3, &mut ctx)
                 .unwrap()
         );
         assert_eq!(
             result
-                .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(3, &mut ctx)
                 .unwrap(),
             Scalar::list(element_dtype, vec![], Nullability::Nullable)
         );
@@ -319,6 +320,7 @@ mod test {
 
     #[test]
     fn non_nullable_take() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let list = ListArray::try_new(
             buffer![0i32, 5, 3, 4].into_array(),
             buffer![0, 2, 3, 3, 4].into_array(),
@@ -348,12 +350,12 @@ mod test {
 
         assert!(
             result
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(0, &mut ctx)
                 .unwrap()
         );
         assert_eq!(
             result
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::list(
                 Arc::clone(&element_dtype),
@@ -364,12 +366,12 @@ mod test {
 
         assert!(
             result
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(1, &mut ctx)
                 .unwrap()
         );
         assert_eq!(
             result
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .unwrap(),
             Scalar::list(
                 Arc::clone(&element_dtype),
@@ -380,12 +382,12 @@ mod test {
 
         assert!(
             result
-                .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(2, &mut ctx)
                 .unwrap()
         );
         assert_eq!(
             result
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .unwrap(),
             Scalar::list(element_dtype, vec![], Nullability::NonNullable)
         );
@@ -458,6 +460,7 @@ mod test {
 
     #[test]
     fn test_u64_offset_accumulation_non_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let elements = buffer![0i32; 200].into_array();
         let offsets = buffer![0u8, 200].into_array();
         let list = ListArray::try_new(elements, offsets, Validity::NonNullable)
@@ -475,18 +478,19 @@ mod test {
         assert_eq!(result_view.len(), 2);
         assert!(
             result_view
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(0, &mut ctx)
                 .unwrap()
         );
         assert!(
             result_view
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(1, &mut ctx)
                 .unwrap()
         );
     }
 
     #[test]
     fn test_u64_offset_accumulation_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let elements = buffer![0i32; 150].into_array();
         let offsets = buffer![0u8, 150, 150].into_array();
         let validity = BoolArray::from_iter(vec![true, false]).into_array();
@@ -505,17 +509,17 @@ mod test {
         assert_eq!(result_view.len(), 3);
         assert!(
             result_view
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(0, &mut ctx)
                 .unwrap()
         );
         assert!(
             result_view
-                .is_invalid(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_invalid(1, &mut ctx)
                 .unwrap()
         );
         assert!(
             result_view
-                .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(2, &mut ctx)
                 .unwrap()
         );
     }

--- a/vortex-array/src/arrays/list/tests.rs
+++ b/vortex-array/src/arrays/list/tests.rs
@@ -39,6 +39,7 @@ fn test_empty_list_array() {
 
 #[test]
 fn test_simple_list_array() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
     let offsets = buffer![0, 2, 4, 5].into_array();
     let validity = Validity::AllValid;
@@ -51,7 +52,7 @@ fn test_simple_list_array() {
             vec![1.into(), 2.into()],
             Nullability::Nullable
         ),
-        list.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        list.execute_scalar(0, &mut ctx)
             .unwrap()
     );
     assert_eq!(
@@ -60,18 +61,19 @@ fn test_simple_list_array() {
             vec![3.into(), 4.into()],
             Nullability::Nullable
         ),
-        list.execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        list.execute_scalar(1, &mut ctx)
             .unwrap()
     );
     assert_eq!(
         Scalar::list(Arc::new(I32.into()), vec![5.into()], Nullability::Nullable),
-        list.execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+        list.execute_scalar(2, &mut ctx)
             .unwrap()
     );
 }
 
 #[test]
 fn test_simple_list_array_from_iter() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let elements = buffer![1i32, 2, 3].into_array();
     let offsets = buffer![0, 2, 3].into_array();
     let validity = Validity::NonNullable;
@@ -84,17 +86,17 @@ fn test_simple_list_array_from_iter() {
 
     assert_eq!(list.len(), list_from_iter.len());
     assert_eq!(
-        list.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        list.execute_scalar(0, &mut ctx)
             .unwrap(),
         list_from_iter
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
     );
     assert_eq!(
-        list.execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        list.execute_scalar(1, &mut ctx)
             .unwrap(),
         list_from_iter
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
     );
 }
@@ -208,6 +210,7 @@ fn test_list_filter_empty_lists() {
 
 #[test]
 fn test_list_filter_with_nulls() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Test filtering lists with null validity.
     let elements = buffer![0..15].into_array();
     let offsets = buffer![0, 3, 7, 10, 12, 15].into_array();
@@ -229,25 +232,25 @@ fn test_list_filter_with_nulls() {
     // Check validity of filtered array using scalar_at (works on any array).
     assert!(
         filtered
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .is_valid()
     );
     assert!(
         !filtered
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .is_valid()
     ); // Was null.
     assert!(
         !filtered
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap()
             .is_valid()
     ); // Was null.
     assert!(
         filtered
-            .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(3, &mut ctx)
             .unwrap()
             .is_valid()
     );
@@ -596,6 +599,7 @@ fn create_list_of_lists_nullable(data: OptVec<OptVec<OptVec<i32>>>) -> ListArray
 #[test]
 #[expect(clippy::cognitive_complexity)]
 fn test_list_of_lists() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data = vec![
         Some(vec![Some(vec![Some(1), Some(2)]), Some(vec![Some(3)])]),
         Some(vec![Some(vec![Some(4), Some(5), Some(6)])]),
@@ -655,7 +659,7 @@ fn test_list_of_lists() {
 
     // Test scalar conversion.
     let scalar = list_of_lists
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(matches!(scalar.dtype(), DType::List(_, _)));
     let list_scalar = scalar.as_list();
@@ -679,6 +683,7 @@ fn test_list_of_lists() {
 
 #[test]
 fn test_list_of_lists_nullable_outer() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Create list of lists with nullable outer, non-nullable inner.
     // Structure: [[[1, 2], [3]], null, [[4, 5, 6]], [[7]]]
     let data = vec![
@@ -702,13 +707,13 @@ fn test_list_of_lists_nullable_outer() {
 
     // First element should be [[1, 2], [3]].
     let first = list_of_lists
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(!first.is_null());
 
     // Second element should be null.
     let second = list_of_lists
-        .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(1, &mut ctx)
         .unwrap();
     assert!(second.is_null());
 
@@ -727,6 +732,7 @@ fn test_list_of_lists_nullable_outer() {
 
 #[test]
 fn test_list_of_lists_nullable_inner() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Create list of lists with non-nullable outer, nullable inner.
     // Structure: [[[1, 2], null, [3]], [[4, 5, 6]], [], [[null, 7]]]
     let data = vec![
@@ -764,13 +770,14 @@ fn test_list_of_lists_nullable_inner() {
     // Check that second inner list is null.
     let second_inner = first_list
         .array()
-        .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(1, &mut ctx)
         .unwrap();
     assert!(second_inner.is_null());
 }
 
 #[test]
 fn test_list_of_lists_both_nullable() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Create list of lists with both nullable.
     // Structure: [[[1, 2], null], null, [[3]], [null]]
     let data = vec![
@@ -794,7 +801,7 @@ fn test_list_of_lists_both_nullable() {
 
     // First outer list should have 2 elements, second is null inner list.
     let first_outer = list_of_lists
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(!first_outer.is_null());
     let first_outer_array = list_of_lists.list_elements_at(0).unwrap();
@@ -808,13 +815,13 @@ fn test_list_of_lists_both_nullable() {
     // Second inner list should be null.
     let second_inner = first_list
         .array()
-        .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(1, &mut ctx)
         .unwrap();
     assert!(second_inner.is_null());
 
     // Second outer list should be null.
     let second_outer = list_of_lists
-        .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(1, &mut ctx)
         .unwrap();
     assert!(second_outer.is_null());
 
@@ -831,7 +838,7 @@ fn test_list_of_lists_both_nullable() {
     assert_eq!(fourth_list.len(), 1);
     let inner = fourth_list
         .array()
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(inner.is_null());
 }
@@ -925,6 +932,7 @@ fn test_offsets_constant() {
 
 #[test]
 fn test_recursive_compact_list_of_lists() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Create a nested list structure: [[[1,2,3], [4,5]], [[6,7,8,9]], [[10], [11,12]]]
     let nested_data = vec![
         Some(vec![
@@ -965,10 +973,10 @@ fn test_recursive_compact_list_of_lists() {
     let recursive_array = recursive.into_array();
     assert_eq!(
         non_recursive_array
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         recursive_array
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
     );
 }

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -14,8 +14,6 @@ use vortex_error::vortex_err;
 
 use crate::ArrayRef;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayParts;

--- a/vortex-array/src/arrays/listview/array.rs
+++ b/vortex-array/src/arrays/listview/array.rs
@@ -340,6 +340,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     }
 
     fn offset_at(&self, index: usize) -> usize {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         assert!(
             index < self.as_ref().len(),
             "Index {index} out of bounds 0..{}",
@@ -350,7 +351,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
             .map(|p| match_each_integer_ptype!(p.ptype(), |P| { p.as_slice::<P>()[index].as_() }))
             .unwrap_or_else(|| {
                 self.offsets()
-                    .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(index, &mut ctx)
                     .vortex_expect("offsets must support execute_scalar")
                     .as_primitive()
                     .as_::<usize>()
@@ -359,6 +360,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
     }
 
     fn size_at(&self, index: usize) -> usize {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         assert!(
             index < self.as_ref().len(),
             "Index {} out of bounds 0..{}",
@@ -370,7 +372,7 @@ pub trait ListViewArrayExt: TypedArrayRef<ListView> {
             .map(|p| match_each_integer_ptype!(p.ptype(), |P| { p.as_slice::<P>()[index].as_() }))
             .unwrap_or_else(|| {
                 self.sizes()
-                    .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(index, &mut ctx)
                     .vortex_expect("sizes must support execute_scalar")
                     .as_primitive()
                     .as_::<usize>()

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -8,6 +8,8 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::ExecutionCtx;
 use crate::IntoArray;
+use crate::LEGACY_SESSION;
+use crate::VortexSessionExecute;
 #[expect(deprecated)]
 use crate::ToCanonical as _;
 use crate::arrays::ExtensionArray;
@@ -189,8 +191,8 @@ pub fn recursive_list_from_list_view(array: ArrayRef) -> VortexResult<ArrayRef> 
         return Ok(array);
     }
 
-    #[expect(deprecated)]
-    let canonical = array.to_canonical()?;
+    let canonical = array
+        .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?;
 
     Ok(match canonical {
         Canonical::List(listview) => {

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -10,8 +10,6 @@ use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::arrays::ExtensionArray;
 use crate::arrays::FixedSizeListArray;
 use crate::arrays::ListArray;

--- a/vortex-array/src/arrays/listview/conversion.rs
+++ b/vortex-array/src/arrays/listview/conversion.rs
@@ -187,12 +187,13 @@ unsafe fn build_list_offsets_from_list_view<O: IntegerPType>(
 ///
 /// The conversion happens bottom-up, processing children before parents.
 pub fn recursive_list_from_list_view(array: ArrayRef) -> VortexResult<ArrayRef> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     if !array.dtype().is_nested() {
         return Ok(array);
     }
 
     let canonical = array
-        .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?;
+        .execute::<Canonical>(&mut ctx)?;
 
     Ok(match canonical {
         Canonical::List(listview) => {

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -6,6 +6,7 @@ use vortex_buffer::BufferMut;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 
+use crate::Canonical;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 #[expect(deprecated)]
@@ -226,7 +227,8 @@ impl ListViewArray {
         #[expect(deprecated)]
         let elements_canonical = self
             .elements()
-            .to_canonical()
+            .clone()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
             .vortex_expect("canonicalize elements for rebuild")
             .into_array();
 

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -202,6 +202,7 @@ impl ListViewArray {
     fn rebuild_list_by_list<O: IntegerPType, NewOffset: IntegerPType, S: IntegerPType>(
         &self,
     ) -> VortexResult<ListViewArray> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let element_dtype = self
             .dtype()
             .as_list_element_opt()
@@ -224,11 +225,10 @@ impl ListViewArray {
         let mut new_sizes = BufferMut::<S>::with_capacity(len);
 
         // Canonicalize the elements up front as we will be slicing the elements quite a lot.
-        #[expect(deprecated)]
         let elements_canonical = self
             .elements()
             .clone()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .vortex_expect("canonicalize elements for rebuild")
             .into_array();
 
@@ -475,6 +475,7 @@ mod tests {
 
     #[test]
     fn test_rebuild_trim_elements_basic() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test trimming both leading and trailing unused elements while preserving gaps in the
         // middle.
         // Elements: [_, _, A, B, _, C, D, _, _]
@@ -516,7 +517,7 @@ mod tests {
         let all_elements = trimmed.elements().to_primitive();
         assert_eq!(
             all_elements
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .unwrap(),
             97i32.into()
         );
@@ -525,6 +526,7 @@ mod tests {
 
     #[test]
     fn test_rebuild_with_trailing_nulls_regression() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Regression test for issue #5412
         // Tests that zero-copy-to-list arrays with trailing NULLs correctly calculate
         // offsets for NULL items to maintain no-overlap invariant
@@ -561,22 +563,22 @@ mod tests {
         // Verify the result is still valid
         assert!(
             exact
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(0, &mut ctx)
                 .unwrap()
         );
         assert!(
             exact
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(1, &mut ctx)
                 .unwrap()
         );
         assert!(
             !exact
-                .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(2, &mut ctx)
                 .unwrap()
         );
         assert!(
             !exact
-                .is_valid(3, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(3, &mut ctx)
                 .unwrap()
         );
 

--- a/vortex-array/src/arrays/listview/rebuild.rs
+++ b/vortex-array/src/arrays/listview/rebuild.rs
@@ -9,8 +9,6 @@ use vortex_error::VortexResult;
 use crate::Canonical;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::aggregate_fn::fns::min_max::min_max;
 use crate::arrays::ConstantArray;
@@ -388,8 +386,6 @@ mod tests {
     use super::ListViewRebuildMode;
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use crate::ToCanonical as _;
     use crate::VortexSessionExecute;
     use crate::arrays::ListViewArray;
     use crate::arrays::PrimitiveArray;

--- a/vortex-array/src/arrays/listview/tests/basic.rs
+++ b/vortex-array/src/arrays/listview/tests/basic.rs
@@ -26,6 +26,7 @@ use crate::validity::Validity;
 
 #[test]
 fn test_basic_listview_comprehensive() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Comprehensive test for basic ListView functionality including scalar_at.
     // Logical lists: [[1,2,3], [4,5], [6,7,8,9]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
@@ -55,7 +56,7 @@ fn test_basic_listview_comprehensive() {
 
     // Test scalar_at which returns entire lists as Scalar values.
     let first_scalar = listview
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert_eq!(
         first_scalar,
@@ -142,17 +143,17 @@ fn test_from_list_array() -> VortexResult<()> {
     // Check validity is preserved.
     assert!(
         list_view
-            .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(0, &mut ctx)
             .unwrap()
     );
     assert!(
         list_view
-            .is_invalid(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_invalid(1, &mut ctx)
             .unwrap()
     );
     assert!(
         list_view
-            .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(2, &mut ctx)
             .unwrap()
     );
 
@@ -170,6 +171,7 @@ fn test_from_list_array() -> VortexResult<()> {
 #[case::constant_offsets(false, true)] // Varying sizes, constant offsets
 #[case::both_constant(true, true)] // Both constant
 fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_offsets: bool) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Logical lists vary by case:
     // - constant_sizes: [[1,2,3], [4,5,6], [7,8,9]] (size 3 each, varying offsets)
     // - constant_offsets: [[1,2,3], [1,2], [1]] (all start at 0, varying sizes)
@@ -215,7 +217,7 @@ fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_o
             listview
                 .list_elements_at(0)
                 .unwrap()
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             1i32.into()
         );
@@ -223,7 +225,7 @@ fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_o
             listview
                 .list_elements_at(1)
                 .unwrap()
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             1i32.into()
         );
@@ -231,7 +233,7 @@ fn test_listview_with_constant_arrays(#[case] const_sizes: bool, #[case] const_o
             listview
                 .list_elements_at(2)
                 .unwrap()
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             1i32.into()
         );

--- a/vortex-array/src/arrays/listview/tests/filter.rs
+++ b/vortex-array/src/arrays/listview/tests/filter.rs
@@ -163,6 +163,7 @@ fn test_filter_constant_arrays() {
 #[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `filter`"]
 #[test]
 fn test_filter_extreme_offsets() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // ListView-specific: Test with very large offsets.
     let elements = PrimitiveArray::from_iter(0i32..10000).into_array();
 
@@ -192,7 +193,7 @@ fn test_filter_extreme_offsets() {
     let list0 = result_list.list_elements_at(0).unwrap();
     assert_eq!(
         list0
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .as_primitive()
             .as_::<i32>()
@@ -201,7 +202,7 @@ fn test_filter_extreme_offsets() {
     );
     assert_eq!(
         list0
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .as_primitive()
             .as_::<i32>()

--- a/vortex-array/src/arrays/listview/tests/filter.rs
+++ b/vortex-array/src/arrays/listview/tests/filter.rs
@@ -12,8 +12,6 @@ use super::common::create_nullable_listview;
 use super::common::create_overlapping_listview;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::arrays::ConstantArray;
 use crate::arrays::ListViewArray;

--- a/vortex-array/src/arrays/listview/tests/nested.rs
+++ b/vortex-array/src/arrays/listview/tests/nested.rs
@@ -24,6 +24,7 @@ use crate::validity::Validity;
 
 #[test]
 fn test_listview_of_listview_with_overlapping() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Create elements that will be shared between inner lists.
     // Elements: [1, 2, 3, 4, 5, 6, 7, 8]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array();
@@ -74,7 +75,7 @@ fn test_listview_of_listview_with_overlapping() {
     // inner[0] should be [1, 2, 3].
     assert_eq!(
         inner0
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .as_primitive()
             .as_::<i32>()
@@ -83,7 +84,7 @@ fn test_listview_of_listview_with_overlapping() {
     );
     assert_eq!(
         inner0
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap()
             .as_primitive()
             .as_::<i32>()
@@ -94,7 +95,7 @@ fn test_listview_of_listview_with_overlapping() {
     // inner[1] should be [3, 4, 5] - shares element 3 with inner[0].
     assert_eq!(
         inner1
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .as_primitive()
             .as_::<i32>()
@@ -103,7 +104,7 @@ fn test_listview_of_listview_with_overlapping() {
     );
     assert_eq!(
         inner1
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .as_primitive()
             .as_::<i32>()
@@ -240,6 +241,7 @@ fn test_mixed_offset_size_types() {
 
 #[test]
 fn test_listview_zero_and_overlapping() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Mix of empty lists, overlapping lists, and normal lists.
     let elements = buffer![1i32, 2, 3, 4, 5].into_array();
 
@@ -287,7 +289,7 @@ fn test_listview_zero_and_overlapping() {
     assert_eq!(inner1.len(), 3); // [1, 2, 3]
     assert_eq!(
         inner1
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .as_primitive()
             .as_::<i32>()
@@ -306,7 +308,7 @@ fn test_listview_zero_and_overlapping() {
     assert_eq!(inner3.len(), 3); // [2, 3, 4]
     assert_eq!(
         inner3
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .as_primitive()
             .as_::<i32>()
@@ -325,6 +327,7 @@ fn test_listview_zero_and_overlapping() {
 
 #[test]
 fn test_listview_of_struct_with_nulls() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Create structs with fields that could be null.
     let struct_fields = StructFields::new(
         FieldNames::from(["id", "value"].as_slice()),
@@ -385,7 +388,7 @@ fn test_listview_of_struct_with_nulls() {
     // The middle element (struct[2]) should be null.
     assert!(
         list1
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .is_null()
     );

--- a/vortex-array/src/arrays/listview/tests/nullability.rs
+++ b/vortex-array/src/arrays/listview/tests/nullability.rs
@@ -21,6 +21,7 @@ use crate::validity::Validity;
 
 #[test]
 fn test_nullable_listview_comprehensive() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Comprehensive test for nullable ListView including scalar_at with nulls.
     // Logical lists: [[1,2], null, [5,6]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
@@ -38,17 +39,17 @@ fn test_nullable_listview_comprehensive() {
     // Check validity.
     assert!(
         listview
-            .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(0, &mut ctx)
             .unwrap()
     );
     assert!(
         listview
-            .is_invalid(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_invalid(1, &mut ctx)
             .unwrap()
     );
     assert!(
         listview
-            .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(2, &mut ctx)
             .unwrap()
     );
 
@@ -60,7 +61,7 @@ fn test_nullable_listview_comprehensive() {
 
     // Test scalar_at with nulls.
     let first = listview
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .unwrap();
     assert!(!first.is_null());
     assert_eq!(
@@ -73,12 +74,12 @@ fn test_nullable_listview_comprehensive() {
     );
 
     let second = listview
-        .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(1, &mut ctx)
         .unwrap();
     assert!(second.is_null());
 
     let third = listview
-        .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(2, &mut ctx)
         .unwrap();
     assert!(!third.is_null());
     assert_eq!(
@@ -95,13 +96,13 @@ fn test_nullable_listview_comprehensive() {
     assert_eq!(null_list_data.len(), 2);
     assert_eq!(
         null_list_data
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         3i32.into()
     );
     assert_eq!(
         null_list_data
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         4i32.into()
     );
@@ -113,6 +114,7 @@ fn test_nullable_listview_comprehensive() {
 #[case::all_valid(Validity::AllValid, vec![true, true, true])]
 #[case::mixed(Validity::from_iter([false, true, false]), vec![false, true, false])]
 fn test_nullable_patterns(#[case] validity: Validity, #[case] expected_validity: Vec<bool>) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Logical lists: [[1,2], [3,4], [5,6]] with varying validity
     let elements = buffer![1i32, 2, 3, 4, 5, 6].into_array();
     let offsets = buffer![0i32, 2, 4].into_array();
@@ -123,7 +125,7 @@ fn test_nullable_patterns(#[case] validity: Validity, #[case] expected_validity:
     for (i, &expected) in expected_validity.iter().enumerate() {
         assert_eq!(
             listview
-                .is_valid(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(i, &mut ctx)
                 .unwrap(),
             expected
         );
@@ -132,6 +134,7 @@ fn test_nullable_patterns(#[case] validity: Validity, #[case] expected_validity:
 
 #[test]
 fn test_nullable_elements() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Test with nullable elements inside the lists.
     // Logical lists: [[Some(1), None], [Some(3), None], [Some(5), Some(6)]]
     let elements =
@@ -150,19 +153,19 @@ fn test_nullable_elements() {
     assert_eq!(first_list.len(), 2);
     assert!(
         !first_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .is_null()
     );
     assert_eq!(
         first_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         1i32.into()
     );
     assert!(
         first_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .is_null()
     );
@@ -171,19 +174,19 @@ fn test_nullable_elements() {
     let second_list = listview.list_elements_at(1).unwrap();
     assert!(
         !second_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .is_null()
     );
     assert_eq!(
         second_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         3i32.into()
     );
     assert!(
         second_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .is_null()
     );
@@ -192,25 +195,25 @@ fn test_nullable_elements() {
     let third_list = listview.list_elements_at(2).unwrap();
     assert!(
         !third_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .is_null()
     );
     assert_eq!(
         third_list
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         5i32.into()
     );
     assert!(
         !third_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .is_null()
     );
     assert_eq!(
         third_list
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap(),
         6i32.into()
     );

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -12,8 +12,6 @@ use super::common::create_large_listview;
 use super::common::create_nullable_listview;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::aggregate_fn::fns::is_constant::is_constant;
 use crate::arrays::BoolArray;

--- a/vortex-array/src/arrays/listview/tests/operations.rs
+++ b/vortex-array/src/arrays/listview/tests/operations.rs
@@ -36,6 +36,7 @@ use crate::validity::Validity;
 
 #[test]
 fn test_slice_comprehensive() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Comprehensive test for basic slicing, full array, and single element cases.
     // Logical lists: [[1,2,3], [4,5], [6,7,8], [9,10]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10].into_array();
@@ -62,10 +63,10 @@ fn test_slice_comprehensive() {
         assert_eq!(
             full_list
                 .array()
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .unwrap(),
             listview
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .unwrap(),
             "Mismatch at index {}",
             i
@@ -135,6 +136,7 @@ fn test_slice_out_of_order() {
 
 #[test]
 fn test_slice_with_nulls() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Test slicing with nullable ListView.
     // Logical lists: [[1,2], null, [5,6], null]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array();
@@ -157,13 +159,13 @@ fn test_slice_with_nulls() {
     assert!(
         sliced_list
             .array()
-            .is_invalid(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_invalid(0, &mut ctx)
             .unwrap()
     ); // Original index 1 was null.
     assert!(
         sliced_list
             .array()
-            .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(1, &mut ctx)
             .unwrap()
     ); // Original index 2 was valid.
 
@@ -269,6 +271,7 @@ fn test_cast_numeric_types(#[case] from_ptype: PType, #[case] to_ptype: PType) {
 
 #[test]
 fn test_cast_with_nulls() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Logical lists: [[10,20], null]
     let elements = buffer![10i32, 20, 30, 40].into_array();
     let offsets = buffer![0u32, 2].into_array();
@@ -293,12 +296,12 @@ fn test_cast_with_nulls() {
     let result_list = result.to_listview();
     assert!(
         result_list
-            .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(0, &mut ctx)
             .unwrap()
     );
     assert!(
         result_list
-            .is_invalid(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_invalid(1, &mut ctx)
             .unwrap()
     );
 }
@@ -525,6 +528,7 @@ fn test_mask_listview_conformance(#[case] listview: ListViewArray) {
 
 #[test]
 fn test_mask_preserves_structure() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // ListView-specific: Verify mask preserves offsets and sizes.
     // Logical lists: [[1,2], [3,4], [5,6], [7,8]]
     let elements = buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array();
@@ -548,22 +552,22 @@ fn test_mask_preserves_structure() {
     // Check validity: true in selection means null.
     assert!(
         !result_list
-            .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(0, &mut ctx)
             .unwrap()
     ); // Masked.
     assert!(
         result_list
-            .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(1, &mut ctx)
             .unwrap()
     ); // Not masked.
     assert!(
         !result_list
-            .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(2, &mut ctx)
             .unwrap()
     ); // Masked.
     assert!(
         !result_list
-            .is_valid(3, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(3, &mut ctx)
             .unwrap()
     ); // Masked.
 
@@ -580,6 +584,7 @@ fn test_mask_preserves_structure() {
 
 #[test]
 fn test_mask_with_existing_nulls() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // ListView-specific: Test interaction between existing nulls and mask.
     // Logical lists: [[10,20], null, [50,60]]
     let elements = buffer![10i32, 20, 30, 40, 50, 60].into_array();
@@ -602,23 +607,24 @@ fn test_mask_with_existing_nulls() {
     // Check combined validity:
     assert!(
         result_list
-            .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(0, &mut ctx)
             .unwrap()
     ); // Was valid, mask is false -> valid.
     assert!(
         !result_list
-            .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(1, &mut ctx)
             .unwrap()
     ); // Was invalid, mask is true -> invalid.
     assert!(
         !result_list
-            .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(2, &mut ctx)
             .unwrap()
     ); // Was valid, mask is true -> invalid.
 }
 
 #[test]
 fn test_mask_with_gaps() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // ListView-specific: Mask with gaps in elements.
     // Logical lists: [[1,2], [5,6], [9,10]] (999 values are gaps)
     let elements = buffer![1i32, 2, 999, 999, 5, 6, 999, 999, 9, 10].into_array();
@@ -635,17 +641,17 @@ fn test_mask_with_gaps() {
     assert_eq!(result_list.len(), 3);
     assert!(
         !result_list
-            .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(0, &mut ctx)
             .unwrap()
     ); // Masked
     assert!(
         result_list
-            .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(1, &mut ctx)
             .unwrap()
     ); // Not masked
     assert!(
         result_list
-            .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(2, &mut ctx)
             .unwrap()
     ); // Not masked
 
@@ -656,6 +662,7 @@ fn test_mask_with_gaps() {
 
 #[test]
 fn test_mask_constant_arrays() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // ListView-specific: Test mask with ConstantArray offsets/sizes.
     // Logical lists: [[200,300], [200,300], [200,300]]
     let elements = buffer![100i32, 200, 300, 400, 500, 600].into_array();
@@ -680,17 +687,17 @@ fn test_mask_constant_arrays() {
     assert_eq!(result_list.len(), 3);
     assert!(
         result_list
-            .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(0, &mut ctx)
             .unwrap()
     );
     assert!(
         !result_list
-            .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(1, &mut ctx)
             .unwrap()
     ); // Masked
     assert!(
         result_list
-            .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(2, &mut ctx)
             .unwrap()
     );
 

--- a/vortex-array/src/arrays/listview/tests/take.rs
+++ b/vortex-array/src/arrays/listview/tests/take.rs
@@ -152,6 +152,7 @@ fn test_take_constant_arrays() {
 #[ignore = "TODO(connor)[ListView]: Don't rebuild ListView after every `take`"]
 #[test]
 fn test_take_extreme_offsets() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // ListView-specific: Test with very large offsets to demonstrate
     // that we keep unreferenced elements.
     let elements = PrimitiveArray::from_iter(0i32..10000).into_array();
@@ -181,7 +182,7 @@ fn test_take_extreme_offsets() {
     let list0 = result_list.list_elements_at(0).unwrap();
     assert_eq!(
         list0
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .as_primitive()
             .as_::<i32>()
@@ -190,7 +191,7 @@ fn test_take_extreme_offsets() {
     );
     assert_eq!(
         list0
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .as_primitive()
             .as_::<i32>()

--- a/vortex-array/src/arrays/listview/tests/take.rs
+++ b/vortex-array/src/arrays/listview/tests/take.rs
@@ -11,8 +11,6 @@ use super::common::create_nullable_listview;
 use super::common::create_overlapping_listview;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::arrays::ConstantArray;
 use crate::arrays::ListViewArray;

--- a/vortex-array/src/arrays/masked/array.rs
+++ b/vortex-array/src/arrays/masked/array.rs
@@ -84,12 +84,13 @@ impl MaskedData {
 impl Array<Masked> {
     /// Constructs a new `MaskedArray`.
     pub fn try_new(child: ArrayRef, validity: Validity) -> VortexResult<Self> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = child.dtype().as_nullable();
         let len = child.len();
         let validity_slot = validity_to_child(&validity, len);
         let data = MaskedData::try_new(
             len,
-            child.all_valid(&mut LEGACY_SESSION.create_execution_ctx())?,
+            child.all_valid(&mut ctx)?,
             validity,
         )?;
         Ok(unsafe {

--- a/vortex-array/src/arrays/masked/tests.rs
+++ b/vortex-array/src/arrays/masked/tests.rs
@@ -44,6 +44,7 @@ fn test_dtype_nullability_with_nullable_child() {
 
 #[test]
 fn test_canonical_dtype_matches_array_dtype() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // The canonical form should have the same nullability as the array's dtype.
     let child = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
     let array = MaskedArray::try_new(child, Validity::AllValid).unwrap();
@@ -51,7 +52,7 @@ fn test_canonical_dtype_matches_array_dtype() -> VortexResult<()> {
     let canonical = array
         .clone()
         .into_array()
-        .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?;
+        .execute::<Canonical>(&mut ctx)?;
     assert_eq!(canonical.dtype(), array.dtype());
     Ok(())
 }
@@ -70,31 +71,32 @@ fn test_masked_child_with_validity() {
     let mut ctx = LEGACY_SESSION.create_execution_ctx();
     assert_eq!(prim.valid_count(&mut ctx).unwrap(), 3);
     assert!(
-        prim.is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+        prim.is_valid(0, &mut ctx)
             .unwrap()
     );
     assert!(
         !prim
-            .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(1, &mut ctx)
             .unwrap()
     );
     assert!(
-        prim.is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+        prim.is_valid(2, &mut ctx)
             .unwrap()
     );
     assert!(
         !prim
-            .is_valid(3, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(3, &mut ctx)
             .unwrap()
     );
     assert!(
-        prim.is_valid(4, &mut LEGACY_SESSION.create_execution_ctx())
+        prim.is_valid(4, &mut ctx)
             .unwrap()
     );
 }
 
 #[test]
 fn test_masked_child_all_valid() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // When validity is AllValid, masked_child should invert to AllInvalid.
     let child = PrimitiveArray::from_iter([10i32, 20, 30]).into_array();
     let array = MaskedArray::try_new(child, Validity::AllValid).unwrap();
@@ -102,7 +104,7 @@ fn test_masked_child_all_valid() {
     assert_eq!(array.len(), 3);
     assert_eq!(
         array
-            .valid_count(&mut LEGACY_SESSION.create_execution_ctx())
+            .valid_count(&mut ctx)
             .unwrap(),
         3
     );

--- a/vortex-array/src/arrays/masked/tests.rs
+++ b/vortex-array/src/arrays/masked/tests.rs
@@ -9,8 +9,6 @@ use super::*;
 use crate::Canonical;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::arrays::PrimitiveArray;
 use crate::assert_arrays_eq;

--- a/vortex-array/src/arrays/masked/vtable/canonical.rs
+++ b/vortex-array/src/arrays/masked/vtable/canonical.rs
@@ -34,10 +34,11 @@ mod tests {
         #[case] array: MaskedArray,
         #[case] expected_nullability: Nullability,
     ) -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let canonical = array
             .clone()
             .into_array()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?;
+            .execute::<Canonical>(&mut ctx)?;
         assert_eq!(canonical.dtype().nullability(), expected_nullability);
         assert_eq!(canonical.dtype(), array.dtype());
         Ok(())
@@ -45,6 +46,7 @@ mod tests {
 
     #[test]
     fn test_canonical_with_nulls() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = MaskedArray::try_new(
             PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]).into_array(),
             Validity::from_iter([true, false, true, false, true]),
@@ -53,32 +55,31 @@ mod tests {
 
         let canonical = array
             .into_array()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?;
+            .execute::<Canonical>(&mut ctx)?;
         let prim = canonical.into_primitive();
 
         // Check that null positions match validity.
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         assert_eq!(prim.valid_count(&mut ctx).unwrap(), 3);
         assert!(
-            prim.is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+            prim.is_valid(0, &mut ctx)
                 .unwrap()
         );
         assert!(
             !prim
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(1, &mut ctx)
                 .unwrap()
         );
         assert!(
-            prim.is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+            prim.is_valid(2, &mut ctx)
                 .unwrap()
         );
         assert!(
             !prim
-                .is_valid(3, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(3, &mut ctx)
                 .unwrap()
         );
         assert!(
-            prim.is_valid(4, &mut LEGACY_SESSION.create_execution_ctx())
+            prim.is_valid(4, &mut ctx)
                 .unwrap()
         );
         Ok(())
@@ -86,6 +87,7 @@ mod tests {
 
     #[test]
     fn test_canonical_all_valid() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = MaskedArray::try_new(
             PrimitiveArray::from_iter([10i32, 20, 30]).into_array(),
             Validity::AllValid,
@@ -94,12 +96,12 @@ mod tests {
 
         let canonical = array
             .into_array()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?;
+            .execute::<Canonical>(&mut ctx)?;
         assert_eq!(canonical.dtype().nullability(), Nullability::Nullable);
         assert_eq!(
             canonical
                 .into_array()
-                .valid_count(&mut LEGACY_SESSION.create_execution_ctx())
+                .valid_count(&mut ctx)
                 .unwrap(),
             3
         );

--- a/vortex-array/src/arrays/masked/vtable/mod.rs
+++ b/vortex-array/src/arrays/masked/vtable/mod.rs
@@ -123,6 +123,7 @@ impl VTable for Masked {
         children: &dyn ArrayChildren,
         _session: &VortexSession,
     ) -> VortexResult<crate::array::ArrayParts<Self>> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         if !metadata.is_empty() {
             vortex_bail!(
                 "MaskedArray expects empty metadata, got {} bytes",
@@ -151,7 +152,7 @@ impl VTable for Masked {
         let validity_slot = validity_to_child(&validity, len);
         let data = MaskedData::try_new(
             len,
-            child.all_valid(&mut LEGACY_SESSION.create_execution_ctx())?,
+            child.all_valid(&mut ctx)?,
             validity,
         )?;
         Ok(

--- a/vortex-array/src/arrays/null/compute/cast.rs
+++ b/vortex-array/src/arrays/null/compute/cast.rs
@@ -51,6 +51,7 @@ mod tests {
 
     #[test]
     fn test_cast_null_to_nullable_succeeds() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let null_array = NullArray::new(5);
         let result = null_array
             .into_array()
@@ -68,7 +69,7 @@ mod tests {
         for i in 0..5 {
             assert!(
                 result
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .unwrap()
                     .is_null()
             );

--- a/vortex-array/src/arrays/null/compute/mod.rs
+++ b/vortex-array/src/arrays/null/compute/mod.rs
@@ -28,6 +28,7 @@ mod test {
 
     #[test]
     fn test_slice_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let nulls = NullArray::new(10);
         #[expect(deprecated)]
         let sliced = nulls.slice(0..4).unwrap().to_null();
@@ -38,7 +39,7 @@ mod test {
             sliced_arr
                 .validity()
                 .unwrap()
-                .to_mask(sliced_arr.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(sliced_arr.len(), &mut ctx)
                 .unwrap(),
             Mask::AllFalse(4)
         ));
@@ -46,6 +47,7 @@ mod test {
 
     #[test]
     fn test_take_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let nulls = NullArray::new(10);
         #[expect(deprecated)]
         let taken = nulls
@@ -59,7 +61,7 @@ mod test {
             taken_arr
                 .validity()
                 .unwrap()
-                .to_mask(taken_arr.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(taken_arr.len(), &mut ctx)
                 .unwrap(),
             Mask::AllFalse(5)
         ));
@@ -67,10 +69,11 @@ mod test {
 
     #[test]
     fn test_scalar_at_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let nulls = NullArray::new(10);
 
         let scalar = nulls
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap();
         assert!(scalar.is_null());
         assert_eq!(scalar.dtype().clone(), DType::Null);

--- a/vortex-array/src/arrays/null/compute/take.rs
+++ b/vortex-array/src/arrays/null/compute/take.rs
@@ -6,8 +6,6 @@ use vortex_error::vortex_bail;
 
 use crate::ArrayRef;
 use crate::IntoArray;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::array::ArrayView;
 use crate::arrays::Null;
 use crate::arrays::NullArray;

--- a/vortex-array/src/arrays/patched/array.rs
+++ b/vortex-array/src/arrays/patched/array.rs
@@ -110,16 +110,17 @@ pub trait PatchedArrayExt: PatchedArraySlotsExt {
 
     #[inline]
     fn lane_range(&self, chunk: usize, lane: usize) -> VortexResult<Range<usize>> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         assert!(chunk * 1024 <= self.as_ref().len() + self.offset());
         assert!(lane < self.n_lanes());
 
         let start = self.lane_offsets().execute_scalar(
             chunk * self.n_lanes() + lane,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         let stop = self.lane_offsets().execute_scalar(
             chunk * self.n_lanes() + lane + 1,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
 
         let start = start

--- a/vortex-array/src/arrays/patched/compute/take.rs
+++ b/vortex-array/src/arrays/patched/compute/take.rs
@@ -171,6 +171,7 @@ mod tests {
 
     #[test]
     fn test_take_basic() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Array with base values [0, 0, 0, 0, 0] patched at indices [1, 3] with values [10, 30]
         let array = make_patched_array(&[0; 5], &[1, 3], &[10, 30], 0..5)?;
 
@@ -178,7 +179,7 @@ mod tests {
         let indices = buffer![0u32, 1, 2, 3, 4].into_array();
         let result = array
             .take(indices)?
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .execute::<Canonical>(&mut ctx)?
             .into_array();
 
         let expected = PrimitiveArray::from_iter([0u16, 10, 0, 30, 0]).into_array();
@@ -189,12 +190,13 @@ mod tests {
 
     #[test]
     fn test_take_sliced() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = make_patched_array(&[0; 10], &[1, 3], &[100, 200], 2..10)?;
 
         let indices = buffer![0u32, 1, 2, 3, 7].into_array();
         let result = array
             .take(indices)?
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .execute::<Canonical>(&mut ctx)?
             .into_array();
 
         let expected = PrimitiveArray::from_iter([0u16, 200, 0, 0, 0]).into_array();
@@ -205,6 +207,7 @@ mod tests {
 
     #[test]
     fn test_take_out_of_order() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Array with base values [0, 0, 0, 0, 0] patched at indices [1, 3] with values [10, 30]
         let array = make_patched_array(&[0; 5], &[1, 3], &[10, 30], 0..5)?;
 
@@ -212,7 +215,7 @@ mod tests {
         let indices = buffer![4u32, 3, 2, 1, 0].into_array();
         let result = array
             .take(indices)?
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .execute::<Canonical>(&mut ctx)?
             .into_array();
 
         let expected = PrimitiveArray::from_iter([0u16, 30, 0, 10, 0]).into_array();
@@ -248,6 +251,7 @@ mod tests {
 
     #[test]
     fn test_take_with_null_indices() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         use crate::arrays::BoolArray;
         use crate::validity::Validity;
 
@@ -269,10 +273,9 @@ mod tests {
                 .into_array(),
             ),
         );
-        #[expect(deprecated)]
         let result = array
             .take(indices.into_array())?
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .execute::<Canonical>(&mut ctx)?
             .into_array();
 
         // Expected: [0, 20, null, 50, 80, null, 50, 80, null, 0]

--- a/vortex-array/src/arrays/patched/compute/take.rs
+++ b/vortex-array/src/arrays/patched/compute/take.rs
@@ -136,8 +136,11 @@ mod tests {
     use vortex_session::VortexSession;
 
     use crate::ArrayRef;
+    use crate::Canonical;
     use crate::ExecutionCtx;
     use crate::IntoArray;
+    use crate::LEGACY_SESSION;
+    use crate::VortexSessionExecute;
     use crate::arrays::Patched;
     use crate::arrays::PrimitiveArray;
     use crate::assert_arrays_eq;
@@ -173,8 +176,10 @@ mod tests {
 
         // Take indices [0, 1, 2, 3, 4] - should get [0, 10, 0, 30, 0]
         let indices = buffer![0u32, 1, 2, 3, 4].into_array();
-        #[expect(deprecated)]
-        let result = array.take(indices)?.to_canonical()?.into_array();
+        let result = array
+            .take(indices)?
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .into_array();
 
         let expected = PrimitiveArray::from_iter([0u16, 10, 0, 30, 0]).into_array();
         assert_arrays_eq!(expected, result);
@@ -187,8 +192,10 @@ mod tests {
         let array = make_patched_array(&[0; 10], &[1, 3], &[100, 200], 2..10)?;
 
         let indices = buffer![0u32, 1, 2, 3, 7].into_array();
-        #[expect(deprecated)]
-        let result = array.take(indices)?.to_canonical()?.into_array();
+        let result = array
+            .take(indices)?
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .into_array();
 
         let expected = PrimitiveArray::from_iter([0u16, 200, 0, 0, 0]).into_array();
         assert_arrays_eq!(expected, result);
@@ -203,8 +210,10 @@ mod tests {
 
         // Take indices in reverse order
         let indices = buffer![4u32, 3, 2, 1, 0].into_array();
-        #[expect(deprecated)]
-        let result = array.take(indices)?.to_canonical()?.into_array();
+        let result = array
+            .take(indices)?
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .into_array();
 
         let expected = PrimitiveArray::from_iter([0u16, 30, 0, 10, 0]).into_array();
         assert_arrays_eq!(expected, result);
@@ -219,12 +228,17 @@ mod tests {
 
         // Take the same patched index multiple times
         let indices = buffer![2u32, 2, 0, 2].into_array();
-        #[expect(deprecated)]
-        let result = array.take(indices)?.to_canonical()?.into_array();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let result = array
+            .take(indices)?
+            .execute::<Canonical>(&mut ctx)?
+            .into_array();
 
         // execute the array.
-        #[expect(deprecated)]
-        let _canonical = result.to_canonical()?.into_primitive();
+        let _canonical = result
+            .clone()
+            .execute::<Canonical>(&mut ctx)?
+            .into_primitive();
 
         let expected = PrimitiveArray::from_iter([99u16, 99, 0, 99]).into_array();
         assert_arrays_eq!(expected, result);
@@ -258,7 +272,7 @@ mod tests {
         #[expect(deprecated)]
         let result = array
             .take(indices.into_array())?
-            .to_canonical()?
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
             .into_array();
 
         // Expected: [0, 20, null, 50, 80, null, 50, 80, null, 0]

--- a/vortex-array/src/arrays/patched/vtable/operations.rs
+++ b/vortex-array/src/arrays/patched/vtable/operations.rs
@@ -62,8 +62,6 @@ mod tests {
 
     use crate::ExecutionCtx;
     use crate::IntoArray;
-    use crate::LEGACY_SESSION;
-    use crate::VortexSessionExecute;
     use crate::arrays::Patched;
     use crate::dtype::Nullability;
     use crate::optimizer::ArrayOptimizer;
@@ -91,25 +89,25 @@ mod tests {
 
         assert_eq!(
             array
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::primitive(0u16, Nullability::NonNullable)
         );
         assert_eq!(
             array
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .unwrap(),
             Scalar::primitive(1u16, Nullability::NonNullable)
         );
         assert_eq!(
             array
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .unwrap(),
             Scalar::primitive(1u16, Nullability::NonNullable)
         );
         assert_eq!(
             array
-                .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(3, &mut ctx)
                 .unwrap(),
             Scalar::primitive(1u16, Nullability::NonNullable)
         );
@@ -136,7 +134,7 @@ mod tests {
 
         for index in 0..array.len() {
             let value = array
-                .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(index, &mut ctx)
                 .unwrap();
 
             if [1, 2, 3].contains(&index) {
@@ -174,14 +172,14 @@ mod tests {
 
         assert_eq!(
             array
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             1u16.into()
         );
         for index in 1..array.len() {
             assert_eq!(
                 array
-                    .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(index, &mut ctx)
                     .unwrap(),
                 0u16.into()
             );

--- a/vortex-array/src/arrays/primitive/array/top_value.rs
+++ b/vortex-array/src/arrays/primitive/array/top_value.rs
@@ -22,6 +22,7 @@ use crate::validity::Validity;
 impl PrimitiveArray {
     /// Compute most common present value of this array
     pub fn top_value(&self) -> VortexResult<Option<(PValue, usize)>> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         if self.is_empty() {
             return Ok(None);
         }
@@ -35,7 +36,7 @@ impl PrimitiveArray {
                 self.as_slice::<P>(),
                 self.as_ref().validity()?.to_mask(
                     self.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx(),
+                    &mut ctx,
                 )?,
             );
             Ok(Some((top.into(), count)))

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -115,6 +115,7 @@ mod test {
     use vortex_error::VortexError;
     use vortex_mask::Mask;
 
+    use crate::Canonical;
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
     use crate::VortexSessionExecute;
@@ -200,7 +201,10 @@ mod test {
         #[expect(deprecated)]
         let error = arr
             .cast(PType::U32.into())
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()))
+            .and_then(|a| {
+                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                    .map(|c| c.into_array())
+            })
             .unwrap_err();
         assert!(matches!(error, VortexError::Compute(..)));
         assert!(error.to_string().contains("values exceed target range"));
@@ -213,7 +217,10 @@ mod test {
         let err = arr
             .into_array()
             .cast(PType::I32.into())
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()))
+            .and_then(|a| {
+                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                    .map(|c| c.into_array())
+            })
             .unwrap_err();
 
         assert!(matches!(err, VortexError::InvalidArgument(..)));
@@ -274,7 +281,10 @@ mod test {
         #[expect(deprecated)]
         let err = arr
             .cast(PType::I32.into())
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()))
+            .and_then(|a| {
+                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                    .map(|c| c.into_array())
+            })
             .unwrap_err();
         assert!(matches!(err, VortexError::Compute(..)));
     }

--- a/vortex-array/src/arrays/primitive/compute/cast.rs
+++ b/vortex-array/src/arrays/primitive/compute/cast.rs
@@ -197,12 +197,12 @@ mod test {
 
     #[test]
     fn cast_i32_u32() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = buffer![-1i32].into_array();
-        #[expect(deprecated)]
         let error = arr
             .cast(PType::U32.into())
             .and_then(|a| {
-                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                a.execute::<Canonical>(&mut ctx)
                     .map(|c| c.into_array())
             })
             .unwrap_err();
@@ -212,13 +212,13 @@ mod test {
 
     #[test]
     fn cast_array_with_nulls_to_nonnullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::from_option_iter([Some(-1i32), None, Some(10)]);
-        #[expect(deprecated)]
         let err = arr
             .into_array()
             .cast(PType::I32.into())
             .and_then(|a| {
-                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                a.execute::<Canonical>(&mut ctx)
                     .map(|c| c.into_array())
             })
             .unwrap_err();
@@ -232,6 +232,7 @@ mod test {
 
     #[test]
     fn cast_with_invalid_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::new(
             buffer![-1i32, 0, 10],
             Validity::from_iter([false, true, true]),
@@ -250,7 +251,7 @@ mod test {
             p.as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(p.as_ref().len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(p.as_ref().len(), &mut ctx)
                 .unwrap(),
             Mask::from(BitBuffer::from(vec![false, true, true]))
         );
@@ -277,12 +278,12 @@ mod test {
     /// to the allocating path and produce an error.
     #[test]
     fn cast_same_width_int_out_of_range_errors() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = buffer![u32::MAX].into_array();
-        #[expect(deprecated)]
         let err = arr
             .cast(PType::I32.into())
             .and_then(|a| {
-                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                a.execute::<Canonical>(&mut ctx)
                     .map(|c| c.into_array())
             })
             .unwrap_err();

--- a/vortex-array/src/arrays/primitive/compute/fill_null.rs
+++ b/vortex-array/src/arrays/primitive/compute/fill_null.rs
@@ -64,6 +64,7 @@ mod test {
 
     #[test]
     fn fill_null_leading_none() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::from_option_iter([None, Some(8u8), None, Some(10), None]);
         #[expect(deprecated)]
         let p = arr
@@ -76,7 +77,7 @@ mod test {
             p.as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(p.as_ref().len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(p.as_ref().len(), &mut ctx)
                 .unwrap()
                 .all_true()
         );
@@ -84,6 +85,7 @@ mod test {
 
     #[test]
     fn fill_null_all_none() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::from_option_iter([Option::<u8>::None, None, None, None, None]);
 
         #[expect(deprecated)]
@@ -97,7 +99,7 @@ mod test {
             p.as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(p.as_ref().len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(p.as_ref().len(), &mut ctx)
                 .unwrap()
                 .all_true()
         );
@@ -105,6 +107,7 @@ mod test {
 
     #[test]
     fn fill_null_nullable_non_null() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::new(
             buffer![8u8, 10, 12, 14, 16],
             Validity::Array(BoolArray::from_iter([true, true, true, true, true]).into_array()),
@@ -120,7 +123,7 @@ mod test {
             p.as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(p.as_ref().len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(p.as_ref().len(), &mut ctx)
                 .unwrap()
                 .all_true()
         );
@@ -128,6 +131,7 @@ mod test {
 
     #[test]
     fn fill_null_non_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = buffer![8u8, 10, 12, 14, 16].into_array();
         #[expect(deprecated)]
         let p = arr.fill_null(Scalar::from(255u8)).unwrap().to_primitive();
@@ -136,7 +140,7 @@ mod test {
             p.as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(p.as_ref().len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(p.as_ref().len(), &mut ctx)
                 .unwrap()
                 .all_true()
         );

--- a/vortex-array/src/arrays/primitive/compute/take/mod.rs
+++ b/vortex-array/src/arrays/primitive/compute/take/mod.rs
@@ -154,6 +154,7 @@ mod test {
 
     #[test]
     fn test_take_with_null_indices() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = PrimitiveArray::new(
             buffer![1i32, 2, 3, 4, 5],
             Validity::Array(BoolArray::from_iter([true, true, false, false, true]).into_array()),
@@ -165,21 +166,21 @@ mod test {
         let actual = values.take(indices.into_array()).unwrap();
         assert_eq!(
             actual
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .vortex_expect("no fail"),
             Scalar::from(Some(1))
         );
         // position 3 is null
         assert_eq!(
             actual
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .vortex_expect("no fail"),
             Scalar::null_native::<i32>()
         );
         // the third index is null
         assert_eq!(
             actual
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .vortex_expect("no fail"),
             Scalar::null_native::<i32>()
         );

--- a/vortex-array/src/arrays/scalar_fn/rules.rs
+++ b/vortex-array/src/arrays/scalar_fn/rules.rs
@@ -75,6 +75,7 @@ impl ArrayReduceRule<ScalarFnVTable> for ScalarFnPackToStructRule {
 struct ScalarFnConstantRule;
 impl ArrayReduceRule<ScalarFnVTable> for ScalarFnConstantRule {
     fn reduce(&self, array: ArrayView<'_, ScalarFnVTable>) -> VortexResult<Option<ArrayRef>> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         if !array.children().iter().all(|c| c.is::<Constant>()) {
             return Ok(None);
         }
@@ -83,7 +84,7 @@ impl ArrayReduceRule<ScalarFnVTable> for ScalarFnConstantRule {
         } else {
             let result = array
                 .array()
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?;
+                .execute_scalar(0, &mut ctx)?;
             Ok(Some(ConstantArray::new(result, array.len()).into_array()))
         }
     }

--- a/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
+++ b/vortex-array/src/arrays/scalar_fn/vtable/operations.rs
@@ -73,6 +73,7 @@ mod tests {
 
     #[test]
     fn test_scalar_fn_add() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let lhs = buffer![1i32, 2, 3].into_array();
         let rhs = buffer![10i32, 20, 30].into_array();
 
@@ -81,7 +82,7 @@ mod tests {
 
         let result = scalar_fn_array
             .into_array()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .execute::<Canonical>(&mut ctx)?
             .into_array();
         let expected = buffer![11i32, 22, 33].into_array();
         assert_arrays_eq!(result, expected);
@@ -91,6 +92,7 @@ mod tests {
 
     #[test]
     fn test_scalar_fn_mul() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let lhs = buffer![2i32, 3, 4].into_array();
         let rhs = buffer![5i32, 6, 7].into_array();
 
@@ -99,7 +101,7 @@ mod tests {
 
         let result = scalar_fn_array
             .into_array()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .execute::<Canonical>(&mut ctx)?
             .into_array();
         let expected = buffer![10i32, 18, 28].into_array();
         assert_arrays_eq!(result, expected);
@@ -109,6 +111,7 @@ mod tests {
 
     #[test]
     fn test_scalar_fn_with_nullable() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let lhs = PrimitiveArray::new(buffer![1i32, 2, 3], Validity::AllValid).into_array();
         let rhs = PrimitiveArray::new(
             buffer![10i32, 20, 30],
@@ -121,7 +124,7 @@ mod tests {
 
         let result = scalar_fn_array
             .into_array()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .execute::<Canonical>(&mut ctx)?
             .into_array();
         let expected = PrimitiveArray::new(
             buffer![11i32, 0, 33],
@@ -135,6 +138,7 @@ mod tests {
 
     #[test]
     fn test_scalar_fn_comparison() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let lhs = buffer![1i32, 5, 3].into_array();
         let rhs = buffer![2i32, 5, 1].into_array();
 
@@ -143,7 +147,7 @@ mod tests {
 
         let result = scalar_fn_array
             .into_array()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .execute::<Canonical>(&mut ctx)?
             .into_array();
         let expected = BoolArray::from_iter([false, true, false]).into_array();
         assert_arrays_eq!(result, expected);

--- a/vortex-array/src/arrays/struct_/compute/mod.rs
+++ b/vortex-array/src/arrays/struct_/compute/mod.rs
@@ -58,6 +58,7 @@ mod tests {
 
     #[test]
     fn take_empty_struct_with_nullable_indices() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let struct_arr = StructArray::try_from_iter_with_validity(
             [("a", BoolArray::from_iter(Vec::<bool>::new()).into_array())],
             Validity::AllValid,
@@ -67,25 +68,26 @@ mod tests {
         let taken = struct_arr
             .take(indices.into_array())
             .unwrap()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .unwrap();
         assert_eq!(taken.len(), 1);
         assert!(
             taken
                 .into_array()
-                .all_invalid(&mut LEGACY_SESSION.create_execution_ctx())
+                .all_invalid(&mut ctx)
                 .unwrap()
         );
     }
 
     #[test]
     fn take_empty_primitive_with_nullable_indices() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::from_iter(Vec::<u64>::new());
         let indices = PrimitiveArray::from_option_iter([Option::<u64>::None]);
         let taken = arr
             .take(indices.into_array())
             .unwrap()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .unwrap();
         assert_eq!(taken.len(), 1);
     }

--- a/vortex-array/src/arrays/struct_/tests.rs
+++ b/vortex-array/src/arrays/struct_/tests.rs
@@ -136,6 +136,7 @@ fn test_duplicate_field_names() {
 
 #[test]
 fn test_uncompressed_size_in_bytes() -> VortexResult<()> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let struct_array = StructArray::new(
         FieldNames::from(["integers"]),
         vec![ConstantArray::new(5, 1000).into_array()],
@@ -146,12 +147,12 @@ fn test_uncompressed_size_in_bytes() -> VortexResult<()> {
     let canonical_size = struct_array
         .clone()
         .into_array()
-        .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+        .execute::<Canonical>(&mut ctx)?
         .into_array()
         .nbytes();
     let uncompressed_size = struct_array
         .statistics()
-        .compute_uncompressed_size_in_bytes(&mut LEGACY_SESSION.create_execution_ctx());
+        .compute_uncompressed_size_in_bytes(&mut ctx);
 
     assert_eq!(canonical_size, 2);
     assert_eq!(uncompressed_size, Some(4000));

--- a/vortex-array/src/arrays/varbin/accessor.rs
+++ b/vortex-array/src/arrays/varbin/accessor.rs
@@ -4,9 +4,6 @@
 use std::iter;
 
 use vortex_error::VortexExpect;
-
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::accessor::ArrayAccessor;
 use crate::arrays::VarBinArray;
 use crate::arrays::varbin::VarBinArrayExt;

--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -184,6 +184,7 @@ impl VarBinData {
         dtype: &DType,
         validity: &Validity,
     ) -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Check offsets are non-nullable integer
         vortex_ensure!(
             offsets.dtype().is_int() && !offsets.dtype().is_nullable(),
@@ -215,7 +216,7 @@ impl VarBinData {
             let last_offset = offsets
                 .execute_scalar(
                     offsets.len() - 1,
-                    &mut LEGACY_SESSION.create_execution_ctx(),
+                    &mut ctx,
                 )?
                 .as_primitive()
                 .as_::<usize>()
@@ -324,6 +325,7 @@ pub trait VarBinArrayExt: TypedArrayRef<VarBin> {
     }
 
     fn offset_at(&self, index: usize) -> usize {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         assert!(
             index <= self.as_ref().len(),
             "Index {index} out of bounds 0..={}",
@@ -332,7 +334,7 @@ pub trait VarBinArrayExt: TypedArrayRef<VarBin> {
 
         (&self
             .offsets()
-            .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(index, &mut ctx)
             .vortex_expect("offsets must support execute_scalar"))
             .try_into()
             .vortex_expect("Failed to convert offset to usize")

--- a/vortex-array/src/arrays/varbin/array.rs
+++ b/vortex-array/src/arrays/varbin/array.rs
@@ -13,8 +13,6 @@ use vortex_error::vortex_err;
 
 use crate::ArrayRef;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::array::Array;
 use crate::array::ArrayParts;

--- a/vortex-array/src/arrays/varbin/builder.rs
+++ b/vortex-array/src/arrays/varbin/builder.rs
@@ -95,6 +95,7 @@ impl<O: IntegerPType> VarBinBuilder<O> {
     }
 
     pub fn finish(self, dtype: DType) -> VarBinArray {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let offsets = PrimitiveArray::new(self.offsets.freeze(), Validity::NonNullable);
         let nulls = self.validity.freeze();
 
@@ -107,7 +108,7 @@ impl<O: IntegerPType> VarBinBuilder<O> {
         {
             let offsets_are_sorted = offsets
                 .statistics()
-                .compute_is_sorted(&mut LEGACY_SESSION.create_execution_ctx())
+                .compute_is_sorted(&mut ctx)
                 .unwrap_or(false);
             debug_assert!(offsets_are_sorted, "VarBinBuilder offsets must be sorted");
         }
@@ -143,6 +144,7 @@ mod tests {
 
     #[test]
     fn test_builder() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut builder = VarBinBuilder::<i32>::with_capacity(0);
         builder.append(Some(b"hello"));
         builder.append(None);
@@ -153,13 +155,13 @@ mod tests {
         assert_eq!(array.dtype().nullability(), Nullable);
         assert_eq!(
             array
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::utf8("hello".to_string(), Nullable)
         );
         assert!(
             array
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .unwrap()
                 .is_null()
         );

--- a/vortex-array/src/arrays/varbin/compute/compare.rs
+++ b/vortex-array/src/arrays/varbin/compute/compare.rs
@@ -161,6 +161,7 @@ mod test {
 
     #[test]
     fn test_binary_compare() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = VarBinArray::from_iter(
             [Some(b"abc".to_vec()), None, Some(b"def".to_vec())],
             DType::Binary(Nullability::Nullable),
@@ -186,7 +187,7 @@ mod test {
                 .unwrap()
                 .to_mask(
                     result.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx()
+                    &mut ctx
                 )
                 .unwrap()
                 .to_bit_buffer(),
@@ -200,6 +201,7 @@ mod test {
 
     #[test]
     fn varbinview_compare() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = VarBinArray::from_iter(
             [Some(b"abc".to_vec()), None, Some(b"def".to_vec())],
             DType::Binary(Nullability::Nullable),
@@ -222,7 +224,7 @@ mod test {
                 .unwrap()
                 .to_mask(
                     result.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx()
+                    &mut ctx
                 )
                 .unwrap()
                 .to_bit_buffer(),

--- a/vortex-array/src/arrays/varbin/compute/filter.rs
+++ b/vortex-array/src/arrays/varbin/compute/filter.rs
@@ -225,6 +225,7 @@ mod test {
 
     #[test]
     fn filter_var_bin_test() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = VarBinArray::from_vec(
             vec![
                 b"hello".as_slice(),
@@ -238,7 +239,7 @@ mod test {
             arr,
             &[0, 2],
             2,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap();
 
@@ -247,6 +248,7 @@ mod test {
 
     #[test]
     fn filter_var_bin_slice_test() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = VarBinArray::from_vec(
             vec![
                 b"hello".as_slice(),
@@ -263,7 +265,7 @@ mod test {
             arr,
             &[(0, 1), (2, 3), (4, 5)],
             3,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap();
 
@@ -272,6 +274,7 @@ mod test {
 
     #[test]
     fn filter_var_bin_slice_null() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let bytes = [
             b"one".as_slice(),
             b"two".as_slice(),
@@ -295,7 +298,7 @@ mod test {
             arr,
             &[(0, 3), (4, 6)],
             5,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap();
 
@@ -313,6 +316,7 @@ mod test {
 
     #[test]
     fn filter_varbin_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let bytes = [b"".as_slice(), b"two".as_slice(), b"two".as_slice()]
             .into_iter()
             .flat_map(|x| x.iter().cloned())
@@ -327,7 +331,7 @@ mod test {
             arr,
             &[(0, 1), (2, 3)],
             2,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap();
 
@@ -336,6 +340,7 @@ mod test {
 
     #[test]
     fn filter_varbin_all_null() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let offsets = buffer![0, 0, 0, 0].into_array();
         let validity = Validity::Array(BoolArray::from_iter([false, false, false]).into_array());
         let arr = VarBinArray::try_new(
@@ -351,7 +356,7 @@ mod test {
             arr,
             &[(0, 1), (2, 3)],
             2,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap();
 

--- a/vortex-array/src/arrays/varbin/vtable/canonical.rs
+++ b/vortex-array/src/arrays/varbin/vtable/canonical.rs
@@ -62,6 +62,7 @@ mod tests {
     #[case(DType::Utf8(Nullability::Nullable))]
     #[case(DType::Binary(Nullability::Nullable))]
     fn test_canonical_varbin_sliced(#[case] dtype: DType) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut varbin = VarBinBuilder::<i32>::with_capacity(10);
         varbin.append_null();
         varbin.append_null();
@@ -79,7 +80,7 @@ mod tests {
 
         assert!(
             !canonical
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(0, &mut ctx)
                 .unwrap()
         );
 

--- a/vortex-array/src/arrays/varbinview/accessor.rs
+++ b/vortex-array/src/arrays/varbinview/accessor.rs
@@ -4,9 +4,6 @@
 use std::iter;
 
 use vortex_error::VortexExpect;
-
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::accessor::ArrayAccessor;
 use crate::arrays::VarBinViewArray;
 use crate::validity::Validity;

--- a/vortex-array/src/arrays/varbinview/compact.rs
+++ b/vortex-array/src/arrays/varbinview/compact.rs
@@ -65,9 +65,10 @@ impl VarBinViewArray {
     where
         F: FnMut(&Ref),
     {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         match self.as_ref().validity()?.to_mask(
             self.as_ref().len(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )? {
             Mask::AllTrue(_) => {
                 for &view in self.views().iter() {
@@ -202,6 +203,7 @@ mod tests {
     use crate::dtype::Nullability;
     #[test]
     fn test_optimize_compacts_buffers() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a VarBinViewArray with some long strings that will create multiple buffers
         let original = VarBinViewArray::from_iter_nullable_str([
             Some("short"),
@@ -219,7 +221,7 @@ mod tests {
         let indices = buffer![0u32, 4u32].into_array();
         let taken = original.take(indices).unwrap();
         let taken = taken
-            .execute::<VarBinViewArray>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<VarBinViewArray>(&mut ctx)
             .unwrap();
         // The taken array should still have the same number of buffers
         assert_eq!(taken.data_buffers().len(), original_buffers);
@@ -241,6 +243,7 @@ mod tests {
 
     #[test]
     fn test_optimize_with_long_strings() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create strings that are definitely longer than 12 bytes
         let long_string_1 = "this is definitely a very long string that exceeds the inline limit";
         let long_string_2 = "another extremely long string that also needs external buffer storage";
@@ -258,7 +261,7 @@ mod tests {
         let indices = buffer![0u32, 2u32].into_array();
         let taken = original.take(indices).unwrap();
         let taken_array = taken
-            .execute::<VarBinViewArray>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<VarBinViewArray>(&mut ctx)
             .unwrap();
 
         // Optimize the taken array
@@ -311,6 +314,7 @@ mod tests {
 
     #[test]
     fn test_selective_compaction_with_threshold_zero() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // threshold=0 should keep all buffers (no compaction)
         let original = VarBinViewArray::from_iter_str([
             "this is a longer string that will be stored in a buffer",
@@ -324,7 +328,7 @@ mod tests {
         let indices = buffer![0u32].into_array();
         let taken = original.take(indices).unwrap();
         let taken = taken
-            .execute::<VarBinViewArray>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<VarBinViewArray>(&mut ctx)
             .unwrap();
         // Compact with threshold=0 (should not compact)
         let compacted = taken.compact_with_threshold(0.0).unwrap();
@@ -338,6 +342,7 @@ mod tests {
 
     #[test]
     fn test_selective_compaction_with_high_threshold() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // threshold=1.0 should compact any buffer with waste
         let original = VarBinViewArray::from_iter_str([
             "this is a longer string that will be stored in a buffer",
@@ -349,7 +354,7 @@ mod tests {
         let indices = buffer![0u32, 2u32].into_array();
         let taken = original.take(indices).unwrap();
         let taken = taken
-            .execute::<VarBinViewArray>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<VarBinViewArray>(&mut ctx)
             .unwrap();
 
         let original_buffers = taken.data_buffers().len();
@@ -388,6 +393,7 @@ mod tests {
 
     #[test]
     fn test_selective_compaction_with_mixed_utilization() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create array with some long strings
         let strings: Vec<String> = (0..10)
             .map(|i| {
@@ -404,7 +410,7 @@ mod tests {
         let indices_array = buffer![0u32, 2u32, 4u32, 6u32, 8u32].into_array();
         let taken = original.take(indices_array).unwrap();
         let taken = taken
-            .execute::<VarBinViewArray>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<VarBinViewArray>(&mut ctx)
             .unwrap();
 
         // Compact with moderate threshold
@@ -419,6 +425,7 @@ mod tests {
 
     #[test]
     fn test_slice_strategy_with_contiguous_range() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create array with strings that will be in one buffer
         let strings: Vec<String> = (0..20)
             .map(|i| format!("this is a long string number {} for slice test", i))
@@ -430,7 +437,7 @@ mod tests {
         let indices_array = buffer![0u32, 1u32, 2u32, 3u32, 4u32].into_array();
         let taken = original.take(indices_array).unwrap();
         let taken = taken
-            .execute::<VarBinViewArray>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<VarBinViewArray>(&mut ctx)
             .unwrap();
         // Get buffer stats before compaction
         let utils_before = taken.buffer_utilizations().unwrap();

--- a/vortex-array/src/arrays/varbinview/tests.rs
+++ b/vortex-array/src/arrays/varbinview/tests.rs
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
-
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::varbinview::BinaryView;
 use crate::assert_arrays_eq;

--- a/vortex-array/src/arrow/datum.rs
+++ b/vortex-array/src/arrow/datum.rs
@@ -89,6 +89,7 @@ pub fn from_arrow_array_with_len<A>(array: A, len: usize, nullable: bool) -> Vor
 where
     ArrayRef: FromArrowArray<A>,
 {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let array = ArrayRef::from_arrow(array, nullable)?;
     if array.len() == len {
         return Ok(array);
@@ -105,7 +106,7 @@ where
 
     Ok(ConstantArray::new(
         array
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .vortex_expect("array of length 1 must support execute_scalar(0)"),
         len,
     )

--- a/vortex-array/src/arrow/executor/decimal.rs
+++ b/vortex-array/src/arrow/executor/decimal.rs
@@ -236,6 +236,7 @@ mod tests {
 
     #[test]
     fn decimal_to_arrow() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Make a very simple i128 and i256 array.
         let decimal_vortex = DecimalArray::new(
             buffer![1i128, 2i128, 3i128, 4i128, 5i128],
@@ -244,7 +245,7 @@ mod tests {
         );
         let arrow = decimal_vortex.into_array().execute_arrow(
             Some(&DataType::Decimal128(19, 2)),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )?;
         assert_eq!(arrow.data_type(), &DataType::Decimal128(19, 2));
         let decimal_array = arrow.as_any().downcast_ref::<Decimal128Array>().unwrap();

--- a/vortex-array/src/arrow/executor/dictionary.rs
+++ b/vortex-array/src/arrow/executor/dictionary.rs
@@ -165,7 +165,8 @@ mod tests {
     }
 
     fn execute(array: crate::ArrayRef, dt: &DataType) -> VortexResult<arrow_array::ArrayRef> {
-        array.execute_arrow(Some(dt), &mut LEGACY_SESSION.create_execution_ctx())
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        array.execute_arrow(Some(dt), &mut ctx)
     }
 
     #[rstest]

--- a/vortex-array/src/arrow/executor/struct_.rs
+++ b/vortex-array/src/arrow/executor/struct_.rs
@@ -278,6 +278,7 @@ mod tests {
 
     #[test]
     fn test_to_arrow() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = StructArray::from_fields(
             vec![
                 (
@@ -313,7 +314,7 @@ mod tests {
         assert_eq!(
             &array.into_array().execute_arrow(
                 Some(&arrow_dtype),
-                &mut LEGACY_SESSION.create_execution_ctx()
+                &mut ctx
             )?,
             &arrow_array
         );

--- a/vortex-array/src/arrow/mod.rs
+++ b/vortex-array/src/arrow/mod.rs
@@ -40,10 +40,12 @@ impl IntoArrowArray for ArrayRef {
     /// Convert this [`crate::ArrayRef`] into an Arrow [`crate::ArrayRef`] by using the array's
     /// preferred (cheapest) Arrow [`DataType`].
     fn into_arrow_preferred(self) -> VortexResult<ArrowArrayRef> {
-        self.execute_arrow(None, &mut LEGACY_SESSION.create_execution_ctx())
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        self.execute_arrow(None, &mut ctx)
     }
 
     fn into_arrow(self, data_type: &DataType) -> VortexResult<ArrowArrayRef> {
-        self.execute_arrow(Some(data_type), &mut LEGACY_SESSION.create_execution_ctx())
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        self.execute_arrow(Some(data_type), &mut ctx)
     }
 }

--- a/vortex-array/src/arrow/record_batch.rs
+++ b/vortex-array/src/arrow/record_batch.rs
@@ -18,10 +18,11 @@ impl StructArray {
         self,
         schema: impl AsRef<Schema>,
     ) -> VortexResult<RecordBatch> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let data_type = DataType::Struct(schema.as_ref().fields.clone());
         let array_ref = self
             .into_array()
-            .execute_arrow(Some(&data_type), &mut LEGACY_SESSION.create_execution_ctx())?;
+            .execute_arrow(Some(&data_type), &mut ctx)?;
         Ok(RecordBatch::from(array_ref.as_struct()))
     }
 }

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -20,8 +20,6 @@ use crate::builders::ArrayBuilder;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::LazyBitBufferBuilder;
 use crate::canonical::Canonical;
-#[expect(deprecated)]
-use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::scalar::Scalar;
@@ -116,8 +114,11 @@ impl ArrayBuilder for BoolBuilder {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
-        #[expect(deprecated)]
-        let bool_array = array.to_bool();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let bool_array = array
+            .clone()
+            .execute::<BoolArray>(&mut ctx)
+            .vortex_expect("extend_from_array_unchecked: failed to canonicalize");
 
         self.inner.append_buffer(&bool_array.to_bit_buffer());
         self.nulls.append_validity_mask(
@@ -127,7 +128,7 @@ impl ArrayBuilder for BoolBuilder {
                 .vortex_expect("validity_mask")
                 .to_mask(
                     bool_array.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx(),
+                    &mut ctx,
                 )
                 .vortex_expect("Failed to compute validity mask"),
         );

--- a/vortex-array/src/builders/bool.rs
+++ b/vortex-array/src/builders/bool.rs
@@ -158,6 +158,7 @@ mod tests {
     use rand::RngExt;
     use rand::SeedableRng;
     use rand::prelude::StdRng;
+    use vortex_error::VortexExpect as _;
     use vortex_error::VortexResult;
 
     use crate::ArrayRef;
@@ -171,8 +172,6 @@ mod tests {
     use crate::builders::BoolBuilder;
     use crate::builders::bool::BoolArray;
     use crate::builders::builder_with_capacity;
-    #[expect(deprecated)]
-    use crate::canonical::ToCanonical as _;
     use crate::dtype::DType;
     use crate::dtype::Nullability;
     use crate::scalar::Scalar;
@@ -206,10 +205,13 @@ mod tests {
             .clone()
             .append_to_builder(builder.as_mut(), &mut ctx)?;
 
-        #[expect(deprecated)]
-        let canon_into = builder.finish().to_bool();
-        #[expect(deprecated)]
-        let into_canon = chunk.to_bool();
+        let canon_into = builder
+            .finish()
+            .execute::<BoolArray>(&mut ctx)
+            .vortex_expect("to_bool failed");
+        let into_canon = chunk
+            .execute::<BoolArray>(&mut ctx)
+            .vortex_expect("to_bool failed");
 
         assert!(
             canon_into

--- a/vortex-array/src/builders/decimal.rs
+++ b/vortex-array/src/builders/decimal.rs
@@ -14,8 +14,6 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::arrays::DecimalArray;
 use crate::builders::ArrayBuilder;
@@ -196,8 +194,11 @@ impl ArrayBuilder for DecimalBuilder {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
-        #[expect(deprecated)]
-        let decimal_array = array.to_decimal();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let decimal_array = array
+            .clone()
+            .execute::<DecimalArray>(&mut ctx)
+            .vortex_expect("extend_from_array_unchecked: failed to canonicalize");
 
         match_each_decimal_value_type!(decimal_array.values_type(), |D| {
             // Extends the values buffer from another buffer of type D where D can be coerced to the
@@ -213,7 +214,7 @@ impl ArrayBuilder for DecimalBuilder {
                 .vortex_expect("validity_mask")
                 .to_mask(
                     decimal_array.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx(),
+                    &mut ctx,
                 )
                 .vortex_expect("Failed to compute validity mask"),
         );
@@ -320,6 +321,7 @@ mod tests {
 
     #[test]
     fn test_mixed_extend() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = 42i8;
 
         let mut i8s = DecimalBuilder::new::<i8>(DecimalDType::new(2, 1), false.into());
@@ -334,10 +336,10 @@ mod tests {
 
         for i in 0..i8s.len() {
             assert_eq!(
-                i8s.execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                i8s.execute_scalar(i, &mut ctx)
                     .unwrap(),
                 i128s
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .unwrap()
             );
         }
@@ -345,6 +347,7 @@ mod tests {
 
     #[test]
     fn test_append_scalar() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         use crate::scalar::Scalar;
 
         // Simply test that the builder accepts its own finish output via scalar.
@@ -364,7 +367,7 @@ mod tests {
         let mut builder2 = DecimalBuilder::new::<i64>(DecimalDType::new(10, 2), true.into());
         for i in 0..array.len() {
             let scalar = array
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .unwrap();
             builder2.append_scalar(&scalar).unwrap();
         }

--- a/vortex-array/src/builders/dict/bytes.rs
+++ b/vortex-array/src/builders/dict/bytes.rs
@@ -19,14 +19,14 @@ use super::DictConstraints;
 use super::DictEncoder;
 use crate::ArrayRef;
 use crate::IntoArray;
+use crate::LEGACY_SESSION;
+use crate::VortexSessionExecute;
 use crate::accessor::ArrayAccessor;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::VarBin;
 use crate::arrays::VarBinView;
 use crate::arrays::VarBinViewArray;
 use crate::arrays::varbinview::build_views::BinaryView;
-#[expect(deprecated)]
-use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::PType;
 use crate::dtype::UnsignedPType;
@@ -173,8 +173,11 @@ impl<Code: UnsignedPType> DictEncoder for BytesDictBuilder<Code> {
         } else {
             // NOTE(aduffy): it is very rare that this path would be taken, only e.g.
             //  if we're performing dictionary encoding downstream of some other compression.
-            #[expect(deprecated)]
-            let varbinview = array.to_varbinview();
+            let mut ctx = LEGACY_SESSION.create_execution_ctx();
+            let varbinview = array
+                .clone()
+                .execute::<VarBinViewArray>(&mut ctx)
+                .vortex_expect("to_varbinview failed");
             self.encode_bytes(&varbinview, len)
         }
     }
@@ -206,23 +209,34 @@ impl<Code: UnsignedPType> DictEncoder for BytesDictBuilder<Code> {
 mod test {
     use std::str;
 
+    use vortex_error::VortexExpect as _;
+
     use crate::IntoArray;
-    #[expect(deprecated)]
-    use crate::ToCanonical as _;
+    use crate::LEGACY_SESSION;
+    use crate::VortexSessionExecute;
     use crate::accessor::ArrayAccessor;
+    use crate::arrays::PrimitiveArray;
     use crate::arrays::VarBinArray;
+    use crate::arrays::VarBinViewArray;
     use crate::arrays::dict::DictArraySlotsExt;
     use crate::builders::dict::dict_encode;
 
     #[test]
     fn encode_varbin() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = VarBinArray::from(vec!["hello", "world", "hello", "again", "world"]);
         let dict = dict_encode(&arr.into_array()).unwrap();
-        #[expect(deprecated)]
-        let codes = dict.codes().to_primitive();
+        let codes = dict
+            .codes()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .vortex_expect("to_primitive failed");
         assert_eq!(codes.as_slice::<u8>(), &[0, 1, 0, 2, 1]);
-        #[expect(deprecated)]
-        let values = dict.values().to_varbinview();
+        let values = dict
+            .values()
+            .clone()
+            .execute::<VarBinViewArray>(&mut ctx)
+            .vortex_expect("to_varbinview failed");
         values.with_iterator(|iter| {
             assert_eq!(
                 iter.flatten()
@@ -235,6 +249,7 @@ mod test {
 
     #[test]
     fn encode_varbin_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr: VarBinArray = vec![
             Some("hello"),
             None,
@@ -248,11 +263,17 @@ mod test {
         .into_iter()
         .collect();
         let dict = dict_encode(&arr.into_array()).unwrap();
-        #[expect(deprecated)]
-        let codes = dict.codes().to_primitive();
+        let codes = dict
+            .codes()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .vortex_expect("to_primitive failed");
         assert_eq!(codes.as_slice::<u8>(), &[0, 1, 2, 0, 1, 3, 2, 1]);
-        #[expect(deprecated)]
-        let values = dict.values().to_varbinview();
+        let values = dict
+            .values()
+            .clone()
+            .execute::<VarBinViewArray>(&mut ctx)
+            .vortex_expect("to_varbinview failed");
         values.with_iterator(|iter| {
             assert_eq!(
                 iter.map(|b| b.map(|v| unsafe { str::from_utf8_unchecked(v) }))
@@ -264,10 +285,14 @@ mod test {
 
     #[test]
     fn repeated_values() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = VarBinArray::from(vec!["a", "a", "b", "b", "a", "b", "a", "b"]);
         let dict = dict_encode(&arr.into_array()).unwrap();
-        #[expect(deprecated)]
-        let values = dict.values().to_varbinview();
+        let values = dict
+            .values()
+            .clone()
+            .execute::<VarBinViewArray>(&mut ctx)
+            .vortex_expect("to_varbinview failed");
         values.with_iterator(|iter| {
             assert_eq!(
                 iter.flatten()
@@ -276,8 +301,11 @@ mod test {
                 vec!["a", "b"]
             );
         });
-        #[expect(deprecated)]
-        let codes = dict.codes().to_primitive();
+        let codes = dict
+            .codes()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .vortex_expect("to_primitive failed");
         assert_eq!(codes.as_slice::<u8>(), &[0, 0, 1, 1, 0, 1, 0, 1]);
     }
 }

--- a/vortex-array/src/builders/dict/mod.rs
+++ b/vortex-array/src/builders/dict/mod.rs
@@ -9,8 +9,6 @@ use vortex_error::vortex_panic;
 
 use crate::ArrayRef;
 use crate::IntoArray;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::arrays::DictArray;
 use crate::arrays::Primitive;
 use crate::arrays::VarBin;
@@ -68,8 +66,7 @@ pub fn dict_encode_with_constraints(
 ) -> VortexResult<DictArray> {
     let mut encoder = dict_encoder(array, constraints);
     let encoded = encoder.encode(array);
-    #[expect(deprecated)]
-    let codes = encoded.to_primitive().narrow()?;
+    let codes = encoded.execute::<PrimitiveArray>(&mut ctx).vortex_expect("to_primitive failed").narrow()?;
     // SAFETY: The encoding process will produce a value set of codes and values
     // All values in the dictionary are guaranteed to be referenced by at least one code
     // since we build the dictionary from the codes we observe during encoding

--- a/vortex-array/src/builders/dict/primitive.rs
+++ b/vortex-array/src/builders/dict/primitive.rs
@@ -15,8 +15,6 @@ use super::DictConstraints;
 use super::DictEncoder;
 use crate::ArrayRef;
 use crate::IntoArray;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::accessor::ArrayAccessor;
 use crate::arrays::PrimitiveArray;
 use crate::arrays::primitive::NativeValue;
@@ -124,10 +122,7 @@ where
     Code: UnsignedPType,
 {
     fn encode(&mut self, array: &ArrayRef) -> ArrayRef {
-        let mut codes = BufferMut::<Code>::with_capacity(array.len());
-
-        #[expect(deprecated)]
-        let prim = array.to_primitive();
+        let mut codes = BufferMut::<Code>::with_capacity(array.len());        let prim = array.execute::<PrimitiveArray>(&mut ctx).vortex_expect("to_primitive failed");
         prim.with_iterator(|it| {
             for value in it {
                 let Some(code) = self.encode_value(value.copied()) else {

--- a/vortex-array/src/builders/extension.rs
+++ b/vortex-array/src/builders/extension.rs
@@ -3,20 +3,21 @@
 
 use std::any::Any;
 
+use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
 use vortex_mask::Mask;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::IntoArray;
+use crate::LEGACY_SESSION;
+use crate::VortexSessionExecute;
 use crate::arrays::ExtensionArray;
 use crate::arrays::extension::ExtensionArrayExt;
 use crate::builders::ArrayBuilder;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::builder_with_capacity;
-use crate::canonical::Canonical;
-#[expect(deprecated)]
-use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::extension::ExtDTypeRef;
 use crate::scalar::ExtScalar;
@@ -100,8 +101,11 @@ impl ArrayBuilder for ExtensionBuilder {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
-        #[expect(deprecated)]
-        let ext_array = array.to_extension();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let ext_array = array
+            .clone()
+            .execute::<ExtensionArray>(&mut ctx)
+            .vortex_expect("extend_from_array_unchecked: failed to get extension array");
         self.storage.extend_from_array(ext_array.storage_array())
     }
 

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -22,8 +22,6 @@ use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::LazyBitBufferBuilder;
 use crate::builders::builder_with_capacity;
 use crate::canonical::Canonical;
-#[expect(deprecated)]
-use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::scalar::ListScalar;
@@ -238,8 +236,11 @@ impl ArrayBuilder for FixedSizeListBuilder {
     /// This will increase the capacity if extending with this `array` would go past the original
     /// capacity.
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
-        #[expect(deprecated)]
-        let fsl = array.to_fixed_size_list();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let fsl = array
+            .clone()
+            .execute::<FixedSizeListArray>(&mut ctx)
+            .vortex_expect("extend_from_array_unchecked: failed to canonicalize");
         if fsl.is_empty() {
             return;
         }
@@ -249,7 +250,7 @@ impl ArrayBuilder for FixedSizeListBuilder {
             array
                 .validity()
                 .vortex_expect("validity_mask in extend_from_array_unchecked")
-                .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(array.len(), &mut ctx)
                 .vortex_expect("Failed to compute validity mask"),
         );
     }
@@ -922,6 +923,7 @@ mod tests {
 
     #[test]
     fn test_append_scalar() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype: Arc<DType> = Arc::new(I32.into());
         let mut builder = FixedSizeListBuilder::with_capacity(Arc::clone(&dtype), 2, Nullable, 10);
 
@@ -944,7 +946,7 @@ mod tests {
         // Check actual values using scalar_at.
 
         let scalar0 = array
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap();
         let list0 = scalar0.as_list();
         assert_eq!(list0.len(), 2);
@@ -954,7 +956,7 @@ mod tests {
         }
 
         let scalar1 = array
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap();
         let list1 = scalar1.as_list();
         assert_eq!(list1.len(), 2);

--- a/vortex-array/src/builders/fixed_size_list.rs
+++ b/vortex-array/src/builders/fixed_size_list.rs
@@ -285,8 +285,6 @@ mod tests {
     use super::FixedSizeListBuilder;
     use crate::IntoArray as _;
     use crate::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use crate::ToCanonical as _;
     use crate::VortexSessionExecute;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::fixed_size_list::FixedSizeListArrayExt;
@@ -339,8 +337,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 2);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.elements().len(), 6);
         assert_eq!(fsl_array.list_size(), 3);
     }
@@ -363,8 +360,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 100);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.list_size(), 0);
         // The elements array should be empty since list_size is 0.
         assert_eq!(fsl_array.elements().len(), 0);
@@ -393,8 +389,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 100);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.list_size(), 0);
         assert_eq!(fsl_array.elements().len(), 0);
     }
@@ -423,8 +418,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 5);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.elements().len(), 10);
     }
 
@@ -437,8 +431,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 0);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.list_size(), 100000000);
         assert_eq!(fsl_array.elements().len(), 0);
     }
@@ -470,8 +463,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 3);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert!(
             fsl_array
                 .validity()
@@ -534,8 +526,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 2);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.elements().len(), 6);
     }
 
@@ -549,14 +540,12 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 5);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.list_size(), 3);
         assert_eq!(fsl_array.elements().len(), 15);
 
         // Check that all elements are zeros.
-        #[expect(deprecated)]
-        let elements_array = fsl_array.elements().to_primitive();
+        let elements_array = fsl_array.elements().execute::<PrimitiveArray>(&mut ctx).vortex_expect("to_primitive failed");
         let elements = elements_array.as_slice::<i32>();
         assert!(elements.iter().all(|&x| x == 0));
     }
@@ -574,8 +563,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 3);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.list_size(), 2);
 
         // Check that all lists are null.
@@ -605,8 +593,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 1);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.list_size(), 2);
 
         // Check that all lists are null.
@@ -631,8 +618,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 1000);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.list_size(), 0);
         assert_eq!(fsl_array.elements().len(), 0);
     }
@@ -683,8 +669,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 6);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.elements().len(), 12);
 
         // Check validity pattern is repeated.
@@ -759,8 +744,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 5);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.list_size(), 0);
         assert_eq!(fsl_array.elements().len(), 0);
 
@@ -872,8 +856,7 @@ mod tests {
         let fsl = builder.finish();
         assert_eq!(fsl.len(), 6);
 
-        #[expect(deprecated)]
-        let fsl_array = fsl.to_fixed_size_list();
+        let fsl_array = fsl.execute::<FixedSizeListArray>(&mut ctx).vortex_expect("to_fixed_size_list failed");
         assert_eq!(fsl_array.elements().len(), 12);
 
         // Check validity.
@@ -1037,8 +1020,7 @@ mod tests {
         assert_eq!(fsl.list_size(), 3);
 
         // Verify elements array: [1, 2, 3, 10, 11, 12, 4, 5, 6, 20, 21, 22].
-        #[expect(deprecated)]
-        let elements = fsl.elements().to_primitive();
+        let elements = fsl.elements().execute::<PrimitiveArray>(&mut ctx).vortex_expect("to_primitive failed");
         assert_eq!(
             elements.as_slice::<i32>(),
             &[1, 2, 3, 10, 11, 12, 4, 5, 6, 20, 21, 22]

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -17,14 +17,15 @@ use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::arrays::ListArray;
+use crate::arrays::ListViewArray;
 use crate::arrays::listview::ListViewArrayExt;
 use crate::builders::ArrayBuilder;
+#[expect(deprecated)]
+use crate::canonical::ToCanonical as _;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::LazyBitBufferBuilder;
 use crate::builders::PrimitiveBuilder;
 use crate::builders::builder_with_capacity;
-#[expect(deprecated)]
-use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::IntegerPType;
 use crate::dtype::Nullability;
@@ -218,8 +219,11 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
-        #[expect(deprecated)]
-        let list = array.to_listview();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let list = array
+            .clone()
+            .execute::<ListViewArray>(&mut ctx)
+            .vortex_expect("extend_from_array_unchecked: failed to canonicalize");
         if list.is_empty() {
             return;
         }
@@ -229,7 +233,7 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
             array
                 .validity()
                 .vortex_expect("validity_mask in extend_from_array_unchecked")
-                .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(array.len(), &mut ctx)
                 .vortex_expect("Failed to compute validity mask"),
         );
 
@@ -512,6 +516,7 @@ mod tests {
 
     #[test]
     pub fn test_array_with_gap() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let one_trailing_unused_element = ListArray::try_new(
             buffer![1, 2, 3, 4].into_array(),
             buffer![0, 3].into_array(),
@@ -539,24 +544,25 @@ mod tests {
 
         assert_eq!(
             one_trailing_unused_element
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             canon_values
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap()
         );
         assert_eq!(
             second_array
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             canon_values
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .unwrap()
         );
     }
 
     #[test]
     fn test_append_scalar() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype: Arc<DType> = Arc::new(I32.into());
         let mut builder = ListBuilder::<u64>::with_capacity(Arc::clone(&dtype), Nullable, 20, 10);
 
@@ -583,7 +589,7 @@ mod tests {
         // Check actual values using scalar_at.
 
         let scalar0 = array
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap();
         let list0 = scalar0.as_list();
         assert_eq!(list0.len(), 2);
@@ -593,7 +599,7 @@ mod tests {
         }
 
         let scalar1 = array
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap();
         let list1 = scalar1.as_list();
         assert_eq!(list1.len(), 3);
@@ -604,7 +610,7 @@ mod tests {
         }
 
         let scalar2 = array
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap();
         let list2 = scalar2.as_list();
         assert!(list2.is_null()); // This should be null.

--- a/vortex-array/src/builders/list.rs
+++ b/vortex-array/src/builders/list.rs
@@ -20,8 +20,6 @@ use crate::arrays::ListArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::listview::ListViewArrayExt;
 use crate::builders::ArrayBuilder;
-#[expect(deprecated)]
-use crate::canonical::ToCanonical as _;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::LazyBitBufferBuilder;
 use crate::builders::PrimitiveBuilder;
@@ -239,10 +237,16 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
 
         // Note that `ListViewArray` has `n` offsets and sizes, not `n+1` offsets like `ListArray`.
         let elements = list.elements();
-        #[expect(deprecated)]
-        let offsets = list.offsets().to_primitive();
-        #[expect(deprecated)]
-        let sizes = list.sizes().to_primitive();
+        let offsets = list
+            .offsets()
+            .clone()
+            .execute::<crate::arrays::PrimitiveArray>(&mut ctx)
+            .vortex_expect("list offsets should be primitive");
+        let sizes = list
+            .sizes()
+            .clone()
+            .execute::<crate::arrays::PrimitiveArray>(&mut ctx)
+            .vortex_expect("list sizes should be primitive");
 
         fn extend_inner<O, OffsetType, SizeType>(
             builder: &mut ListBuilder<O>,
@@ -313,8 +317,12 @@ impl<O: IntegerPType> ArrayBuilder for ListBuilder<O> {
     }
 
     fn finish_into_canonical(&mut self) -> Canonical {
-        #[expect(deprecated)]
-        let listview = self.finish_into_list().into_array().to_listview();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let listview = self
+            .finish_into_list()
+            .into_array()
+            .execute::<ListViewArray>(&mut ctx)
+            .vortex_expect("finish_into_canonical: failed to get listview");
         Canonical::List(listview)
     }
 }
@@ -330,9 +338,9 @@ mod tests {
 
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use crate::ToCanonical as _;
+    use crate::VortexSessionExecute;
     use crate::arrays::ChunkedArray;
+    use crate::arrays::ListViewArray;
     use crate::arrays::PrimitiveArray;
     use crate::arrays::list::ListArrayExt;
     use crate::arrays::listview::ListViewArrayExt;
@@ -344,7 +352,6 @@ mod tests {
     use crate::dtype::IntegerPType;
     use crate::dtype::Nullability;
     use crate::dtype::PType::I32;
-    use crate::executor::VortexSessionExecute;
     use crate::scalar::Scalar;
     use crate::validity::Validity;
 
@@ -387,8 +394,10 @@ mod tests {
         let list = builder.finish();
         assert_eq!(list.len(), 2);
 
-        #[expect(deprecated)]
-        let list_array = list.to_listview();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let list_array = list
+            .execute::<ListViewArray>(&mut ctx)
+            .vortex_expect("to listview");
 
         assert_eq!(list_array.list_elements_at(0).unwrap().len(), 3);
         assert_eq!(list_array.list_elements_at(1).unwrap().len(), 3);
@@ -440,8 +449,10 @@ mod tests {
         let list = builder.finish();
         assert_eq!(list.len(), 3);
 
-        #[expect(deprecated)]
-        let list_array = list.to_listview();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let list_array = list
+            .execute::<ListViewArray>(&mut ctx)
+            .vortex_expect("to listview");
 
         assert_eq!(list_array.list_elements_at(0).unwrap().len(), 3);
         assert_eq!(list_array.list_elements_at(1).unwrap().len(), 0);
@@ -464,7 +475,6 @@ mod tests {
         builder.extend_from_array(&list.slice(0..0).unwrap());
         builder.extend_from_array(&list.slice(1..3).unwrap());
 
-        #[expect(deprecated)]
         let expected = ListArray::from_iter_opt_slow::<O, _, _>(
             [
                 Some(vec![0, 1, 2]),
@@ -479,7 +489,9 @@ mod tests {
             Arc::new(DType::Primitive(I32, NonNullable)),
         )
         .unwrap()
-        .to_listview();
+        .into_array()
+        .execute::<ListViewArray>(&mut ctx)
+        .vortex_expect("to listview");
 
         let actual = builder.finish_into_canonical().into_listview();
 
@@ -539,8 +551,12 @@ mod tests {
             DType::List(Arc::new(DType::Primitive(I32, NonNullable)), NonNullable),
         );
 
-        #[expect(deprecated)]
-        let canon_values = chunked_list.unwrap().as_array().to_listview();
+        let canon_values = chunked_list
+            .unwrap()
+            .as_array()
+            .clone()
+            .execute::<ListViewArray>(&mut ctx)
+            .vortex_expect("to listview");
 
         assert_eq!(
             one_trailing_unused_element

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -21,9 +21,9 @@ use vortex_mask::Mask;
 use crate::ArrayRef;
 use crate::Canonical;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
+#[expect(deprecated)]
+use crate::canonical::ToCanonical as _;
 use crate::array::IntoArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
@@ -294,8 +294,11 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
-        #[expect(deprecated)]
-        let listview = array.to_listview();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let listview = array
+            .clone()
+            .execute::<ListViewArray>(&mut ctx)
+            .vortex_expect("extend_from_array_unchecked: failed to canonicalize");
         if listview.is_empty() {
             return;
         }
@@ -311,7 +314,7 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
             array
                 .validity()
                 .vortex_expect("validity_mask in extend_from_array_unchecked")
-                .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(array.len(), &mut ctx)
                 .vortex_expect("Failed to compute validity mask"),
         );
 

--- a/vortex-array/src/builders/listview.rs
+++ b/vortex-array/src/builders/listview.rs
@@ -22,8 +22,6 @@ use crate::ArrayRef;
 use crate::Canonical;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
-#[expect(deprecated)]
-use crate::canonical::ToCanonical as _;
 use crate::array::IntoArray;
 use crate::arrays::ListViewArray;
 use crate::arrays::PrimitiveArray;
@@ -346,8 +344,11 @@ impl<O: IntegerPType, S: IntegerPType> ArrayBuilder for ListViewBuilder<O, S> {
         let uninit_range = self.offsets_builder.uninit_range(extend_length);
 
         // This should be cheap because we didn't compress after rebuilding.
-        #[expect(deprecated)]
-        let new_offsets = listview.offsets().to_primitive();
+        let new_offsets = listview
+            .offsets()
+            .clone()
+            .execute::<crate::arrays::PrimitiveArray>(&mut ctx)
+            .vortex_expect("listview offsets should be primitive");
 
         match_each_integer_ptype!(new_offsets.ptype(), |A| {
             adjust_and_extend_offsets::<O, A>(

--- a/vortex-array/src/builders/primitive.rs
+++ b/vortex-array/src/builders/primitive.rs
@@ -19,8 +19,6 @@ use crate::builders::ArrayBuilder;
 use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::LazyBitBufferBuilder;
 use crate::canonical::Canonical;
-#[expect(deprecated)]
-use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::NativePType;
 use crate::dtype::Nullability;
@@ -178,8 +176,11 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
-        #[expect(deprecated)]
-        let array = array.to_primitive();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array = array
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .vortex_expect("extend_from_array_unchecked: failed to canonicalize");
 
         // This should be checked in `extend_from_array` but we can check it again.
         debug_assert_eq!(
@@ -196,7 +197,7 @@ impl<T: NativePType> ArrayBuilder for PrimitiveBuilder<T> {
                 .vortex_expect("validity_mask")
                 .to_mask(
                     array.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx(),
+                    &mut ctx,
                 )
                 .vortex_expect("Failed to compute validity mask"),
         );
@@ -418,6 +419,7 @@ mod tests {
     /// This test ensures the new API works correctly.
     #[test]
     fn test_append_mask_on_uninit_range() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut builder = PrimitiveBuilder::<i32>::with_capacity(Nullability::Nullable, 5);
         let mut range = builder.uninit_range(3);
 
@@ -442,19 +444,19 @@ mod tests {
         // Check validity using scalar_at - nulls will return is_null() = true.
         assert!(
             !array
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap()
                 .is_null()
         );
         assert!(
             array
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .unwrap()
                 .is_null()
         );
         assert!(
             !array
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .unwrap()
                 .is_null()
         );
@@ -509,6 +511,7 @@ mod tests {
     /// modify individual bits with relative indexing.
     #[test]
     fn test_set_bit_relative_indexing() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut builder = PrimitiveBuilder::<i32>::with_capacity(Nullability::Nullable, 10);
 
         // First add some values to the builder.
@@ -547,13 +550,13 @@ mod tests {
         // Check validity - the first two should be valid (from append_value).
         assert!(
             !array
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap()
                 .is_null()
         ); // initial value 100
         assert!(
             !array
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .unwrap()
                 .is_null()
         ); // initial value 200
@@ -561,19 +564,19 @@ mod tests {
         // Check the range items with modified validity.
         assert!(
             !array
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .unwrap()
                 .is_null()
         ); // range index 0 - set to valid
         assert!(
             array
-                .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(3, &mut ctx)
                 .unwrap()
                 .is_null()
         ); // range index 1 - left as null
         assert!(
             !array
-                .execute_scalar(4, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(4, &mut ctx)
                 .unwrap()
                 .is_null()
         ); // range index 2 - set to valid

--- a/vortex-array/src/builders/struct_.rs
+++ b/vortex-array/src/builders/struct_.rs
@@ -22,8 +22,6 @@ use crate::builders::DEFAULT_BUILDER_CAPACITY;
 use crate::builders::LazyBitBufferBuilder;
 use crate::builders::builder_with_capacity;
 use crate::canonical::Canonical;
-#[expect(deprecated)]
-use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::dtype::Nullability;
 use crate::dtype::StructFields;
@@ -169,8 +167,11 @@ impl ArrayBuilder for StructBuilder {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
-        #[expect(deprecated)]
-        let array = array.to_struct();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array = array
+            .clone()
+            .execute::<StructArray>(&mut ctx)
+            .vortex_expect("extend_from_array_unchecked: failed to canonicalize");
 
         for (a, builder) in array
             .iter_unmasked_fields()
@@ -183,7 +184,7 @@ impl ArrayBuilder for StructBuilder {
             array
                 .validity()
                 .vortex_expect("validity_mask")
-                .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(array.len(), &mut ctx)
                 .vortex_expect("Failed to compute validity mask"),
         );
     }
@@ -244,6 +245,7 @@ mod tests {
 
     #[test]
     fn test_append_nullable_struct() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let sdt = StructFields::new(["a", "b"].into(), vec![I32.into(), I32.into()]);
         let dtype = DType::Struct(sdt.clone(), Nullability::Nullable);
         let mut builder = StructBuilder::with_capacity(sdt, Nullability::Nullable, 0);
@@ -259,7 +261,7 @@ mod tests {
         assert_eq!(struct_.dtype(), &dtype);
         assert_eq!(
             struct_
-                .valid_count(&mut LEGACY_SESSION.create_execution_ctx())
+                .valid_count(&mut ctx)
                 .unwrap(),
             1
         );

--- a/vortex-array/src/builders/tests.rs
+++ b/vortex-array/src/builders/tests.rs
@@ -72,6 +72,7 @@ use crate::scalar::Scalar;
     Timestamp::new(TimeUnit::Milliseconds, Nullability::NonNullable).erased()
 ))]
 fn test_append_zeros_matches_default_value(#[case] dtype: DType) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let num_elements = 5;
 
     // Builder 1: Use append_zeros.
@@ -94,10 +95,10 @@ fn test_append_zeros_matches_default_value(#[case] dtype: DType) {
     // Compare each element.
     for i in 0..num_elements {
         let scalar_zeros = array_zeros
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .unwrap();
         let scalar_manual = array_manual
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .unwrap();
 
         assert_eq!(
@@ -188,6 +189,7 @@ fn test_append_nulls_panics_on_non_nullable(#[case] dtype: DType, #[case] count:
 #[case::nullable_utf8(DType::Utf8(Nullability::Nullable), true)]
 #[case::non_nullable_utf8(DType::Utf8(Nullability::NonNullable), false)]
 fn test_append_defaults_behavior(#[case] dtype: DType, #[case] should_be_null: bool) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let mut builder = builder_with_capacity(&dtype, 3);
     builder.append_defaults(3);
     let array = builder.finish();
@@ -196,7 +198,7 @@ fn test_append_defaults_behavior(#[case] dtype: DType, #[case] should_be_null: b
 
     for i in 0..3 {
         let scalar = array
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .unwrap();
         if should_be_null {
             assert!(scalar.is_null(), "Element at index {} should be null", i);
@@ -226,6 +228,7 @@ fn compare_to_canonical_methods<F>(dtype: &DType, mut fill_builder: F)
 where
     F: FnMut(&mut dyn ArrayBuilder),
 {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     use crate::IntoArray;
 
     // Create two identical builders.
@@ -238,10 +241,9 @@ where
 
     // Get canonical arrays using both methods.
     let canonical_direct = builder1.finish_into_canonical();
-    #[expect(deprecated)]
     let canonical_indirect = builder2
         .finish()
-        .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+        .execute::<Canonical>(&mut ctx)
         .vortex_expect("to_canonical failed");
 
     // Convert both to arrays for comparison.
@@ -254,10 +256,10 @@ where
     // Compare each element.
     for i in 0..array_direct.len() {
         let scalar_direct = array_direct
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .unwrap();
         let scalar_indirect = array_indirect
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .unwrap();
 
         assert_eq!(
@@ -513,6 +515,7 @@ fn test_to_canonical_f32() {
     Timestamp::new(TimeUnit::Milliseconds, Nullability::NonNullable).erased()
 ))]
 fn test_append_scalar_comprehensive(#[case] dtype: DType) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let num_elements = 3;
     let mut builder = builder_with_capacity(&dtype, num_elements * 2);
 
@@ -548,7 +551,7 @@ fn test_append_scalar_comprehensive(#[case] dtype: DType) {
     // Verify each scalar matches.
     for (i, expected_scalar) in scalars.iter().enumerate() {
         let actual_scalar = array
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .unwrap();
         assert_scalars_equal(&actual_scalar, expected_scalar, &dtype, i);
     }
@@ -556,7 +559,7 @@ fn test_append_scalar_comprehensive(#[case] dtype: DType) {
     // If nullable, verify the last element is null.
     if dtype.is_nullable() {
         let null_scalar = array
-            .execute_scalar(num_elements, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(num_elements, &mut ctx)
             .unwrap();
         assert!(
             null_scalar.is_null(),
@@ -687,6 +690,7 @@ fn assert_scalars_equal(actual: &Scalar, expected: &Scalar, dtype: &DType, index
 #[case::utf8(DType::Utf8(Nullability::Nullable))]
 #[case::binary(DType::Binary(Nullability::Nullable))]
 fn test_append_scalar_mixed_nulls(#[case] dtype: DType) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let mut builder = builder_with_capacity(&dtype, 6);
 
     // Create a pattern of valid, null, valid, null, valid.
@@ -705,31 +709,31 @@ fn test_append_scalar_mixed_nulls(#[case] dtype: DType) {
     // Check the pattern.
     assert!(
         !array
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .is_null()
     );
     assert!(
         array
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .is_null()
     );
     assert!(
         !array
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap()
             .is_null()
     );
     assert!(
         array
-            .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(3, &mut ctx)
             .unwrap()
             .is_null()
     );
     assert!(
         !array
-            .execute_scalar(4, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(4, &mut ctx)
             .unwrap()
             .is_null()
     );
@@ -737,7 +741,7 @@ fn test_append_scalar_mixed_nulls(#[case] dtype: DType) {
     // Verify non-null values match.
     assert_scalars_equal(
         &array
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap(),
         &test_scalars[0],
         &dtype,
@@ -745,7 +749,7 @@ fn test_append_scalar_mixed_nulls(#[case] dtype: DType) {
     );
     assert_scalars_equal(
         &array
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap(),
         &test_scalars[1],
         &dtype,
@@ -753,7 +757,7 @@ fn test_append_scalar_mixed_nulls(#[case] dtype: DType) {
     );
     assert_scalars_equal(
         &array
-            .execute_scalar(4, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(4, &mut ctx)
             .unwrap(),
         &test_scalars[2],
         &dtype,
@@ -794,6 +798,7 @@ fn test_append_scalar_wrong_dtype_rejection() {
 /// with the same scalar instance.
 #[test]
 fn test_append_scalar_repeated_same_instance() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let dtype = DType::Primitive(PType::I32, Nullability::NonNullable);
     let mut builder = builder_with_capacity(&dtype, 5);
 
@@ -810,7 +815,7 @@ fn test_append_scalar_repeated_same_instance() {
     // All values should be 42.
     for i in 0..5 {
         let actual = array
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .unwrap();
         assert_eq!(
             actual.as_primitive().typed_value::<i32>(),

--- a/vortex-array/src/builders/tests.rs
+++ b/vortex-array/src/builders/tests.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use rstest::rstest;
 use vortex_error::VortexExpect;
 
+use crate::Canonical;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
 use crate::builders::ArrayBuilder;
@@ -240,7 +241,7 @@ where
     #[expect(deprecated)]
     let canonical_indirect = builder2
         .finish()
-        .to_canonical()
+        .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
         .vortex_expect("to_canonical failed");
 
     // Convert both to arrays for comparison.

--- a/vortex-array/src/builders/varbinview.rs
+++ b/vortex-array/src/builders/varbinview.rs
@@ -28,8 +28,6 @@ use crate::arrays::varbinview::compact::BufferUtilization;
 use crate::builders::ArrayBuilder;
 use crate::builders::LazyBitBufferBuilder;
 use crate::canonical::Canonical;
-#[expect(deprecated)]
-use crate::canonical::ToCanonical as _;
 use crate::dtype::DType;
 use crate::scalar::Scalar;
 
@@ -295,8 +293,11 @@ impl ArrayBuilder for VarBinViewBuilder {
     }
 
     unsafe fn extend_from_array_unchecked(&mut self, array: &ArrayRef) {
-        #[expect(deprecated)]
-        let array = array.to_varbinview();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array = array
+            .clone()
+            .execute::<VarBinViewArray>(&mut ctx)
+            .vortex_expect("extend_from_array_unchecked: failed to canonicalize");
         self.flush_in_progress();
 
         self.push_only_validity_mask(
@@ -306,7 +307,7 @@ impl ArrayBuilder for VarBinViewBuilder {
                 .vortex_expect("validity_mask")
                 .to_mask(
                     array.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx(),
+                    &mut ctx,
                 )
                 .vortex_expect("Failed to compute validity mask"),
         );
@@ -332,7 +333,7 @@ impl ArrayBuilder for VarBinViewBuilder {
                     .vortex_expect("validity_mask")
                     .to_mask(
                         array.as_ref().len(),
-                        &mut LEGACY_SESSION.create_execution_ctx(),
+                        &mut ctx,
                     )
                     .vortex_expect("Failed to compute validity mask")
                 {
@@ -1038,6 +1039,7 @@ mod tests {
 
     #[test]
     fn test_large_value_allocation() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         use super::BufferGrowthStrategy;
         use super::VarBinViewBuilder;
 
@@ -1060,7 +1062,7 @@ mod tests {
 
         // Verify the value was stored correctly
         let retrieved = array
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .as_binary()
             .value()

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -15,6 +15,8 @@ use vortex_error::vortex_panic;
 use crate::ArrayRef;
 use crate::Executable;
 use crate::ExecutionCtx;
+use crate::LEGACY_SESSION;
+use crate::VortexSessionExecute;
 use crate::IntoArray;
 use crate::array::ArrayView;
 use crate::array::child_to_validity;
@@ -473,57 +475,66 @@ pub trait ToCanonical {
 #[expect(deprecated)]
 impl ToCanonical for ArrayRef {
     fn to_null(&self) -> NullArray {
-        #[expect(deprecated)]
-        let result = self.to_canonical().vortex_expect("to_canonical failed");
-        result.into_null()
+        self.clone()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .vortex_expect("to_canonical failed")
+            .into_null()
     }
 
     fn to_bool(&self) -> BoolArray {
-        #[expect(deprecated)]
-        let result = self.to_canonical().vortex_expect("to_canonical failed");
-        result.into_bool()
+        self.clone()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .vortex_expect("to_canonical failed")
+            .into_bool()
     }
 
     fn to_primitive(&self) -> PrimitiveArray {
-        #[expect(deprecated)]
-        let result = self.to_canonical().vortex_expect("to_canonical failed");
-        result.into_primitive()
+        self.clone()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .vortex_expect("to_canonical failed")
+            .into_primitive()
     }
 
     fn to_decimal(&self) -> DecimalArray {
-        #[expect(deprecated)]
-        let result = self.to_canonical().vortex_expect("to_canonical failed");
-        result.into_decimal()
+        self.clone()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .vortex_expect("to_canonical failed")
+            .into_decimal()
     }
 
     fn to_struct(&self) -> StructArray {
-        #[expect(deprecated)]
-        let result = self.to_canonical().vortex_expect("to_canonical failed");
-        result.into_struct()
+        self.clone()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .vortex_expect("to_canonical failed")
+            .into_struct()
     }
 
     fn to_listview(&self) -> ListViewArray {
-        #[expect(deprecated)]
-        let result = self.to_canonical().vortex_expect("to_canonical failed");
-        result.into_listview()
+        self.clone()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .vortex_expect("to_canonical failed")
+            .into_listview()
     }
 
     fn to_fixed_size_list(&self) -> FixedSizeListArray {
-        #[expect(deprecated)]
-        let result = self.to_canonical().vortex_expect("to_canonical failed");
-        result.into_fixed_size_list()
+        self.clone()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .vortex_expect("to_canonical failed")
+            .into_fixed_size_list()
     }
 
     fn to_varbinview(&self) -> VarBinViewArray {
-        #[expect(deprecated)]
-        let result = self.to_canonical().vortex_expect("to_canonical failed");
-        result.into_varbinview()
+        self.clone()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .vortex_expect("to_canonical failed")
+            .into_varbinview()
     }
 
     fn to_extension(&self) -> ExtensionArray {
-        #[expect(deprecated)]
-        let result = self.to_canonical().vortex_expect("to_canonical failed");
-        result.into_extension()
+        self.clone()
+            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .vortex_expect("to_canonical failed")
+            .into_extension()
     }
 }
 

--- a/vortex-array/src/canonical.rs
+++ b/vortex-array/src/canonical.rs
@@ -475,64 +475,73 @@ pub trait ToCanonical {
 #[expect(deprecated)]
 impl ToCanonical for ArrayRef {
     fn to_null(&self) -> NullArray {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.clone()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .vortex_expect("to_canonical failed")
             .into_null()
     }
 
     fn to_bool(&self) -> BoolArray {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.clone()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .vortex_expect("to_canonical failed")
             .into_bool()
     }
 
     fn to_primitive(&self) -> PrimitiveArray {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.clone()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .vortex_expect("to_canonical failed")
             .into_primitive()
     }
 
     fn to_decimal(&self) -> DecimalArray {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.clone()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .vortex_expect("to_canonical failed")
             .into_decimal()
     }
 
     fn to_struct(&self) -> StructArray {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.clone()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .vortex_expect("to_canonical failed")
             .into_struct()
     }
 
     fn to_listview(&self) -> ListViewArray {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.clone()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .vortex_expect("to_canonical failed")
             .into_listview()
     }
 
     fn to_fixed_size_list(&self) -> FixedSizeListArray {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.clone()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .vortex_expect("to_canonical failed")
             .into_fixed_size_list()
     }
 
     fn to_varbinview(&self) -> VarBinViewArray {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.clone()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .vortex_expect("to_canonical failed")
             .into_varbinview()
     }
 
     fn to_extension(&self) -> ExtensionArray {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.clone()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .vortex_expect("to_canonical failed")
             .into_extension()
     }

--- a/vortex-array/src/compute/conformance/binary_numeric.rs
+++ b/vortex-array/src/compute/conformance/binary_numeric.rs
@@ -31,10 +31,9 @@ use crate::ArrayRef;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::RecursiveCanonical;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::arrays::ConstantArray;
+use crate::arrays::PrimitiveArray;
 use crate::builtins::ArrayBuiltins;
 use crate::dtype::DType;
 use crate::dtype::NativePType;
@@ -44,11 +43,12 @@ use crate::scalar::PrimitiveScalar;
 use crate::scalar::Scalar;
 
 fn to_vec_of_scalar(array: &ArrayRef) -> Vec<Scalar> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Not fast, but obviously correct
     (0..array.len())
         .map(|index| {
             array
-                .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(index, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         })
         .collect_vec()
@@ -93,8 +93,11 @@ fn test_standard_binary_numeric<T: NativePType + Num + Copy>(array: ArrayRef)
 where
     Scalar: From<T>,
 {
-    #[expect(deprecated)]
-    let canonicalized_array = array.to_primitive();
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let canonicalized_array = array
+        .clone()
+        .execute::<PrimitiveArray>(&mut ctx)
+        .vortex_expect("test_standard_binary_numeric: failed to canonicalize");
     let original_values = to_vec_of_scalar(&canonicalized_array.into_array());
 
     let one = T::from(1)
@@ -119,7 +122,7 @@ where
         let result = array
             .binary(rhs_const.clone(), op.into())
             .vortex_expect("apply shouldn't fail")
-            .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<RecursiveCanonical>(&mut ctx)
             .map(|c| c.0.into_array());
 
         // Skip this operator if the entire operation fails
@@ -157,7 +160,7 @@ where
 
         // Test scalar operator array (e.g., 1 + array)
         let result = rhs_const.binary(array.clone(), op.into()).and_then(|a| {
-            a.execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            a.execute::<RecursiveCanonical>(&mut ctx)
                 .map(|c| c.0.into_array())
         });
 
@@ -330,8 +333,11 @@ where
     T: NativePType + Num + Copy + std::fmt::Debug,
     Scalar: From<T>,
 {
-    #[expect(deprecated)]
-    let canonicalized_array = array.to_primitive();
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let canonicalized_array = array
+        .clone()
+        .execute::<PrimitiveArray>(&mut ctx)
+        .vortex_expect("test_binary_numeric_with_scalar: failed to canonicalize");
     let original_values = to_vec_of_scalar(&canonicalized_array.into_array());
 
     let scalar = Scalar::from(scalar_value)
@@ -363,7 +369,7 @@ where
         let result = array
             .binary(rhs_const, op.into())
             .vortex_expect("apply failed")
-            .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<RecursiveCanonical>(&mut ctx)
             .map(|x| x.0.into_array());
 
         // Skip if the entire operation fails

--- a/vortex-array/src/compute/conformance/cast.rs
+++ b/vortex-array/src/compute/conformance/cast.rs
@@ -20,9 +20,10 @@ use crate::scalar::Scalar;
 
 /// Cast and force execution via `to_canonical`, returning the canonical array.
 fn cast_and_execute(array: &ArrayRef, dtype: DType) -> VortexResult<ArrayRef> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     Ok(array
         .cast(dtype)?
-        .execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+        .execute::<RecursiveCanonical>(&mut ctx)?
         .0
         .into_array())
 }
@@ -64,6 +65,7 @@ pub fn test_cast_conformance(array: &ArrayRef) {
 }
 
 fn test_cast_identity(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Casting to the same type should be a no-op
     let result = cast_and_execute(&array.clone(), array.dtype().clone())
         .vortex_expect("cast should succeed in conformance test");
@@ -74,16 +76,17 @@ fn test_cast_identity(array: &ArrayRef) {
     for i in 0..array.len().min(10) {
         assert_eq!(
             array
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
 }
 
 fn test_cast_from_null(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Null can be cast to itself
     let result = cast_and_execute(&array.clone(), DType::Null)
         .vortex_expect("cast should succeed in conformance test");
@@ -109,7 +112,7 @@ fn test_cast_from_null(array: &ArrayRef) {
         for i in 0..array.len().min(10) {
             assert!(
                 result
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test")
                     .is_null()
             );
@@ -128,8 +131,9 @@ fn test_cast_from_null(array: &ArrayRef) {
 }
 
 fn test_cast_to_non_nullable(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     if array
-        .invalid_count(&mut LEGACY_SESSION.create_execution_ctx())
+        .invalid_count(&mut ctx)
         .vortex_expect("invalid_count should succeed in conformance test")
         == 0
     {
@@ -141,10 +145,10 @@ fn test_cast_to_non_nullable(array: &ArrayRef) {
         for i in 0..array.len().min(10) {
             assert_eq!(
                 array
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test"),
                 non_nullable
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test")
             );
         }
@@ -157,10 +161,10 @@ fn test_cast_to_non_nullable(array: &ArrayRef) {
         for i in 0..array.len().min(10) {
             assert_eq!(
                 array
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test"),
                 back_to_nullable
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test")
             );
         }
@@ -182,6 +186,7 @@ fn test_cast_to_non_nullable(array: &ArrayRef) {
 }
 
 fn test_cast_to_nullable(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let nullable = cast_and_execute(&array.clone(), array.dtype().as_nullable())
         .vortex_expect("arrays without nulls can cast to nullable");
     assert_eq!(nullable.dtype(), &array.dtype().as_nullable());
@@ -190,10 +195,10 @@ fn test_cast_to_nullable(array: &ArrayRef) {
     for i in 0..array.len().min(10) {
         assert_eq!(
             array
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             nullable
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
@@ -206,9 +211,9 @@ fn test_cast_to_nullable(array: &ArrayRef) {
     for i in 0..array.len().min(10) {
         assert_eq!(
             array
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
-            back.execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            back.execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
@@ -288,20 +293,20 @@ fn test_cast_to_primitive(array: &ArrayRef, target_ptype: PType, test_round_trip
         array
             .validity()
             .vortex_expect("validity_mask should succeed in conformance test")
-            .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+            .to_mask(array.len(), &mut ctx)
             .vortex_expect("Failed to compute validity mask"),
         casted
             .validity()
             .vortex_expect("validity_mask should succeed in conformance test")
-            .to_mask(casted.len(), &mut LEGACY_SESSION.create_execution_ctx())
+            .to_mask(casted.len(), &mut ctx)
             .vortex_expect("Failed to compute validity mask")
     );
     for i in 0..array.len().min(10) {
         let original = array
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         let casted = casted
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         assert_eq!(
             original

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -51,6 +51,7 @@ use crate::scalar_fn::fns::operators::Operator;
 /// - Applies take with these indices
 /// - Verifies both results are identical
 fn test_filter_take_consistency(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len == 0 {
         return;
@@ -90,10 +91,10 @@ fn test_filter_take_consistency(array: &ArrayRef) {
 
     for i in 0..filtered.len() {
         let filtered_val = filtered
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         let taken_val = taken
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         assert_eq!(
             filtered_val, taken_val,
@@ -119,6 +120,7 @@ fn test_filter_take_consistency(array: &ArrayRef) {
 /// This test ensures that mask operations compose correctly, which is critical for
 /// complex query operations that may apply multiple filters.
 fn test_double_mask_consistency(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len == 0 {
         return;
@@ -164,10 +166,10 @@ fn test_double_mask_consistency(array: &ArrayRef) {
 
     for i in 0..double_masked.len() {
         let double_val = double_masked
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         let direct_val = directly_masked
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         assert_eq!(
             double_val, direct_val,
@@ -192,6 +194,7 @@ fn test_double_mask_consistency(array: &ArrayRef) {
 /// This is an identity operation that should be optimized in implementations
 /// to avoid unnecessary copying.
 fn test_filter_identity(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len == 0 {
         return;
@@ -214,10 +217,10 @@ fn test_filter_identity(array: &ArrayRef) {
 
     for i in 0..len {
         let original_val = array
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         let filtered_val = filtered
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         assert_eq!(
             filtered_val, original_val,
@@ -241,6 +244,7 @@ fn test_filter_identity(array: &ArrayRef) {
 /// Masking always produces a nullable array, even when no values are actually masked.
 /// This test ensures the type system handles this correctly.
 fn test_mask_identity(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len == 0 {
         return;
@@ -270,10 +274,10 @@ fn test_mask_identity(array: &ArrayRef) {
 
     for i in 0..len {
         let original_val = array
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         let masked_val = masked
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         let expected_val = original_val.clone().into_nullable();
         assert_eq!(
@@ -299,6 +303,7 @@ fn test_mask_identity(array: &ArrayRef) {
 /// When a filter mask represents a contiguous range, it should be equivalent to
 /// a slice operation. Some implementations may optimize this case.
 fn test_slice_filter_consistency(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len < 4 {
         return; // Need at least 4 elements for meaningful test
@@ -329,10 +334,10 @@ fn test_slice_filter_consistency(array: &ArrayRef) {
 
     for i in 0..filtered.len() {
         let filtered_val = filtered
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         let sliced_val = sliced
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         assert_eq!(
             filtered_val, sliced_val,
@@ -356,6 +361,7 @@ fn test_slice_filter_consistency(array: &ArrayRef) {
 /// # Why This Matters
 /// Sequential takes are a common pattern that can be optimized to slice operations.
 fn test_take_slice_consistency(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len < 3 {
         return; // Need at least 3 elements
@@ -384,10 +390,10 @@ fn test_take_slice_consistency(array: &ArrayRef) {
 
     for i in 0..taken.len() {
         let taken_val = taken
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         let sliced_val = sliced
-            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(i, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test");
         assert_eq!(
             taken_val, sliced_val,
@@ -399,6 +405,7 @@ fn test_take_slice_consistency(array: &ArrayRef) {
 
 /// Tests that filter preserves relative ordering
 fn test_filter_preserves_order(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len < 4 {
         return;
@@ -417,26 +424,26 @@ fn test_filter_preserves_order(array: &ArrayRef) {
     if len >= 4 {
         assert_eq!(
             filtered
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             array
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
         assert_eq!(
             filtered
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             array
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
         assert_eq!(
             filtered
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             array
-                .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(3, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
@@ -444,6 +451,7 @@ fn test_filter_preserves_order(array: &ArrayRef) {
 
 /// Tests that take with repeated indices works correctly
 fn test_take_repeated_indices(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len == 0 {
         return;
@@ -459,10 +467,10 @@ fn test_take_repeated_indices(array: &ArrayRef) {
     for i in 0..3 {
         assert_eq!(
             taken
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             array
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
@@ -470,6 +478,7 @@ fn test_take_repeated_indices(array: &ArrayRef) {
 
 /// Tests mask and filter interaction with nulls
 fn test_mask_filter_null_consistency(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len < 3 {
         return;
@@ -499,10 +508,10 @@ fn test_mask_filter_null_consistency(array: &ArrayRef) {
     for i in 0..filtered.len() {
         assert_eq!(
             filtered
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             direct_filtered
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
@@ -539,6 +548,7 @@ fn test_empty_operations_consistency(array: &ArrayRef) {
 
 /// Tests that take preserves array properties
 fn test_take_preserves_properties(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len == 0 {
         return;
@@ -556,10 +566,10 @@ fn test_take_preserves_properties(array: &ArrayRef) {
     for i in 0..len {
         assert_eq!(
             taken
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             array
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
@@ -583,6 +593,7 @@ fn test_take_preserves_properties(array: &ArrayRef) {
 /// Nullable indices are a powerful feature that allows introducing nulls during
 /// a take operation, which is useful for outer joins and similar operations.
 fn test_nullable_indices_consistency(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len < 3 {
         return; // Need at least 3 elements to test indices 0 and 2
@@ -611,11 +622,11 @@ fn test_nullable_indices_consistency(array: &ArrayRef) {
 
     // Check first element (from index 0)
     let expected_0 = array
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .vortex_expect("scalar_at should succeed in conformance test")
         .into_nullable();
     let actual_0 = taken
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .vortex_expect("scalar_at should succeed in conformance test");
     assert_eq!(
         actual_0, expected_0,
@@ -625,7 +636,7 @@ fn test_nullable_indices_consistency(array: &ArrayRef) {
 
     // Check second element (should be null)
     let actual_1 = taken
-        .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(1, &mut ctx)
         .vortex_expect("scalar_at should succeed in conformance test");
     assert!(
         actual_1.is_null(),
@@ -634,11 +645,11 @@ fn test_nullable_indices_consistency(array: &ArrayRef) {
 
     // Check third element (from index 2)
     let expected_2 = array
-        .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(2, &mut ctx)
         .vortex_expect("scalar_at should succeed in conformance test")
         .into_nullable();
     let actual_2 = taken
-        .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(2, &mut ctx)
         .vortex_expect("scalar_at should succeed in conformance test");
     assert_eq!(
         actual_2, expected_2,
@@ -649,6 +660,7 @@ fn test_nullable_indices_consistency(array: &ArrayRef) {
 
 /// Tests large array consistency
 fn test_large_array_consistency(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len < 1000 {
         return;
@@ -673,10 +685,10 @@ fn test_large_array_consistency(array: &ArrayRef) {
     for i in 0..taken.len() {
         assert_eq!(
             taken
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             filtered
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
@@ -699,6 +711,7 @@ fn test_large_array_consistency(array: &ArrayRef) {
 /// This test catches bugs where an encoding might implement one comparison
 /// correctly but fail on its logical inverse.
 fn test_comparison_inverse_consistency(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len == 0 {
         return;
@@ -715,7 +728,7 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
         return;
     } else {
         array
-            .execute_scalar(len / 2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(len / 2, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test")
     };
 
@@ -741,10 +754,10 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
 
         for i in 0..inverted_eq.len() {
             let inv_val = inverted_eq
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             let neq_val = neq_result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             assert_eq!(
                 inv_val, neq_val,
@@ -769,10 +782,10 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
 
         for i in 0..inverted_gt.len() {
             let inv_val = inverted_gt
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             let lte_val = lte_result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             assert_eq!(
                 inv_val, lte_val,
@@ -797,10 +810,10 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
 
         for i in 0..inverted_lt.len() {
             let inv_val = inverted_lt
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             let gte_val = gte_result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             assert_eq!(
                 inv_val, gte_val,
@@ -827,6 +840,7 @@ fn test_comparison_inverse_consistency(array: &ArrayRef) {
 /// Ensures that comparison operations maintain mathematical ordering properties
 /// regardless of operand order.
 fn test_comparison_symmetry_consistency(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len == 0 {
         return;
@@ -843,7 +857,7 @@ fn test_comparison_symmetry_consistency(array: &ArrayRef) {
         return;
     } else {
         array
-            .execute_scalar(len / 2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(len / 2, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test")
     };
 
@@ -868,10 +882,10 @@ fn test_comparison_symmetry_consistency(array: &ArrayRef) {
 
         for i in 0..arr_gt_scalar.len() {
             let arr_gt = arr_gt_scalar
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             let scalar_lt = scalar_lt_arr
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             assert_eq!(
                 arr_gt, scalar_lt,
@@ -890,10 +904,10 @@ fn test_comparison_symmetry_consistency(array: &ArrayRef) {
     ) {
         for i in 0..arr_eq_scalar.len() {
             let arr_eq = arr_eq_scalar
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             let scalar_eq = scalar_eq_arr
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             assert_eq!(
                 arr_eq, scalar_eq,
@@ -921,6 +935,7 @@ fn test_comparison_symmetry_consistency(array: &ArrayRef) {
 /// This test catches bugs where encodings might optimize boolean operations
 /// incorrectly, breaking fundamental logical properties.
 fn test_boolean_demorgan_consistency(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     if !matches!(array.dtype(), DType::Bool(_)) {
         return;
     }
@@ -952,10 +967,10 @@ fn test_boolean_demorgan_consistency(array: &ArrayRef) {
 
         for i in 0..not_a_and_b.len() {
             let left = not_a_and_b
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             let right = not_a_or_not_b
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             assert_eq!(
                 left, right,
@@ -980,10 +995,10 @@ fn test_boolean_demorgan_consistency(array: &ArrayRef) {
 
         for i in 0..not_a_or_b.len() {
             let left = not_a_or_b
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             let right = not_a_and_not_b
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             assert_eq!(
                 left, right,
@@ -1124,6 +1139,7 @@ fn test_slice_aggregate_consistency(array: &ArrayRef) {
 /// offset information during cast operations. Such bugs can lead to incorrect data being
 /// returned after casting a sliced array.
 fn test_cast_slice_consistency(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len < 5 {
         return; // Need at least 5 elements for meaningful slice
@@ -1136,7 +1152,7 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
     // Get canonical form of the original array
     let canonical = array
         .clone()
-        .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+        .execute::<Canonical>(&mut ctx)
         .vortex_expect("to_canonical failed");
 
     // Choose appropriate target dtype based on the array's type
@@ -1264,7 +1280,7 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
         let slice_then_cast = match sliced
             .cast(target_dtype.clone())
             .and_then(|a| {
-                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                a.execute::<Canonical>(&mut ctx)
                     .map(|c| c.into_array())
             })
         {
@@ -1284,14 +1300,14 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
         // Compare each value against the canonical form
         for i in 0..slice_then_cast.len() {
             let slice_cast_val = slice_then_cast
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
 
             // Get the corresponding value from the canonical array (adjusted for slice offset)
             let canonical_val = canonical
                 .clone()
                 .into_array()
-                .execute_scalar(start + i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(start + i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
 
             // Cast the canonical scalar to the target dtype
@@ -1320,7 +1336,7 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
             .clone()
             .cast(target_dtype.clone())
             .and_then(|a| {
-                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                a.execute::<Canonical>(&mut ctx)
                     .map(|c| c.into_array())
             })
         {
@@ -1340,10 +1356,10 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
 
         for i in 0..slice_then_cast.len() {
             let slice_cast_val = slice_then_cast
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             let cast_slice_val = cast_then_slice
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test");
             assert_eq!(
                 slice_cast_val, cast_slice_val,

--- a/vortex-array/src/compute/conformance/consistency.rs
+++ b/vortex-array/src/compute/conformance/consistency.rs
@@ -27,6 +27,7 @@ use vortex_error::vortex_panic;
 use vortex_mask::Mask;
 
 use crate::ArrayRef;
+use crate::Canonical;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
 use crate::VortexSessionExecute;
@@ -1029,8 +1030,10 @@ fn test_slice_aggregate_consistency(array: &ArrayRef) {
     let sliced = array
         .slice(start..end)
         .vortex_expect("slice should succeed in conformance test");
-    #[expect(deprecated)]
-    let canonical = array.to_canonical().vortex_expect("to_canonical failed");
+    let canonical = array
+        .clone()
+        .execute::<Canonical>(&mut ctx)
+        .vortex_expect("to_canonical failed");
     let canonical_sliced = canonical
         .into_array()
         .slice(start..end)
@@ -1131,8 +1134,10 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
     let end = 7.min(len - 2).max(start + 1); // Ensure we have at least 1 element
 
     // Get canonical form of the original array
-    #[expect(deprecated)]
-    let canonical = array.to_canonical().vortex_expect("to_canonical failed");
+    let canonical = array
+        .clone()
+        .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+        .vortex_expect("to_canonical failed");
 
     // Choose appropriate target dtype based on the array's type
     let target_dtypes = match array.dtype() {
@@ -1256,10 +1261,13 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
             .vortex_expect("slice should succeed in conformance test");
 
         // Try to cast the sliced array (force execution via to_canonical)
-        let slice_then_cast = match sliced.cast(target_dtype.clone()).and_then(|a| {
-            #[expect(deprecated)]
-            a.to_canonical().map(|c| c.into_array())
-        }) {
+        let slice_then_cast = match sliced
+            .cast(target_dtype.clone())
+            .and_then(|a| {
+                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                    .map(|c| c.into_array())
+            })
+        {
             Ok(result) => result,
             Err(_) => continue, // Skip if cast fails
         };
@@ -1308,10 +1316,14 @@ fn test_cast_slice_consistency(array: &ArrayRef) {
         }
 
         // Also test the other way: cast then slice
-        let casted = match array.clone().cast(target_dtype.clone()).and_then(|a| {
-            #[expect(deprecated)]
-            a.to_canonical().map(|c| c.into_array())
-        }) {
+        let casted = match array
+            .clone()
+            .cast(target_dtype.clone())
+            .and_then(|a| {
+                a.execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                    .map(|c| c.into_array())
+            })
+        {
             Ok(result) => result,
             Err(_) => continue, // Skip if cast fails
         };

--- a/vortex-array/src/compute/conformance/filter.rs
+++ b/vortex-array/src/compute/conformance/filter.rs
@@ -82,6 +82,7 @@ fn test_none_filter(array: &ArrayRef) {
 }
 
 fn test_selective_filter(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len < 2 {
         return; // Skip for very small arrays
@@ -100,10 +101,10 @@ fn test_selective_filter(array: &ArrayRef) {
     for (filtered_idx, i) in (0..len).step_by(2).enumerate() {
         assert_eq!(
             filtered
-                .execute_scalar(filtered_idx, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(filtered_idx, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             array
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
@@ -120,24 +121,25 @@ fn test_selective_filter(array: &ArrayRef) {
         assert_eq!(filtered.len(), 2);
         assert_eq!(
             filtered
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             array
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
         assert_eq!(
             filtered
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             array
-                .execute_scalar(len - 1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(len - 1, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
 }
 
 fn test_single_element_filter(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len == 0 {
         return;
@@ -153,10 +155,10 @@ fn test_single_element_filter(array: &ArrayRef) {
     assert_eq!(filtered.len(), 1);
     assert_eq!(
         filtered
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test"),
         array
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test")
     );
 
@@ -171,10 +173,10 @@ fn test_single_element_filter(array: &ArrayRef) {
         assert_eq!(filtered.len(), 1);
         assert_eq!(
             filtered
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             array
-                .execute_scalar(len - 1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(len - 1, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
@@ -221,6 +223,7 @@ fn test_mismatched_lengths(array: &ArrayRef) {
 
 /// Tests filtering with alternating true/false pattern
 fn test_alternating_pattern_filter(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     let pattern = create_alternating_pattern(len);
     let expected_count = pattern.iter().filter(|&&v| v).count();
@@ -237,10 +240,10 @@ fn test_alternating_pattern_filter(array: &ArrayRef) {
         if keep {
             assert_eq!(
                 filtered
-                    .execute_scalar(filtered_idx, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(filtered_idx, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test"),
                 array
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test")
             );
             filtered_idx += 1;

--- a/vortex-array/src/compute/conformance/mask.rs
+++ b/vortex-array/src/compute/conformance/mask.rs
@@ -37,6 +37,7 @@ pub fn test_mask_conformance(array: &ArrayRef) {
 
 /// Tests masking with a heterogeneous pattern
 fn test_heterogenous_mask(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
 
     // Create a pattern where roughly half the values are masked
@@ -54,16 +55,16 @@ fn test_heterogenous_mask(array: &ArrayRef) {
         if masked_out {
             assert!(
                 !masked
-                    .is_valid(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .is_valid(i, &mut ctx)
                     .vortex_expect("is_valid should succeed in conformance test")
             );
         } else {
             assert_eq!(
                 masked
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test"),
                 array
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test")
                     .into_nullable()
             );
@@ -73,6 +74,7 @@ fn test_heterogenous_mask(array: &ArrayRef) {
 
 /// Tests that an empty mask (all false) preserves all elements
 fn test_empty_mask(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     let all_unmasked = vec![false; len];
     let mask_array = Mask::from_iter(all_unmasked);
@@ -87,10 +89,10 @@ fn test_empty_mask(array: &ArrayRef) {
     for i in 0..len {
         assert_eq!(
             masked
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             array
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
                 .into_nullable()
         );
@@ -99,6 +101,7 @@ fn test_empty_mask(array: &ArrayRef) {
 
 /// Tests that a full mask (all true) makes all elements null
 fn test_full_mask(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     let all_masked = vec![true; len];
     let mask_array = Mask::from_iter(all_masked);
@@ -113,7 +116,7 @@ fn test_full_mask(array: &ArrayRef) {
     for i in 0..len {
         assert!(
             !masked
-                .is_valid(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(i, &mut ctx)
                 .vortex_expect("is_valid should succeed in conformance test")
         );
     }
@@ -121,6 +124,7 @@ fn test_full_mask(array: &ArrayRef) {
 
 /// Tests alternating mask pattern
 fn test_alternating_mask(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     let pattern: Vec<bool> = (0..len).map(|i| i % 2 == 0).collect();
     let mask_array = Mask::from_iter(pattern);
@@ -135,16 +139,16 @@ fn test_alternating_mask(array: &ArrayRef) {
         if i % 2 == 0 {
             assert!(
                 !masked
-                    .is_valid(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .is_valid(i, &mut ctx)
                     .vortex_expect("is_valid should succeed in conformance test")
             );
         } else {
             assert_eq!(
                 masked
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test"),
                 array
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test")
                     .into_nullable()
             );
@@ -154,6 +158,7 @@ fn test_alternating_mask(array: &ArrayRef) {
 
 /// Tests sparse mask (only a few elements masked)
 fn test_sparse_mask(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len < 10 {
         return; // Skip for small arrays
@@ -173,7 +178,7 @@ fn test_sparse_mask(array: &ArrayRef) {
     let valid_count = (0..len)
         .filter(|&i| {
             masked
-                .is_valid(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(i, &mut ctx)
                 .vortex_expect("is_valid should succeed in conformance test")
         })
         .count();
@@ -185,7 +190,7 @@ fn test_sparse_mask(array: &ArrayRef) {
         .filter(|&i| {
             pattern[i]
                 || !array
-                    .is_valid(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .is_valid(i, &mut ctx)
                     .vortex_expect("is_valid should succeed in conformance test")
         })
         .count();
@@ -195,6 +200,7 @@ fn test_sparse_mask(array: &ArrayRef) {
 
 /// Tests masking a single element
 fn test_single_element_mask(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
 
     // Mask only the first element
@@ -208,17 +214,17 @@ fn test_single_element_mask(array: &ArrayRef) {
         .vortex_expect("mask should succeed in conformance test");
     assert!(
         !masked
-            .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .is_valid(0, &mut ctx)
             .vortex_expect("is_valid should succeed in conformance test")
     );
 
     for i in 1..len {
         assert_eq!(
             masked
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             array
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
                 .into_nullable()
         );
@@ -227,6 +233,7 @@ fn test_single_element_mask(array: &ArrayRef) {
 
 /// Tests double masking operations
 fn test_double_mask(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
 
     // Create two different mask patterns
@@ -249,16 +256,16 @@ fn test_double_mask(array: &ArrayRef) {
         if mask1_pattern[i] || mask2_pattern[i] {
             assert!(
                 !double_masked
-                    .is_valid(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .is_valid(i, &mut ctx)
                     .vortex_expect("is_valid should succeed in conformance test")
             );
         } else {
             assert_eq!(
                 double_masked
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test"),
                 array
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test")
                     .into_nullable()
             );
@@ -268,6 +275,7 @@ fn test_double_mask(array: &ArrayRef) {
 
 /// Tests masking with nullable mask (nulls treated as false)
 fn test_nullable_mask_input(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     if len < 3 {
         return; // Skip for very small arrays
@@ -282,7 +290,7 @@ fn test_nullable_mask_input(array: &ArrayRef) {
     let nullable_mask = BoolArray::new(bool_array.to_bit_buffer(), validity);
 
     let mask_array =
-        nullable_mask.to_mask_fill_null_false(&mut LEGACY_SESSION.create_execution_ctx());
+        nullable_mask.to_mask_fill_null_false(&mut ctx);
     let masked = array
         .clone()
         .mask((!&mask_array).into_array())
@@ -293,16 +301,16 @@ fn test_nullable_mask_input(array: &ArrayRef) {
         if bool_values[i] && validity_values[i] {
             assert!(
                 !masked
-                    .is_valid(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .is_valid(i, &mut ctx)
                     .vortex_expect("is_valid should succeed in conformance test")
             );
         } else {
             assert_eq!(
                 masked
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test"),
                 array
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test")
                     .into_nullable()
             );

--- a/vortex-array/src/compute/conformance/search_sorted.rs
+++ b/vortex-array/src/compute/conformance/search_sorted.rs
@@ -22,6 +22,7 @@ pub fn all_null() -> ArrayRef {
 }
 
 pub fn sparse_high_null_fill() -> ArrayRef {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     PrimitiveArray::new(buffer![0; 20], Validity::AllInvalid)
         .patch(
             &Patches::new(
@@ -32,13 +33,14 @@ pub fn sparse_high_null_fill() -> ArrayRef {
                 None,
             )
             .unwrap(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap()
         .into_array()
 }
 
 pub fn sparse_high_non_null_fill() -> ArrayRef {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     PrimitiveArray::new(buffer![22; 20], Validity::NonNullable)
         .patch(
             &Patches::new(
@@ -49,13 +51,14 @@ pub fn sparse_high_non_null_fill() -> ArrayRef {
                 None,
             )
             .unwrap(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap()
         .into_array()
 }
 
 pub fn sparse_low() -> ArrayRef {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     PrimitiveArray::new(buffer![60; 20], Validity::NonNullable)
         .patch(
             &Patches::new(
@@ -66,13 +69,14 @@ pub fn sparse_low() -> ArrayRef {
                 None,
             )
             .unwrap(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap()
         .into_array()
 }
 
 pub fn sparse_low_high() -> ArrayRef {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     PrimitiveArray::new(buffer![30; 20], Validity::NonNullable)
         .patch(
             &Patches::new(
@@ -83,13 +87,14 @@ pub fn sparse_low_high() -> ArrayRef {
                 None,
             )
             .unwrap(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap()
         .into_array()
 }
 
 pub fn sparse_edge_patch_high() -> ArrayRef {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     PrimitiveArray::new(buffer![33; 20], Validity::NonNullable)
         .patch(
             &Patches::new(
@@ -100,13 +105,14 @@ pub fn sparse_edge_patch_high() -> ArrayRef {
                 None,
             )
             .unwrap(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap()
         .into_array()
 }
 
 pub fn sparse_edge_patch_low() -> ArrayRef {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     PrimitiveArray::new(buffer![22; 20], Validity::NonNullable)
         .patch(
             &Patches::new(
@@ -117,7 +123,7 @@ pub fn sparse_edge_patch_low() -> ArrayRef {
                 None,
             )
             .unwrap(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap()
         .into_array()

--- a/vortex-array/src/compute/conformance/take.rs
+++ b/vortex-array/src/compute/conformance/take.rs
@@ -110,6 +110,7 @@ fn test_take_none(array: &ArrayRef) {
 
 #[expect(clippy::cast_possible_truncation)]
 fn test_take_selective(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
 
     // Take every other element
@@ -128,17 +129,18 @@ fn test_take_selective(array: &ArrayRef) {
             array
                 .execute_scalar(
                     original_idx as usize,
-                    &mut LEGACY_SESSION.create_execution_ctx()
+                    &mut ctx
                 )
                 .vortex_expect("scalar_at should succeed in conformance test"),
             result
-                .execute_scalar(result_idx, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(result_idx, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
 }
 
 fn test_take_first_and_last(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     let indices = PrimitiveArray::from_iter([0u64, (len - 1) as u64]);
     let result = array
@@ -148,24 +150,25 @@ fn test_take_first_and_last(array: &ArrayRef) {
     assert_eq!(result.len(), 2);
     assert_eq!(
         array
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test"),
         result
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test")
     );
     assert_eq!(
         array
-            .execute_scalar(len - 1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(len - 1, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test"),
         result
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test")
     );
 }
 
 #[expect(clippy::cast_possible_truncation)]
 fn test_take_with_nullable_indices(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
 
     // Create indices with some null values
@@ -193,17 +196,17 @@ fn test_take_with_nullable_indices(array: &ArrayRef) {
         match idx_opt {
             Some(idx) => {
                 let expected = array
-                    .execute_scalar(*idx as usize, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(*idx as usize, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test");
                 let actual = result
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .vortex_expect("scalar_at should succeed in conformance test");
                 assert_eq!(expected, actual);
             }
             None => {
                 assert!(
                     result
-                        .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                        .execute_scalar(i, &mut ctx)
                         .vortex_expect("scalar_at should succeed in conformance test")
                         .is_null()
                 );
@@ -213,6 +216,7 @@ fn test_take_with_nullable_indices(array: &ArrayRef) {
 }
 
 fn test_take_repeated_indices(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     if array.is_empty() {
         return;
     }
@@ -225,12 +229,12 @@ fn test_take_repeated_indices(array: &ArrayRef) {
 
     assert_eq!(result.len(), 3);
     let first_elem = array
-        .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+        .execute_scalar(0, &mut ctx)
         .vortex_expect("scalar_at should succeed in conformance test");
     for i in 0..3 {
         assert_eq!(
             result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             first_elem
         );
@@ -248,6 +252,7 @@ fn test_empty_indices(array: &ArrayRef) {
 }
 
 fn test_take_reverse(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     // Take elements in reverse order
     let indices = PrimitiveArray::from_iter((0..len as u64).rev());
@@ -261,16 +266,17 @@ fn test_take_reverse(array: &ArrayRef) {
     for i in 0..len {
         assert_eq!(
             array
-                .execute_scalar(len - 1 - i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(len - 1 - i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
 }
 
 fn test_take_single_middle(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     let middle_idx = len / 2;
 
@@ -282,16 +288,17 @@ fn test_take_single_middle(array: &ArrayRef) {
     assert_eq!(result.len(), 1);
     assert_eq!(
         array
-            .execute_scalar(middle_idx, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(middle_idx, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test"),
         result
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .vortex_expect("scalar_at should succeed in conformance test")
     );
 }
 
 #[expect(clippy::cast_possible_truncation)]
 fn test_take_random_unsorted(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
 
     // Create a pseudo-random but deterministic pattern
@@ -313,16 +320,17 @@ fn test_take_random_unsorted(array: &ArrayRef) {
     for (i, &idx) in indices.iter().enumerate() {
         assert_eq!(
             array
-                .execute_scalar(idx as usize, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(idx as usize, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
 }
 
 fn test_take_contiguous_range(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
     let start = len / 4;
     let end = len / 2;
@@ -339,10 +347,10 @@ fn test_take_contiguous_range(array: &ArrayRef) {
     for i in 0..(end - start) {
         assert_eq!(
             array
-                .execute_scalar(start + i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(start + i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
@@ -350,6 +358,7 @@ fn test_take_contiguous_range(array: &ArrayRef) {
 
 #[expect(clippy::cast_possible_truncation)]
 fn test_take_mixed_repeated(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let len = array.len();
 
     // Create pattern with some repeated indices
@@ -375,10 +384,10 @@ fn test_take_mixed_repeated(array: &ArrayRef) {
     for (i, &idx) in indices.iter().enumerate() {
         assert_eq!(
             array
-                .execute_scalar(idx as usize, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(idx as usize, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }
@@ -386,6 +395,7 @@ fn test_take_mixed_repeated(array: &ArrayRef) {
 
 #[expect(clippy::cast_possible_truncation)]
 fn test_take_large_indices(array: &ArrayRef) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // Test with a large number of indices to stress test performance
     let len = array.len();
     let num_indices = 10000.min(len * 3);
@@ -407,10 +417,10 @@ fn test_take_large_indices(array: &ArrayRef) {
         let expected_idx = indices[i] as usize;
         assert_eq!(
             array
-                .execute_scalar(expected_idx, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(expected_idx, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test"),
             result
-                .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(i, &mut ctx)
                 .vortex_expect("scalar_at should succeed in conformance test")
         );
     }

--- a/vortex-array/src/compute/conformance/take.rs
+++ b/vortex-array/src/compute/conformance/take.rs
@@ -63,16 +63,19 @@ fn test_take_all(array: &ArrayRef) {
     assert_eq!(result.len(), len);
     assert_eq!(result.dtype(), array.dtype());
 
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+
     // Verify elements match
-    #[expect(deprecated)]
-    let array_canonical = array
-        .to_canonical()
-        .vortex_expect("to_canonical failed on array");
-    #[expect(deprecated)]
-    let result_canonical = result
-        .to_canonical()
-        .vortex_expect("to_canonical failed on result");
-    match (array_canonical, result_canonical) {
+    match (
+        array
+            .clone()
+            .execute::<Canonical>(&mut ctx)
+            .vortex_expect("to_canonical failed on array"),
+        result
+            .clone()
+            .execute::<Canonical>(&mut ctx)
+            .vortex_expect("to_canonical failed on result"),
+    ) {
         (Canonical::Primitive(orig_prim), Canonical::Primitive(result_prim)) => {
             assert_eq!(
                 orig_prim.buffer_handle().to_host_sync(),
@@ -84,10 +87,10 @@ fn test_take_all(array: &ArrayRef) {
             for i in 0..len {
                 assert_eq!(
                     array
-                        .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                        .execute_scalar(i, &mut ctx)
                         .vortex_expect("scalar_at should succeed in conformance test"),
                     result
-                        .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                        .execute_scalar(i, &mut ctx)
                         .vortex_expect("scalar_at should succeed in conformance test")
                 );
             }

--- a/vortex-array/src/display/mod.rs
+++ b/vortex-array/src/display/mod.rs
@@ -583,6 +583,7 @@ impl ArrayRef {
                 use crate::canonical::ToCanonical as _;
                 use crate::dtype::DType;
 
+                let mut ctx = LEGACY_SESSION.create_execution_ctx();
                 let mut builder = tabled::builder::Builder::default();
 
                 // Special logic for struct arrays.
@@ -590,7 +591,7 @@ impl ArrayRef {
                     // For non-struct arrays, simply display a single column table without header.
                     for row_idx in 0..self.len() {
                         let value = self
-                            .execute_scalar(row_idx, &mut LEGACY_SESSION.create_execution_ctx())
+                            .execute_scalar(row_idx, &mut ctx)
                             .map_or_else(|e| format!("<error: {e}>"), |s| s.to_string());
                         builder.push_record([value]);
                     }
@@ -607,7 +608,7 @@ impl ArrayRef {
 
                 for row_idx in 0..self.len() {
                     if !self
-                        .is_valid(row_idx, &mut LEGACY_SESSION.create_execution_ctx())
+                        .is_valid(row_idx, &mut ctx)
                         .unwrap_or(false)
                     {
                         let null_row = vec!["null".to_string(); sf.names().len()];
@@ -618,7 +619,7 @@ impl ArrayRef {
                             crate::arrays::struct_::StructArrayExt::iter_unmasked_fields(&struct_)
                         {
                             let value = field_array
-                                .execute_scalar(row_idx, &mut LEGACY_SESSION.create_execution_ctx())
+                                .execute_scalar(row_idx, &mut ctx)
                                 .map_or_else(|e| format!("<error: {e}>"), |s| s.to_string());
                             row.push(value);
                         }
@@ -636,7 +637,7 @@ impl ArrayRef {
 
                 for row_idx in 0..self.len() {
                     if !self
-                        .is_valid(row_idx, &mut LEGACY_SESSION.create_execution_ctx())
+                        .is_valid(row_idx, &mut ctx)
                         .unwrap_or(false)
                     {
                         table.modify(

--- a/vortex-array/src/display/mod.rs
+++ b/vortex-array/src/display/mod.rs
@@ -17,6 +17,7 @@ pub use extractors::NbytesExtractor;
 pub use extractors::StatsExtractor;
 use itertools::Itertools as _;
 pub use tree_display::TreeDisplay;
+use vortex_error::VortexExpect as _;
 
 use crate::ArrayRef;
 use crate::LEGACY_SESSION;
@@ -579,8 +580,8 @@ impl ArrayRef {
             }
             #[cfg(feature = "table-display")]
             DisplayOptions::TableDisplay => {
-                #[expect(deprecated)]
-                use crate::canonical::ToCanonical as _;
+                use crate::Canonical;
+                use crate::arrays::StructArray;
                 use crate::dtype::DType;
 
                 let mut ctx = LEGACY_SESSION.create_execution_ctx();
@@ -602,8 +603,11 @@ impl ArrayRef {
                     return write!(f, "{table}");
                 };
 
-                #[expect(deprecated)]
-                let struct_ = self.to_struct();
+                let struct_ = self
+                    .clone()
+                    .execute::<Canonical>(&mut ctx)
+                    .vortex_expect("to_canonical failed")
+                    .into_struct();
                 builder.push_record(sf.names().iter().map(|name| name.to_string()));
 
                 for row_idx in 0..self.len() {

--- a/vortex-array/src/expr/stats/mod.rs
+++ b/vortex-array/src/expr/stats/mod.rs
@@ -220,9 +220,10 @@ mod test {
 
     #[test]
     fn min_of_nulls_is_not_panic() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let min = PrimitiveArray::from_option_iter::<i32, _>([None, None, None, None])
             .statistics()
-            .compute_as::<i64>(Stat::Min, &mut LEGACY_SESSION.create_execution_ctx());
+            .compute_as::<i64>(Stat::Min, &mut ctx);
 
         assert_eq!(min, None);
     }

--- a/vortex-array/src/normalize.rs
+++ b/vortex-array/src/normalize.rs
@@ -103,6 +103,7 @@ mod tests {
     use super::NormalizeOptions;
     use super::Operation;
     use crate::ArrayRef;
+    use crate::Canonical;
     use crate::ExecutionCtx;
     use crate::IntoArray;
     use crate::array::VTable;
@@ -219,10 +220,8 @@ mod tests {
         assert_eq!(normalized.len(), 3);
 
         // Verify the data: codes [1,0,1] -> values [20, 10, 20]
-        #[expect(deprecated)]
-        let normalized_canonical = normalized.to_canonical()?;
         assert_arrays_eq!(
-            normalized_canonical,
+            normalized.execute::<Canonical>(&mut ctx)?,
             PrimitiveArray::from_iter(vec![20i32, 10, 20])
         );
 

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -175,9 +175,10 @@ impl Patches {
         // Perform validation of components when they are host-resident.
         // This is not possible to do eagerly when the data is on GPU memory.
         if indices.is_host() && values.is_host() {
+            let mut ctx = LEGACY_SESSION.create_execution_ctx();
             let max = usize::try_from(&indices.execute_scalar(
                 indices.len() - 1,
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )?)
             .map_err(|_| vortex_err!("indices must be a number"))?;
             vortex_ensure!(
@@ -293,12 +294,13 @@ impl Patches {
 
     #[inline]
     pub fn chunk_offset_at(&self, idx: usize) -> VortexResult<usize> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let Some(chunk_offsets) = &self.chunk_offsets else {
             vortex_bail!("chunk_offsets must be set to retrieve offset at index")
         };
 
         chunk_offsets
-            .execute_scalar(idx, &mut LEGACY_SESSION.create_execution_ctx())?
+            .execute_scalar(idx, &mut ctx)?
             .as_primitive()
             .as_::<usize>()
             .ok_or_else(|| vortex_err!("chunk offset does not fit in usize"))
@@ -367,11 +369,12 @@ impl Patches {
 
     /// Get the patched value at a given index if it exists.
     pub fn get_patched(&self, index: usize) -> VortexResult<Option<Scalar>> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.search_index(index)?
             .to_found()
             .map(|patch_idx| {
                 self.values()
-                    .execute_scalar(patch_idx, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(patch_idx, &mut ctx)
             })
             .transpose()
     }
@@ -553,9 +556,10 @@ impl Patches {
 
     /// Returns the minimum patch index
     pub fn min_index(&self) -> VortexResult<usize> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let first = self
             .indices
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?
+            .execute_scalar(0, &mut ctx)?
             .as_primitive()
             .as_::<usize>()
             .ok_or_else(|| vortex_err!("index does not fit in usize"))?;
@@ -564,11 +568,12 @@ impl Patches {
 
     /// Returns the maximum patch index
     pub fn max_index(&self) -> VortexResult<usize> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let last = self
             .indices
             .execute_scalar(
                 self.indices.len() - 1,
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )?
             .as_primitive()
             .as_::<usize>()
@@ -653,6 +658,7 @@ impl Patches {
 
     /// Slice the patches by a range of the patched array.
     pub fn slice(&self, range: Range<usize>) -> VortexResult<Option<Self>> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let slice_start_idx = self.search_index(range.start)?.to_index();
         let slice_end_idx = self.search_index(range.end)?.to_index();
 
@@ -678,7 +684,7 @@ impl Patches {
             .as_ref()
             .map(|new_chunk_offsets| -> VortexResult<usize> {
                 let new_chunk_base = new_chunk_offsets
-                    .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?
+                    .execute_scalar(0, &mut ctx)?
                     .as_primitive()
                     .as_::<usize>()
                     .ok_or_else(|| vortex_err!("chunk offset does not fit in usize"))?;
@@ -1128,6 +1134,7 @@ mod test {
 
     #[test]
     fn test_filter() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             100,
             0,
@@ -1140,7 +1147,7 @@ mod test {
         let filtered = patches
             .filter(
                 &Mask::from_indices(100, vec![10, 20, 30]),
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap()
             .unwrap();
@@ -1151,6 +1158,7 @@ mod test {
 
     #[test]
     fn take_with_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             20,
             0,
@@ -1164,7 +1172,7 @@ mod test {
             .take(
                 &PrimitiveArray::new(buffer![9, 0], Validity::from_iter(vec![true, false]))
                     .into_array(),
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap()
             .unwrap();
@@ -1185,7 +1193,7 @@ mod test {
                 .unwrap()
                 .to_mask(
                     primitive_values.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx()
+                    &mut ctx
                 )
                 .unwrap(),
             Mask::from_iter(vec![true])
@@ -1194,6 +1202,7 @@ mod test {
 
     #[test]
     fn take_search_with_nulls_chunked() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             20,
             0,
@@ -1207,7 +1216,7 @@ mod test {
             .take_search(
                 PrimitiveArray::new(buffer![9, 0], Validity::from_iter([true, false])),
                 true,
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap()
             .unwrap();
@@ -1228,7 +1237,7 @@ mod test {
                 .unwrap()
                 .to_mask(
                     primitive_values.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx()
+                    &mut ctx
                 )
                 .unwrap(),
             Mask::from_iter([true, false])
@@ -1237,6 +1246,7 @@ mod test {
 
     #[test]
     fn take_search_chunked_multiple_chunks() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             2048,
             0,
@@ -1250,7 +1260,7 @@ mod test {
             .take_search(
                 PrimitiveArray::new(buffer![500, 1200, 999], Validity::AllValid),
                 true,
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap()
             .unwrap();
@@ -1264,6 +1274,7 @@ mod test {
 
     #[test]
     fn take_search_chunked_indices_with_no_patches() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             20,
             0,
@@ -1277,7 +1288,7 @@ mod test {
             .take_search(
                 PrimitiveArray::new(buffer![3, 4, 5], Validity::AllValid),
                 true,
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap();
 
@@ -1286,6 +1297,7 @@ mod test {
 
     #[test]
     fn take_search_chunked_interleaved() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             30,
             0,
@@ -1299,7 +1311,7 @@ mod test {
             .take_search(
                 PrimitiveArray::new(buffer![10, 15, 20, 99], Validity::AllValid),
                 true,
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap()
             .unwrap();
@@ -1313,6 +1325,7 @@ mod test {
 
     #[test]
     fn test_take_search_multiple_chunk_offsets() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             1500,
             0,
@@ -1326,7 +1339,7 @@ mod test {
             .take_search(
                 PrimitiveArray::new(BufferMut::from_iter(0..1500u64), Validity::AllValid),
                 false,
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap()
             .unwrap();
@@ -1366,6 +1379,7 @@ mod test {
 
     #[test]
     fn test_mask_all_true() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             10,
             0,
@@ -1377,13 +1391,14 @@ mod test {
 
         let mask = Mask::new_true(10);
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap();
         assert!(masked.is_none());
     }
 
     #[test]
     fn test_mask_all_false() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             10,
             0,
@@ -1395,7 +1410,7 @@ mod test {
 
         let mask = Mask::new_false(10);
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap()
             .unwrap();
 
@@ -1407,19 +1422,19 @@ mod test {
         assert!(
             masked
                 .values()
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(0, &mut ctx)
                 .unwrap()
         );
         assert!(
             masked
                 .values()
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(1, &mut ctx)
                 .unwrap()
         );
         assert!(
             masked
                 .values()
-                .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(2, &mut ctx)
                 .unwrap()
         );
 
@@ -1429,6 +1444,7 @@ mod test {
 
     #[test]
     fn test_mask_partial() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             10,
             0,
@@ -1443,7 +1459,7 @@ mod test {
             false, false, true, false, false, false, false, false, true, false,
         ]);
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap()
             .unwrap();
 
@@ -1457,6 +1473,7 @@ mod test {
 
     #[test]
     fn test_mask_with_offset() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             10,
             5,                                  // offset
@@ -1472,7 +1489,7 @@ mod test {
         ]);
 
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap()
             .unwrap();
         assert_eq!(masked.array_len(), 10);
@@ -1483,6 +1500,7 @@ mod test {
 
     #[test]
     fn test_mask_nullable_values() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             10,
             0,
@@ -1497,7 +1515,7 @@ mod test {
             false, false, true, false, false, false, false, false, false, false,
         ]);
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap()
             .unwrap();
 
@@ -1510,18 +1528,18 @@ mod test {
         assert_eq!(masked_values.len(), 2);
         assert!(
             !masked_values
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(0, &mut ctx)
                 .unwrap()
         ); // the null value at index 5
         assert!(
             masked_values
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(1, &mut ctx)
                 .unwrap()
         ); // the 300 value at index 8
         assert_eq!(
             i32::try_from(
                 &masked_values
-                    .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(1, &mut ctx)
                     .unwrap()
             )
             .unwrap(),
@@ -1531,6 +1549,7 @@ mod test {
 
     #[test]
     fn test_filter_keep_all() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             10,
             0,
@@ -1543,7 +1562,7 @@ mod test {
         // Keep all indices (mask with indices 0-9)
         let mask = Mask::from_indices(10, (0..10).collect());
         let filtered = patches
-            .filter(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .filter(&mask, &mut ctx)
             .unwrap()
             .unwrap();
 
@@ -1556,6 +1575,7 @@ mod test {
 
     #[test]
     fn test_filter_none() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             10,
             0,
@@ -1568,13 +1588,14 @@ mod test {
         // Filter out all (empty mask means keep nothing)
         let mask = Mask::from_indices(10, vec![]);
         let filtered = patches
-            .filter(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .filter(&mask, &mut ctx)
             .unwrap();
         assert!(filtered.is_none());
     }
 
     #[test]
     fn test_filter_with_indices() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             10,
             0,
@@ -1587,7 +1608,7 @@ mod test {
         // Keep indices 2, 5, 9 (so patches at 2 and 5 remain)
         let mask = Mask::from_indices(10, vec![2, 5, 9]);
         let filtered = patches
-            .filter(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .filter(&mask, &mut ctx)
             .unwrap()
             .unwrap();
 
@@ -1672,6 +1693,7 @@ mod test {
 
     #[test]
     fn test_patch_values() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             10,
             0,
@@ -1686,7 +1708,7 @@ mod test {
         assert_eq!(
             i32::try_from(
                 &values
-                    .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(0, &mut ctx)
                     .unwrap()
             )
             .unwrap(),
@@ -1695,7 +1717,7 @@ mod test {
         assert_eq!(
             i32::try_from(
                 &values
-                    .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(1, &mut ctx)
                     .unwrap()
             )
             .unwrap(),
@@ -1704,7 +1726,7 @@ mod test {
         assert_eq!(
             i32::try_from(
                 &values
-                    .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(2, &mut ctx)
                     .unwrap()
             )
             .unwrap(),
@@ -1752,6 +1774,7 @@ mod test {
 
     #[test]
     fn test_mask_boundary_patches() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test masking patches at array boundaries
         let patches = Patches::new(
             10,
@@ -1766,7 +1789,7 @@ mod test {
             true, false, false, false, false, false, false, false, false, false,
         ]);
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap();
         assert!(masked.is_some());
         let masked = masked.unwrap();
@@ -1776,6 +1799,7 @@ mod test {
 
     #[test]
     fn test_mask_all_patches_removed() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test when all patches are masked out
         let patches = Patches::new(
             10,
@@ -1791,13 +1815,14 @@ mod test {
             false, false, true, false, false, true, false, false, true, false,
         ]);
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap();
         assert!(masked.is_none());
     }
 
     #[test]
     fn test_mask_no_patches_removed() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test when no patches are masked
         let patches = Patches::new(
             10,
@@ -1813,7 +1838,7 @@ mod test {
             true, false, false, true, false, false, true, false, false, true,
         ]);
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap()
             .unwrap();
 
@@ -1826,6 +1851,7 @@ mod test {
 
     #[test]
     fn test_mask_single_patch() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test with a single patch
         let patches = Patches::new(
             5,
@@ -1839,14 +1865,14 @@ mod test {
         // Mask that removes the single patch
         let mask = Mask::from_iter([false, false, true, false, false]);
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap();
         assert!(masked.is_none());
 
         // Mask that keeps the single patch
         let mask = Mask::from_iter([true, false, false, true, false]);
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap()
             .unwrap();
         assert_arrays_eq!(masked.indices(), PrimitiveArray::from_iter([2u64]));
@@ -1854,6 +1880,7 @@ mod test {
 
     #[test]
     fn test_mask_contiguous_patches() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test with contiguous patches
         let patches = Patches::new(
             10,
@@ -1869,7 +1896,7 @@ mod test {
             false, false, false, false, true, true, false, false, false, false,
         ]);
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap()
             .unwrap();
 
@@ -1879,6 +1906,7 @@ mod test {
 
     #[test]
     fn test_mask_with_large_offset() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test with a large offset that shifts all indices
         let patches = Patches::new(
             20,
@@ -1895,7 +1923,7 @@ mod test {
             false, false, false, false, false, false, false, false,
         ]);
         let masked = patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap()
             .unwrap();
 
@@ -1906,6 +1934,7 @@ mod test {
     #[test]
     #[should_panic(expected = "Filter mask length 5 does not match array length 10")]
     fn test_mask_wrong_length() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let patches = Patches::new(
             10,
             0,
@@ -1918,7 +1947,7 @@ mod test {
         // Mask with wrong length
         let mask = Mask::from_iter([false, false, true, false, false]);
         patches
-            .mask(&mask, &mut LEGACY_SESSION.create_execution_ctx())
+            .mask(&mask, &mut ctx)
             .unwrap();
     }
 

--- a/vortex-array/src/patches.rs
+++ b/vortex-array/src/patches.rs
@@ -10,6 +10,7 @@ use num_traits::NumCast;
 use vortex_buffer::BitBuffer;
 use vortex_buffer::BufferMut;
 use vortex_error::VortexError;
+use vortex_error::VortexExpect as _;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_error::vortex_ensure;
@@ -22,8 +23,6 @@ use crate::ArrayRef;
 use crate::ExecutionCtx;
 use crate::IntoArray;
 use crate::LEGACY_SESSION;
-#[expect(deprecated)]
-use crate::ToCanonical as _;
 use crate::VortexSessionExecute;
 use crate::arrays::PrimitiveArray;
 use crate::builtins::ArrayBuiltins;
@@ -411,8 +410,11 @@ impl Patches {
     /// with the insertion point if not found.
     fn search_index_binary_search(indices: &ArrayRef, needle: usize) -> VortexResult<SearchResult> {
         if indices.is_canonical() {
-            #[expect(deprecated)]
-            let primitive = indices.to_primitive();
+            let mut ctx = LEGACY_SESSION.create_execution_ctx();
+            let primitive = indices
+                .clone()
+                .execute::<PrimitiveArray>(&mut ctx)
+                .vortex_expect("to_primitive failed");
             match_each_integer_ptype!(primitive.ptype(), |T| {
                 let Ok(needle) = T::try_from(needle) else {
                     // If the needle is not of type T, then it cannot possibly be in this array.
@@ -1121,10 +1123,10 @@ mod test {
     use vortex_buffer::buffer;
     use vortex_mask::Mask;
 
+    use vortex_error::VortexExpect as _;
+
     use crate::IntoArray;
     use crate::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use crate::ToCanonical as _;
     use crate::VortexSessionExecute;
     use crate::assert_arrays_eq;
     use crate::patches::Patches;
@@ -1176,10 +1178,16 @@ mod test {
             )
             .unwrap()
             .unwrap();
-        #[expect(deprecated)]
-        let primitive_values = taken.values().to_primitive();
-        #[expect(deprecated)]
-        let primitive_indices = taken.indices().to_primitive();
+        let primitive_values = taken
+            .values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .vortex_expect("to_primitive failed");
+        let primitive_indices = taken
+            .indices()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .vortex_expect("to_primitive failed");
         assert_eq!(taken.array_len(), 2);
         assert_arrays_eq!(
             primitive_values,
@@ -1221,8 +1229,11 @@ mod test {
             .unwrap()
             .unwrap();
 
-        #[expect(deprecated)]
-        let primitive_values = taken.values().to_primitive();
+        let primitive_values = taken
+            .values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .vortex_expect("to_primitive failed");
         assert_eq!(taken.array_len(), 2);
         assert_arrays_eq!(
             primitive_values,
@@ -1523,8 +1534,11 @@ mod test {
         assert_arrays_eq!(masked.indices(), PrimitiveArray::from_iter([5u64, 8]));
 
         // Values should be the null and 300
-        #[expect(deprecated)]
-        let masked_values = masked.values().to_primitive();
+        let masked_values = masked
+            .values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .vortex_expect("to_primitive failed");
         assert_eq!(masked_values.len(), 2);
         assert!(
             !masked_values
@@ -1703,8 +1717,11 @@ mod test {
         )
         .unwrap();
 
-        #[expect(deprecated)]
-        let values = patches.values().to_primitive();
+        let values = patches
+            .values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .vortex_expect("to_primitive failed");
         assert_eq!(
             i32::try_from(
                 &values

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -384,6 +384,7 @@ mod tests {
         #[case] upper_strict: StrictComparison,
         #[case] expected: Vec<u64>,
     ) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let lower = buffer![0, 0, 0, 0, 2].into_array();
         let array = buffer![1, 0, 1, 0, 1].into_array();
         let upper = buffer![2, 1, 1, 0, 0].into_array();
@@ -397,7 +398,7 @@ mod tests {
                 lower_strict,
                 upper_strict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap()
         .to_bool();
@@ -408,6 +409,7 @@ mod tests {
 
     #[test]
     fn test_constants() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let lower = buffer![0, 0, 2, 0, 2].into_array();
         let array = buffer![1, 0, 1, 0, 1].into_array();
 
@@ -427,7 +429,7 @@ mod tests {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::NonStrict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap()
         .to_bool();
@@ -446,7 +448,7 @@ mod tests {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::NonStrict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap()
         .to_bool();
@@ -465,7 +467,7 @@ mod tests {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::NonStrict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap()
         .to_bool();
@@ -475,6 +477,7 @@ mod tests {
 
     #[test]
     fn test_between_decimal() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = buffer![100i128, 200i128, 300i128, 400i128];
         let decimal_type = DecimalDType::new(3, 2);
         let array = DecimalArray::new(values, decimal_type, Validity::NonNullable).into_array();
@@ -507,7 +510,7 @@ mod tests {
                 lower_strict: StrictComparison::Strict,
                 upper_strict: StrictComparison::NonStrict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap();
         assert_arrays_eq!(
@@ -524,7 +527,7 @@ mod tests {
                 lower_strict: StrictComparison::NonStrict,
                 upper_strict: StrictComparison::Strict,
             },
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap();
         assert_arrays_eq!(

--- a/vortex-array/src/scalar_fn/fns/binary/boolean.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/boolean.rs
@@ -124,27 +124,28 @@ mod tests {
         BoolArray::from_iter([Some(true), Some(true), Some(false), Some(false)]).into_array(),
     )]
     fn test_or(#[case] lhs: ArrayRef, #[case] rhs: ArrayRef) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let r = lhs.binary(rhs, Operator::Or).unwrap();
         #[expect(deprecated)]
         let r = r.to_bool().into_array();
 
         let v0 = r
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .as_bool()
             .value();
         let v1 = r
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .as_bool()
             .value();
         let v2 = r
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap()
             .as_bool()
             .value();
         let v3 = r
-            .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(3, &mut ctx)
             .unwrap()
             .as_bool()
             .value();
@@ -165,30 +166,31 @@ mod tests {
         BoolArray::from_iter([Some(true), Some(true), Some(false), Some(false)]).into_array(),
     )]
     fn test_and(#[case] lhs: ArrayRef, #[case] rhs: ArrayRef) {
-        #[expect(deprecated)]
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let r = lhs
             .binary(rhs, Operator::And)
             .unwrap()
-            .to_bool()
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap()
             .into_array();
 
         let v0 = r
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap()
             .as_bool()
             .value();
         let v1 = r
-            .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(1, &mut ctx)
             .unwrap()
             .as_bool()
             .value();
         let v2 = r
-            .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(2, &mut ctx)
             .unwrap()
             .as_bool()
             .value();
         let v3 = r
-            .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(3, &mut ctx)
             .unwrap()
             .as_bool()
             .value();

--- a/vortex-array/src/scalar_fn/fns/binary/compare.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/compare.rs
@@ -349,6 +349,7 @@ mod tests {
 
     #[test]
     fn constant_compare() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let left = ConstantArray::new(Scalar::from(2u32), 10);
         let right = ConstantArray::new(Scalar::from(10u32), 10);
 
@@ -358,7 +359,7 @@ mod tests {
             .unwrap();
         assert_eq!(result.len(), 10);
         let scalar = result
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(0, &mut ctx)
             .unwrap();
         assert_eq!(scalar.as_bool().value(), Some(false));
     }
@@ -539,6 +540,7 @@ mod tests {
 
     #[test]
     fn test_empty_list() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let list = ListViewArray::new(
             BoolArray::from_iter(Vec::<bool>::new()).into_array(),
             buffer![0i32, 0i32, 0i32].into_array(),
@@ -553,19 +555,19 @@ mod tests {
             .unwrap();
         assert!(
             result
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap()
                 .is_valid()
         );
         assert!(
             result
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(1, &mut ctx)
                 .unwrap()
                 .is_valid()
         );
         assert!(
             result
-                .execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(2, &mut ctx)
                 .unwrap()
                 .is_valid()
         );

--- a/vortex-array/src/scalar_fn/fns/binary/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/mod.rs
@@ -450,6 +450,7 @@ mod tests {
     /// using `make_comparator` instead of Arrow's `cmp` functions which don't support nested types.
     #[test]
     fn test_struct_comparison() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         use crate::IntoArray;
         use crate::arrays::StructArray;
 
@@ -497,7 +498,7 @@ mod tests {
         let result_equal = lhs_struct.binary(rhs_struct_equal, Operator::Eq).unwrap();
         assert_eq!(
             result_equal
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .vortex_expect("value"),
             Scalar::bool(true, Nullability::NonNullable),
             "Equal structs should be equal"
@@ -508,7 +509,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             result_different
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .vortex_expect("value"),
             Scalar::bool(false, Nullability::NonNullable),
             "Different structs should not be equal"

--- a/vortex-array/src/scalar_fn/fns/binary/numeric.rs
+++ b/vortex-array/src/scalar_fn/fns/binary/numeric.rs
@@ -87,13 +87,14 @@ mod test {
     use crate::scalar_fn::fns::operators::Operator;
 
     fn sub_scalar(array: &ArrayRef, scalar: impl Into<Scalar>) -> VortexResult<ArrayRef> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         array
             .binary(
                 ConstantArray::new(scalar, array.len()).into_array(),
                 Operator::Sub,
             )
             .and_then(|a| {
-                a.execute::<RecursiveCanonical>(&mut LEGACY_SESSION.create_execution_ctx())
+                a.execute::<RecursiveCanonical>(&mut ctx)
             })
             .map(|a| a.0.into_array())
     }

--- a/vortex-array/src/scalar_fn/fns/case_when.rs
+++ b/vortex-array/src/scalar_fn/fns/case_when.rs
@@ -1115,6 +1115,7 @@ mod tests {
 
     #[test]
     fn test_evaluate_nary_string_output() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Exercises merge_case_branches with a non-primitive (Utf8) builder.
         let test_array =
             StructArray::from_fields(&[("value", buffer![1i32, 2, 3, 4].into_array())])
@@ -1134,19 +1135,19 @@ mod tests {
 
         let result = evaluate_expr(&expr, &test_array);
         assert_eq!(
-            result.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?,
+            result.execute_scalar(0, &mut ctx)?,
             Scalar::utf8("low", Nullability::NonNullable)
         );
         assert_eq!(
-            result.execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())?,
+            result.execute_scalar(1, &mut ctx)?,
             Scalar::utf8("low", Nullability::NonNullable)
         );
         assert_eq!(
-            result.execute_scalar(2, &mut LEGACY_SESSION.create_execution_ctx())?,
+            result.execute_scalar(2, &mut ctx)?,
             Scalar::utf8("high", Nullability::NonNullable)
         );
         assert_eq!(
-            result.execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())?,
+            result.execute_scalar(3, &mut ctx)?,
             Scalar::utf8("high", Nullability::NonNullable)
         );
         Ok(())

--- a/vortex-array/src/scalar_fn/fns/is_not_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_not_null.rs
@@ -159,6 +159,7 @@ mod tests {
 
     #[test]
     fn evaluate_mask() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let test_array =
             PrimitiveArray::from_option_iter(vec![Some(1), None, Some(2), None, Some(3)])
                 .into_array();
@@ -172,7 +173,7 @@ mod tests {
         for (i, expected_value) in expected.iter().enumerate() {
             assert_eq!(
                 result
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .unwrap(),
                 Scalar::bool(*expected_value, Nullability::NonNullable)
             );
@@ -181,6 +182,7 @@ mod tests {
 
     #[test]
     fn evaluate_all_true() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let test_array = buffer![1, 2, 3, 4, 5].into_array();
 
         let result = test_array.clone().apply(&is_not_null(root())).unwrap();
@@ -189,7 +191,7 @@ mod tests {
         for i in 0..result.len() {
             assert_eq!(
                 result
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .unwrap(),
                 Scalar::bool(true, Nullability::NonNullable)
             );
@@ -198,6 +200,7 @@ mod tests {
 
     #[test]
     fn evaluate_all_false() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let test_array =
             PrimitiveArray::from_option_iter(vec![None::<i32>, None, None, None, None])
                 .into_array();
@@ -208,7 +211,7 @@ mod tests {
         for i in 0..result.len() {
             assert_eq!(
                 result
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .unwrap(),
                 Scalar::bool(false, Nullability::NonNullable)
             );
@@ -217,6 +220,7 @@ mod tests {
 
     #[test]
     fn evaluate_struct() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let test_array = StructArray::from_fields(&[(
             "a",
             PrimitiveArray::from_option_iter(vec![Some(1), None, Some(2), None, Some(3)])
@@ -237,7 +241,7 @@ mod tests {
         for (i, expected_value) in expected.iter().enumerate() {
             assert_eq!(
                 result
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .unwrap(),
                 Scalar::bool(*expected_value, Nullability::NonNullable)
             );

--- a/vortex-array/src/scalar_fn/fns/is_null.rs
+++ b/vortex-array/src/scalar_fn/fns/is_null.rs
@@ -160,6 +160,7 @@ mod tests {
 
     #[test]
     fn evaluate_mask() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let test_array =
             PrimitiveArray::from_option_iter(vec![Some(1), None, Some(2), None, Some(3)])
                 .into_array();
@@ -173,7 +174,7 @@ mod tests {
         for (i, expected_value) in expected.iter().enumerate() {
             assert_eq!(
                 result
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .unwrap(),
                 Scalar::bool(*expected_value, Nullability::NonNullable)
             );
@@ -182,6 +183,7 @@ mod tests {
 
     #[test]
     fn evaluate_all_false() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let test_array = buffer![1, 2, 3, 4, 5].into_array();
 
         let result = test_array.clone().apply(&is_null(root())).unwrap();
@@ -191,7 +193,7 @@ mod tests {
         for i in 0..result.len() {
             assert_eq!(
                 result
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .unwrap(),
                 Scalar::bool(false, Nullability::NonNullable)
             );
@@ -200,6 +202,7 @@ mod tests {
 
     #[test]
     fn evaluate_all_true() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let test_array =
             PrimitiveArray::from_option_iter(vec![None::<i32>, None, None, None, None])
                 .into_array();
@@ -211,7 +214,7 @@ mod tests {
         for i in 0..result.len() {
             assert_eq!(
                 result
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .unwrap(),
                 Scalar::bool(true, Nullability::NonNullable)
             );
@@ -220,6 +223,7 @@ mod tests {
 
     #[test]
     fn evaluate_struct() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let test_array = StructArray::from_fields(&[(
             "a",
             PrimitiveArray::from_option_iter(vec![Some(1), None, Some(2), None, Some(3)])
@@ -240,7 +244,7 @@ mod tests {
         for (i, expected_value) in expected.iter().enumerate() {
             assert_eq!(
                 result
-                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(i, &mut ctx)
                     .unwrap(),
                 Scalar::bool(*expected_value, Nullability::NonNullable)
             );

--- a/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/list_contains/mod.rs
@@ -501,18 +501,19 @@ mod tests {
 
     #[test]
     pub fn test_one() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = test_array();
 
         let expr = list_contains(root(), lit(1));
         let item = arr.apply(&expr).unwrap();
 
         assert_eq!(
-            item.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            item.execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::bool(true, Nullability::Nullable)
         );
         assert_eq!(
-            item.execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            item.execute_scalar(1, &mut ctx)
                 .unwrap(),
             Scalar::bool(false, Nullability::Nullable)
         );
@@ -520,18 +521,19 @@ mod tests {
 
     #[test]
     pub fn test_all() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = test_array();
 
         let expr = list_contains(root(), lit(2));
         let item = arr.apply(&expr).unwrap();
 
         assert_eq!(
-            item.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            item.execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::bool(true, Nullability::Nullable)
         );
         assert_eq!(
-            item.execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            item.execute_scalar(1, &mut ctx)
                 .unwrap(),
             Scalar::bool(true, Nullability::Nullable)
         );
@@ -539,18 +541,19 @@ mod tests {
 
     #[test]
     pub fn test_none() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = test_array();
 
         let expr = list_contains(root(), lit(4));
         let item = arr.apply(&expr).unwrap();
 
         assert_eq!(
-            item.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            item.execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::bool(false, Nullability::Nullable)
         );
         assert_eq!(
-            item.execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            item.execute_scalar(1, &mut ctx)
                 .unwrap(),
             Scalar::bool(false, Nullability::Nullable)
         );
@@ -558,6 +561,7 @@ mod tests {
 
     #[test]
     pub fn test_empty() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = ListArray::try_new(
             PrimitiveArray::from_iter(vec![1, 1, 2, 2, 2]).into_array(),
             PrimitiveArray::from_iter(vec![0, 5, 5]).into_array(),
@@ -570,12 +574,12 @@ mod tests {
         let item = arr.apply(&expr).unwrap();
 
         assert_eq!(
-            item.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            item.execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::bool(true, Nullability::Nullable)
         );
         assert_eq!(
-            item.execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
+            item.execute_scalar(1, &mut ctx)
                 .unwrap(),
             Scalar::bool(false, Nullability::Nullable)
         );
@@ -583,6 +587,7 @@ mod tests {
 
     #[test]
     pub fn test_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = ListArray::try_new(
             PrimitiveArray::from_iter(vec![1, 1, 2, 2, 2]).into_array(),
             PrimitiveArray::from_iter(vec![0, 5, 5]).into_array(),
@@ -595,13 +600,13 @@ mod tests {
         let item = arr.apply(&expr).unwrap();
 
         assert_eq!(
-            item.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+            item.execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::bool(true, Nullability::Nullable)
         );
         assert!(
             !item
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
+                .is_valid(1, &mut ctx)
                 .unwrap()
         );
     }
@@ -679,6 +684,7 @@ mod tests {
 
     #[test]
     pub fn test_constant_scalars() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = test_array();
 
         // Both list and needle are constants - should use scalar optimization
@@ -693,7 +699,7 @@ mod tests {
         let result = arr.clone().apply(&expr).unwrap();
         assert_eq!(
             result
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::bool(true, Nullability::NonNullable)
         );
@@ -703,7 +709,7 @@ mod tests {
         let result = arr.apply(&expr).unwrap();
         assert_eq!(
             result
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, &mut ctx)
                 .unwrap(),
             Scalar::bool(false, Nullability::NonNullable)
         );

--- a/vortex-array/src/search_sorted.rs
+++ b/vortex-array/src/search_sorted.rs
@@ -266,7 +266,8 @@ fn search_sorted_side_idx<F: FnMut(usize) -> VortexResult<Ordering>>(
 
 impl IndexOrd<Scalar> for ArrayRef {
     fn index_cmp(&self, idx: usize, elem: &Scalar) -> VortexResult<Option<Ordering>> {
-        let scalar_a = self.execute_scalar(idx, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let scalar_a = self.execute_scalar(idx, &mut ctx)?;
         Ok(scalar_a.partial_cmp(elem))
     }
 

--- a/vortex-array/src/stats/stats_set.rs
+++ b/vortex-array/src/stats/stats_set.rs
@@ -877,6 +877,7 @@ mod test {
 
     #[test]
     fn merge_unordered() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array =
             PrimitiveArray::from_option_iter([Some(1), None, Some(2), Some(42), Some(10000), None]);
         let all_stats = all::<Stat>()
@@ -885,7 +886,7 @@ mod test {
             .collect_vec();
         array
             .statistics()
-            .compute_all(&all_stats, &mut LEGACY_SESSION.create_execution_ctx())
+            .compute_all(&all_stats, &mut ctx)
             .unwrap();
 
         let stats = array.statistics().to_owned();

--- a/vortex-array/src/test_harness.rs
+++ b/vortex-array/src/test_harness.rs
@@ -27,10 +27,11 @@ pub fn check_metadata(name: &str, metadata: &[u8]) {
 
 /// Outputs the indices of the true values in a BoolArray
 pub fn to_int_indices(indices_bits: BoolArray) -> VortexResult<Vec<u64>> {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let buffer = indices_bits.to_bit_buffer();
     let mask = indices_bits.as_ref().validity()?.to_mask(
         indices_bits.as_ref().len(),
-        &mut LEGACY_SESSION.create_execution_ctx(),
+        &mut ctx,
     )?;
     Ok(buffer
         .iter()

--- a/vortex-array/src/validity.rs
+++ b/vortex-array/src/validity.rs
@@ -131,11 +131,12 @@ impl Validity {
     /// Returns whether the `index` item is valid.
     #[inline]
     pub fn is_valid(&self, index: usize) -> VortexResult<bool> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         Ok(match self {
             Self::NonNullable | Self::AllValid => true,
             Self::AllInvalid => false,
             Self::Array(a) => a
-                .execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(index, &mut ctx)
                 .vortex_expect("Validity array must support execute_scalar")
                 .as_bool()
                 .value()
@@ -157,12 +158,13 @@ impl Validity {
     }
 
     pub fn take(&self, indices: &ArrayRef) -> VortexResult<Self> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         match self {
             Self::NonNullable => {
                 let len = indices.len();
                 let indices_mask = indices
                     .validity()?
-                    .to_mask(len, &mut LEGACY_SESSION.create_execution_ctx())?;
+                    .to_mask(len, &mut ctx)?;
                 match indices_mask.bit_buffer() {
                     AllOr::All => {
                         if indices.dtype().is_nullable() {
@@ -179,7 +181,7 @@ impl Validity {
                 let len = indices.len();
                 let indices_mask = indices
                     .validity()?
-                    .to_mask(len, &mut LEGACY_SESSION.create_execution_ctx())?;
+                    .to_mask(len, &mut ctx)?;
                 match indices_mask.bit_buffer() {
                     AllOr::All => Ok(Self::AllValid),
                     AllOr::None => Ok(Self::AllInvalid),
@@ -363,6 +365,7 @@ impl Validity {
     /// Convert into a non-nullable variant
     #[inline]
     pub fn into_non_nullable(self, len: usize) -> Option<Validity> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         match self {
             _ if len == 0 => Some(Validity::NonNullable),
             Self::NonNullable => Some(Self::NonNullable),
@@ -371,7 +374,7 @@ impl Validity {
             Self::Array(is_valid) => {
                 is_valid
                     .statistics()
-                    .compute_min::<bool>(&mut LEGACY_SESSION.create_execution_ctx())
+                    .compute_min::<bool>(&mut ctx)
                     .vortex_expect("validity array must support min")
                     .then(|| {
                         // min true => all true
@@ -395,10 +398,11 @@ impl Validity {
     /// Create Validity by copying the given array's validity.
     #[inline]
     pub fn copy_from_array(array: &ArrayRef) -> VortexResult<Self> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let len = array.len();
         let mask = array
             .validity()?
-            .to_mask(len, &mut LEGACY_SESSION.create_execution_ctx())?;
+            .to_mask(len, &mut ctx)?;
         Ok(Validity::from_mask(mask, array.dtype().nullability()))
     }
 
@@ -613,7 +617,7 @@ mod tests {
                     0,
                     &indices,
                     &patches,
-                    &mut LEGACY_SESSION.create_execution_ctx(),
+                    &mut ctx,
                 )
                 .unwrap()
                 .mask_eq(&expected, &mut ctx)
@@ -624,13 +628,14 @@ mod tests {
     #[test]
     #[should_panic]
     fn out_of_bounds_patch() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         Validity::NonNullable
             .patch(
                 2,
                 0,
                 &buffer![4].into_array(),
                 &Validity::AllInvalid,
-                &mut LEGACY_SESSION.create_execution_ctx(),
+                &mut ctx,
             )
             .unwrap();
     }

--- a/vortex-array/src/variants.rs
+++ b/vortex-array/src/variants.rs
@@ -134,17 +134,19 @@ impl PrimitiveTyped<'_> {
 
     /// Return the primitive value at the given index.
     pub fn value(&self, idx: usize) -> VortexResult<Option<PValue>> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         self.0
-            .is_valid(idx, &mut LEGACY_SESSION.create_execution_ctx())?
+            .is_valid(idx, &mut ctx)?
             .then(|| self.value_unchecked(idx))
             .transpose()
     }
 
     /// Return the primitive value at the given index, ignoring nullability.
     pub fn value_unchecked(&self, idx: usize) -> VortexResult<PValue> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         Ok(self
             .0
-            .execute_scalar(idx, &mut LEGACY_SESSION.create_execution_ctx())?
+            .execute_scalar(idx, &mut ctx)?
             .as_primitive()
             .pvalue()
             .unwrap_or_else(|| PValue::zero(&self.ptype())))
@@ -165,9 +167,10 @@ impl IndexOrd<Option<PValue>> for PrimitiveTyped<'_> {
 // TODO(ngates): add generics to the `value` function and implement this over T.
 impl IndexOrd<PValue> for PrimitiveTyped<'_> {
     fn index_cmp(&self, idx: usize, elem: &PValue) -> VortexResult<Option<Ordering>> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         assert!(
             self.0
-                .all_valid(&mut LEGACY_SESSION.create_execution_ctx())?
+                .all_valid(&mut ctx)?
         );
         let value = self.value_unchecked(idx)?;
         Ok(value.partial_cmp(elem))


### PR DESCRIPTION
We want all method that work with buffers to have an execution code.