### PR TITLE
break: remove deprecated methods and plumb ExecutionCtx

### DIFF
--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -143,8 +143,8 @@ fn compress_rd<T: ALPRDFloat + NativePType>(bencher: Bencher, args: (usize, f64)
     let encoder = RDEncoder::new(primitive.as_slice::<T>());
 
     bencher
-        .with_inputs(|| (&primitive, &encoder))
-        .bench_refs(|(primitive, encoder)| encoder.encode(primitive.as_view()))
+        .with_inputs(|| (&primitive, &encoder, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(primitive, encoder, ctx)| encoder.encode(primitive.as_view(), ctx))
 }
 
 #[divan::bench(types = [f32, f64], args = RD_BENCH_ARGS)]
@@ -152,7 +152,7 @@ fn decompress_rd<T: ALPRDFloat + NativePType>(bencher: Bencher, args: (usize, f6
     let (n, fraction_patch) = args;
     let primitive = make_rd_array::<T>(n, fraction_patch);
     let encoder = RDEncoder::new(primitive.as_slice::<T>());
-    let encoded = encoder.encode(primitive.as_view());
+    let encoded = encoder.encode(primitive.as_view(), &mut LEGACY_SESSION.create_execution_ctx());
 
     bencher
         .with_inputs(|| (&encoded, LEGACY_SESSION.create_execution_ctx()))

--- a/encodings/alp/benches/alp_compress.rs
+++ b/encodings/alp/benches/alp_compress.rs
@@ -152,7 +152,10 @@ fn decompress_rd<T: ALPRDFloat + NativePType>(bencher: Bencher, args: (usize, f6
     let (n, fraction_patch) = args;
     let primitive = make_rd_array::<T>(n, fraction_patch);
     let encoder = RDEncoder::new(primitive.as_slice::<T>());
-    let encoded = encoder.encode(primitive.as_view(), &mut LEGACY_SESSION.create_execution_ctx());
+    let encoded = encoder.encode(
+        primitive.as_view(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    );
 
     bencher
         .with_inputs(|| (&encoded, LEGACY_SESSION.create_execution_ctx()))

--- a/encodings/alp/public-api.lock
+++ b/encodings/alp/public-api.lock
@@ -146,7 +146,7 @@ impl vortex_alp::ALPRD
 
 pub unsafe fn vortex_alp::ALPRD::new_unchecked(dtype: vortex_array::dtype::DType, left_parts: vortex_array::array::erased::ArrayRef, left_parts_dictionary: vortex_buffer::buffer::Buffer<u16>, right_parts: vortex_array::array::erased::ArrayRef, right_bit_width: u8, left_parts_patches: core::option::Option<vortex_array::patches::Patches>) -> vortex_alp::ALPRDArray
 
-pub fn vortex_alp::ALPRD::try_new(dtype: vortex_array::dtype::DType, left_parts: vortex_array::array::erased::ArrayRef, left_parts_dictionary: vortex_buffer::buffer::Buffer<u16>, right_parts: vortex_array::array::erased::ArrayRef, right_bit_width: u8, left_parts_patches: core::option::Option<vortex_array::patches::Patches>) -> vortex_error::VortexResult<vortex_alp::ALPRDArray>
+pub fn vortex_alp::ALPRD::try_new(dtype: vortex_array::dtype::DType, left_parts: vortex_array::array::erased::ArrayRef, left_parts_dictionary: vortex_buffer::buffer::Buffer<u16>, right_parts: vortex_array::array::erased::ArrayRef, right_bit_width: u8, left_parts_patches: core::option::Option<vortex_array::patches::Patches>, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_alp::ALPRDArray>
 
 impl core::clone::Clone for vortex_alp::ALPRD
 
@@ -380,7 +380,7 @@ pub struct vortex_alp::RDEncoder
 
 impl vortex_alp::RDEncoder
 
-pub fn vortex_alp::RDEncoder::encode(&self, array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>) -> vortex_alp::ALPRDArray
+pub fn vortex_alp::RDEncoder::encode(&self, array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_alp::ALPRDArray
 
 pub fn vortex_alp::RDEncoder::from_parts(right_bit_width: u8, codes: alloc::vec::Vec<u16>) -> Self
 

--- a/encodings/alp/src/alp/array.rs
+++ b/encodings/alp/src/alp/array.rs
@@ -526,8 +526,6 @@ mod tests {
     use vortex_array::Canonical;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
@@ -785,6 +783,7 @@ mod tests {
     #[case(1000, 200)]
     #[case(2048, 512)]
     fn test_sliced_to_primitive(#[case] size: usize, #[case] slice_start: usize) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values: Vec<Option<f64>> = (0..size)
             .map(|i| {
                 if i % 5 == 0 {
@@ -798,19 +797,13 @@ mod tests {
             .collect();
 
         let array = PrimitiveArray::from_option_iter(values.clone());
-        let encoded = alp_encode(
-            array.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let encoded = alp_encode(array.as_view(), None, &mut ctx).unwrap();
 
         let slice_end = size - slice_start;
         let slice_len = slice_end - slice_start;
         let sliced_encoded = encoded.slice(slice_start..slice_end).unwrap();
 
-        #[expect(deprecated)]
-        let result_primitive = sliced_encoded.to_primitive();
+        let result_primitive = sliced_encoded.execute::<PrimitiveArray>(&mut ctx).unwrap();
 
         for idx in 0..slice_len {
             let expected_value = values[slice_start + idx];
@@ -819,10 +812,7 @@ mod tests {
                 .as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(
-                    result_primitive.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx(),
-                )
+                .to_mask(result_primitive.as_ref().len(), &mut ctx)
                 .unwrap()
                 .value(idx);
             assert_eq!(

--- a/encodings/alp/src/alp/compress.rs
+++ b/encodings/alp/src/alp/compress.rs
@@ -136,8 +136,6 @@ mod tests {
     use f64::consts::E;
     use f64::consts::PI;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::assert_arrays_eq;
     use vortex_array::dtype::NativePType;
@@ -273,16 +271,14 @@ mod tests {
 
     #[test]
     fn roundtrips_all_null() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let original =
             PrimitiveArray::new(buffer![195.26274f64, PI, -48.815685], Validity::AllInvalid);
-        let alp_arr = alp_encode(
-            original.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
-        #[expect(deprecated)]
-        let decompressed = alp_arr.into_array().to_primitive();
+        let alp_arr = alp_encode(original.as_view(), None, &mut ctx).unwrap();
+        let decompressed = alp_arr
+            .into_array()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
 
         assert_eq!(
             // The second and third values become exceptions and are replaced
@@ -295,18 +291,17 @@ mod tests {
 
     #[test]
     fn non_finite_numbers() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let original = PrimitiveArray::new(
             buffer![0.0f32, -0.0, f32::NAN, f32::NEG_INFINITY, f32::INFINITY],
             Validity::NonNullable,
         );
-        let encoded = alp_encode(
-            original.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
-        #[expect(deprecated)]
-        let decoded = encoded.as_array().to_primitive();
+        let encoded = alp_encode(original.as_view(), None, &mut ctx).unwrap();
+        let decoded = encoded
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         for idx in 0..original.len() {
             let decoded_val = decoded.as_slice::<f32>()[idx];
             let original_val = original.as_slice::<f32>()[idx];
@@ -319,6 +314,7 @@ mod tests {
 
     #[test]
     fn test_chunk_offsets() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut values = vec![1.0f64; 3072];
 
         values[1023] = PI;
@@ -326,118 +322,141 @@ mod tests {
         values[1025] = PI;
 
         let array = PrimitiveArray::new(Buffer::from(values), Validity::NonNullable);
-        let encoded = alp_encode(
-            array.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let encoded = alp_encode(array.as_view(), None, &mut ctx).unwrap();
         let patches = encoded.patches().unwrap();
 
-        #[expect(deprecated)]
-        let chunk_offsets = patches.chunk_offsets().clone().unwrap().to_primitive();
+        let chunk_offsets = patches
+            .chunk_offsets()
+            .clone()
+            .unwrap()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_offsets = PrimitiveArray::from_iter(vec![0u64, 1, 3]);
         assert_arrays_eq!(chunk_offsets, expected_offsets);
 
-        #[expect(deprecated)]
-        let patch_indices = patches.indices().to_primitive();
+        let patch_indices = patches
+            .indices()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_indices = PrimitiveArray::from_iter(vec![1023u64, 1024, 1025]);
         assert_arrays_eq!(patch_indices, expected_indices);
 
-        #[expect(deprecated)]
-        let patch_values = patches.values().to_primitive();
+        let patch_values = patches
+            .values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_values = PrimitiveArray::from_iter(vec![PI, E, PI]);
         assert_arrays_eq!(patch_values, expected_values);
     }
 
     #[test]
     fn test_chunk_offsets_no_patches_in_middle() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut values = vec![1.0f64; 3072];
         values[0] = PI;
         values[2048] = E;
 
         let array = PrimitiveArray::new(Buffer::from(values), Validity::NonNullable);
-        let encoded = alp_encode(
-            array.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let encoded = alp_encode(array.as_view(), None, &mut ctx).unwrap();
         let patches = encoded.patches().unwrap();
 
-        #[expect(deprecated)]
-        let chunk_offsets = patches.chunk_offsets().clone().unwrap().to_primitive();
+        let chunk_offsets = patches
+            .chunk_offsets()
+            .clone()
+            .unwrap()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_offsets = PrimitiveArray::from_iter(vec![0u64, 1, 1]);
         assert_arrays_eq!(chunk_offsets, expected_offsets);
 
-        #[expect(deprecated)]
-        let patch_indices = patches.indices().to_primitive();
+        let patch_indices = patches
+            .indices()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_indices = PrimitiveArray::from_iter(vec![0u64, 2048]);
         assert_arrays_eq!(patch_indices, expected_indices);
 
-        #[expect(deprecated)]
-        let patch_values = patches.values().to_primitive();
+        let patch_values = patches
+            .values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_values = PrimitiveArray::from_iter(vec![PI, E]);
         assert_arrays_eq!(patch_values, expected_values);
     }
 
     #[test]
     fn test_chunk_offsets_trailing_empty_chunks() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut values = vec![1.0f64; 3072];
         values[0] = PI;
 
         let array = PrimitiveArray::new(Buffer::from(values), Validity::NonNullable);
-        let encoded = alp_encode(
-            array.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let encoded = alp_encode(array.as_view(), None, &mut ctx).unwrap();
         let patches = encoded.patches().unwrap();
 
-        #[expect(deprecated)]
-        let chunk_offsets = patches.chunk_offsets().clone().unwrap().to_primitive();
+        let chunk_offsets = patches
+            .chunk_offsets()
+            .clone()
+            .unwrap()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_offsets = PrimitiveArray::from_iter(vec![0u64, 1, 1]);
         assert_arrays_eq!(chunk_offsets, expected_offsets);
 
-        #[expect(deprecated)]
-        let patch_indices = patches.indices().to_primitive();
+        let patch_indices = patches
+            .indices()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_indices = PrimitiveArray::from_iter(vec![0u64]);
         assert_arrays_eq!(patch_indices, expected_indices);
 
-        #[expect(deprecated)]
-        let patch_values = patches.values().to_primitive();
+        let patch_values = patches
+            .values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_values = PrimitiveArray::from_iter(vec![PI]);
         assert_arrays_eq!(patch_values, expected_values);
     }
 
     #[test]
     fn test_chunk_offsets_single_chunk() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut values = vec![1.0f64; 512];
         values[0] = PI;
         values[100] = E;
 
         let array = PrimitiveArray::new(Buffer::from(values), Validity::NonNullable);
-        let encoded = alp_encode(
-            array.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let encoded = alp_encode(array.as_view(), None, &mut ctx).unwrap();
         let patches = encoded.patches().unwrap();
 
-        #[expect(deprecated)]
-        let chunk_offsets = patches.chunk_offsets().clone().unwrap().to_primitive();
+        let chunk_offsets = patches
+            .chunk_offsets()
+            .clone()
+            .unwrap()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_offsets = PrimitiveArray::from_iter(vec![0u64]);
         assert_arrays_eq!(chunk_offsets, expected_offsets);
 
-        #[expect(deprecated)]
-        let patch_indices = patches.indices().to_primitive();
+        let patch_indices = patches
+            .indices()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_indices = PrimitiveArray::from_iter(vec![0u64, 100]);
         assert_arrays_eq!(patch_indices, expected_indices);
 
-        #[expect(deprecated)]
-        let patch_values = patches.values().to_primitive();
+        let patch_values = patches
+            .values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected_values = PrimitiveArray::from_iter(vec![PI, E]);
         assert_arrays_eq!(patch_values, expected_values);
     }
@@ -526,21 +545,16 @@ mod tests {
 
     #[test]
     fn test_slice_half_chunk_nullable_roundtrip() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = (0..1024)
             .map(|i| if i % 3 == 0 { None } else { Some(2.5f32) })
             .collect::<Vec<_>>();
 
         let original = PrimitiveArray::from_option_iter(values);
-        let encoded = alp_encode(
-            original.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let encoded = alp_encode(original.as_view(), None, &mut ctx).unwrap();
 
         let sliced_alp = encoded.slice(512..1024).unwrap();
-        #[expect(deprecated)]
-        let decoded = sliced_alp.to_primitive();
+        let decoded = sliced_alp.execute::<PrimitiveArray>(&mut ctx).unwrap();
 
         let expected_slice = original.slice(512..1024).unwrap();
         assert_arrays_eq!(decoded, expected_slice);

--- a/encodings/alp/src/alp/compute/cast.rs
+++ b/encodings/alp/src/alp/compute/cast.rs
@@ -61,8 +61,6 @@ mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
@@ -80,14 +78,10 @@ mod tests {
 
     #[test]
     fn issue_5766_test_cast_alp_with_patches_to_nullable() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = buffer![1.234f32, f32::NAN, 2.345, f32::INFINITY, 3.456].into_array();
-        #[expect(deprecated)]
-        let values_primitive = values.to_primitive();
-        let alp = alp_encode(
-            values_primitive.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )?;
+        let values_primitive = values.clone().execute::<PrimitiveArray>(&mut ctx)?;
+        let alp = alp_encode(values_primitive.as_view(), None, &mut ctx)?;
 
         assert!(
             alp.patches().is_some(),
@@ -99,8 +93,7 @@ mod tests {
 
         let expected = values.cast(nullable_dtype)?;
 
-        #[expect(deprecated)]
-        let casted_prim = casted.to_canonical()?.into_primitive();
+        let casted_prim = casted.execute::<PrimitiveArray>(&mut ctx)?;
         assert_arrays_eq!(casted_prim, expected);
 
         Ok(())
@@ -108,14 +101,10 @@ mod tests {
 
     #[test]
     fn test_cast_alp_f32_to_f64() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = buffer![1.5f32, 2.5, 3.5, 4.5].into_array();
-        #[expect(deprecated)]
-        let values_primitive = values.to_primitive();
-        let alp = alp_encode(
-            values_primitive.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )?;
+        let values_primitive = values.execute::<PrimitiveArray>(&mut ctx)?;
+        let alp = alp_encode(values_primitive.as_view(), None, &mut ctx)?;
 
         let casted = alp
             .into_array()
@@ -125,8 +114,7 @@ mod tests {
             &DType::Primitive(PType::F64, Nullability::NonNullable)
         );
 
-        #[expect(deprecated)]
-        let decoded = casted.to_canonical()?.into_primitive();
+        let decoded = casted.execute::<PrimitiveArray>(&mut ctx)?;
         let values = decoded.as_slice::<f64>();
         assert_eq!(values.len(), 4);
         assert!((values[0] - 1.5).abs() < f64::EPSILON);
@@ -137,14 +125,10 @@ mod tests {
 
     #[test]
     fn test_cast_alp_to_int() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = buffer![1.0f32, 2.0, 3.0, 4.0].into_array();
-        #[expect(deprecated)]
-        let values_primitive = values.to_primitive();
-        let alp = alp_encode(
-            values_primitive.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )?;
+        let values_primitive = values.execute::<PrimitiveArray>(&mut ctx)?;
+        let alp = alp_encode(values_primitive.as_view(), None, &mut ctx)?;
 
         let casted = alp
             .into_array()
@@ -154,8 +138,7 @@ mod tests {
             &DType::Primitive(PType::I32, Nullability::NonNullable)
         );
 
-        #[expect(deprecated)]
-        let decoded = casted.to_canonical()?.into_primitive();
+        let decoded = casted.execute::<PrimitiveArray>(&mut ctx)?;
         assert_arrays_eq!(decoded, PrimitiveArray::from_iter([1i32, 2, 3, 4]));
 
         Ok(())
@@ -168,14 +151,10 @@ mod tests {
     #[case(buffer![42.42f64].into_array())]
     #[case(buffer![0.0f32, -1.5, 2.5, -3.5, 4.5].into_array())]
     fn test_cast_alp_conformance(#[case] array: vortex_array::ArrayRef) -> VortexResult<()> {
-        #[expect(deprecated)]
-        let array_primitive = array.to_primitive();
-        let alp = alp_encode(
-            array_primitive.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .vortex_expect("cannot fail");
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array_primitive = array.execute::<PrimitiveArray>(&mut ctx)?;
+        let alp = alp_encode(array_primitive.as_view(), None, &mut ctx)
+            .vortex_expect("cannot fail");
         test_cast_conformance(&alp.into_array());
 
         Ok(())

--- a/encodings/alp/src/alp/compute/cast.rs
+++ b/encodings/alp/src/alp/compute/cast.rs
@@ -153,8 +153,8 @@ mod tests {
     fn test_cast_alp_conformance(#[case] array: vortex_array::ArrayRef) -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array_primitive = array.execute::<PrimitiveArray>(&mut ctx)?;
-        let alp = alp_encode(array_primitive.as_view(), None, &mut ctx)
-            .vortex_expect("cannot fail");
+        let alp =
+            alp_encode(array_primitive.as_view(), None, &mut ctx).vortex_expect("cannot fail");
         test_cast_conformance(&alp.into_array());
 
         Ok(())

--- a/encodings/alp/src/alp/compute/compare.rs
+++ b/encodings/alp/src/alp/compute/compare.rs
@@ -153,8 +153,6 @@ mod tests {
     use rstest::rstest;
     use vortex_array::ArrayRef;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::ConstantArray;
@@ -185,16 +183,15 @@ mod tests {
 
     #[test]
     fn basic_comparison_test() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([1.234f32; 1025]);
-        let encoded = alp_encode(
-            array.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let encoded = alp_encode(array.as_view(), None, &mut ctx).unwrap();
         assert!(encoded.patches().is_none());
-        #[expect(deprecated)]
-        let encoded_prim = encoded.encoded().to_primitive();
+        let encoded_prim = encoded
+            .encoded()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         assert_eq!(encoded_prim.as_slice::<i32>(), vec![1234; 1025]);
 
         let r = alp_scalar_compare(encoded.as_view(), 1.3_f32, CompareOperator::Eq)
@@ -212,16 +209,15 @@ mod tests {
 
     #[test]
     fn comparison_with_unencodable_value() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([1.234f32; 1025]);
-        let encoded = alp_encode(
-            array.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let encoded = alp_encode(array.as_view(), None, &mut ctx).unwrap();
         assert!(encoded.patches().is_none());
-        #[expect(deprecated)]
-        let encoded_prim = encoded.encoded().to_primitive();
+        let encoded_prim = encoded
+            .encoded()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         assert_eq!(encoded_prim.as_slice::<i32>(), vec![1234; 1025]);
 
         let r_eq = alp_scalar_compare(encoded.as_view(), 1.234444_f32, CompareOperator::Eq)
@@ -239,16 +235,15 @@ mod tests {
 
     #[test]
     fn comparison_range() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([0.0605_f32; 10]);
-        let encoded = alp_encode(
-            array.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let encoded = alp_encode(array.as_view(), None, &mut ctx).unwrap();
         assert!(encoded.patches().is_none());
-        #[expect(deprecated)]
-        let encoded_prim = encoded.encoded().to_primitive();
+        let encoded_prim = encoded
+            .encoded()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         assert_eq!(encoded_prim.as_slice::<i32>(), vec![605; 10]);
 
         // !(0.0605_f32 >= 0.06051_f32);
@@ -282,16 +277,15 @@ mod tests {
 
     #[test]
     fn comparison_zeroes() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([0.0_f32; 10]);
-        let encoded = alp_encode(
-            array.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let encoded = alp_encode(array.as_view(), None, &mut ctx).unwrap();
         assert!(encoded.patches().is_none());
-        #[expect(deprecated)]
-        let encoded_prim = encoded.encoded().to_primitive();
+        let encoded_prim = encoded
+            .encoded()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         assert_eq!(encoded_prim.as_slice::<i32>(), vec![0; 10]);
 
         let r_gte =

--- a/encodings/alp/src/alp/compute/filter.rs
+++ b/encodings/alp/src/alp/compute/filter.rs
@@ -45,8 +45,6 @@ mod test {
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::compute::conformance::filter::test_filter_conformance;
@@ -64,14 +62,9 @@ mod test {
         11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0
     ].into_array())]
     fn test_filter_alp_conformance(#[case] array: ArrayRef) {
-        #[expect(deprecated)]
-        let array_primitive = array.to_primitive();
-        let alp = alp_encode(
-            array_primitive.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array_primitive = array.execute::<PrimitiveArray>(&mut ctx).unwrap();
+        let alp = alp_encode(array_primitive.as_view(), None, &mut ctx).unwrap();
         test_filter_conformance(&alp.into_array());
     }
 }

--- a/encodings/alp/src/alp/compute/mask.rs
+++ b/encodings/alp/src/alp/compute/mask.rs
@@ -57,8 +57,6 @@ mod test {
     use rstest::rstest;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
@@ -80,48 +78,34 @@ mod test {
         1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0
     ].into_array())]
     fn test_mask_alp_conformance(#[case] array: vortex_array::ArrayRef) {
-        #[expect(deprecated)]
-        let array_primitive = array.to_primitive();
-        let alp = alp_encode(
-            array_primitive.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array_primitive = array.execute::<PrimitiveArray>(&mut ctx).unwrap();
+        let alp = alp_encode(array_primitive.as_view(), None, &mut ctx).unwrap();
         test_mask_conformance(&alp.into_array());
     }
 
     #[test]
     fn test_mask_alp_with_patches() {
         use std::f64::consts::PI;
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // PI doesn't encode cleanly with ALP, so it creates patches.
         let values: Vec<f64> = (0..100)
             .map(|i| if i % 4 == 3 { PI } else { 1.0 })
             .collect();
         let array = PrimitiveArray::from_iter(values);
-        let alp = alp_encode(
-            array.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let alp = alp_encode(array.as_view(), None, &mut ctx).unwrap();
         assert!(alp.patches().is_some(), "expected patches");
         test_mask_conformance(&alp.into_array());
     }
 
     #[test]
     fn test_mask_alp_with_patches_casts_surviving_patch_values_to_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = PrimitiveArray::from_iter([1.234f32, f32::NAN, 2.345, f32::INFINITY, 3.456]);
-        let alp = alp_encode(
-            values.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let alp = alp_encode(values.as_view(), None, &mut ctx).unwrap();
         assert!(alp.patches().is_some(), "expected patches");
 
         let keep_mask = BoolArray::from_iter([false, true, true, true, true]).into_array();
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let masked = <crate::ALP as MaskKernel>::mask(alp.as_view(), &keep_mask, &mut ctx)
             .unwrap()
             .unwrap();

--- a/encodings/alp/src/alp/compute/take.rs
+++ b/encodings/alp/src/alp/compute/take.rs
@@ -43,8 +43,6 @@ mod test {
     use rstest::rstest;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::compute::conformance::take::test_take_conformance;
@@ -58,14 +56,9 @@ mod test {
     #[case(PrimitiveArray::from_option_iter([Some(1.1f32), None, Some(2.2), Some(3.3), None]).into_array())]
     #[case(buffer![42.42f64].into_array())]
     fn test_take_alp_conformance(#[case] array: vortex_array::ArrayRef) {
-        #[expect(deprecated)]
-        let array_primitive = array.to_primitive();
-        let alp = alp_encode(
-            array_primitive.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array_primitive = array.execute::<PrimitiveArray>(&mut ctx).unwrap();
+        let alp = alp_encode(array_primitive.as_view(), None, &mut ctx).unwrap();
         test_take_conformance(&alp.into_array());
     }
 }

--- a/encodings/alp/src/alp_rd/array.rs
+++ b/encodings/alp/src/alp_rd/array.rs
@@ -16,6 +16,7 @@ use vortex_array::ArrayId;
 use vortex_array::ArrayParts;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
+use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
@@ -213,7 +214,13 @@ impl VTable for ALPRD {
                 )
             })
             .transpose()?;
-        let left_parts_patches = ALPRDData::canonicalize_patches(&left_parts, left_parts_patches)?;
+        // NOTE: `VTable::deserialize` has a fixed trait signature without `ExecutionCtx`, so we
+        // cannot plumb a ctx in here. We construct a legacy ctx locally at this trait boundary.
+        let left_parts_patches = ALPRDData::canonicalize_patches(
+            &left_parts,
+            left_parts_patches,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         let slots = ALPRDData::make_slots(&left_parts, &right_parts, &left_parts_patches);
         let data = ALPRDData::new(
             left_parts_dictionary,
@@ -371,9 +378,11 @@ impl ALPRD {
         right_parts: ArrayRef,
         right_bit_width: u8,
         left_parts_patches: Option<Patches>,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ALPRDArray> {
         let len = left_parts.len();
-        let left_parts_patches = ALPRDData::canonicalize_patches(&left_parts, left_parts_patches)?;
+        let left_parts_patches =
+            ALPRDData::canonicalize_patches(&left_parts, left_parts_patches, ctx)?;
         let slots = ALPRDData::make_slots(&left_parts, &right_parts, &left_parts_patches);
         let data = ALPRDData::new(left_parts_dictionary, right_bit_width, left_parts_patches);
         Array::try_from_parts(ArrayParts::new(ALPRD, dtype, len, data).with_slots(slots))
@@ -404,13 +413,11 @@ impl ALPRDData {
     fn canonicalize_patches(
         left_parts: &ArrayRef,
         left_parts_patches: Option<Patches>,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<Patches>> {
         left_parts_patches
             .map(|patches| {
-                if !patches
-                    .values()
-                    .all_valid(&mut LEGACY_SESSION.create_execution_ctx())?
-                {
+                if !patches.values().all_valid(ctx)? {
                     vortex_bail!("patches must be all valid: {}", patches.values());
                 }
                 // TODO(ngates): assert the DType, don't cast it.
@@ -418,9 +425,8 @@ impl ALPRDData {
                 let mut patches = patches.cast_values(&left_parts.dtype().as_nonnullable())?;
                 // Force execution of the lazy cast so patch values are materialized
                 // before serialization.
-                #[expect(deprecated)]
-                let canonical = patches.values().to_canonical()?.into_array();
-                *patches.values_mut() = canonical;
+                let canonical = patches.values().clone().execute::<Canonical>(ctx)?;
+                *patches.values_mut() = canonical.into_array();
                 Ok(patches)
             })
             .transpose()
@@ -662,8 +668,8 @@ impl ValidityChild<ALPRD> for ALPRD {
 mod test {
     use prost::Message;
     use rstest::rstest;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::dtype::PType;
@@ -681,6 +687,7 @@ mod test {
         #[case] reals: Vec<T>,
         #[case] seed: T,
     ) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         assert_eq!(reals.len(), 1024, "test expects 1024-length fixture");
         // Null out some of the values.
         let mut reals: Vec<Option<T>> = reals.into_iter().map(Some).collect();
@@ -694,10 +701,13 @@ mod test {
         // Pick a seed that we know will trigger lots of patches.
         let encoder: alp_rd::RDEncoder = alp_rd::RDEncoder::new(&[seed.powi(-2)]);
 
-        let rd_array = encoder.encode(real_array.as_view());
+        let rd_array = encoder.encode(real_array.as_view(), &mut ctx);
 
-        #[expect(deprecated)]
-        let decoded = rd_array.as_array().to_primitive();
+        let decoded = rd_array
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
 
         assert_arrays_eq!(decoded, PrimitiveArray::from_option_iter(reals));
     }

--- a/encodings/alp/src/alp_rd/compute/cast.rs
+++ b/encodings/alp/src/alp_rd/compute/cast.rs
@@ -4,6 +4,8 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
@@ -28,6 +30,8 @@ impl CastReduce for ALPRD {
                     .with_nullability(dtype.nullability()),
             )?;
 
+            // NOTE: `CastReduce::cast` has a fixed trait signature without `ExecutionCtx`, so we
+            // construct a legacy ctx locally at this trait boundary.
             return Ok(Some(
                 ALPRD::try_new(
                     dtype.clone(),
@@ -36,6 +40,7 @@ impl CastReduce for ALPRD {
                     array.right_parts().clone(),
                     array.right_bit_width(),
                     array.left_parts_patches(),
+                    &mut LEGACY_SESSION.create_execution_ctx(),
                 )?
                 .into_array(),
             ));
@@ -50,8 +55,8 @@ impl CastReduce for ALPRD {
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::builtins::ArrayBuiltins;
     use vortex_array::compute::conformance::cast::test_cast_conformance;
@@ -63,10 +68,11 @@ mod tests {
 
     #[test]
     fn test_cast_alprd_f32_to_f64() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = vec![1.0f32, 1.1, 1.2, 1.3, 1.4];
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        let alprd = encoder.encode(arr.as_view());
+        let alprd = encoder.encode(arr.as_view(), &mut ctx);
 
         let casted = alprd
             .into_array()
@@ -77,8 +83,7 @@ mod tests {
             &DType::Primitive(PType::F64, Nullability::NonNullable)
         );
 
-        #[expect(deprecated)]
-        let decoded = casted.to_primitive();
+        let decoded = casted.execute::<PrimitiveArray>(&mut ctx).unwrap();
         let f64_values = decoded.as_slice::<f64>();
         assert_eq!(f64_values.len(), 5);
         assert!((f64_values[0] - 1.0).abs() < f64::EPSILON);
@@ -87,11 +92,12 @@ mod tests {
 
     #[test]
     fn test_cast_alprd_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr =
             PrimitiveArray::from_option_iter([Some(10.0f64), None, Some(10.1), Some(10.2), None]);
         let values = vec![10.0f64, 10.1, 10.2];
         let encoder = RDEncoder::new(&values);
-        let alprd = encoder.encode(arr.as_view());
+        let alprd = encoder.encode(arr.as_view(), &mut ctx);
 
         // Cast to NonNullable should fail since we have nulls
         let result = alprd
@@ -116,31 +122,31 @@ mod tests {
         let values = vec![1.23f32, 4.56, 7.89, 10.11, 12.13];
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     #[case::f64({
         let values = vec![100.1f64, 200.2, 300.3, 400.4, 500.5];
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     #[case::single({
         let values = vec![42.42f64];
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     #[case::negative({
         let values = vec![0.0f32, -1.5, 2.5, -3.5, 4.5];
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     #[case::nullable({
         let arr = PrimitiveArray::from_option_iter([Some(1.1f32), None, Some(2.2), Some(3.3), None]);
         let values = vec![1.1f32, 2.2, 3.3];
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     fn test_cast_alprd_conformance(#[case] alprd: crate::alp_rd::ALPRDArray) {
         test_cast_conformance(&alprd.into_array());

--- a/encodings/alp/src/alp_rd/compute/filter.rs
+++ b/encodings/alp/src/alp_rd/compute/filter.rs
@@ -32,6 +32,7 @@ impl FilterKernel for ALPRD {
                 array.right_parts().filter(mask.clone())?,
                 array.right_bit_width(),
                 left_parts_exceptions,
+                ctx,
             )?
             .into_array(),
         ))
@@ -42,6 +43,8 @@ impl FilterKernel for ALPRD {
 mod test {
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::compute::conformance::filter::test_filter_conformance;
@@ -57,8 +60,9 @@ mod test {
     #[case(0.1f32, 0.2f32, 3e25f32)]
     #[case(0.1f64, 0.2f64, 3e100f64)]
     fn test_filter<T: ALPRDFloat>(#[case] a: T, #[case] b: T, #[case] outlier: T) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::new(buffer![a, b, outlier], Validity::NonNullable);
-        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view());
+        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view(), &mut ctx);
 
         // Make sure that we're testing the exception pathway.
         assert!(encoded.left_parts_patches().is_some());
@@ -74,9 +78,13 @@ mod test {
     #[case(0.1f32, 0.2f32, 3e25f32)]
     #[case(0.1f64, 0.2f64, 3e100f64)]
     fn test_filter_simple<T: ALPRDFloat>(#[case] a: T, #[case] b: T, #[case] outlier: T) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         test_filter_conformance(
             &RDEncoder::new(&[a, b])
-                .encode(PrimitiveArray::from_iter([a, b, outlier, b, outlier]).as_view())
+                .encode(
+                    PrimitiveArray::from_iter([a, b, outlier, b, outlier]).as_view(),
+                    &mut ctx,
+                )
                 .into_array(),
         );
     }
@@ -85,11 +93,13 @@ mod test {
     #[case(0.1f32, 3e25f32)]
     #[case(0.5f64, 1e100f64)]
     fn test_filter_with_nulls<T: ALPRDFloat>(#[case] a: T, #[case] outlier: T) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         test_filter_conformance(
             &RDEncoder::new(&[a])
                 .encode(
                     PrimitiveArray::from_option_iter([Some(a), None, Some(outlier), Some(a), None])
                         .as_view(),
+                    &mut ctx,
                 )
                 .into_array(),
         );

--- a/encodings/alp/src/alp_rd/compute/mask.rs
+++ b/encodings/alp/src/alp_rd/compute/mask.rs
@@ -4,6 +4,8 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
 use vortex_array::scalar_fn::EmptyOptions;
 use vortex_array::scalar_fn::fns::mask::Mask as MaskExpr;
@@ -20,6 +22,8 @@ impl MaskReduce for ALPRD {
             EmptyOptions,
             [array.left_parts().clone(), mask.clone()],
         )?;
+        // NOTE: `MaskReduce::mask` has a fixed trait signature without `ExecutionCtx`, so we
+        // construct a legacy ctx locally at this trait boundary.
         Ok(Some(
             ALPRD::try_new(
                 array.dtype().as_nullable(),
@@ -28,6 +32,7 @@ impl MaskReduce for ALPRD {
                 array.right_parts().clone(),
                 array.right_bit_width(),
                 array.left_parts_patches(),
+                &mut LEGACY_SESSION.create_execution_ctx(),
             )?
             .into_array(),
         ))
@@ -38,6 +43,8 @@ impl MaskReduce for ALPRD {
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::compute::conformance::mask::test_mask_conformance;
 
@@ -48,9 +55,13 @@ mod tests {
     #[case(0.1f32, 0.2f32, 3e25f32)]
     #[case(0.1f64, 0.2f64, 3e100f64)]
     fn test_mask_simple<T: ALPRDFloat>(#[case] a: T, #[case] b: T, #[case] outlier: T) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         test_mask_conformance(
             &RDEncoder::new(&[a, b])
-                .encode(PrimitiveArray::from_iter([a, b, outlier, b, outlier]).as_view())
+                .encode(
+                    PrimitiveArray::from_iter([a, b, outlier, b, outlier]).as_view(),
+                    &mut ctx,
+                )
                 .into_array(),
         );
     }
@@ -59,11 +70,13 @@ mod tests {
     #[case(0.1f32, 3e25f32)]
     #[case(0.5f64, 1e100f64)]
     fn test_mask_with_nulls<T: ALPRDFloat>(#[case] a: T, #[case] outlier: T) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         test_mask_conformance(
             &RDEncoder::new(&[a])
                 .encode(
                     PrimitiveArray::from_option_iter([Some(a), None, Some(outlier), Some(a), None])
                         .as_view(),
+                    &mut ctx,
                 )
                 .into_array(),
         );

--- a/encodings/alp/src/alp_rd/compute/mod.rs
+++ b/encodings/alp/src/alp_rd/compute/mod.rs
@@ -10,6 +10,8 @@ mod take;
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::compute::conformance::binary_numeric::test_binary_numeric_array;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
@@ -23,47 +25,47 @@ mod tests {
         let values = vec![1.0f32, 1.1, 1.2, 1.3, 1.4];
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     #[case::f64_array({
         let values = vec![100.0f64, 100.01, 100.02, 100.03, 100.04];
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     // Nullable arrays
     #[case::nullable_f32({
         let values = vec![1.0f32, 1.2, 1.3];
         let arr = PrimitiveArray::from_option_iter([Some(1.0f32), None, Some(1.2), Some(1.3), None]);
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     #[case::nullable_f64({
         let values = vec![10.0f64, 10.2, 10.3];
         let arr = PrimitiveArray::from_option_iter([Some(10.0f64), None, Some(10.2), Some(10.3), None]);
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     // Edge cases
     #[case::single_element({
         let values = vec![42.42f64];
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     // Arrays with small deltas (good for RD encoding)
     #[case::small_deltas({
         let values = vec![1000.0f32, 1000.001, 1000.002, 1000.003, 1000.004];
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     // Large arrays
     #[case::large_f32({
         let values: Vec<f32> = (0..1000).map(|i| 100.0 + i as f32 * 0.01).collect();
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     fn test_alp_rd_consistency(#[case] array: ALPRDArray) {
         test_array_consistency(&array.into_array());
@@ -74,25 +76,25 @@ mod tests {
         let values = vec![1.0f32, 1.1, 1.2, 1.3, 1.4];
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     #[case::f64_basic({
         let values = vec![100.0f64, 100.01, 100.02, 100.03, 100.04];
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     #[case::f32_large({
         let values: Vec<f32> = (0..100).map(|i| 50.0 + i as f32 * 0.1).collect();
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     #[case::f64_large({
         let values: Vec<f64> = (0..100).map(|i| 1000.0 + i as f64 * 0.01).collect();
         let arr = PrimitiveArray::from_iter(values.clone());
         let encoder = RDEncoder::new(&values);
-        encoder.encode(arr.as_view())
+        encoder.encode(arr.as_view(), &mut LEGACY_SESSION.create_execution_ctx())
     })]
     fn test_alp_rd_binary_numeric(#[case] array: ALPRDArray) {
         test_binary_numeric_array(array.into_array());

--- a/encodings/alp/src/alp_rd/compute/take.rs
+++ b/encodings/alp/src/alp_rd/compute/take.rs
@@ -48,6 +48,7 @@ impl TakeExecute for ALPRD {
                 right_parts,
                 array.right_bit_width(),
                 left_parts_exceptions,
+                ctx,
             )?
             .into_array(),
         ))
@@ -58,8 +59,8 @@ impl TakeExecute for ALPRD {
 mod test {
     use rstest::rstest;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::compute::conformance::take::test_take_conformance;
@@ -75,8 +76,9 @@ mod test {
         use vortex_array::IntoArray as _;
         use vortex_buffer::buffer;
 
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([a, b, outlier]);
-        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view());
+        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view(), &mut ctx);
 
         assert!(encoded.left_parts_patches().is_some());
         assert!(
@@ -87,11 +89,11 @@ mod test {
                 .is_unsigned_int()
         );
 
-        #[expect(deprecated)]
         let taken = encoded
             .take(buffer![0, 2].into_array())
             .unwrap()
-            .to_primitive();
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
 
         assert_arrays_eq!(taken, PrimitiveArray::from_iter([a, outlier]));
     }
@@ -100,8 +102,9 @@ mod test {
     #[case(0.1f32, 0.2f32, 3e25f32)]
     #[case(0.1f64, 0.2f64, 3e100f64)]
     fn take_with_nulls<T: ALPRDFloat>(#[case] a: T, #[case] b: T, #[case] outlier: T) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([a, b, outlier]);
-        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view());
+        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view(), &mut ctx);
 
         assert!(encoded.left_parts_patches().is_some());
         assert!(
@@ -112,11 +115,11 @@ mod test {
                 .is_unsigned_int()
         );
 
-        #[expect(deprecated)]
         let taken = encoded
             .take(PrimitiveArray::from_option_iter([Some(0), Some(2), None]).into_array())
             .unwrap()
-            .to_primitive();
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
 
         assert_arrays_eq!(
             taken,
@@ -128,9 +131,13 @@ mod test {
     #[case(0.1f32, 0.2f32, 3e25f32)]
     #[case(0.1f64, 0.2f64, 3e100f64)]
     fn test_take_conformance_alprd<T: ALPRDFloat>(#[case] a: T, #[case] b: T, #[case] outlier: T) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         test_take_conformance(
             &RDEncoder::new(&[a, b])
-                .encode(PrimitiveArray::from_iter([a, b, outlier, b, outlier]).as_view())
+                .encode(
+                    PrimitiveArray::from_iter([a, b, outlier, b, outlier]).as_view(),
+                    &mut ctx,
+                )
                 .into_array(),
         );
     }
@@ -139,11 +146,13 @@ mod test {
     #[case(0.1f32, 3e25f32)]
     #[case(0.5f64, 1e100f64)]
     fn test_take_with_nulls_conformance<T: ALPRDFloat>(#[case] a: T, #[case] outlier: T) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         test_take_conformance(
             &RDEncoder::new(&[a])
                 .encode(
                     PrimitiveArray::from_option_iter([Some(a), None, Some(outlier), Some(a), None])
                         .as_view(),
+                    &mut ctx,
                 )
                 .into_array(),
         );

--- a/encodings/alp/src/alp_rd/mod.rs
+++ b/encodings/alp/src/alp_rd/mod.rs
@@ -182,11 +182,11 @@ impl RDEncoder {
     ///
     /// Each value will be split into a left and right component, which are compressed individually.
     // TODO(joe): make fallible
-    pub fn encode(&self, array: ArrayView<'_, Primitive>) -> ALPRDArray {
-        match_each_alp_float_ptype!(array.ptype(), |P| { self.encode_generic::<P>(array) })
+    pub fn encode(&self, array: ArrayView<'_, Primitive>, ctx: &mut ExecutionCtx) -> ALPRDArray {
+        match_each_alp_float_ptype!(array.ptype(), |P| { self.encode_generic::<P>(array, ctx) })
     }
 
-    fn encode_generic<T>(&self, array: ArrayView<'_, Primitive>) -> ALPRDArray
+    fn encode_generic<T>(&self, array: ArrayView<'_, Primitive>, ctx: &mut ExecutionCtx) -> ALPRDArray
     where
         T: ALPRDFloat + NativePType,
         T::UINT: NativePType,
@@ -285,6 +285,7 @@ impl RDEncoder {
             packed_right,
             self.right_bit_width,
             exceptions,
+            ctx,
         )
         .vortex_expect("ALPRDArray construction in encode")
     }

--- a/encodings/alp/src/alp_rd/mod.rs
+++ b/encodings/alp/src/alp_rd/mod.rs
@@ -186,7 +186,11 @@ impl RDEncoder {
         match_each_alp_float_ptype!(array.ptype(), |P| { self.encode_generic::<P>(array, ctx) })
     }
 
-    fn encode_generic<T>(&self, array: ArrayView<'_, Primitive>, ctx: &mut ExecutionCtx) -> ALPRDArray
+    fn encode_generic<T>(
+        &self,
+        array: ArrayView<'_, Primitive>,
+        ctx: &mut ExecutionCtx,
+    ) -> ALPRDArray
     where
         T: ALPRDFloat + NativePType,
         T::UINT: NativePType,

--- a/encodings/alp/src/alp_rd/ops.rs
+++ b/encodings/alp/src/alp_rd/ops.rs
@@ -66,6 +66,8 @@ impl OperationsVTable<ALPRD> for ALPRD {
 #[cfg(test)]
 mod test {
     use rstest::rstest;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::scalar::Scalar;
@@ -78,8 +80,9 @@ mod test {
     #[case(0.1f32, 0.2f32, 3e25f32)]
     #[case(0.1f64, 0.2f64, 3e100f64)]
     fn test_slice<T: ALPRDFloat>(#[case] a: T, #[case] b: T, #[case] outlier: T) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([a, b, outlier]);
-        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view());
+        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view(), &mut ctx);
 
         assert!(encoded.left_parts_patches().is_some());
         assert_arrays_eq!(encoded, array);
@@ -93,19 +96,21 @@ mod test {
         #[case] b: T,
         #[case] outlier: T,
     ) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([a, b, outlier]);
-        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view());
+        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view(), &mut ctx);
         assert!(encoded.left_parts_patches().is_some());
         assert_arrays_eq!(encoded, array);
     }
 
     #[test]
     fn nullable_scalar_at() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let a = 0.1f64;
         let b = 0.2f64;
         let outlier = 3e100f64;
         let array = PrimitiveArray::from_option_iter([Some(a), Some(b), Some(outlier)]);
-        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view());
+        let encoded = RDEncoder::new(&[a, b]).encode(array.as_view(), &mut ctx);
         assert!(encoded.left_parts_patches().is_some());
         assert_arrays_eq!(
             encoded,

--- a/encodings/datetime-parts/public-api.lock
+++ b/encodings/datetime-parts/public-api.lock
@@ -4,7 +4,7 @@ pub struct vortex_datetime_parts::DateTimeParts
 
 impl vortex_datetime_parts::DateTimeParts
 
-pub fn vortex_datetime_parts::DateTimeParts::try_from_temporal(temporal: vortex_array::arrays::datetime::TemporalArray) -> vortex_error::VortexResult<vortex_datetime_parts::DateTimePartsArray>
+pub fn vortex_datetime_parts::DateTimeParts::try_from_temporal(temporal: vortex_array::arrays::datetime::TemporalArray, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_datetime_parts::DateTimePartsArray>
 
 pub fn vortex_datetime_parts::DateTimeParts::try_new(dtype: vortex_array::dtype::DType, days: vortex_array::array::erased::ArrayRef, seconds: vortex_array::array::erased::ArrayRef, subseconds: vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_datetime_parts::DateTimePartsArray>
 
@@ -56,7 +56,7 @@ pub fn vortex_datetime_parts::DateTimeParts::validity_child(array: vortex_array:
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_datetime_parts::DateTimeParts
 
-pub fn vortex_datetime_parts::DateTimeParts::take(array: vortex_array::array::view::ArrayView<'_, Self>, indices: &vortex_array::array::erased::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::erased::ArrayRef>>
+pub fn vortex_datetime_parts::DateTimeParts::take(array: vortex_array::array::view::ArrayView<'_, Self>, indices: &vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::erased::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterReduce for vortex_datetime_parts::DateTimeParts
 
@@ -87,12 +87,6 @@ pub fn vortex_datetime_parts::DateTimePartsData::validate(dtype: &vortex_array::
 impl core::clone::Clone for vortex_datetime_parts::DateTimePartsData
 
 pub fn vortex_datetime_parts::DateTimePartsData::clone(&self) -> vortex_datetime_parts::DateTimePartsData
-
-impl core::convert::TryFrom<vortex_array::arrays::datetime::TemporalData> for vortex_datetime_parts::DateTimePartsData
-
-pub type vortex_datetime_parts::DateTimePartsData::Error = vortex_error::VortexError
-
-pub fn vortex_datetime_parts::DateTimePartsData::try_from(array: vortex_array::arrays::datetime::TemporalArray) -> core::result::Result<Self, Self::Error>
 
 impl core::fmt::Debug for vortex_datetime_parts::DateTimePartsData
 
@@ -184,6 +178,6 @@ pub fn T::subseconds(&self) -> &vortex_array::array::erased::ArrayRef
 
 pub fn vortex_datetime_parts::initialize(session: &vortex_session::VortexSession)
 
-pub fn vortex_datetime_parts::split_temporal(array: vortex_array::arrays::datetime::TemporalArray) -> vortex_error::VortexResult<vortex_datetime_parts::TemporalParts>
+pub fn vortex_datetime_parts::split_temporal(array: vortex_array::arrays::datetime::TemporalArray, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_datetime_parts::TemporalParts>
 
 pub type vortex_datetime_parts::DateTimePartsArray = vortex_array::array::typed::Array<vortex_datetime_parts::DateTimeParts>

--- a/encodings/datetime-parts/src/array.rs
+++ b/encodings/datetime-parts/src/array.rs
@@ -271,13 +271,16 @@ impl DateTimeParts {
     }
 
     /// Construct a [`DateTimePartsArray`] from a [`TemporalArray`].
-    pub fn try_from_temporal(temporal: TemporalArray) -> VortexResult<DateTimePartsArray> {
+    pub fn try_from_temporal(
+        temporal: TemporalArray,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<DateTimePartsArray> {
         let dtype = temporal.dtype().clone();
         let TemporalParts {
             days,
             seconds,
             subseconds,
-        } = split_temporal(temporal)?;
+        } = split_temporal(temporal, ctx)?;
         Self::try_new(dtype, days, seconds, subseconds)
     }
 }

--- a/encodings/datetime-parts/src/canonical.rs
+++ b/encodings/datetime-parts/src/canonical.rs
@@ -140,13 +140,15 @@ mod test {
             ],
             validity.clone(),
         );
-        let date_times = DateTimeParts::try_from_temporal(TemporalArray::new_timestamp(
-            milliseconds.clone().into_array(),
-            TimeUnit::Milliseconds,
-            Some("UTC".into()),
-        ))?;
-
         let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let date_times = DateTimeParts::try_from_temporal(
+            TemporalArray::new_timestamp(
+                milliseconds.clone().into_array(),
+                TimeUnit::Milliseconds,
+                Some("UTC".into()),
+            ),
+            &mut ctx,
+        )?;
 
         assert!(
             date_times

--- a/encodings/datetime-parts/src/compress.rs
+++ b/encodings/datetime-parts/src/compress.rs
@@ -2,19 +2,16 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::TemporalArray;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::PType;
 use vortex_buffer::BufferMut;
-use vortex_error::VortexError;
 use vortex_error::VortexResult;
 
-use crate::DateTimePartsData;
 use crate::timestamp;
 pub struct TemporalParts {
     pub days: ArrayRef,
@@ -26,12 +23,16 @@ pub struct TemporalParts {
 ///
 /// Splitting the components by granularity creates more small values, which enables better
 /// cascading compression.
-pub fn split_temporal(array: TemporalArray) -> VortexResult<TemporalParts> {
-    #[expect(deprecated)]
-    let temporal_values = array.temporal_values().to_primitive();
+pub fn split_temporal(
+    array: TemporalArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<TemporalParts> {
+    let temporal_values = array
+        .temporal_values()
+        .clone()
+        .execute::<PrimitiveArray>(ctx)?;
 
     // After this operation, timestamps will be a PrimitiveArray<i64>
-    #[expect(deprecated)]
     let timestamps = temporal_values
         .clone()
         .into_array()
@@ -39,7 +40,7 @@ pub fn split_temporal(array: TemporalArray) -> VortexResult<TemporalParts> {
             PType::I64,
             temporal_values.dtype().nullability(),
         ))?
-        .to_primitive();
+        .execute::<PrimitiveArray>(ctx)?;
 
     let length = timestamps.len();
     let mut days = BufferMut::with_capacity(length);
@@ -60,34 +61,11 @@ pub fn split_temporal(array: TemporalArray) -> VortexResult<TemporalParts> {
     })
 }
 
-impl TryFrom<TemporalArray> for DateTimePartsData {
-    type Error = VortexError;
-
-    fn try_from(array: TemporalArray) -> Result<Self, Self::Error> {
-        let ext_dtype = array.ext_dtype();
-        let TemporalParts {
-            days,
-            seconds,
-            subseconds,
-        } = split_temporal(array)?;
-        DateTimePartsData::validate(
-            &DType::Extension(ext_dtype),
-            &days,
-            &seconds,
-            &subseconds,
-            days.len(),
-        )?;
-        Ok(DateTimePartsData {})
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::TemporalArray;
@@ -105,6 +83,7 @@ mod tests {
     #[case(Validity::AllInvalid)]
     #[case(Validity::from_iter([true, false, true]))]
     fn test_split_temporal(#[case] validity: Validity) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let milliseconds = PrimitiveArray::new(
             buffer![
                 86_400i64,            // element with only day component
@@ -120,11 +99,9 @@ mod tests {
             days,
             seconds,
             subseconds,
-        } = split_temporal(temporal_array).unwrap();
+        } = split_temporal(temporal_array, &mut ctx).unwrap();
 
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        #[expect(deprecated)]
-        let days_prim = days.to_primitive();
+        let days_prim = days.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert!(
             days_prim
                 .validity()
@@ -132,16 +109,14 @@ mod tests {
                 .mask_eq(&validity, &mut ctx)
                 .unwrap()
         );
-        #[expect(deprecated)]
-        let seconds_prim = seconds.to_primitive();
+        let seconds_prim = seconds.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert!(matches!(
             seconds_prim
                 .validity()
                 .vortex_expect("seconds validity should be derivable"),
             Validity::NonNullable
         ));
-        #[expect(deprecated)]
-        let subseconds_prim = subseconds.to_primitive();
+        let subseconds_prim = subseconds.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert!(matches!(
             subseconds_prim
                 .validity()

--- a/encodings/datetime-parts/src/compress.rs
+++ b/encodings/datetime-parts/src/compress.rs
@@ -23,10 +23,7 @@ pub struct TemporalParts {
 ///
 /// Splitting the components by granularity creates more small values, which enables better
 /// cascading compression.
-pub fn split_temporal(
-    array: TemporalArray,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<TemporalParts> {
+pub fn split_temporal(array: TemporalArray, ctx: &mut ExecutionCtx) -> VortexResult<TemporalParts> {
     let temporal_values = array
         .temporal_values()
         .clone()

--- a/encodings/datetime-parts/src/compute/cast.rs
+++ b/encodings/datetime-parts/src/compute/cast.rs
@@ -35,7 +35,10 @@ impl CastReduce for DateTimeParts {
 mod tests {
     use rstest::rstest;
     use vortex_array::ArrayRef;
+    use vortex_array::Canonical;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::TemporalArray;
     use vortex_array::builtins::ArrayBuiltins;
@@ -49,19 +52,22 @@ mod tests {
     use crate::DateTimePartsArray;
 
     fn date_time_array(validity: Validity) -> ArrayRef {
-        DateTimeParts::try_from_temporal(TemporalArray::new_timestamp(
-            PrimitiveArray::new(
-                buffer![
-                    86_400i64,            // element with only day component
-                    86_400i64 + 1000,     // element with day + second components
-                    86_400i64 + 1000 + 1, // element with day + second + sub-second components
-                ],
-                validity,
-            )
-            .into_array(),
-            TimeUnit::Milliseconds,
-            Some("UTC".into()),
-        ))
+        DateTimeParts::try_from_temporal(
+            TemporalArray::new_timestamp(
+                PrimitiveArray::new(
+                    buffer![
+                        86_400i64,            // element with only day component
+                        86_400i64 + 1000,     // element with day + second components
+                        86_400i64 + 1000 + 1, // element with day + second + sub-second components
+                    ],
+                    validity,
+                )
+                .into_array(),
+                TimeUnit::Milliseconds,
+                Some("UTC".into()),
+            ),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
         .unwrap()
         .into_array()
     }
@@ -89,19 +95,18 @@ mod tests {
     #[case(Validity::AllInvalid)]
     #[case(Validity::from_iter([true, false, true]))]
     fn test_bad_cast_fails(#[case] validity: Validity) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = date_time_array(validity);
-        // Cast to incompatible type - force evaluation via to_canonical
-        #[expect(deprecated)]
+        // Cast to incompatible type - force evaluation via execute::<Canonical>
         let result = array
             .cast(DType::Bool(Nullability::NonNullable))
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()));
+            .and_then(|a| a.execute::<Canonical>(&mut ctx).map(|c| c.into_array()));
         assert!(result.is_err(), "Expected error, got: {result:?}");
 
-        // Cast nullable with nulls to non-nullable - force evaluation via to_canonical
-        #[expect(deprecated)]
+        // Cast nullable with nulls to non-nullable - force evaluation via execute::<Canonical>
         let result = array
             .cast(array.dtype().with_nullability(Nullability::NonNullable))
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()));
+            .and_then(|a| a.execute::<Canonical>(&mut ctx).map(|c| c.into_array()));
         assert!(result.is_err(), "Expected error, got: {result:?}");
     }
 
@@ -116,7 +121,7 @@ mod tests {
         ].into_array(),
         TimeUnit::Milliseconds,
         Some("UTC".into())
-    )).unwrap())]
+    ), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
     #[case(DateTimeParts::try_from_temporal(TemporalArray::new_timestamp(
         PrimitiveArray::from_option_iter([
             Some(0i64),
@@ -127,12 +132,12 @@ mod tests {
         ]).into_array(),
         TimeUnit::Milliseconds,
         Some("UTC".into())
-    )).unwrap())]
+    ), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
     #[case(DateTimeParts::try_from_temporal(TemporalArray::new_timestamp(
         buffer![86_400_000_000_000i64].into_array(), // 1 day in ns
         TimeUnit::Nanoseconds,
         Some("UTC".into())
-    )).unwrap())]
+    ), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
     fn test_cast_datetime_parts_conformance(#[case] array: DateTimePartsArray) {
         use vortex_array::compute::conformance::cast::test_cast_conformance;
         test_cast_conformance(&array.into_array());

--- a/encodings/datetime-parts/src/compute/compare.rs
+++ b/encodings/datetime-parts/src/compute/compare.rs
@@ -202,6 +202,8 @@ fn compare_dtp(
 #[cfg(test)]
 mod test {
     use rstest::rstest;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::TemporalArray;
     use vortex_array::dtype::IntegerPType;
@@ -217,11 +219,14 @@ mod test {
         value: T,
         validity: Validity,
     ) -> DateTimePartsArray {
-        DateTimeParts::try_from_temporal(TemporalArray::new_timestamp(
-            PrimitiveArray::new(buffer![value], validity).into_array(),
-            TimeUnit::Seconds,
-            Some("UTC".into()),
-        ))
+        DateTimeParts::try_from_temporal(
+            TemporalArray::new_timestamp(
+                PrimitiveArray::new(buffer![value], validity).into_array(),
+                TimeUnit::Seconds,
+                Some("UTC".into()),
+            ),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
         .expect("Failed to construct DateTimePartsArray from TemporalArray")
     }
 

--- a/encodings/datetime-parts/src/compute/filter.rs
+++ b/encodings/datetime-parts/src/compute/filter.rs
@@ -27,6 +27,8 @@ impl FilterReduce for DateTimeParts {
 #[cfg(test)]
 mod test {
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::TemporalArray;
     use vortex_array::compute::conformance::filter::test_filter_conformance;
@@ -37,6 +39,7 @@ mod test {
 
     #[test]
     fn test_filter_datetime_parts() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create temporal arrays and convert to DateTimePartsArray
         let timestamps = buffer![
             0i64,
@@ -50,7 +53,7 @@ mod test {
         let temporal =
             TemporalArray::new_timestamp(timestamps, TimeUnit::Milliseconds, Some("UTC".into()));
 
-        let array = DateTimeParts::try_from_temporal(temporal).unwrap();
+        let array = DateTimeParts::try_from_temporal(temporal, &mut ctx).unwrap();
         test_filter_conformance(&array.into_array());
 
         // Test with nullable values
@@ -66,7 +69,7 @@ mod test {
         let temporal =
             TemporalArray::new_timestamp(timestamps, TimeUnit::Milliseconds, Some("UTC".into()));
 
-        let array = DateTimeParts::try_from_temporal(temporal).unwrap();
+        let array = DateTimeParts::try_from_temporal(temporal, &mut ctx).unwrap();
         test_filter_conformance(&array.into_array());
     }
 }

--- a/encodings/datetime-parts/src/compute/mod.rs
+++ b/encodings/datetime-parts/src/compute/mod.rs
@@ -15,6 +15,8 @@ mod take;
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::TemporalArray;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
@@ -25,7 +27,8 @@ mod tests {
     use crate::DateTimePartsArray;
 
     fn dtp_from_temporal(temporal: TemporalArray) -> DateTimePartsArray {
-        DateTimeParts::try_from_temporal(temporal).unwrap()
+        DateTimeParts::try_from_temporal(temporal, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     #[rstest]

--- a/encodings/datetime-parts/src/compute/rules.rs
+++ b/encodings/datetime-parts/src/compute/rules.rs
@@ -179,6 +179,8 @@ fn is_constant_zero(array: &ArrayRef) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::TemporalArray;
     use vortex_array::arrays::scalar_fn::ScalarFnFactoryExt;
@@ -217,7 +219,7 @@ mod tests {
             time_unit,
             None,
         );
-        DateTimeParts::try_from_temporal(temporal)
+        DateTimeParts::try_from_temporal(temporal, &mut LEGACY_SESSION.create_execution_ctx())
             .vortex_expect("TemporalArray must produce valid DateTimeParts")
     }
 
@@ -350,7 +352,7 @@ mod tests {
             TimeUnit::Seconds,
             None,
         );
-        let dtp = DateTimeParts::try_from_temporal(temporal).unwrap();
+        let dtp = DateTimeParts::try_from_temporal(temporal, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
         let len = dtp.len();
 
         // Compare against midnight constant

--- a/encodings/datetime-parts/src/compute/rules.rs
+++ b/encodings/datetime-parts/src/compute/rules.rs
@@ -352,7 +352,9 @@ mod tests {
             TimeUnit::Seconds,
             None,
         );
-        let dtp = DateTimeParts::try_from_temporal(temporal, &mut LEGACY_SESSION.create_execution_ctx()).unwrap();
+        let dtp =
+            DateTimeParts::try_from_temporal(temporal, &mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap();
         let len = dtp.len();
 
         // Compare against midnight constant

--- a/encodings/datetime-parts/src/compute/take.rs
+++ b/encodings/datetime-parts/src/compute/take.rs
@@ -5,8 +5,7 @@ use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::dict::TakeExecute;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::Nullability;
@@ -21,10 +20,10 @@ use crate::array::DateTimePartsArrayExt;
 fn take_datetime_parts(
     array: ArrayView<DateTimeParts>,
     indices: &ArrayRef,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     // we go ahead and canonicalize here to avoid worst-case canonicalizing 3 separate times
-    #[expect(deprecated)]
-    let indices = indices.to_primitive();
+    let indices = indices.clone().execute::<PrimitiveArray>(ctx)?;
 
     let taken_days = array.days().take(indices.clone().into_array())?;
     let taken_seconds = array.seconds().take(indices.clone().into_array())?;
@@ -87,9 +86,9 @@ impl TakeExecute for DateTimeParts {
     fn take(
         array: ArrayView<'_, Self>,
         indices: &ArrayRef,
-        _ctx: &mut ExecutionCtx,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        take_datetime_parts(array, indices).map(Some)
+        take_datetime_parts(array, indices, ctx).map(Some)
     }
 }
 
@@ -97,6 +96,8 @@ impl TakeExecute for DateTimeParts {
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::TemporalArray;
     use vortex_array::compute::conformance::take::test_take_conformance;
@@ -117,7 +118,7 @@ mod tests {
         ].into_array(),
         TimeUnit::Milliseconds,
         Some("UTC".into())
-    )).unwrap())]
+    ), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
     #[case(DateTimeParts::try_from_temporal(TemporalArray::new_timestamp(
         PrimitiveArray::from_option_iter([
             Some(0i64),
@@ -128,12 +129,12 @@ mod tests {
         ]).into_array(),
         TimeUnit::Milliseconds,
         Some("UTC".into())
-    )).unwrap())]
+    ), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
     #[case(DateTimeParts::try_from_temporal(TemporalArray::new_timestamp(
         buffer![86_400_000i64].into_array(),
         TimeUnit::Milliseconds,
         Some("UTC".into())
-    )).unwrap())]
+    ), &mut LEGACY_SESSION.create_execution_ctx()).unwrap())]
     fn test_take_datetime_parts_conformance(#[case] array: DateTimePartsArray) {
         test_take_conformance(&array.into_array());
     }

--- a/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/cast.rs
+++ b/encodings/decimal-byte-parts/src/decimal_byte_parts/compute/cast.rs
@@ -46,9 +46,11 @@ impl CastReduce for DecimalByteParts {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::Canonical;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::DecimalArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::builtins::ArrayBuiltins;
     use vortex_array::compute::conformance::cast::test_cast_conformance;
@@ -62,6 +64,7 @@ mod tests {
 
     #[test]
     fn test_cast_decimal_byte_parts_nullability() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(10, 2);
         let array =
             DecimalByteParts::try_new(buffer![100i32, 200, 300, 400].into_array(), decimal_dtype)
@@ -78,13 +81,13 @@ mod tests {
         );
 
         // Verify the values are preserved
-        #[expect(deprecated)]
-        let decoded = casted.to_decimal();
+        let decoded = casted.execute::<DecimalArray>(&mut ctx).unwrap();
         assert_eq!(decoded.len(), 4);
     }
 
     #[test]
     fn test_cast_decimal_byte_parts_nullable_to_non_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let decimal_dtype = DecimalDType::new(10, 2);
         let array = DecimalByteParts::try_new(
             PrimitiveArray::from_option_iter([Some(100i32), None, Some(300)]).into_array(),
@@ -92,12 +95,11 @@ mod tests {
         )
         .unwrap();
 
-        // Cast to non-nullable should fail due to nulls - force evaluation via to_canonical
-        #[expect(deprecated)]
+        // Cast to non-nullable should fail due to nulls - force evaluation via execute::<Canonical>
         let result = array
             .into_array()
             .cast(DType::Decimal(decimal_dtype, Nullability::NonNullable))
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()));
+            .and_then(|a| a.execute::<Canonical>(&mut ctx).map(|c| c.into_array()));
         assert!(result.is_err());
     }
 

--- a/encodings/fastlanes/benches/bitpacking_take.rs
+++ b/encodings/fastlanes/benches/bitpacking_take.rs
@@ -28,7 +28,9 @@ fn main() {
 fn take_10_stratified(bencher: Bencher) {
     let values = fixture(65_536, 8);
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
     let indices = PrimitiveArray::from_iter((0..10).map(|i| i * 6_553));
 
     bencher
@@ -46,7 +48,9 @@ fn take_10_stratified(bencher: Bencher) {
 fn take_10_contiguous(bencher: Bencher) {
     let values = fixture(65_536, 8);
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
     let indices = buffer![0..10].into_array();
 
     bencher
@@ -65,7 +69,9 @@ fn take_10k_random(bencher: Bencher) {
     let values = fixture(65_536, 8);
     let range = Uniform::new(0, values.len()).unwrap();
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
 
     let rng = StdRng::seed_from_u64(0);
     let indices = PrimitiveArray::from_iter(rng.sample_iter(range).take(10_000).map(|i| i as u32));
@@ -85,7 +91,9 @@ fn take_10k_random(bencher: Bencher) {
 fn take_10k_contiguous(bencher: Bencher) {
     let values = fixture(65_536, 8);
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
     let indices = PrimitiveArray::from_iter(0..10_000);
 
     bencher
@@ -103,7 +111,9 @@ fn take_10k_contiguous(bencher: Bencher) {
 fn take_10k_dispersed(bencher: Bencher) {
     let values = fixture(65_536, 8);
     let uncompressed = PrimitiveArray::new(values.clone(), Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
     let indices = PrimitiveArray::from_iter((0..10_000).map(|i| (i * 42) % values.len() as u64));
 
     bencher
@@ -121,7 +131,9 @@ fn take_10k_dispersed(bencher: Bencher) {
 fn take_10k_first_chunk_only(bencher: Bencher) {
     let values = fixture(65_536, 8);
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
     let indices = PrimitiveArray::from_iter((0..10_000).map(|i| ((i * 42) % 1024) as u64));
 
     bencher
@@ -159,7 +171,9 @@ const NUM_EXCEPTIONS: u32 = 1024;
 fn patched_take_10_stratified(bencher: Bencher) {
     let values = (0u32..BIG_BASE2 + NUM_EXCEPTIONS).collect::<Buffer<u32>>();
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
 
     assert!(packed.patches().is_some());
     assert_eq!(
@@ -184,7 +198,9 @@ fn patched_take_10_stratified(bencher: Bencher) {
 fn patched_take_10_contiguous(bencher: Bencher) {
     let values = (0u32..BIG_BASE2 + NUM_EXCEPTIONS).collect::<Buffer<u32>>();
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
 
     assert!(packed.patches().is_some());
     assert_eq!(
@@ -209,7 +225,9 @@ fn patched_take_10_contiguous(bencher: Bencher) {
 fn patched_take_10k_random(bencher: Bencher) {
     let values = (0u32..BIG_BASE2 + NUM_EXCEPTIONS).collect::<Buffer<u32>>();
     let uncompressed = PrimitiveArray::new(values.clone(), Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
 
     let rng = StdRng::seed_from_u64(0);
     let range = Uniform::new(0, values.len()).unwrap();
@@ -230,7 +248,9 @@ fn patched_take_10k_random(bencher: Bencher) {
 fn patched_take_10k_contiguous_not_patches(bencher: Bencher) {
     let values = (0u32..BIG_BASE2 + NUM_EXCEPTIONS).collect::<Buffer<u32>>();
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
     let indices = PrimitiveArray::from_iter((0u32..NUM_EXCEPTIONS).cycle().take(10000));
 
     bencher
@@ -248,7 +268,9 @@ fn patched_take_10k_contiguous_not_patches(bencher: Bencher) {
 fn patched_take_10k_contiguous_patches(bencher: Bencher) {
     let values = (0u32..BIG_BASE2 + NUM_EXCEPTIONS).collect::<Buffer<u32>>();
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
 
     assert!(packed.patches().is_some());
     assert_eq!(
@@ -274,7 +296,9 @@ fn patched_take_10k_contiguous_patches(bencher: Bencher) {
 fn patched_take_10k_dispersed(bencher: Bencher) {
     let values = (0u32..BIG_BASE2 + NUM_EXCEPTIONS).collect::<Buffer<u32>>();
     let uncompressed = PrimitiveArray::new(values.clone(), Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
     let indices = PrimitiveArray::from_iter((0..10_000).map(|i| (i * 42) % values.len() as u64));
 
     bencher
@@ -292,7 +316,9 @@ fn patched_take_10k_dispersed(bencher: Bencher) {
 fn patched_take_10k_first_chunk_only(bencher: Bencher) {
     let values = (0u32..BIG_BASE2 + NUM_EXCEPTIONS).collect::<Buffer<u32>>();
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
     let indices = PrimitiveArray::from_iter((0..10_000).map(|i| ((i * 42) % 1024) as u64));
 
     bencher
@@ -310,7 +336,9 @@ fn patched_take_10k_first_chunk_only(bencher: Bencher) {
 fn patched_take_10k_adversarial(bencher: Bencher) {
     let values = (0u32..BIG_BASE2 + NUM_EXCEPTIONS).collect::<Buffer<u32>>();
     let uncompressed = PrimitiveArray::new(values, Validity::NonNullable);
-    let packed = bitpack_to_best_bit_width(&uncompressed).unwrap();
+    let packed =
+        bitpack_to_best_bit_width(&uncompressed, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
     let per_chunk_count = 100;
     let indices = PrimitiveArray::from_iter(
         (0..(NUM_EXCEPTIONS + 1024) / 1024)

--- a/encodings/fastlanes/benches/canonicalize_bench.rs
+++ b/encodings/fastlanes/benches/canonicalize_bench.rs
@@ -48,7 +48,14 @@ fn into_canonical_non_nullable(
 
     let chunks = (0..chunk_count)
         .map(|_| {
-            make_array(&mut rng, chunk_len, fraction_patched, 0.0).vortex_expect("make_array works")
+            make_array(
+                &mut rng,
+                chunk_len,
+                fraction_patched,
+                0.0,
+                &mut SESSION.create_execution_ctx(),
+            )
+            .vortex_expect("make_array works")
         })
         .collect::<Vec<_>>();
 
@@ -72,7 +79,14 @@ fn canonical_into_non_nullable(
 
     let chunks = (0..chunk_count)
         .map(|_| {
-            make_array(&mut rng, chunk_len, fraction_patched, 0.0).vortex_expect("make_array works")
+            make_array(
+                &mut rng,
+                chunk_len,
+                fraction_patched,
+                0.0,
+                &mut SESSION.create_execution_ctx(),
+            )
+            .vortex_expect("make_array works")
         })
         .collect::<Vec<_>>();
 
@@ -113,8 +127,14 @@ fn into_canonical_nullable(
 
     let chunks = (0..chunk_count)
         .map(|_| {
-            make_array(&mut rng, chunk_len, fraction_patched, 0.05)
-                .vortex_expect("make_array works")
+            make_array(
+                &mut rng,
+                chunk_len,
+                fraction_patched,
+                0.05,
+                &mut SESSION.create_execution_ctx(),
+            )
+            .vortex_expect("make_array works")
         })
         .collect::<Vec<_>>();
 
@@ -138,8 +158,14 @@ fn canonical_into_nullable(
 
     let chunks = (0..chunk_count)
         .map(|_| {
-            make_array(&mut rng, chunk_len, fraction_patched, 0.05)
-                .vortex_expect("make_array works")
+            make_array(
+                &mut rng,
+                chunk_len,
+                fraction_patched,
+                0.05,
+                &mut SESSION.create_execution_ctx(),
+            )
+            .vortex_expect("make_array works")
         })
         .collect::<Vec<_>>();
 

--- a/encodings/fastlanes/benches/compute_between.rs
+++ b/encodings/fastlanes/benches/compute_between.rs
@@ -12,8 +12,6 @@ use vortex_alp::alp_encode;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::NativePType;
@@ -41,7 +39,9 @@ fn generate_bit_pack_primitive_array<T: NativePType + NumCast>(
         .map(|_| T::from_usize(rng.random_range(0..10_000)).vortex_expect(""))
         .collect::<PrimitiveArray>();
 
-    bitpack_to_best_bit_width(&a).vortex_expect("").into_array()
+    bitpack_to_best_bit_width(&a, &mut LEGACY_SESSION.create_execution_ctx())
+        .vortex_expect("")
+        .into_array()
 }
 
 fn generate_alp_bit_pack_primitive_array<T: NativePType + NumCast>(
@@ -52,17 +52,16 @@ fn generate_alp_bit_pack_primitive_array<T: NativePType + NumCast>(
         .map(|_| T::from_usize(rng.random_range(0..10_000)).vortex_expect(""))
         .collect::<PrimitiveArray>();
 
-    let alp = alp_encode(
-        a.as_view(),
-        None,
-        &mut LEGACY_SESSION.create_execution_ctx(),
-    )
-    .vortex_expect("");
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let alp = alp_encode(a.as_view(), None, &mut ctx).vortex_expect("");
 
-    #[expect(deprecated)]
-    let encoded = alp.encoded().to_primitive();
+    let encoded = alp
+        .encoded()
+        .clone()
+        .execute::<PrimitiveArray>(&mut ctx)
+        .vortex_expect("");
 
-    let bp = bitpack_to_best_bit_width(&encoded)
+    let bp = bitpack_to_best_bit_width(&encoded, &mut ctx)
         .vortex_expect("")
         .into_array();
     ALP::new(bp, alp.exponents(), None).into_array()

--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -468,7 +468,7 @@ pub struct vortex_fastlanes::RLE
 
 impl vortex_fastlanes::RLE
 
-pub fn vortex_fastlanes::RLE::encode(array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>) -> vortex_error::VortexResult<vortex_fastlanes::RLEArray>
+pub fn vortex_fastlanes::RLE::encode(array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_fastlanes::RLEArray>
 
 pub unsafe fn vortex_fastlanes::RLE::new_unchecked(values: vortex_array::array::erased::ArrayRef, indices: vortex_array::array::erased::ArrayRef, values_idx_offsets: vortex_array::array::erased::ArrayRef, offset: usize, length: usize) -> vortex_fastlanes::RLEArray
 
@@ -532,7 +532,7 @@ pub struct vortex_fastlanes::RLEData
 
 impl vortex_fastlanes::RLEData
 
-pub fn vortex_fastlanes::RLEData::encode(array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>) -> vortex_error::VortexResult<vortex_fastlanes::RLEArray>
+pub fn vortex_fastlanes::RLEData::encode(array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_fastlanes::RLEArray>
 
 impl vortex_fastlanes::RLEData
 

--- a/encodings/fastlanes/public-api.lock
+++ b/encodings/fastlanes/public-api.lock
@@ -16,21 +16,21 @@ pub fn vortex_fastlanes::bit_transpose::untranspose_validity(validity: &vortex_a
 
 pub mod vortex_fastlanes::bitpack_compress
 
-pub fn vortex_fastlanes::bitpack_compress::bit_width_histogram(array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>) -> vortex_error::VortexResult<alloc::vec::Vec<usize>>
+pub fn vortex_fastlanes::bitpack_compress::bit_width_histogram(array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<alloc::vec::Vec<usize>>
 
-pub fn vortex_fastlanes::bitpack_compress::bitpack_encode(array: &vortex_array::arrays::primitive::vtable::PrimitiveArray, bit_width: u8, bit_width_freq: core::option::Option<&[usize]>) -> vortex_error::VortexResult<vortex_fastlanes::BitPackedArray>
+pub fn vortex_fastlanes::bitpack_compress::bitpack_encode(array: &vortex_array::arrays::primitive::vtable::PrimitiveArray, bit_width: u8, bit_width_freq: core::option::Option<&[usize]>, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_fastlanes::BitPackedArray>
 
 pub unsafe fn vortex_fastlanes::bitpack_compress::bitpack_encode_unchecked(array: vortex_array::arrays::primitive::vtable::PrimitiveArray, bit_width: u8) -> vortex_error::VortexResult<vortex_fastlanes::BitPackedArray>
 
 pub fn vortex_fastlanes::bitpack_compress::bitpack_primitive<T: vortex_array::dtype::ptype::NativePType + fastlanes::bitpacking::BitPacking>(array: &[T], bit_width: u8) -> vortex_buffer::buffer::Buffer<T>
 
-pub fn vortex_fastlanes::bitpack_compress::bitpack_to_best_bit_width(array: &vortex_array::arrays::primitive::vtable::PrimitiveArray) -> vortex_error::VortexResult<vortex_fastlanes::BitPackedArray>
+pub fn vortex_fastlanes::bitpack_compress::bitpack_to_best_bit_width(array: &vortex_array::arrays::primitive::vtable::PrimitiveArray, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_fastlanes::BitPackedArray>
 
 pub unsafe fn vortex_fastlanes::bitpack_compress::bitpack_unchecked(parray: &vortex_array::arrays::primitive::vtable::PrimitiveArray, bit_width: u8) -> vortex_buffer::ByteBuffer
 
 pub fn vortex_fastlanes::bitpack_compress::find_best_bit_width(ptype: vortex_array::dtype::ptype::PType, bit_width_freq: &[usize]) -> vortex_error::VortexResult<u8>
 
-pub fn vortex_fastlanes::bitpack_compress::gather_patches(parray: &vortex_array::arrays::primitive::vtable::PrimitiveArray, bit_width: u8, num_exceptions_hint: usize) -> vortex_error::VortexResult<core::option::Option<vortex_array::patches::Patches>>
+pub fn vortex_fastlanes::bitpack_compress::gather_patches(parray: &vortex_array::arrays::primitive::vtable::PrimitiveArray, bit_width: u8, num_exceptions_hint: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::patches::Patches>>
 
 pub mod vortex_fastlanes::bitpack_decompress
 
@@ -120,7 +120,7 @@ pub struct vortex_fastlanes::BitPacked
 
 impl vortex_fastlanes::BitPacked
 
-pub fn vortex_fastlanes::BitPacked::encode(array: &vortex_array::array::erased::ArrayRef, bit_width: u8) -> vortex_error::VortexResult<vortex_fastlanes::BitPackedArray>
+pub fn vortex_fastlanes::BitPacked::encode(array: &vortex_array::array::erased::ArrayRef, bit_width: u8, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_fastlanes::BitPackedArray>
 
 pub fn vortex_fastlanes::BitPacked::into_parts(array: vortex_fastlanes::BitPackedArray) -> vortex_fastlanes::BitPackedDataParts
 
@@ -196,7 +196,7 @@ impl vortex_fastlanes::BitPackedData
 
 pub fn vortex_fastlanes::BitPackedData::bit_width(&self) -> u8
 
-pub fn vortex_fastlanes::BitPackedData::encode(array: &vortex_array::array::erased::ArrayRef, bit_width: u8) -> vortex_error::VortexResult<vortex_fastlanes::BitPackedArray>
+pub fn vortex_fastlanes::BitPackedData::encode(array: &vortex_array::array::erased::ArrayRef, bit_width: u8, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_fastlanes::BitPackedArray>
 
 pub fn vortex_fastlanes::BitPackedData::max_packed_value(&self) -> usize
 
@@ -522,7 +522,7 @@ pub fn vortex_fastlanes::RLE::validity(array: vortex_array::array::view::ArrayVi
 
 impl vortex_array::arrays::slice::SliceKernel for vortex_fastlanes::RLE
 
-pub fn vortex_fastlanes::RLE::slice(array: vortex_array::array::view::ArrayView<'_, Self>, range: core::ops::range::Range<usize>, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::erased::ArrayRef>>
+pub fn vortex_fastlanes::RLE::slice(array: vortex_array::array::view::ArrayView<'_, Self>, range: core::ops::range::Range<usize>, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::erased::ArrayRef>>
 
 impl vortex_array::scalar_fn::fns::cast::kernel::CastReduce for vortex_fastlanes::RLE
 
@@ -638,7 +638,7 @@ pub fn vortex_fastlanes::RLEArrayExt::offset(&self) -> usize
 
 pub fn vortex_fastlanes::RLEArrayExt::values(&self) -> &vortex_array::array::erased::ArrayRef
 
-pub fn vortex_fastlanes::RLEArrayExt::values_idx_offset(&self, chunk_idx: usize) -> usize
+pub fn vortex_fastlanes::RLEArrayExt::values_idx_offset(&self, chunk_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> usize
 
 pub fn vortex_fastlanes::RLEArrayExt::values_idx_offsets(&self) -> &vortex_array::array::erased::ArrayRef
 
@@ -650,7 +650,7 @@ pub fn T::offset(&self) -> usize
 
 pub fn T::values(&self) -> &vortex_array::array::erased::ArrayRef
 
-pub fn T::values_idx_offset(&self, chunk_idx: usize) -> usize
+pub fn T::values_idx_offset(&self, chunk_idx: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> usize
 
 pub fn T::values_idx_offsets(&self) -> &vortex_array::array::erased::ArrayRef
 

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -5,9 +5,8 @@ use fastlanes::BitPacking;
 use itertools::Itertools;
 use num_traits::PrimInt;
 use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
@@ -32,10 +31,13 @@ use crate::BitPacked;
 use crate::BitPackedArray;
 use crate::bitpack_decompress;
 
-pub fn bitpack_to_best_bit_width(array: &PrimitiveArray) -> VortexResult<BitPackedArray> {
-    let bit_width_freq = bit_width_histogram(array.as_view())?;
+pub fn bitpack_to_best_bit_width(
+    array: &PrimitiveArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<BitPackedArray> {
+    let bit_width_freq = bit_width_histogram(array.as_view(), ctx)?;
     let best_bit_width = find_best_bit_width(array.ptype(), &bit_width_freq)?;
-    bitpack_encode(array, best_bit_width, Some(&bit_width_freq))
+    bitpack_encode(array, best_bit_width, Some(&bit_width_freq), ctx)
 }
 
 #[expect(unused_comparisons, clippy::absurd_extreme_comparisons)]
@@ -43,10 +45,11 @@ pub fn bitpack_encode(
     array: &PrimitiveArray,
     bit_width: u8,
     bit_width_freq: Option<&[usize]>,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<BitPackedArray> {
     let bit_width_freq = match bit_width_freq {
         Some(freq) => freq,
-        None => &bit_width_histogram(array.as_view())?,
+        None => &bit_width_histogram(array.as_view(), ctx)?,
     };
 
     // Check array contains no negative values.
@@ -54,7 +57,7 @@ pub fn bitpack_encode(
         let has_negative_values = match_each_integer_ptype!(array.ptype(), |P| {
             array
                 .statistics()
-                .compute_min::<P>(&mut LEGACY_SESSION.create_execution_ctx())
+                .compute_min::<P>(ctx)
                 .unwrap_or_default()
                 < 0
         });
@@ -76,7 +79,7 @@ pub fn bitpack_encode(
     // SAFETY: we check that array only contains non-negative values.
     let packed = unsafe { bitpack_unchecked(array, bit_width) };
     let patches = (num_exceptions > 0)
-        .then(|| gather_patches(array, bit_width, num_exceptions))
+        .then(|| gather_patches(array, bit_width, num_exceptions, ctx))
         .transpose()?
         .flatten();
 
@@ -199,6 +202,7 @@ pub fn gather_patches(
     parray: &PrimitiveArray,
     bit_width: u8,
     num_exceptions_hint: usize,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<Patches>> {
     let patch_validity = match parray.validity()? {
         Validity::NonNullable => Validity::NonNullable,
@@ -206,10 +210,7 @@ pub fn gather_patches(
     };
 
     let array_len = parray.len();
-    let validity_mask = parray
-        .as_ref()
-        .validity()?
-        .to_mask(parray.len(), &mut LEGACY_SESSION.create_execution_ctx())?;
+    let validity_mask = parray.as_ref().validity()?.to_mask(parray.len(), ctx)?;
 
     let patches = if array_len < u8::MAX as usize {
         match_each_integer_ptype!(parray.ptype(), |T| {
@@ -300,12 +301,18 @@ where
     }
 }
 
-pub fn bit_width_histogram(array: ArrayView<'_, Primitive>) -> VortexResult<Vec<usize>> {
-    match_each_integer_ptype!(array.ptype(), |P| { bit_width_histogram_typed::<P>(array) })
+pub fn bit_width_histogram(
+    array: ArrayView<'_, Primitive>,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Vec<usize>> {
+    match_each_integer_ptype!(array.ptype(), |P| {
+        bit_width_histogram_typed::<P>(array, ctx)
+    })
 }
 
 fn bit_width_histogram_typed<T: NativePType + PrimInt>(
     array: ArrayView<'_, Primitive>,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<Vec<usize>> {
     let bit_width: fn(T) -> usize =
         |v: T| (8 * size_of::<T>()) - (PrimInt::leading_zeros(v) as usize);
@@ -313,10 +320,7 @@ fn bit_width_histogram_typed<T: NativePType + PrimInt>(
     let mut bit_widths = vec![0usize; size_of::<T>() * 8 + 1];
     match array
         .validity()?
-        .to_mask(
-            array.as_ref().len(),
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )?
+        .to_mask(array.as_ref().len(), ctx)?
         .bit_buffer()
     {
         AllOr::All => {
@@ -388,9 +392,8 @@ pub mod test_harness {
     use rand::RngExt;
     use rand::rngs::StdRng;
     use vortex_array::ArrayRef;
+    use vortex_array::ExecutionCtx;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::validity::Validity;
     use vortex_buffer::BufferMut;
@@ -403,6 +406,7 @@ pub mod test_harness {
         len: usize,
         fraction_patches: f64,
         fraction_null: f64,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ArrayRef> {
         let values = (0..len)
             .map(|_| {
@@ -414,15 +418,14 @@ pub mod test_harness {
             })
             .collect::<BufferMut<i32>>();
 
-        #[expect(deprecated)]
         let values = if fraction_null == 0.0 {
-            values.into_array().to_primitive()
+            values.into_array().execute::<PrimitiveArray>(ctx)?
         } else {
             let validity = Validity::from_iter((0..len).map(|_| !rng.random_bool(fraction_null)));
             PrimitiveArray::new(values, validity)
         };
 
-        bitpack_encode(&values, 12, None).map(|a| a.into_array())
+        bitpack_encode(&values, 12, None, ctx).map(|a| a.into_array())
     }
 }
 
@@ -432,8 +435,6 @@ mod test {
 
     use rand::SeedableRng;
     use rand::rngs::StdRng;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::ChunkedArray;
     use vortex_array::assert_arrays_eq;
@@ -465,13 +466,14 @@ mod test {
 
     #[test]
     fn null_patches() {
+        let mut ctx = SESSION.create_execution_ctx();
         let valid_values = (0..24).map(|v| v < 1 << 4).collect::<Vec<_>>();
         let values = PrimitiveArray::new(
             (0u32..24).collect::<Buffer<_>>(),
             Validity::from_iter(valid_values),
         );
         assert!(values.ptype().is_unsigned_int());
-        let compressed = BitPackedData::encode(&values.into_array(), 4).unwrap();
+        let compressed = BitPackedData::encode(&values.into_array(), 4, &mut ctx).unwrap();
         assert!(compressed.patches().is_none());
         assert_eq!(
             (0..(1 << 4)).collect::<Vec<_>>(),
@@ -479,10 +481,7 @@ mod test {
                 .as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(
-                    compressed.as_ref().len(),
-                    &mut SESSION.create_execution_ctx()
-                )
+                .to_mask(compressed.as_ref().len(), &mut ctx)
                 .unwrap()
                 .to_bit_buffer()
                 .set_indices()
@@ -492,28 +491,30 @@ mod test {
 
     #[test]
     fn compress_signed_fails() {
+        let mut ctx = SESSION.create_execution_ctx();
         let values: Buffer<i64> = (-500..500).collect();
         let array = PrimitiveArray::new(values, Validity::AllValid);
         assert!(array.ptype().is_signed_int());
 
-        let err = BitPackedData::encode(&array.into_array(), 1024u32.ilog2() as u8).unwrap_err();
+        let err =
+            BitPackedData::encode(&array.into_array(), 1024u32.ilog2() as u8, &mut ctx).unwrap_err();
         assert!(matches!(err, VortexError::InvalidArgument(_, _)));
     }
 
     #[test]
     fn canonicalize_chunked_of_bitpacked() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         let mut rng = StdRng::seed_from_u64(0);
 
         let chunks = (0..10)
-            .map(|_| make_array(&mut rng, 100, 0.25, 0.25).unwrap())
+            .map(|_| make_array(&mut rng, 100, 0.25, 0.25, &mut ctx).unwrap())
             .collect::<Vec<_>>();
         let chunked = ChunkedArray::from_iter(chunks).into_array();
 
-        #[expect(deprecated)]
-        let into_ca = chunked.to_primitive();
+        let into_ca = chunked.clone().execute::<PrimitiveArray>(&mut ctx)?;
         let mut primitive_builder =
             PrimitiveBuilder::<i32>::with_capacity(chunked.dtype().nullability(), 10 * 100);
-        chunked.append_to_builder(&mut primitive_builder, &mut SESSION.create_execution_ctx())?;
+        chunked.append_to_builder(&mut primitive_builder, &mut ctx)?;
         let ca_into = primitive_builder.finish();
 
         assert_arrays_eq!(into_ca, ca_into);
@@ -529,7 +530,8 @@ mod test {
     }
 
     #[test]
-    fn test_chunk_offsets() {
+    fn test_chunk_offsets() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         let patch_value = 1u32 << 20;
         let patch_indices = [100usize, 200, 3000, 3100];
         let mut values = vec![0u32; 4096usize];
@@ -539,21 +541,27 @@ mod test {
             .for_each(|&idx| values[idx] = patch_value);
 
         let array = PrimitiveArray::from_iter(values);
-        let bitpacked = bitpack_encode(&array, 4, None).unwrap();
+        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx).unwrap();
 
         let patches = bitpacked.patches().unwrap();
-        #[expect(deprecated)]
-        let chunk_offsets = patches.chunk_offsets().as_ref().unwrap().to_primitive();
+        let chunk_offsets = patches
+            .chunk_offsets()
+            .as_ref()
+            .unwrap()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
 
         // chunk 0 (0-1023): patches at 100, 200 -> starts at patch index 0
         // chunk 1 (1024-2047): no patches -> points to patch index 2
         // chunk 2 (2048-3071): patch at 3000 -> starts at patch index 2
         // chunk 3 (3072-4095): patch at 3100 -> starts at patch index 3
         assert_arrays_eq!(chunk_offsets, PrimitiveArray::from_iter([0u64, 2, 2, 3]));
+        Ok(())
     }
 
     #[test]
-    fn test_chunk_offsets_no_patches_in_middle() {
+    fn test_chunk_offsets_no_patches_in_middle() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         let patch_value = 1u32 << 20;
         let patch_indices = [100usize, 200, 2500];
         let mut values = vec![0u32; 3072usize];
@@ -563,17 +571,23 @@ mod test {
             .for_each(|&idx| values[idx] = patch_value);
 
         let array = PrimitiveArray::from_iter(values);
-        let bitpacked = bitpack_encode(&array, 4, None).unwrap();
+        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx).unwrap();
 
         let patches = bitpacked.patches().unwrap();
-        #[expect(deprecated)]
-        let chunk_offsets = patches.chunk_offsets().as_ref().unwrap().to_primitive();
+        let chunk_offsets = patches
+            .chunk_offsets()
+            .as_ref()
+            .unwrap()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
 
         assert_arrays_eq!(chunk_offsets, PrimitiveArray::from_iter([0u64, 2, 2]));
+        Ok(())
     }
 
     #[test]
-    fn test_chunk_offsets_trailing_empty_chunks() {
+    fn test_chunk_offsets_trailing_empty_chunks() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         let patch_value = 1u32 << 20;
         let patch_indices = [100usize, 200, 1500];
         let mut values = vec![0u32; 5120usize];
@@ -583,11 +597,15 @@ mod test {
             .for_each(|&idx| values[idx] = patch_value);
 
         let array = PrimitiveArray::from_iter(values);
-        let bitpacked = bitpack_encode(&array, 4, None).unwrap();
+        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx).unwrap();
 
         let patches = bitpacked.patches().unwrap();
-        #[expect(deprecated)]
-        let chunk_offsets = patches.chunk_offsets().as_ref().unwrap().to_primitive();
+        let chunk_offsets = patches
+            .chunk_offsets()
+            .as_ref()
+            .unwrap()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
 
         // chunk 0 (0-1023): patches at 100, 200 -> starts at patch index 0
         // chunk 1 (1024-2047): patch at 1500 -> starts at patch index 2
@@ -595,10 +613,12 @@ mod test {
         // chunk 3 (3072-4095): no patches -> points to patch index 3 (remaining chunks filled)
         // chunk 4 (4096-5119): no patches -> points to patch index 3 (remaining chunks filled)
         assert_arrays_eq!(chunk_offsets, PrimitiveArray::from_iter([0u64, 2, 3, 3, 3]));
+        Ok(())
     }
 
     #[test]
-    fn test_chunk_offsets_single_chunk() {
+    fn test_chunk_offsets_single_chunk() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         let patch_value = 1u32 << 20;
         let patch_indices = [100usize, 200];
         let mut values = vec![0u32; 500usize];
@@ -608,13 +628,18 @@ mod test {
             .for_each(|&idx| values[idx] = patch_value);
 
         let array = PrimitiveArray::from_iter(values);
-        let bitpacked = bitpack_encode(&array, 4, None).unwrap();
+        let bitpacked = bitpack_encode(&array, 4, None, &mut ctx).unwrap();
 
         let patches = bitpacked.patches().unwrap();
-        #[expect(deprecated)]
-        let chunk_offsets = patches.chunk_offsets().as_ref().unwrap().to_primitive();
+        let chunk_offsets = patches
+            .chunk_offsets()
+            .as_ref()
+            .unwrap()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
 
         // Single chunk starting at patch index 0.
         assert_arrays_eq!(chunk_offsets, PrimitiveArray::from_iter([0u64]));
+        Ok(())
     }
 }

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_compress.rs
@@ -55,11 +55,7 @@ pub fn bitpack_encode(
     // Check array contains no negative values.
     if array.ptype().is_signed_int() {
         let has_negative_values = match_each_integer_ptype!(array.ptype(), |P| {
-            array
-                .statistics()
-                .compute_min::<P>(ctx)
-                .unwrap_or_default()
-                < 0
+            array.statistics().compute_min::<P>(ctx).unwrap_or_default() < 0
         });
         if has_negative_values {
             vortex_bail!(InvalidArgument: "cannot bitpack_encode array containing negative integers")
@@ -496,8 +492,8 @@ mod test {
         let array = PrimitiveArray::new(values, Validity::AllValid);
         assert!(array.ptype().is_signed_int());
 
-        let err =
-            BitPackedData::encode(&array.into_array(), 1024u32.ilog2() as u8, &mut ctx).unwrap_err();
+        let err = BitPackedData::encode(&array.into_array(), 1024u32.ilog2() as u8, &mut ctx)
+            .unwrap_err();
         assert!(matches!(err, VortexError::InvalidArgument(_, _)));
     }
 

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -189,8 +189,7 @@ mod tests {
     fn compression_roundtrip(n: usize) {
         let mut ctx = SESSION.create_execution_ctx();
         let values = PrimitiveArray::from_iter((0..n).map(|i| (i % 2047) as u16));
-        let compressed =
-            BitPackedData::encode(&values.clone().into_array(), 11, &mut ctx).unwrap();
+        let compressed = BitPackedData::encode(&values.clone().into_array(), 11, &mut ctx).unwrap();
         assert_arrays_eq!(compressed, values);
 
         values

--- a/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
+++ b/encodings/fastlanes/src/bitpacking/array/bitpack_decompress.rs
@@ -160,8 +160,6 @@ mod tests {
 
     use vortex_array::Canonical;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::assert_arrays_eq;
     use vortex_array::dtype::Nullability;
@@ -178,7 +176,7 @@ mod tests {
     use crate::bitpack_compress::bitpack_encode;
 
     fn encode(array: &PrimitiveArray, bit_width: u8) -> BitPackedArray {
-        bitpack_encode(array, bit_width, None).unwrap()
+        bitpack_encode(array, bit_width, None, &mut SESSION.create_execution_ctx()).unwrap()
     }
 
     static SESSION: LazyLock<VortexSession> =
@@ -189,8 +187,10 @@ mod tests {
     }
 
     fn compression_roundtrip(n: usize) {
+        let mut ctx = SESSION.create_execution_ctx();
         let values = PrimitiveArray::from_iter((0..n).map(|i| (i % 2047) as u16));
-        let compressed = BitPackedData::encode(&values.clone().into_array(), 11).unwrap();
+        let compressed =
+            BitPackedData::encode(&values.clone().into_array(), 11, &mut ctx).unwrap();
         assert_arrays_eq!(compressed, values);
 
         values
@@ -220,8 +220,10 @@ mod tests {
 
     #[test]
     fn test_all_zeros() -> VortexResult<()> {
-        #[expect(deprecated)]
-        let zeros = buffer![0u16, 0, 0, 0].into_array().to_primitive();
+        let mut ctx = SESSION.create_execution_ctx();
+        let zeros = buffer![0u16, 0, 0, 0]
+            .into_array()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let bitpacked = encode(&zeros, 0);
         let actual = unpack(&bitpacked)?;
         assert_arrays_eq!(actual, PrimitiveArray::from_iter([0u16, 0, 0, 0]));
@@ -230,8 +232,10 @@ mod tests {
 
     #[test]
     fn test_simple_patches() -> VortexResult<()> {
-        #[expect(deprecated)]
-        let zeros = buffer![0u16, 1, 0, 1].into_array().to_primitive();
+        let mut ctx = SESSION.create_execution_ctx();
+        let zeros = buffer![0u16, 1, 0, 1]
+            .into_array()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let bitpacked = encode(&zeros, 0);
         let actual = unpack(&bitpacked)?;
         assert_arrays_eq!(actual, PrimitiveArray::from_iter([0u16, 1, 0, 1]));
@@ -240,8 +244,10 @@ mod tests {
 
     #[test]
     fn test_one_full_chunk() -> VortexResult<()> {
-        #[expect(deprecated)]
-        let zeros = BufferMut::from_iter(0u16..1024).into_array().to_primitive();
+        let mut ctx = SESSION.create_execution_ctx();
+        let zeros = BufferMut::from_iter(0u16..1024)
+            .into_array()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let bitpacked = encode(&zeros, 10);
         let actual = unpack(&bitpacked)?;
         assert_arrays_eq!(actual, PrimitiveArray::from_iter(0u16..1024));
@@ -250,10 +256,10 @@ mod tests {
 
     #[test]
     fn test_three_full_chunks_with_patches() -> VortexResult<()> {
-        #[expect(deprecated)]
+        let mut ctx = SESSION.create_execution_ctx();
         let zeros = BufferMut::from_iter((5u16..1029).chain(5u16..1029).chain(5u16..1029))
             .into_array()
-            .to_primitive();
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let bitpacked = encode(&zeros, 10);
         assert!(bitpacked.patches().is_some());
         let actual = unpack(&bitpacked)?;
@@ -266,8 +272,10 @@ mod tests {
 
     #[test]
     fn test_one_full_chunk_and_one_short_chunk_no_patch() -> VortexResult<()> {
-        #[expect(deprecated)]
-        let zeros = BufferMut::from_iter(0u16..1025).into_array().to_primitive();
+        let mut ctx = SESSION.create_execution_ctx();
+        let zeros = BufferMut::from_iter(0u16..1025)
+            .into_array()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let bitpacked = encode(&zeros, 11);
         assert!(bitpacked.patches().is_none());
         let actual = unpack(&bitpacked)?;
@@ -277,10 +285,10 @@ mod tests {
 
     #[test]
     fn test_one_full_chunk_and_one_short_chunk_with_patches() -> VortexResult<()> {
-        #[expect(deprecated)]
+        let mut ctx = SESSION.create_execution_ctx();
         let zeros = BufferMut::from_iter(512u16..1537)
             .into_array()
-            .to_primitive();
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let bitpacked = encode(&zeros, 10);
         assert_eq!(bitpacked.len(), 1025);
         assert!(bitpacked.patches().is_some());
@@ -291,42 +299,36 @@ mod tests {
 
     #[test]
     fn test_offset_and_short_chunk_and_patches() -> VortexResult<()> {
-        #[expect(deprecated)]
+        let mut ctx = SESSION.create_execution_ctx();
         let zeros = BufferMut::from_iter(512u16..1537)
             .into_array()
-            .to_primitive();
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let bitpacked = encode(&zeros, 10);
         assert_eq!(bitpacked.len(), 1025);
         assert!(bitpacked.patches().is_some());
         let slice_ref = bitpacked.into_array().slice(1023..1025).unwrap();
-        let actual = {
-            let mut ctx = SESSION.create_execution_ctx();
-            slice_ref
-                .execute::<Canonical>(&mut ctx)
-                .unwrap()
-                .into_primitive()
-        };
+        let actual = slice_ref
+            .execute::<Canonical>(&mut ctx)
+            .unwrap()
+            .into_primitive();
         assert_arrays_eq!(actual, PrimitiveArray::from_iter([1535u16, 1536]));
         Ok(())
     }
 
     #[test]
     fn test_offset_and_short_chunk_with_chunks_between_and_patches() -> VortexResult<()> {
-        #[expect(deprecated)]
+        let mut ctx = SESSION.create_execution_ctx();
         let zeros = BufferMut::from_iter(512u16..2741)
             .into_array()
-            .to_primitive();
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let bitpacked = encode(&zeros, 10);
         assert_eq!(bitpacked.len(), 2229);
         assert!(bitpacked.patches().is_some());
         let slice_ref = bitpacked.into_array().slice(1023..2049).unwrap();
-        let actual = {
-            let mut ctx = SESSION.create_execution_ctx();
-            slice_ref
-                .execute::<Canonical>(&mut ctx)
-                .unwrap()
-                .into_primitive()
-        };
+        let actual = slice_ref
+            .execute::<Canonical>(&mut ctx)
+            .unwrap()
+            .into_primitive();
         assert_arrays_eq!(
             actual,
             PrimitiveArray::from_iter((1023u16..2049).map(|x| x + 512))

--- a/encodings/fastlanes/src/bitpacking/array/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/array/mod.rs
@@ -6,6 +6,7 @@ use std::fmt::Formatter;
 
 use fastlanes::BitPacking;
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::TypedArrayRef;
 use vortex_array::array_slots;
 use vortex_array::arrays::Primitive;
@@ -254,12 +255,16 @@ impl BitPackedData {
     ///
     /// If the requested bit-width for packing is larger than the array's native width, an
     /// error will be returned.
-    pub fn encode(array: &ArrayRef, bit_width: u8) -> VortexResult<BitPackedArray> {
+    pub fn encode(
+        array: &ArrayRef,
+        bit_width: u8,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<BitPackedArray> {
         let parray: PrimitiveArray = array
             .clone()
             .try_downcast::<Primitive>()
             .map_err(|a| vortex_err!(InvalidArgument: "Bitpacking can only encode primitive arrays, got {}", a.encoding_id()))?;
-        bitpack_encode(&parray, bit_width, None)
+        bitpack_encode(&parray, bit_width, None, ctx)
     }
 
     /// Calculate the maximum value that **can** be contained by this array, given its bit-width.
@@ -333,8 +338,8 @@ impl<T: TypedArrayRef<crate::BitPacked>> BitPackedArrayExt for T {}
 #[cfg(test)]
 mod test {
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_buffer::Buffer;
@@ -344,6 +349,7 @@ mod test {
 
     #[test]
     fn test_encode() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = [
             Some(1u64),
             None,
@@ -354,32 +360,40 @@ mod test {
             Some(u64::MAX),
         ];
         let uncompressed = PrimitiveArray::from_option_iter(values);
-        let packed = BitPackedData::encode(&uncompressed.into_array(), 1).unwrap();
+        let packed = BitPackedData::encode(&uncompressed.into_array(), 1, &mut ctx).unwrap();
         let expected = PrimitiveArray::from_option_iter(values);
-        #[expect(deprecated)]
-        let packed_primitive = packed.as_array().to_primitive();
+        let packed_primitive = packed
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         assert_arrays_eq!(packed_primitive, expected);
     }
 
     #[test]
     fn test_encode_too_wide() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = [Some(1u8), None, Some(1), None, Some(1), None];
         let uncompressed = PrimitiveArray::from_option_iter(values);
-        let _packed = BitPackedData::encode(&uncompressed.clone().into_array(), 8)
+        let _packed = BitPackedData::encode(&uncompressed.clone().into_array(), 8, &mut ctx)
             .expect_err("Cannot pack value into the same width");
-        let _packed = BitPackedData::encode(&uncompressed.into_array(), 9)
+        let _packed = BitPackedData::encode(&uncompressed.into_array(), 9, &mut ctx)
             .expect_err("Cannot pack value into larger width");
     }
 
     #[test]
     fn signed_with_patches() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values: Buffer<i32> = (0i32..=512).collect();
         let parray = values.clone().into_array();
 
-        let packed_with_patches = BitPackedData::encode(&parray, 9).unwrap();
+        let packed_with_patches = BitPackedData::encode(&parray, 9, &mut ctx).unwrap();
         assert!(packed_with_patches.patches().is_some());
-        #[expect(deprecated)]
-        let packed_primitive = packed_with_patches.as_array().to_primitive();
+        let packed_primitive = packed_with_patches
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         assert_arrays_eq!(
             packed_primitive,
             PrimitiveArray::new(values, vortex_array::validity::Validity::NonNullable)

--- a/encodings/fastlanes/src/bitpacking/array/unpack_iter.rs
+++ b/encodings/fastlanes/src/bitpacking/array/unpack_iter.rs
@@ -55,12 +55,14 @@ impl<T: PhysicalPType<Physical: BitPacking>> UnpackStrategy<T> for BitPackingStr
 /// #[gat(Item)]
 /// use lending_iterator::prelude::LendingIterator;
 /// use vortex_array::IntoArray;
+/// use vortex_array::VortexSessionExecute;
 /// use vortex_buffer::buffer;
 /// use vortex_fastlanes::BitPackedData;
 /// use vortex_fastlanes::BitPackedArrayExt;
 /// use vortex_fastlanes::unpack_iter::BitUnpackedChunks;
 ///
-/// let array = BitPackedData::encode(&buffer![2, 3, 4, 5].into_array(), 2).unwrap();
+/// let mut ctx = vortex_array::LEGACY_SESSION.create_execution_ctx();
+/// let array = BitPackedData::encode(&buffer![2, 3, 4, 5].into_array(), 2, &mut ctx).unwrap();
 /// let mut unpacked_chunks: BitUnpackedChunks<i32> = array.unpacked_chunks().unwrap();
 ///
 /// if let Some(header) = unpacked_chunks.initial() {

--- a/encodings/fastlanes/src/bitpacking/compute/cast.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/cast.rs
@@ -53,6 +53,8 @@ mod tests {
     use rstest::rstest;
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::builtins::ArrayBuiltins;
@@ -66,7 +68,7 @@ mod tests {
     use crate::BitPackedData;
 
     fn bp(array: &ArrayRef, bit_width: u8) -> BitPackedArray {
-        BitPackedData::encode(array, bit_width).unwrap()
+        BitPackedData::encode(array, bit_width, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     #[test]

--- a/encodings/fastlanes/src/bitpacking/compute/filter.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/filter.rs
@@ -178,8 +178,8 @@ fn filter_with_indices<T: NativePType + BitPacking>(
 #[cfg(test)]
 mod test {
     use vortex_array::IntoArray as _;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::compute::conformance::filter::test_filter_conformance;
@@ -193,9 +193,10 @@ mod test {
 
     #[test]
     fn take_indices() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 6).unwrap();
+        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 6, &mut ctx).unwrap();
 
         let mask = Mask::from_indices(bitpacked.len(), vec![0, 125, 2047, 2049, 2151, 2790]);
 
@@ -208,9 +209,10 @@ mod test {
 
     #[test]
     fn take_sliced_indices() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 6).unwrap();
+        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 6, &mut ctx).unwrap();
         let sliced = bitpacked.slice(128..2050).unwrap();
 
         let mask = Mask::from_indices(sliced.len(), vec![1919, 1921]);
@@ -221,13 +223,13 @@ mod test {
 
     #[test]
     fn filter_bitpacked() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 6).unwrap();
+        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 6, &mut ctx).unwrap();
         let filtered = bitpacked
             .filter(Mask::from_indices(4096, (0..1024).collect()))
             .unwrap();
-        #[expect(deprecated)]
-        let filtered_prim = filtered.to_primitive();
+        let filtered_prim = filtered.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(
             filtered_prim,
             PrimitiveArray::from_iter((0..1024).map(|i| (i % 63) as u8))
@@ -236,14 +238,15 @@ mod test {
 
     #[test]
     fn filter_bitpacked_signed() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values: Buffer<i64> = (0..500).collect();
         let unpacked = PrimitiveArray::new(values.clone(), Validity::NonNullable);
-        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 9).unwrap();
-        #[expect(deprecated)]
+        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 9, &mut ctx).unwrap();
         let filtered = bitpacked
             .filter(Mask::from_indices(values.len(), (0..250).collect()))
             .unwrap()
-            .to_primitive();
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
 
         assert_arrays_eq!(
             filtered,
@@ -253,19 +256,20 @@ mod test {
 
     #[test]
     fn test_filter_bitpacked_conformance() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test with u8 values
         let unpacked = buffer![1u8, 2, 3, 4, 5].into_array();
-        let bitpacked = BitPackedData::encode(&unpacked, 3).unwrap();
+        let bitpacked = BitPackedData::encode(&unpacked, 3, &mut ctx).unwrap();
         test_filter_conformance(&bitpacked.into_array());
 
         // Test with u32 values
         let unpacked = buffer![100u32, 200, 300, 400, 500].into_array();
-        let bitpacked = BitPackedData::encode(&unpacked, 9).unwrap();
+        let bitpacked = BitPackedData::encode(&unpacked, 9, &mut ctx).unwrap();
         test_filter_conformance(&bitpacked.into_array());
 
         // Test with nullable values
         let unpacked = PrimitiveArray::from_option_iter([Some(1u16), None, Some(3), Some(4), None]);
-        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 3).unwrap();
+        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 3, &mut ctx).unwrap();
         test_filter_conformance(&bitpacked.into_array());
     }
 
@@ -276,22 +280,23 @@ mod test {
     /// This test ensures that the type handling is correct.
     #[test]
     fn filter_bitpacked_signed_with_patches() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create signed integer values where some exceed the bit width (causing patches).
         // Values 0-127 fit in 7 bits, but 1000 and 2000 do not.
         let values: Vec<i32> = vec![0, 10, 1000, 20, 30, 2000, 40, 50, 60, 70];
         let unpacked = PrimitiveArray::from_iter(values.clone());
-        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 7).unwrap();
+        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 7, &mut ctx).unwrap();
         assert!(
             bitpacked.patches().is_some(),
             "Expected patches for values exceeding bit width"
         );
 
         // Filter to include some patched and some non-patched values.
-        #[expect(deprecated)]
         let filtered = bitpacked
             .filter(Mask::from_indices(values.len(), vec![0, 2, 5, 9]))
             .unwrap()
-            .to_primitive();
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
 
         assert_arrays_eq!(filtered, PrimitiveArray::from_iter([0i32, 1000, 2000, 70]));
     }
@@ -302,6 +307,7 @@ mod test {
     /// that doesn't fully decompress the array first.
     #[test]
     fn filter_bitpacked_signed_with_patches_low_selectivity() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a larger array with signed integers and some patches.
         let values: Vec<i32> = (0..1000)
             .map(|i| {
@@ -313,7 +319,7 @@ mod test {
             })
             .collect();
         let unpacked = PrimitiveArray::from_iter(values.clone());
-        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 7).unwrap();
+        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 7, &mut ctx).unwrap();
         assert!(
             bitpacked.patches().is_some(),
             "Expected patches for values exceeding bit width"
@@ -321,11 +327,11 @@ mod test {
 
         // Use low selectivity (only select 2% of values) to avoid full decompression.
         let indices: Vec<usize> = (0..20).collect();
-        #[expect(deprecated)]
         let filtered = bitpacked
             .filter(Mask::from_indices(values.len(), indices))
             .unwrap()
-            .to_primitive();
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
 
         let expected: Vec<i32> = values[0..20].to_vec();
         assert_arrays_eq!(filtered, PrimitiveArray::from_iter(expected));

--- a/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/is_constant.rs
@@ -8,8 +8,6 @@ use lending_iterator::LendingIterator;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::aggregate_fn::fns::is_constant::IsConstant;
 use vortex_array::aggregate_fn::fns::is_constant::primitive::IS_CONST_LANE_WIDTH;
@@ -46,7 +44,7 @@ impl DynAggregateKernel for BitPackedIsConstantKernel {
         };
 
         let result = match_each_integer_ptype!(array.dtype().as_ptype(), |P| {
-            bitpacked_is_constant::<P, { IS_CONST_LANE_WIDTH / size_of::<P>() }>(array)?
+            bitpacked_is_constant::<P, { IS_CONST_LANE_WIDTH / size_of::<P>() }>(array, ctx)?
         });
 
         Ok(Some(IsConstant::make_partial(batch, result, ctx)?))
@@ -55,16 +53,18 @@ impl DynAggregateKernel for BitPackedIsConstantKernel {
 
 fn bitpacked_is_constant<T: BitPackedUnpack, const WIDTH: usize>(
     array: ArrayView<'_, BitPacked>,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<bool> {
     let mut bit_unpack_iterator = array.unpacked_chunks::<T>()?;
-    let patches = array.patches().map(|p| {
-        #[expect(deprecated)]
-        let values = p.values().to_primitive();
-        #[expect(deprecated)]
-        let indices = p.indices().to_primitive();
-        let offset = p.offset();
-        (indices, values, offset)
-    });
+    let patches = array
+        .patches()
+        .map(|p| -> VortexResult<_> {
+            let values = p.values().clone().execute::<PrimitiveArray>(ctx)?;
+            let indices = p.indices().clone().execute::<PrimitiveArray>(ctx)?;
+            let offset = p.offset();
+            Ok((indices, values, offset))
+        })
+        .transpose()?;
 
     let mut header_constant_value = None;
     let mut current_idx = 0;
@@ -195,8 +195,8 @@ mod tests {
 
     #[test]
     fn is_constant_with_patches() -> VortexResult<()> {
-        let array = BitPackedData::encode(&buffer![4; 1025].into_array(), 2)?;
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array = BitPackedData::encode(&buffer![4; 1025].into_array(), 2, &mut ctx)?;
         assert!(is_constant(&array.into_array(), &mut ctx)?);
         Ok(())
     }

--- a/encodings/fastlanes/src/bitpacking/compute/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/mod.rs
@@ -53,7 +53,13 @@ mod tests {
     use crate::bitpacking::compute::chunked_indices;
 
     fn bp(array: &PrimitiveArray, bit_width: u8) -> BitPackedArray {
-        bitpack_encode(array, bit_width, None, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
+        bitpack_encode(
+            array,
+            bit_width,
+            None,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     #[test]

--- a/encodings/fastlanes/src/bitpacking/compute/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/mod.rs
@@ -42,6 +42,8 @@ fn chunked_indices<F: FnMut(usize, &[usize])>(
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::compute::conformance::binary_numeric::test_binary_numeric_array;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
@@ -51,7 +53,7 @@ mod tests {
     use crate::bitpacking::compute::chunked_indices;
 
     fn bp(array: &PrimitiveArray, bit_width: u8) -> BitPackedArray {
-        bitpack_encode(array, bit_width, None).unwrap()
+        bitpack_encode(array, bit_width, None, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     #[test]

--- a/encodings/fastlanes/src/bitpacking/compute/slice.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/slice.rs
@@ -46,6 +46,8 @@ impl SliceReduce for BitPacked {
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::SliceArray;
     use vortex_error::VortexResult;
@@ -55,8 +57,9 @@ mod tests {
 
     #[test]
     fn test_reduce_parent_returns_bitpacked_slice() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = PrimitiveArray::from_iter(0u32..2048);
-        let bitpacked = bitpack_encode(&values, 11, None)?;
+        let bitpacked = bitpack_encode(&values, 11, None, &mut ctx)?;
 
         let slice_array = SliceArray::new(bitpacked.clone().into_array(), 500..1500);
 

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -166,8 +166,6 @@ mod test {
     use rstest::rstest;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
@@ -182,11 +180,12 @@ mod test {
 
     #[test]
     fn take_indices() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let indices = buffer![0, 125, 2047, 2049, 2151, 2790].into_array();
 
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 6).unwrap();
+        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 6, &mut ctx).unwrap();
 
         let primitive_result = bitpacked.take(indices).unwrap();
         assert_arrays_eq!(
@@ -197,8 +196,9 @@ mod test {
 
     #[test]
     fn take_with_patches() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let unpacked = Buffer::from_iter(0u32..1024).into_array();
-        let bitpacked = BitPackedData::encode(&unpacked, 2).unwrap();
+        let bitpacked = BitPackedData::encode(&unpacked, 2, &mut ctx).unwrap();
 
         let indices = buffer![0, 2, 4, 6].into_array();
 
@@ -208,11 +208,12 @@ mod test {
 
     #[test]
     fn take_sliced_indices() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let indices = buffer![1919, 1921].into_array();
 
         // Create a u8 array modulo 63.
         let unpacked = PrimitiveArray::from_iter((0..4096).map(|i| (i % 63) as u8));
-        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 6).unwrap();
+        let bitpacked = BitPackedData::encode(&unpacked.into_array(), 6, &mut ctx).unwrap();
         let sliced = bitpacked.slice(128..2050).unwrap();
 
         let primitive_result = sliced.take(indices).unwrap();
@@ -222,10 +223,11 @@ mod test {
     #[test]
     #[cfg_attr(miri, ignore)] // This test is too slow on miri
     fn take_random_indices() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let num_patches: usize = 128;
         let values = (0..u16::MAX as u32 + num_patches as u32).collect::<Buffer<_>>();
         let uncompressed = PrimitiveArray::new(values.clone(), Validity::NonNullable);
-        let packed = BitPackedData::encode(&uncompressed.into_array(), 16).unwrap();
+        let packed = BitPackedData::encode(&uncompressed.into_array(), 16, &mut ctx).unwrap();
         assert!(packed.patches().is_some());
 
         let rng = rng();
@@ -235,7 +237,6 @@ mod test {
         let taken = packed.take(random_indices.clone().into_array()).unwrap();
 
         // sanity check
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         random_indices
             .as_slice::<u32>()
             .iter()
@@ -255,14 +256,16 @@ mod test {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn take_signed_with_patches() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let start =
-            BitPackedData::encode(&buffer![1i32, 2i32, 3i32, 4i32].into_array(), 1).unwrap();
+            BitPackedData::encode(&buffer![1i32, 2i32, 3i32, 4i32].into_array(), 1, &mut ctx)
+                .unwrap();
 
         let taken_primitive = take_primitive::<u32, u64>(
             start.as_view(),
             &PrimitiveArray::from_iter([0u64, 1, 2, 3]),
             Validity::NonNullable,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut ctx,
         )
         .unwrap();
         assert_arrays_eq!(taken_primitive, PrimitiveArray::from_iter([1i32, 2, 3, 4]));
@@ -270,8 +273,10 @@ mod test {
 
     #[test]
     fn take_nullable_with_nullables() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let start =
-            BitPackedData::encode(&buffer![1i32, 2i32, 3i32, 4i32].into_array(), 1).unwrap();
+            BitPackedData::encode(&buffer![1i32, 2i32, 3i32, 4i32].into_array(), 1, &mut ctx)
+                .unwrap();
 
         let taken_primitive = start
             .take(
@@ -282,26 +287,24 @@ mod test {
             taken_primitive,
             PrimitiveArray::from_option_iter([Some(1i32), Some(2), None, Some(4)])
         );
-        #[expect(deprecated)]
-        let taken_primitive_prim = taken_primitive.to_primitive();
-        assert_eq!(
-            taken_primitive_prim
-                .invalid_count(&mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap(),
-            1
-        );
+        let taken_primitive_prim = taken_primitive.execute::<PrimitiveArray>(&mut ctx).unwrap();
+        assert_eq!(taken_primitive_prim.invalid_count(&mut ctx).unwrap(), 1);
+    }
+
+    fn bp(array: vortex_array::ArrayRef, bit_width: u8) -> BitPackedArray {
+        BitPackedData::encode(&array, bit_width, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     #[rstest]
-    #[case(BitPackedData::encode(&PrimitiveArray::from_iter((0..100).map(|i| (i % 63) as u8)).into_array(), 6).unwrap())]
-    #[case(BitPackedData::encode(&PrimitiveArray::from_iter((0..256).map(|i| i as u32)).into_array(), 8).unwrap())]
-    #[case(BitPackedData::encode(&buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array(), 3).unwrap())]
-    #[case(BitPackedData::encode(
-        &PrimitiveArray::from_option_iter([Some(10u16), None, Some(20), Some(30), None]).into_array(),
+    #[case(bp(PrimitiveArray::from_iter((0..100).map(|i| (i % 63) as u8)).into_array(), 6))]
+    #[case(bp(PrimitiveArray::from_iter((0..256).map(|i| i as u32)).into_array(), 8))]
+    #[case(bp(buffer![1i32, 2, 3, 4, 5, 6, 7, 8].into_array(), 3))]
+    #[case(bp(
+        PrimitiveArray::from_option_iter([Some(10u16), None, Some(20), Some(30), None]).into_array(),
         5
-    ).unwrap())]
-    #[case(BitPackedData::encode(&buffer![42u32].into_array(), 6).unwrap())]
-    #[case(BitPackedData::encode(&PrimitiveArray::from_iter((0..1024).map(|i| i as u32)).into_array(), 8).unwrap())]
+    ))]
+    #[case(bp(buffer![42u32].into_array(), 6))]
+    #[case(bp(PrimitiveArray::from_iter((0..1024).map(|i| i as u32)).into_array(), 8))]
     fn test_take_bitpacked_conformance(#[case] bitpacked: BitPackedArray) {
         use vortex_array::compute::conformance::take::test_take_conformance;
         test_take_conformance(&bitpacked.into_array());

--- a/encodings/fastlanes/src/bitpacking/compute/take.rs
+++ b/encodings/fastlanes/src/bitpacking/compute/take.rs
@@ -292,7 +292,12 @@ mod test {
     }
 
     fn bp(array: vortex_array::ArrayRef, bit_width: u8) -> BitPackedArray {
-        BitPackedData::encode(&array, bit_width, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
+        BitPackedData::encode(
+            &array,
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     #[rstest]

--- a/encodings/fastlanes/src/bitpacking/plugin.rs
+++ b/encodings/fastlanes/src/bitpacking/plugin.rs
@@ -95,6 +95,7 @@ mod tests {
 
     use vortex_array::ArrayPlugin;
     use vortex_array::IntoArray;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PatchedArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::patched::PatchedArraySlotsExt;
@@ -120,11 +121,12 @@ mod tests {
 
     #[test]
     fn test_decode_bitpacked_patches() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         // Create values where some exceed the bit width, causing patches.
         // With bit_width=9, max value is 511. Values >=512 become patches.
         let values: Buffer<i32> = (0i32..=512).collect();
         let parray = values.into_array();
-        let bitpacked = BitPackedData::encode(&parray, 9)?;
+        let bitpacked = BitPackedData::encode(&parray, 9, &mut ctx)?;
 
         assert!(
             bitpacked.patches().is_some(),
@@ -170,10 +172,11 @@ mod tests {
 
     #[test]
     fn bitpacked_without_patches_stays_bitpacked() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         // With bit_width=16, max value is 65535. All values 0..100 fit.
         let values: Buffer<i32> = (0i32..100).collect();
         let parray = values.into_array();
-        let bitpacked = BitPackedData::encode(&parray, 16)?;
+        let bitpacked = BitPackedData::encode(&parray, 16, &mut ctx)?;
 
         assert!(
             bitpacked.patches().is_none(),

--- a/encodings/fastlanes/src/bitpacking/vtable/mod.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/mod.rs
@@ -353,7 +353,11 @@ impl BitPacked {
     }
 
     /// Encode an array into a bitpacked representation with the given bit width.
-    pub fn encode(array: &ArrayRef, bit_width: u8) -> VortexResult<BitPackedArray> {
-        BitPackedData::encode(array, bit_width)
+    pub fn encode(
+        array: &ArrayRef,
+        bit_width: u8,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<BitPackedArray> {
+        BitPackedData::encode(array, bit_width, ctx)
     }
 }

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -143,8 +143,7 @@ mod test {
     fn slice_empty_patches() {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // We create an array that has 1 element that does not fit in the 6-bit range.
-        let array =
-            BitPackedData::encode(&buffer![0u32..=64].into_array(), 6, &mut ctx).unwrap();
+        let array = BitPackedData::encode(&buffer![0u32..=64].into_array(), 6, &mut ctx).unwrap();
 
         assert!(array.patches().is_some());
 

--- a/encodings/fastlanes/src/bitpacking/vtable/operations.rs
+++ b/encodings/fastlanes/src/bitpacking/vtable/operations.rs
@@ -58,7 +58,7 @@ mod test {
     use crate::bitpacking::array::BitPackedArrayExt;
 
     fn bp(array: &ArrayRef, bit_width: u8) -> BitPackedArray {
-        BitPackedData::encode(array, bit_width).unwrap()
+        BitPackedData::encode(array, bit_width, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     fn slice_via_reduce(array: &BitPackedArray, range: Range<usize>) -> BitPackedArray {
@@ -141,8 +141,10 @@ mod test {
 
     #[test]
     fn slice_empty_patches() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // We create an array that has 1 element that does not fit in the 6-bit range.
-        let array = BitPackedData::encode(&buffer![0u32..=64].into_array(), 6).unwrap();
+        let array =
+            BitPackedData::encode(&buffer![0u32..=64].into_array(), 6, &mut ctx).unwrap();
 
         assert!(array.patches().is_some());
 
@@ -213,9 +215,10 @@ mod test {
 
     #[test]
     fn scalar_at() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = (0u32..257).collect::<Buffer<_>>();
         let uncompressed = values.clone().into_array();
-        let packed = BitPackedData::encode(&uncompressed, 8).unwrap();
+        let packed = BitPackedData::encode(&uncompressed, 8, &mut ctx).unwrap();
         assert!(packed.patches().is_some());
 
         let patches = packed.patches().unwrap().indices().clone();

--- a/encodings/fastlanes/src/delta/array/delta_compress.rs
+++ b/encodings/fastlanes/src/delta/array/delta_compress.rs
@@ -27,7 +27,7 @@ pub fn delta_compress(
         // Fill-forward null values so that transposed deltas at null positions remain
         // small. Without this, bitpacking may skip patches for null positions, and the
         // corrupted delta values propagate through the cumulative sum during decompression.
-        let filled = fill_forward_nulls(array.to_buffer::<T>(), &validity);
+        let filled = fill_forward_nulls(array.to_buffer::<T>(), &validity, ctx)?;
         let (bases, deltas) = compress_primitive::<T, { T::LANES }>(&filled);
         // TODO(robert): This can be avoided if we add TransposedBoolArray that performs index translation when necessary.
         let validity = transpose_validity(&validity, ctx)?;
@@ -96,8 +96,6 @@ mod tests {
 
     use rstest::rstest;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
@@ -132,12 +130,13 @@ mod tests {
     /// where null positions contain arbitrary values. Without fill-forward, the delta cumulative
     /// sum propagates corrupted values from null positions.
     #[test]
-    fn delta_bitpacked_trailing_nulls() {
+    fn delta_bitpacked_trailing_nulls() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_option_iter(
             (0u8..200).map(|i| (!(50..100).contains(&i)).then_some(i)),
         );
-        let (bases, deltas) = delta_compress(&array, &mut SESSION.create_execution_ctx()).unwrap();
-        let bitpacked_deltas = bitpack_encode(&deltas, 1, None).unwrap();
+        let (bases, deltas) = delta_compress(&array, &mut ctx).unwrap();
+        let bitpacked_deltas = bitpack_encode(&deltas, 1, None, &mut ctx).unwrap();
         let packed_delta = Delta::try_new(
             bases.into_array(),
             bitpacked_deltas.into_array(),
@@ -145,8 +144,11 @@ mod tests {
             array.len(),
         )
         .vortex_expect("Delta array construction should succeed");
-        #[expect(deprecated)]
-        let packed_delta_prim = packed_delta.as_array().to_primitive();
+        let packed_delta_prim = packed_delta
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         assert_arrays_eq!(packed_delta_prim, array);
+        Ok(())
     }
 }

--- a/encodings/fastlanes/src/delta/vtable/operations.rs
+++ b/encodings/fastlanes/src/delta/vtable/operations.rs
@@ -4,8 +4,7 @@
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::scalar::Scalar;
 use vortex_array::vtable::OperationsVTable;
 use vortex_error::VortexResult;
@@ -17,8 +16,10 @@ impl OperationsVTable<Delta> for Delta {
         index: usize,
         ctx: &mut ExecutionCtx,
     ) -> VortexResult<Scalar> {
-        #[expect(deprecated)]
-        let decompressed = array.array().slice(index..index + 1)?.to_primitive();
+        let decompressed = array
+            .array()
+            .slice(index..index + 1)?
+            .execute::<PrimitiveArray>(ctx)?;
         decompressed.into_array().execute_scalar(0, ctx)
     }
 }

--- a/encodings/fastlanes/src/for/array/for_compress.rs
+++ b/encodings/fastlanes/src/for/array/for_compress.rs
@@ -52,8 +52,6 @@ mod test {
     use std::sync::LazyLock;
 
     use itertools::Itertools;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::primitive::PrimitiveArrayExt;
     use vortex_array::assert_arrays_eq;
@@ -130,32 +128,31 @@ mod test {
 
     #[test]
     fn test_decompress_fused() {
+        let mut ctx = SESSION.create_execution_ctx();
         // Create a range offset by a million.
         let expect = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7 + 10));
         let array = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7));
-        let bp = BitPackedData::encode(&array.into_array(), 3).unwrap();
+        let bp = BitPackedData::encode(&array.into_array(), 3, &mut ctx).unwrap();
         let compressed = FoR::try_new(bp.into_array(), 10u32.into()).unwrap();
         assert_arrays_eq!(compressed, expect);
     }
 
     #[test]
     fn test_decompress_fused_patches() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         // Create a range offset by a million.
         let expect = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7 + 10));
         let array = PrimitiveArray::from_iter((0u32..1024).map(|x| x % 7));
-        let bp = BitPackedData::encode(&array.into_array(), 2).unwrap();
+        let bp = BitPackedData::encode(&array.into_array(), 2, &mut ctx).unwrap();
         let compressed = FoR::try_new(bp.clone().into_array(), 10u32.into())?;
-        let decompressed = fused_decompress::<u32>(
-            &compressed,
-            bp.as_view(),
-            &mut SESSION.create_execution_ctx(),
-        )?;
+        let decompressed = fused_decompress::<u32>(&compressed, bp.as_view(), &mut ctx)?;
         assert_arrays_eq!(decompressed, expect);
         Ok(())
     }
 
     #[test]
     fn test_overflow() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter(i8::MIN..=i8::MAX);
         let compressed = FoRData::encode(array.clone()).unwrap();
         assert_eq!(
@@ -167,16 +164,16 @@ mod test {
                 .unwrap()
         );
 
-        #[expect(deprecated)]
         let encoded = compressed
             .encoded()
-            .to_primitive()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?
             .reinterpret_cast(PType::U8);
         let unsigned: Vec<u8> = (0..=u8::MAX).collect_vec();
         let expected_unsigned = PrimitiveArray::from_iter(unsigned);
         assert_eq!(encoded.as_slice::<u8>(), expected_unsigned.as_slice::<u8>());
 
-        let decompressed = decompress(&compressed, &mut SESSION.create_execution_ctx())?;
+        let decompressed = decompress(&compressed, &mut ctx)?;
         array
             .as_slice::<i8>()
             .iter()
@@ -184,12 +181,7 @@ mod test {
             .for_each(|(i, v)| {
                 assert_eq!(
                     *v,
-                    i8::try_from(
-                        &compressed
-                            .execute_scalar(i, &mut SESSION.create_execution_ctx())
-                            .unwrap()
-                    )
-                    .unwrap()
+                    i8::try_from(&compressed.execute_scalar(i, &mut ctx).unwrap()).unwrap()
                 );
             });
         assert_arrays_eq!(decompressed, array);

--- a/encodings/fastlanes/src/for/compute/is_sorted.rs
+++ b/encodings/fastlanes/src/for/compute/is_sorted.rs
@@ -4,8 +4,6 @@
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::aggregate_fn::AggregateFnRef;
 use vortex_array::aggregate_fn::fns::is_sorted::IsSorted;
 use vortex_array::aggregate_fn::fns::is_sorted::is_sorted;
@@ -36,8 +34,7 @@ impl DynAggregateKernel for FoRIsSortedKernel {
             return Ok(None);
         };
 
-        #[expect(deprecated)]
-        let encoded = array.encoded().to_primitive();
+        let encoded = array.encoded().clone().execute::<PrimitiveArray>(ctx)?;
         let unsigned_array = PrimitiveArray::from_buffer_handle(
             encoded.buffer_handle().clone(),
             encoded.ptype().to_unsigned(),

--- a/encodings/fastlanes/src/lib.rs
+++ b/encodings/fastlanes/src/lib.rs
@@ -7,12 +7,13 @@ pub use bitpacking::*;
 pub use delta::*;
 pub use r#for::*;
 pub use rle::*;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::bool::BoolArrayExt;
 use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_buffer::BufferMut;
+use vortex_error::VortexResult;
 
 pub mod bit_transpose;
 mod bitpacking;
@@ -78,13 +79,16 @@ pub fn initialize(session: &VortexSession) {
 pub(crate) fn fill_forward_nulls<T: Copy + Default>(
     values: Buffer<T>,
     validity: &Validity,
-) -> Buffer<T> {
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Buffer<T>> {
     match validity {
-        Validity::NonNullable | Validity::AllValid => values,
-        Validity::AllInvalid => Buffer::zeroed(values.len()),
+        Validity::NonNullable | Validity::AllValid => Ok(values),
+        Validity::AllInvalid => Ok(Buffer::zeroed(values.len())),
         Validity::Array(validity_array) => {
-            #[expect(deprecated)]
-            let bit_buffer = validity_array.to_bool().to_bit_buffer();
+            let bit_buffer = validity_array
+                .clone()
+                .execute::<BoolArray>(ctx)?
+                .to_bit_buffer();
             let mut last_valid = T::default();
             match values.try_into_mut() {
                 Ok(mut to_fill_mut) => {
@@ -99,7 +103,7 @@ pub(crate) fn fill_forward_nulls<T: Copy + Default>(
                             *v = last_valid;
                         }
                     }
-                    to_fill_mut.freeze()
+                    Ok(to_fill_mut.freeze())
                 }
                 Err(to_fill) => {
                     let mut to_fill_mut = BufferMut::<T>::with_capacity(to_fill.len());
@@ -121,7 +125,7 @@ pub(crate) fn fill_forward_nulls<T: Copy + Default>(
                         out.write(last_valid);
                     }
                     unsafe { to_fill_mut.set_len(to_fill.len()) };
-                    to_fill_mut.freeze()
+                    Ok(to_fill_mut.freeze())
                 }
             }
         }
@@ -132,6 +136,7 @@ pub(crate) fn fill_forward_nulls<T: Copy + Default>(
 mod test {
     use std::sync::LazyLock;
 
+    use vortex_array::VortexSessionExecute;
     use vortex_array::session::ArraySessionExt;
     use vortex_buffer::BitBufferMut;
     use vortex_session::VortexSession;
@@ -148,7 +153,8 @@ mod test {
     });
 
     #[test]
-    fn fill_forward_nulls_resets_at_chunk_boundary() {
+    fn fill_forward_nulls_resets_at_chunk_boundary() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         // Build a buffer spanning two chunks where the last valid value in chunk 0
         // is non-zero. Null positions at the start of chunk 1 must get T::default()
         // (0), not the carry-over from chunk 0.
@@ -160,7 +166,7 @@ mod test {
         validity_bits.set(FL_CHUNK_SIZE - 1); // only this position is valid
 
         let validity = Validity::from(validity_bits.freeze());
-        let result = fill_forward_nulls(values.freeze(), &validity);
+        let result = fill_forward_nulls(values.freeze(), &validity, &mut ctx)?;
 
         // Within chunk 0, nulls before the valid element get 0 (default), and the
         // valid element itself is 42.
@@ -174,5 +180,6 @@ mod test {
                 "position {i} should be 0, not carried from chunk 0"
             );
         }
+        Ok(())
     }
 }

--- a/encodings/fastlanes/src/rle/array/mod.rs
+++ b/encodings/fastlanes/src/rle/array/mod.rs
@@ -5,9 +5,8 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 
 use vortex_array::ArrayRef;
-use vortex_array::LEGACY_SESSION;
+use vortex_array::ExecutionCtx;
 use vortex_array::TypedArrayRef;
-use vortex_array::VortexSessionExecute;
 use vortex_error::VortexExpect as _;
 use vortex_error::VortexResult;
 use vortex_error::vortex_ensure;
@@ -111,16 +110,16 @@ pub trait RLEArrayExt: TypedArrayRef<crate::RLE> {
         clippy::expect_used,
         reason = "expect is safe here as scalar_at returns a valid primitive"
     )]
-    fn values_idx_offset(&self, chunk_idx: usize) -> usize {
+    fn values_idx_offset(&self, chunk_idx: usize, ctx: &mut ExecutionCtx) -> usize {
         self.values_idx_offsets()
-            .execute_scalar(chunk_idx, &mut LEGACY_SESSION.create_execution_ctx())
+            .execute_scalar(chunk_idx, ctx)
             .expect("index must be in bounds")
             .as_primitive()
             .as_::<usize>()
             .expect("index must be of type usize")
             - self
                 .values_idx_offsets()
-                .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
+                .execute_scalar(0, ctx)
                 .expect("index must be in bounds")
                 .as_primitive()
                 .as_::<usize>()
@@ -142,8 +141,6 @@ mod tests {
     use vortex_array::Canonical;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::primitive::PrimitiveArrayExt;
@@ -237,10 +234,13 @@ mod tests {
         let rle_array = RLE::try_new(values, indices_with_validity, values_idx_offsets, 0, 5)
             .vortex_expect("RLEData is always valid");
 
-        #[expect(deprecated)]
-        let valid_slice = rle_array.slice(0..3).unwrap().to_primitive();
-        // TODO(joe): replace with compute null count
         let mut ctx = SESSION.create_execution_ctx();
+        let valid_slice = rle_array
+            .slice(0..3)
+            .unwrap()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
+        // TODO(joe): replace with compute null count
         assert!(valid_slice.all_valid(&mut ctx).unwrap());
 
         let mixed_slice = rle_array.slice(1..5).unwrap();
@@ -347,6 +347,7 @@ mod tests {
 
     #[test]
     fn test_multi_chunk_two_chunks() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = PrimitiveArray::from_iter([10u32, 20, 30, 40]).into_array();
         let indices = PrimitiveArray::from_iter([0u16, 1].repeat(1024)).into_array();
         let values_idx_offsets = PrimitiveArray::from_iter([0u64, 2]).into_array();
@@ -356,18 +357,21 @@ mod tests {
         assert_eq!(rle_array.len(), 2048);
         assert_eq!(rle_array.values().len(), 4);
 
-        assert_eq!(rle_array.values_idx_offset(0), 0);
-        assert_eq!(rle_array.values_idx_offset(1), 2);
+        assert_eq!(rle_array.values_idx_offset(0, &mut ctx), 0);
+        assert_eq!(rle_array.values_idx_offset(1, &mut ctx), 2);
     }
 
     #[test]
-    fn test_rle_serialization() {
+    fn test_rle_serialization() -> VortexResult<()> {
+        let mut exec_ctx = SESSION.create_execution_ctx();
         let primitive = PrimitiveArray::from_iter((0..2048).map(|i| (i / 100) as u32));
-        let rle_array = RLEData::encode(primitive.as_view()).unwrap();
+        let rle_array = RLEData::encode(primitive.as_view(), &mut exec_ctx).unwrap();
         assert_eq!(rle_array.len(), 2048);
 
-        #[expect(deprecated)]
-        let original_data = rle_array.as_array().to_primitive();
+        let original_data = rle_array
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut exec_ctx)?;
 
         let ctx = ArrayContext::empty();
         let serialized = rle_array
@@ -391,16 +395,17 @@ mod tests {
             )
             .unwrap();
 
-        #[expect(deprecated)]
-        let decoded_data = decoded.to_primitive();
+        let decoded_data = decoded.execute::<PrimitiveArray>(&mut exec_ctx)?;
 
         assert_arrays_eq!(original_data, decoded_data);
+        Ok(())
     }
 
     #[test]
-    fn test_rle_serialization_slice() {
+    fn test_rle_serialization_slice() -> VortexResult<()> {
+        let mut exec_ctx = SESSION.create_execution_ctx();
         let primitive = PrimitiveArray::from_iter((0..2048).map(|i| (i / 100) as u32));
-        let rle_array = RLEData::encode(primitive.as_view()).unwrap();
+        let rle_array = RLEData::encode(primitive.as_view(), &mut exec_ctx).unwrap();
 
         let sliced = RLE::try_new(
             rle_array.values().clone(),
@@ -435,12 +440,14 @@ mod tests {
             )
             .unwrap();
 
-        #[expect(deprecated)]
-        let original_data = sliced.as_array().to_primitive();
-        #[expect(deprecated)]
-        let decoded_data = decoded.to_primitive();
+        let original_data = sliced
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut exec_ctx)?;
+        let decoded_data = decoded.execute::<PrimitiveArray>(&mut exec_ctx)?;
 
         assert_arrays_eq!(original_data, decoded_data);
+        Ok(())
     }
 
     /// Regression test: re-encoding RLE indices with RLE must not corrupt
@@ -453,6 +460,7 @@ mod tests {
     /// because chunk 1 only had 1 unique value and index 1 was out of bounds.
     #[test]
     fn test_recompress_indices_no_cross_chunk_leak() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         let len = FL_CHUNK_SIZE + 100;
         let mut values: Vec<Option<i16>> = vec![None; len];
         // Two distinct values in chunk 0 → indices 0 and 1.
@@ -461,13 +469,16 @@ mod tests {
         // Chunk 1 (positions 1024..) is all-null.
 
         let original = PrimitiveArray::from_option_iter(values);
-        let rle = RLEData::encode(original.as_view())?;
+        let rle = RLEData::encode(original.as_view(), &mut ctx)?;
 
         // Simulate cascading compression: narrow u16->u8 then re-encode with RLE,
         // matching the path taken by the BtrBlocks compressor.
-        #[expect(deprecated)]
-        let indices_prim = rle.indices().to_primitive().narrow()?;
-        let re_encoded = RLEData::encode(indices_prim.as_view())?;
+        let indices_prim = rle
+            .indices()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?
+            .narrow()?;
+        let re_encoded = RLEData::encode(indices_prim.as_view(), &mut ctx)?;
 
         // Reconstruct the outer RLE with re-encoded indices.
         // SAFETY: we only replace the indices child; all other invariants hold.
@@ -482,8 +493,10 @@ mod tests {
         };
 
         // Decompress — panicked before the fill_forward_nulls chunk-boundary fix.
-        #[expect(deprecated)]
-        let decoded = reconstructed.as_array().to_primitive();
+        let decoded = reconstructed
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         assert_arrays_eq!(decoded, original);
         Ok(())
     }

--- a/encodings/fastlanes/src/rle/array/rle_compress.rs
+++ b/encodings/fastlanes/src/rle/array/rle_compress.rs
@@ -326,8 +326,9 @@ mod tests {
     #[case::f16((-2000..2000).map(|i| f16::from_f32(i as f32)).collect::<Buffer<f16>>())]
     #[case::f32((-2000..2000).map(|i| i as f32).collect::<Buffer<f32>>())]
     #[case::f64((-2000..2000).map(|i| i as f64).collect::<Buffer<f64>>())]
-    fn test_roundtrip_primitive_types<T: NativePType>(#[case] values: Buffer<T>) -> VortexResult<()>
-    {
+    fn test_roundtrip_primitive_types<T: NativePType>(
+        #[case] values: Buffer<T>,
+    ) -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let primitive = values
             .clone()
@@ -549,15 +550,13 @@ mod tests {
     #[case(vec![f16::ZERO, f16::NEG_ZERO])]
     #[case(vec![0f32, -0f32])]
     #[case(vec![0f64, -0f64])]
-    fn test_float_zeros<T: NativePType + fastlanes::RLE>(#[case] values: Vec<T>) -> VortexResult<()>
-    {
+    fn test_float_zeros<T: NativePType + fastlanes::RLE>(
+        #[case] values: Vec<T>,
+    ) -> VortexResult<()> {
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let primitive = PrimitiveArray::from_iter(values);
         let rle = RLEData::encode(primitive.as_view(), &mut ctx).unwrap();
-        let decoded = rle
-            .as_array()
-            .clone()
-            .execute::<PrimitiveArray>(&mut ctx)?;
+        let decoded = rle.as_array().clone().execute::<PrimitiveArray>(&mut ctx)?;
         assert_arrays_eq!(primitive, decoded);
         Ok(())
     }

--- a/encodings/fastlanes/src/rle/array/rle_compress.rs
+++ b/encodings/fastlanes/src/rle/array/rle_compress.rs
@@ -5,9 +5,9 @@ use std::mem;
 
 use fastlanes::RLE as FastLanesRLE;
 use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
+use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::bool::BoolArrayExt;
@@ -28,23 +28,26 @@ use crate::fill_forward_nulls;
 
 impl RLEData {
     /// Encodes a primitive array of unsigned integers using FastLanes RLE.
-    pub fn encode(array: ArrayView<'_, Primitive>) -> VortexResult<RLEArray> {
+    pub fn encode(
+        array: ArrayView<'_, Primitive>,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<RLEArray> {
         let array = array.into_owned();
-        match_each_native_ptype!(array.ptype(), |T| { rle_encode_typed::<T>(&array) })
+        match_each_native_ptype!(array.ptype(), |T| { rle_encode_typed::<T>(&array, ctx) })
     }
 }
 
 /// Encodes a primitive array of unsigned integers using FastLanes RLE.
 ///
 /// In case the input array length is % 1024 != 0, the last chunk is padded.
-fn rle_encode_typed<T>(array: &PrimitiveArray) -> VortexResult<RLEArray>
+fn rle_encode_typed<T>(array: &PrimitiveArray, ctx: &mut ExecutionCtx) -> VortexResult<RLEArray>
 where
     T: NativePType + FastLanesRLE,
     NativeValue<T>: FastLanesRLE,
 {
     // Fill-forward null values so the RLE encoder doesn't see garbage at null positions,
     // which would create spurious run boundaries and inflate the dictionary.
-    let values = fill_forward_nulls(array.to_buffer::<T>(), &array.validity()?);
+    let values = fill_forward_nulls(array.to_buffer::<T>(), &array.validity()?, ctx)?;
     let len = values.len();
     let padded_len = len.next_multiple_of(FL_CHUNK_SIZE);
 
@@ -113,7 +116,7 @@ where
 
     RLE::try_new(
         values_buf.into_array(),
-        PrimitiveArray::new(indices_buf.freeze(), padded_validity(array)).into_array(),
+        PrimitiveArray::new(indices_buf.freeze(), padded_validity(array, ctx)?).into_array(),
         values_idx_offsets.into_array(),
         0,
         array.len(),
@@ -121,30 +124,29 @@ where
 }
 
 /// Returns validity padded to the next 1024 chunk for a given array.
-fn padded_validity(array: &PrimitiveArray) -> Validity {
+fn padded_validity(array: &PrimitiveArray, ctx: &mut ExecutionCtx) -> VortexResult<Validity> {
     match array
         .validity()
         .vortex_expect("RLE validity should be derivable")
     {
-        Validity::NonNullable => Validity::NonNullable,
-        Validity::AllValid => Validity::AllValid,
-        Validity::AllInvalid => Validity::AllInvalid,
+        Validity::NonNullable => Ok(Validity::NonNullable),
+        Validity::AllValid => Ok(Validity::AllValid),
+        Validity::AllInvalid => Ok(Validity::AllInvalid),
         Validity::Array(validity_array) => {
             let len = array.len();
             let padded_len = len.next_multiple_of(FL_CHUNK_SIZE);
 
             if len == padded_len {
-                return Validity::Array(validity_array);
+                return Ok(Validity::Array(validity_array));
             }
 
             let mut builder = BitBufferMut::with_capacity(padded_len);
 
-            #[expect(deprecated)]
-            let bool_array = validity_array.to_bool();
+            let bool_array = validity_array.execute::<BoolArray>(ctx)?;
             builder.append_buffer(&bool_array.to_bit_buffer());
             builder.append_n(false, padded_len - len);
 
-            Validity::from(builder.freeze())
+            Ok(Validity::from(builder.freeze()))
         }
     }
 }
@@ -152,9 +154,10 @@ fn padded_validity(array: &PrimitiveArray) -> Validity {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::ExecutionCtx;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::ConstantArray;
     use vortex_array::arrays::MaskedArray;
     use vortex_array::arrays::PrimitiveArray;
@@ -168,91 +171,128 @@ mod tests {
     use crate::rle::array::RLEArrayExt;
 
     #[test]
-    fn test_encode_decode() {
+    fn test_encode_decode() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // u8
         let array_u8: Buffer<u8> = buffer![1, 1, 2, 2, 3, 3];
-        let encoded_u8 =
-            RLEData::encode(PrimitiveArray::new(array_u8, Validity::NonNullable).as_view())
-                .unwrap();
-        #[expect(deprecated)]
-        let decoded_u8 = encoded_u8.as_array().to_primitive();
+        let encoded_u8 = RLEData::encode(
+            PrimitiveArray::new(array_u8, Validity::NonNullable).as_view(),
+            &mut ctx,
+        )
+        .unwrap();
+        let decoded_u8 = encoded_u8
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let expected_u8 = PrimitiveArray::from_iter(vec![1u8, 1, 2, 2, 3, 3]);
         assert_arrays_eq!(decoded_u8, expected_u8);
 
         // u16
         let array_u16: Buffer<u16> = buffer![100, 100, 200, 200];
-        let encoded_u16 =
-            RLEData::encode(PrimitiveArray::new(array_u16, Validity::NonNullable).as_view())
-                .unwrap();
-        #[expect(deprecated)]
-        let decoded_u16 = encoded_u16.as_array().to_primitive();
+        let encoded_u16 = RLEData::encode(
+            PrimitiveArray::new(array_u16, Validity::NonNullable).as_view(),
+            &mut ctx,
+        )
+        .unwrap();
+        let decoded_u16 = encoded_u16
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let expected_u16 = PrimitiveArray::from_iter(vec![100u16, 100, 200, 200]);
         assert_arrays_eq!(decoded_u16, expected_u16);
 
         // u64
         let array_u64: Buffer<u64> = buffer![1000, 1000, 2000];
-        let encoded_u64 =
-            RLEData::encode(PrimitiveArray::new(array_u64, Validity::NonNullable).as_view())
-                .unwrap();
-        #[expect(deprecated)]
-        let decoded_u64 = encoded_u64.as_array().to_primitive();
+        let encoded_u64 = RLEData::encode(
+            PrimitiveArray::new(array_u64, Validity::NonNullable).as_view(),
+            &mut ctx,
+        )
+        .unwrap();
+        let decoded_u64 = encoded_u64
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let expected_u64 = PrimitiveArray::from_iter(vec![1000u64, 1000, 2000]);
         assert_arrays_eq!(decoded_u64, expected_u64);
+        Ok(())
     }
 
     #[test]
     fn test_length() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values: Buffer<u32> = buffer![1, 1, 2, 2, 2, 3];
-        let encoded =
-            RLEData::encode(PrimitiveArray::new(values, Validity::NonNullable).as_view()).unwrap();
+        let encoded = RLEData::encode(
+            PrimitiveArray::new(values, Validity::NonNullable).as_view(),
+            &mut ctx,
+        )
+        .unwrap();
         assert_eq!(encoded.len(), 6);
     }
 
     #[test]
     fn test_empty_length() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values: Buffer<u32> = Buffer::empty();
-        let encoded =
-            RLEData::encode(PrimitiveArray::new(values, Validity::NonNullable).as_view()).unwrap();
+        let encoded = RLEData::encode(
+            PrimitiveArray::new(values, Validity::NonNullable).as_view(),
+            &mut ctx,
+        )
+        .unwrap();
 
         assert_eq!(encoded.len(), 0);
         assert_eq!(encoded.values().len(), 0);
     }
 
     #[test]
-    fn test_single_value() {
+    fn test_single_value() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values: Buffer<u16> = vec![42; 2000].into_iter().collect();
 
-        let encoded =
-            RLEData::encode(PrimitiveArray::new(values, Validity::NonNullable).as_view()).unwrap();
+        let encoded = RLEData::encode(
+            PrimitiveArray::new(values, Validity::NonNullable).as_view(),
+            &mut ctx,
+        )
+        .unwrap();
         assert_eq!(encoded.values().len(), 2); // 2 chunks, each storing value 42
 
-        #[expect(deprecated)]
-        let decoded = encoded.as_array().to_primitive(); // Verify round-trip
+        let decoded = encoded
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?; // Verify round-trip
         let expected = PrimitiveArray::from_iter(vec![42u16; 2000]);
         assert_arrays_eq!(decoded, expected);
+        Ok(())
     }
 
     #[test]
-    fn test_all_different() {
+    fn test_all_different() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values: Buffer<u8> = (0u8..=255).collect();
 
-        let encoded =
-            RLEData::encode(PrimitiveArray::new(values, Validity::NonNullable).as_view()).unwrap();
+        let encoded = RLEData::encode(
+            PrimitiveArray::new(values, Validity::NonNullable).as_view(),
+            &mut ctx,
+        )
+        .unwrap();
         assert_eq!(encoded.values().len(), 256);
 
-        #[expect(deprecated)]
-        let decoded = encoded.as_array().to_primitive(); // Verify round-trip
+        let decoded = encoded
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?; // Verify round-trip
         let expected = PrimitiveArray::from_iter((0u8..=255).collect::<Vec<_>>());
         assert_arrays_eq!(decoded, expected);
+        Ok(())
     }
 
     #[test]
     fn test_partial_last_chunk() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test array with partial last chunk (not divisible by 1024)
         let values: Buffer<u32> = (0..1500).map(|i| (i / 100) as u32).collect();
         let array = PrimitiveArray::new(values, Validity::NonNullable);
 
-        let encoded = RLEData::encode(array.as_view()).unwrap();
+        let encoded = RLEData::encode(array.as_view(), &mut ctx).unwrap();
 
         assert_eq!(encoded.len(), 1500);
         assert_arrays_eq!(encoded, array);
@@ -262,11 +302,12 @@ mod tests {
 
     #[test]
     fn test_two_full_chunks() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Array that spans exactly 2 chunks (2048 elements)
         let values: Buffer<u32> = (0..2048).map(|i| (i / 100) as u32).collect();
         let array = PrimitiveArray::new(values, Validity::NonNullable);
 
-        let encoded = RLEData::encode(array.as_view()).unwrap();
+        let encoded = RLEData::encode(array.as_view(), &mut ctx).unwrap();
 
         assert_eq!(encoded.len(), 2048);
         assert_arrays_eq!(encoded, array);
@@ -285,12 +326,18 @@ mod tests {
     #[case::f16((-2000..2000).map(|i| f16::from_f32(i as f32)).collect::<Buffer<f16>>())]
     #[case::f32((-2000..2000).map(|i| i as f32).collect::<Buffer<f32>>())]
     #[case::f64((-2000..2000).map(|i| i as f64).collect::<Buffer<f64>>())]
-    fn test_roundtrip_primitive_types<T: NativePType>(#[case] values: Buffer<T>) {
-        #[expect(deprecated)]
-        let primitive = values.clone().into_array().to_primitive();
-        let result = RLEData::encode(primitive.as_view()).unwrap();
-        #[expect(deprecated)]
-        let decoded = result.as_array().to_primitive();
+    fn test_roundtrip_primitive_types<T: NativePType>(#[case] values: Buffer<T>) -> VortexResult<()>
+    {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let primitive = values
+            .clone()
+            .into_array()
+            .execute::<PrimitiveArray>(&mut ctx)?;
+        let result = RLEData::encode(primitive.as_view(), &mut ctx).unwrap();
+        let decoded = result
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let expected = PrimitiveArray::new(
             values,
             primitive
@@ -298,6 +345,7 @@ mod tests {
                 .vortex_expect("primitive validity should be derivable"),
         );
         assert_arrays_eq!(decoded, expected);
+        Ok(())
     }
 
     /// Replaces the indices of an RLE array with MaskedArray(ConstantArray(1u16), validity).
@@ -306,9 +354,11 @@ mod tests {
     /// Valid when every chunk has at least two RLE dictionary entries (the
     /// fill-forward default at index 0 and the actual value at index 1), which
     /// holds whenever the first position of each chunk is null.
-    fn with_masked_constant_indices(rle: &RLEArray) -> VortexResult<RLEArray> {
-        #[expect(deprecated)]
-        let indices_prim = rle.indices().to_primitive();
+    fn with_masked_constant_indices(
+        rle: &RLEArray,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<RLEArray> {
+        let indices_prim = rle.indices().clone().execute::<PrimitiveArray>(ctx)?;
         let masked_indices = MaskedArray::try_new(
             ConstantArray::new(1u16, indices_prim.len()).into_array(),
             indices_prim.validity()?,
@@ -325,40 +375,44 @@ mod tests {
 
     #[test]
     fn test_encode_all_null_chunk() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values: Vec<Option<u32>> = vec![None; FL_CHUNK_SIZE];
         let original = PrimitiveArray::from_option_iter(values);
-        let rle = RLEData::encode(original.as_view())?;
-        let decoded = with_masked_constant_indices(&rle)?;
+        let rle = RLEData::encode(original.as_view(), &mut ctx)?;
+        let decoded = with_masked_constant_indices(&rle, &mut ctx)?;
         assert_arrays_eq!(decoded, original);
         Ok(())
     }
 
     #[test]
     fn test_encode_all_null_chunk_then_value_chunk() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // First chunk is entirely null, second chunk has a value preceded by nulls.
         let mut values: Vec<Option<u32>> = vec![None; 2 * FL_CHUNK_SIZE];
         values[FL_CHUNK_SIZE + 100] = Some(42);
         let original = PrimitiveArray::from_option_iter(values);
-        let rle = RLEData::encode(original.as_view())?;
-        let decoded = with_masked_constant_indices(&rle)?;
+        let rle = RLEData::encode(original.as_view(), &mut ctx)?;
+        let decoded = with_masked_constant_indices(&rle, &mut ctx)?;
         assert_arrays_eq!(decoded, original);
         Ok(())
     }
 
     #[test]
     fn test_encode_one_value_near_end() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Single distinct value near the end of the chunk.
         let mut values: Vec<Option<u32>> = vec![None; FL_CHUNK_SIZE];
         values[1000] = Some(42);
         let original = PrimitiveArray::from_option_iter(values);
-        let rle = RLEData::encode(original.as_view())?;
-        let decoded = with_masked_constant_indices(&rle)?;
+        let rle = RLEData::encode(original.as_view(), &mut ctx)?;
+        let decoded = with_masked_constant_indices(&rle, &mut ctx)?;
         assert_arrays_eq!(decoded, original);
         Ok(())
     }
 
     #[test]
     fn test_encode_value_chunk_then_all_null_remainder() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // 1085 elements (2 chunks: 1024 + 61 padded to 1024).
         // Chunk 0 has -1i16 at scattered positions (273..=366), rest null.
         // Chunk 1 (the remainder) is entirely null.
@@ -373,8 +427,8 @@ mod tests {
             values[pos] = Some(-1);
         }
         let original = PrimitiveArray::from_option_iter(values);
-        let rle = RLEData::encode(original.as_view())?;
-        let decoded = with_masked_constant_indices(&rle)?;
+        let rle = RLEData::encode(original.as_view(), &mut ctx)?;
+        let decoded = with_masked_constant_indices(&rle, &mut ctx)?;
         assert_arrays_eq!(decoded, original);
         Ok(())
     }
@@ -384,9 +438,11 @@ mod tests {
     /// This simulates a compressor that doesn't preserve index values at null
     /// positions, which can happen when indices are further compressed and the
     /// compressor clobbers invalid entries with arbitrary data.
-    fn with_random_invalid_indices(rle: &RLEArray) -> VortexResult<RLEArray> {
-        #[expect(deprecated)]
-        let indices_prim = rle.indices().to_primitive();
+    fn with_random_invalid_indices(
+        rle: &RLEArray,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<RLEArray> {
+        let indices_prim = rle.indices().clone().execute::<PrimitiveArray>(ctx)?;
         let mut indices_data: Vec<u16> = indices_prim.as_slice::<u16>().to_vec();
 
         // Use a simple deterministic "random" sequence.
@@ -416,43 +472,47 @@ mod tests {
 
     #[test]
     fn test_random_invalid_indices_all_null_chunk() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values: Vec<Option<u32>> = vec![None; FL_CHUNK_SIZE];
         let original = PrimitiveArray::from_option_iter(values);
-        let rle = RLEData::encode(original.as_view())?;
-        let clobbered = with_random_invalid_indices(&rle)?;
+        let rle = RLEData::encode(original.as_view(), &mut ctx)?;
+        let clobbered = with_random_invalid_indices(&rle, &mut ctx)?;
         assert_arrays_eq!(clobbered, original);
         Ok(())
     }
 
     #[test]
     fn test_random_invalid_indices_sparse_values() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut values: Vec<Option<u32>> = vec![None; FL_CHUNK_SIZE];
         values[0] = Some(10);
         values[500] = Some(20);
         values[1000] = Some(30);
         let original = PrimitiveArray::from_option_iter(values);
-        let rle = RLEData::encode(original.as_view())?;
-        let clobbered = with_random_invalid_indices(&rle)?;
+        let rle = RLEData::encode(original.as_view(), &mut ctx)?;
+        let clobbered = with_random_invalid_indices(&rle, &mut ctx)?;
         assert_arrays_eq!(clobbered, original);
         Ok(())
     }
 
     #[test]
     fn test_random_invalid_indices_multi_chunk() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Two chunks: first has scattered values, second is all null.
         let mut values: Vec<Option<i16>> = vec![None; 2 * FL_CHUNK_SIZE];
         values[0] = Some(10);
         values[500] = Some(20);
         values[FL_CHUNK_SIZE + 100] = Some(42);
         let original = PrimitiveArray::from_option_iter(values);
-        let rle = RLEData::encode(original.as_view())?;
-        let clobbered = with_random_invalid_indices(&rle)?;
+        let rle = RLEData::encode(original.as_view(), &mut ctx)?;
+        let clobbered = with_random_invalid_indices(&rle, &mut ctx)?;
         assert_arrays_eq!(clobbered, original);
         Ok(())
     }
 
     #[test]
     fn test_random_invalid_indices_partial_last_chunk() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // 1085 elements: chunk 0 has values at scattered positions, chunk 1 is
         // a partial (61 elements padded to 1024) that is entirely null.
         let mut values: Vec<Option<u32>> = vec![None; 1085];
@@ -460,14 +520,15 @@ mod tests {
             values[i] = Some(i as u32);
         }
         let original = PrimitiveArray::from_option_iter(values);
-        let rle = RLEData::encode(original.as_view())?;
-        let clobbered = with_random_invalid_indices(&rle)?;
+        let rle = RLEData::encode(original.as_view(), &mut ctx)?;
+        let clobbered = with_random_invalid_indices(&rle, &mut ctx)?;
         assert_arrays_eq!(clobbered, original);
         Ok(())
     }
 
     #[test]
     fn test_random_invalid_indices_mostly_valid() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Most positions are valid, only a few are null with garbage indices.
         let mut values: Vec<Option<u64>> =
             (0..FL_CHUNK_SIZE).map(|i| Some((i / 100) as u64)).collect();
@@ -476,8 +537,8 @@ mod tests {
             values[i] = None;
         }
         let original = PrimitiveArray::from_option_iter(values);
-        let rle = RLEData::encode(original.as_view())?;
-        let clobbered = with_random_invalid_indices(&rle)?;
+        let rle = RLEData::encode(original.as_view(), &mut ctx)?;
+        let clobbered = with_random_invalid_indices(&rle, &mut ctx)?;
         assert_arrays_eq!(clobbered, original);
         Ok(())
     }
@@ -488,11 +549,16 @@ mod tests {
     #[case(vec![f16::ZERO, f16::NEG_ZERO])]
     #[case(vec![0f32, -0f32])]
     #[case(vec![0f64, -0f64])]
-    fn test_float_zeros<T: NativePType + fastlanes::RLE>(#[case] values: Vec<T>) {
+    fn test_float_zeros<T: NativePType + fastlanes::RLE>(#[case] values: Vec<T>) -> VortexResult<()>
+    {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let primitive = PrimitiveArray::from_iter(values);
-        let rle = RLEData::encode(primitive.as_view()).unwrap();
-        #[expect(deprecated)]
-        let decoded = rle.as_array().to_primitive();
+        let rle = RLEData::encode(primitive.as_view(), &mut ctx).unwrap();
+        let decoded = rle
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         assert_arrays_eq!(primitive, decoded);
+        Ok(())
     }
 }

--- a/encodings/fastlanes/src/rle/compute/cast.rs
+++ b/encodings/fastlanes/src/rle/compute/cast.rs
@@ -45,7 +45,11 @@ impl CastReduce for RLE {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::Canonical;
+    use vortex_array::ExecutionCtx;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::builtins::ArrayBuiltins;
@@ -59,17 +63,18 @@ mod tests {
     use crate::RLEData;
     use crate::rle::RLEArray;
 
-    fn rle(primitive: &PrimitiveArray) -> RLEArray {
-        RLEData::encode(primitive.as_view()).unwrap()
+    fn rle(primitive: &PrimitiveArray, ctx: &mut ExecutionCtx) -> RLEArray {
+        RLEData::encode(primitive.as_view(), ctx).unwrap()
     }
 
     #[test]
     fn try_cast_rle_success() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let primitive = PrimitiveArray::new(
             Buffer::from_iter([10u8, 20, 30, 40, 50]),
             Validity::from_iter([true, true, true, true, true]),
         );
-        let encoded = rle(&primitive);
+        let encoded = rle(&primitive, &mut ctx);
 
         let casted = encoded
             .into_array()
@@ -81,16 +86,16 @@ mod tests {
     #[test]
     #[should_panic]
     fn try_cast_rle_fail() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let primitive = PrimitiveArray::new(
             Buffer::from_iter([10u8, 20, 30, 40, 50]),
             Validity::from_iter([true, false, true, true, false]),
         );
-        let encoded = rle(&primitive);
-        #[expect(deprecated)]
+        let encoded = rle(&primitive, &mut ctx);
         let result = encoded
             .into_array()
             .cast(DType::Primitive(PType::U8, Nullability::NonNullable))
-            .and_then(|a| a.to_canonical().map(|c| c.into_array()));
+            .and_then(|a| a.execute::<Canonical>(&mut ctx).map(|c| c.into_array()));
         result.unwrap();
     }
 
@@ -144,7 +149,8 @@ mod tests {
         )
     )]
     fn test_cast_rle_conformance(#[case] primitive: PrimitiveArray) {
-        let rle_array = rle(&primitive);
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let rle_array = rle(&primitive, &mut ctx);
         test_cast_conformance(&rle_array.into_array());
     }
 }

--- a/encodings/fastlanes/src/rle/kernel.rs
+++ b/encodings/fastlanes/src/rle/kernel.rs
@@ -23,15 +23,15 @@ impl SliceKernel for RLE {
     fn slice(
         array: ArrayView<'_, Self>,
         range: Range<usize>,
-        _ctx: &mut ExecutionCtx,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let offset_in_chunk = array.offset();
         let chunk_start_idx = (offset_in_chunk + range.start) / FL_CHUNK_SIZE;
         let chunk_end_idx = (offset_in_chunk + range.end).div_ceil(FL_CHUNK_SIZE);
 
-        let values_start_idx = array.values_idx_offset(chunk_start_idx);
+        let values_start_idx = array.values_idx_offset(chunk_start_idx, ctx);
         let values_end_idx = if chunk_end_idx < array.values_idx_offsets().len() {
-            array.values_idx_offset(chunk_end_idx)
+            array.values_idx_offset(chunk_end_idx, ctx)
         } else {
             array.values().len()
         };

--- a/encodings/fastlanes/src/rle/vtable/mod.rs
+++ b/encodings/fastlanes/src/rle/vtable/mod.rs
@@ -244,8 +244,11 @@ impl RLE {
     }
 
     /// Encode a primitive array using FastLanes RLE.
-    pub fn encode(array: ArrayView<'_, Primitive>) -> VortexResult<RLEArray> {
-        RLEData::encode(array)
+    pub fn encode(
+        array: ArrayView<'_, Primitive>,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<RLEArray> {
+        RLEData::encode(array, ctx)
     }
 }
 

--- a/encodings/fastlanes/src/rle/vtable/operations.rs
+++ b/encodings/fastlanes/src/rle/vtable/operations.rs
@@ -29,7 +29,7 @@ impl OperationsVTable<RLE> for RLE {
             .vortex_expect("Index must not be null");
 
         let chunk_id = (offset_in_chunk + index) / FL_CHUNK_SIZE;
-        let value_idx_offset = array.values_idx_offset(chunk_id);
+        let value_idx_offset = array.values_idx_offset(chunk_id, ctx);
 
         let scalar = array
             .values()
@@ -43,8 +43,6 @@ impl OperationsVTable<RLE> for RLE {
 mod tests {
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
@@ -170,20 +168,21 @@ mod tests {
 
     #[test]
     fn test_scalar_at_multiple_chunks() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test accessing elements around chunk boundaries
         let values: Buffer<u16> = (0..3000).map(|i| (i / 50) as u16).collect();
         let expected: Vec<u16> = (0..3000).map(|i| (i / 50) as u16).collect();
         let array = values.into_array();
 
-        #[expect(deprecated)]
-        let encoded = RLEData::encode(array.to_primitive().as_view()).unwrap();
+        let primitive = array.execute::<PrimitiveArray>(&mut ctx).unwrap();
+        let encoded = RLEData::encode(primitive.as_view(), &mut ctx).unwrap();
 
         // Access scalars from multiple chunks.
         for &idx in &[1023, 1024, 1025, 2047, 2048, 2049] {
             if idx < encoded.len() {
                 let original_value = expected[idx];
                 let encoded_value = encoded
-                    .execute_scalar(idx, &mut LEGACY_SESSION.create_execution_ctx())
+                    .execute_scalar(idx, &mut ctx)
                     .unwrap()
                     .as_primitive()
                     .as_::<u16>()
@@ -265,9 +264,13 @@ mod tests {
 
     #[test]
     fn test_slice_decode_with_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = fixture::rle_array_with_nulls();
-        #[expect(deprecated)]
-        let sliced = array.slice(1..4).unwrap().to_primitive(); // [null, 20, 20]
+        let sliced = array
+            .slice(1..4)
+            .unwrap()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap(); // [null, 20, 20]
 
         let expected = PrimitiveArray::from_option_iter([Option::<u32>::None, Some(20), Some(20)]);
         assert_arrays_eq!(sliced.into_array(), expected.into_array());
@@ -283,12 +286,13 @@ mod tests {
 
     #[test]
     fn test_slice_across_chunk_boundaries() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values: Buffer<u32> = (0..2100).map(|i| (i / 100) as u32).collect();
         let expected: Vec<u32> = (0..2100).map(|i| (i / 100) as u32).collect();
         let array = values.into_array();
 
-        #[expect(deprecated)]
-        let encoded = RLEData::encode(array.to_primitive().as_view()).unwrap();
+        let primitive = array.execute::<PrimitiveArray>(&mut ctx).unwrap();
+        let encoded = RLEData::encode(primitive.as_view(), &mut ctx).unwrap();
 
         // Slice across first and second chunk.
         let slice = encoded.slice(500..1500).unwrap();

--- a/encodings/fsst/benches/chunked_dict_fsst_builder.rs
+++ b/encodings/fsst/benches/chunked_dict_fsst_builder.rs
@@ -37,8 +37,9 @@ fn make_dict_fsst_chunks<T: NativePType>(
     unique_values: usize,
     chunk_count: usize,
 ) -> ArrayRef {
+    let mut ctx = SESSION.create_execution_ctx();
     (0..chunk_count)
-        .map(|_| gen_dict_fsst_test_data::<T>(len, unique_values, 20, 30).into_array())
+        .map(|_| gen_dict_fsst_test_data::<T>(len, unique_values, 20, 30, &mut ctx).into_array())
         .collect::<ChunkedArray>()
         .into_array()
 }

--- a/encodings/fsst/benches/fsst_compress.rs
+++ b/encodings/fsst/benches/fsst_compress.rs
@@ -57,9 +57,9 @@ fn compress_fsst(bencher: Bencher, (string_count, avg_len, unique_chars): (usize
     let array = generate_test_data(string_count, avg_len, unique_chars);
     let compressor = fsst_train_compressor(&array);
     bencher
-        .with_inputs(|| (&array, &compressor))
-        .bench_refs(|(array, compressor)| {
-            fsst_compress(*array, array.len(), array.dtype(), compressor)
+        .with_inputs(|| (&array, &compressor, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(array, compressor, ctx)| {
+            fsst_compress(*array, array.len(), array.dtype(), compressor, ctx)
         })
 }
 
@@ -69,7 +69,13 @@ fn decompress_fsst(bencher: Bencher, (string_count, avg_len, unique_chars): (usi
     let compressor = fsst_train_compressor(&array);
     let len = array.len();
     let dtype = array.dtype().clone();
-    let encoded = fsst_compress(array, len, &dtype, &compressor);
+    let encoded = fsst_compress(
+        array,
+        len,
+        &dtype,
+        &compressor,
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    );
 
     bencher
         .with_inputs(|| (&encoded, LEGACY_SESSION.create_execution_ctx()))
@@ -88,7 +94,13 @@ fn train_compressor(bencher: Bencher, (string_count, avg_len, unique_chars): (us
 fn pushdown_compare(bencher: Bencher, (string_count, avg_len, unique_chars): (usize, usize, u8)) {
     let array = generate_test_data(string_count, avg_len, unique_chars);
     let compressor = fsst_train_compressor(&array);
-    let fsst_array = fsst_compress(&array, array.len(), array.dtype(), &compressor);
+    let fsst_array = fsst_compress(
+        &array,
+        array.len(),
+        array.dtype(),
+        &compressor,
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    );
     let constant = ConstantArray::new(Scalar::from(&b"const"[..]), array.len());
 
     bencher
@@ -117,7 +129,13 @@ fn canonicalize_compare(
 ) {
     let array = generate_test_data(string_count, avg_len, unique_chars);
     let compressor = fsst_train_compressor(&array);
-    let fsst_array = fsst_compress(&array, array.len(), array.dtype(), &compressor);
+    let fsst_array = fsst_compress(
+        &array,
+        array.len(),
+        array.dtype(),
+        &compressor,
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    );
     let constant = ConstantArray::new(Scalar::from(&b"const"[..]), array.len());
 
     bencher
@@ -217,13 +235,14 @@ fn generate_chunked_test_data(
     avg_len: usize,
     unique_chars: u8,
 ) -> ChunkedArray {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     (0..chunk_size)
         .map(|_| {
             let array = generate_test_data(string_count, avg_len, unique_chars);
             let compressor = fsst_train_compressor(&array);
             let len = array.len();
             let dtype = array.dtype().clone();
-            fsst_compress(array, len, &dtype, &compressor).into_array()
+            fsst_compress(array, len, &dtype, &compressor, &mut ctx).into_array()
         })
         .collect::<ChunkedArray>()
 }

--- a/encodings/fsst/benches/fsst_like.rs
+++ b/encodings/fsst/benches/fsst_like.rs
@@ -35,13 +35,20 @@ static SESSION: LazyLock<VortexSession> =
 
 const N: usize = NUM_STRINGS;
 
-static FSST_URLS: LazyLock<FSSTArray> = LazyLock::new(|| make_fsst_short_urls(N));
-static FSST_CB_URLS: LazyLock<FSSTArray> = LazyLock::new(|| make_fsst_clickbench_urls(N));
-static FSST_LOG_LINES: LazyLock<FSSTArray> = LazyLock::new(|| make_fsst_log_lines(N));
-static FSST_JSON_STRINGS: LazyLock<FSSTArray> = LazyLock::new(|| make_fsst_json_strings(N));
-static FSST_FILE_PATHS: LazyLock<FSSTArray> = LazyLock::new(|| make_fsst_file_paths(N));
-static FSST_EMAILS: LazyLock<FSSTArray> = LazyLock::new(|| make_fsst_emails(N));
-static FSST_RARE_MATCH: LazyLock<FSSTArray> = LazyLock::new(|| make_fsst_rare_match(N));
+static FSST_URLS: LazyLock<FSSTArray> =
+    LazyLock::new(|| make_fsst_short_urls(N, &mut SESSION.create_execution_ctx()));
+static FSST_CB_URLS: LazyLock<FSSTArray> =
+    LazyLock::new(|| make_fsst_clickbench_urls(N, &mut SESSION.create_execution_ctx()));
+static FSST_LOG_LINES: LazyLock<FSSTArray> =
+    LazyLock::new(|| make_fsst_log_lines(N, &mut SESSION.create_execution_ctx()));
+static FSST_JSON_STRINGS: LazyLock<FSSTArray> =
+    LazyLock::new(|| make_fsst_json_strings(N, &mut SESSION.create_execution_ctx()));
+static FSST_FILE_PATHS: LazyLock<FSSTArray> =
+    LazyLock::new(|| make_fsst_file_paths(N, &mut SESSION.create_execution_ctx()));
+static FSST_EMAILS: LazyLock<FSSTArray> =
+    LazyLock::new(|| make_fsst_emails(N, &mut SESSION.create_execution_ctx()));
+static FSST_RARE_MATCH: LazyLock<FSSTArray> =
+    LazyLock::new(|| make_fsst_rare_match(N, &mut SESSION.create_execution_ctx()));
 
 enum Dataset {
     Urls,

--- a/encodings/fsst/benches/fsst_url_compare.rs
+++ b/encodings/fsst/benches/fsst_url_compare.rs
@@ -57,7 +57,13 @@ fn pick_url_with_domain(data: &VarBinArray, domain: &str) -> String {
 fn eq_pushdown_high_match(bencher: Bencher) {
     let data = &*URL_DATA;
     let compressor = fsst_train_compressor(data);
-    let fsst_array = fsst_compress(data, data.len(), data.dtype(), &compressor);
+    let fsst_array = fsst_compress(
+        data,
+        data.len(),
+        data.dtype(),
+        &compressor,
+        &mut SESSION.create_execution_ctx(),
+    );
     let match_url = pick_url_with_domain(data, HIGH_MATCH_DOMAIN);
     let constant = ConstantArray::new(Scalar::from(match_url.as_str()), NUM_URLS);
 
@@ -78,7 +84,13 @@ fn eq_pushdown_high_match(bencher: Bencher) {
 fn eq_pushdown_low_match(bencher: Bencher) {
     let data = &*URL_DATA;
     let compressor = fsst_train_compressor(data);
-    let fsst_array = fsst_compress(data, data.len(), data.dtype(), &compressor);
+    let fsst_array = fsst_compress(
+        data,
+        data.len(),
+        data.dtype(),
+        &compressor,
+        &mut SESSION.create_execution_ctx(),
+    );
     let match_url = pick_url_with_domain(data, LOW_MATCH_DOMAIN);
     let constant = ConstantArray::new(Scalar::from(match_url.as_str()), NUM_URLS);
 
@@ -99,7 +111,13 @@ fn eq_pushdown_low_match(bencher: Bencher) {
 fn eq_canonicalize_high_match(bencher: Bencher) {
     let data = &*URL_DATA;
     let compressor = fsst_train_compressor(data);
-    let fsst_array = fsst_compress(data, data.len(), data.dtype(), &compressor);
+    let fsst_array = fsst_compress(
+        data,
+        data.len(),
+        data.dtype(),
+        &compressor,
+        &mut SESSION.create_execution_ctx(),
+    );
     let match_url = pick_url_with_domain(data, HIGH_MATCH_DOMAIN);
     let constant = ConstantArray::new(Scalar::from(match_url.as_str()), NUM_URLS);
 
@@ -123,7 +141,13 @@ fn eq_canonicalize_high_match(bencher: Bencher) {
 fn eq_canonicalize_low_match(bencher: Bencher) {
     let data = &*URL_DATA;
     let compressor = fsst_train_compressor(data);
-    let fsst_array = fsst_compress(data, data.len(), data.dtype(), &compressor);
+    let fsst_array = fsst_compress(
+        data,
+        data.len(),
+        data.dtype(),
+        &compressor,
+        &mut SESSION.create_execution_ctx(),
+    );
     let match_url = pick_url_with_domain(data, LOW_MATCH_DOMAIN);
     let constant = ConstantArray::new(Scalar::from(match_url.as_str()), NUM_URLS);
 
@@ -151,7 +175,13 @@ fn eq_canonicalize_low_match(bencher: Bencher) {
 fn like_substr_high_match(bencher: Bencher) {
     let data = &*URL_DATA;
     let compressor = fsst_train_compressor(data);
-    let fsst_array = fsst_compress(data, data.len(), data.dtype(), &compressor);
+    let fsst_array = fsst_compress(
+        data,
+        data.len(),
+        data.dtype(),
+        &compressor,
+        &mut SESSION.create_execution_ctx(),
+    );
     let pattern = format!("%{HIGH_MATCH_DOMAIN}%");
     let expr = like(root(), lit(pattern.as_str()));
 
@@ -172,7 +202,13 @@ fn like_substr_high_match(bencher: Bencher) {
 fn like_substr_low_match(bencher: Bencher) {
     let data = &*URL_DATA;
     let compressor = fsst_train_compressor(data);
-    let fsst_array = fsst_compress(data, data.len(), data.dtype(), &compressor);
+    let fsst_array = fsst_compress(
+        data,
+        data.len(),
+        data.dtype(),
+        &compressor,
+        &mut SESSION.create_execution_ctx(),
+    );
     let pattern = format!("%{LOW_MATCH_DOMAIN}%");
     let expr = like(root(), lit(pattern.as_str()));
 

--- a/encodings/fsst/public-api.lock
+++ b/encodings/fsst/public-api.lock
@@ -4,7 +4,7 @@ pub struct vortex_fsst::FSST
 
 impl vortex_fsst::FSST
 
-pub fn vortex_fsst::FSST::try_new(dtype: vortex_array::dtype::DType, symbols: vortex_buffer::buffer::Buffer<fsst::Symbol>, symbol_lengths: vortex_buffer::buffer::Buffer<u8>, codes: vortex_array::arrays::varbin::vtable::VarBinArray, uncompressed_lengths: vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_fsst::FSSTArray>
+pub fn vortex_fsst::FSST::try_new(dtype: vortex_array::dtype::DType, symbols: vortex_buffer::buffer::Buffer<fsst::Symbol>, symbol_lengths: vortex_buffer::buffer::Buffer<u8>, codes: vortex_array::arrays::varbin::vtable::VarBinArray, uncompressed_lengths: vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_fsst::FSSTArray>
 
 impl core::clone::Clone for vortex_fsst::FSST
 
@@ -56,7 +56,7 @@ pub fn vortex_fsst::FSST::validity(array: vortex_array::array::view::ArrayView<'
 
 impl vortex_array::arrays::dict::take::TakeExecute for vortex_fsst::FSST
 
-pub fn vortex_fsst::FSST::take(array: vortex_array::array::view::ArrayView<'_, Self>, indices: &vortex_array::array::erased::ArrayRef, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::erased::ArrayRef>>
+pub fn vortex_fsst::FSST::take(array: vortex_array::array::view::ArrayView<'_, Self>, indices: &vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::erased::ArrayRef>>
 
 impl vortex_array::arrays::filter::kernel::FilterKernel for vortex_fsst::FSST
 
@@ -100,7 +100,7 @@ pub fn vortex_fsst::FSSTData::symbols(&self) -> &vortex_buffer::buffer::Buffer<f
 
 pub fn vortex_fsst::FSSTData::try_new(symbols: vortex_buffer::buffer::Buffer<fsst::Symbol>, symbol_lengths: vortex_buffer::buffer::Buffer<u8>, codes_bytes: vortex_array::buffer::BufferHandle, len: usize) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_fsst::FSSTData::validate(&self, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::array::erased::ArrayRef>]) -> vortex_error::VortexResult<()>
+pub fn vortex_fsst::FSSTData::validate(&self, dtype: &vortex_array::dtype::DType, len: usize, slots: &[core::option::Option<vortex_array::array::erased::ArrayRef>], ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 impl core::clone::Clone for vortex_fsst::FSSTData
 
@@ -176,9 +176,9 @@ pub fn T::uncompressed_lengths(&self) -> &vortex_array::array::erased::ArrayRef
 
 pub fn T::uncompressed_lengths_dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_fsst::fsst_compress<A: vortex_array::accessor::ArrayAccessor<[u8]>>(strings: A, len: usize, dtype: &vortex_array::dtype::DType, compressor: &fsst::Compressor) -> vortex_fsst::FSSTArray
+pub fn vortex_fsst::fsst_compress<A: vortex_array::accessor::ArrayAccessor<[u8]>>(strings: A, len: usize, dtype: &vortex_array::dtype::DType, compressor: &fsst::Compressor, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_fsst::FSSTArray
 
-pub fn vortex_fsst::fsst_compress_iter<'a, I>(iter: I, len: usize, dtype: vortex_array::dtype::DType, compressor: &fsst::Compressor) -> vortex_fsst::FSSTArray where I: core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a [u8]>>
+pub fn vortex_fsst::fsst_compress_iter<'a, I>(iter: I, len: usize, dtype: vortex_array::dtype::DType, compressor: &fsst::Compressor, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_fsst::FSSTArray where I: core::iter::traits::iterator::Iterator<Item = core::option::Option<&'a [u8]>>
 
 pub fn vortex_fsst::fsst_train_compressor<A: vortex_array::accessor::ArrayAccessor<[u8]>>(array: &A) -> fsst::Compressor
 

--- a/encodings/fsst/public-api.lock
+++ b/encodings/fsst/public-api.lock
@@ -76,7 +76,7 @@ pub fn vortex_fsst::FSST::cast(array: vortex_array::array::view::ArrayView<'_, S
 
 impl vortex_array::scalar_fn::fns::like::kernel::LikeKernel for vortex_fsst::FSST
 
-pub fn vortex_fsst::FSST::like(array: vortex_array::array::view::ArrayView<'_, Self>, pattern: &vortex_array::array::erased::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions, _ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::erased::ArrayRef>>
+pub fn vortex_fsst::FSST::like(array: vortex_array::array::view::ArrayView<'_, Self>, pattern: &vortex_array::array::erased::ArrayRef, options: vortex_array::scalar_fn::fns::like::LikeOptions, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::erased::ArrayRef>>
 
 pub struct vortex_fsst::FSSTData
 

--- a/encodings/fsst/src/array.rs
+++ b/encodings/fsst/src/array.rs
@@ -115,7 +115,9 @@ impl VTable for FSST {
         len: usize,
         slots: &[Option<ArrayRef>],
     ) -> VortexResult<()> {
-        data.validate(dtype, len, slots)
+        // TODO(ctx): trait fixes - VTable::validate has a fixed signature.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        data.validate(dtype, len, slots, &mut ctx)
     }
 
     fn nbuffers(_array: ArrayView<'_, Self>) -> usize {
@@ -235,6 +237,8 @@ impl VTable for FSST {
                 vortex_bail!("Expected 2 or 3 children, got {}", children.len());
             };
 
+            // TODO(ctx): trait fixes - VTable::deserialize has a fixed signature.
+            let mut ctx = LEGACY_SESSION.create_execution_ctx();
             FSSTData::validate_parts(
                 &symbols,
                 &symbol_lengths,
@@ -244,6 +248,7 @@ impl VTable for FSST {
                 &uncompressed_lengths,
                 dtype,
                 len,
+                &mut ctx,
             )?;
             let slots = vec![
                 Some(uncompressed_lengths),
@@ -385,6 +390,7 @@ impl FSST {
         symbol_lengths: Buffer<u8>,
         codes: VarBinArray,
         uncompressed_lengths: ArrayRef,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<FSSTArray> {
         let len = codes.len();
         FSSTData::validate_parts_from_codes(
@@ -394,6 +400,7 @@ impl FSST {
             &uncompressed_lengths,
             &dtype,
             len,
+            ctx,
         )?;
         let slots = FSSTData::make_slots(&codes, &uncompressed_lengths);
         let codes_bytes = codes.bytes_handle().clone();
@@ -437,6 +444,8 @@ impl FSST {
             len,
         )?;
 
+        // TODO(ctx): trait fixes - VTable::deserialize has a fixed signature.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         FSSTData::validate_parts_from_codes(
             symbols,
             symbol_lengths,
@@ -444,6 +453,7 @@ impl FSST {
             &uncompressed_lengths,
             dtype,
             len,
+            &mut ctx,
         )?;
         let slots = FSSTData::make_slots(&codes, &uncompressed_lengths);
         let codes_bytes = codes.bytes_handle().clone();
@@ -516,6 +526,7 @@ impl FSSTData {
         dtype: &DType,
         len: usize,
         slots: &[Option<ArrayRef>],
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         let codes_offsets = slots[CODES_OFFSETS_SLOT]
             .as_ref()
@@ -529,6 +540,7 @@ impl FSSTData {
             uncompressed_lengths_from_slots(slots),
             dtype,
             len,
+            ctx,
         )
     }
 
@@ -543,6 +555,7 @@ impl FSSTData {
         uncompressed_lengths: &ArrayRef,
         dtype: &DType,
         len: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         vortex_ensure!(
             matches!(dtype, DType::Binary(_) | DType::Utf8(_)),
@@ -582,10 +595,7 @@ impl FSSTData {
         // Validate that last offset doesn't exceed bytes length (when host-resident).
         if codes_bytes.is_on_host() && codes_offsets.is_host() && !codes_offsets.is_empty() {
             let last_offset: usize = (&codes_offsets
-                .execute_scalar(
-                    codes_offsets.len() - 1,
-                    &mut LEGACY_SESSION.create_execution_ctx(),
-                )
+                .execute_scalar(codes_offsets.len() - 1, ctx)
                 .vortex_expect("offsets must support scalar_at"))
                 .try_into()
                 .vortex_expect("Failed to convert offset to usize");
@@ -608,6 +618,7 @@ impl FSSTData {
         uncompressed_lengths: &ArrayRef,
         dtype: &DType,
         len: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         Self::validate_parts(
             symbols,
@@ -618,6 +629,7 @@ impl FSSTData {
             uncompressed_lengths,
             dtype,
             len,
+            ctx,
         )
     }
 
@@ -792,11 +804,13 @@ mod test {
         let symbol_lengths = Buffer::<u8>::copy_from([3, 8]);
 
         let compressor = Compressor::rebuild_from(symbols.as_slice(), symbol_lengths.as_slice());
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let fsst_array = fsst_compress_iter(
             [Some(b"abcabcab".as_ref()), Some(b"defghijk".as_ref())].into_iter(),
             2,
             DType::Utf8(Nullability::NonNullable),
             &compressor,
+            &mut ctx,
         );
 
         let compressed_codes = fsst_array.codes();

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -96,10 +96,10 @@ mod tests {
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
     use vortex_array::VortexSessionExecute;
-    use vortex_array::arrays::VarBinViewArray;
     use vortex_array::accessor::ArrayAccessor;
     use vortex_array::arrays::ChunkedArray;
     use vortex_array::arrays::VarBinArray;
+    use vortex_array::arrays::VarBinViewArray;
     use vortex_array::builders::ArrayBuilder;
     use vortex_array::builders::VarBinViewBuilder;
     use vortex_array::dtype::DType;

--- a/encodings/fsst/src/canonical.rs
+++ b/encodings/fsst/src/canonical.rs
@@ -95,9 +95,8 @@ mod tests {
     use rand::prelude::StdRng;
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::VarBinViewArray;
     use vortex_array::accessor::ArrayAccessor;
     use vortex_array::arrays::ChunkedArray;
     use vortex_array::arrays::VarBinArray;
@@ -149,13 +148,15 @@ mod tests {
     }
 
     fn make_data_chunked() -> (ChunkedArray, Vec<Option<Vec<u8>>>) {
+        let mut ctx = SESSION.create_execution_ctx();
         #[expect(clippy::type_complexity)]
         let (arr_vec, data_vec): (Vec<ArrayRef>, Vec<Vec<Option<Vec<u8>>>>) = (0..10)
             .map(|_| {
                 let (array, data) = make_data();
                 let compressor = fsst_train_compressor(&array);
                 (
-                    fsst_compress(&array, array.len(), array.dtype(), &compressor).into_array(),
+                    fsst_compress(&array, array.len(), array.dtype(), &compressor, &mut ctx)
+                        .into_array(),
                     data,
                 )
             })
@@ -169,6 +170,7 @@ mod tests {
 
     #[test]
     fn test_to_canonical() -> VortexResult<()> {
+        let mut ctx = SESSION.create_execution_ctx();
         let (chunked_arr, data) = make_data_chunked();
 
         let mut builder =
@@ -176,7 +178,7 @@ mod tests {
         chunked_arr
             .clone()
             .into_array()
-            .append_to_builder(&mut builder, &mut SESSION.create_execution_ctx())?;
+            .append_to_builder(&mut builder, &mut ctx)?;
 
         {
             let arr = builder.finish_into_canonical().into_varbinview();
@@ -186,8 +188,10 @@ mod tests {
         };
 
         {
-            #[expect(deprecated)]
-            let arr2 = chunked_arr.as_array().to_varbinview();
+            let arr2 = chunked_arr
+                .as_array()
+                .clone()
+                .execute::<VarBinViewArray>(&mut ctx)?;
             let res2 =
                 arr2.with_iterator(|iter| iter.map(|b| b.map(|v| v.to_vec())).collect::<Vec<_>>());
             assert_eq!(data, res2)
@@ -205,14 +209,16 @@ mod tests {
             [Some(b"long enough too".to_vec().into_boxed_slice())],
             dtype,
         );
+        let mut ctx = SESSION.create_execution_ctx();
         let fsst_array = fsst_compress(
             &varbin,
             varbin.len(),
             varbin.dtype(),
             &fsst_train_compressor(&varbin),
+            &mut ctx,
         )
         .into_array();
-        fsst_array.append_to_builder(&mut builder, &mut SESSION.create_execution_ctx())?;
+        fsst_array.append_to_builder(&mut builder, &mut ctx)?;
 
         let _result = builder.finish_into_varbinview();
         Ok(())

--- a/encodings/fsst/src/compress.rs
+++ b/encodings/fsst/src/compress.rs
@@ -5,6 +5,7 @@
 
 use fsst::Compressor;
 use fsst::Symbol;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::varbin::builder::VarBinBuilder;
@@ -21,8 +22,9 @@ pub fn fsst_compress<A: ArrayAccessor<[u8]>>(
     len: usize,
     dtype: &DType,
     compressor: &Compressor,
+    ctx: &mut ExecutionCtx,
 ) -> FSSTArray {
-    strings.with_iterator(|iter| fsst_compress_iter(iter, len, dtype.clone(), compressor))
+    strings.with_iterator(|iter| fsst_compress_iter(iter, len, dtype.clone(), compressor, ctx))
 }
 
 /// Train a compressor from an array.
@@ -61,6 +63,7 @@ pub fn fsst_compress_iter<'a, I>(
     len: usize,
     dtype: DType,
     compressor: &Compressor,
+    ctx: &mut ExecutionCtx,
 ) -> FSSTArray
 where
     I: Iterator<Item = Option<&'a [u8]>>,
@@ -102,7 +105,7 @@ where
 
     let uncompressed_lengths = uncompressed_lengths.into_array();
 
-    FSST::try_new(dtype, symbols, symbol_lengths, codes, uncompressed_lengths)
+    FSST::try_new(dtype, symbols, symbol_lengths, codes, uncompressed_lengths, ctx)
         .vortex_expect("FSST parts must be valid")
 }
 
@@ -128,16 +131,16 @@ mod tests {
 
         let compressor = CompressorBuilder::default().build();
 
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let compressed = fsst_compress_iter(
             [Some(big_string.as_bytes())].into_iter(),
             1,
             DType::Utf8(Nullability::NonNullable),
             &compressor,
+            &mut ctx,
         );
 
-        let decoded = compressed
-            .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let decoded = compressed.execute_scalar(0, &mut ctx).unwrap();
 
         let expected = Scalar::utf8(big_string, Nullability::NonNullable);
 

--- a/encodings/fsst/src/compress.rs
+++ b/encodings/fsst/src/compress.rs
@@ -105,8 +105,15 @@ where
 
     let uncompressed_lengths = uncompressed_lengths.into_array();
 
-    FSST::try_new(dtype, symbols, symbol_lengths, codes, uncompressed_lengths, ctx)
-        .vortex_expect("FSST parts must be valid")
+    FSST::try_new(
+        dtype,
+        symbols,
+        symbol_lengths,
+        codes,
+        uncompressed_lengths,
+        ctx,
+    )
+    .vortex_expect("FSST parts must be valid")
 }
 
 #[cfg(test)]

--- a/encodings/fsst/src/compute/cast.rs
+++ b/encodings/fsst/src/compute/cast.rs
@@ -4,6 +4,8 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::VarBin;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
@@ -23,6 +25,8 @@ impl CastReduce for FSST {
                 .into_array()
                 .cast(array.codes_dtype().with_nullability(dtype.nullability()))?;
 
+            // TODO(ctx): trait fixes - CastReduce::cast has a fixed signature.
+            let mut ctx = LEGACY_SESSION.create_execution_ctx();
             Ok(Some(
                 FSST::try_new(
                     dtype.clone(),
@@ -30,6 +34,7 @@ impl CastReduce for FSST {
                     array.symbol_lengths().clone(),
                     new_codes.as_::<VarBin>().into_owned(),
                     array.uncompressed_lengths().clone(),
+                    &mut ctx,
                 )?
                 .into_array(),
             ))
@@ -43,6 +48,8 @@ impl CastReduce for FSST {
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::VarBinArray;
     use vortex_array::builtins::ArrayBuiltins;
     use vortex_array::compute::conformance::cast::test_cast_conformance;
@@ -54,6 +61,7 @@ mod tests {
 
     #[test]
     fn test_cast_fsst_nullability() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let strings = VarBinArray::from_iter(
             vec![Some("hello"), Some("world"), Some("hello world")],
             DType::Utf8(Nullability::NonNullable),
@@ -62,7 +70,7 @@ mod tests {
         let compressor = fsst_train_compressor(&strings);
         let len = strings.len();
         let dtype = strings.dtype().clone();
-        let fsst = fsst_compress(strings, len, &dtype, &compressor);
+        let fsst = fsst_compress(strings, len, &dtype, &compressor, &mut ctx);
 
         // Cast to nullable
         let casted = fsst
@@ -86,8 +94,9 @@ mod tests {
         DType::Utf8(Nullability::NonNullable)
     ))]
     fn test_cast_fsst_conformance(#[case] array: VarBinArray) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let compressor = fsst_train_compressor(&array);
-        let fsst = fsst_compress(&array, array.len(), array.dtype(), &compressor);
+        let fsst = fsst_compress(&array, array.len(), array.dtype(), &compressor, &mut ctx);
         test_cast_conformance(&fsst.into_array());
     }
 }

--- a/encodings/fsst/src/compute/compare.rs
+++ b/encodings/fsst/src/compute/compare.rs
@@ -123,8 +123,8 @@ fn compare_fsst_constant(
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::ConstantArray;
     use vortex_array::arrays::VarBinArray;
@@ -141,6 +141,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_compare_fsst() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let lhs = VarBinArray::from_iter(
             [
                 Some("hello"),
@@ -154,18 +155,18 @@ mod tests {
         let compressor = fsst_train_compressor(&lhs);
         let len = lhs.len();
         let dtype = lhs.dtype().clone();
-        let lhs = fsst_compress(lhs, len, &dtype, &compressor);
+        let lhs = fsst_compress(lhs, len, &dtype, &compressor, &mut ctx);
 
         let rhs = ConstantArray::new("world", lhs.len());
 
         // Ensure fastpath for Eq exists, and returns correct answer
-        #[expect(deprecated)]
         let equals = lhs
             .clone()
             .into_array()
             .binary(rhs.clone().into_array(), Operator::Eq)
             .unwrap()
-            .to_bool();
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap();
 
         assert_eq!(equals.dtype(), &DType::Bool(Nullability::Nullable));
 
@@ -175,13 +176,13 @@ mod tests {
         );
 
         // Ensure fastpath for Eq exists, and returns correct answer
-        #[expect(deprecated)]
         let not_equals = lhs
             .clone()
             .into_array()
             .binary(rhs.into_array(), Operator::NotEq)
             .unwrap()
-            .to_bool();
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap();
 
         assert_eq!(not_equals.dtype(), &DType::Bool(Nullability::Nullable));
         assert_arrays_eq!(

--- a/encodings/fsst/src/compute/filter.rs
+++ b/encodings/fsst/src/compute/filter.rs
@@ -37,6 +37,7 @@ impl FilterKernel for FSST {
                 array.symbol_lengths().clone(),
                 filtered_codes,
                 array.uncompressed_lengths().filter(mask.clone())?,
+                ctx,
             )?
             .into_array(),
         ))

--- a/encodings/fsst/src/compute/like.rs
+++ b/encodings/fsst/src/compute/like.rs
@@ -5,9 +5,8 @@ use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::arrays::BoolArray;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::varbin::VarBinArrayExt;
 use vortex_array::match_each_integer_ptype;
 use vortex_array::scalar_fn::fns::like::LikeKernel;
@@ -24,7 +23,7 @@ impl LikeKernel for FSST {
         array: ArrayView<'_, Self>,
         pattern: &ArrayRef,
         options: LikeOptions,
-        _ctx: &mut ExecutionCtx,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         let Some(pattern_scalar) = pattern.as_constant() else {
             return Ok(None);
@@ -59,8 +58,7 @@ impl LikeKernel for FSST {
 
         let negated = options.negated;
         let codes = array.codes();
-        #[expect(deprecated)]
-        let offsets = codes.offsets().to_primitive();
+        let offsets = codes.offsets().clone().execute::<PrimitiveArray>(ctx)?;
         let all_bytes = codes.bytes();
         let all_bytes = all_bytes.as_slice();
         let n = codes.len();
@@ -115,7 +113,13 @@ mod tests {
         let compressor = fsst_train_compressor(&varbin);
         let len = varbin.len();
         let dtype = varbin.dtype().clone();
-        fsst_compress(varbin, len, &dtype, &compressor)
+        fsst_compress(
+            varbin,
+            len,
+            &dtype,
+            &compressor,
+            &mut SESSION.create_execution_ctx(),
+        )
     }
 
     fn run_like(array: FSSTArray, pattern: &str, opts: LikeOptions) -> VortexResult<BoolArray> {

--- a/encodings/fsst/src/compute/mod.rs
+++ b/encodings/fsst/src/compute/mod.rs
@@ -25,7 +25,7 @@ impl TakeExecute for FSST {
     fn take(
         array: ArrayView<'_, Self>,
         indices: &ArrayRef,
-        _ctx: &mut ExecutionCtx,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         Ok(Some(
             FSST::try_new(
@@ -38,7 +38,7 @@ impl TakeExecute for FSST {
                 {
                     let codes = array.codes();
                     let codes = codes.as_view();
-                    <VarBin as TakeExecute>::take(codes, indices, _ctx)?
+                    <VarBin as TakeExecute>::take(codes, indices, ctx)?
                         .vortex_expect("VarBin take kernel always returns Some")
                 }
                 .try_downcast::<VarBin>()
@@ -49,6 +49,7 @@ impl TakeExecute for FSST {
                     .fill_null(Scalar::zero_value(
                         &array.uncompressed_lengths_dtype().clone(),
                     ))?,
+                ctx,
             )?
             .into_array(),
         ))
@@ -58,7 +59,10 @@ impl TakeExecute for FSST {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use vortex_array::ExecutionCtx;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::VarBinArray;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
@@ -72,9 +76,10 @@ mod tests {
 
     #[test]
     fn test_take_null() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = VarBinArray::from_iter([Some("h")], DType::Utf8(Nullability::NonNullable));
         let compr = fsst_train_compressor(&arr);
-        let fsst = fsst_compress(&arr, arr.len(), arr.dtype(), &compr);
+        let fsst = fsst_compress(&arr, arr.len(), arr.dtype(), &compr, &mut ctx);
 
         let idx1: PrimitiveArray = (0..1).collect();
 
@@ -105,23 +110,26 @@ mod tests {
         DType::Utf8(Nullability::NonNullable),
     ))]
     fn test_take_fsst_conformance(#[case] varbin: VarBinArray) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let compressor = fsst_train_compressor(&varbin);
-        let array = fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor);
+        let array = fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor, &mut ctx);
         test_take_conformance(&array.into_array());
     }
 
+    type FsstBuilder = fn(&mut ExecutionCtx) -> FSSTArray;
+
     #[rstest]
     // Basic string arrays
-    #[case::fsst_simple({
+    #[case::fsst_simple(|ctx: &mut ExecutionCtx| {
         let varbin = VarBinArray::from_iter(
             ["hello world", "testing fsst", "compression test", "data array", "vortex encoding"].map(Some),
             DType::Utf8(Nullability::NonNullable),
         );
         let compressor = fsst_train_compressor(&varbin);
-        fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor)
+        fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor, ctx)
     })]
     // Nullable strings
-    #[case::fsst_nullable({
+    #[case::fsst_nullable(|ctx: &mut ExecutionCtx| {
         let varbin = VarBinArray::from_iter(
             [Some("hello"), None, Some("world"), Some("test"), None],
             DType::Utf8(Nullability::Nullable),
@@ -129,27 +137,27 @@ mod tests {
         let compressor = fsst_train_compressor(&varbin);
         let len = varbin.len();
         let dtype = varbin.dtype().clone();
-        fsst_compress(varbin, len, &dtype, &compressor)
+        fsst_compress(varbin, len, &dtype, &compressor, ctx)
     })]
     // Repetitive patterns (good for FSST compression)
-    #[case::fsst_repetitive({
+    #[case::fsst_repetitive(|ctx: &mut ExecutionCtx| {
         let varbin = VarBinArray::from_iter(
             ["http://example.com", "http://test.com", "http://vortex.dev", "http://data.org"].map(Some),
             DType::Utf8(Nullability::NonNullable),
         );
         let compressor = fsst_train_compressor(&varbin);
-        fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor)
+        fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor, ctx)
     })]
     // Edge cases
-    #[case::fsst_single({
+    #[case::fsst_single(|ctx: &mut ExecutionCtx| {
         let varbin = VarBinArray::from_iter(
             ["single element"].map(Some),
             DType::Utf8(Nullability::NonNullable),
         );
         let compressor = fsst_train_compressor(&varbin);
-        fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor)
+        fsst_compress(&varbin, varbin.len(), varbin.dtype(), &compressor, ctx)
     })]
-    #[case::fsst_empty_strings({
+    #[case::fsst_empty_strings(|ctx: &mut ExecutionCtx| {
         let varbin = VarBinArray::from_iter(
             ["", "test", "", "hello", ""].map(Some),
             DType::Utf8(Nullability::NonNullable),
@@ -157,10 +165,10 @@ mod tests {
         let compressor = fsst_train_compressor(&varbin);
         let len = varbin.len();
         let dtype = varbin.dtype().clone();
-        fsst_compress(varbin, len, &dtype, &compressor)
+        fsst_compress(varbin, len, &dtype, &compressor, ctx)
     })]
     // Large arrays
-    #[case::fsst_large({
+    #[case::fsst_large(|ctx: &mut ExecutionCtx| {
         let data: Vec<Option<&str>> = (0..1500)
             .map(|i| Some(match i % 10 {
                 0 => "https://www.example.com/page",
@@ -179,10 +187,12 @@ mod tests {
         let compressor = fsst_train_compressor(&varbin);
         let len = varbin.len();
         let dtype = varbin.dtype().clone();
-        fsst_compress(varbin, len, &dtype, &compressor)
+        fsst_compress(varbin, len, &dtype, &compressor, ctx)
     })]
 
-    fn test_fsst_consistency(#[case] array: FSSTArray) {
+    fn test_fsst_consistency(#[case] build: FsstBuilder) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array = build(&mut ctx);
         test_array_consistency(&array.into_array());
     }
 }

--- a/encodings/fsst/src/dfa/tests.rs
+++ b/encodings/fsst/src/dfa/tests.rs
@@ -229,7 +229,13 @@ fn make_fsst_str(strings: &[Option<&str>]) -> FSSTArray {
     let compressor = fsst_train_compressor(&varbin);
     let len = varbin.len();
     let dtype = varbin.dtype().clone();
-    fsst_compress(varbin, len, &dtype, &compressor, &mut SESSION.create_execution_ctx())
+    fsst_compress(
+        varbin,
+        len,
+        &dtype,
+        &compressor,
+        &mut SESSION.create_execution_ctx(),
+    )
 }
 
 fn run_like(array: FSSTArray, pattern_arr: ArrayRef) -> VortexResult<BoolArray> {

--- a/encodings/fsst/src/dfa/tests.rs
+++ b/encodings/fsst/src/dfa/tests.rs
@@ -229,7 +229,7 @@ fn make_fsst_str(strings: &[Option<&str>]) -> FSSTArray {
     let compressor = fsst_train_compressor(&varbin);
     let len = varbin.len();
     let dtype = varbin.dtype().clone();
-    fsst_compress(varbin, len, &dtype, &compressor)
+    fsst_compress(varbin, len, &dtype, &compressor, &mut SESSION.create_execution_ctx())
 }
 
 fn run_like(array: FSSTArray, pattern_arr: ArrayRef) -> VortexResult<BoolArray> {

--- a/encodings/fsst/src/kernel.rs
+++ b/encodings/fsst/src/kernel.rs
@@ -58,7 +58,8 @@ mod tests {
         let compressor = fsst_train_compressor(&input);
         let len = input.len();
         let dtype = input.dtype().clone();
-        fsst_compress(input, len, &dtype, &compressor).into_array()
+        let mut ctx = SESSION.create_execution_ctx();
+        fsst_compress(input, len, &dtype, &compressor, &mut ctx).into_array()
     }
 
     #[test]
@@ -131,8 +132,10 @@ mod tests {
         let input = builder.finish(DType::Utf8(Nullability::Nullable));
 
         let compressor = fsst_train_compressor(&input);
+        let mut ctx = SESSION.create_execution_ctx();
         let fsst_array: ArrayRef =
-            fsst_compress(input.clone(), input.len(), input.dtype(), &compressor).into_array();
+            fsst_compress(input.clone(), input.len(), input.dtype(), &compressor, &mut ctx)
+                .into_array();
 
         // Filter: only select the last element (index 22)
         let mut mask = vec![false; 22];
@@ -140,7 +143,6 @@ mod tests {
         let mask = Mask::from_iter(mask);
 
         let filter_array = FilterArray::new(fsst_array, mask.clone()).into_array();
-        let mut ctx = SESSION.create_execution_ctx();
         let result = filter_array.execute::<Canonical>(&mut ctx)?;
 
         let expected = input.filter(mask)?;
@@ -160,13 +162,14 @@ mod tests {
         let input = builder.finish(DType::Utf8(Nullability::Nullable));
 
         let compressor = fsst_train_compressor(&input);
+        let mut ctx = SESSION.create_execution_ctx();
         let fsst_array: ArrayRef =
-            fsst_compress(input.clone(), input.len(), input.dtype(), &compressor).into_array();
+            fsst_compress(input.clone(), input.len(), input.dtype(), &compressor, &mut ctx)
+                .into_array();
 
         let mask = Mask::from_iter([true, false, true]);
 
         let filter_array = FilterArray::new(fsst_array, mask.clone()).into_array();
-        let mut ctx = SESSION.create_execution_ctx();
         let result = filter_array.execute::<Canonical>(&mut ctx)?;
 
         let expected = input.filter(mask)?;

--- a/encodings/fsst/src/kernel.rs
+++ b/encodings/fsst/src/kernel.rs
@@ -133,9 +133,14 @@ mod tests {
 
         let compressor = fsst_train_compressor(&input);
         let mut ctx = SESSION.create_execution_ctx();
-        let fsst_array: ArrayRef =
-            fsst_compress(input.clone(), input.len(), input.dtype(), &compressor, &mut ctx)
-                .into_array();
+        let fsst_array: ArrayRef = fsst_compress(
+            input.clone(),
+            input.len(),
+            input.dtype(),
+            &compressor,
+            &mut ctx,
+        )
+        .into_array();
 
         // Filter: only select the last element (index 22)
         let mut mask = vec![false; 22];
@@ -163,9 +168,14 @@ mod tests {
 
         let compressor = fsst_train_compressor(&input);
         let mut ctx = SESSION.create_execution_ctx();
-        let fsst_array: ArrayRef =
-            fsst_compress(input.clone(), input.len(), input.dtype(), &compressor, &mut ctx)
-                .into_array();
+        let fsst_array: ArrayRef = fsst_compress(
+            input.clone(),
+            input.len(),
+            input.dtype(),
+            &compressor,
+            &mut ctx,
+        )
+        .into_array();
 
         let mask = Mask::from_iter([true, false, true]);
 

--- a/encodings/fsst/src/test_utils.rs
+++ b/encodings/fsst/src/test_utils.rs
@@ -7,6 +7,7 @@ use rand::RngExt;
 use rand::SeedableRng;
 use rand::prelude::StdRng;
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -20,7 +21,12 @@ use crate::FSSTArray;
 use crate::fsst_compress;
 use crate::fsst_train_compressor;
 
-pub fn gen_fsst_test_data(len: usize, avg_str_len: usize, unique_chars: u8) -> ArrayRef {
+pub fn gen_fsst_test_data(
+    len: usize,
+    avg_str_len: usize,
+    unique_chars: u8,
+    ctx: &mut ExecutionCtx,
+) -> ArrayRef {
     let mut rng = StdRng::seed_from_u64(0);
     let mut strings = Vec::with_capacity(len);
 
@@ -45,7 +51,7 @@ pub fn gen_fsst_test_data(len: usize, avg_str_len: usize, unique_chars: u8) -> A
 
     let len = varbin.len();
     let dtype = varbin.dtype().clone();
-    fsst_compress(varbin, len, &dtype, &compressor).into_array()
+    fsst_compress(varbin, len, &dtype, &compressor, ctx).into_array()
 }
 
 pub fn gen_dict_fsst_test_data<T: NativePType>(
@@ -53,8 +59,9 @@ pub fn gen_dict_fsst_test_data<T: NativePType>(
     unique_values: usize,
     str_len: usize,
     unique_char_count: u8,
+    ctx: &mut ExecutionCtx,
 ) -> DictArray {
-    let values = gen_fsst_test_data(len, str_len, unique_char_count);
+    let values = gen_fsst_test_data(len, str_len, unique_char_count, ctx);
     let mut rng = StdRng::seed_from_u64(0);
     let codes = (0..len)
         .map(|_| T::from(rng.random_range(0..unique_values)).unwrap())
@@ -136,12 +143,12 @@ pub fn generate_url_data_n(n: usize) -> VarBinArray {
     VarBinArray::from_iter(urls, DType::Utf8(Nullability::NonNullable))
 }
 
-pub fn make_fsst_urls(n: usize) -> FSSTArray {
+pub fn make_fsst_urls(n: usize, ctx: &mut ExecutionCtx) -> FSSTArray {
     let varbin = generate_url_data_n(n);
     let compressor = fsst_train_compressor(&varbin);
     let len = varbin.len();
     let dtype = varbin.dtype().clone();
-    fsst_compress(varbin, len, &dtype, &compressor)
+    fsst_compress(varbin, len, &dtype, &compressor, ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -228,7 +235,7 @@ pub fn generate_clickbench_urls(n: usize) -> Vec<String> {
         .collect()
 }
 
-pub fn make_fsst_clickbench_urls(n: usize) -> FSSTArray {
+pub fn make_fsst_clickbench_urls(n: usize, ctx: &mut ExecutionCtx) -> FSSTArray {
     let urls = generate_clickbench_urls(n);
     let varbin = VarBinArray::from_iter(
         urls.iter().map(|s| Some(s.as_str())),
@@ -237,7 +244,7 @@ pub fn make_fsst_clickbench_urls(n: usize) -> FSSTArray {
     let compressor = fsst_train_compressor(&varbin);
     let len = varbin.len();
     let dtype = varbin.dtype().clone();
-    fsst_compress(varbin, len, &dtype, &compressor)
+    fsst_compress(varbin, len, &dtype, &compressor, ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -296,7 +303,7 @@ pub fn generate_short_urls(n: usize) -> Vec<String> {
         .collect()
 }
 
-pub fn make_fsst_short_urls(n: usize) -> FSSTArray {
+pub fn make_fsst_short_urls(n: usize, ctx: &mut ExecutionCtx) -> FSSTArray {
     let urls = generate_short_urls(n);
     let varbin = VarBinArray::from_iter(
         urls.iter().map(|s| Some(s.as_str())),
@@ -305,7 +312,7 @@ pub fn make_fsst_short_urls(n: usize) -> FSSTArray {
     let compressor = fsst_train_compressor(&varbin);
     let len = varbin.len();
     let dtype = varbin.dtype().clone();
-    fsst_compress(varbin, len, &dtype, &compressor)
+    fsst_compress(varbin, len, &dtype, &compressor, ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -368,7 +375,7 @@ pub fn generate_log_lines(n: usize) -> Vec<String> {
         .collect()
 }
 
-pub fn make_fsst_log_lines(n: usize) -> FSSTArray {
+pub fn make_fsst_log_lines(n: usize, ctx: &mut ExecutionCtx) -> FSSTArray {
     let lines = generate_log_lines(n);
     let varbin = VarBinArray::from_iter(
         lines.iter().map(|s| Some(s.as_str())),
@@ -377,7 +384,7 @@ pub fn make_fsst_log_lines(n: usize) -> FSSTArray {
     let compressor = fsst_train_compressor(&varbin);
     let len = varbin.len();
     let dtype = varbin.dtype().clone();
-    fsst_compress(varbin, len, &dtype, &compressor)
+    fsst_compress(varbin, len, &dtype, &compressor, ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -427,7 +434,7 @@ pub fn generate_json_strings(n: usize) -> Vec<String> {
         .collect()
 }
 
-pub fn make_fsst_json_strings(n: usize) -> FSSTArray {
+pub fn make_fsst_json_strings(n: usize, ctx: &mut ExecutionCtx) -> FSSTArray {
     let jsons = generate_json_strings(n);
     let varbin = VarBinArray::from_iter(
         jsons.iter().map(|s| Some(s.as_str())),
@@ -436,7 +443,7 @@ pub fn make_fsst_json_strings(n: usize) -> FSSTArray {
     let compressor = fsst_train_compressor(&varbin);
     let len = varbin.len();
     let dtype = varbin.dtype().clone();
-    fsst_compress(varbin, len, &dtype, &compressor)
+    fsst_compress(varbin, len, &dtype, &compressor, ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -499,7 +506,7 @@ pub fn generate_file_paths(n: usize) -> Vec<String> {
         .collect()
 }
 
-pub fn make_fsst_file_paths(n: usize) -> FSSTArray {
+pub fn make_fsst_file_paths(n: usize, ctx: &mut ExecutionCtx) -> FSSTArray {
     let paths = generate_file_paths(n);
     let varbin = VarBinArray::from_iter(
         paths.iter().map(|s| Some(s.as_str())),
@@ -508,7 +515,7 @@ pub fn make_fsst_file_paths(n: usize) -> FSSTArray {
     let compressor = fsst_train_compressor(&varbin);
     let len = varbin.len();
     let dtype = varbin.dtype().clone();
-    fsst_compress(varbin, len, &dtype, &compressor)
+    fsst_compress(varbin, len, &dtype, &compressor, ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -552,7 +559,7 @@ pub fn generate_emails(n: usize) -> Vec<String> {
         .collect()
 }
 
-pub fn make_fsst_emails(n: usize) -> FSSTArray {
+pub fn make_fsst_emails(n: usize, ctx: &mut ExecutionCtx) -> FSSTArray {
     let emails = generate_emails(n);
     let varbin = VarBinArray::from_iter(
         emails.iter().map(|s| Some(s.as_str())),
@@ -561,7 +568,7 @@ pub fn make_fsst_emails(n: usize) -> FSSTArray {
     let compressor = fsst_train_compressor(&varbin);
     let len = varbin.len();
     let dtype = varbin.dtype().clone();
-    fsst_compress(varbin, len, &dtype, &compressor)
+    fsst_compress(varbin, len, &dtype, &compressor, ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -591,7 +598,7 @@ pub fn generate_rare_match_strings(n: usize, match_rate: f64) -> Vec<String> {
         .collect()
 }
 
-pub fn make_fsst_rare_match(n: usize) -> FSSTArray {
+pub fn make_fsst_rare_match(n: usize, ctx: &mut ExecutionCtx) -> FSSTArray {
     let strings = generate_rare_match_strings(n, 0.00001);
     let varbin = VarBinArray::from_iter(
         strings.iter().map(|s| Some(s.as_str())),
@@ -600,5 +607,5 @@ pub fn make_fsst_rare_match(n: usize) -> FSSTArray {
     let compressor = fsst_train_compressor(&varbin);
     let len = varbin.len();
     let dtype = varbin.dtype().clone();
-    fsst_compress(varbin, len, &dtype, &compressor)
+    fsst_compress(varbin, len, &dtype, &compressor, ctx)
 }

--- a/encodings/fsst/src/tests.rs
+++ b/encodings/fsst/src/tests.rs
@@ -3,8 +3,9 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::varbin::builder::VarBinBuilder;
 use vortex_array::assert_arrays_eq;
 use vortex_array::assert_nth_scalar;
@@ -30,11 +31,13 @@ pub(crate) fn build_fsst_array() -> ArrayRef {
     let compressor = fsst_train_compressor(&input_array);
     let len = input_array.len();
     let dtype = input_array.dtype().clone();
-    fsst_compress(input_array, len, &dtype, &compressor).into_array()
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    fsst_compress(input_array, len, &dtype, &compressor, &mut ctx).into_array()
 }
 
 #[test]
 fn test_fsst_array_ops() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     // first test the scalar_at values
     let fsst_array = build_fsst_array();
     assert_nth_scalar!(
@@ -96,8 +99,11 @@ fn test_fsst_array_ops() {
     );
 
     // test to_canonical
-    #[expect(deprecated)]
-    let canonical_array = fsst_array.to_varbinview().into_array();
+    let canonical_array = fsst_array
+        .clone()
+        .execute::<VarBinViewArray>(&mut ctx)
+        .unwrap()
+        .into_array();
 
     assert_arrays_eq!(fsst_array, canonical_array);
 }

--- a/encodings/pco/public-api.lock
+++ b/encodings/pco/public-api.lock
@@ -4,7 +4,7 @@ pub struct vortex_pco::Pco
 
 impl vortex_pco::Pco
 
-pub fn vortex_pco::Pco::from_primitive(parray: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>, level: usize, values_per_page: usize) -> vortex_error::VortexResult<vortex_pco::PcoArray>
+pub fn vortex_pco::Pco::from_primitive(parray: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>, level: usize, values_per_page: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_pco::PcoArray>
 
 impl core::clone::Clone for vortex_pco::Pco
 
@@ -86,9 +86,9 @@ impl vortex_pco::PcoData
 
 pub fn vortex_pco::PcoData::decompress(&self, unsliced_validity: &vortex_array::validity::Validity, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::primitive::vtable::PrimitiveArray>
 
-pub fn vortex_pco::PcoData::from_array(array: vortex_array::array::erased::ArrayRef, level: usize, nums_per_page: usize) -> vortex_error::VortexResult<Self>
+pub fn vortex_pco::PcoData::from_array(array: vortex_array::array::erased::ArrayRef, level: usize, nums_per_page: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_pco::PcoData::from_primitive(parray: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>, level: usize, values_per_page: usize) -> vortex_error::VortexResult<Self>
+pub fn vortex_pco::PcoData::from_primitive(parray: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>, level: usize, values_per_page: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_pco::PcoData::is_empty(&self) -> bool
 

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -258,8 +258,14 @@ fn collect_valid(
     parray: ArrayView<'_, Primitive>,
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<PrimitiveArray> {
-    let mask = parray.array().validity()?.to_mask(parray.array().len(), ctx)?;
-    let result = parray.array().filter(mask)?.execute::<PrimitiveArray>(ctx)?;
+    let mask = parray
+        .array()
+        .validity()?
+        .to_mask(parray.array().len(), ctx)?;
+    let result = parray
+        .array()
+        .filter(mask)?
+        .execute::<PrimitiveArray>(ctx)?;
     Ok(result)
 }
 

--- a/encodings/pco/src/array.rs
+++ b/encodings/pco/src/array.rs
@@ -28,11 +28,7 @@ use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::Precision;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::buffer::BufferHandle;
@@ -258,13 +254,12 @@ pub(crate) fn number_type_from_ptype(ptype: PType) -> NumberType {
     }
 }
 
-fn collect_valid(parray: ArrayView<'_, Primitive>) -> VortexResult<PrimitiveArray> {
-    let mask = parray.array().validity()?.to_mask(
-        parray.array().len(),
-        &mut LEGACY_SESSION.create_execution_ctx(),
-    )?;
-    #[expect(deprecated)]
-    let result = parray.array().filter(mask)?.to_primitive();
+fn collect_valid(
+    parray: ArrayView<'_, Primitive>,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<PrimitiveArray> {
+    let mask = parray.array().validity()?.to_mask(parray.array().len(), ctx)?;
+    let result = parray.array().filter(mask)?.execute::<PrimitiveArray>(ctx)?;
     Ok(result)
 }
 
@@ -299,10 +294,11 @@ impl Pco {
         parray: ArrayView<'_, Primitive>,
         level: usize,
         values_per_page: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<PcoArray> {
         let dtype = parray.dtype().clone();
         let validity = parray.validity()?;
-        let data = PcoData::from_primitive(parray, level, values_per_page)?;
+        let data = PcoData::from_primitive(parray, level, values_per_page, ctx)?;
         Self::try_new(dtype, data, validity)
     }
 }
@@ -408,8 +404,15 @@ impl PcoData {
         parray: ArrayView<'_, Primitive>,
         level: usize,
         values_per_page: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
-        Self::from_primitive_with_values_per_chunk(parray, level, VALUES_PER_CHUNK, values_per_page)
+        Self::from_primitive_with_values_per_chunk(
+            parray,
+            level,
+            VALUES_PER_CHUNK,
+            values_per_page,
+            ctx,
+        )
     }
 
     pub(crate) fn from_primitive_with_values_per_chunk(
@@ -417,6 +420,7 @@ impl PcoData {
         level: usize,
         values_per_chunk: usize,
         values_per_page: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
         let number_type = number_type_from_dtype(parray.dtype());
         let values_per_page = if values_per_page == 0 {
@@ -430,7 +434,7 @@ impl PcoData {
             .with_compression_level(level)
             .with_paging_spec(PagingSpec::EqualPagesUpTo(values_per_page));
 
-        let values = collect_valid(parray)?;
+        let values = collect_valid(parray, ctx)?;
         let n_values = values.len();
 
         let fc = FileCompressor::default();
@@ -484,14 +488,19 @@ impl PcoData {
         ))
     }
 
-    pub fn from_array(array: ArrayRef, level: usize, nums_per_page: usize) -> VortexResult<Self> {
+    pub fn from_array(
+        array: ArrayRef,
+        level: usize,
+        nums_per_page: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Self> {
         let parray = array.try_downcast::<Primitive>().map_err(|a| {
             vortex_err!(
                 "Pco can only encode primitive arrays, got {}",
                 a.encoding_id()
             )
         })?;
-        Self::from_primitive(parray.as_view(), level, nums_per_page)
+        Self::from_primitive(parray.as_view(), level, nums_per_page, ctx)
     }
 
     pub fn decompress(
@@ -649,6 +658,8 @@ impl OperationsVTable<Pco> for Pco {
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::validity::Validity;
@@ -658,12 +669,13 @@ mod tests {
 
     #[test]
     fn test_slice_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a nullable array with some nulls
         let values = PrimitiveArray::new(
             buffer![10u32, 20, 30, 40, 50, 60],
             Validity::from_iter([false, true, true, true, true, false]),
         );
-        let pco = Pco::from_primitive(values.as_view(), 0, 128).unwrap();
+        let pco = Pco::from_primitive(values.as_view(), 0, 128, &mut ctx).unwrap();
         assert_arrays_eq!(
             pco,
             PrimitiveArray::from_option_iter([

--- a/encodings/pco/src/compute/cast.rs
+++ b/encodings/pco/src/compute/cast.rs
@@ -59,6 +59,8 @@ impl CastReduce for Pco {
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::builtins::ArrayBuiltins;
@@ -73,8 +75,9 @@ mod tests {
 
     #[test]
     fn test_cast_pco_f32_to_f64() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = PrimitiveArray::from_iter([1.0f32, 2.0, 3.0, 4.0, 5.0]);
-        let pco = Pco::from_primitive(values.as_view(), 0, 128).unwrap();
+        let pco = Pco::from_primitive(values.as_view(), 0, 128, &mut ctx).unwrap();
 
         let casted = pco
             .into_array()
@@ -93,9 +96,10 @@ mod tests {
 
     #[test]
     fn test_cast_pco_nullability_change() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test casting from NonNullable to Nullable
         let values = PrimitiveArray::from_iter([10u32, 20, 30, 40]);
-        let pco = Pco::from_primitive(values.as_view(), 0, 128).unwrap();
+        let pco = Pco::from_primitive(values.as_view(), 0, 128, &mut ctx).unwrap();
 
         let casted = pco
             .into_array()
@@ -109,11 +113,12 @@ mod tests {
 
     #[test]
     fn test_cast_sliced_pco_nullable_to_nonnullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = PrimitiveArray::new(
             buffer![10u32, 20, 30, 40, 50, 60],
             Validity::from_iter([true, true, true, true, true, true]),
         );
-        let pco = Pco::from_primitive(values.as_view(), 0, 128).unwrap();
+        let pco = Pco::from_primitive(values.as_view(), 0, 128, &mut ctx).unwrap();
         let sliced = pco.slice(1..5).unwrap();
         let casted = sliced
             .cast(DType::Primitive(PType::U32, Nullability::NonNullable))
@@ -128,6 +133,7 @@ mod tests {
 
     #[test]
     fn test_cast_sliced_pco_part_valid_to_nonnullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = PrimitiveArray::from_option_iter([
             None,
             Some(20u32),
@@ -136,7 +142,7 @@ mod tests {
             Some(50),
             Some(60),
         ]);
-        let pco = Pco::from_primitive(values.as_view(), 0, 128).unwrap();
+        let pco = Pco::from_primitive(values.as_view(), 0, 128, &mut ctx).unwrap();
         let sliced = pco.slice(1..5).unwrap();
         let casted = sliced
             .cast(DType::Primitive(PType::U32, Nullability::NonNullable))
@@ -170,7 +176,8 @@ mod tests {
         Validity::NonNullable,
     ))]
     fn test_cast_pco_conformance(#[case] values: PrimitiveArray) {
-        let pco = Pco::from_primitive(values.as_view(), 0, 128).unwrap();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let pco = Pco::from_primitive(values.as_view(), 0, 128, &mut ctx).unwrap();
         test_cast_conformance(&pco.into_array());
     }
 }

--- a/encodings/pco/src/compute/mod.rs
+++ b/encodings/pco/src/compute/mod.rs
@@ -17,50 +17,90 @@ mod tests {
 
     fn pco_f32() -> PcoArray {
         let values = PrimitiveArray::from_iter([1.23f32, 4.56, 7.89, 10.11, 12.13]);
-        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap()
+        Pco::from_primitive(
+            values.as_view(),
+            0,
+            128,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     fn pco_f64() -> PcoArray {
         let values = PrimitiveArray::from_iter([100.1f64, 200.2, 300.3, 400.4, 500.5]);
-        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap()
+        Pco::from_primitive(
+            values.as_view(),
+            0,
+            128,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     fn pco_i32() -> PcoArray {
         let values = PrimitiveArray::from_iter([100i32, 200, 300, 400, 500]);
-        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap()
+        Pco::from_primitive(
+            values.as_view(),
+            0,
+            128,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     fn pco_u64() -> PcoArray {
         let values = PrimitiveArray::from_iter([1000u64, 2000, 3000, 4000]);
-        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap()
+        Pco::from_primitive(
+            values.as_view(),
+            0,
+            128,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     fn pco_i16() -> PcoArray {
         let values = PrimitiveArray::from_iter([10i16, 20, 30, 40, 50]);
-        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap()
+        Pco::from_primitive(
+            values.as_view(),
+            0,
+            128,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     fn pco_i32_alt() -> PcoArray {
         let values = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]);
-        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap()
+        Pco::from_primitive(
+            values.as_view(),
+            0,
+            128,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     fn pco_single() -> PcoArray {
         let values = PrimitiveArray::from_iter([42.42f64]);
-        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap()
+        Pco::from_primitive(
+            values.as_view(),
+            0,
+            128,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     fn pco_large() -> PcoArray {
         let values = PrimitiveArray::from_iter(0u32..1000);
-        Pco::from_primitive(values.as_view(), 3, 128, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap()
+        Pco::from_primitive(
+            values.as_view(),
+            3,
+            128,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     #[rstest]

--- a/encodings/pco/src/compute/mod.rs
+++ b/encodings/pco/src/compute/mod.rs
@@ -7,6 +7,8 @@ mod cast;
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
 
@@ -15,42 +17,50 @@ mod tests {
 
     fn pco_f32() -> PcoArray {
         let values = PrimitiveArray::from_iter([1.23f32, 4.56, 7.89, 10.11, 12.13]);
-        Pco::from_primitive(values.as_view(), 0, 128).unwrap()
+        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_f64() -> PcoArray {
         let values = PrimitiveArray::from_iter([100.1f64, 200.2, 300.3, 400.4, 500.5]);
-        Pco::from_primitive(values.as_view(), 0, 128).unwrap()
+        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_i32() -> PcoArray {
         let values = PrimitiveArray::from_iter([100i32, 200, 300, 400, 500]);
-        Pco::from_primitive(values.as_view(), 0, 128).unwrap()
+        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_u64() -> PcoArray {
         let values = PrimitiveArray::from_iter([1000u64, 2000, 3000, 4000]);
-        Pco::from_primitive(values.as_view(), 0, 128).unwrap()
+        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_i16() -> PcoArray {
         let values = PrimitiveArray::from_iter([10i16, 20, 30, 40, 50]);
-        Pco::from_primitive(values.as_view(), 0, 128).unwrap()
+        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_i32_alt() -> PcoArray {
         let values = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]);
-        Pco::from_primitive(values.as_view(), 0, 128).unwrap()
+        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_single() -> PcoArray {
         let values = PrimitiveArray::from_iter([42.42f64]);
-        Pco::from_primitive(values.as_view(), 0, 128).unwrap()
+        Pco::from_primitive(values.as_view(), 0, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     fn pco_large() -> PcoArray {
         let values = PrimitiveArray::from_iter(0u32..1000);
-        Pco::from_primitive(values.as_view(), 3, 128).unwrap()
+        Pco::from_primitive(values.as_view(), 3, 128, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
     }
 
     #[rstest]

--- a/encodings/pco/src/tests.rs
+++ b/encodings/pco/src/tests.rs
@@ -167,7 +167,10 @@ fn test_validity_vtable() {
     let compressed = Pco::from_primitive(array.as_view(), 3, 0, &mut ctx).unwrap();
     let arr = compressed.as_array();
     assert_eq!(
-        arr.validity().unwrap().to_mask(arr.len(), &mut ctx).unwrap(),
+        arr.validity()
+            .unwrap()
+            .to_mask(arr.len(), &mut ctx)
+            .unwrap(),
         Mask::from_iter(mask_bools)
     );
     let sliced = compressed.slice(1..4).unwrap();

--- a/encodings/pco/src/tests.rs
+++ b/encodings/pco/src/tests.rs
@@ -7,8 +7,6 @@ use std::sync::LazyLock;
 use vortex_array::ArrayContext;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -43,14 +41,14 @@ static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
 use crate::Pco;
 #[test]
 fn test_compress_decompress() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data: Vec<i32> = (0..200).collect();
     let array = PrimitiveArray::from_iter(data.clone());
-    let compressed = Pco::from_primitive(array.as_view(), 3, 0).unwrap();
+    let compressed = Pco::from_primitive(array.as_view(), 3, 0, &mut ctx).unwrap();
     // this data should be compressible
     assert!(compressed.pages.len() < array.into_array().nbytes() as usize);
 
     // check full decompression works
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let unsliced_validity = child_to_validity(
         &compressed.as_ref().slots()[0],
         compressed.dtype().nullability(),
@@ -71,13 +69,13 @@ fn test_compress_decompress() {
 
 #[test]
 fn test_compress_decompress_small() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let array = PrimitiveArray::from_option_iter([None, Some(1)]);
-    let compressed = Pco::from_primitive(array.as_view(), 3, 0).unwrap();
+    let compressed = Pco::from_primitive(array.as_view(), 3, 0, &mut ctx).unwrap();
 
     let expected = array.into_array();
     assert_arrays_eq!(compressed, expected);
 
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let unsliced_validity = child_to_validity(
         &compressed.as_ref().slots()[0],
         compressed.dtype().nullability(),
@@ -88,10 +86,10 @@ fn test_compress_decompress_small() {
 
 #[test]
 fn test_empty() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data: Vec<i32> = vec![];
     let array = PrimitiveArray::from_iter(data.clone());
-    let compressed = Pco::from_primitive(array.as_view(), 3, 100).unwrap();
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let compressed = Pco::from_primitive(array.as_view(), 3, 100, &mut ctx).unwrap();
     let unsliced_validity = child_to_validity(
         &compressed.as_ref().slots()[0],
         compressed.dtype().nullability(),
@@ -102,6 +100,7 @@ fn test_empty() {
 
 #[test]
 fn test_validity_and_multiple_chunks_and_pages() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data: Vec<i32> = (0..200).collect();
     let mut validity: Vec<bool> = vec![true; 200];
     validity[7..15].fill(false);
@@ -121,6 +120,7 @@ fn test_validity_and_multiple_chunks_and_pages() {
             compression_level,
             values_per_chunk,
             values_per_page,
+            &mut ctx,
         )
         .unwrap(),
         validity,
@@ -141,10 +141,8 @@ fn test_validity_and_multiple_chunks_and_pages() {
     let slice = compressed.slice(100..103).unwrap();
     assert_nth_scalar!(slice, 0, 100);
     assert_nth_scalar!(slice, 2, 102);
-    #[expect(deprecated)]
-    let primitive = slice.to_primitive();
+    let primitive = slice.execute::<PrimitiveArray>(&mut ctx).unwrap();
 
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     assert!(
         primitive
             .validity()
@@ -159,19 +157,17 @@ fn test_validity_and_multiple_chunks_and_pages() {
 
 #[test]
 fn test_validity_vtable() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data: Vec<i32> = (0..5).collect();
     let mask_bools = vec![false, true, true, false, true];
     let array = PrimitiveArray::new(
         Buffer::from(data),
         Validity::Array(BoolArray::from_iter(mask_bools.clone()).into_array()),
     );
-    let compressed = Pco::from_primitive(array.as_view(), 3, 0).unwrap();
+    let compressed = Pco::from_primitive(array.as_view(), 3, 0, &mut ctx).unwrap();
     let arr = compressed.as_array();
     assert_eq!(
-        arr.validity()
-            .unwrap()
-            .to_mask(arr.len(), &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap(),
+        arr.validity().unwrap().to_mask(arr.len(), &mut ctx).unwrap(),
         Mask::from_iter(mask_bools)
     );
     let sliced = compressed.slice(1..4).unwrap();
@@ -179,7 +175,7 @@ fn test_validity_vtable() {
         sliced
             .validity()
             .unwrap()
-            .to_mask(sliced.len(), &mut LEGACY_SESSION.create_execution_ctx())
+            .to_mask(sliced.len(), &mut ctx)
             .unwrap(),
         Mask::from_iter(vec![true, true, false])
     );
@@ -187,8 +183,9 @@ fn test_validity_vtable() {
 
 #[test]
 fn test_serde() -> VortexResult<()> {
+    let mut ctx = SESSION.create_execution_ctx();
     let data: PrimitiveArray = (0i32..1_000_000).collect();
-    let pco = Pco::from_primitive(data.as_view(), 3, 100)?.into_array();
+    let pco = Pco::from_primitive(data.as_view(), 3, 100, &mut ctx)?.into_array();
 
     let context = ArrayContext::empty();
 
@@ -213,7 +210,6 @@ fn test_serde() -> VortexResult<()> {
         &ReadContext::new(context.to_ids()),
         &SESSION,
     )?;
-    let mut ctx = SESSION.create_execution_ctx();
     let data_type = data.dtype().to_arrow_dtype()?;
     let pco_arrow = pco.execute_arrow(Some(&data_type), &mut ctx)?;
     let decoded_arrow = decoded.execute_arrow(Some(&data_type), &mut ctx)?;

--- a/encodings/runend/benches/run_end_compress.rs
+++ b/encodings/runend/benches/run_end_compress.rs
@@ -47,8 +47,8 @@ fn compress(bencher: Bencher, (length, run_step): (usize, usize)) {
     );
 
     bencher
-        .with_inputs(|| &values)
-        .bench_refs(|values| runend_encode(values.as_view()));
+        .with_inputs(|| (&values, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(values, ctx)| runend_encode(values.as_view(), ctx));
 }
 
 #[divan::bench(types = [u8, u16, u32, u64], args = BENCH_ARGS)]
@@ -64,7 +64,7 @@ fn decompress<T: IntegerPType>(bencher: Bencher, (length, run_step): (usize, usi
         .collect::<Buffer<_>>()
         .into_array();
 
-    let run_end_array = RunEnd::new(ends, values);
+    let run_end_array = RunEnd::new(ends, values, &mut LEGACY_SESSION.create_execution_ctx());
     let array = run_end_array.into_array();
 
     bencher
@@ -88,8 +88,9 @@ fn take_indices(bencher: Bencher, (length, run_step): (usize, usize)) {
     );
 
     let source_array = PrimitiveArray::from_iter(0..(length as i32)).into_array();
-    let (ends, values) = runend_encode(values.as_view());
-    let runend_array = RunEnd::try_new(ends.into_array(), values)
+    let mut encode_ctx = LEGACY_SESSION.create_execution_ctx();
+    let (ends, values) = runend_encode(values.as_view(), &mut encode_ctx);
+    let runend_array = RunEnd::try_new(ends.into_array(), values, &mut encode_ctx)
         .unwrap()
         .into_array();
 
@@ -121,7 +122,7 @@ fn decompress_utf8(bencher: Bencher, (length, run_step): (usize, usize)) {
     let values = VarBinViewArray::from_iter_str((0..num_runs).map(|i| format!("run_value_{i}")))
         .into_array();
 
-    let run_end_array = RunEnd::new(ends, values);
+    let run_end_array = RunEnd::new(ends, values, &mut LEGACY_SESSION.create_execution_ctx());
     let array = run_end_array.into_array();
 
     bencher

--- a/encodings/runend/benches/run_end_decode.rs
+++ b/encodings/runend/benches/run_end_decode.rs
@@ -6,6 +6,8 @@
 use std::fmt;
 
 use divan::Bencher;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::validity::Validity;
@@ -208,9 +210,15 @@ fn decode_bool(bencher: Bencher, args: BoolBenchArgs) {
     } = args;
     let (ends, values) = create_bool_test_data(total_length, avg_run_length, distribution);
     bencher
-        .with_inputs(|| (ends.clone(), values.clone()))
-        .bench_refs(|(ends, values)| {
-            runend_decode_bools(ends.clone(), values.clone(), 0, total_length)
+        .with_inputs(|| {
+            (
+                ends.clone(),
+                values.clone(),
+                LEGACY_SESSION.create_execution_ctx(),
+            )
+        })
+        .bench_refs(|(ends, values, ctx)| {
+            runend_decode_bools(ends.clone(), values.clone(), 0, total_length, ctx)
         });
 }
 
@@ -371,8 +379,14 @@ fn decode_bool_nullable(bencher: Bencher, args: NullableBoolBenchArgs) {
     let (ends, values) =
         create_nullable_bool_test_data(total_length, avg_run_length, distribution, validity);
     bencher
-        .with_inputs(|| (ends.clone(), values.clone()))
-        .bench_refs(|(ends, values)| {
-            runend_decode_bools(ends.clone(), values.clone(), 0, total_length)
+        .with_inputs(|| {
+            (
+                ends.clone(),
+                values.clone(),
+                LEGACY_SESSION.create_execution_ctx(),
+            )
+        })
+        .bench_refs(|(ends, values, ctx)| {
+            runend_decode_bools(ends.clone(), values.clone(), 0, total_length, ctx)
         });
 }

--- a/encodings/runend/benches/run_end_null_count.rs
+++ b/encodings/runend/benches/run_end_null_count.rs
@@ -72,5 +72,5 @@ fn fixture(n: usize, run_step: usize, valid_density: f64) -> RunEndArray {
     )
     .into_array();
 
-    RunEnd::new(ends, values)
+    RunEnd::new(ends, values, &mut LEGACY_SESSION.create_execution_ctx())
 }

--- a/encodings/runend/public-api.lock
+++ b/encodings/runend/public-api.lock
@@ -2,17 +2,17 @@ pub mod vortex_runend
 
 pub mod vortex_runend::compress
 
-pub fn vortex_runend::compress::runend_decode_primitive(ends: vortex_array::arrays::primitive::vtable::PrimitiveArray, values: vortex_array::arrays::primitive::vtable::PrimitiveArray, offset: usize, length: usize) -> vortex_error::VortexResult<vortex_array::arrays::primitive::vtable::PrimitiveArray>
+pub fn vortex_runend::compress::runend_decode_primitive(ends: vortex_array::arrays::primitive::vtable::PrimitiveArray, values: vortex_array::arrays::primitive::vtable::PrimitiveArray, offset: usize, length: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::primitive::vtable::PrimitiveArray>
 
 pub fn vortex_runend::compress::runend_decode_typed_primitive<T: vortex_array::dtype::ptype::NativePType>(run_ends: impl core::iter::traits::iterator::Iterator<Item = usize>, values: &[T], values_validity: vortex_mask::Mask, values_nullability: vortex_array::dtype::nullability::Nullability, length: usize) -> vortex_array::arrays::primitive::vtable::PrimitiveArray
 
-pub fn vortex_runend::compress::runend_decode_varbinview(ends: vortex_array::arrays::primitive::vtable::PrimitiveArray, values: vortex_array::arrays::varbinview::vtable::VarBinViewArray, offset: usize, length: usize) -> vortex_error::VortexResult<vortex_array::arrays::varbinview::vtable::VarBinViewArray>
+pub fn vortex_runend::compress::runend_decode_varbinview(ends: vortex_array::arrays::primitive::vtable::PrimitiveArray, values: vortex_array::arrays::varbinview::vtable::VarBinViewArray, offset: usize, length: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::arrays::varbinview::vtable::VarBinViewArray>
 
-pub fn vortex_runend::compress::runend_encode(array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>) -> (vortex_array::arrays::primitive::vtable::PrimitiveArray, vortex_array::array::erased::ArrayRef)
+pub fn vortex_runend::compress::runend_encode(array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>, ctx: &mut vortex_array::executor::ExecutionCtx) -> (vortex_array::arrays::primitive::vtable::PrimitiveArray, vortex_array::array::erased::ArrayRef)
 
 pub mod vortex_runend::decompress_bool
 
-pub fn vortex_runend::decompress_bool::runend_decode_bools(ends: vortex_array::arrays::primitive::vtable::PrimitiveArray, values: vortex_array::arrays::bool::vtable::BoolArray, offset: usize, length: usize) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_runend::decompress_bool::runend_decode_bools(ends: vortex_array::arrays::primitive::vtable::PrimitiveArray, values: vortex_array::arrays::bool::vtable::BoolArray, offset: usize, length: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_runend::decompress_bool::runend_decode_typed_bool(run_ends: impl core::iter::traits::iterator::Iterator<Item = usize>, values: &vortex_buffer::bit::buf::BitBuffer, values_validity: vortex_mask::Mask, values_nullability: vortex_array::dtype::nullability::Nullability, length: usize) -> vortex_array::array::erased::ArrayRef
 
@@ -20,13 +20,13 @@ pub struct vortex_runend::RunEnd
 
 impl vortex_runend::RunEnd
 
-pub fn vortex_runend::RunEnd::encode(array: vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_runend::RunEndArray>
+pub fn vortex_runend::RunEnd::encode(array: vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_runend::RunEndArray>
 
-pub fn vortex_runend::RunEnd::new(ends: vortex_array::array::erased::ArrayRef, values: vortex_array::array::erased::ArrayRef) -> vortex_runend::RunEndArray
+pub fn vortex_runend::RunEnd::new(ends: vortex_array::array::erased::ArrayRef, values: vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_runend::RunEndArray
 
-pub unsafe fn vortex_runend::RunEnd::new_unchecked(ends: vortex_array::array::erased::ArrayRef, values: vortex_array::array::erased::ArrayRef, offset: usize, length: usize) -> vortex_runend::RunEndArray
+pub unsafe fn vortex_runend::RunEnd::new_unchecked(ends: vortex_array::array::erased::ArrayRef, values: vortex_array::array::erased::ArrayRef, offset: usize, length: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_runend::RunEndArray
 
-pub fn vortex_runend::RunEnd::try_new(ends: vortex_array::array::erased::ArrayRef, values: vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<vortex_runend::RunEndArray>
+pub fn vortex_runend::RunEnd::try_new(ends: vortex_array::array::erased::ArrayRef, values: vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_runend::RunEndArray>
 
 pub fn vortex_runend::RunEnd::try_new_offset_length(ends: vortex_array::array::erased::ArrayRef, values: vortex_array::array::erased::ArrayRef, offset: usize, length: usize) -> vortex_error::VortexResult<vortex_runend::RunEndArray>
 
@@ -100,7 +100,7 @@ pub struct vortex_runend::RunEndData
 
 impl vortex_runend::RunEndData
 
-pub fn vortex_runend::RunEndData::encode(array: vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<Self>
+pub fn vortex_runend::RunEndData::encode(array: vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_runend::RunEndData::into_parts(self, ends: vortex_array::array::erased::ArrayRef, values: vortex_array::array::erased::ArrayRef) -> vortex_runend::RunEndDataParts
 

--- a/encodings/runend/src/arbitrary.rs
+++ b/encodings/runend/src/arbitrary.rs
@@ -5,6 +5,8 @@ use arbitrary::Arbitrary;
 use arbitrary::Result;
 use arbitrary::Unstructured;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::arbitrary::ArbitraryArray;
 use vortex_array::dtype::DType;
@@ -39,11 +41,13 @@ impl ArbitraryRunEndArray {
         // Number of runs (values/ends pairs)
         let num_runs = u.int_in_range(0..=20)?;
 
+        // TODO(ctx): trait fixes - Arbitrary::arbitrary has a fixed signature.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         if num_runs == 0 {
             // Empty RunEndArray
             let ends = PrimitiveArray::from_iter(Vec::<u64>::new()).into_array();
             let values = ArbitraryArray::arbitrary_with(u, Some(0), dtype)?.0;
-            let runend_array = RunEnd::try_new(ends, values)
+            let runend_array = RunEnd::try_new(ends, values, &mut ctx)
                 .vortex_expect("Empty RunEndArray creation should succeed");
             return Ok(ArbitraryRunEndArray(runend_array));
         }
@@ -55,7 +59,7 @@ impl ArbitraryRunEndArray {
         // Each end must be > previous end, and first end must be >= 1
         let ends = random_strictly_sorted_ends(u, num_runs, len)?;
 
-        let runend_array = RunEnd::try_new(ends, values)
+        let runend_array = RunEnd::try_new(ends, values, &mut ctx)
             .vortex_expect("RunEndArray creation should succeed in arbitrary impl");
 
         Ok(ArbitraryRunEndArray(runend_array))

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -99,7 +99,9 @@ impl VTable for RunEnd {
         let values = slots[VALUES_SLOT]
             .as_ref()
             .vortex_expect("RunEndArray values slot");
-        RunEndData::validate_parts(ends, values, data.offset, len)?;
+        // TODO(ctx): trait fixes - VTable::validate has a fixed signature.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        RunEndData::validate_parts(ends, values, data.offset, len, &mut ctx)?;
         vortex_ensure!(
             values.dtype() == dtype,
             "expected dtype {}, got {}",
@@ -254,10 +256,11 @@ impl RunEnd {
         values: ArrayRef,
         offset: usize,
         length: usize,
+        ctx: &mut ExecutionCtx,
     ) -> RunEndArray {
         let dtype = values.dtype().clone();
         let slots = vec![Some(ends.clone()), Some(values.clone())];
-        RunEndData::validate_parts(&ends, &values, offset, length)
+        RunEndData::validate_parts(&ends, &values, offset, length, ctx)
             .vortex_expect("RunEndArray validation failed");
         let data = unsafe { RunEndData::new_unchecked(offset) };
         unsafe {
@@ -268,8 +271,12 @@ impl RunEnd {
     }
 
     /// Build a new [`RunEndArray`] from ends and values.
-    pub fn try_new(ends: ArrayRef, values: ArrayRef) -> VortexResult<RunEndArray> {
-        let len = RunEndData::logical_len_from_ends(&ends)?;
+    pub fn try_new(
+        ends: ArrayRef,
+        values: ArrayRef,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<RunEndArray> {
+        let len = RunEndData::logical_len_from_ends(&ends, ctx)?;
         let dtype = values.dtype().clone();
         let slots = vec![Some(ends), Some(values)];
         let data = RunEndData::new(0);
@@ -290,14 +297,14 @@ impl RunEnd {
     }
 
     /// Build a new [`RunEndArray`] from ends and values (panics on invalid input).
-    pub fn new(ends: ArrayRef, values: ArrayRef) -> RunEndArray {
-        Self::try_new(ends, values).vortex_expect("RunEndData is always valid")
+    pub fn new(ends: ArrayRef, values: ArrayRef, ctx: &mut ExecutionCtx) -> RunEndArray {
+        Self::try_new(ends, values, ctx).vortex_expect("RunEndData is always valid")
     }
 
     /// Run the array through run-end encoding.
-    pub fn encode(array: ArrayRef) -> VortexResult<RunEndArray> {
+    pub fn encode(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<RunEndArray> {
         if let Some(parray) = array.as_opt::<Primitive>() {
-            let (ends, values) = runend_encode(parray);
+            let (ends, values) = runend_encode(parray, ctx);
             let ends = ends.into_array();
             let len = array.len();
             let dtype = values.dtype().clone();
@@ -311,13 +318,11 @@ impl RunEnd {
 }
 
 impl RunEndData {
-    fn logical_len_from_ends(ends: &ArrayRef) -> VortexResult<usize> {
+    fn logical_len_from_ends(ends: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<usize> {
         if ends.is_empty() {
             Ok(0)
         } else {
-            usize::try_from(
-                &ends.execute_scalar(ends.len() - 1, &mut LEGACY_SESSION.create_execution_ctx())?,
-            )
+            usize::try_from(&ends.execute_scalar(ends.len() - 1, ctx)?)
         }
     }
 
@@ -326,6 +331,7 @@ impl RunEndData {
         values: &ArrayRef,
         offset: usize,
         length: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<()> {
         // DType validation
         vortex_ensure!(
@@ -359,10 +365,9 @@ impl RunEndData {
             // Run ends must be strictly sorted for binary search to work correctly.
             let pre_validation = ends.statistics().to_owned();
 
-            let mut ctx = LEGACY_SESSION.create_execution_ctx();
             let is_sorted = ends
                 .statistics()
-                .compute_is_strict_sorted(&mut ctx)
+                .compute_is_strict_sorted(ctx)
                 .unwrap_or(false);
 
             // Preserve the original statistics since compute_is_strict_sorted may have mutated them.
@@ -378,17 +383,13 @@ impl RunEndData {
 
         // Validate the offset and length are valid for the given ends and values
         if offset != 0 && length != 0 {
-            let first_run_end = usize::try_from(
-                &ends.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?,
-            )?;
+            let first_run_end = usize::try_from(&ends.execute_scalar(0, ctx)?)?;
             if first_run_end < offset {
                 vortex_bail!("First run end {first_run_end} must be >= offset {offset}");
             }
         }
 
-        let last_run_end = usize::try_from(
-            &ends.execute_scalar(ends.len() - 1, &mut LEGACY_SESSION.create_execution_ctx())?,
-        )?;
+        let last_run_end = usize::try_from(&ends.execute_scalar(ends.len() - 1, ctx)?)?;
         let min_required_end = offset + length;
         if last_run_end < min_required_end {
             vortex_bail!("Last run end {last_run_end} must be >= offset+length {min_required_end}");
@@ -444,9 +445,9 @@ impl RunEndData {
     }
 
     /// Run the array through run-end encoding.
-    pub fn encode(array: ArrayRef) -> VortexResult<Self> {
+    pub fn encode(array: ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         if let Some(parray) = array.as_opt::<Primitive>() {
-            let (_ends, _values) = runend_encode(parray);
+            let (_ends, _values) = runend_encode(parray, ctx);
             // SAFETY: runend_encode handles this
             unsafe { Ok(Self::new_unchecked(0)) }
         } else {
@@ -468,15 +469,20 @@ impl ValidityVTable<RunEnd> for RunEnd {
         Ok(match array.values().validity()? {
             Validity::NonNullable | Validity::AllValid => Validity::AllValid,
             Validity::AllInvalid => Validity::AllInvalid,
-            Validity::Array(values_validity) => Validity::Array(unsafe {
-                RunEnd::new_unchecked(
-                    array.ends().clone(),
-                    values_validity,
-                    array.offset(),
-                    array.len(),
-                )
-                .into_array()
-            }),
+            Validity::Array(values_validity) => {
+                // TODO(ctx): trait fixes - ValidityVTable::validity has a fixed signature.
+                let mut ctx = LEGACY_SESSION.create_execution_ctx();
+                Validity::Array(unsafe {
+                    RunEnd::new_unchecked(
+                        array.ends().clone(),
+                        values_validity,
+                        array.offset(),
+                        array.len(),
+                        &mut ctx,
+                    )
+                    .into_array()
+                })
+            }
         })
     }
 }
@@ -490,18 +496,18 @@ pub(super) fn run_end_canonicalize(
     Ok(match array.dtype() {
         DType::Bool(_) => {
             let bools = array.values().clone().execute_as("values", ctx)?;
-            runend_decode_bools(pends, bools, array.offset(), array.len())?
+            runend_decode_bools(pends, bools, array.offset(), array.len(), ctx)?
         }
         DType::Primitive(..) => {
             let pvalues = array.values().clone().execute_as("values", ctx)?;
-            runend_decode_primitive(pends, pvalues, array.offset(), array.len())?.into_array()
+            runend_decode_primitive(pends, pvalues, array.offset(), array.len(), ctx)?.into_array()
         }
         DType::Utf8(_) | DType::Binary(_) => {
             let values = array
                 .values()
                 .clone()
                 .execute_as::<VarBinViewArray>("values", ctx)?;
-            runend_decode_varbinview(pends, values, array.offset(), array.len())?.into_array()
+            runend_decode_varbinview(pends, values, array.offset(), array.len(), ctx)?.into_array()
         }
         _ => vortex_bail!("Unsupported RunEnd value type: {}", array.dtype()),
     })
@@ -510,6 +516,8 @@ pub(super) fn run_end_canonicalize(
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::DictArray;
     use vortex_array::arrays::VarBinViewArray;
     use vortex_array::assert_arrays_eq;
@@ -522,9 +530,11 @@ mod tests {
 
     #[test]
     fn test_runend_constructor() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = RunEnd::new(
             buffer![2u32, 5, 10].into_array(),
             buffer![1i32, 2, 3].into_array(),
+            &mut ctx,
         );
         assert_eq!(arr.len(), 10);
         assert_eq!(
@@ -541,8 +551,9 @@ mod tests {
 
     #[test]
     fn test_runend_utf8() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = VarBinViewArray::from_iter_str(["a", "b", "c"]).into_array();
-        let arr = RunEnd::new(buffer![2u32, 5, 10].into_array(), values);
+        let arr = RunEnd::new(buffer![2u32, 5, 10].into_array(), values, &mut ctx);
         assert_eq!(arr.len(), 10);
         assert_eq!(arr.dtype(), &DType::Utf8(Nullability::NonNullable));
 
@@ -554,11 +565,14 @@ mod tests {
 
     #[test]
     fn test_runend_dict() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dict_values = VarBinViewArray::from_iter_str(["x", "y", "z"]).into_array();
         let dict_codes = buffer![0u32, 1, 2].into_array();
         let dict = DictArray::try_new(dict_codes, dict_values).unwrap();
 
-        let arr = RunEnd::try_new(buffer![2u32, 5, 10].into_array(), dict.into_array()).unwrap();
+        let arr =
+            RunEnd::try_new(buffer![2u32, 5, 10].into_array(), dict.into_array(), &mut ctx)
+                .unwrap();
         assert_eq!(arr.len(), 10);
 
         let expected =

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -570,9 +570,12 @@ mod tests {
         let dict_codes = buffer![0u32, 1, 2].into_array();
         let dict = DictArray::try_new(dict_codes, dict_values).unwrap();
 
-        let arr =
-            RunEnd::try_new(buffer![2u32, 5, 10].into_array(), dict.into_array(), &mut ctx)
-                .unwrap();
+        let arr = RunEnd::try_new(
+            buffer![2u32, 5, 10].into_array(),
+            dict.into_array(),
+            &mut ctx,
+        )
+        .unwrap();
         assert_eq!(arr.len(), 10);
 
         let expected =

--- a/encodings/runend/src/array.rs
+++ b/encodings/runend/src/array.rs
@@ -415,12 +415,12 @@ impl RunEndData {
     /// # use vortex_error::VortexResult;
     /// # use vortex_runend::RunEnd;
     /// # fn main() -> VortexResult<()> {
+    /// let mut ctx = LEGACY_SESSION.create_execution_ctx();
     /// let ends = buffer![2u8, 3u8].into_array();
     /// let values = BoolArray::from_iter([false, true]).into_array();
-    /// let run_end = RunEnd::new(ends, values);
+    /// let run_end = RunEnd::new(ends, values, &mut ctx);
     ///
     /// // Array encodes
-    /// let mut ctx = LEGACY_SESSION.create_execution_ctx();
     /// assert_eq!(run_end.execute_scalar(0, &mut ctx)?, false.into());
     /// assert_eq!(run_end.execute_scalar(1, &mut ctx)?, false.into());
     /// assert_eq!(run_end.execute_scalar(2, &mut ctx)?, true.into());

--- a/encodings/runend/src/arrow.rs
+++ b/encodings/runend/src/arrow.rs
@@ -5,6 +5,8 @@ use arrow_array::RunArray;
 use arrow_array::types::RunEndIndexType;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::arrow::FromArrowArray;
@@ -53,7 +55,9 @@ where
         };
 
         // SAFETY: arrow-rs enforces the RunEndArray invariants, we inherit their guarantees.
-        RunEndData::validate_parts(&ends_slice, &values_slice, offset, len)?;
+        // TODO(ctx): trait fixes - FromArrowArray::from_arrow has a fixed signature.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        RunEndData::validate_parts(&ends_slice, &values_slice, offset, len, &mut ctx)?;
         Ok(unsafe { RunEndData::new_unchecked(offset) })
     }
 }
@@ -76,6 +80,7 @@ mod tests {
     use rstest::rstest;
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray as _;
+    use vortex_array::LEGACY_SESSION;
     use vortex_array::VortexSessionExecute as _;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::primitive::PrimitiveArrayExt;
@@ -331,7 +336,11 @@ mod tests {
         #[case] expected_ends: &[i32],
         #[case] expected_values: &[i32],
     ) -> VortexResult<()> {
-        let array = RunEnd::encode(PrimitiveArray::from_iter(input.iter().copied()).into_array())?;
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array = RunEnd::encode(
+            PrimitiveArray::from_iter(input.iter().copied()).into_array(),
+            &mut ctx,
+        )?;
         let sliced = array.into_array().slice(slice_range.clone())?;
         let target = ree_type(DataType::Int32, DataType::Int32);
         let result = execute(sliced, &target)?;

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -56,7 +56,6 @@ pub fn runend_encode(
         }
         Validity::Array(a) => {
             let bool_array = a
-                .clone()
                 .execute::<BoolArray>(ctx)
                 .vortex_expect("validity array must be convertible to bool");
             Some(bool_array.to_bit_buffer())

--- a/encodings/runend/src/compress.rs
+++ b/encodings/runend/src/compress.rs
@@ -4,11 +4,8 @@
 use itertools::Itertools;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Primitive;
@@ -37,7 +34,10 @@ use vortex_mask::Mask;
 use crate::iter::trimmed_ends_iter;
 
 /// Run-end encode a `PrimitiveArray`, returning a tuple of `(ends, values)`.
-pub fn runend_encode(array: ArrayView<Primitive>) -> (PrimitiveArray, ArrayRef) {
+pub fn runend_encode(
+    array: ArrayView<Primitive>,
+    ctx: &mut ExecutionCtx,
+) -> (PrimitiveArray, ArrayRef) {
     let validity = match array
         .validity()
         .vortex_expect("run-end validity should be derivable")
@@ -55,8 +55,10 @@ pub fn runend_encode(array: ArrayView<Primitive>) -> (PrimitiveArray, ArrayRef) 
             );
         }
         Validity::Array(a) => {
-            #[expect(deprecated)]
-            let bool_array = a.to_bool();
+            let bool_array = a
+                .clone()
+                .execute::<BoolArray>(ctx)
+                .vortex_expect("validity array must be convertible to bool");
             Some(bool_array.to_bit_buffer())
         }
     };
@@ -183,11 +185,12 @@ pub fn runend_decode_primitive(
     values: PrimitiveArray,
     offset: usize,
     length: usize,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<PrimitiveArray> {
-    let validity_mask = values.as_ref().validity()?.to_mask(
-        values.as_ref().len(),
-        &mut LEGACY_SESSION.create_execution_ctx(),
-    )?;
+    let validity_mask = values
+        .as_ref()
+        .validity()?
+        .to_mask(values.as_ref().len(), ctx)?;
     Ok(match_each_native_ptype!(values.ptype(), |P| {
         match_each_unsigned_integer_ptype!(ends.ptype(), |E| {
             runend_decode_typed_primitive(
@@ -286,11 +289,12 @@ pub fn runend_decode_varbinview(
     values: VarBinViewArray,
     offset: usize,
     length: usize,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<VarBinViewArray> {
-    let validity_mask = values.as_ref().validity()?.to_mask(
-        values.as_ref().len(),
-        &mut LEGACY_SESSION.create_execution_ctx(),
-    )?;
+    let validity_mask = values
+        .as_ref()
+        .validity()?
+        .to_mask(values.as_ref().len(), ctx)?;
     let views = values.views();
 
     let (decoded_views, validity) = match_each_unsigned_integer_ptype!(ends.ptype(), |E| {
@@ -314,9 +318,9 @@ pub fn runend_decode_varbinview(
 }
 
 #[cfg(test)]
-mod test {
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+mod tests {
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::validity::Validity;
@@ -328,58 +332,62 @@ mod test {
     use crate::compress::runend_encode;
 
     #[test]
-    fn encode() {
+    fn encode() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::from_iter([1i32, 1, 2, 2, 2, 3, 3, 3, 3, 3]);
-        let (ends, values) = runend_encode(arr.as_view());
-        #[expect(deprecated)]
-        let values = values.to_primitive();
+        let (ends, values) = runend_encode(arr.as_view(), &mut ctx);
+        let values = values.execute::<PrimitiveArray>(&mut ctx)?;
 
         let expected_ends = PrimitiveArray::from_iter(vec![2u8, 5, 10]);
         assert_arrays_eq!(ends, expected_ends);
         let expected_values = PrimitiveArray::from_iter(vec![1i32, 2, 3]);
         assert_arrays_eq!(values, expected_values);
+        Ok(())
     }
 
     #[test]
-    fn encode_nullable() {
+    fn encode_nullable() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::new(
             buffer![1i32, 1, 2, 2, 2, 3, 3, 3, 3, 3],
             Validity::from(BitBuffer::from(vec![
                 true, true, false, false, true, true, true, true, false, false,
             ])),
         );
-        let (ends, values) = runend_encode(arr.as_view());
-        #[expect(deprecated)]
-        let values = values.to_primitive();
+        let (ends, values) = runend_encode(arr.as_view(), &mut ctx);
+        let values = values.execute::<PrimitiveArray>(&mut ctx)?;
 
         let expected_ends = PrimitiveArray::from_iter(vec![2u8, 4, 5, 8, 10]);
         assert_arrays_eq!(ends, expected_ends);
         let expected_values =
             PrimitiveArray::from_option_iter(vec![Some(1i32), None, Some(2), Some(3), None]);
         assert_arrays_eq!(values, expected_values);
+        Ok(())
     }
 
     #[test]
-    fn encode_all_null() {
+    fn encode_all_null() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = PrimitiveArray::new(
             buffer![0, 0, 0, 0, 0],
             Validity::from(BitBuffer::new_unset(5)),
         );
-        let (ends, values) = runend_encode(arr.as_view());
-        #[expect(deprecated)]
-        let values = values.to_primitive();
+        let (ends, values) = runend_encode(arr.as_view(), &mut ctx);
+        let values = values.execute::<PrimitiveArray>(&mut ctx)?;
 
         let expected_ends = PrimitiveArray::from_iter(vec![5u64]);
         assert_arrays_eq!(ends, expected_ends);
         let expected_values = PrimitiveArray::from_option_iter(vec![Option::<i32>::None]);
         assert_arrays_eq!(values, expected_values);
+        Ok(())
     }
 
     #[test]
     fn decode() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let ends = PrimitiveArray::from_iter([2u32, 5, 10]);
         let values = PrimitiveArray::from_iter([1i32, 2, 3]);
-        let decoded = runend_decode_primitive(ends, values, 0, 10)?;
+        let decoded = runend_decode_primitive(ends, values, 0, 10, &mut ctx)?;
 
         let expected = PrimitiveArray::from_iter(vec![1i32, 1, 2, 2, 2, 3, 3, 3, 3, 3]);
         assert_arrays_eq!(decoded, expected);

--- a/encodings/runend/src/compute/cast.rs
+++ b/encodings/runend/src/compute/cast.rs
@@ -4,6 +4,8 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::dtype::DType;
 use vortex_array::scalar_fn::fns::cast::CastReduce;
@@ -16,6 +18,8 @@ impl CastReduce for RunEnd {
         // Cast the values array to the target type
         let casted_values = array.values().cast(dtype.clone())?;
 
+        // TODO(ctx): trait fixes - CastReduce::cast has a fixed signature.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // SAFETY: casting does not affect the ends being valid
         unsafe {
             Ok(Some(
@@ -24,6 +28,7 @@ impl CastReduce for RunEnd {
                     casted_values,
                     array.offset(),
                     array.len(),
+                    &mut ctx,
                 )
                 .into_array(),
             ))
@@ -36,8 +41,6 @@ mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
@@ -54,9 +57,11 @@ mod tests {
 
     #[test]
     fn test_cast_runend_i32_to_i64() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let runend = RunEnd::try_new(
             buffer![3u64, 5, 8, 10].into_array(),
             buffer![100i32, 200, 100, 300].into_array(),
+            &mut ctx,
         )
         .unwrap();
 
@@ -70,53 +75,34 @@ mod tests {
         );
 
         // Verify by decoding to canonical form
-        #[expect(deprecated)]
-        let decoded = casted.to_primitive();
+        let decoded = casted.execute::<PrimitiveArray>(&mut ctx).unwrap();
         // RunEnd encoding should expand to [100, 100, 100, 200, 200, 100, 100, 100, 300, 300]
         assert_eq!(decoded.len(), 10);
         assert_eq!(
-            TryInto::<i64>::try_into(
-                &decoded
-                    .execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())
-                    .unwrap()
-            )
-            .unwrap(),
+            TryInto::<i64>::try_into(&decoded.execute_scalar(0, &mut ctx).unwrap()).unwrap(),
             100i64
         );
         assert_eq!(
-            TryInto::<i64>::try_into(
-                &decoded
-                    .execute_scalar(3, &mut LEGACY_SESSION.create_execution_ctx())
-                    .unwrap()
-            )
-            .unwrap(),
+            TryInto::<i64>::try_into(&decoded.execute_scalar(3, &mut ctx).unwrap()).unwrap(),
             200i64
         );
         assert_eq!(
-            TryInto::<i64>::try_into(
-                &decoded
-                    .execute_scalar(5, &mut LEGACY_SESSION.create_execution_ctx())
-                    .unwrap()
-            )
-            .unwrap(),
+            TryInto::<i64>::try_into(&decoded.execute_scalar(5, &mut ctx).unwrap()).unwrap(),
             100i64
         );
         assert_eq!(
-            TryInto::<i64>::try_into(
-                &decoded
-                    .execute_scalar(8, &mut LEGACY_SESSION.create_execution_ctx())
-                    .unwrap()
-            )
-            .unwrap(),
+            TryInto::<i64>::try_into(&decoded.execute_scalar(8, &mut ctx).unwrap()).unwrap(),
             300i64
         );
     }
 
     #[test]
     fn test_cast_runend_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let runend = RunEnd::try_new(
             buffer![2u64, 4, 7].into_array(),
             PrimitiveArray::from_option_iter([Some(10i32), None, Some(20)]).into_array(),
+            &mut ctx,
         )
         .unwrap();
 
@@ -132,10 +118,12 @@ mod tests {
 
     #[test]
     fn test_cast_runend_with_offset() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a RunEndArray: [100, 100, 100, 200, 200, 300, 300, 300, 300, 300]
         let runend = RunEnd::try_new(
             buffer![3u64, 5, 10].into_array(),
             buffer![100i32, 200, 300].into_array(),
+            &mut ctx,
         )
         .unwrap();
 
@@ -157,28 +145,37 @@ mod tests {
         );
     }
 
+    type RunEndBuilder = fn(&mut vortex_array::ExecutionCtx) -> RunEndArray;
+
     #[rstest]
-    #[case(RunEnd::try_new(
+    #[case(|ctx: &mut vortex_array::ExecutionCtx| RunEnd::try_new(
         buffer![3u64, 5, 8].into_array(),
-        buffer![100i32, 200, 300].into_array()
+        buffer![100i32, 200, 300].into_array(),
+        ctx,
     ).unwrap())]
-    #[case(RunEnd::try_new(
+    #[case(|ctx: &mut vortex_array::ExecutionCtx| RunEnd::try_new(
         buffer![1u64, 4, 10].into_array(),
-        buffer![1.5f32, 2.5, 3.5].into_array()
+        buffer![1.5f32, 2.5, 3.5].into_array(),
+        ctx,
     ).unwrap())]
-    #[case(RunEnd::try_new(
+    #[case(|ctx: &mut vortex_array::ExecutionCtx| RunEnd::try_new(
         buffer![2u64, 3, 5].into_array(),
-        PrimitiveArray::from_option_iter([Some(42i32), None, Some(84)]).into_array()
+        PrimitiveArray::from_option_iter([Some(42i32), None, Some(84)]).into_array(),
+        ctx,
     ).unwrap())]
-    #[case(RunEnd::try_new(
+    #[case(|ctx: &mut vortex_array::ExecutionCtx| RunEnd::try_new(
         buffer![10u64].into_array(),
-        buffer![255u8].into_array()
+        buffer![255u8].into_array(),
+        ctx,
     ).unwrap())]
-    #[case(RunEnd::try_new(
+    #[case(|ctx: &mut vortex_array::ExecutionCtx| RunEnd::try_new(
         buffer![2u64, 4, 6, 8, 10].into_array(),
-        BoolArray::from_iter(vec![true, false, true, false, true]).into_array()
+        BoolArray::from_iter(vec![true, false, true, false, true]).into_array(),
+        ctx,
     ).unwrap())]
-    fn test_cast_runend_conformance(#[case] array: RunEndArray) {
+    fn test_cast_runend_conformance(#[case] build: RunEndBuilder) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array = build(&mut ctx);
         test_cast_conformance(&array.into_array());
     }
 }

--- a/encodings/runend/src/compute/compare.rs
+++ b/encodings/runend/src/compute/compare.rs
@@ -36,6 +36,7 @@ impl CompareKernel for RunEnd {
                 values.execute::<BoolArray>(ctx)?,
                 lhs.offset(),
                 lhs.len(),
+                ctx,
             )
             .map(Some);
         }
@@ -47,7 +48,10 @@ impl CompareKernel for RunEnd {
 
 #[cfg(test)]
 mod test {
+    use vortex_array::ExecutionCtx;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::ConstantArray;
     use vortex_array::arrays::PrimitiveArray;
@@ -58,14 +62,18 @@ mod test {
     use crate::RunEnd;
     use crate::RunEndArray;
 
-    fn ree_array() -> RunEndArray {
-        RunEnd::encode(PrimitiveArray::from_iter([1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5]).into_array())
-            .unwrap()
+    fn ree_array(ctx: &mut ExecutionCtx) -> RunEndArray {
+        RunEnd::encode(
+            PrimitiveArray::from_iter([1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5]).into_array(),
+            ctx,
+        )
+        .unwrap()
     }
 
     #[test]
     fn compare_run_end() {
-        let arr = ree_array();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let arr = ree_array(&mut ctx);
         let res = arr
             .into_array()
             .binary(ConstantArray::new(5, 12).into_array(), Operator::Eq)

--- a/encodings/runend/src/compute/fill_null.rs
+++ b/encodings/runend/src/compute/fill_null.rs
@@ -4,6 +4,8 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::builtins::ArrayBuiltins;
 use vortex_array::scalar::Scalar;
 use vortex_array::scalar_fn::fns::fill_null::FillNullReduce;
@@ -18,6 +20,8 @@ impl FillNullReduce for RunEnd {
         fill_value: &Scalar,
     ) -> VortexResult<Option<ArrayRef>> {
         let new_values = array.values().fill_null(fill_value.clone())?;
+        // TODO(ctx): trait fixes - FillNullReduce::fill_null has a fixed signature.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // SAFETY: modifying values only, does not affect ends
         Ok(Some(
             unsafe {
@@ -26,6 +30,7 @@ impl FillNullReduce for RunEnd {
                     new_values,
                     array.offset(),
                     array.len(),
+                    &mut ctx,
                 )
             }
             .into_array(),

--- a/encodings/runend/src/compute/filter.rs
+++ b/encodings/runend/src/compute/filter.rs
@@ -42,6 +42,7 @@ impl FilterKernel for RunEnd {
                 array,
                 mask_values.indices(),
                 &Validity::NonNullable,
+                ctx,
             )?))
         } else {
             let primitive_run_ends = array.ends().clone().execute::<PrimitiveArray>(ctx)?;
@@ -64,6 +65,7 @@ impl FilterKernel for RunEnd {
                         values,
                         0,
                         mask_values.true_count(),
+                        ctx,
                     )
                     .into_array(),
                 ))
@@ -126,8 +128,11 @@ mod tests {
     use crate::RunEndArray;
 
     fn ree_array() -> RunEndArray {
-        RunEnd::encode(PrimitiveArray::from_iter([1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5]).into_array())
-            .unwrap()
+        RunEnd::encode(
+            PrimitiveArray::from_iter([1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5]).into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -135,11 +140,13 @@ mod tests {
         let arr = ree_array().slice(2..7).unwrap();
         let filtered = arr.filter(Mask::from_iter([true, false, false, true, true]))?;
 
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         assert_arrays_eq!(
             filtered,
             RunEnd::new(
                 PrimitiveArray::from_iter([1u8, 2, 3]).into_array(),
-                PrimitiveArray::from_iter([1i32, 4, 2]).into_array()
+                PrimitiveArray::from_iter([1i32, 4, 2]).into_array(),
+                &mut ctx,
             )
         );
         Ok(())
@@ -157,7 +164,8 @@ mod tests {
             .iter()
             .flat_map(|&v| std::iter::repeat_n(v, 32))
             .collect();
-        let arr = RunEnd::encode(PrimitiveArray::from_iter(values).into_array())?;
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let arr = RunEnd::encode(PrimitiveArray::from_iter(values).into_array(), &mut ctx)?;
 
         // Slice off the first 16 rows. Slice(RunEnd), 112 rows, 4 runs.
         let sliced = arr.into_array().slice(16..128)?;
@@ -166,7 +174,6 @@ mod tests {
         let mask = Mask::from_iter((0..sliced.len()).map(|i| i % 2 == 0));
         let filtered = sliced.filter(mask)?;
 
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let executed = filtered.execute_until::<RunEnd>(&mut ctx)?;
         assert_eq!(
             executed.encoding_id().as_ref(),

--- a/encodings/runend/src/compute/mod.rs
+++ b/encodings/runend/src/compute/mod.rs
@@ -15,6 +15,8 @@ pub(crate) mod take_from;
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
     use vortex_buffer::buffer;
@@ -25,24 +27,30 @@ mod tests {
     #[rstest]
     // Simple run-end arrays
     #[case::runend_i32(RunEnd::encode(
-        buffer![1i32, 1, 1, 2, 2, 3, 3, 3, 3].into_array()
+        buffer![1i32, 1, 1, 2, 2, 3, 3, 3, 3].into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
     ).unwrap())]
     #[case::runend_single_run(RunEnd::encode(
-        buffer![5i32, 5, 5, 5, 5].into_array()
+        buffer![5i32, 5, 5, 5, 5].into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
     ).unwrap())]
     #[case::runend_alternating(RunEnd::encode(
-        buffer![1i32, 2, 1, 2, 1, 2].into_array()
+        buffer![1i32, 2, 1, 2, 1, 2].into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
     ).unwrap())]
     // Different types
     #[case::runend_u64(RunEnd::encode(
-        buffer![100u64, 100, 200, 200, 200].into_array()
+        buffer![100u64, 100, 200, 200, 200].into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
     ).unwrap())]
     // Edge cases
     #[case::runend_single(RunEnd::encode(
-        buffer![42i32].into_array()
+        buffer![42i32].into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
     ).unwrap())]
     #[case::runend_large(RunEnd::encode(
-        PrimitiveArray::from_iter((0..1000).map(|i| i / 10)).into_array()
+        PrimitiveArray::from_iter((0..1000).map(|i| i / 10)).into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
     ).unwrap())]
 
     fn test_runend_consistency(#[case] array: RunEndArray) {

--- a/encodings/runend/src/compute/take.rs
+++ b/encodings/runend/src/compute/take.rs
@@ -7,8 +7,6 @@ use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::dict::TakeExecute;
 use vortex_array::match_each_integer_ptype;
@@ -51,7 +49,7 @@ impl TakeExecute for RunEnd {
         });
 
         let indices_validity = primitive_indices.validity()?;
-        take_indices_unchecked(array, &checked_indices, &indices_validity).map(Some)
+        take_indices_unchecked(array, &checked_indices, &indices_validity, ctx).map(Some)
     }
 }
 
@@ -60,9 +58,9 @@ pub fn take_indices_unchecked<T: AsPrimitive<usize>>(
     array: ArrayView<'_, RunEnd>,
     indices: &[T],
     validity: &Validity,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    #[expect(deprecated)]
-    let ends = array.ends().to_primitive();
+    let ends = array.ends().clone().execute::<PrimitiveArray>(ctx)?;
     let ends_len = ends.len();
 
     // TODO(joe): use the validity mask to skip search sorted.
@@ -91,7 +89,7 @@ pub fn take_indices_unchecked<T: AsPrimitive<usize>>(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use rstest::rstest;
     use vortex_array::ArrayRef;
     use vortex_array::Canonical;
@@ -107,7 +105,11 @@ mod test {
     use crate::RunEndArray;
 
     fn ree_array() -> RunEndArray {
-        RunEnd::encode(buffer![1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5].into_array()).unwrap()
+        RunEnd::encode(
+            buffer![1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5].into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -157,6 +159,7 @@ mod test {
     #[case(ree_array())]
     #[case(RunEnd::encode(
         buffer![1u8, 1, 2, 2, 2, 3, 3, 3, 3, 4].into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
     ).unwrap())]
     #[case(RunEnd::encode(
         PrimitiveArray::from_option_iter([
@@ -169,11 +172,14 @@ mod test {
             Some(20),
         ])
         .into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
     ).unwrap())]
-    #[case(RunEnd::encode(buffer![42i32, 42, 42, 42, 42].into_array())
+    #[case(RunEnd::encode(buffer![42i32, 42, 42, 42, 42].into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx())
         .unwrap())]
     #[case(RunEnd::encode(
         buffer![1i32, 2, 3, 4, 5, 6, 7, 8, 9, 10].into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
     ).unwrap())]
     #[case({
         let mut values = Vec::new();
@@ -182,7 +188,11 @@ mod test {
                 values.push(i);
             }
         }
-        RunEnd::encode(PrimitiveArray::from_iter(values).into_array()).unwrap()
+        RunEnd::encode(
+            PrimitiveArray::from_iter(values).into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap()
     })]
     fn test_take_runend_conformance(#[case] array: RunEndArray) {
         test_take_conformance(&array.into_array());
@@ -193,6 +203,7 @@ mod test {
     #[case({
         let array = RunEnd::encode(
             buffer![1i32, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3].into_array(),
+            &mut LEGACY_SESSION.create_execution_ctx(),
         )
         .unwrap();
         array.slice(2..8).unwrap()

--- a/encodings/runend/src/compute/take_from.rs
+++ b/encodings/runend/src/compute/take_from.rs
@@ -25,7 +25,7 @@ impl ExecuteParentKernel<RunEnd> for RunEndTakeFrom {
         array: ArrayView<'_, RunEnd>,
         dict: ArrayView<'_, Dict>,
         child_idx: usize,
-        _ctx: &mut ExecutionCtx,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
         if child_idx != 0 {
             return Ok(None);
@@ -44,6 +44,7 @@ impl ExecuteParentKernel<RunEnd> for RunEndTakeFrom {
                 dict.values().take(array.values().clone())?,
                 array.offset(),
                 array.len(),
+                ctx,
             )
         };
         //
@@ -53,6 +54,7 @@ impl ExecuteParentKernel<RunEnd> for RunEndTakeFrom {
 
 #[cfg(test)]
 mod tests {
+    use vortex_array::Canonical;
     use vortex_array::ExecutionCtx;
     use vortex_array::IntoArray;
     use vortex_array::arrays::DictArray;
@@ -74,8 +76,8 @@ mod tests {
     /// Dict values: `[2, 3]`
     /// Codes:       `[0, 0, 0, 1, 1, 0, 0]`
     /// RunEnd encoded codes: ends=`[3, 5, 7]`, values=`[0, 1, 0]`
-    fn make_dict_with_runend_codes() -> (RunEndArray, DictArray) {
-        let codes = RunEnd::encode(buffer![0u32, 0, 0, 1, 1, 0, 0].into_array()).unwrap();
+    fn make_dict_with_runend_codes(ctx: &mut ExecutionCtx) -> (RunEndArray, DictArray) {
+        let codes = RunEnd::encode(buffer![0u32, 0, 0, 1, 1, 0, 0].into_array(), ctx).unwrap();
         let values = buffer![2i32, 3].into_array();
         let dict = DictArray::try_new(codes.clone().into_array(), values).unwrap();
         (codes, dict)
@@ -83,23 +85,23 @@ mod tests {
 
     #[test]
     fn test_execute_parent_no_offset() -> VortexResult<()> {
-        let (codes, dict) = make_dict_with_runend_codes();
         let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
 
         let result = RunEndTakeFrom
             .execute_parent(codes.as_view(), dict.as_view(), 0, &mut ctx)?
             .expect("kernel should return Some");
 
         let expected = PrimitiveArray::from_iter([2i32, 2, 2, 3, 3, 2, 2]);
-        #[expect(deprecated)]
-        let canonical = result.to_canonical()?.into_array();
+        let canonical = result.execute::<Canonical>(&mut ctx)?.into_array();
         assert_arrays_eq!(canonical, expected);
         Ok(())
     }
 
     #[test]
     fn test_execute_parent_with_offset() -> VortexResult<()> {
-        let (codes, dict) = make_dict_with_runend_codes();
+        let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
         // Slice codes to positions 2..5 → logical codes [0, 1, 1] → values [2, 3, 3]
         let sliced_codes = unsafe {
             RunEnd::new_unchecked(
@@ -107,24 +109,24 @@ mod tests {
                 codes.values().clone(),
                 2, // offset
                 3, // len
+                &mut ctx,
             )
         };
-        let mut ctx = ExecutionCtx::new(VortexSession::empty());
 
         let result = RunEndTakeFrom
             .execute_parent(sliced_codes.as_view(), dict.as_view(), 0, &mut ctx)?
             .expect("kernel should return Some");
 
         let expected = PrimitiveArray::from_iter([2i32, 3, 3]);
-        #[expect(deprecated)]
-        let canonical = result.to_canonical()?.into_array();
+        let canonical = result.execute::<Canonical>(&mut ctx)?.into_array();
         assert_arrays_eq!(canonical, expected);
         Ok(())
     }
 
     #[test]
     fn test_execute_parent_offset_at_run_boundary() -> VortexResult<()> {
-        let (codes, dict) = make_dict_with_runend_codes();
+        let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
         // Slice codes to positions 3..7 → logical codes [1, 1, 0, 0] → values [3, 3, 2, 2]
         let sliced_codes = unsafe {
             RunEnd::new_unchecked(
@@ -132,24 +134,24 @@ mod tests {
                 codes.values().clone(),
                 3, // offset at exact run boundary
                 4, // len
+                &mut ctx,
             )
         };
-        let mut ctx = ExecutionCtx::new(VortexSession::empty());
 
         let result = RunEndTakeFrom
             .execute_parent(sliced_codes.as_view(), dict.as_view(), 0, &mut ctx)?
             .expect("kernel should return Some");
 
         let expected = PrimitiveArray::from_iter([3i32, 3, 2, 2]);
-        #[expect(deprecated)]
-        let canonical = result.to_canonical()?.into_array();
+        let canonical = result.execute::<Canonical>(&mut ctx)?.into_array();
         assert_arrays_eq!(canonical, expected);
         Ok(())
     }
 
     #[test]
     fn test_execute_parent_single_element_offset() -> VortexResult<()> {
-        let (codes, dict) = make_dict_with_runend_codes();
+        let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
         // Slice to single element at position 4 → code=1 → value=3
         let sliced_codes = unsafe {
             RunEnd::new_unchecked(
@@ -157,25 +159,24 @@ mod tests {
                 codes.values().slice(1..3)?,
                 4, // offset
                 1, // len
+                &mut ctx,
             )
         };
-        let mut ctx = ExecutionCtx::new(VortexSession::empty());
 
         let result = RunEndTakeFrom
             .execute_parent(sliced_codes.as_view(), dict.as_view(), 0, &mut ctx)?
             .expect("kernel should return Some");
 
         let expected = PrimitiveArray::from_iter([3i32]);
-        #[expect(deprecated)]
-        let canonical = result.to_canonical()?.into_array();
+        let canonical = result.execute::<Canonical>(&mut ctx)?.into_array();
         assert_arrays_eq!(canonical, expected);
         Ok(())
     }
 
     #[test]
     fn test_execute_parent_returns_none_for_non_codes_child() -> VortexResult<()> {
-        let (codes, dict) = make_dict_with_runend_codes();
         let mut ctx = ExecutionCtx::new(VortexSession::empty());
+        let (codes, dict) = make_dict_with_runend_codes(&mut ctx);
 
         let result = RunEndTakeFrom.execute_parent(codes.as_view(), dict.as_view(), 1, &mut ctx)?;
         assert!(result.is_none());

--- a/encodings/runend/src/decompress_bool.rs
+++ b/encodings/runend/src/decompress_bool.rs
@@ -8,9 +8,8 @@
 
 use itertools::Itertools;
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -37,11 +36,12 @@ pub fn runend_decode_bools(
     values: BoolArray,
     offset: usize,
     length: usize,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
-    let validity = values.as_ref().validity()?.to_mask(
-        values.as_ref().len(),
-        &mut LEGACY_SESSION.create_execution_ctx(),
-    )?;
+    let validity = values
+        .as_ref()
+        .validity()?
+        .to_mask(values.as_ref().len(), ctx)?;
     let values_buf = values.to_bit_buffer();
     let nullability = values.dtype().nullability();
 
@@ -247,8 +247,6 @@ fn decode_nullable_sequential(
 #[cfg(test)]
 mod tests {
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
@@ -262,10 +260,11 @@ mod tests {
 
     #[test]
     fn decode_bools_alternating() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Alternating true/false: [T, T, F, F, F, T, T, T, T, T]
         let ends = PrimitiveArray::from_iter([2u32, 5, 10]);
         let values = BoolArray::from(BitBuffer::from(vec![true, false, true]));
-        let decoded = runend_decode_bools(ends, values, 0, 10)?;
+        let decoded = runend_decode_bools(ends, values, 0, 10, &mut ctx)?;
 
         let expected = BoolArray::from(BitBuffer::from(vec![
             true, true, false, false, false, true, true, true, true, true,
@@ -276,10 +275,11 @@ mod tests {
 
     #[test]
     fn decode_bools_mostly_true() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Mostly true: [T, T, T, T, T, F, T, T, T, T]
         let ends = PrimitiveArray::from_iter([5u32, 6, 10]);
         let values = BoolArray::from(BitBuffer::from(vec![true, false, true]));
-        let decoded = runend_decode_bools(ends, values, 0, 10)?;
+        let decoded = runend_decode_bools(ends, values, 0, 10, &mut ctx)?;
 
         let expected = BoolArray::from(BitBuffer::from(vec![
             true, true, true, true, true, false, true, true, true, true,
@@ -290,10 +290,11 @@ mod tests {
 
     #[test]
     fn decode_bools_mostly_false() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Mostly false: [F, F, F, F, F, T, F, F, F, F]
         let ends = PrimitiveArray::from_iter([5u32, 6, 10]);
         let values = BoolArray::from(BitBuffer::from(vec![false, true, false]));
-        let decoded = runend_decode_bools(ends, values, 0, 10)?;
+        let decoded = runend_decode_bools(ends, values, 0, 10, &mut ctx)?;
 
         let expected = BoolArray::from(BitBuffer::from(vec![
             false, false, false, false, false, true, false, false, false, false,
@@ -304,9 +305,10 @@ mod tests {
 
     #[test]
     fn decode_bools_all_true_single_run() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let ends = PrimitiveArray::from_iter([10u32]);
         let values = BoolArray::from(BitBuffer::from(vec![true]));
-        let decoded = runend_decode_bools(ends, values, 0, 10)?;
+        let decoded = runend_decode_bools(ends, values, 0, 10, &mut ctx)?;
 
         let expected = BoolArray::from(BitBuffer::from(vec![
             true, true, true, true, true, true, true, true, true, true,
@@ -317,9 +319,10 @@ mod tests {
 
     #[test]
     fn decode_bools_all_false_single_run() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let ends = PrimitiveArray::from_iter([10u32]);
         let values = BoolArray::from(BitBuffer::from(vec![false]));
-        let decoded = runend_decode_bools(ends, values, 0, 10)?;
+        let decoded = runend_decode_bools(ends, values, 0, 10, &mut ctx)?;
 
         let expected = BoolArray::from(BitBuffer::from(vec![
             false, false, false, false, false, false, false, false, false, false,
@@ -330,10 +333,11 @@ mod tests {
 
     #[test]
     fn decode_bools_with_offset() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test with offset: [T, T, F, F, F, T, T, T, T, T] -> slice [2..8] = [F, F, F, T, T, T]
         let ends = PrimitiveArray::from_iter([2u32, 5, 10]);
         let values = BoolArray::from(BitBuffer::from(vec![true, false, true]));
-        let decoded = runend_decode_bools(ends, values, 2, 6)?;
+        let decoded = runend_decode_bools(ends, values, 2, 6, &mut ctx)?;
 
         let expected =
             BoolArray::from(BitBuffer::from(vec![false, false, false, true, true, true]));
@@ -345,13 +349,14 @@ mod tests {
     fn decode_bools_nullable() -> VortexResult<()> {
         use vortex_array::validity::Validity;
 
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // 3 runs: T (valid), F (null), T (valid) -> [T, T, null, null, null, T, T, T, T, T]
         let ends = PrimitiveArray::from_iter([2u32, 5, 10]);
         let values = BoolArray::new(
             BitBuffer::from(vec![true, false, true]),
             Validity::from(BitBuffer::from(vec![true, false, true])),
         );
-        let decoded = runend_decode_bools(ends, values, 0, 10)?;
+        let decoded = runend_decode_bools(ends, values, 0, 10, &mut ctx)?;
 
         // Expected: values=[T, T, F, F, F, T, T, T, T, T], validity=[1, 1, 0, 0, 0, 1, 1, 1, 1, 1]
         let expected = BoolArray::new(
@@ -368,14 +373,15 @@ mod tests {
 
     #[test]
     fn decode_bools_nullable_few_runs() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test few runs (uses fast path): 5 runs of length 2000 each
         let ends = PrimitiveArray::from_iter([2000u32, 4000, 6000, 8000, 10000]);
         let values = BoolArray::new(
             BitBuffer::from(vec![true, false, true, false, true]),
             Validity::from(BitBuffer::from(vec![true, false, true, false, true])),
         );
-        #[expect(deprecated)]
-        let decoded = runend_decode_bools(ends, values, 0, 10000)?.to_bool();
+        let decoded =
+            runend_decode_bools(ends, values, 0, 10000, &mut ctx)?.execute::<BoolArray>(&mut ctx)?;
 
         // Check length and a few values
         assert_eq!(decoded.len(), 10000);
@@ -384,10 +390,7 @@ mod tests {
             decoded
                 .as_ref()
                 .validity()?
-                .to_mask(
-                    decoded.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx()
-                )
+                .to_mask(decoded.as_ref().len(), &mut ctx)
                 .unwrap()
                 .value(0)
         );
@@ -397,10 +400,7 @@ mod tests {
             !decoded
                 .as_ref()
                 .validity()?
-                .to_mask(
-                    decoded.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx()
-                )
+                .to_mask(decoded.as_ref().len(), &mut ctx)
                 .unwrap()
                 .value(2000)
         );
@@ -409,10 +409,7 @@ mod tests {
             decoded
                 .as_ref()
                 .validity()?
-                .to_mask(
-                    decoded.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx()
-                )
+                .to_mask(decoded.as_ref().len(), &mut ctx)
                 .unwrap()
                 .value(4000)
         );

--- a/encodings/runend/src/decompress_bool.rs
+++ b/encodings/runend/src/decompress_bool.rs
@@ -380,8 +380,8 @@ mod tests {
             BitBuffer::from(vec![true, false, true, false, true]),
             Validity::from(BitBuffer::from(vec![true, false, true, false, true])),
         );
-        let decoded =
-            runend_decode_bools(ends, values, 0, 10000, &mut ctx)?.execute::<BoolArray>(&mut ctx)?;
+        let decoded = runend_decode_bools(ends, values, 0, 10000, &mut ctx)?
+            .execute::<BoolArray>(&mut ctx)?;
 
         // Check length and a few values
         assert_eq!(decoded.len(), 10000);

--- a/encodings/runend/src/kernel.rs
+++ b/encodings/runend/src/kernel.rs
@@ -7,8 +7,6 @@ use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Slice;
 use vortex_array::arrays::dict::TakeExecuteAdaptor;
@@ -45,13 +43,17 @@ impl ExecuteParentKernel<RunEnd> for RunEndSliceKernel {
         array: ArrayView<'_, RunEnd>,
         parent: ArrayView<'_, Slice>,
         _child_idx: usize,
-        _ctx: &mut ExecutionCtx,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<ArrayRef>> {
-        slice(array, parent.slice_range().clone()).map(Some)
+        slice(array, parent.slice_range().clone(), ctx).map(Some)
     }
 }
 
-fn slice(array: ArrayView<'_, RunEnd>, range: Range<usize>) -> VortexResult<ArrayRef> {
+fn slice(
+    array: ArrayView<'_, RunEnd>,
+    range: Range<usize>,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
     let new_length = range.len();
 
     let slice_begin = array.find_physical_index(range.start)?;
@@ -59,9 +61,7 @@ fn slice(array: ArrayView<'_, RunEnd>, range: Range<usize>) -> VortexResult<Arra
 
     // If the sliced range contains only a single run, opt to return a ConstantArray.
     if slice_begin + 1 == slice_end {
-        let value = array
-            .values()
-            .execute_scalar(slice_begin, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let value = array.values().execute_scalar(slice_begin, ctx)?;
         return Ok(ConstantArray::new(value, new_length).into_array());
     }
 
@@ -72,6 +72,7 @@ fn slice(array: ArrayView<'_, RunEnd>, range: Range<usize>) -> VortexResult<Arra
             array.values().slice(slice_begin..slice_end)?,
             range.start + array.offset(),
             new_length,
+            ctx,
         )
         .into_array()
     })

--- a/encodings/runend/src/ops.rs
+++ b/encodings/runend/src/ops.rs
@@ -65,9 +65,11 @@ mod tests {
 
     #[test]
     fn slice_array() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = RunEnd::try_new(
             buffer![2u32, 5, 10].into_array(),
             buffer![1i32, 2, 3].into_array(),
+            &mut ctx,
         )
         .unwrap()
         .slice(3..8)
@@ -84,9 +86,11 @@ mod tests {
 
     #[test]
     fn double_slice() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = RunEnd::try_new(
             buffer![2u32, 5, 10].into_array(),
             buffer![1i32, 2, 3].into_array(),
+            &mut ctx,
         )
         .unwrap()
         .slice(3..8)
@@ -101,9 +105,11 @@ mod tests {
 
     #[test]
     fn slice_end_inclusive() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = RunEnd::try_new(
             buffer![2u32, 5, 10].into_array(),
             buffer![1i32, 2, 3].into_array(),
+            &mut ctx,
         )
         .unwrap()
         .slice(4..10)
@@ -120,9 +126,11 @@ mod tests {
 
     #[test]
     fn slice_at_end() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let re_array = RunEnd::try_new(
             buffer![7_u64, 10].into_array(),
             buffer![2_u64, 3].into_array(),
+            &mut ctx,
         )
         .unwrap();
 
@@ -134,9 +142,11 @@ mod tests {
 
     #[test]
     fn slice_single_end() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let re_array = RunEnd::try_new(
             buffer![7_u64, 10].into_array(),
             buffer![2_u64, 3].into_array(),
+            &mut ctx,
         )
         .unwrap();
 
@@ -144,26 +154,31 @@ mod tests {
 
         let sliced_array = re_array.slice(2..5).unwrap();
 
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         assert!(is_constant(&sliced_array, &mut ctx).unwrap())
     }
 
     #[test]
     fn ree_scalar_at_end() {
-        let scalar = RunEnd::encode(buffer![1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5].into_array())
-            .unwrap()
-            .execute_scalar(11, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let scalar = RunEnd::encode(
+            buffer![1, 1, 1, 4, 4, 4, 2, 2, 5, 5, 5, 5].into_array(),
+            &mut ctx,
+        )
+        .unwrap()
+        .execute_scalar(11, &mut ctx)
+        .unwrap();
         assert_eq!(scalar, 5.into());
     }
 
     #[test]
     fn slice_along_run_boundaries() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create a runend array with runs: [1, 1, 1] [4, 4, 4] [2, 2] [5, 5, 5, 5]
         // Run ends at indices: 3, 6, 8, 12
         let arr = RunEnd::try_new(
             buffer![3u32, 6, 8, 12].into_array(),
             buffer![1i32, 4, 2, 5].into_array(),
+            &mut ctx,
         )
         .unwrap();
 

--- a/encodings/runend/src/rules.rs
+++ b/encodings/runend/src/rules.rs
@@ -4,6 +4,8 @@
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::Constant;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::ScalarFnArray;
@@ -80,6 +82,8 @@ impl ArrayParentReduceRule<RunEnd> for RunEndScalarFnRule {
             ScalarFnArray::try_new(parent.scalar_fn().clone(), new_children, values_len)?
                 .into_array();
 
+        // TODO(ctx): trait fixes - ArrayParentReduceRule::reduce_parent has a fixed signature.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         Ok(Some(
             unsafe {
                 RunEnd::new_unchecked(
@@ -87,6 +91,7 @@ impl ArrayParentReduceRule<RunEnd> for RunEndScalarFnRule {
                     new_values,
                     run_end.offset(),
                     run_end.len(),
+                    &mut ctx,
                 )
             }
             .into_array(),

--- a/encodings/sequence/public-api.lock
+++ b/encodings/sequence/public-api.lock
@@ -122,6 +122,6 @@ pub vortex_sequence::SequenceDataParts::ptype: vortex_array::dtype::ptype::PType
 
 pub fn vortex_sequence::initialize(session: &vortex_session::VortexSession)
 
-pub fn vortex_sequence::sequence_encode(primitive_array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::erased::ArrayRef>>
+pub fn vortex_sequence::sequence_encode(primitive_array: vortex_array::array::view::ArrayView<'_, vortex_array::arrays::primitive::vtable::Primitive>, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<vortex_array::array::erased::ArrayRef>>
 
 pub type vortex_sequence::SequenceArray = vortex_array::array::typed::Array<vortex_sequence::Sequence>

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -7,9 +7,8 @@ use num_traits::CheckedAdd;
 use num_traits::CheckedSub;
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::NativePType;
@@ -90,16 +89,14 @@ pub fn sequence_decompress(array: &SequenceArray) -> VortexResult<ArrayRef> {
 ///    we might want a different array for that since sequence provide fast access.
 pub fn sequence_encode(
     primitive_array: ArrayView<'_, Primitive>,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<Option<ArrayRef>> {
     if primitive_array.is_empty() {
         // we cannot encode an empty array
         return Ok(None);
     }
 
-    if !primitive_array
-        .array()
-        .all_valid(&mut LEGACY_SESSION.create_execution_ctx())?
-    {
+    if !primitive_array.array().all_valid(ctx)? {
         return Ok(None);
     }
 
@@ -153,8 +150,8 @@ fn encode_primitive_array<P: NativePType + Into<PValue> + CheckedAdd + CheckedSu
 mod tests {
     #[expect(unused_imports)]
     use itertools::Itertools;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
 
@@ -162,47 +159,49 @@ mod tests {
 
     #[test]
     fn test_encode_array_success() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let primitive_array = PrimitiveArray::from_iter([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        let encoded = sequence_encode(primitive_array.as_view()).unwrap();
+        let encoded = sequence_encode(primitive_array.as_view(), &mut ctx).unwrap();
         assert!(encoded.is_some());
-        #[expect(deprecated)]
-        let decoded = encoded.unwrap().to_primitive();
+        let decoded = encoded.unwrap().execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(decoded, primitive_array);
     }
 
     #[test]
     fn test_encode_array_1_success() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let primitive_array = PrimitiveArray::from_iter([0]);
-        let encoded = sequence_encode(primitive_array.as_view()).unwrap();
+        let encoded = sequence_encode(primitive_array.as_view(), &mut ctx).unwrap();
         assert!(encoded.is_some());
-        #[expect(deprecated)]
-        let decoded = encoded.unwrap().to_primitive();
+        let decoded = encoded.unwrap().execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(decoded, primitive_array);
     }
 
     #[test]
     fn test_encode_array_fail() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let primitive_array = PrimitiveArray::from_iter([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
 
-        let encoded = sequence_encode(primitive_array.as_view()).unwrap();
+        let encoded = sequence_encode(primitive_array.as_view(), &mut ctx).unwrap();
         assert!(encoded.is_none());
     }
 
     #[test]
     fn test_encode_array_fail_oob() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let primitive_array = PrimitiveArray::from_iter(vec![100i8; 1000]);
 
-        let encoded = sequence_encode(primitive_array.as_view()).unwrap();
+        let encoded = sequence_encode(primitive_array.as_view(), &mut ctx).unwrap();
         assert!(encoded.is_none());
     }
 
     #[test]
     fn test_encode_all_u8_values() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let primitive_array = PrimitiveArray::from_iter(0u8..=255);
-        let encoded = sequence_encode(primitive_array.as_view()).unwrap();
+        let encoded = sequence_encode(primitive_array.as_view(), &mut ctx).unwrap();
         assert!(encoded.is_some());
-        #[expect(deprecated)]
-        let decoded = encoded.unwrap().to_primitive();
+        let decoded = encoded.unwrap().execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(decoded, primitive_array);
     }
 }

--- a/encodings/sequence/src/compress.rs
+++ b/encodings/sequence/src/compress.rs
@@ -163,7 +163,10 @@ mod tests {
         let primitive_array = PrimitiveArray::from_iter([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
         let encoded = sequence_encode(primitive_array.as_view(), &mut ctx).unwrap();
         assert!(encoded.is_some());
-        let decoded = encoded.unwrap().execute::<PrimitiveArray>(&mut ctx).unwrap();
+        let decoded = encoded
+            .unwrap()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         assert_arrays_eq!(decoded, primitive_array);
     }
 
@@ -173,7 +176,10 @@ mod tests {
         let primitive_array = PrimitiveArray::from_iter([0]);
         let encoded = sequence_encode(primitive_array.as_view(), &mut ctx).unwrap();
         assert!(encoded.is_some());
-        let decoded = encoded.unwrap().execute::<PrimitiveArray>(&mut ctx).unwrap();
+        let decoded = encoded
+            .unwrap()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         assert_arrays_eq!(decoded, primitive_array);
     }
 
@@ -201,7 +207,10 @@ mod tests {
         let primitive_array = PrimitiveArray::from_iter(0u8..=255);
         let encoded = sequence_encode(primitive_array.as_view(), &mut ctx).unwrap();
         assert!(encoded.is_some());
-        let decoded = encoded.unwrap().execute::<PrimitiveArray>(&mut ctx).unwrap();
+        let decoded = encoded
+            .unwrap()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         assert_arrays_eq!(decoded, primitive_array);
     }
 }

--- a/encodings/sequence/src/compute/cast.rs
+++ b/encodings/sequence/src/compute/cast.rs
@@ -89,8 +89,8 @@ impl CastReduce for Sequence {
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::builtins::ArrayBuiltins;
@@ -119,6 +119,7 @@ mod tests {
 
     #[test]
     fn test_cast_sequence_u32_to_i64() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let sequence = Sequence::try_new_typed(100u32, 10u32, Nullability::NonNullable, 4).unwrap();
 
         let casted = sequence
@@ -131,13 +132,13 @@ mod tests {
         );
 
         // Verify the values
-        #[expect(deprecated)]
-        let decoded = casted.to_primitive();
+        let decoded = casted.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(decoded, PrimitiveArray::from_iter([100i64, 110, 120, 130]));
     }
 
     #[test]
     fn test_cast_sequence_i16_to_i32_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test ptype change AND nullability change in one cast
         let sequence = Sequence::try_new_typed(5i16, 3i16, Nullability::NonNullable, 3).unwrap();
 
@@ -151,8 +152,7 @@ mod tests {
         );
 
         // Verify the values
-        #[expect(deprecated)]
-        let decoded = casted.to_primitive();
+        let decoded = casted.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(
             decoded,
             PrimitiveArray::from_option_iter([Some(5i32), Some(8), Some(11)])
@@ -161,6 +161,7 @@ mod tests {
 
     #[test]
     fn test_cast_sequence_to_float_delegates_to_canonical() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let sequence = Sequence::try_new_typed(0i32, 1i32, Nullability::NonNullable, 5).unwrap();
 
         // Cast to float should delegate to canonical (SequenceArray doesn't support float)
@@ -175,8 +176,7 @@ mod tests {
         );
 
         // Verify the values were correctly converted
-        #[expect(deprecated)]
-        let decoded = casted.to_primitive();
+        let decoded = casted.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(
             decoded,
             PrimitiveArray::from_iter([0.0f32, 1.0, 2.0, 3.0, 4.0])

--- a/encodings/sparse/public-api.lock
+++ b/encodings/sparse/public-api.lock
@@ -4,7 +4,7 @@ pub struct vortex_sparse::Sparse
 
 impl vortex_sparse::Sparse
 
-pub fn vortex_sparse::Sparse::encode(array: &vortex_array::array::erased::ArrayRef, fill_value: core::option::Option<vortex_array::scalar::Scalar>) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_sparse::Sparse::encode(array: &vortex_array::array::erased::ArrayRef, fill_value: core::option::Option<vortex_array::scalar::Scalar>, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_sparse::Sparse::try_new(indices: vortex_array::array::erased::ArrayRef, values: vortex_array::array::erased::ArrayRef, len: usize, fill_value: vortex_array::scalar::Scalar) -> vortex_error::VortexResult<vortex_sparse::SparseArray>
 
@@ -82,7 +82,7 @@ impl vortex_sparse::SparseData
 
 pub fn vortex_sparse::SparseData::dtype(&self) -> &vortex_array::dtype::DType
 
-pub fn vortex_sparse::SparseData::encode(array: &vortex_array::array::erased::ArrayRef, fill_value: core::option::Option<vortex_array::scalar::Scalar>) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_sparse::SparseData::encode(array: &vortex_array::array::erased::ArrayRef, fill_value: core::option::Option<vortex_array::scalar::Scalar>, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_sparse::SparseData::fill_scalar(&self) -> &vortex_array::scalar::Scalar
 

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -8,8 +8,6 @@ use num_traits::NumCast;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::ListViewArray;
@@ -165,6 +163,7 @@ fn execute_sparse_lists(
                 array.len(),
                 total_canonical_values,
                 validity,
+                ctx,
             )
         })
     }))
@@ -178,6 +177,7 @@ fn execute_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
     len: usize,
     total_canonical_values: usize,
     validity: Validity,
+    ctx: &mut ExecutionCtx,
 ) -> ArrayRef {
     // Create the builder with appropriate types. It is easy to just use the same type for both
     // `offsets` and `sizes` since we have no other constraints.
@@ -204,7 +204,7 @@ fn execute_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
             builder
                 .append_value(
                     patch_values
-                        .execute_scalar(patch_idx, &mut LEGACY_SESSION.create_execution_ctx())
+                        .execute_scalar(patch_idx, ctx)
                         .vortex_expect("scalar_at")
                         .as_list(),
                 )
@@ -250,6 +250,7 @@ fn execute_sparse_fixed_size_list(
             fill_value,
             array.len(),
             validity,
+            ctx,
         )
         .into_array()
     }))
@@ -267,6 +268,7 @@ fn execute_sparse_fixed_size_list_inner<I: IntegerPType>(
     fill_value: ListScalar,
     array_len: usize,
     validity: Validity,
+    ctx: &mut ExecutionCtx,
 ) -> FixedSizeListArray {
     let list_size = values.list_size();
     let element_dtype = values.elements().dtype();
@@ -302,7 +304,7 @@ fn execute_sparse_fixed_size_list_inner<I: IntegerPType>(
                 builder
                     .append_scalar(
                         &patch_list
-                            .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                            .execute_scalar(i, ctx)
                             .vortex_expect("scalar_at"),
                     )
                     .vortex_expect("element dtype must match");
@@ -566,8 +568,6 @@ mod test {
     use vortex_array::Canonical;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::DecimalArray;
@@ -605,11 +605,15 @@ mod test {
     #[case(Some(false))]
     #[case(None)]
     fn test_sparse_bool(#[case] fill_value: Option<bool>) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let indices = buffer![0u64, 1, 7].into_array();
         let values = BoolArray::from_iter([Some(true), None, Some(false)]).into_array();
         let sparse_bools = Sparse::try_new(indices, values, 10, Scalar::from(fill_value)).unwrap();
-        #[expect(deprecated)]
-        let actual = sparse_bools.as_array().to_bool();
+        let actual = sparse_bools
+            .as_array()
+            .clone()
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap();
 
         let expected = BoolArray::from_iter([
             Some(true),
@@ -632,13 +636,17 @@ mod test {
     #[case(Some(-1i32))]
     #[case(None)]
     fn test_sparse_primitive(#[case] fill_value: Option<i32>) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let indices = buffer![0u64, 1, 7].into_array();
         let values = PrimitiveArray::from_option_iter([Some(0i32), None, Some(1)]).into_array();
         let sparse_ints = Sparse::try_new(indices, values, 10, Scalar::from(fill_value)).unwrap();
         assert_eq!(*sparse_ints.dtype(), DType::Primitive(PType::I32, Nullable));
 
-        #[expect(deprecated)]
-        let flat_ints = sparse_ints.as_array().to_primitive();
+        let flat_ints = sparse_ints
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let expected = PrimitiveArray::from_option_iter([
             Some(0i32),
             None,
@@ -657,6 +665,7 @@ mod test {
 
     #[test]
     fn test_sparse_struct_valid_fill() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let field_names = FieldNames::from_iter(["a", "b"]);
         let field_types = vec![
             DType::Primitive(PType::I32, Nullable),
@@ -721,13 +730,17 @@ mod test {
         .unwrap()
         .into_array();
 
-        #[expect(deprecated)]
-        let actual = sparse_struct.as_array().to_struct();
+        let actual = sparse_struct
+            .as_array()
+            .clone()
+            .execute::<StructArray>(&mut ctx)
+            .unwrap();
         assert_arrays_eq!(actual, expected);
     }
 
     #[test]
     fn test_sparse_struct_invalid_fill() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let field_names = FieldNames::from_iter(["a", "b"]);
         let field_types = vec![
             DType::Primitive(PType::I32, Nullable),
@@ -789,13 +802,17 @@ mod test {
         .unwrap()
         .into_array();
 
-        #[expect(deprecated)]
-        let actual = sparse_struct.as_array().to_struct();
+        let actual = sparse_struct
+            .as_array()
+            .clone()
+            .execute::<StructArray>(&mut ctx)
+            .unwrap();
         assert_arrays_eq!(actual, expected);
     }
 
     #[test]
     fn test_sparse_decimal() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let indices = buffer![0u32, 1u32, 7u32, 8u32].into_array();
         let decimal_dtype = DecimalDType::new(3, 2);
         let patch_values = DecimalArray::new(
@@ -818,10 +835,11 @@ mod test {
         .into_arrow_preferred()
         .unwrap();
 
-        #[expect(deprecated)]
         let actual = sparse_struct
             .as_array()
-            .to_decimal()
+            .clone()
+            .execute::<DecimalArray>(&mut ctx)
+            .unwrap()
             .into_array()
             .into_arrow_preferred()
             .unwrap();
@@ -832,6 +850,7 @@ mod test {
 
     #[test]
     fn test_sparse_utf8_varbinview_non_null_fill() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let strings = <VarBinViewArray as FromIterator<_>>::from_iter([
             Some("hello"),
             Some("goodbye"),
@@ -851,8 +870,12 @@ mod test {
         )
         .unwrap();
 
-        #[expect(deprecated)]
-        let actual = array.as_array().to_varbinview().into_array();
+        let actual = array
+            .as_array()
+            .clone()
+            .execute::<VarBinViewArray>(&mut ctx)
+            .unwrap()
+            .into_array();
         let expected = <VarBinViewArray as FromIterator<_>>::from_iter([
             Some("hello"),
             Some("123"),
@@ -874,6 +897,7 @@ mod test {
 
     #[test]
     fn test_sparse_utf8_varbinview_null_fill() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let strings = <VarBinViewArray as FromIterator<_>>::from_iter([
             Some("hello"),
             Some("goodbye"),
@@ -893,8 +917,12 @@ mod test {
         )
         .unwrap();
 
-        #[expect(deprecated)]
-        let actual = array.as_array().to_varbinview().into_array();
+        let actual = array
+            .as_array()
+            .clone()
+            .execute::<VarBinViewArray>(&mut ctx)
+            .unwrap()
+            .into_array();
         let expected = <VarBinViewArray as FromIterator<_>>::from_iter([
             Some("hello"),
             None,
@@ -916,6 +944,7 @@ mod test {
 
     #[test]
     fn test_sparse_utf8_varbinview_non_nullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let strings =
             VarBinViewArray::from_iter_str(["hello", "goodbye", "hello", "bonjour", "你好"])
                 .into_array();
@@ -928,8 +957,12 @@ mod test {
         )
         .unwrap();
 
-        #[expect(deprecated)]
-        let actual = array.as_array().to_varbinview().into_array();
+        let actual = array
+            .as_array()
+            .clone()
+            .execute::<VarBinViewArray>(&mut ctx)
+            .unwrap()
+            .into_array();
         let expected = VarBinViewArray::from_iter_str([
             "hello", "123", "123", "goodbye", "hello", "bonjour", "123", "123", "你好",
         ])
@@ -940,6 +973,7 @@ mod test {
 
     #[test]
     fn test_sparse_utf8_varbin_null_fill() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let strings = <VarBinArray as FromIterator<_>>::from_iter([
             Some("hello"),
             Some("goodbye"),
@@ -959,8 +993,12 @@ mod test {
         )
         .unwrap();
 
-        #[expect(deprecated)]
-        let actual = array.as_array().to_varbinview().into_array();
+        let actual = array
+            .as_array()
+            .clone()
+            .execute::<VarBinViewArray>(&mut ctx)
+            .unwrap()
+            .into_array();
         let expected = <VarBinViewArray as FromIterator<_>>::from_iter([
             Some("hello"),
             None,
@@ -982,6 +1020,7 @@ mod test {
 
     #[test]
     fn test_sparse_binary_varbinview_non_null_fill() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let binaries = VarBinViewArray::from_iter_nullable_bin([
             Some(b"hello" as &[u8]),
             Some(b"goodbye"),
@@ -1001,8 +1040,12 @@ mod test {
         )
         .unwrap();
 
-        #[expect(deprecated)]
-        let actual = array.as_array().to_varbinview().into_array();
+        let actual = array
+            .as_array()
+            .clone()
+            .execute::<VarBinViewArray>(&mut ctx)
+            .unwrap()
+            .into_array();
         let expected = VarBinViewArray::from_iter_nullable_bin([
             Some(b"hello" as &[u8]),
             Some(b"123"),
@@ -1024,6 +1067,7 @@ mod test {
 
     #[test]
     fn test_sparse_list_null_fill() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Use ListViewArray consistently
         let elements = buffer![1i32, 2, 1, 2].into_array();
         // Create ListView with offsets and sizes
@@ -1045,11 +1089,8 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
-            .into_array();
-        #[expect(deprecated)]
-        let result_listview = actual.to_listview();
+        let actual = sparse.execute::<Canonical>(&mut ctx)?.into_array();
+        let result_listview = actual.execute::<ListViewArray>(&mut ctx)?;
 
         // Check the structure
         assert_eq!(result_listview.len(), 6);
@@ -1063,8 +1104,10 @@ mod test {
         assert_eq!(result_listview.size_at(5), 1); // [2]
 
         // Verify actual values
-        #[expect(deprecated)]
-        let elements_array = result_listview.elements().to_primitive();
+        let elements_array = result_listview
+            .elements()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let elements_slice = elements_array.as_slice::<i32>();
 
         let list0_offset = result_listview.offset_at(0);
@@ -1084,6 +1127,7 @@ mod test {
 
     #[test]
     fn test_sparse_list_null_fill_sliced_sparse_values() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create ListViewArray with 8 elements forming 8 single-element lists
         let elements = buffer![1i32, 2, 1, 2, 1, 2, 1, 2].into_array();
         let offsets = buffer![0u32, 1, 2, 3, 4, 5, 6, 7].into_array();
@@ -1104,11 +1148,12 @@ mod test {
             .into_array();
 
         let actual = sparse
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+            .execute::<Canonical>(&mut ctx)
             .vortex_expect("no fail")
             .into_array();
-        #[expect(deprecated)]
-        let result_listview = actual.to_listview();
+        let result_listview = actual
+            .execute::<ListViewArray>(&mut ctx)
+            .vortex_expect("no fail");
 
         // Check the structure
         assert_eq!(result_listview.len(), 6);
@@ -1122,8 +1167,11 @@ mod test {
         assert_eq!(result_listview.size_at(5), 1); // [2] - extra element beyond original slice
 
         // Verify actual values
-        #[expect(deprecated)]
-        let elements_array = result_listview.elements().to_primitive();
+        let elements_array = result_listview
+            .elements()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let elements_slice = elements_array.as_slice::<i32>();
 
         let list0_offset = result_listview.offset_at(0);
@@ -1135,6 +1183,7 @@ mod test {
 
     #[test]
     fn test_sparse_list_non_null_fill() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Create ListViewArray with 4 single-element lists
         let elements = buffer![1i32, 2, 1, 2].into_array();
         let offsets = buffer![0u32, 1, 2, 3].into_array();
@@ -1151,11 +1200,8 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
-            .into_array();
-        #[expect(deprecated)]
-        let result_listview = actual.to_listview();
+        let actual = sparse.execute::<Canonical>(&mut ctx)?.into_array();
+        let result_listview = actual.execute::<ListViewArray>(&mut ctx)?;
 
         // Check the structure
         assert_eq!(result_listview.len(), 6);
@@ -1169,8 +1215,10 @@ mod test {
         assert_eq!(result_listview.size_at(5), 1); // [2] from sparse
 
         // Verify actual values
-        #[expect(deprecated)]
-        let elements_array = result_listview.elements().to_primitive();
+        let elements_array = result_listview
+            .elements()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let elements_slice = elements_array.as_slice::<i32>();
 
         // List 0: [1]
@@ -1209,6 +1257,7 @@ mod test {
 
     #[test]
     fn test_sparse_binary_varbin_null_fill() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let strings = <VarBinArray as FromIterator<_>>::from_iter([
             Some(b"hello" as &[u8]),
             Some(b"goodbye"),
@@ -1228,8 +1277,12 @@ mod test {
         )
         .unwrap();
 
-        #[expect(deprecated)]
-        let actual = array.as_array().to_varbinview().into_array();
+        let actual = array
+            .as_array()
+            .clone()
+            .execute::<VarBinViewArray>(&mut ctx)
+            .unwrap()
+            .into_array();
         let expected = VarBinViewArray::from_iter_nullable_bin([
             Some(b"hello" as &[u8]),
             None,
@@ -1472,6 +1525,7 @@ mod test {
 
     #[test]
     fn test_sparse_list_grows_offset_type() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let elements = buffer![1i32, 2, 1, 2].into_array();
         let offsets = buffer![0u8, 1, 2, 3, 4].into_array();
         let lists = ListArray::try_new(elements, offsets, Validity::AllValid)
@@ -1484,9 +1538,7 @@ mod test {
             .unwrap()
             .into_array();
 
-        let actual = sparse
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
-            .into_array();
+        let actual = sparse.execute::<Canonical>(&mut ctx)?.into_array();
         let mut expected_elements = buffer_mut![1, 2, 1, 2];
         expected_elements.extend(buffer![42i32; 252]);
         let expected = ListArray::try_new(
@@ -1497,8 +1549,7 @@ mod test {
         .unwrap()
         .into_array();
 
-        #[expect(deprecated)]
-        let actual_listview = actual.to_listview();
+        let actual_listview = actual.clone().execute::<ListViewArray>(&mut ctx)?;
         assert_eq!(
             actual_listview.offsets().dtype(),
             &DType::Primitive(PType::U16, NonNullable)
@@ -1516,6 +1567,7 @@ mod test {
 
     #[test]
     fn test_sparse_listview_null_fill_with_gaps() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // This test specifically catches the bug where the old implementation
         // incorrectly tracked `last_valid_offset` as the START of the last list
         // instead of properly handling ListView's offset/size pairs.
@@ -1555,12 +1607,12 @@ mod test {
         .unwrap();
 
         // Convert to canonical form - this triggers the function we're testing
-        let canonical = sparse
-            .into_array()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
-            .into_array();
-        #[expect(deprecated)]
-        let result_listview = canonical.to_listview();
+        let canonical = sparse.into_array().execute::<Canonical>(&mut ctx)?.into_array();
+        let result_listview = canonical.execute::<ListViewArray>(&mut ctx)?;
+        let elements_primitive = result_listview
+            .elements()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
 
         // Verify the structure
         assert_eq!(result_listview.len(), 10);
@@ -1572,9 +1624,7 @@ mod test {
             if size == 0 {
                 vec![] // null/empty list
             } else {
-                #[expect(deprecated)]
-                let elements = result_listview.elements().to_primitive();
-                let slice = elements.as_slice::<i32>();
+                let slice = elements_primitive.as_slice::<i32>();
                 slice[offset..offset + size].to_vec()
             }
         };
@@ -1597,6 +1647,7 @@ mod test {
 
     #[test]
     fn test_sparse_listview_sliced_values_null_fill() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // This test uses sliced ListView values to ensure proper handling
         // of non-zero starting offsets in the source data.
 
@@ -1639,12 +1690,12 @@ mod test {
         let sparse =
             Sparse::try_new(indices, values, 5, Scalar::null(sliced.dtype().clone())).unwrap();
 
-        let canonical = sparse
-            .into_array()
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
-            .into_array();
-        #[expect(deprecated)]
-        let result_listview = canonical.to_listview();
+        let canonical = sparse.into_array().execute::<Canonical>(&mut ctx)?.into_array();
+        let result_listview = canonical.execute::<ListViewArray>(&mut ctx)?;
+        let elements_primitive = result_listview
+            .elements()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?;
 
         assert_eq!(result_listview.len(), 5);
 
@@ -1655,9 +1706,7 @@ mod test {
             if size == 0 {
                 vec![] // null/empty list
             } else {
-                #[expect(deprecated)]
-                let elements = result_listview.elements().to_primitive();
-                let slice = elements.as_slice::<i32>();
+                let slice = elements_primitive.as_slice::<i32>();
                 slice[offset..offset + size].to_vec()
             }
         };

--- a/encodings/sparse/src/canonical.rs
+++ b/encodings/sparse/src/canonical.rs
@@ -169,6 +169,7 @@ fn execute_sparse_lists(
     }))
 }
 
+#[expect(clippy::too_many_arguments)]
 fn execute_sparse_lists_inner<I: IntegerPType, O: IntegerPType>(
     patch_indices: &[I],
     patch_values: ListViewArray,
@@ -302,11 +303,7 @@ fn execute_sparse_fixed_size_list_inner<I: IntegerPType>(
                 .vortex_expect("fixed_size_list_elements_at");
             for i in 0..list_size as usize {
                 builder
-                    .append_scalar(
-                        &patch_list
-                            .execute_scalar(i, ctx)
-                            .vortex_expect("scalar_at"),
-                    )
+                    .append_scalar(&patch_list.execute_scalar(i, ctx).vortex_expect("scalar_at"))
                     .vortex_expect("element dtype must match");
             }
         } else {
@@ -1607,7 +1604,10 @@ mod test {
         .unwrap();
 
         // Convert to canonical form - this triggers the function we're testing
-        let canonical = sparse.into_array().execute::<Canonical>(&mut ctx)?.into_array();
+        let canonical = sparse
+            .into_array()
+            .execute::<Canonical>(&mut ctx)?
+            .into_array();
         let result_listview = canonical.execute::<ListViewArray>(&mut ctx)?;
         let elements_primitive = result_listview
             .elements()
@@ -1690,7 +1690,10 @@ mod test {
         let sparse =
             Sparse::try_new(indices, values, 5, Scalar::null(sliced.dtype().clone())).unwrap();
 
-        let canonical = sparse.into_array().execute::<Canonical>(&mut ctx)?.into_array();
+        let canonical = sparse
+            .into_array()
+            .execute::<Canonical>(&mut ctx)?
+            .into_array();
         let result_listview = canonical.execute::<ListViewArray>(&mut ctx)?;
         let elements_primitive = result_listview
             .elements()

--- a/encodings/sparse/src/compute/cast.rs
+++ b/encodings/sparse/src/compute/cast.rs
@@ -36,8 +36,8 @@ impl CastReduce for Sparse {
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::builtins::ArrayBuiltins;
@@ -53,6 +53,7 @@ mod tests {
 
     #[test]
     fn test_cast_sparse_i32_to_i64() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let sparse = Sparse::try_new(
             buffer![2u64, 5, 8].into_array(),
             buffer![100i32, 200, 300].into_array(),
@@ -71,8 +72,7 @@ mod tests {
         );
 
         let expected = PrimitiveArray::from_iter([0i64, 0, 100, 0, 0, 200, 0, 0, 300, 0]);
-        #[expect(deprecated)]
-        let casted_primitive = casted.to_primitive();
+        let casted_primitive = casted.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(casted_primitive, expected);
     }
 
@@ -127,6 +127,7 @@ mod tests {
 
     #[test]
     fn test_cast_sparse_null_fill_all_patched_to_non_nullable() -> vortex_error::VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Regression test for https://github.com/vortex-data/vortex/issues/6932
         //
         // When all positions are patched the null fill is unused, so a cast to
@@ -149,8 +150,7 @@ mod tests {
         );
 
         let expected = PrimitiveArray::from_iter([10u64, 20, 30, 40, 50]);
-        #[expect(deprecated)]
-        let casted_primitive = casted.to_primitive();
+        let casted_primitive = casted.execute::<PrimitiveArray>(&mut ctx)?;
         assert_arrays_eq!(casted_primitive, expected);
         Ok(())
     }

--- a/encodings/sparse/src/lib.rs
+++ b/encodings/sparse/src/lib.rs
@@ -20,12 +20,10 @@ use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::Precision;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::bool::BoolArrayExt;
 use vortex_array::buffer::BufferHandle;
 use vortex_array::builtins::ArrayBuiltins;
@@ -270,8 +268,12 @@ impl Sparse {
     }
 
     /// Encode the given array as a [`SparseArray`].
-    pub fn encode(array: &ArrayRef, fill_value: Option<Scalar>) -> VortexResult<ArrayRef> {
-        SparseData::encode(array, fill_value)
+    pub fn encode(
+        array: &ArrayRef,
+        fill_value: Option<Scalar>,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
+        SparseData::encode(array, fill_value, ctx)
     }
 }
 
@@ -396,7 +398,11 @@ impl SparseData {
     /// Encode given array as a SparseArray.
     ///
     /// Optionally provided fill value will be respected if the array is less than 90% null.
-    pub fn encode(array: &ArrayRef, fill_value: Option<Scalar>) -> VortexResult<ArrayRef> {
+    pub fn encode(
+        array: &ArrayRef,
+        fill_value: Option<Scalar>,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<ArrayRef> {
         if let Some(fill_value) = fill_value.as_ref()
             && !array.dtype().eq_ignore_nullability(fill_value.dtype())
         {
@@ -406,9 +412,7 @@ impl SparseData {
                 fill_value.dtype()
             )
         }
-        let mask = array
-            .validity()?
-            .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())?;
+        let mask = array.validity()?.to_mask(array.len(), ctx)?;
 
         if mask.all_false() {
             // Array is constant NULL
@@ -417,10 +421,9 @@ impl SparseData {
             );
         } else if mask.false_count() as f64 > (0.9 * mask.len() as f64) {
             // Array is dominated by NULL but has non-NULL values
-            // TODO(joe): use exe ctx?
             let non_null_values = array
                 .filter(mask.clone())?
-                .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+                .execute::<Canonical>(ctx)?
                 .into_array();
             let non_null_indices = match mask.indices() {
                 AllOr::All => {
@@ -454,8 +457,7 @@ impl SparseData {
             fill.cast(array.dtype())?
         } else {
             // TODO(robert): Support other dtypes, only thing missing is getting most common value out of the array
-            #[expect(deprecated)]
-            let primitive = array.to_primitive();
+            let primitive = array.clone().execute::<PrimitiveArray>(ctx)?;
             let (top_pvalue, _) = primitive
                 .top_value()?
                 .vortex_expect("Non empty or all null array");
@@ -464,16 +466,15 @@ impl SparseData {
         };
 
         let fill_array = ConstantArray::new(fill.clone(), array.len()).into_array();
-        #[expect(deprecated)]
         let non_top_bool = array
             .binary(fill_array.clone(), Operator::NotEq)?
             .fill_null(Scalar::bool(true, Nullability::NonNullable))?
-            .to_bool();
+            .execute::<BoolArray>(ctx)?;
         let non_top_mask = Mask::from_buffer(non_top_bool.to_bit_buffer());
 
         let non_top_values = array
             .filter(non_top_mask.clone())?
-            .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?
+            .execute::<Canonical>(ctx)?
             .into_array();
 
         let indices: Buffer<u64> = match non_top_mask {
@@ -746,26 +747,26 @@ mod test {
 
     #[test]
     fn encode_with_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let original = PrimitiveArray::new(
             buffer![0i32, 1, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4],
             Validity::from_iter(vec![
                 true, true, false, true, false, true, false, true, true, false, true, false,
             ]),
         );
-        let sparse = Sparse::encode(&original.clone().into_array(), None)
+        let sparse = Sparse::encode(&original.clone().into_array(), None, &mut ctx)
             .vortex_expect("Sparse::encode should succeed for test data");
         assert_eq!(
             sparse
                 .validity()
                 .unwrap()
-                .to_mask(sparse.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(sparse.len(), &mut ctx)
                 .unwrap(),
             Mask::from_iter(vec![
                 true, true, false, true, false, true, false, true, true, false, true, false,
             ])
         );
-        #[expect(deprecated)]
-        let sparse_primitive = sparse.to_primitive();
+        let sparse_primitive = sparse.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(sparse_primitive, original);
     }
 

--- a/encodings/sparse/src/ops.rs
+++ b/encodings/sparse/src/ops.rs
@@ -25,8 +25,8 @@ impl OperationsVTable<Sparse> for Sparse {
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_buffer::buffer;
@@ -35,6 +35,7 @@ mod tests {
 
     #[test]
     fn slice_partially_invalid() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = buffer![0u64].into_array();
         let indices = buffer![0u8].into_array();
 
@@ -43,8 +44,7 @@ mod tests {
         let mut expected = vec![999u64; 1000];
         expected[0] = 0;
 
-        #[expect(deprecated)]
-        let values = sliced.to_primitive();
+        let values = sliced.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(values, PrimitiveArray::from_iter(expected));
     }
 }

--- a/encodings/zigzag/src/array.rs
+++ b/encodings/zigzag/src/array.rs
@@ -271,9 +271,8 @@ impl ValidityChild<ZigZag> for ZigZag {
 mod test {
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::PrimitiveArray;
     use vortex_array::scalar::Scalar;
     use vortex_buffer::buffer;
 
@@ -282,12 +281,11 @@ mod test {
 
     #[test]
     fn test_compute_statistics() -> VortexResult<()> {
-        #[expect(deprecated)]
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = buffer![1i32, -5i32, 2, 3, 4, 5, 6, 7, 8, 9, 10]
             .into_array()
-            .to_primitive();
+            .execute::<PrimitiveArray>(&mut ctx)?;
         let zigzag = zigzag_encode(array.as_view())?;
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
 
         assert_eq!(
             zigzag.statistics().compute_max::<i32>(&mut ctx),

--- a/encodings/zigzag/src/compress.rs
+++ b/encodings/zigzag/src/compress.rs
@@ -78,8 +78,8 @@ where
 #[cfg(test)]
 mod test {
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::assert_arrays_eq;
 
     use super::*;
@@ -87,42 +87,42 @@ mod test {
 
     #[test]
     fn test_compress_i8() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i8..100).as_view())
             .unwrap()
             .into_array();
         assert!(compressed.is::<ZigZag>());
-        #[expect(deprecated)]
-        let decompressed = compressed.to_primitive();
+        let decompressed = compressed.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(decompressed, PrimitiveArray::from_iter(-100_i8..100));
     }
     #[test]
     fn test_compress_i16() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i16..100).as_view())
             .unwrap()
             .into_array();
         assert!(compressed.is::<ZigZag>());
-        #[expect(deprecated)]
-        let decompressed = compressed.to_primitive();
+        let decompressed = compressed.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(decompressed, PrimitiveArray::from_iter(-100_i16..100));
     }
     #[test]
     fn test_compress_i32() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i32..100).as_view())
             .unwrap()
             .into_array();
         assert!(compressed.is::<ZigZag>());
-        #[expect(deprecated)]
-        let decompressed = compressed.to_primitive();
+        let decompressed = compressed.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(decompressed, PrimitiveArray::from_iter(-100_i32..100));
     }
     #[test]
     fn test_compress_i64() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let compressed = zigzag_encode(PrimitiveArray::from_iter(-100_i64..100).as_view())
             .unwrap()
             .into_array();
         assert!(compressed.is::<ZigZag>());
-        #[expect(deprecated)]
-        let decompressed = compressed.to_primitive();
+        let decompressed = compressed.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(decompressed, PrimitiveArray::from_iter(-100_i64..100));
     }
 }

--- a/encodings/zigzag/src/compute/mod.rs
+++ b/encodings/zigzag/src/compute/mod.rs
@@ -74,8 +74,6 @@ mod tests {
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
@@ -189,8 +187,8 @@ mod tests {
     fn test_take_zigzag_conformance(#[case] array: ArrayRef) -> VortexResult<()> {
         use vortex_array::compute::conformance::take::test_take_conformance;
 
-        #[expect(deprecated)]
-        let array_primitive = array.to_primitive();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array_primitive = array.execute::<PrimitiveArray>(&mut ctx)?;
         let zigzag = zigzag_encode(array_primitive.as_view())?;
         test_take_conformance(&zigzag.into_array());
         Ok(())

--- a/encodings/zstd/benches/listview_rebuild.rs
+++ b/encodings/zstd/benches/listview_rebuild.rs
@@ -5,6 +5,8 @@
 
 use divan::Bencher;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ListViewArray;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::listview::ListViewRebuildMode;
@@ -21,7 +23,7 @@ fn rebuild_naive(bencher: Bencher) {
     let validity = dudes.validity().unwrap();
     let dudes = Zstd::try_new(
         dtype,
-        ZstdData::from_array(dudes, 9, 1024).unwrap(),
+        ZstdData::from_array(dudes, 9, 1024, &mut LEGACY_SESSION.create_execution_ctx()).unwrap(),
         validity,
     )
     .unwrap()

--- a/encodings/zstd/public-api.lock
+++ b/encodings/zstd/public-api.lock
@@ -6,11 +6,11 @@ impl vortex_zstd::Zstd
 
 pub fn vortex_zstd::Zstd::decompress(array: &vortex_zstd::ZstdArray, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
-pub fn vortex_zstd::Zstd::from_primitive(parray: &vortex_array::arrays::primitive::vtable::PrimitiveArray, level: i32, values_per_frame: usize) -> vortex_error::VortexResult<vortex_zstd::ZstdArray>
+pub fn vortex_zstd::Zstd::from_primitive(parray: &vortex_array::arrays::primitive::vtable::PrimitiveArray, level: i32, values_per_frame: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_zstd::ZstdArray>
 
-pub fn vortex_zstd::Zstd::from_var_bin_view(vbv: &vortex_array::arrays::varbinview::vtable::VarBinViewArray, level: i32, values_per_frame: usize) -> vortex_error::VortexResult<vortex_zstd::ZstdArray>
+pub fn vortex_zstd::Zstd::from_var_bin_view(vbv: &vortex_array::arrays::varbinview::vtable::VarBinViewArray, level: i32, values_per_frame: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_zstd::ZstdArray>
 
-pub fn vortex_zstd::Zstd::from_var_bin_view_without_dict(vbv: &vortex_array::arrays::varbinview::vtable::VarBinViewArray, level: i32, values_per_frame: usize) -> vortex_error::VortexResult<vortex_zstd::ZstdArray>
+pub fn vortex_zstd::Zstd::from_var_bin_view_without_dict(vbv: &vortex_array::arrays::varbinview::vtable::VarBinViewArray, level: i32, values_per_frame: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_zstd::ZstdArray>
 
 pub fn vortex_zstd::Zstd::try_new(dtype: vortex_array::dtype::DType, data: vortex_zstd::ZstdData, validity: vortex_array::validity::Validity) -> vortex_error::VortexResult<vortex_zstd::ZstdArray>
 
@@ -100,15 +100,15 @@ impl vortex_zstd::ZstdData
 
 pub fn vortex_zstd::ZstdData::from_array(array: vortex_array::array::erased::ArrayRef, level: i32, values_per_frame: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_zstd::ZstdData::from_canonical(canonical: &vortex_array::canonical::Canonical, level: i32, values_per_frame: usize) -> vortex_error::VortexResult<core::option::Option<Self>>
+pub fn vortex_zstd::ZstdData::from_canonical(canonical: &vortex_array::canonical::Canonical, level: i32, values_per_frame: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<core::option::Option<Self>>
 
-pub fn vortex_zstd::ZstdData::from_primitive(parray: &vortex_array::arrays::primitive::vtable::PrimitiveArray, level: i32, values_per_frame: usize) -> vortex_error::VortexResult<Self>
+pub fn vortex_zstd::ZstdData::from_primitive(parray: &vortex_array::arrays::primitive::vtable::PrimitiveArray, level: i32, values_per_frame: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_zstd::ZstdData::from_primitive_without_dict(parray: &vortex_array::arrays::primitive::vtable::PrimitiveArray, level: i32, values_per_frame: usize) -> vortex_error::VortexResult<Self>
+pub fn vortex_zstd::ZstdData::from_primitive_without_dict(parray: &vortex_array::arrays::primitive::vtable::PrimitiveArray, level: i32, values_per_frame: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_zstd::ZstdData::from_var_bin_view(vbv: &vortex_array::arrays::varbinview::vtable::VarBinViewArray, level: i32, values_per_frame: usize) -> vortex_error::VortexResult<Self>
+pub fn vortex_zstd::ZstdData::from_var_bin_view(vbv: &vortex_array::arrays::varbinview::vtable::VarBinViewArray, level: i32, values_per_frame: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
-pub fn vortex_zstd::ZstdData::from_var_bin_view_without_dict(vbv: &vortex_array::arrays::varbinview::vtable::VarBinViewArray, level: i32, values_per_frame: usize) -> vortex_error::VortexResult<Self>
+pub fn vortex_zstd::ZstdData::from_var_bin_view_without_dict(vbv: &vortex_array::arrays::varbinview::vtable::VarBinViewArray, level: i32, values_per_frame: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_zstd::ZstdData::into_parts(self, validity: vortex_array::validity::Validity) -> vortex_zstd::ZstdDataParts
 

--- a/encodings/zstd/public-api.lock
+++ b/encodings/zstd/public-api.lock
@@ -98,7 +98,7 @@ pub struct vortex_zstd::ZstdData
 
 impl vortex_zstd::ZstdData
 
-pub fn vortex_zstd::ZstdData::from_array(array: vortex_array::array::erased::ArrayRef, level: i32, values_per_frame: usize) -> vortex_error::VortexResult<Self>
+pub fn vortex_zstd::ZstdData::from_array(array: vortex_array::array::erased::ArrayRef, level: i32, values_per_frame: usize, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_zstd::ZstdData::from_canonical(canonical: &vortex_array::canonical::Canonical, level: i32, values_per_frame: usize) -> vortex_error::VortexResult<core::option::Option<Self>>
 

--- a/encodings/zstd/src/array.rs
+++ b/encodings/zstd/src/array.rs
@@ -21,11 +21,7 @@ use vortex_array::Canonical;
 use vortex_array::ExecutionCtx;
 use vortex_array::ExecutionResult;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::Precision;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -270,11 +266,12 @@ impl Zstd {
         vbv: &VarBinViewArray,
         level: i32,
         values_per_frame: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ZstdArray> {
         let validity = vbv.validity()?;
         Self::try_new(
             vbv.dtype().clone(),
-            ZstdData::from_var_bin_view_without_dict(vbv, level, values_per_frame)?,
+            ZstdData::from_var_bin_view_without_dict(vbv, level, values_per_frame, ctx)?,
             validity,
         )
     }
@@ -284,11 +281,12 @@ impl Zstd {
         parray: &PrimitiveArray,
         level: i32,
         values_per_frame: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ZstdArray> {
         let validity = parray.validity()?;
         Self::try_new(
             parray.dtype().clone(),
-            ZstdData::from_primitive(parray, level, values_per_frame)?,
+            ZstdData::from_primitive(parray, level, values_per_frame, ctx)?,
             validity,
         )
     }
@@ -298,11 +296,12 @@ impl Zstd {
         vbv: &VarBinViewArray,
         level: i32,
         values_per_frame: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ZstdArray> {
         let validity = vbv.validity()?;
         Self::try_new(
             vbv.dtype().clone(),
-            ZstdData::from_var_bin_view(vbv, level, values_per_frame)?,
+            ZstdData::from_var_bin_view(vbv, level, values_per_frame, ctx)?,
             validity,
         )
     }
@@ -366,21 +365,23 @@ fn choose_max_dict_size(uncompressed_size: usize) -> usize {
     (uncompressed_size / 100).clamp(256, 100 * 1024)
 }
 
-fn collect_valid_primitive(parray: &PrimitiveArray) -> VortexResult<PrimitiveArray> {
-    let mask = parray.as_ref().validity()?.to_mask(
-        parray.as_ref().len(),
-        &mut LEGACY_SESSION.create_execution_ctx(),
-    )?;
-    #[expect(deprecated)]
-    let result = parray.filter(mask)?.to_primitive();
+fn collect_valid_primitive(
+    parray: &PrimitiveArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<PrimitiveArray> {
+    let mask = parray
+        .as_ref()
+        .validity()?
+        .to_mask(parray.as_ref().len(), ctx)?;
+    let result = parray.filter(mask)?.execute::<PrimitiveArray>(ctx)?;
     Ok(result)
 }
 
-fn collect_valid_vbv(vbv: &VarBinViewArray) -> VortexResult<(ByteBuffer, Vec<usize>)> {
-    let mask = vbv.as_ref().validity()?.to_mask(
-        vbv.as_ref().len(),
-        &mut LEGACY_SESSION.create_execution_ctx(),
-    )?;
+fn collect_valid_vbv(
+    vbv: &VarBinViewArray,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<(ByteBuffer, Vec<usize>)> {
+    let mask = vbv.as_ref().validity()?.to_mask(vbv.as_ref().len(), ctx)?;
     let buffer_and_value_byte_indices = match mask.bit_buffer() {
         AllOr::None => (Buffer::empty(), Vec::new()),
         _ => {
@@ -625,8 +626,9 @@ impl ZstdData {
         parray: &PrimitiveArray,
         level: i32,
         values_per_frame: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
-        Self::from_primitive_impl(parray, level, values_per_frame, true)
+        Self::from_primitive_impl(parray, level, values_per_frame, true, ctx)
     }
 
     /// Creates a ZstdArray from a primitive array without using a dictionary.
@@ -646,8 +648,9 @@ impl ZstdData {
         parray: &PrimitiveArray,
         level: i32,
         values_per_frame: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
-        Self::from_primitive_impl(parray, level, values_per_frame, false)
+        Self::from_primitive_impl(parray, level, values_per_frame, false, ctx)
     }
 
     fn from_primitive_impl(
@@ -655,11 +658,12 @@ impl ZstdData {
         level: i32,
         values_per_frame: usize,
         use_dictionary: bool,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
         let byte_width = parray.ptype().byte_width();
 
         // We compress only the valid elements.
-        let values = collect_valid_primitive(parray)?;
+        let values = collect_valid_primitive(parray, ctx)?;
         let n_values = values.len();
         let values_per_frame = if values_per_frame > 0 {
             values_per_frame
@@ -709,8 +713,9 @@ impl ZstdData {
         vbv: &VarBinViewArray,
         level: i32,
         values_per_frame: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
-        Self::from_var_bin_view_impl(vbv, level, values_per_frame, true)
+        Self::from_var_bin_view_impl(vbv, level, values_per_frame, true, ctx)
     }
 
     /// Creates a ZstdArray from a VarBinView array without using a dictionary.
@@ -730,8 +735,9 @@ impl ZstdData {
         vbv: &VarBinViewArray,
         level: i32,
         values_per_frame: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
-        Self::from_var_bin_view_impl(vbv, level, values_per_frame, false)
+        Self::from_var_bin_view_impl(vbv, level, values_per_frame, false, ctx)
     }
 
     fn from_var_bin_view_impl(
@@ -739,6 +745,7 @@ impl ZstdData {
         level: i32,
         values_per_frame: usize,
         use_dictionary: bool,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
         // Approach for strings: we prefix each string with its length as a u32.
         // This is the same as what Parquet does. In some cases it may be better
@@ -746,7 +753,7 @@ impl ZstdData {
         // this approach is simpler and can be best in cases when there is
         // mutual information between strings and their lengths.
         // We compress only the valid elements.
-        let (value_bytes, value_byte_indices) = collect_valid_vbv(vbv)?;
+        let (value_bytes, value_byte_indices) = collect_valid_vbv(vbv, ctx)?;
         let n_values = value_byte_indices.len();
         let values_per_frame = if values_per_frame > 0 {
             values_per_frame
@@ -785,26 +792,33 @@ impl ZstdData {
         canonical: &Canonical,
         level: i32,
         values_per_frame: usize,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Option<Self>> {
         match canonical {
             Canonical::Primitive(parray) => Ok(Some(ZstdData::from_primitive(
                 parray,
                 level,
                 values_per_frame,
+                ctx,
             )?)),
             Canonical::VarBinView(vbv) => Ok(Some(ZstdData::from_var_bin_view(
                 vbv,
                 level,
                 values_per_frame,
+                ctx,
             )?)),
             _ => Ok(None),
         }
     }
 
-    pub fn from_array(array: ArrayRef, level: i32, values_per_frame: usize) -> VortexResult<Self> {
-        #[expect(deprecated)]
-        let canonical = array.to_canonical()?;
-        Self::from_canonical(&canonical, level, values_per_frame)?
+    pub fn from_array(
+        array: ArrayRef,
+        level: i32,
+        values_per_frame: usize,
+        ctx: &mut ExecutionCtx,
+    ) -> VortexResult<Self> {
+        let canonical = array.execute::<Canonical>(ctx)?;
+        Self::from_canonical(&canonical, level, values_per_frame, ctx)?
             .ok_or_else(|| vortex_err!("Zstd can only encode Primitive and VarBinView arrays"))
     }
 

--- a/encodings/zstd/src/compute/cast.rs
+++ b/encodings/zstd/src/compute/cast.rs
@@ -201,9 +201,8 @@ mod tests {
         Validity::NonNullable,
     ))]
     fn test_cast_zstd_conformance(#[case] values: PrimitiveArray) {
-        let zstd =
-            Zstd::from_primitive(&values, 0, 0, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap();
+        let zstd = Zstd::from_primitive(&values, 0, 0, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap();
         test_cast_conformance(&zstd.into_array());
     }
 }

--- a/encodings/zstd/src/compute/cast.rs
+++ b/encodings/zstd/src/compute/cast.rs
@@ -88,8 +88,8 @@ impl CastReduce for Zstd {
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::assert_arrays_eq;
     use vortex_array::builtins::ArrayBuiltins;
@@ -104,8 +104,9 @@ mod tests {
 
     #[test]
     fn test_cast_zstd_i32_to_i64() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]);
-        let zstd = Zstd::from_primitive(&values, 0, 0).unwrap();
+        let zstd = Zstd::from_primitive(&values, 0, 0, &mut ctx).unwrap();
 
         let casted = zstd
             .into_array()
@@ -116,15 +117,15 @@ mod tests {
             &DType::Primitive(PType::I64, Nullability::NonNullable)
         );
 
-        #[expect(deprecated)]
-        let decoded = casted.to_primitive();
+        let decoded = casted.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(decoded, PrimitiveArray::from_iter([1i64, 2, 3, 4, 5]));
     }
 
     #[test]
     fn test_cast_zstd_nullability_change() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = PrimitiveArray::from_iter([10u32, 20, 30, 40]);
-        let zstd = Zstd::from_primitive(&values, 0, 0).unwrap();
+        let zstd = Zstd::from_primitive(&values, 0, 0, &mut ctx).unwrap();
 
         let casted = zstd
             .into_array()
@@ -138,11 +139,12 @@ mod tests {
 
     #[test]
     fn test_cast_sliced_zstd_nullable_to_nonnullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = PrimitiveArray::new(
             buffer![10u32, 20, 30, 40, 50, 60],
             Validity::from_iter([true, true, true, true, true, true]),
         );
-        let zstd = Zstd::from_primitive(&values, 0, 128).unwrap();
+        let zstd = Zstd::from_primitive(&values, 0, 128, &mut ctx).unwrap();
         let sliced = zstd.slice(1..5).unwrap();
         let casted = sliced
             .cast(DType::Primitive(PType::U32, Nullability::NonNullable))
@@ -152,13 +154,13 @@ mod tests {
             &DType::Primitive(PType::U32, Nullability::NonNullable)
         );
         // Verify the values are correct
-        #[expect(deprecated)]
-        let decoded = casted.to_primitive();
+        let decoded = casted.execute::<PrimitiveArray>(&mut ctx).unwrap();
         assert_arrays_eq!(decoded, PrimitiveArray::from_iter([20u32, 30, 40, 50]));
     }
 
     #[test]
     fn test_cast_sliced_zstd_part_valid_to_nonnullable() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = PrimitiveArray::from_option_iter([
             None,
             Some(20u32),
@@ -167,7 +169,7 @@ mod tests {
             Some(50),
             Some(60),
         ]);
-        let zstd = Zstd::from_primitive(&values, 0, 128).unwrap();
+        let zstd = Zstd::from_primitive(&values, 0, 128, &mut ctx).unwrap();
         let sliced = zstd.slice(1..5).unwrap();
         let casted = sliced
             .cast(DType::Primitive(PType::U32, Nullability::NonNullable))
@@ -176,8 +178,7 @@ mod tests {
             casted.dtype(),
             &DType::Primitive(PType::U32, Nullability::NonNullable)
         );
-        #[expect(deprecated)]
-        let decoded = casted.to_primitive();
+        let decoded = casted.execute::<PrimitiveArray>(&mut ctx).unwrap();
         let expected = PrimitiveArray::from_iter([20u32, 30, 40, 50]);
         assert_arrays_eq!(decoded, expected);
     }
@@ -200,7 +201,9 @@ mod tests {
         Validity::NonNullable,
     ))]
     fn test_cast_zstd_conformance(#[case] values: PrimitiveArray) {
-        let zstd = Zstd::from_primitive(&values, 0, 0).unwrap();
+        let zstd =
+            Zstd::from_primitive(&values, 0, 0, &mut LEGACY_SESSION.create_execution_ctx())
+                .unwrap();
         test_cast_conformance(&zstd.into_array());
     }
 }

--- a/encodings/zstd/src/compute/mod.rs
+++ b/encodings/zstd/src/compute/mod.rs
@@ -7,6 +7,8 @@ mod cast;
 mod tests {
     use rstest::rstest;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::compute::conformance::consistency::test_array_consistency;
     use vortex_buffer::buffer;
@@ -16,23 +18,23 @@ mod tests {
 
     fn zstd_i32() -> ZstdArray {
         let values = PrimitiveArray::from_iter([100i32, 200, 300, 400, 500]);
-        Zstd::from_primitive(&values, 0, 0).unwrap()
+        Zstd::from_primitive(&values, 0, 0, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     fn zstd_f64() -> ZstdArray {
         let values = PrimitiveArray::from_iter([1.1f64, 2.2, 3.3, 4.4, 5.5]);
-        Zstd::from_primitive(&values, 0, 0).unwrap()
+        Zstd::from_primitive(&values, 0, 0, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     fn zstd_u32() -> ZstdArray {
         let values = PrimitiveArray::from_iter([10u32, 20, 30, 40, 50]);
-        Zstd::from_primitive(&values, 0, 0).unwrap()
+        Zstd::from_primitive(&values, 0, 0, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     fn zstd_nullable_i64() -> ZstdArray {
         let values =
             PrimitiveArray::from_option_iter([Some(1000i64), None, Some(3000), Some(4000), None]);
-        Zstd::from_primitive(&values, 0, 0).unwrap()
+        Zstd::from_primitive(&values, 0, 0, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     fn zstd_single() -> ZstdArray {
@@ -40,7 +42,7 @@ mod tests {
             buffer![42i64],
             vortex_array::validity::Validity::NonNullable,
         );
-        Zstd::from_primitive(&values, 0, 0).unwrap()
+        Zstd::from_primitive(&values, 0, 0, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     fn zstd_large() -> ZstdArray {
@@ -48,7 +50,7 @@ mod tests {
             buffer![0u32..1000],
             vortex_array::validity::Validity::NonNullable,
         );
-        Zstd::from_primitive(&values, 3, 0).unwrap()
+        Zstd::from_primitive(&values, 3, 0, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     fn zstd_all_same() -> ZstdArray {
@@ -56,12 +58,12 @@ mod tests {
             buffer![42i32; 100],
             vortex_array::validity::Validity::NonNullable,
         );
-        Zstd::from_primitive(&values, 0, 0).unwrap()
+        Zstd::from_primitive(&values, 0, 0, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     fn zstd_negative() -> ZstdArray {
         let values = PrimitiveArray::from_iter([-100i32, -50, 0, 50, 100]);
-        Zstd::from_primitive(&values, 0, 0).unwrap()
+        Zstd::from_primitive(&values, 0, 0, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
     }
 
     #[rstest]

--- a/encodings/zstd/src/test.rs
+++ b/encodings/zstd/src/test.rs
@@ -4,8 +4,6 @@
 
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::PrimitiveArray;
@@ -23,16 +21,16 @@ use crate::Zstd;
 
 #[test]
 fn test_zstd_compress_decompress() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data: Vec<i32> = (0..200).collect();
     let array = PrimitiveArray::from_iter(data.clone());
 
-    let compressed = Zstd::from_primitive(&array, 3, 0).unwrap();
+    let compressed = Zstd::from_primitive(&array, 3, 0, &mut ctx).unwrap();
     // this data should be compressible
     assert!(compressed.frames.len() < array.into_array().nbytes() as usize);
     assert!(compressed.dictionary.is_none());
 
     // check full decompression works
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let decompressed = Zstd::decompress(&compressed, &mut ctx).unwrap();
     assert_arrays_eq!(decompressed, PrimitiveArray::from_iter(data));
 
@@ -49,19 +47,21 @@ fn test_zstd_compress_decompress() {
 
 #[test]
 fn test_zstd_empty() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data: Vec<i32> = vec![];
     let array = PrimitiveArray::new(
         data.iter().cloned().collect::<Buffer<_>>(),
         Validity::NonNullable,
     );
 
-    let compressed = Zstd::from_primitive(&array, 3, 100).unwrap();
+    let compressed = Zstd::from_primitive(&array, 3, 100, &mut ctx).unwrap();
 
     assert_arrays_eq!(compressed, PrimitiveArray::from_iter(data));
 }
 
 #[test]
 fn test_zstd_with_validity_and_multi_frame() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data: Vec<i32> = (0..200).collect();
     let mut validity: Vec<bool> = vec![false; 200];
     validity[3] = true;
@@ -71,18 +71,17 @@ fn test_zstd_with_validity_and_multi_frame() {
         Validity::Array(BoolArray::from_iter(validity).into_array()),
     );
 
-    let compressed = Zstd::from_primitive(&array, 0, 30).unwrap();
+    let compressed = Zstd::from_primitive(&array, 0, 30, &mut ctx).unwrap();
     assert!(compressed.dictionary.is_none());
     assert_nth_scalar!(compressed, 0, None::<i32>);
     assert_nth_scalar!(compressed, 3, 3);
     assert_nth_scalar!(compressed, 10, None::<i32>);
     assert_nth_scalar!(compressed, 177, 177);
 
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    #[expect(deprecated)]
     let decompressed = Zstd::decompress(&compressed, &mut ctx)
         .unwrap()
-        .to_primitive();
+        .execute::<PrimitiveArray>(&mut ctx)
+        .unwrap();
     let decompressed_values = decompressed.as_slice::<i32>();
     assert_eq!(decompressed_values[3], 3);
     assert_eq!(decompressed_values[177], 177);
@@ -96,15 +95,9 @@ fn test_zstd_with_validity_and_multi_frame() {
 
     // check slicing works
     let slice = compressed.slice(176..179).unwrap();
-    #[expect(deprecated)]
-    let primitive = slice.to_primitive();
+    let primitive = slice.execute::<PrimitiveArray>(&mut ctx).unwrap();
     assert_eq!(
-        i32::try_from(
-            &primitive
-                .execute_scalar(1, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        )
-        .unwrap(),
+        i32::try_from(&primitive.execute_scalar(1, &mut ctx).unwrap()).unwrap(),
         177
     );
     assert!(
@@ -121,39 +114,39 @@ fn test_zstd_with_validity_and_multi_frame() {
 
 #[test]
 fn test_zstd_with_dict() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data: Vec<i32> = (0..200).collect();
     let array = PrimitiveArray::new(
         data.iter().cloned().collect::<Buffer<_>>(),
         Validity::NonNullable,
     );
 
-    let compressed = Zstd::from_primitive(&array, 0, 16).unwrap();
+    let compressed = Zstd::from_primitive(&array, 0, 16, &mut ctx).unwrap();
     assert!(compressed.dictionary.is_some());
     assert_nth_scalar!(compressed, 0, 0);
     assert_nth_scalar!(compressed, 199, 199);
 
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    #[expect(deprecated)]
     let decompressed = Zstd::decompress(&compressed, &mut ctx)
         .unwrap()
-        .to_primitive();
+        .execute::<PrimitiveArray>(&mut ctx)
+        .unwrap();
     assert_arrays_eq!(decompressed, PrimitiveArray::from_iter(data));
 
     // check slicing works
     let slice = compressed.slice(176..179).unwrap();
-    #[expect(deprecated)]
-    let primitive = slice.to_primitive();
+    let primitive = slice.execute::<PrimitiveArray>(&mut ctx).unwrap();
     assert_arrays_eq!(primitive, PrimitiveArray::from_iter([176, 177, 178]));
 }
 
 #[test]
 fn test_validity_vtable() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let mask_bools = vec![false, true, true, false, true];
     let array = PrimitiveArray::new(
         (0..5).collect::<Buffer<_>>(),
         Validity::Array(BoolArray::from_iter(mask_bools.clone()).into_array()),
     );
-    let compressed = Zstd::from_primitive(&array, 3, 0).unwrap();
+    let compressed = Zstd::from_primitive(&array, 3, 0, &mut ctx).unwrap();
     let arr = compressed.as_array();
     assert_eq!(
         arr.validity()
@@ -175,6 +168,7 @@ fn test_validity_vtable() {
 
 #[test]
 fn test_zstd_var_bin_view() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data: [Option<&'static [u8]>; 5] = [
         Some(b"foo"),
         Some(b"bar"),
@@ -184,7 +178,7 @@ fn test_zstd_var_bin_view() {
     ];
     let array = VarBinViewArray::from_iter(data, DType::Utf8(Nullability::Nullable));
 
-    let compressed = Zstd::from_var_bin_view(&array, 0, 3).unwrap();
+    let compressed = Zstd::from_var_bin_view(&array, 0, 3, &mut ctx).unwrap();
     assert!(compressed.dictionary.is_none());
     assert_nth_scalar!(compressed, 0, "foo");
     assert_nth_scalar!(compressed, 1, "bar");
@@ -200,6 +194,7 @@ fn test_zstd_var_bin_view() {
 
 #[test]
 fn test_zstd_decompress_var_bin_view() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data: [Option<&'static [u8]>; 5] = [
         Some(b"foo"),
         Some(b"bar"),
@@ -209,7 +204,7 @@ fn test_zstd_decompress_var_bin_view() {
     ];
     let array = VarBinViewArray::from_iter(data, DType::Utf8(Nullability::Nullable));
 
-    let compressed = Zstd::from_var_bin_view(&array, 0, 3).unwrap();
+    let compressed = Zstd::from_var_bin_view(&array, 0, 3, &mut ctx).unwrap();
     assert!(compressed.dictionary.is_none());
     assert_nth_scalar!(compressed, 0, "foo");
     assert_nth_scalar!(compressed, 1, "bar");
@@ -217,11 +212,10 @@ fn test_zstd_decompress_var_bin_view() {
     assert_nth_scalar!(compressed, 3, "Lorem ipsum dolor sit amet");
     assert_nth_scalar!(compressed, 4, "baz");
 
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    #[expect(deprecated)]
     let decompressed = Zstd::decompress(&compressed, &mut ctx)
         .unwrap()
-        .to_varbinview();
+        .execute::<VarBinViewArray>(&mut ctx)
+        .unwrap();
     assert_nth_scalar!(decompressed, 0, "foo");
     assert_nth_scalar!(decompressed, 1, "bar");
     assert_nth_scalar!(decompressed, 2, None::<String>);
@@ -231,8 +225,10 @@ fn test_zstd_decompress_var_bin_view() {
 
 #[test]
 fn test_sliced_array_children() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data: Vec<Option<i32>> = (0..10).map(|v| (v != 5).then_some(v)).collect();
-    let compressed = Zstd::from_primitive(&PrimitiveArray::from_option_iter(data), 0, 100).unwrap();
+    let compressed =
+        Zstd::from_primitive(&PrimitiveArray::from_option_iter(data), 0, 100, &mut ctx).unwrap();
     let sliced = compressed.slice(0..4).unwrap();
     sliced.children();
 }
@@ -241,11 +237,12 @@ fn test_sliced_array_children() {
 /// the buffer alignment when compressing primitive arrays.
 #[test]
 fn test_zstd_frame_start_buffer_alignment() {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let data = vec![0u8; 2];
     let aligned_buffer = Buffer::copy_from_aligned(&data, Alignment::new(8));
     // u8 array now has a 8-byte alignment.
     let array = PrimitiveArray::new(aligned_buffer, Validity::NonNullable);
-    let compressed = Zstd::from_primitive(&array, 0, 1);
+    let compressed = Zstd::from_primitive(&array, 0, 1, &mut ctx);
 
     assert!(compressed.is_ok());
 }

--- a/fuzz/fuzz_targets/file_io.rs
+++ b/fuzz/fuzz_targets/file_io.rs
@@ -8,9 +8,8 @@ use libfuzzer_sys::Corpus;
 use libfuzzer_sys::fuzz_target;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::arrays::bool::BoolArrayExt;
 use vortex_array::builtins::ArrayBuiltins;
@@ -46,14 +45,16 @@ fuzz_target!(|fuzz: FuzzFileAction| -> Corpus {
         return Corpus::Reject;
     }
 
+    let mut ctx = SESSION.create_execution_ctx();
     let expected_array = {
         let bool_mask = array_data
             .clone()
             .apply(&filter_expr.clone().unwrap_or_else(|| lit(true)))
             .vortex_expect("filter expression evaluation should succeed in fuzz test");
-        #[expect(deprecated)]
-        let bool_mask_bool = bool_mask.to_bool();
-        let mask = bool_mask_bool.to_mask_fill_null_false(&mut SESSION.create_execution_ctx());
+        let bool_mask_bool = bool_mask
+            .execute::<BoolArray>(&mut ctx)
+            .vortex_expect("execute bool");
+        let mask = bool_mask_bool.to_mask_fill_null_false(&mut ctx);
         let filtered = array_data
             .filter(mask)
             .vortex_expect("filter operation should succeed in fuzz test");
@@ -111,13 +112,12 @@ fuzz_target!(|fuzz: FuzzFileAction| -> Corpus {
         output_array.dtype()
     );
 
-    #[expect(deprecated)]
     let bool_result = expected_array
         .binary(output_array.clone(), Operator::Eq)
         .vortex_expect("compare operation should succeed in fuzz test")
-        .to_bool();
+        .execute::<BoolArray>(&mut ctx)
+        .vortex_expect("execute bool");
     let true_count = bool_result.to_bit_buffer().true_count();
-    let mut ctx = SESSION.create_execution_ctx();
     if true_count != expected_array.len()
         && (bool_result
             .into_array()

--- a/fuzz/src/array/cast.rs
+++ b/fuzz/src/array/cast.rs
@@ -2,11 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability::Nullable;
@@ -16,7 +13,11 @@ use vortex_array::validity::Validity;
 use vortex_buffer::Buffer;
 use vortex_error::VortexResult;
 
-pub fn cast_canonical_array(array: &ArrayRef, target: &DType) -> VortexResult<Option<ArrayRef>> {
+pub fn cast_canonical_array(
+    array: &ArrayRef,
+    target: &DType,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Option<ArrayRef>> {
     // TODO(joe): support more casting options
     let is_int_to_int = target.is_int() && array.dtype().is_int();
     let is_float_to_float = target.is_float() && array.dtype().is_float();
@@ -36,18 +37,14 @@ pub fn cast_canonical_array(array: &ArrayRef, target: &DType) -> VortexResult<Op
                 match_each_integer_ptype!(target.as_ptype(), |Out| {
                     #[allow(clippy::cast_possible_truncation)]
                     {
-                        #[expect(deprecated)]
-                        let prim = array.to_primitive();
+                        let prim = array.clone().execute::<PrimitiveArray>(ctx)?;
                         PrimitiveArray::new(
                             prim.as_slice::<In>()
                                 .iter()
                                 .map(|v| *v as Out)
                                 .collect::<Buffer<Out>>(),
                             Validity::from_mask(
-                                array.validity()?.to_mask(
-                                    array.len(),
-                                    &mut LEGACY_SESSION.create_execution_ctx(),
-                                )?,
+                                array.validity()?.to_mask(array.len(), ctx)?,
                                 target.nullability(),
                             ),
                         )
@@ -69,8 +66,7 @@ pub fn cast_canonical_array(array: &ArrayRef, target: &DType) -> VortexResult<Op
 
         match (from_ptype, to_ptype) {
             (PType::F32, PType::F64) => {
-                #[expect(deprecated)]
-                let prim = array.to_primitive();
+                let prim = array.clone().execute::<PrimitiveArray>(ctx)?;
                 Ok(Some(
                     PrimitiveArray::new(
                         prim.as_slice::<f32>()
@@ -78,9 +74,7 @@ pub fn cast_canonical_array(array: &ArrayRef, target: &DType) -> VortexResult<Op
                             .map(|v| *v as f64)
                             .collect::<Buffer<f64>>(),
                         Validity::from_mask(
-                            array
-                                .validity()?
-                                .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())?,
+                            array.validity()?.to_mask(array.len(), ctx)?,
                             target.nullability(),
                         ),
                     )
@@ -88,8 +82,7 @@ pub fn cast_canonical_array(array: &ArrayRef, target: &DType) -> VortexResult<Op
                 ))
             }
             (PType::F64, PType::F32) => {
-                #[expect(deprecated)]
-                let prim = array.to_primitive();
+                let prim = array.clone().execute::<PrimitiveArray>(ctx)?;
                 #[expect(clippy::cast_possible_truncation)]
                 Ok(Some(
                     PrimitiveArray::new(
@@ -98,9 +91,7 @@ pub fn cast_canonical_array(array: &ArrayRef, target: &DType) -> VortexResult<Op
                             .map(|v| *v as f32)
                             .collect::<Buffer<f32>>(),
                         Validity::from_mask(
-                            array
-                                .validity()?
-                                .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())?,
+                            array.validity()?.to_mask(array.len(), ctx)?,
                             target.nullability(),
                         ),
                     )

--- a/fuzz/src/array/compare.rs
+++ b/fuzz/src/array/compare.rs
@@ -2,13 +2,13 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::BoolArray;
+use vortex_array::arrays::DecimalArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::bool::BoolArrayExt;
 use vortex_array::arrays::primitive::NativeValue;
 use vortex_array::dtype::DType;
@@ -27,6 +27,7 @@ pub fn compare_canonical_array(
     array: &ArrayRef,
     value: &Scalar,
     operator: CompareOperator,
+    ctx: &mut ExecutionCtx,
 ) -> ArrayRef {
     if value.is_null() {
         return BoolArray::new(BitBuffer::new_unset(array.len()), Validity::AllInvalid)
@@ -41,8 +42,10 @@ pub fn compare_canonical_array(
                 .as_bool()
                 .value()
                 .vortex_expect("nulls handled before");
-            #[expect(deprecated)]
-            let bool_array = array.to_bool();
+            let bool_array = array
+                .clone()
+                .execute::<BoolArray>(ctx)
+                .vortex_expect("to bool");
             compare_to(
                 bool_array
                     .to_bit_buffer()
@@ -51,7 +54,7 @@ pub fn compare_canonical_array(
                         array
                             .validity()
                             .vortex_expect("validity_mask")
-                            .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                            .to_mask(array.len(), ctx)
                             .vortex_expect("Failed to compute validity mask")
                             .to_bit_buffer()
                             .iter(),
@@ -64,8 +67,10 @@ pub fn compare_canonical_array(
         }
         DType::Primitive(p, _) => {
             let primitive = value.as_primitive();
-            #[expect(deprecated)]
-            let primitive_array = array.to_primitive();
+            let primitive_array = array
+                .clone()
+                .execute::<PrimitiveArray>(ctx)
+                .vortex_expect("to primitive");
             match_each_native_ptype!(p, |P| {
                 let pval = primitive
                     .typed_value::<P>()
@@ -79,7 +84,7 @@ pub fn compare_canonical_array(
                             array
                                 .validity()
                                 .vortex_expect("validity_mask")
-                                .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                                .to_mask(array.len(), ctx)
                                 .vortex_expect("Failed to compute validity mask")
                                 .to_bit_buffer()
                                 .iter(),
@@ -93,8 +98,10 @@ pub fn compare_canonical_array(
         }
         DType::Decimal(..) => {
             let decimal = value.as_decimal();
-            #[expect(deprecated)]
-            let decimal_array = array.to_decimal();
+            let decimal_array = array
+                .clone()
+                .execute::<DecimalArray>(ctx)
+                .vortex_expect("to decimal");
             match_each_decimal_value_type!(decimal_array.values_type(), |D| {
                 let dval = decimal
                     .decimal_value()
@@ -110,7 +117,7 @@ pub fn compare_canonical_array(
                             array
                                 .validity()
                                 .vortex_expect("validity_mask")
-                                .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                                .to_mask(array.len(), ctx)
                                 .vortex_expect("Failed to compute validity mask")
                                 .to_bit_buffer()
                                 .iter(),
@@ -123,8 +130,10 @@ pub fn compare_canonical_array(
             })
         }
         DType::Utf8(_) => {
-            #[expect(deprecated)]
-            let varbinview = array.to_varbinview();
+            let varbinview = array
+                .clone()
+                .execute::<VarBinViewArray>(ctx)
+                .vortex_expect("to varbinview");
             varbinview.with_iterator(|iter| {
                 let utf8_value = value.as_utf8();
                 compare_to(
@@ -136,8 +145,10 @@ pub fn compare_canonical_array(
             })
         }
         DType::Binary(_) => {
-            #[expect(deprecated)]
-            let varbinview = array.to_varbinview();
+            let varbinview = array
+                .clone()
+                .execute::<VarBinViewArray>(ctx)
+                .vortex_expect("to varbinview");
             varbinview.with_iterator(|iter| {
                 let binary_value = value.as_binary();
                 compare_to(
@@ -151,9 +162,8 @@ pub fn compare_canonical_array(
             })
         }
         DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {
-            let mut ctx = LEGACY_SESSION.create_execution_ctx();
             let scalar_vals: Vec<Scalar> = (0..array.len())
-                .map(|i| array.execute_scalar(i, &mut ctx).vortex_expect("scalar_at"))
+                .map(|i| array.execute_scalar(i, ctx).vortex_expect("scalar_at"))
                 .collect();
             BoolArray::from_iter(scalar_vals.iter().map(|v| {
                 scalar_cmp(v, value, operator)

--- a/fuzz/src/array/fill_null.rs
+++ b/fuzz/src/array/fill_null.rs
@@ -41,9 +41,7 @@ pub fn fill_null_canonical_array(
         Canonical::Primitive(array) => {
             fill_primitive_array(array, fill_value, result_nullability, ctx)
         }
-        Canonical::Decimal(array) => {
-            fill_decimal_array(array, fill_value, result_nullability, ctx)
-        }
+        Canonical::Decimal(array) => fill_decimal_array(array, fill_value, result_nullability, ctx),
         Canonical::VarBinView(array) => {
             fill_varbinview_array(array, fill_value, result_nullability, ctx)
         }

--- a/fuzz/src/array/fill_null.rs
+++ b/fuzz/src/array/fill_null.rs
@@ -5,11 +5,8 @@ use std::sync::Arc;
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::DecimalArray;
@@ -34,16 +31,21 @@ use vortex_error::VortexResult;
 pub fn fill_null_canonical_array(
     canonical: Canonical,
     fill_value: &Scalar,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let result_nullability = fill_value.dtype().nullability();
 
     Ok(match canonical {
         Canonical::Null(array) => ConstantArray::new(fill_value.clone(), array.len()).into_array(),
-        Canonical::Bool(array) => fill_bool_array(array, fill_value, result_nullability),
-        Canonical::Primitive(array) => fill_primitive_array(array, fill_value, result_nullability),
-        Canonical::Decimal(array) => fill_decimal_array(array, fill_value, result_nullability),
+        Canonical::Bool(array) => fill_bool_array(array, fill_value, result_nullability, ctx),
+        Canonical::Primitive(array) => {
+            fill_primitive_array(array, fill_value, result_nullability, ctx)
+        }
+        Canonical::Decimal(array) => {
+            fill_decimal_array(array, fill_value, result_nullability, ctx)
+        }
         Canonical::VarBinView(array) => {
-            fill_varbinview_array(array, fill_value, result_nullability)
+            fill_varbinview_array(array, fill_value, result_nullability, ctx)
         }
         Canonical::Struct(_)
         | Canonical::List(_)
@@ -57,6 +59,7 @@ fn fill_bool_array(
     array: BoolArray,
     fill_value: &Scalar,
     result_nullability: Nullability,
+    ctx: &mut ExecutionCtx,
 ) -> ArrayRef {
     let fill_bool = fill_value
         .as_bool()
@@ -72,8 +75,9 @@ fn fill_bool_array(
         }
         Validity::AllInvalid => ConstantArray::new(fill_value.clone(), array.len()).into_array(),
         Validity::Array(validity_array) => {
-            #[expect(deprecated)]
-            let validity_bool = validity_array.to_bool();
+            let validity_bool = validity_array
+                .execute::<BoolArray>(ctx)
+                .vortex_expect("validity to bool");
             let validity_bits = validity_bool.into_bit_buffer();
             let data_bits = array.into_bit_buffer();
 
@@ -103,6 +107,7 @@ fn fill_primitive_array(
     array: PrimitiveArray,
     fill_value: &Scalar,
     result_nullability: Nullability,
+    ctx: &mut ExecutionCtx,
 ) -> ArrayRef {
     match_each_native_ptype!(array.ptype(), |T| {
         let fill_val = T::try_from(fill_value)
@@ -119,8 +124,9 @@ fn fill_primitive_array(
                 ConstantArray::new(fill_value.clone(), array.len()).into_array()
             }
             Validity::Array(validity_array) => {
-                #[expect(deprecated)]
-                let validity_bool_array = validity_array.to_bool();
+                let validity_bool_array = validity_array
+                    .execute::<BoolArray>(ctx)
+                    .vortex_expect("validity to bool");
                 let validity_bits = validity_bool_array.to_bit_buffer();
                 let data_slice = array.as_slice::<T>();
 
@@ -144,6 +150,7 @@ fn fill_decimal_array(
     array: DecimalArray,
     fill_value: &Scalar,
     result_nullability: Nullability,
+    ctx: &mut ExecutionCtx,
 ) -> ArrayRef {
     let decimal_dtype = array.decimal_dtype();
     let decimal_scalar = fill_value.as_decimal();
@@ -166,8 +173,9 @@ fn fill_decimal_array(
                 ConstantArray::new(fill_value.clone(), array.len()).into_array()
             }
             Validity::Array(validity_array) => {
-                #[expect(deprecated)]
-                let validity_bool_array = validity_array.to_bool();
+                let validity_bool_array = validity_array
+                    .execute::<BoolArray>(ctx)
+                    .vortex_expect("validity to bool");
                 let validity_bits = validity_bool_array.to_bit_buffer();
                 let data_buffer = array.buffer::<D>();
 
@@ -192,6 +200,7 @@ fn fill_varbinview_array(
     array: VarBinViewArray,
     fill_value: &Scalar,
     result_nullability: Nullability,
+    ctx: &mut ExecutionCtx,
 ) -> ArrayRef {
     let array_ref = array.clone().into_array();
     match array
@@ -201,8 +210,9 @@ fn fill_varbinview_array(
         Validity::NonNullable | Validity::AllValid => array.into_array(),
         Validity::AllInvalid => ConstantArray::new(fill_value.clone(), array.len()).into_array(),
         Validity::Array(validity_array) => {
-            #[expect(deprecated)]
-            let validity_bool_array = validity_array.to_bool();
+            let validity_bool_array = validity_array
+                .execute::<BoolArray>(ctx)
+                .vortex_expect("validity to bool");
             let validity_bits = validity_bool_array.to_bit_buffer();
 
             match array.dtype() {
@@ -215,7 +225,7 @@ fn fill_varbinview_array(
                         .map(|i| {
                             if validity_bits.value(i) {
                                 array_ref
-                                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                                    .execute_scalar(i, ctx)
                                     .vortex_expect("scalar_at")
                                     .as_utf8()
                                     .value()
@@ -229,8 +239,10 @@ fn fill_varbinview_array(
                     let string_refs: Vec<&str> = strings.iter().map(|s| s.as_str()).collect();
                     let result = VarBinViewArray::from_iter_str(string_refs).into_array();
                     if result_nullability == Nullability::Nullable {
-                        #[expect(deprecated)]
-                        let result_vbv = result.to_varbinview();
+                        let result_vbv = result
+                            .clone()
+                            .execute::<VarBinViewArray>(ctx)
+                            .vortex_expect("to varbinview");
                         VarBinViewArray::new_handle(
                             result_vbv.views_handle().clone(),
                             Arc::clone(result_vbv.data_buffers()),
@@ -251,7 +263,7 @@ fn fill_varbinview_array(
                         .map(|i| {
                             if validity_bits.value(i) {
                                 array_ref
-                                    .execute_scalar(i, &mut LEGACY_SESSION.create_execution_ctx())
+                                    .execute_scalar(i, ctx)
                                     .vortex_expect("scalar_at")
                                     .as_binary()
                                     .value()
@@ -265,8 +277,10 @@ fn fill_varbinview_array(
                     let binary_refs: Vec<&[u8]> = binaries.iter().map(|b| b.as_slice()).collect();
                     let result = VarBinViewArray::from_iter_bin(binary_refs).into_array();
                     if result_nullability == Nullability::Nullable {
-                        #[expect(deprecated)]
-                        let result_vbv = result.to_varbinview();
+                        let result_vbv = result
+                            .clone()
+                            .execute::<VarBinViewArray>(ctx)
+                            .vortex_expect("to varbinview");
                         VarBinViewArray::new_handle(
                             result_vbv.views_handle().clone(),
                             Arc::clone(result_vbv.data_buffers()),
@@ -316,10 +330,11 @@ mod tests {
 
     #[test]
     fn test_fill_null_primitive() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), None, Some(5)]);
         let fill_value = Scalar::from(42i32);
 
-        let result = fill_null_canonical_array(canonical(array), &fill_value).unwrap();
+        let result = fill_null_canonical_array(canonical(array), &fill_value, &mut ctx).unwrap();
 
         let expected = PrimitiveArray::from_iter([1i32, 42, 3, 42, 5]);
         assert_arrays_eq!(expected, result);
@@ -327,12 +342,13 @@ mod tests {
 
     #[test]
     fn test_fill_null_bool() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let data_buffer = BitBuffer::from(vec![true, false, false, false]);
         let validity_buffer = BitBuffer::from(vec![true, false, true, false]);
         let array = BoolArray::new(data_buffer, Validity::from(validity_buffer));
         let fill_value = Scalar::from(true);
 
-        let result = fill_null_canonical_array(canonical(array), &fill_value).unwrap();
+        let result = fill_null_canonical_array(canonical(array), &fill_value, &mut ctx).unwrap();
 
         let expected = BoolArray::from(BitBuffer::from(vec![true, true, false, true]));
         assert_arrays_eq!(expected, result);
@@ -340,13 +356,14 @@ mod tests {
 
     #[test]
     fn test_fill_null_string() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = VarBinViewArray::from_iter(
             [Some("hello"), None, Some("world")].iter().copied(),
             DType::Utf8(Nullability::Nullable),
         );
         let fill_value = Scalar::utf8("default", Nullability::NonNullable);
 
-        let result = fill_null_canonical_array(canonical(array), &fill_value).unwrap();
+        let result = fill_null_canonical_array(canonical(array), &fill_value, &mut ctx).unwrap();
 
         let expected = VarBinViewArray::from_iter_str(["hello", "default", "world"]);
         assert_arrays_eq!(expected, result);
@@ -354,10 +371,11 @@ mod tests {
 
     #[test]
     fn test_fill_null_all_invalid() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_option_iter([None::<i32>, None, None]);
         let fill_value = Scalar::from(100i32);
 
-        let result = fill_null_canonical_array(canonical(array), &fill_value).unwrap();
+        let result = fill_null_canonical_array(canonical(array), &fill_value, &mut ctx).unwrap();
 
         let expected = PrimitiveArray::from_iter([100i32, 100, 100]);
         assert_arrays_eq!(expected, result);
@@ -365,10 +383,11 @@ mod tests {
 
     #[test]
     fn test_fill_null_no_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([1i32, 2, 3]);
         let fill_value = Scalar::from(42i32);
 
-        let result = fill_null_canonical_array(canonical(array), &fill_value).unwrap();
+        let result = fill_null_canonical_array(canonical(array), &fill_value, &mut ctx).unwrap();
 
         let expected = PrimitiveArray::from_iter([1i32, 2, 3]);
         assert_arrays_eq!(expected, result);
@@ -377,10 +396,11 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_fill_null_with_null_value_errors() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3)]);
         let fill_value = Scalar::null(DType::Primitive(PType::I32, Nullability::Nullable));
 
-        let result = fill_null_canonical_array(canonical(array), &fill_value);
+        let result = fill_null_canonical_array(canonical(array), &fill_value, &mut ctx);
 
         assert!(result.is_err());
         assert!(
@@ -393,6 +413,7 @@ mod tests {
 
     #[test]
     fn test_fill_null_decimal_i32() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = DecimalArray::from_option_iter(
             [Some(100i32), None, Some(300i32), None, Some(500i32)],
             DecimalDType::new(10, 2),
@@ -403,7 +424,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = fill_null_canonical_array(canonical(array), &fill_value).unwrap();
+        let result = fill_null_canonical_array(canonical(array), &fill_value, &mut ctx).unwrap();
 
         let expected = DecimalArray::from_iter(
             [100i32, 999i32, 300i32, 999i32, 500i32],
@@ -414,6 +435,7 @@ mod tests {
 
     #[test]
     fn test_fill_null_decimal_i64() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = DecimalArray::from_option_iter(
             [Some(1000i64), None, Some(3000i64)],
             DecimalDType::new(15, 3),
@@ -424,7 +446,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = fill_null_canonical_array(canonical(array), &fill_value).unwrap();
+        let result = fill_null_canonical_array(canonical(array), &fill_value, &mut ctx).unwrap();
 
         let expected =
             DecimalArray::from_iter([1000i64, 9999i64, 3000i64], DecimalDType::new(15, 3));
@@ -433,6 +455,7 @@ mod tests {
 
     #[test]
     fn test_fill_null_decimal_i128() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = DecimalArray::from_option_iter(
             [Some(10000i128), None, Some(30000i128), None],
             DecimalDType::new(20, 4),
@@ -443,7 +466,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = fill_null_canonical_array(canonical(array), &fill_value).unwrap();
+        let result = fill_null_canonical_array(canonical(array), &fill_value, &mut ctx).unwrap();
 
         let expected = DecimalArray::from_iter(
             [10000i128, 99999i128, 30000i128, 99999i128],
@@ -454,6 +477,7 @@ mod tests {
 
     #[test]
     fn test_fill_null_decimal_all_invalid() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array =
             DecimalArray::from_option_iter([None::<i64>, None, None], DecimalDType::new(10, 2));
         let fill_value = Scalar::decimal(
@@ -462,7 +486,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = fill_null_canonical_array(canonical(array), &fill_value).unwrap();
+        let result = fill_null_canonical_array(canonical(array), &fill_value, &mut ctx).unwrap();
 
         let expected = DecimalArray::from_option_iter(
             [Some(777i64), Some(777i64), Some(777i64)],
@@ -476,6 +500,7 @@ mod tests {
 
     #[test]
     fn test_fill_null_decimal_no_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = DecimalArray::from_option_iter(
             [Some(100i32), Some(200i32), Some(300i32)],
             DecimalDType::new(10, 2),
@@ -486,7 +511,7 @@ mod tests {
             Nullability::NonNullable,
         );
 
-        let result = fill_null_canonical_array(canonical(array), &fill_value).unwrap();
+        let result = fill_null_canonical_array(canonical(array), &fill_value, &mut ctx).unwrap();
 
         let expected = DecimalArray::from_option_iter(
             [Some(100i32), Some(200i32), Some(300i32)],

--- a/fuzz/src/array/filter.rs
+++ b/fuzz/src/array/filter.rs
@@ -2,11 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::DecimalArray;
@@ -25,12 +22,13 @@ use vortex_error::VortexResult;
 
 use crate::array::take_canonical_array_non_nullable_indices;
 
-pub fn filter_canonical_array(array: &ArrayRef, filter: &[bool]) -> VortexResult<ArrayRef> {
+pub fn filter_canonical_array(
+    array: &ArrayRef,
+    filter: &[bool],
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
     let validity = if array.dtype().is_nullable() {
-        let validity_buff = array
-            .validity()?
-            .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())?
-            .to_bit_buffer();
+        let validity_buff = array.validity()?.to_mask(array.len(), ctx)?.to_bit_buffer();
         Validity::from_iter(
             filter
                 .iter()
@@ -44,8 +42,7 @@ pub fn filter_canonical_array(array: &ArrayRef, filter: &[bool]) -> VortexResult
 
     match array.dtype() {
         DType::Bool(_) => {
-            #[expect(deprecated)]
-            let bool_array = array.to_bool();
+            let bool_array = array.clone().execute::<BoolArray>(ctx)?;
             Ok(BoolArray::new(
                 BitBuffer::from_iter(
                     filter
@@ -59,8 +56,7 @@ pub fn filter_canonical_array(array: &ArrayRef, filter: &[bool]) -> VortexResult
             .into_array())
         }
         DType::Primitive(p, _) => match_each_native_ptype!(p, |P| {
-            #[expect(deprecated)]
-            let primitive_array = array.to_primitive();
+            let primitive_array = array.clone().execute::<PrimitiveArray>(ctx)?;
             Ok(PrimitiveArray::new(
                 filter
                     .iter()
@@ -73,8 +69,7 @@ pub fn filter_canonical_array(array: &ArrayRef, filter: &[bool]) -> VortexResult
             .into_array())
         }),
         DType::Decimal(d, _) => {
-            #[expect(deprecated)]
-            let decimal_array = array.to_decimal();
+            let decimal_array = array.clone().execute::<DecimalArray>(ctx)?;
             match_each_decimal_value_type!(decimal_array.values_type(), |D| {
                 let buf = decimal_array.buffer::<D>();
                 Ok(DecimalArray::new(
@@ -91,8 +86,7 @@ pub fn filter_canonical_array(array: &ArrayRef, filter: &[bool]) -> VortexResult
             })
         }
         DType::Utf8(_) | DType::Binary(_) => {
-            #[expect(deprecated)]
-            let utf8 = array.to_varbinview();
+            let utf8 = array.clone().execute::<VarBinViewArray>(ctx)?;
             let values = utf8.with_iterator(|iter| {
                 iter.zip(filter.iter())
                     .filter(|(_, f)| **f)
@@ -102,11 +96,10 @@ pub fn filter_canonical_array(array: &ArrayRef, filter: &[bool]) -> VortexResult
             Ok(VarBinViewArray::from_iter(values, array.dtype().clone()).into_array())
         }
         DType::Struct(..) => {
-            #[expect(deprecated)]
-            let struct_array = array.to_struct();
+            let struct_array = array.clone().execute::<StructArray>(ctx)?;
             let filtered_children = struct_array
                 .iter_unmasked_fields()
-                .map(|c| filter_canonical_array(c, filter))
+                .map(|c| filter_canonical_array(c, filter, ctx))
                 .collect::<VortexResult<Vec<_>>>()?;
 
             StructArray::try_new_with_dtype(
@@ -124,7 +117,7 @@ pub fn filter_canonical_array(array: &ArrayRef, filter: &[bool]) -> VortexResult
                     indices.push(idx);
                 }
             }
-            take_canonical_array_non_nullable_indices(array, indices.as_slice())
+            take_canonical_array_non_nullable_indices(array, indices.as_slice(), ctx)
         }
         d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
             unreachable!("DType {d} not supported for fuzzing")

--- a/fuzz/src/array/mask.rs
+++ b/fuzz/src/array/mask.rs
@@ -5,11 +5,8 @@ use std::sync::Arc;
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::ExtensionArray;
@@ -35,7 +32,7 @@ use vortex_mask::Mask;
 /// This needs to be coherent with applications of Mask.
 /// The result is always nullable. The result has the same length as self.
 #[inline]
-pub fn mask_validity(validity: &Validity, mask: &Mask) -> Validity {
+pub fn mask_validity(validity: &Validity, mask: &Mask, ctx: &mut ExecutionCtx) -> Validity {
     let out = match mask.bit_buffer() {
         AllOr::All => validity.clone().into_nullable(),
         AllOr::None => Validity::AllInvalid,
@@ -45,8 +42,10 @@ pub fn mask_validity(validity: &Validity, mask: &Mask) -> Validity {
                 Validity::from_bit_buffer(make_valid.clone(), Nullability::Nullable)
             }
             Validity::Array(is_valid) => {
-                #[expect(deprecated)]
-                let is_valid = is_valid.to_bool();
+                let is_valid = is_valid
+                    .clone()
+                    .execute::<BoolArray>(ctx)
+                    .vortex_expect("validity to bool");
                 Validity::from_bit_buffer(
                     is_valid.to_bit_buffer() & make_valid,
                     Nullability::Nullable,
@@ -62,18 +61,22 @@ pub fn mask_validity(validity: &Validity, mask: &Mask) -> Validity {
 /// Apply mask on the canonical form of the array to get a consistent baseline.
 /// This implementation manually applies the mask to each canonical type
 /// without using the mask_fn method, to serve as an independent baseline for testing.
-pub fn mask_canonical_array(canonical: Canonical, mask: &Mask) -> VortexResult<ArrayRef> {
+pub fn mask_canonical_array(
+    canonical: Canonical,
+    mask: &Mask,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
     Ok(match canonical {
         Canonical::Null(array) => {
             // Null arrays are already all invalid, masking has no effect
             array.into_array()
         }
         Canonical::Bool(array) => {
-            let new_validity = mask_validity(&array.validity()?, mask);
+            let new_validity = mask_validity(&array.validity()?, mask, ctx);
             BoolArray::new(array.to_bit_buffer(), new_validity).into_array()
         }
         Canonical::Primitive(array) => {
-            let new_validity = mask_validity(&array.validity()?, mask);
+            let new_validity = mask_validity(&array.validity()?, mask, ctx);
             PrimitiveArray::from_buffer_handle(
                 array.buffer_handle().clone(),
                 array.ptype(),
@@ -82,14 +85,14 @@ pub fn mask_canonical_array(canonical: Canonical, mask: &Mask) -> VortexResult<A
             .into_array()
         }
         Canonical::Decimal(array) => {
-            let new_validity = mask_validity(&array.validity()?, mask);
+            let new_validity = mask_validity(&array.validity()?, mask, ctx);
             match_each_decimal_value_type!(array.values_type(), |D| {
                 DecimalArray::new(array.buffer::<D>(), array.decimal_dtype(), new_validity)
                     .into_array()
             })
         }
         Canonical::VarBinView(array) => {
-            let new_validity = mask_validity(&array.validity()?, mask);
+            let new_validity = mask_validity(&array.validity()?, mask, ctx);
             VarBinViewArray::new_handle(
                 array.views_handle().clone(),
                 Arc::clone(array.data_buffers()),
@@ -99,7 +102,7 @@ pub fn mask_canonical_array(canonical: Canonical, mask: &Mask) -> VortexResult<A
             .into_array()
         }
         Canonical::List(array) => {
-            let new_validity = mask_validity(&array.validity()?, mask);
+            let new_validity = mask_validity(&array.validity()?, mask, ctx);
 
             // SAFETY: Since we are only masking the validity and everything else comes from an
             // already valid `ListViewArray`, all of the invariants are still upheld.
@@ -115,7 +118,7 @@ pub fn mask_canonical_array(canonical: Canonical, mask: &Mask) -> VortexResult<A
             .into_array()
         }
         Canonical::FixedSizeList(array) => {
-            let new_validity = mask_validity(&array.validity()?, mask);
+            let new_validity = mask_validity(&array.validity()?, mask, ctx);
             FixedSizeListArray::new(
                 array.elements().clone(),
                 array.list_size(),
@@ -125,7 +128,7 @@ pub fn mask_canonical_array(canonical: Canonical, mask: &Mask) -> VortexResult<A
             .into_array()
         }
         Canonical::Struct(array) => {
-            let new_validity = mask_validity(&array.validity()?, mask);
+            let new_validity = mask_validity(&array.validity()?, mask, ctx);
             StructArray::try_new_with_dtype(
                 array.unmasked_fields(),
                 array.struct_fields().clone(),
@@ -137,14 +140,9 @@ pub fn mask_canonical_array(canonical: Canonical, mask: &Mask) -> VortexResult<A
         }
         Canonical::Extension(array) => {
             // Recursively mask the storage array
-            let masked_storage = mask_canonical_array(
-                array
-                    .storage_array()
-                    .clone()
-                    .execute::<Canonical>(&mut LEGACY_SESSION.create_execution_ctx())?,
-                mask,
-            )
-            .vortex_expect("mask_canonical_array should succeed in fuzz test");
+            let storage_canonical = array.storage_array().clone().execute::<Canonical>(ctx)?;
+            let masked_storage = mask_canonical_array(storage_canonical, mask, ctx)
+                .vortex_expect("mask_canonical_array should succeed in fuzz test");
 
             let ext_dtype = array
                 .ext_dtype()
@@ -186,28 +184,26 @@ mod tests {
 
     #[test]
     fn test_mask_null_array() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = NullArray::new(5);
         let mask = Mask::from_iter([true, false, true, false, true]);
 
-        let result = mask_canonical_array(canonical(array), &mask).unwrap();
+        let result = mask_canonical_array(canonical(array), &mask, &mut ctx).unwrap();
 
         assert_eq!(result.len(), 5);
         // All values should still be null
         for i in 0..5 {
-            assert!(
-                !result
-                    .is_valid(i, &mut LEGACY_SESSION.create_execution_ctx())
-                    .unwrap()
-            );
+            assert!(!result.is_valid(i, &mut ctx).unwrap());
         }
     }
 
     #[test]
     fn test_mask_bool_array() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = BoolArray::from_iter([true, false, true, false, true]);
         let mask = Mask::from_iter([false, true, true, false, true]);
 
-        let result = mask_canonical_array(canonical(array), &mask).unwrap();
+        let result = mask_canonical_array(canonical(array), &mask, &mut ctx).unwrap();
 
         let expected = BoolArray::from_iter([None, Some(false), Some(true), None, Some(true)]);
         assert_arrays_eq!(result, expected);
@@ -215,10 +211,11 @@ mod tests {
 
     #[test]
     fn test_mask_primitive_array() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]);
         let mask = Mask::from_iter([true, false, true, false, true]);
 
-        let result = mask_canonical_array(canonical(array), &mask).unwrap();
+        let result = mask_canonical_array(canonical(array), &mask, &mut ctx).unwrap();
 
         let expected = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), None, Some(5)]);
         assert_arrays_eq!(result, expected);
@@ -226,10 +223,11 @@ mod tests {
 
     #[test]
     fn test_mask_primitive_array_with_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_option_iter([Some(1i32), None, Some(3), Some(4), None]);
         let mask = Mask::from_iter([false, true, true, false, true]);
 
-        let result = mask_canonical_array(canonical(array), &mask).unwrap();
+        let result = mask_canonical_array(canonical(array), &mask, &mut ctx).unwrap();
 
         let expected = PrimitiveArray::from_option_iter([None, None, Some(3i32), None, None]);
         assert_arrays_eq!(result, expected);
@@ -237,6 +235,7 @@ mod tests {
 
     #[test]
     fn test_mask_decimal_array() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let dtype = DecimalDType::new(10, 2);
         let array = DecimalArray::from_option_iter(
             [Some(1i128), Some(2), Some(3), Some(4), Some(5)],
@@ -244,7 +243,7 @@ mod tests {
         );
         let mask = Mask::from_iter([true, true, false, true, true]);
 
-        let result = mask_canonical_array(canonical(array), &mask).unwrap();
+        let result = mask_canonical_array(canonical(array), &mask, &mut ctx).unwrap();
 
         let expected =
             DecimalArray::from_option_iter([Some(1i128), Some(2), None, Some(4), Some(5)], dtype);
@@ -253,10 +252,11 @@ mod tests {
 
     #[test]
     fn test_mask_varbinview_array() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = VarBinViewArray::from_iter_str(["one", "two", "three", "four", "five"]);
         let mask = Mask::from_iter([false, true, false, true, false]);
 
-        let result = mask_canonical_array(canonical(array), &mask).unwrap();
+        let result = mask_canonical_array(canonical(array), &mask, &mut ctx).unwrap();
 
         let expected =
             VarBinViewArray::from_iter_nullable_str([None, Some("two"), None, Some("four"), None]);
@@ -265,6 +265,7 @@ mod tests {
 
     #[test]
     fn test_mask_list_array() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6]).into_array();
         let offsets = PrimitiveArray::from_iter([0i32, 2, 4]).into_array();
         let sizes = PrimitiveArray::from_iter([2i32, 2, 2]).into_array();
@@ -275,56 +276,34 @@ mod tests {
 
         let mask = Mask::from_iter([true, false, true]);
 
-        let result = mask_canonical_array(canonical(array), &mask).unwrap();
+        let result = mask_canonical_array(canonical(array), &mask, &mut ctx).unwrap();
 
         assert_eq!(result.len(), 3);
-        assert!(
-            result
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            !result
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            result
-                .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
+        assert!(result.is_valid(0, &mut ctx).unwrap());
+        assert!(!result.is_valid(1, &mut ctx).unwrap());
+        assert!(result.is_valid(2, &mut ctx).unwrap());
     }
 
     #[test]
     fn test_mask_fixed_size_list_array() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let elements = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5, 6]).into_array();
         let array =
             FixedSizeListArray::try_new(elements, 2, Nullability::NonNullable.into(), 3).unwrap();
 
         let mask = Mask::from_iter([false, true, false]);
 
-        let result = mask_canonical_array(canonical(array), &mask).unwrap();
+        let result = mask_canonical_array(canonical(array), &mask, &mut ctx).unwrap();
 
         assert_eq!(result.len(), 3);
-        assert!(
-            !result
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            result
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            !result
-                .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
+        assert!(!result.is_valid(0, &mut ctx).unwrap());
+        assert!(result.is_valid(1, &mut ctx).unwrap());
+        assert!(!result.is_valid(2, &mut ctx).unwrap());
     }
 
     #[test]
     fn test_mask_struct_array() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let field1 = PrimitiveArray::from_iter([1i32, 2, 3]).into_array();
         let field2 = PrimitiveArray::from_iter([4i32, 5, 6]).into_array();
         let fields = vec![field1, field2];
@@ -339,32 +318,21 @@ mod tests {
 
         let mask = Mask::from_iter([true, false, true]);
 
-        let result = mask_canonical_array(canonical(array), &mask).unwrap();
+        let result = mask_canonical_array(canonical(array), &mask, &mut ctx).unwrap();
 
         assert_eq!(result.len(), 3);
-        assert!(
-            result
-                .is_valid(0, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            !result
-                .is_valid(1, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
-        assert!(
-            result
-                .is_valid(2, &mut LEGACY_SESSION.create_execution_ctx())
-                .unwrap()
-        );
+        assert!(result.is_valid(0, &mut ctx).unwrap());
+        assert!(!result.is_valid(1, &mut ctx).unwrap());
+        assert!(result.is_valid(2, &mut ctx).unwrap());
     }
 
     #[test]
     fn test_mask_all_false() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]);
         let mask = Mask::AllFalse(5);
 
-        let result = mask_canonical_array(canonical(array), &mask).unwrap();
+        let result = mask_canonical_array(canonical(array), &mask, &mut ctx).unwrap();
 
         let expected = PrimitiveArray::from_option_iter([None, None, None, None, None::<i32>]);
         assert_arrays_eq!(result, expected);
@@ -372,10 +340,11 @@ mod tests {
 
     #[test]
     fn test_mask_all_true() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter([1i32, 2, 3, 4, 5]);
         let mask = Mask::AllTrue(5);
 
-        let result = mask_canonical_array(canonical(array), &mask).unwrap();
+        let result = mask_canonical_array(canonical(array), &mask, &mut ctx).unwrap();
 
         let expected =
             PrimitiveArray::from_option_iter([Some(1i32), Some(2), Some(3), Some(4), Some(5)]);
@@ -384,9 +353,10 @@ mod tests {
 
     #[test]
     fn test_mask_empty_array() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::from_iter(Vec::<i32>::new());
         for mask in [Mask::AllFalse(0), Mask::AllTrue(0)] {
-            let result = mask_canonical_array(canonical(array.clone()), &mask).unwrap();
+            let result = mask_canonical_array(canonical(array.clone()), &mask, &mut ctx).unwrap();
             assert_eq!(result.len(), 0);
         }
     }

--- a/fuzz/src/array/mod.rs
+++ b/fuzz/src/array/mod.rs
@@ -40,6 +40,7 @@ use strum::EnumIter;
 use strum::IntoEnumIterator;
 use tracing::debug;
 use vortex_array::ArrayRef;
+use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::fns::min_max::MinMaxResult;
@@ -202,7 +203,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                 ActionType::Slice => {
                     let start = u.choose_index(current_array.len())?;
                     let stop = u.int_in_range(start..=current_array.len())?;
-                    current_array = slice_canonical_array(&current_array, start, stop)
+                    current_array = slice_canonical_array(&current_array, start, stop, &mut ctx)
                         .vortex_expect("slice_canonical_array should succeed in fuzz test");
 
                     (
@@ -218,7 +219,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     let indices = random_vec_in_range(u, 0, current_array.len() - 1)?;
                     let nullable = indices.contains(&None);
 
-                    current_array = take_canonical_array(&current_array, &indices)
+                    current_array = take_canonical_array(&current_array, &indices, &mut ctx)
                         .vortex_expect("take_canonical_array should succeed in fuzz test");
                     let indices_array = if nullable {
                         PrimitiveArray::from_option_iter(
@@ -260,7 +261,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                         return Err(EmptyChoose);
                     }
 
-                    let sorted = sort_canonical_array(&current_array)
+                    let sorted = sort_canonical_array(&current_array, &mut ctx)
                         .vortex_expect("sort_canonical_array should succeed in fuzz test");
 
                     let side = if u.arbitrary()? {
@@ -271,9 +272,10 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     (
                         Action::SearchSorted(scalar.clone(), side),
                         ExpectedValue::Search(
-                            search_sorted_canonical_array(&sorted, &scalar, side).vortex_expect(
-                                "search_sorted_canonical_array should succeed in fuzz test",
-                            ),
+                            search_sorted_canonical_array(&sorted, &scalar, side, &mut ctx)
+                                .vortex_expect(
+                                    "search_sorted_canonical_array should succeed in fuzz test",
+                                ),
                         ),
                     )
                 }
@@ -281,7 +283,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     let mask = (0..current_array.len())
                         .map(|_| bool::arbitrary(u))
                         .collect::<arbitrary::Result<Vec<_>>>()?;
-                    current_array = filter_canonical_array(&current_array, &mask)
+                    current_array = filter_canonical_array(&current_array, &mask, &mut ctx)
                         .vortex_expect("filter_canonical_array should succeed in fuzz test");
                     (
                         Action::Filter(Mask::from_iter(mask)),
@@ -300,7 +302,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     };
 
                     let op = u.arbitrary()?;
-                    current_array = compare_canonical_array(&current_array, &scalar, op);
+                    current_array = compare_canonical_array(&current_array, &scalar, op, &mut ctx);
                     (
                         Action::Compare(scalar, op),
                         ExpectedValue::Array(current_array.clone()),
@@ -312,7 +314,7 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     {
                         return Err(EmptyChoose);
                     }
-                    let Some(result) = cast_canonical_array(&current_array, &to)
+                    let Some(result) = cast_canonical_array(&current_array, &to, &mut ctx)
                         .vortex_expect("should fail to create array")
                     else {
                         return Err(EmptyChoose);
@@ -327,20 +329,20 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     }
 
                     // Sum - returns a scalar, does NOT update current_array (terminal operation)
-                    #[expect(deprecated)]
                     let current_array_canonical = current_array
-                        .to_canonical()
-                        .vortex_expect("to_canonical should succeed in fuzz test");
+                        .clone()
+                        .execute::<Canonical>(&mut ctx)
+                        .vortex_expect("execute canonical should succeed in fuzz test");
                     let sum_result = sum_canonical_array(current_array_canonical, &mut ctx)
                         .vortex_expect("sum_canonical_array should succeed in fuzz test");
                     (Action::Sum, ExpectedValue::Scalar(sum_result))
                 }
                 ActionType::MinMax => {
                     // MinMax - returns a scalar, does NOT update current_array (terminal operation)
-                    #[expect(deprecated)]
                     let current_array_canonical = current_array
-                        .to_canonical()
-                        .vortex_expect("to_canonical should succeed in fuzz test");
+                        .clone()
+                        .execute::<Canonical>(&mut ctx)
+                        .vortex_expect("execute canonical should succeed in fuzz test");
                     let min_max_result = min_max_canonical_array(current_array_canonical, &mut ctx)
                         .vortex_expect("min_max_canonical_array should succeed in fuzz test");
                     (Action::MinMax, ExpectedValue::MinMax(min_max_result))
@@ -368,12 +370,12 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     }
 
                     // Compute expected result on canonical form
-                    #[expect(deprecated)]
                     let current_array_canonical = current_array
-                        .to_canonical()
-                        .vortex_expect("to_canonical should succeed in fuzz test");
+                        .clone()
+                        .execute::<Canonical>(&mut ctx)
+                        .vortex_expect("execute canonical should succeed in fuzz test");
                     let expected_result =
-                        fill_null_canonical_array(current_array_canonical, &fill_value)
+                        fill_null_canonical_array(current_array_canonical, &fill_value, &mut ctx)
                             .vortex_expect("fill_null_canonical_array should succeed in fuzz test");
                     // Update current_array to the result for chaining
                     current_array = expected_result.clone();
@@ -389,13 +391,14 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                         .collect::<arbitrary::Result<Vec<_>>>()?;
 
                     // Compute expected result on canonical form
-                    #[expect(deprecated)]
                     let current_array_canonical = current_array
-                        .to_canonical()
-                        .vortex_expect("to_canonical should succeed in fuzz test");
+                        .clone()
+                        .execute::<Canonical>(&mut ctx)
+                        .vortex_expect("execute canonical should succeed in fuzz test");
                     let expected_result = mask_canonical_array(
                         current_array_canonical,
                         &Mask::from_iter(mask.clone()),
+                        &mut ctx,
                     )
                     .vortex_expect("mask_canonical_array should succeed in fuzz test");
                     // Update current_array to the result for chaining
@@ -424,11 +427,11 @@ impl<'a> Arbitrary<'a> for FuzzArrayAction {
                     let expected_scalars: Vec<Scalar> = indices_vec
                         .iter()
                         .map(|&idx| {
-                            #[expect(deprecated)]
                             let canonical = current_array
-                                .to_canonical()
-                                .vortex_expect("to_canonical should succeed in fuzz test");
-                            scalar_at_canonical_array(canonical, idx).vortex_expect(
+                                .clone()
+                                .execute::<Canonical>(&mut ctx)
+                                .vortex_expect("execute canonical should succeed in fuzz test");
+                            scalar_at_canonical_array(canonical, idx, &mut ctx).vortex_expect(
                                 "scalar_at_canonical_array should succeed in fuzz test",
                             )
                         })
@@ -581,10 +584,10 @@ pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> VortexFuzzResult<bool> {
         debug!(id = i, action = ?action);
         match action {
             Action::Compress(strategy) => {
-                #[expect(deprecated)]
                 let canonical = current_array
-                    .to_canonical()
-                    .vortex_expect("to_canonical should succeed in fuzz test");
+                    .clone()
+                    .execute::<Canonical>(&mut ctx)
+                    .vortex_expect("execute canonical should succeed in fuzz test");
                 current_array = compress_array(&canonical.into_array(), strategy);
                 assert_array_eq(&expected.array(), &current_array, i)?;
             }
@@ -604,7 +607,7 @@ pub fn run_fuzz_action(fuzz_action: FuzzArrayAction) -> VortexFuzzResult<bool> {
                 assert_array_eq(&expected.array(), &current_array, i)?;
             }
             Action::SearchSorted(s, side) => {
-                let mut sorted = sort_canonical_array(&current_array)
+                let mut sorted = sort_canonical_array(&current_array, &mut ctx)
                     .vortex_expect("sort_canonical_array should succeed in fuzz test");
 
                 if !current_array.is_canonical() {

--- a/fuzz/src/array/scalar_at.rs
+++ b/fuzz/src/array/scalar_at.rs
@@ -4,9 +4,8 @@
 use std::sync::Arc;
 
 use vortex_array::Canonical;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::bool::BoolArrayExt;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
@@ -24,9 +23,13 @@ use vortex_error::VortexResult;
 /// Baseline implementation of scalar_at that works on canonical arrays.
 /// This implementation manually extracts the scalar value from each canonical type
 /// without using the scalar_at method, to serve as an independent baseline for testing.
-pub fn scalar_at_canonical_array(canonical: Canonical, index: usize) -> VortexResult<Scalar> {
+pub fn scalar_at_canonical_array(
+    canonical: Canonical,
+    index: usize,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<Scalar> {
     let canonical_ref = canonical.clone().into_array();
-    if canonical_ref.is_invalid(index, &mut LEGACY_SESSION.create_execution_ctx())? {
+    if canonical_ref.is_invalid(index, ctx)? {
         return Ok(Scalar::null(canonical_ref.dtype().clone()));
     }
     Ok(match canonical {
@@ -54,11 +57,11 @@ pub fn scalar_at_canonical_array(canonical: Canonical, index: usize) -> VortexRe
             let list = array.list_elements_at(index)?;
             let children: Vec<Scalar> = (0..list.len())
                 .map(|i| {
-                    #[expect(deprecated)]
                     let canonical = list
-                        .to_canonical()
+                        .clone()
+                        .execute::<Canonical>(ctx)
                         .vortex_expect("to_canonical should succeed in fuzz test");
-                    scalar_at_canonical_array(canonical, i)
+                    scalar_at_canonical_array(canonical, i, ctx)
                         .vortex_expect("scalar_at_canonical_array should succeed in fuzz test")
                 })
                 .collect();
@@ -72,11 +75,11 @@ pub fn scalar_at_canonical_array(canonical: Canonical, index: usize) -> VortexRe
             let list = array.fixed_size_list_elements_at(index)?;
             let children: Vec<Scalar> = (0..list.len())
                 .map(|i| {
-                    #[expect(deprecated)]
                     let canonical = list
-                        .to_canonical()
+                        .clone()
+                        .execute::<Canonical>(ctx)
                         .vortex_expect("to_canonical should succeed in fuzz test");
-                    scalar_at_canonical_array(canonical, i)
+                    scalar_at_canonical_array(canonical, i, ctx)
                         .vortex_expect("scalar_at_canonical_array should succeed in fuzz test")
                 })
                 .collect();
@@ -86,20 +89,19 @@ pub fn scalar_at_canonical_array(canonical: Canonical, index: usize) -> VortexRe
             let field_scalars: Vec<Scalar> = array
                 .iter_unmasked_fields()
                 .map(|field| {
-                    #[expect(deprecated)]
                     let canonical = field
-                        .to_canonical()
+                        .clone()
+                        .execute::<Canonical>(ctx)
                         .vortex_expect("to_canonical should succeed in fuzz test");
-                    scalar_at_canonical_array(canonical, index)
+                    scalar_at_canonical_array(canonical, index, ctx)
                         .vortex_expect("scalar_at_canonical_array should succeed in fuzz test")
                 })
                 .collect();
             Scalar::struct_(array.dtype().clone(), field_scalars)
         }
         Canonical::Extension(array) => {
-            #[expect(deprecated)]
-            let storage_canonical = array.storage_array().to_canonical()?;
-            let storage_scalar = scalar_at_canonical_array(storage_canonical, index)?;
+            let storage_canonical = array.storage_array().clone().execute::<Canonical>(ctx)?;
+            let storage_scalar = scalar_at_canonical_array(storage_canonical, index, ctx)?;
             Scalar::extension_ref(array.ext_dtype().clone(), storage_scalar)
         }
         Canonical::Variant(_) => unreachable!("Variant arrays are not fuzzed"),

--- a/fuzz/src/array/search_sorted.rs
+++ b/fuzz/src/array/search_sorted.rs
@@ -5,11 +5,12 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 
 use vortex_array::ArrayRef;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
+use vortex_array::ExecutionCtx;
 use vortex_array::accessor::ArrayAccessor;
+use vortex_array::arrays::BoolArray;
+use vortex_array::arrays::DecimalArray;
+use vortex_array::arrays::PrimitiveArray;
+use vortex_array::arrays::VarBinViewArray;
 use vortex_array::arrays::bool::BoolArrayExt;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::NativePType;
@@ -63,18 +64,15 @@ pub fn search_sorted_canonical_array(
     array: &ArrayRef,
     scalar: &Scalar,
     side: SearchSortedSide,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<SearchResult> {
     match array.dtype() {
         DType::Bool(_) => {
-            #[expect(deprecated)]
-            let bool_array = array.to_bool();
+            let bool_array = array.clone().execute::<BoolArray>(ctx)?;
             let validity = bool_array
                 .as_ref()
                 .validity()?
-                .to_mask(
-                    bool_array.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx(),
-                )?
+                .to_mask(bool_array.as_ref().len(), ctx)?
                 .to_bit_buffer();
             let opt_values = bool_array
                 .to_bit_buffer()
@@ -86,15 +84,11 @@ pub fn search_sorted_canonical_array(
             SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
         }
         DType::Primitive(p, _) => {
-            #[expect(deprecated)]
-            let primitive_array = array.to_primitive();
+            let primitive_array = array.clone().execute::<PrimitiveArray>(ctx)?;
             let validity = primitive_array
                 .as_ref()
                 .validity()?
-                .to_mask(
-                    primitive_array.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx(),
-                )?
+                .to_mask(primitive_array.as_ref().len(), ctx)?
                 .to_bit_buffer();
             match_each_native_ptype!(p, |P| {
                 let opt_values = primitive_array
@@ -109,15 +103,11 @@ pub fn search_sorted_canonical_array(
             })
         }
         DType::Decimal(d, _) => {
-            #[expect(deprecated)]
-            let decimal_array = array.to_decimal();
+            let decimal_array = array.clone().execute::<DecimalArray>(ctx)?;
             let validity = decimal_array
                 .as_ref()
                 .validity()?
-                .to_mask(
-                    decimal_array.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx(),
-                )?
+                .to_mask(decimal_array.as_ref().len(), ctx)?
                 .to_bit_buffer();
             match_each_decimal_value_type!(decimal_array.values_type(), |D| {
                 let buf = decimal_array.buffer::<D>();
@@ -142,8 +132,7 @@ pub fn search_sorted_canonical_array(
             })
         }
         DType::Utf8(_) | DType::Binary(_) => {
-            #[expect(deprecated)]
-            let utf8 = array.to_varbinview();
+            let utf8 = array.clone().execute::<VarBinViewArray>(ctx)?;
             let opt_values =
                 utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>());
             let to_find = if matches!(array.dtype(), DType::Utf8(_)) {
@@ -154,9 +143,8 @@ pub fn search_sorted_canonical_array(
             SearchNullableSlice(opt_values).search_sorted(&Some(to_find), side)
         }
         DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {
-            let mut ctx = LEGACY_SESSION.create_execution_ctx();
             let scalar_vals = (0..array.len())
-                .map(|i| array.execute_scalar(i, &mut ctx))
+                .map(|i| array.execute_scalar(i, ctx))
                 .collect::<VortexResult<Vec<_>>>()?;
             scalar_vals.search_sorted(&scalar.cast(array.dtype())?, side)
         }

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -29,10 +29,7 @@ pub fn slice_canonical_array(
     ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let validity = if array.dtype().is_nullable() {
-        let bool_buff = array
-            .validity()?
-            .to_mask(array.len(), ctx)?
-            .to_bit_buffer();
+        let bool_buff = array.validity()?.to_mask(array.len(), ctx)?.to_bit_buffer();
         Validity::from(bool_buff.slice(start..stop))
     } else {
         Validity::NonNullable

--- a/fuzz/src/array/slice.rs
+++ b/fuzz/src/array/slice.rs
@@ -2,11 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::DecimalArray;
@@ -29,11 +26,12 @@ pub fn slice_canonical_array(
     array: &ArrayRef,
     start: usize,
     stop: usize,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let validity = if array.dtype().is_nullable() {
         let bool_buff = array
             .validity()?
-            .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())?
+            .to_mask(array.len(), ctx)?
             .to_bit_buffer();
         Validity::from(bool_buff.slice(start..stop))
     } else {
@@ -42,14 +40,12 @@ pub fn slice_canonical_array(
 
     match array.dtype() {
         DType::Bool(_) => {
-            #[expect(deprecated)]
-            let bool_array = array.to_bool();
+            let bool_array = array.clone().execute::<BoolArray>(ctx)?;
             let sliced_bools = bool_array.to_bit_buffer().slice(start..stop);
             Ok(BoolArray::new(sliced_bools, validity).into_array())
         }
         DType::Primitive(p, _) => {
-            #[expect(deprecated)]
-            let primitive_array = array.to_primitive();
+            let primitive_array = array.clone().execute::<PrimitiveArray>(ctx)?;
             match_each_native_ptype!(p, |P| {
                 Ok(PrimitiveArray::new(
                     primitive_array.to_buffer::<P>().slice(start..stop),
@@ -59,8 +55,7 @@ pub fn slice_canonical_array(
             })
         }
         DType::Utf8(_) | DType::Binary(_) => {
-            #[expect(deprecated)]
-            let utf8 = array.to_varbinview();
+            let utf8 = array.clone().execute::<VarBinViewArray>(ctx)?;
             let values =
                 utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>());
             Ok(VarBinViewArray::from_iter(
@@ -70,11 +65,10 @@ pub fn slice_canonical_array(
             .into_array())
         }
         DType::Struct(..) => {
-            #[expect(deprecated)]
-            let struct_array = array.to_struct();
+            let struct_array = array.clone().execute::<StructArray>(ctx)?;
             let sliced_children = struct_array
                 .iter_unmasked_fields()
-                .map(|c| slice_canonical_array(c, start, stop))
+                .map(|c| slice_canonical_array(c, start, stop, ctx))
                 .collect::<VortexResult<Vec<_>>>()?;
             StructArray::try_new_with_dtype(
                 sliced_children,
@@ -85,11 +79,10 @@ pub fn slice_canonical_array(
             .map(|a| a.into_array())
         }
         DType::List(..) => {
-            #[expect(deprecated)]
-            let list_array = array.to_listview();
+            let list_array = array.clone().execute::<ListViewArray>(ctx)?;
 
-            let offsets = slice_canonical_array(list_array.offsets(), start, stop)?;
-            let sizes = slice_canonical_array(list_array.sizes(), start, stop)?;
+            let offsets = slice_canonical_array(list_array.offsets(), start, stop, ctx)?;
+            let sizes = slice_canonical_array(list_array.sizes(), start, stop, ctx)?;
 
             // Since the list view elements can be stored out of order, we cannot slice it.
             let elements = list_array.elements().clone();
@@ -104,19 +97,21 @@ pub fn slice_canonical_array(
             .into_array())
         }
         DType::FixedSizeList(..) => {
-            #[expect(deprecated)]
-            let fsl_array = array.to_fixed_size_list();
+            let fsl_array = array.clone().execute::<FixedSizeListArray>(ctx)?;
             let list_size = fsl_array.list_size() as usize;
-            let elements =
-                slice_canonical_array(fsl_array.elements(), start * list_size, stop * list_size)?;
+            let elements = slice_canonical_array(
+                fsl_array.elements(),
+                start * list_size,
+                stop * list_size,
+                ctx,
+            )?;
             let new_len = stop - start;
 
             FixedSizeListArray::try_new(elements, fsl_array.list_size(), validity, new_len)
                 .map(|a| a.into_array())
         }
         DType::Decimal(decimal_dtype, _) => {
-            #[expect(deprecated)]
-            let decimal_array = array.to_decimal();
+            let decimal_array = array.clone().execute::<DecimalArray>(ctx)?;
             Ok(
                 match_each_decimal_value_type!(decimal_array.values_type(), |D| {
                     DecimalArray::new(

--- a/fuzz/src/array/sort.rs
+++ b/fuzz/src/array/sort.rs
@@ -4,11 +4,8 @@
 use std::cmp::Ordering;
 
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::DecimalArray;
@@ -24,11 +21,13 @@ use vortex_error::VortexResult;
 
 use crate::array::take_canonical_array_non_nullable_indices;
 
-pub fn sort_canonical_array(array: &ArrayRef) -> VortexResult<ArrayRef> {
+pub fn sort_canonical_array(
+    array: &ArrayRef,
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
     match array.dtype() {
         DType::Bool(_) => {
-            #[expect(deprecated)]
-            let bool_array = array.to_bool();
+            let bool_array = array.clone().execute::<BoolArray>(ctx)?;
             let mut opt_values = bool_array
                 .to_bit_buffer()
                 .iter()
@@ -36,10 +35,7 @@ pub fn sort_canonical_array(array: &ArrayRef) -> VortexResult<ArrayRef> {
                     bool_array
                         .as_ref()
                         .validity()?
-                        .to_mask(
-                            bool_array.as_ref().len(),
-                            &mut LEGACY_SESSION.create_execution_ctx(),
-                        )?
+                        .to_mask(bool_array.as_ref().len(), ctx)?
                         .to_bit_buffer()
                         .iter(),
                 )
@@ -49,8 +45,7 @@ pub fn sort_canonical_array(array: &ArrayRef) -> VortexResult<ArrayRef> {
             Ok(BoolArray::from_iter(opt_values).into_array())
         }
         DType::Primitive(p, _) => {
-            #[expect(deprecated)]
-            let primitive_array = array.to_primitive();
+            let primitive_array = array.clone().execute::<PrimitiveArray>(ctx)?;
             match_each_native_ptype!(p, |P| {
                 let mut opt_values = primitive_array
                     .as_slice::<P>()
@@ -60,10 +55,7 @@ pub fn sort_canonical_array(array: &ArrayRef) -> VortexResult<ArrayRef> {
                         primitive_array
                             .as_ref()
                             .validity()?
-                            .to_mask(
-                                primitive_array.as_ref().len(),
-                                &mut LEGACY_SESSION.create_execution_ctx(),
-                            )?
+                            .to_mask(primitive_array.as_ref().len(), ctx)?
                             .to_bit_buffer()
                             .iter(),
                     )
@@ -74,8 +66,7 @@ pub fn sort_canonical_array(array: &ArrayRef) -> VortexResult<ArrayRef> {
             })
         }
         DType::Decimal(d, _) => {
-            #[expect(deprecated)]
-            let decimal_array = array.to_decimal();
+            let decimal_array = array.clone().execute::<DecimalArray>(ctx)?;
             match_each_decimal_value_type!(decimal_array.values_type(), |D| {
                 let buf = decimal_array.buffer::<D>();
                 let mut opt_values = buf
@@ -86,10 +77,7 @@ pub fn sort_canonical_array(array: &ArrayRef) -> VortexResult<ArrayRef> {
                         decimal_array
                             .as_ref()
                             .validity()?
-                            .to_mask(
-                                decimal_array.as_ref().len(),
-                                &mut LEGACY_SESSION.create_execution_ctx(),
-                            )?
+                            .to_mask(decimal_array.as_ref().len(), ctx)?
                             .to_bit_buffer()
                             .iter(),
                     )
@@ -100,8 +88,7 @@ pub fn sort_canonical_array(array: &ArrayRef) -> VortexResult<ArrayRef> {
             })
         }
         DType::Utf8(_) | DType::Binary(_) => {
-            #[expect(deprecated)]
-            let utf8 = array.to_varbinview();
+            let utf8 = array.clone().execute::<VarBinViewArray>(ctx)?;
             let mut opt_values =
                 utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>());
             opt_values.sort();
@@ -109,18 +96,13 @@ pub fn sort_canonical_array(array: &ArrayRef) -> VortexResult<ArrayRef> {
         }
         DType::Struct(..) | DType::List(..) | DType::FixedSizeList(..) => {
             let mut sort_indices = (0..array.len()).collect::<Vec<_>>();
-            let mut ctx = LEGACY_SESSION.create_execution_ctx();
             sort_indices.sort_by(|a, b| {
-                let lhs = array
-                    .execute_scalar(*a, &mut ctx)
-                    .vortex_expect("scalar_at");
-                let rhs = array
-                    .execute_scalar(*b, &mut ctx)
-                    .vortex_expect("scalar_at");
+                let lhs = array.execute_scalar(*a, ctx).vortex_expect("scalar_at");
+                let rhs = array.execute_scalar(*b, ctx).vortex_expect("scalar_at");
                 lhs.partial_cmp(&rhs)
                     .vortex_expect("must be a valid comparison")
             });
-            take_canonical_array_non_nullable_indices(array, &sort_indices)
+            take_canonical_array_non_nullable_indices(array, &sort_indices, ctx)
         }
         d @ (DType::Null | DType::Extension(_) | DType::Variant(_)) => {
             unreachable!("DType {d} not supported for fuzzing")

--- a/fuzz/src/array/sort.rs
+++ b/fuzz/src/array/sort.rs
@@ -21,10 +21,7 @@ use vortex_error::VortexResult;
 
 use crate::array::take_canonical_array_non_nullable_indices;
 
-pub fn sort_canonical_array(
-    array: &ArrayRef,
-    ctx: &mut ExecutionCtx,
-) -> VortexResult<ArrayRef> {
+pub fn sort_canonical_array(array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<ArrayRef> {
     match array.dtype() {
         DType::Bool(_) => {
             let bool_array = array.clone().execute::<BoolArray>(ctx)?;

--- a/fuzz/src/array/take.rs
+++ b/fuzz/src/array/take.rs
@@ -2,11 +2,8 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::DecimalArray;
@@ -31,6 +28,7 @@ use vortex_error::VortexResult;
 pub fn take_canonical_array_non_nullable_indices(
     array: &ArrayRef,
     indices: &[usize],
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     take_canonical_array(
         array,
@@ -39,16 +37,21 @@ pub fn take_canonical_array_non_nullable_indices(
             .map(|i| Some(*i))
             .collect::<Vec<_>>()
             .as_slice(),
+        ctx,
     )
 }
 
-pub fn take_canonical_array(array: &ArrayRef, indices: &[Option<usize>]) -> VortexResult<ArrayRef> {
+pub fn take_canonical_array(
+    array: &ArrayRef,
+    indices: &[Option<usize>],
+    ctx: &mut ExecutionCtx,
+) -> VortexResult<ArrayRef> {
     let nullable: Nullability = indices.contains(&None).into();
 
     let validity = if array.dtype().is_nullable() || nullable == Nullability::Nullable {
         let validity_idx = array
             .validity()?
-            .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())?
+            .to_mask(array.len(), ctx)?
             .to_bit_buffer();
 
         Validity::from_iter(
@@ -65,8 +68,7 @@ pub fn take_canonical_array(array: &ArrayRef, indices: &[Option<usize>]) -> Vort
 
     match array.dtype() {
         DType::Bool(_) => {
-            #[expect(deprecated)]
-            let bool_array = array.to_bool();
+            let bool_array = array.clone().execute::<BoolArray>(ctx)?;
             let vec_values = bool_array.to_bit_buffer().iter().collect::<Vec<_>>();
             Ok(BoolArray::new(
                 indices_slice_non_opt
@@ -78,8 +80,7 @@ pub fn take_canonical_array(array: &ArrayRef, indices: &[Option<usize>]) -> Vort
             .into_array())
         }
         DType::Primitive(p, _) => {
-            #[expect(deprecated)]
-            let primitive_array = array.to_primitive();
+            let primitive_array = array.clone().execute::<PrimitiveArray>(ctx)?;
             match_each_native_ptype!(p, |P| {
                 Ok(take_primitive::<P>(
                     primitive_array,
@@ -89,8 +90,7 @@ pub fn take_canonical_array(array: &ArrayRef, indices: &[Option<usize>]) -> Vort
             })
         }
         DType::Decimal(d, _) => {
-            #[expect(deprecated)]
-            let decimal_array = array.to_decimal();
+            let decimal_array = array.clone().execute::<DecimalArray>(ctx)?;
 
             match_each_decimal_value_type!(decimal_array.values_type(), |D| {
                 Ok(take_decimal::<D>(
@@ -102,8 +102,7 @@ pub fn take_canonical_array(array: &ArrayRef, indices: &[Option<usize>]) -> Vort
             })
         }
         DType::Utf8(_) | DType::Binary(_) => {
-            #[expect(deprecated)]
-            let utf8 = array.to_varbinview();
+            let utf8 = array.clone().execute::<VarBinViewArray>(ctx)?;
             let values =
                 utf8.with_iterator(|iter| iter.map(|v| v.map(|u| u.to_vec())).collect::<Vec<_>>());
             Ok(VarBinViewArray::from_iter(
@@ -115,11 +114,10 @@ pub fn take_canonical_array(array: &ArrayRef, indices: &[Option<usize>]) -> Vort
             .into_array())
         }
         DType::Struct(..) => {
-            #[expect(deprecated)]
-            let struct_array = array.to_struct();
+            let struct_array = array.clone().execute::<StructArray>(ctx)?;
             let taken_children = struct_array
                 .iter_unmasked_fields()
-                .map(|c| take_canonical_array_non_nullable_indices(c, indices_slice_non_opt))
+                .map(|c| take_canonical_array_non_nullable_indices(c, indices_slice_non_opt, ctx))
                 .collect::<VortexResult<Vec<_>>>()?;
 
             StructArray::try_new(
@@ -135,12 +133,11 @@ pub fn take_canonical_array(array: &ArrayRef, indices: &[Option<usize>]) -> Vort
                 &array.dtype().union_nullability(nullable),
                 indices_slice_non_opt.len(),
             );
-            let mut ctx = LEGACY_SESSION.create_execution_ctx();
             for idx in indices {
                 if let Some(idx) = idx {
                     builder.append_scalar(
                         &array
-                            .execute_scalar(*idx, &mut ctx)?
+                            .execute_scalar(*idx, ctx)?
                             .cast(&array.dtype().union_nullability(nullable))
                             .vortex_expect("cannot cast scalar nullability"),
                     )?;

--- a/fuzz/src/array/take.rs
+++ b/fuzz/src/array/take.rs
@@ -49,10 +49,7 @@ pub fn take_canonical_array(
     let nullable: Nullability = indices.contains(&None).into();
 
     let validity = if array.dtype().is_nullable() || nullable == Nullability::Nullable {
-        let validity_idx = array
-            .validity()?
-            .to_mask(array.len(), ctx)?
-            .to_bit_buffer();
+        let validity_idx = array.validity()?.to_mask(array.len(), ctx)?.to_bit_buffer();
 
         Validity::from_iter(
             indices

--- a/fuzz/src/compress.rs
+++ b/fuzz/src/compress.rs
@@ -9,10 +9,14 @@
 use arbitrary::Arbitrary;
 use arbitrary::Unstructured;
 use vortex_array::ArrayRef;
+use vortex_array::Canonical;
 use vortex_array::IntoArray;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::constant::ArbitraryConstantArray;
 use vortex_array::arrays::dict::ArbitraryDictArray;
 use vortex_runend::ArbitraryRunEndArray;
+
+use crate::SESSION;
 
 /// Which compressed encoding to generate.
 #[derive(Debug, Clone, Copy)]
@@ -70,9 +74,10 @@ pub fn run_compress_roundtrip(fuzz: FuzzCompressRoundtrip) -> crate::error::Vort
     let original_len = array.len();
     let original_dtype = array.dtype().clone();
 
+    let mut ctx = SESSION.create_execution_ctx();
+
     // Try to canonicalize - this is the main thing we're testing
-    #[expect(deprecated)]
-    let canonical = match array.to_canonical() {
+    let canonical = match array.clone().execute::<Canonical>(&mut ctx) {
         Ok(c) => c,
         Err(e) => {
             // Canonicalization failed - this is a bug

--- a/fuzz/src/fsst_like.rs
+++ b/fuzz/src/fsst_like.rs
@@ -113,8 +113,14 @@ pub fn run_fsst_like_fuzz(fuzz: FuzzFsstLike) -> VortexFuzzResult<bool> {
 
     // Train FSST compressor and compress.
     let compressor = fsst_train_compressor(&varbin);
-    let fsst_array: FSSTArray =
-        fsst_compress(varbin.clone(), varbin.len(), varbin.dtype(), &compressor);
+    let mut ctx = SESSION.create_execution_ctx();
+    let fsst_array: FSSTArray = fsst_compress(
+        varbin.clone(),
+        varbin.len(),
+        varbin.dtype(),
+        &compressor,
+        &mut ctx,
+    );
 
     let opts = LikeOptions {
         negated,

--- a/vortex-bench/src/datasets/mod.rs
+++ b/vortex-bench/src/datasets/mod.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use serde::Deserialize;
 use serde::Serialize;
 use vortex::array::ArrayRef;
+use vortex::array::ExecutionCtx;
 
 use crate::clickbench::Flavor;
 
@@ -25,7 +26,7 @@ use std::path::PathBuf;
 pub trait Dataset {
     fn name(&self) -> &str;
 
-    async fn to_vortex_array(&self) -> Result<ArrayRef>;
+    async fn to_vortex_array(&self, ctx: &mut ExecutionCtx) -> Result<ArrayRef>;
 
     /// Get the path to the parquet file for this dataset.
     ///

--- a/vortex-bench/src/datasets/struct_list_of_ints.rs
+++ b/vortex-bench/src/datasets/struct_list_of_ints.rs
@@ -11,6 +11,7 @@ use rand::RngExt;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
 use vortex::array::ArrayRef;
+use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
 use vortex::array::LEGACY_SESSION;
 use vortex::array::VortexSessionExecute;
@@ -63,7 +64,7 @@ impl Dataset for StructListOfInts {
         &self.name
     }
 
-    async fn to_vortex_array(&self) -> Result<ArrayRef> {
+    async fn to_vortex_array(&self, _ctx: &mut ExecutionCtx) -> Result<ArrayRef> {
         let names: FieldNames = (0..self.num_columns)
             .map(|col_idx| col_idx.to_string())
             .collect();
@@ -115,7 +116,8 @@ impl Dataset for StructListOfInts {
 
         idempotent_async(&parquet_path, |temp_path| async move {
             // Generate the data
-            let array = self.to_vortex_array().await?;
+            let mut ctx = LEGACY_SESSION.create_execution_ctx();
+            let array = self.to_vortex_array(&mut ctx).await?;
 
             // Convert to Arrow RecordBatches and write to parquet
             let chunked = array.as_::<vortex::array::arrays::Chunked>();

--- a/vortex-bench/src/datasets/taxi_data.rs
+++ b/vortex-bench/src/datasets/taxi_data.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use tokio::fs::File as TokioFile;
 use tokio::io::AsyncWriteExt;
 use vortex::array::ArrayRef;
+use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
 use vortex::array::stream::ArrayStreamExt;
 use vortex::file::OpenOptionsSessionExt;
@@ -37,7 +38,7 @@ impl Dataset for TaxiData {
         "taxi"
     }
 
-    async fn to_vortex_array(&self) -> Result<ArrayRef> {
+    async fn to_vortex_array(&self, _ctx: &mut ExecutionCtx) -> Result<ArrayRef> {
         fetch_taxi_data().await
     }
 

--- a/vortex-bench/src/datasets/tpch_l_comment.rs
+++ b/vortex-bench/src/datasets/tpch_l_comment.rs
@@ -110,9 +110,7 @@ impl Dataset for TPCHLCommentCanonical {
 
     async fn to_vortex_array(&self, ctx: &mut ExecutionCtx) -> Result<ArrayRef> {
         let comments_chunked = TPCHLCommentChunked.to_vortex_array(ctx).await?;
-        let comments_canonical = comments_chunked
-            .execute::<StructArray>(ctx)?
-            .into_array();
+        let comments_canonical = comments_chunked.execute::<StructArray>(ctx)?.into_array();
         Ok(ChunkedArray::from_iter([comments_canonical]).into_array())
     }
 

--- a/vortex-bench/src/datasets/tpch_l_comment.rs
+++ b/vortex-bench/src/datasets/tpch_l_comment.rs
@@ -8,10 +8,11 @@ use async_trait::async_trait;
 use futures::TryStreamExt;
 use glob::glob;
 use vortex::array::ArrayRef;
+use vortex::array::Canonical;
+use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
 use vortex::array::arrays::ChunkedArray;
+use vortex::array::arrays::StructArray;
 use vortex::dtype::Nullability::NonNullable;
 use vortex::expr::col;
 use vortex::expr::pack;
@@ -52,7 +53,7 @@ impl Dataset for TPCHLCommentChunked {
         "TPC-H l_comment chunked"
     }
 
-    async fn to_vortex_array(&self) -> Result<ArrayRef> {
+    async fn to_vortex_array(&self, ctx: &mut ExecutionCtx) -> Result<ArrayRef> {
         let base_path = "tpch".to_data_path();
         let scale_factor_dir = base_path.join("1.0");
         let data_dir = scale_factor_dir.join(Format::OnDiskVortex.name());
@@ -77,10 +78,13 @@ impl Dataset for TPCHLCommentChunked {
             let file_chunks: Vec<_> = file
                 .scan()?
                 .with_projection(pack(vec![("l_comment", col("l_comment"))], NonNullable))
-                .map(|a| {
-                    #[expect(deprecated)]
-                    let canonical = a.to_canonical()?;
-                    Ok(canonical.into_array())
+                .map({
+                    let ctx = ctx.clone();
+                    move |a| {
+                        let mut ctx = ctx.clone();
+                        let canonical = a.execute::<Canonical>(&mut ctx)?;
+                        Ok(canonical.into_array())
+                    }
                 })
                 .into_array_stream()?
                 .try_collect()
@@ -104,10 +108,11 @@ impl Dataset for TPCHLCommentCanonical {
         "TPC-H l_comment canonical"
     }
 
-    async fn to_vortex_array(&self) -> Result<ArrayRef> {
-        let comments_chunked = TPCHLCommentChunked.to_vortex_array().await?;
-        #[expect(deprecated)]
-        let comments_canonical = comments_chunked.to_struct().into_array();
+    async fn to_vortex_array(&self, ctx: &mut ExecutionCtx) -> Result<ArrayRef> {
+        let comments_chunked = TPCHLCommentChunked.to_vortex_array(ctx).await?;
+        let comments_canonical = comments_chunked
+            .execute::<StructArray>(ctx)?
+            .into_array();
         Ok(ChunkedArray::from_iter([comments_canonical]).into_array())
     }
 

--- a/vortex-bench/src/downloadable_dataset.rs
+++ b/vortex-bench/src/downloadable_dataset.rs
@@ -4,6 +4,7 @@
 use async_trait::async_trait;
 use tokio::fs::File;
 use vortex::array::ArrayRef;
+use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
 use vortex::array::stream::ArrayStreamExt;
 use vortex::file::OpenOptionsSessionExt;
@@ -57,7 +58,7 @@ impl Dataset for DownloadableDataset {
         }
     }
 
-    async fn to_vortex_array(&self) -> anyhow::Result<ArrayRef> {
+    async fn to_vortex_array(&self, _ctx: &mut ExecutionCtx) -> anyhow::Result<ArrayRef> {
         let parquet = self.to_parquet_path().await?;
         let dir = format!("{}/", self.name()).to_data_path();
         let vortex = dir.join(format!("{}.vortex", self.name()));

--- a/vortex-bench/src/public_bi.rs
+++ b/vortex-bench/src/public_bi.rs
@@ -26,6 +26,7 @@ use tracing::info;
 use tracing::trace;
 use url::Url;
 use vortex::array::ArrayRef;
+use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
 use vortex::array::stream::ArrayStreamExt;
 use vortex::error::VortexResult;
@@ -452,7 +453,7 @@ impl Dataset for PBIBenchmark {
         &self.name
     }
 
-    async fn to_vortex_array(&self) -> anyhow::Result<ArrayRef> {
+    async fn to_vortex_array(&self, _ctx: &mut ExecutionCtx) -> anyhow::Result<ArrayRef> {
         let dataset = self.dataset()?;
         dataset.write_as_vortex().await?;
         // reading only the first table, each table in a PBI benchmark

--- a/vortex-btrblocks/benches/compress.rs
+++ b/vortex-btrblocks/benches/compress.rs
@@ -13,8 +13,9 @@ mod benchmarks {
     use rand::prelude::StdRng;
     use vortex_array::ArrayRef;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
+    use vortex_array::arrays::PrimitiveArray;
     use vortex_btrblocks::BtrBlocksCompressor;
     use vortex_buffer::buffer_mut;
     use vortex_utils::aliases::hash_set::HashSet;
@@ -40,8 +41,10 @@ mod benchmarks {
 
     #[divan::bench]
     fn btrblocks(bencher: Bencher) {
-        #[expect(deprecated)]
-        let array = make_clickbench_window_name().to_primitive();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let array = make_clickbench_window_name()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let compressor = BtrBlocksCompressor::default();
         bencher
             .with_inputs(|| &array)

--- a/vortex-btrblocks/public-api.lock
+++ b/vortex-btrblocks/public-api.lock
@@ -98,7 +98,7 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::float::ALP
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::float::ALPRDScheme
 
-pub fn vortex_btrblocks::schemes::float::ALPRDScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::float::ALPRDScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::float::ALPRDScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
 
@@ -270,7 +270,7 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::integer::B
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::integer::BitPackingScheme
 
-pub fn vortex_btrblocks::schemes::integer::BitPackingScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::integer::BitPackingScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::integer::BitPackingScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
 
@@ -706,4 +706,4 @@ pub fn vortex_btrblocks::BtrBlocksCompressorBuilder::fmt(&self, f: &mut core::fm
 
 pub const vortex_btrblocks::ALL_SCHEMES: &[&dyn vortex_compressor::scheme::Scheme]
 
-pub fn vortex_btrblocks::compress_patches(patches: vortex_array::patches::Patches) -> vortex_error::VortexResult<vortex_array::patches::Patches>
+pub fn vortex_btrblocks::compress_patches(patches: vortex_array::patches::Patches, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<vortex_array::patches::Patches>

--- a/vortex-btrblocks/public-api.lock
+++ b/vortex-btrblocks/public-api.lock
@@ -230,7 +230,7 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::float::Pco
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::float::PcoScheme
 
-pub fn vortex_btrblocks::schemes::float::PcoScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::float::PcoScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::float::PcoScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
 
@@ -368,7 +368,7 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::integer::P
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::integer::PcoScheme
 
-pub fn vortex_btrblocks::schemes::integer::PcoScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::integer::PcoScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::integer::PcoScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
 
@@ -436,7 +436,7 @@ impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::integer::S
 
 pub fn vortex_btrblocks::schemes::integer::SequenceScheme::ancestor_exclusions(&self) -> alloc::vec::Vec<vortex_compressor::scheme::AncestorExclusion>
 
-pub fn vortex_btrblocks::schemes::integer::SequenceScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::integer::SequenceScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::integer::SequenceScheme::expected_compression_ratio(&self, data: &mut vortex_compressor::stats::cache::ArrayAndStats, ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
 
@@ -614,7 +614,7 @@ impl core::marker::StructuralPartialEq for vortex_btrblocks::schemes::string::Zs
 
 impl vortex_compressor::scheme::Scheme for vortex_btrblocks::schemes::string::ZstdScheme
 
-pub fn vortex_btrblocks::schemes::string::ZstdScheme::compress(&self, _compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
+pub fn vortex_btrblocks::schemes::string::ZstdScheme::compress(&self, compressor: &vortex_compressor::compressor::CascadingCompressor, data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_error::VortexResult<vortex_array::array::erased::ArrayRef>
 
 pub fn vortex_btrblocks::schemes::string::ZstdScheme::expected_compression_ratio(&self, _data: &mut vortex_compressor::stats::cache::ArrayAndStats, _ctx: vortex_compressor::ctx::CompressorContext) -> vortex_compressor::estimate::CompressionEstimate
 

--- a/vortex-btrblocks/src/schemes/decimal.rs
+++ b/vortex-btrblocks/src/schemes/decimal.rs
@@ -6,8 +6,7 @@
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
+use vortex_array::arrays::DecimalArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::decimal::narrowed_decimal;
 use vortex_array::dtype::DecimalType;
@@ -60,8 +59,10 @@ impl Scheme for DecimalScheme {
     ) -> VortexResult<ArrayRef> {
         // TODO(joe): add support splitting i128/256 buffers into chunks of primitive values
         // for compression. 2 for i128 and 4 for i256.
-        #[expect(deprecated)]
-        let decimal = data.array().clone().to_decimal();
+        let decimal = data
+            .array()
+            .clone()
+            .execute::<DecimalArray>(&mut compressor.execution_ctx())?;
         let decimal = narrowed_decimal(decimal);
         let validity = decimal.validity()?;
         let prim = match decimal.values_type() {

--- a/vortex-btrblocks/src/schemes/float.rs
+++ b/vortex-btrblocks/src/schemes/float.rs
@@ -14,10 +14,9 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::Patched;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::patched::use_experimental_patches;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::dtype::PType;
@@ -111,7 +110,7 @@ impl Scheme for ALPScheme {
         let alp_encoded = alp_encode(
             data.array_as_primitive(),
             None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
+            &mut compressor.execution_ctx(),
         )?;
 
         // Compress the ALP ints.
@@ -132,13 +131,16 @@ impl Scheme for ALPScheme {
                 Some(p) => Ok(Patched::from_array_and_patches(
                     alp_array,
                     &p,
-                    &mut LEGACY_SESSION.create_execution_ctx(),
+                    &mut compressor.execution_ctx(),
                 )?
                 .with_stats_set(alp_stats)
                 .into_array()),
             }
         } else {
-            let patches = alp_encoded.patches().map(compress_patches).transpose()?;
+            let patches = alp_encoded
+                .patches()
+                .map(|p| compress_patches(p, &mut compressor.execution_ctx()))
+                .transpose()?;
 
             Ok(ALP::new(compressed_alp_ints, exponents, patches).into_array())
         }
@@ -169,7 +171,7 @@ impl Scheme for ALPRDScheme {
 
     fn compress(
         &self,
-        _compressor: &CascadingCompressor,
+        compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
         _ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
@@ -181,11 +183,14 @@ impl Scheme for ALPRDScheme {
             ptype => vortex_panic!("cannot ALPRD compress ptype {ptype}"),
         };
 
-        let alp_rd = encoder.encode(primitive_array);
+        let alp_rd = encoder.encode(primitive_array, &mut compressor.execution_ctx());
         let dtype = alp_rd.dtype().clone();
         let right_bit_width = alp_rd.right_bit_width();
         let mut parts = ALPRDArrayOwnedExt::into_data_parts(alp_rd);
-        parts.left_parts_patches = parts.left_parts_patches.map(compress_patches).transpose()?;
+        parts.left_parts_patches = parts
+            .left_parts_patches
+            .map(|p| compress_patches(p, &mut compressor.execution_ctx()))
+            .transpose()?;
 
         Ok(vortex_alp::ALPRD::try_new(
             dtype,
@@ -194,6 +199,7 @@ impl Scheme for ALPRDScheme {
             parts.right_parts,
             right_bit_width,
             parts.left_parts_patches,
+            &mut compressor.execution_ctx(),
         )?
         .into_array())
     }
@@ -227,7 +233,10 @@ impl Scheme for NullDominatedSparseScheme {
         _ctx: CompressorContext,
     ) -> CompressionEstimate {
         let len = data.array_len() as f64;
-        let stats = data.float_stats();
+        // TRAIT-IMPL BOUNDARY: `Scheme::expected_compression_ratio` has a fixed signature
+        // and does not receive an `ExecutionCtx`, so we fall back to the legacy session here.
+        let mut exec_ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.float_stats(&mut exec_ctx);
         let value_count = stats.value_count();
 
         // All-null arrays should be compressed as constant instead anyways.
@@ -251,11 +260,15 @@ impl Scheme for NullDominatedSparseScheme {
         ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
         // We pass None as we only run this pathway for NULL-dominated float arrays.
-        let sparse_encoded = Sparse::encode(data.array(), None)?;
+        let sparse_encoded = Sparse::encode(data.array(), None, &mut compressor.execution_ctx())?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<Sparse>() {
-            #[expect(deprecated)]
-            let indices = sparse.patches().indices().to_primitive().narrow()?;
+            let indices = sparse
+                .patches()
+                .indices()
+                .clone()
+                .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+                .narrow()?;
             let compressed_indices =
                 compressor.compress_child(&indices.into_array(), &ctx, self.id(), 0)?;
 
@@ -292,7 +305,7 @@ impl Scheme for PcoScheme {
 
     fn compress(
         &self,
-        _compressor: &CascadingCompressor,
+        compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
         _ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
@@ -300,6 +313,7 @@ impl Scheme for PcoScheme {
             data.array_as_primitive(),
             pco::DEFAULT_COMPRESSION_LEVEL,
             8192,
+            &mut compressor.execution_ctx(),
         )?
         .into_array())
     }
@@ -337,7 +351,12 @@ impl Scheme for FloatRLEScheme {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
-        if data.float_stats().average_run_length() < super::integer::RUN_LENGTH_THRESHOLD {
+        // TRAIT-IMPL BOUNDARY: `Scheme::expected_compression_ratio` has a fixed signature
+        // and does not receive an `ExecutionCtx`, so we fall back to the legacy session here.
+        let mut exec_ctx = LEGACY_SESSION.create_execution_ctx();
+        if data.float_stats(&mut exec_ctx).average_run_length()
+            < super::integer::RUN_LENGTH_THRESHOLD
+        {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 

--- a/vortex-btrblocks/src/schemes/integer.rs
+++ b/vortex-btrblocks/src/schemes/integer.rs
@@ -7,11 +7,10 @@ use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::Patched;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::patched::use_experimental_patches;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::scalar::Scalar;
@@ -140,7 +139,9 @@ impl Scheme for FoRScheme {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
-        let stats = data.integer_stats();
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.integer_stats(&mut local_ctx);
 
         // Only apply when the min is not already zero.
         if stats.erased().min_is_zero() {
@@ -187,11 +188,15 @@ impl Scheme for FoRScheme {
         data: &mut ArrayAndStats,
         ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
-        #[expect(deprecated)]
-        let primitive = data.array().to_primitive();
+        let primitive = data
+            .array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
         let for_array = FoR::encode(primitive)?;
-        #[expect(deprecated)]
-        let biased = for_array.encoded().to_primitive();
+        let biased = for_array
+            .encoded()
+            .clone()
+            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
 
         // Immediately bitpack. If any other scheme was preferable, it would be chosen instead
         // of bitpacking.
@@ -275,7 +280,9 @@ impl Scheme for ZigZagScheme {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
-        let stats = data.integer_stats();
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.integer_stats(&mut local_ctx);
 
         // ZigZag is only useful when there are negative values.
         if !stats.erased().min_is_negative() {
@@ -293,8 +300,10 @@ impl Scheme for ZigZagScheme {
     ) -> VortexResult<ArrayRef> {
         // Zigzag encode the values, then recursively compress the inner values.
         let zag = zigzag_encode(data.array_as_primitive())?;
-        #[expect(deprecated)]
-        let encoded = zag.encoded().to_primitive();
+        let encoded = zag
+            .encoded()
+            .clone()
+            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
 
         let compressed = compressor.compress_child(&encoded.into_array(), &ctx, self.id(), 0)?;
 
@@ -318,7 +327,9 @@ impl Scheme for BitPackingScheme {
         data: &mut ArrayAndStats,
         _ctx: CompressorContext,
     ) -> CompressionEstimate {
-        let stats = data.integer_stats();
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.integer_stats(&mut local_ctx);
 
         // BitPacking only works for non-negative values.
         if stats.erased().min_is_negative() {
@@ -330,13 +341,13 @@ impl Scheme for BitPackingScheme {
 
     fn compress(
         &self,
-        _compressor: &CascadingCompressor,
+        compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
         _ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
         let primitive_array = data.array_as_primitive();
 
-        let histogram = bit_width_histogram(primitive_array)?;
+        let histogram = bit_width_histogram(primitive_array, &mut compressor.execution_ctx())?;
         let bw = find_best_bit_width(primitive_array.ptype(), &histogram)?;
 
         // If best bw is determined to be the current bit-width, return the original array.
@@ -346,7 +357,12 @@ impl Scheme for BitPackingScheme {
 
         // Otherwise we can bitpack the array.
         let primitive_array = primitive_array.into_owned();
-        let packed = bitpack_encode(&primitive_array, bw, Some(&histogram))?;
+        let packed = bitpack_encode(
+            &primitive_array,
+            bw,
+            Some(&histogram),
+            &mut compressor.execution_ctx(),
+        )?;
 
         let packed_stats = packed.statistics().to_owned();
         let ptype = packed.dtype().as_ptype();
@@ -368,17 +384,19 @@ impl Scheme for BitPackingScheme {
 
             match patches {
                 None => array,
-                Some(p) => Patched::from_array_and_patches(
-                    array,
-                    &p,
-                    &mut LEGACY_SESSION.create_execution_ctx(),
-                )?
-                .with_stats_set(packed_stats)
-                .into_array(),
+                Some(p) => {
+                    Patched::from_array_and_patches(array, &p, &mut compressor.execution_ctx())?
+                        .with_stats_set(packed_stats)
+                        .into_array()
+                }
             }
         } else {
             // Compress patches and place back into BitPackedArray.
-            let patches = parts.patches.take().map(compress_patches).transpose()?;
+            let patches = parts
+                .patches
+                .take()
+                .map(|p| compress_patches(p, &mut compressor.execution_ctx()))
+                .transpose()?;
             parts.patches = patches;
             BitPacked::try_new(
                 parts.packed,
@@ -446,7 +464,9 @@ impl Scheme for SparseScheme {
         _ctx: CompressorContext,
     ) -> CompressionEstimate {
         let len = data.array_len() as f64;
-        let stats = data.integer_stats();
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.integer_stats(&mut local_ctx);
         let value_count = stats.value_count();
 
         // All-null arrays should be compressed as constant instead anyways.
@@ -492,7 +512,7 @@ impl Scheme for SparseScheme {
     ) -> VortexResult<ArrayRef> {
         let len = data.array_len();
         // TODO(connor): Fight the borrow checker (needs interior mutability)!
-        let stats = data.integer_stats().clone();
+        let stats = data.integer_stats(&mut compressor.execution_ctx()).clone();
         let array = data.array();
 
         let (most_frequent_value, most_frequent_count) = stats
@@ -522,11 +542,15 @@ impl Scheme for SparseScheme {
                 most_frequent_value.ptype(),
                 array.dtype().nullability(),
             )),
+            &mut compressor.execution_ctx(),
         )?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<Sparse>() {
-            #[expect(deprecated)]
-            let sparse_values_primitive = sparse.patches().values().to_primitive();
+            let sparse_values_primitive = sparse
+                .patches()
+                .values()
+                .clone()
+                .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
             let compressed_values = compressor.compress_child(
                 &sparse_values_primitive.into_array(),
                 &ctx,
@@ -534,8 +558,12 @@ impl Scheme for SparseScheme {
                 0,
             )?;
 
-            #[expect(deprecated)]
-            let indices = sparse.patches().indices().to_primitive().narrow()?;
+            let indices = sparse
+                .patches()
+                .indices()
+                .clone()
+                .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+                .narrow()?;
 
             let compressed_indices =
                 compressor.compress_child(&indices.into_array(), &ctx, self.id(), 1)?;
@@ -615,7 +643,13 @@ impl Scheme for RunEndScheme {
         _ctx: CompressorContext,
     ) -> CompressionEstimate {
         // If the run length is below the threshold, drop it.
-        if data.integer_stats().average_run_length() < RUN_END_THRESHOLD {
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
+        if data
+            .integer_stats(&mut local_ctx)
+            .average_run_length()
+            < RUN_END_THRESHOLD
+        {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
@@ -629,10 +663,12 @@ impl Scheme for RunEndScheme {
         ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
         // Run-end encode the ends.
-        let (ends, values) = runend_encode(data.array_as_primitive());
+        let (ends, values) =
+            runend_encode(data.array_as_primitive(), &mut compressor.execution_ctx());
 
-        #[expect(deprecated)]
-        let values_primitive = values.to_primitive();
+        let values_primitive = values
+            .clone()
+            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
         let compressed_values =
             compressor.compress_child(&values_primitive.into_array(), &ctx, self.id(), 0)?;
 
@@ -640,8 +676,14 @@ impl Scheme for RunEndScheme {
 
         // SAFETY: compression doesn't affect invariants.
         Ok(unsafe {
-            RunEnd::new_unchecked(compressed_ends, compressed_values, 0, data.array_len())
-                .into_array()
+            RunEnd::new_unchecked(
+                compressed_ends,
+                compressed_values,
+                0,
+                data.array_len(),
+                &mut compressor.execution_ctx(),
+            )
+            .into_array()
         })
     }
 }
@@ -686,7 +728,9 @@ impl Scheme for SequenceScheme {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
-        let stats = data.integer_stats();
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.integer_stats(&mut local_ctx);
 
         // `SequenceArray` does not support nulls.
         if stats.null_count() > 0 {
@@ -706,8 +750,12 @@ impl Scheme for SequenceScheme {
         // why do we divide the ratio by 2???
 
         CompressionEstimate::Deferred(DeferredEstimate::Callback(Box::new(
-            |_compressor, data, _ctx| {
-                let Some(encoded) = sequence_encode(data.array_as_primitive())? else {
+            |compressor, data, _ctx| {
+                let Some(encoded) = sequence_encode(
+                    data.array_as_primitive(),
+                    &mut compressor.execution_ctx(),
+                )?
+                else {
                     // If we are unable to sequence encode this array, make sure we skip.
                     return Ok(EstimateVerdict::Skip);
                 };
@@ -722,16 +770,16 @@ impl Scheme for SequenceScheme {
 
     fn compress(
         &self,
-        _compressor: &CascadingCompressor,
+        compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
         _ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
-        let stats = data.integer_stats();
+        let stats = data.integer_stats(&mut compressor.execution_ctx());
 
         if stats.null_count() > 0 {
             vortex_bail!("sequence encoding does not support nulls");
         }
-        sequence_encode(data.array_as_primitive())?
+        sequence_encode(data.array_as_primitive(), &mut compressor.execution_ctx())?
             .ok_or_else(|| vortex_err!("cannot sequence encode array"))
     }
 }
@@ -763,7 +811,7 @@ impl Scheme for PcoScheme {
 
     fn compress(
         &self,
-        _compressor: &CascadingCompressor,
+        compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
         _ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
@@ -771,6 +819,7 @@ impl Scheme for PcoScheme {
             data.array_as_primitive(),
             pco::DEFAULT_COMPRESSION_LEVEL,
             8192,
+            &mut compressor.execution_ctx(),
         )?
         .into_array())
     }
@@ -783,18 +832,23 @@ pub(crate) fn rle_compress(
     data: &mut ArrayAndStats,
     ctx: CompressorContext,
 ) -> VortexResult<ArrayRef> {
-    let rle_array = RLE::encode(data.array_as_primitive())?;
+    let rle_array = RLE::encode(data.array_as_primitive(), &mut compressor.execution_ctx())?;
 
-    #[expect(deprecated)]
-    let rle_values_primitive = rle_array.values().to_primitive();
+    let rle_values_primitive = rle_array
+        .values()
+        .clone()
+        .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
     let compressed_values =
         compressor.compress_child(&rle_values_primitive.into_array(), &ctx, scheme.id(), 0)?;
 
     // Delta is an unstable encoding, once we deem it stable we can switch over to this always.
     #[cfg(feature = "unstable_encodings")]
     let compressed_indices = {
-        #[expect(deprecated)]
-        let rle_indices_primitive = rle_array.indices().to_primitive().narrow()?;
+        let rle_indices_primitive = rle_array
+            .indices()
+            .clone()
+            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .narrow()?;
         try_compress_delta(
             compressor,
             &rle_indices_primitive.into_array(),
@@ -806,13 +860,19 @@ pub(crate) fn rle_compress(
 
     #[cfg(not(feature = "unstable_encodings"))]
     let compressed_indices = {
-        #[expect(deprecated)]
-        let rle_indices_primitive = rle_array.indices().to_primitive().narrow()?;
+        let rle_indices_primitive = rle_array
+            .indices()
+            .clone()
+            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .narrow()?;
         compressor.compress_child(&rle_indices_primitive.into_array(), &ctx, scheme.id(), 1)?
     };
 
-    #[expect(deprecated)]
-    let rle_offsets_primitive = rle_array.values_idx_offsets().to_primitive().narrow()?;
+    let rle_offsets_primitive = rle_array
+        .values_idx_offsets()
+        .clone()
+        .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+        .narrow()?;
     let compressed_offsets =
         compressor.compress_child(&rle_offsets_primitive.into_array(), &ctx, scheme.id(), 2)?;
 
@@ -837,8 +897,9 @@ fn try_compress_delta(
     parent_id: SchemeId,
     child_index: usize,
 ) -> VortexResult<ArrayRef> {
-    #[expect(deprecated)]
-    let child_primitive = child.to_primitive();
+    let child_primitive = child
+        .clone()
+        .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
     let (bases, deltas) =
         vortex_fastlanes::delta_compress(&child_primitive, &mut compressor.execution_ctx())?;
 
@@ -882,7 +943,9 @@ impl Scheme for IntRLEScheme {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
-        if data.integer_stats().average_run_length() < RUN_LENGTH_THRESHOLD {
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
+        if data.integer_stats(&mut local_ctx).average_run_length() < RUN_LENGTH_THRESHOLD {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 

--- a/vortex-btrblocks/src/schemes/integer.rs
+++ b/vortex-btrblocks/src/schemes/integer.rs
@@ -645,11 +645,7 @@ impl Scheme for RunEndScheme {
         // If the run length is below the threshold, drop it.
         // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
         let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
-        if data
-            .integer_stats(&mut local_ctx)
-            .average_run_length()
-            < RUN_END_THRESHOLD
-        {
+        if data.integer_stats(&mut local_ctx).average_run_length() < RUN_END_THRESHOLD {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
         }
 
@@ -666,9 +662,7 @@ impl Scheme for RunEndScheme {
         let (ends, values) =
             runend_encode(data.array_as_primitive(), &mut compressor.execution_ctx());
 
-        let values_primitive = values
-            .clone()
-            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
+        let values_primitive = values.execute::<PrimitiveArray>(&mut compressor.execution_ctx())?;
         let compressed_values =
             compressor.compress_child(&values_primitive.into_array(), &ctx, self.id(), 0)?;
 
@@ -751,10 +745,8 @@ impl Scheme for SequenceScheme {
 
         CompressionEstimate::Deferred(DeferredEstimate::Callback(Box::new(
             |compressor, data, _ctx| {
-                let Some(encoded) = sequence_encode(
-                    data.array_as_primitive(),
-                    &mut compressor.execution_ctx(),
-                )?
+                let Some(encoded) =
+                    sequence_encode(data.array_as_primitive(), &mut compressor.execution_ctx())?
                 else {
                     // If we are unable to sequence encode this array, make sure we skip.
                     return Ok(EstimateVerdict::Skip);

--- a/vortex-btrblocks/src/schemes/patches.rs
+++ b/vortex-btrblocks/src/schemes/patches.rs
@@ -2,32 +2,33 @@
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
 use vortex_array::ArrayRef;
+use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::patches::Patches;
 use vortex_error::VortexError;
 use vortex_error::VortexResult;
 
 /// Compresses the given patches by downscaling integers and checking for constant values.
-pub fn compress_patches(patches: Patches) -> VortexResult<Patches> {
+pub fn compress_patches(patches: Patches, ctx: &mut ExecutionCtx) -> VortexResult<Patches> {
     // Downscale the patch indices.
-    #[expect(deprecated)]
-    let indices = patches.indices().to_primitive().narrow()?.into_array();
+    let indices = patches
+        .indices()
+        .clone()
+        .execute::<PrimitiveArray>(ctx)?
+        .narrow()?
+        .into_array();
 
     // Check if the values are constant.
     let values = patches.values();
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let values = if values
         .statistics()
-        .compute_is_constant(&mut ctx)
+        .compute_is_constant(ctx)
         .unwrap_or_default()
     {
-        ConstantArray::new(values.execute_scalar(0, &mut ctx)?, values.len()).into_array()
+        ConstantArray::new(values.execute_scalar(0, ctx)?, values.len()).into_array()
     } else {
         values.clone()
     };
@@ -35,8 +36,11 @@ pub fn compress_patches(patches: Patches) -> VortexResult<Patches> {
         .chunk_offsets()
         .as_ref()
         .map(|offsets| {
-            #[expect(deprecated)]
-            let offsets_primitive = offsets.to_primitive().narrow()?.into_array();
+            let offsets_primitive = offsets
+                .clone()
+                .execute::<PrimitiveArray>(ctx)?
+                .narrow()?
+                .into_array();
             Ok::<ArrayRef, VortexError>(offsets_primitive)
         })
         .transpose()?;

--- a/vortex-btrblocks/src/schemes/string.rs
+++ b/vortex-btrblocks/src/schemes/string.rs
@@ -6,8 +6,9 @@
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::VarBinArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::arrays::varbin::VarBinArrayExt;
@@ -87,10 +88,19 @@ impl Scheme for FSSTScheme {
     ) -> VortexResult<ArrayRef> {
         let utf8 = data.array_as_utf8().into_owned();
         let compressor_fsst = fsst_train_compressor(&utf8);
-        let fsst = fsst_compress(&utf8, utf8.len(), utf8.dtype(), &compressor_fsst);
+        let fsst = fsst_compress(
+            &utf8,
+            utf8.len(),
+            utf8.dtype(),
+            &compressor_fsst,
+            &mut compressor.execution_ctx(),
+        );
 
-        #[expect(deprecated)]
-        let uncompressed_lengths_primitive = fsst.uncompressed_lengths().to_primitive().narrow()?;
+        let uncompressed_lengths_primitive = fsst
+            .uncompressed_lengths()
+            .clone()
+            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .narrow()?;
         let compressed_original_lengths = compressor.compress_child(
             &uncompressed_lengths_primitive.into_array(),
             &ctx,
@@ -98,8 +108,12 @@ impl Scheme for FSSTScheme {
             0,
         )?;
 
-        #[expect(deprecated)]
-        let codes_offsets_primitive = fsst.codes().offsets().to_primitive().narrow()?;
+        let codes_offsets_primitive = fsst
+            .codes()
+            .offsets()
+            .clone()
+            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .narrow()?;
         let compressed_codes_offsets =
             compressor.compress_child(&codes_offsets_primitive.into_array(), &ctx, self.id(), 1)?;
         let compressed_codes = VarBinArray::try_new(
@@ -115,6 +129,7 @@ impl Scheme for FSSTScheme {
             fsst.symbol_lengths().clone(),
             compressed_codes,
             compressed_original_lengths,
+            &mut compressor.execution_ctx(),
         )?;
 
         Ok(fsst.into_array())
@@ -155,7 +170,9 @@ impl Scheme for NullDominatedSparseScheme {
         _ctx: CompressorContext,
     ) -> CompressionEstimate {
         let len = data.array_len() as f64;
-        let stats = data.string_stats();
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.string_stats(&mut local_ctx);
         let value_count = stats.value_count();
 
         // All-null arrays should be compressed as constant instead anyways.
@@ -179,12 +196,16 @@ impl Scheme for NullDominatedSparseScheme {
         ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
         // We pass None as we only run this pathway for NULL-dominated string arrays.
-        let sparse_encoded = Sparse::encode(data.array(), None)?;
+        let sparse_encoded = Sparse::encode(data.array(), None, &mut compressor.execution_ctx())?;
 
         if let Some(sparse) = sparse_encoded.as_opt::<Sparse>() {
             // Compress the indices only (not the values for strings).
-            #[expect(deprecated)]
-            let indices = sparse.patches().indices().to_primitive().narrow()?;
+            let indices = sparse
+                .patches()
+                .indices()
+                .clone()
+                .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+                .narrow()?;
             let compressed_indices =
                 compressor.compress_child(&indices.into_array(), &ctx, self.id(), 0)?;
 
@@ -221,12 +242,18 @@ impl Scheme for ZstdScheme {
 
     fn compress(
         &self,
-        _compressor: &CascadingCompressor,
+        compressor: &CascadingCompressor,
         data: &mut ArrayAndStats,
         _ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
         let compacted = data.array_as_utf8().into_owned().compact_buffers()?;
-        Ok(vortex_zstd::Zstd::from_var_bin_view_without_dict(&compacted, 3, 8192)?.into_array())
+        Ok(vortex_zstd::Zstd::from_var_bin_view_without_dict(
+            &compacted,
+            3,
+            8192,
+            &mut compressor.execution_ctx(),
+        )?
+        .into_array())
     }
 }
 
@@ -255,7 +282,7 @@ impl Scheme for ZstdBuffersScheme {
         _ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
         Ok(
-            vortex_zstd::ZstdBuffers::compress(data.array(), 3, &vortex_array::LEGACY_SESSION)?
+            vortex_zstd::ZstdBuffers::compress(data.array(), 3, &LEGACY_SESSION)?
                 .into_array(),
         )
     }

--- a/vortex-btrblocks/src/schemes/string.rs
+++ b/vortex-btrblocks/src/schemes/string.rs
@@ -281,10 +281,7 @@ impl Scheme for ZstdBuffersScheme {
         data: &mut ArrayAndStats,
         _ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
-        Ok(
-            vortex_zstd::ZstdBuffers::compress(data.array(), 3, &LEGACY_SESSION)?
-                .into_array(),
-        )
+        Ok(vortex_zstd::ZstdBuffers::compress(data.array(), 3, &LEGACY_SESSION)?.into_array())
     }
 }
 

--- a/vortex-btrblocks/src/schemes/temporal.rs
+++ b/vortex-btrblocks/src/schemes/temporal.rs
@@ -6,12 +6,10 @@
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
-use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::fns::is_constant::is_constant;
 use vortex_array::arrays::ConstantArray;
+use vortex_array::arrays::ExtensionArray;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::TemporalArray;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
 use vortex_array::dtype::extension::Matcher;
@@ -76,8 +74,7 @@ impl Scheme for TemporalScheme {
         ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
         let array = data.array().clone();
-        #[expect(deprecated)]
-        let ext_array = array.to_extension();
+        let ext_array = array.execute::<ExtensionArray>(&mut compressor.execution_ctx())?;
         let temporal_array = TemporalArray::try_from(ext_array.clone().into_array())?;
 
         // Check for constant array and return early if so.
@@ -88,7 +85,7 @@ impl Scheme for TemporalScheme {
 
         if is_constant {
             return Ok(ConstantArray::new(
-                ext_array.execute_scalar(0, &mut LEGACY_SESSION.create_execution_ctx())?,
+                ext_array.execute_scalar(0, &mut compressor.execution_ctx())?,
                 ext_array.len(),
             )
             .into_array());
@@ -99,17 +96,20 @@ impl Scheme for TemporalScheme {
             days,
             seconds,
             subseconds,
-        } = split_temporal(temporal_array)?;
+        } = split_temporal(temporal_array, &mut compressor.execution_ctx())?;
 
-        #[expect(deprecated)]
-        let days_primitive = days.to_primitive().narrow()?;
+        let days_primitive = days
+            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .narrow()?;
         let days = compressor.compress_child(&days_primitive.into_array(), &ctx, self.id(), 0)?;
-        #[expect(deprecated)]
-        let seconds_primitive = seconds.to_primitive().narrow()?;
+        let seconds_primitive = seconds
+            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .narrow()?;
         let seconds =
             compressor.compress_child(&seconds_primitive.into_array(), &ctx, self.id(), 1)?;
-        #[expect(deprecated)]
-        let subseconds_primitive = subseconds.to_primitive().narrow()?;
+        let subseconds_primitive = subseconds
+            .execute::<PrimitiveArray>(&mut compressor.execution_ctx())?
+            .narrow()?;
         let subseconds =
             compressor.compress_child(&subseconds_primitive.into_array(), &ctx, self.id(), 2)?;
 

--- a/vortex-compressor/benches/dict_encode.rs
+++ b/vortex-compressor/benches/dict_encode.rs
@@ -5,6 +5,8 @@
 
 use divan::Bencher;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::builders::dict::dict_encode;
@@ -40,7 +42,7 @@ fn encode_generic(bencher: Bencher) {
 #[divan::bench]
 fn encode_specialized(bencher: Bencher) {
     let array = make_array();
-    let stats = IntegerStats::generate(&array);
+    let stats = IntegerStats::generate(&array, &mut LEGACY_SESSION.create_execution_ctx());
     bencher
         .with_inputs(|| &stats)
         .bench_refs(|stats| integer_dictionary_encode(array.as_view(), stats));

--- a/vortex-compressor/benches/stats_calc.rs
+++ b/vortex-compressor/benches/stats_calc.rs
@@ -58,7 +58,7 @@ mod benchmarks {
         bencher
             .with_inputs(|| (&values, LEGACY_SESSION.create_execution_ctx()))
             .bench_refs(|(values, ctx)| {
-                IntegerStats::generate_opts(*values, GenerateStatsOptions::default(), ctx);
+                IntegerStats::generate_opts(values, GenerateStatsOptions::default(), ctx);
             });
     }
 
@@ -74,7 +74,7 @@ mod benchmarks {
             .with_inputs(|| (&values, LEGACY_SESSION.create_execution_ctx()))
             .bench_refs(|(values, ctx)| {
                 IntegerStats::generate_opts(
-                    *values,
+                    values,
                     GenerateStatsOptions {
                         count_distinct_values: false,
                     },

--- a/vortex-compressor/benches/stats_calc.rs
+++ b/vortex-compressor/benches/stats_calc.rs
@@ -5,6 +5,8 @@
 #[divan::bench_group(items_count = 64_000u32, bytes_count = 256_000u32)]
 mod benchmarks {
     use divan::Bencher;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::validity::Validity;
     use vortex_buffer::Buffer;
@@ -53,9 +55,11 @@ mod benchmarks {
             Distribution::LongRuns => generate_runs(64),
         };
 
-        bencher.with_inputs(|| &values).bench_refs(|values| {
-            IntegerStats::generate_opts(values, GenerateStatsOptions::default());
-        });
+        bencher
+            .with_inputs(|| (&values, LEGACY_SESSION.create_execution_ctx()))
+            .bench_refs(|(values, ctx)| {
+                IntegerStats::generate_opts(*values, GenerateStatsOptions::default(), ctx);
+            });
     }
 
     #[divan::bench(args = [Distribution::LowCardinality, Distribution::ShortRuns, Distribution::LongRuns])]
@@ -66,14 +70,17 @@ mod benchmarks {
             Distribution::LongRuns => generate_runs(64),
         };
 
-        bencher.with_inputs(|| &values).bench_refs(|values| {
-            IntegerStats::generate_opts(
-                values,
-                GenerateStatsOptions {
-                    count_distinct_values: false,
-                },
-            );
-        });
+        bencher
+            .with_inputs(|| (&values, LEGACY_SESSION.create_execution_ctx()))
+            .bench_refs(|(values, ctx)| {
+                IntegerStats::generate_opts(
+                    *values,
+                    GenerateStatsOptions {
+                        count_distinct_values: false,
+                    },
+                    ctx,
+                );
+            });
     }
 }
 

--- a/vortex-compressor/public-api.lock
+++ b/vortex-compressor/public-api.lock
@@ -690,25 +690,25 @@ pub fn vortex_compressor::stats::ArrayAndStats::array_as_utf8(&self) -> vortex_a
 
 pub fn vortex_compressor::stats::ArrayAndStats::array_len(&self) -> usize
 
-pub fn vortex_compressor::stats::ArrayAndStats::bool_stats(&mut self) -> &vortex_compressor::stats::BoolStats
+pub fn vortex_compressor::stats::ArrayAndStats::bool_stats(&mut self, ctx: &mut vortex_array::executor::ExecutionCtx) -> &vortex_compressor::stats::BoolStats
 
-pub fn vortex_compressor::stats::ArrayAndStats::float_stats(&mut self) -> &vortex_compressor::stats::FloatStats
+pub fn vortex_compressor::stats::ArrayAndStats::float_stats(&mut self, ctx: &mut vortex_array::executor::ExecutionCtx) -> &vortex_compressor::stats::FloatStats
 
 pub fn vortex_compressor::stats::ArrayAndStats::get_or_insert_with<T: 'static>(&mut self, f: impl core::ops::function::FnOnce() -> T) -> &T
 
-pub fn vortex_compressor::stats::ArrayAndStats::integer_stats(&mut self) -> &vortex_compressor::stats::IntegerStats
+pub fn vortex_compressor::stats::ArrayAndStats::integer_stats(&mut self, ctx: &mut vortex_array::executor::ExecutionCtx) -> &vortex_compressor::stats::IntegerStats
 
 pub fn vortex_compressor::stats::ArrayAndStats::into_array(self) -> vortex_array::array::erased::ArrayRef
 
 pub fn vortex_compressor::stats::ArrayAndStats::new(array: vortex_array::array::erased::ArrayRef, opts: vortex_compressor::stats::GenerateStatsOptions) -> Self
 
-pub fn vortex_compressor::stats::ArrayAndStats::string_stats(&mut self) -> &vortex_compressor::stats::StringStats
+pub fn vortex_compressor::stats::ArrayAndStats::string_stats(&mut self, ctx: &mut vortex_array::executor::ExecutionCtx) -> &vortex_compressor::stats::StringStats
 
 pub struct vortex_compressor::stats::BoolStats
 
 impl vortex_compressor::stats::BoolStats
 
-pub fn vortex_compressor::stats::BoolStats::generate(input: &vortex_array::arrays::bool::vtable::BoolArray) -> vortex_error::VortexResult<Self>
+pub fn vortex_compressor::stats::BoolStats::generate(input: &vortex_array::arrays::bool::vtable::BoolArray, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<Self>
 
 pub fn vortex_compressor::stats::BoolStats::is_constant(&self) -> bool
 
@@ -748,9 +748,9 @@ pub fn vortex_compressor::stats::FloatStats::average_run_length(&self) -> u32
 
 pub fn vortex_compressor::stats::FloatStats::erased(&self) -> &vortex_compressor::stats::FloatErasedStats
 
-pub fn vortex_compressor::stats::FloatStats::generate(input: &vortex_array::arrays::primitive::vtable::PrimitiveArray) -> Self
+pub fn vortex_compressor::stats::FloatStats::generate(input: &vortex_array::arrays::primitive::vtable::PrimitiveArray, ctx: &mut vortex_array::executor::ExecutionCtx) -> Self
 
-pub fn vortex_compressor::stats::FloatStats::generate_opts(input: &vortex_array::arrays::primitive::vtable::PrimitiveArray, opts: vortex_compressor::stats::GenerateStatsOptions) -> Self
+pub fn vortex_compressor::stats::FloatStats::generate_opts(input: &vortex_array::arrays::primitive::vtable::PrimitiveArray, opts: vortex_compressor::stats::GenerateStatsOptions, ctx: &mut vortex_array::executor::ExecutionCtx) -> Self
 
 pub fn vortex_compressor::stats::FloatStats::null_count(&self) -> u32
 
@@ -838,9 +838,9 @@ pub fn vortex_compressor::stats::IntegerStats::average_run_length(&self) -> u32
 
 pub fn vortex_compressor::stats::IntegerStats::erased(&self) -> &vortex_compressor::stats::IntegerErasedStats
 
-pub fn vortex_compressor::stats::IntegerStats::generate(input: &vortex_array::arrays::primitive::vtable::PrimitiveArray) -> Self
+pub fn vortex_compressor::stats::IntegerStats::generate(input: &vortex_array::arrays::primitive::vtable::PrimitiveArray, ctx: &mut vortex_array::executor::ExecutionCtx) -> Self
 
-pub fn vortex_compressor::stats::IntegerStats::generate_opts(input: &vortex_array::arrays::primitive::vtable::PrimitiveArray, opts: vortex_compressor::stats::GenerateStatsOptions) -> Self
+pub fn vortex_compressor::stats::IntegerStats::generate_opts(input: &vortex_array::arrays::primitive::vtable::PrimitiveArray, opts: vortex_compressor::stats::GenerateStatsOptions, ctx: &mut vortex_array::executor::ExecutionCtx) -> Self
 
 pub fn vortex_compressor::stats::IntegerStats::null_count(&self) -> u32
 
@@ -912,9 +912,9 @@ impl vortex_compressor::stats::StringStats
 
 pub fn vortex_compressor::stats::StringStats::estimated_distinct_count(&self) -> core::option::Option<u32>
 
-pub fn vortex_compressor::stats::StringStats::generate(input: &vortex_array::arrays::varbinview::vtable::VarBinViewArray) -> Self
+pub fn vortex_compressor::stats::StringStats::generate(input: &vortex_array::arrays::varbinview::vtable::VarBinViewArray, ctx: &mut vortex_array::executor::ExecutionCtx) -> Self
 
-pub fn vortex_compressor::stats::StringStats::generate_opts(input: &vortex_array::arrays::varbinview::vtable::VarBinViewArray, opts: vortex_compressor::stats::GenerateStatsOptions) -> Self
+pub fn vortex_compressor::stats::StringStats::generate_opts(input: &vortex_array::arrays::varbinview::vtable::VarBinViewArray, opts: vortex_compressor::stats::GenerateStatsOptions, ctx: &mut vortex_array::executor::ExecutionCtx) -> Self
 
 pub fn vortex_compressor::stats::StringStats::null_count(&self) -> u32
 

--- a/vortex-compressor/src/builtins/constant/bool.rs
+++ b/vortex-compressor/src/builtins/constant/bool.rs
@@ -5,6 +5,8 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_error::VortexResult;
 
 use crate::CascadingCompressor;
@@ -37,7 +39,9 @@ impl Scheme for BoolConstantScheme {
         }
 
         let array_len = data.array().len();
-        let stats = data.bool_stats();
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.bool_stats(&mut ctx);
 
         // We want to use `Constant` if there are only nulls in the array.
         if stats.value_count() == 0 {

--- a/vortex-compressor/src/builtins/constant/float.rs
+++ b/vortex-compressor/src/builtins/constant/float.rs
@@ -5,6 +5,8 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::fns::is_constant::is_constant;
 use vortex_error::VortexResult;
 
@@ -40,7 +42,10 @@ impl Scheme for FloatConstantScheme {
         }
 
         let array_len = data.array().len();
-        let stats = data.float_stats();
+        // TRAIT-IMPL BOUNDARY: `Scheme::expected_compression_ratio` has a fixed signature
+        // and does not receive an `ExecutionCtx`, so we fall back to the legacy session here.
+        let mut exec_ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.float_stats(&mut exec_ctx);
 
         // Note that we only compute distinct counts if other schemes have requested it.
         if let Some(distinct_count) = stats.distinct_count() {

--- a/vortex-compressor/src/builtins/constant/integer.rs
+++ b/vortex-compressor/src/builtins/constant/integer.rs
@@ -5,6 +5,8 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_error::VortexResult;
 
 use super::is_integer_primitive;
@@ -38,7 +40,9 @@ impl Scheme for IntConstantScheme {
         }
 
         let array_len = data.array().len();
-        let stats = data.integer_stats();
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.integer_stats(&mut ctx);
 
         // Note that we only compute distinct counts if other schemes have requested it.
         if let Some(distinct_count) = stats.distinct_count() {

--- a/vortex-compressor/src/builtins/constant/string.rs
+++ b/vortex-compressor/src/builtins/constant/string.rs
@@ -5,6 +5,8 @@
 
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::fns::is_constant::is_constant;
 use vortex_error::VortexResult;
 
@@ -40,7 +42,9 @@ impl Scheme for StringConstantScheme {
         }
 
         let array_len = data.array().len();
-        let stats = data.string_stats();
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.string_stats(&mut local_ctx);
 
         // We want to use `Constant` if there are only nulls in the array.
         if stats.value_count() == 0 {

--- a/vortex-compressor/src/builtins/dict/float.rs
+++ b/vortex-compressor/src/builtins/dict/float.rs
@@ -10,6 +10,8 @@ use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
@@ -85,7 +87,10 @@ impl Scheme for FloatDictScheme {
         data: &mut ArrayAndStats,
         _ctx: CompressorContext,
     ) -> CompressionEstimate {
-        let stats = data.float_stats();
+        // TRAIT-IMPL BOUNDARY: `Scheme::expected_compression_ratio` has a fixed signature
+        // and does not receive an `ExecutionCtx`, so we fall back to the legacy session here.
+        let mut exec_ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.float_stats(&mut exec_ctx);
 
         if stats.value_count() == 0 {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
@@ -111,7 +116,10 @@ impl Scheme for FloatDictScheme {
         ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
         // TODO(connor): Fight the borrow checker (needs interior mutability)!
-        let stats = data.float_stats().clone();
+        let stats = {
+            let mut exec_ctx = compressor.execution_ctx();
+            data.float_stats(&mut exec_ctx).clone()
+        };
         let dict = dictionary_encode(data.array_as_primitive(), &stats)?;
 
         let has_all_values_referenced = dict.has_all_values_referenced();
@@ -242,21 +250,23 @@ impl_encode!(f64, u64);
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::dict::DictArraySlotsExt;
     use vortex_array::assert_arrays_eq;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
 
     use super::dictionary_encode;
     use crate::stats::FloatStats;
     use crate::stats::GenerateStatsOptions;
 
     #[test]
-    fn test_float_dict_encode() {
+    fn test_float_dict_encode() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = buffer![1f32, 2f32, 2f32, 0f32, 1f32];
         let validity =
             Validity::Array(BoolArray::from_iter([true, true, true, false, true]).into_array());
@@ -267,8 +277,9 @@ mod tests {
             GenerateStatsOptions {
                 count_distinct_values: true,
             },
+            &mut ctx,
         );
-        let dict_array = dictionary_encode(array.as_view(), &stats).unwrap();
+        let dict_array = dictionary_encode(array.as_view(), &stats)?;
         assert_eq!(dict_array.values().len(), 2);
         assert_eq!(dict_array.codes().len(), 5);
 
@@ -277,8 +288,12 @@ mod tests {
             Validity::Array(BoolArray::from_iter([true, true, true, false, true]).into_array()),
         )
         .into_array();
-        #[expect(deprecated)]
-        let undict = dict_array.as_array().to_primitive().into_array();
+        let undict = dict_array
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?
+            .into_array();
         assert_arrays_eq!(undict, expected);
+        Ok(())
     }
 }

--- a/vortex-compressor/src/builtins/dict/integer.rs
+++ b/vortex-compressor/src/builtins/dict/integer.rs
@@ -10,6 +10,8 @@ use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::PrimitiveArray;
@@ -60,7 +62,9 @@ impl Scheme for IntDictScheme {
         _ctx: CompressorContext,
     ) -> CompressionEstimate {
         let bit_width = data.array_as_primitive().ptype().bit_width();
-        let stats = data.integer_stats();
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.integer_stats(&mut ctx);
 
         if stats.value_count() == 0 {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);
@@ -105,7 +109,7 @@ impl Scheme for IntDictScheme {
         ctx: CompressorContext,
     ) -> VortexResult<ArrayRef> {
         // TODO(connor): Fight the borrow checker (needs interior mutability)!
-        let stats = data.integer_stats().clone();
+        let stats = data.integer_stats(&mut compressor.execution_ctx()).clone();
         let dict = dictionary_encode(data.array_as_primitive(), &stats)?;
 
         // Values = child 0.
@@ -249,20 +253,22 @@ impl_encode!(i64);
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::dict::DictArraySlotsExt;
     use vortex_array::assert_arrays_eq;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
 
     use super::dictionary_encode;
     use crate::stats::IntegerStats;
 
     #[test]
-    fn test_dict_encode_integer_stats() {
+    fn test_dict_encode_integer_stats() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let data = buffer![100i32, 200, 100, 0, 100];
         let validity =
             Validity::Array(BoolArray::from_iter([true, true, true, false, true]).into_array());
@@ -273,8 +279,9 @@ mod tests {
             crate::stats::GenerateStatsOptions {
                 count_distinct_values: true,
             },
+            &mut ctx,
         );
-        let dict_array = dictionary_encode(array.as_view(), &stats).unwrap();
+        let dict_array = dictionary_encode(array.as_view(), &stats)?;
         assert_eq!(dict_array.values().len(), 2);
         assert_eq!(dict_array.codes().len(), 5);
 
@@ -283,8 +290,12 @@ mod tests {
             Validity::Array(BoolArray::from_iter([true, true, true, false, true]).into_array()),
         )
         .into_array();
-        #[expect(deprecated)]
-        let undict = dict_array.as_array().to_primitive().into_array();
+        let undict = dict_array
+            .as_array()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)?
+            .into_array();
         assert_arrays_eq!(undict, expected);
+        Ok(())
     }
 }

--- a/vortex-compressor/src/builtins/dict/string.rs
+++ b/vortex-compressor/src/builtins/dict/string.rs
@@ -9,6 +9,8 @@
 use vortex_array::ArrayRef;
 use vortex_array::Canonical;
 use vortex_array::IntoArray;
+use vortex_array::LEGACY_SESSION;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::dict::DictArrayExt;
@@ -70,7 +72,9 @@ impl Scheme for StringDictScheme {
         data: &mut ArrayAndStats,
         _ctx: CompressorContext,
     ) -> CompressionEstimate {
-        let stats = data.string_stats();
+        // TODO(ctx): trait fixes - Scheme::expected_compression_ratio has a fixed signature.
+        let mut local_ctx = LEGACY_SESSION.create_execution_ctx();
+        let stats = data.string_stats(&mut local_ctx);
 
         if stats.value_count() == 0 {
             return CompressionEstimate::Verdict(EstimateVerdict::Skip);

--- a/vortex-compressor/src/compressor.rs
+++ b/vortex-compressor/src/compressor.rs
@@ -13,14 +13,13 @@ use vortex_array::CanonicalValidity;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
 use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ConstantArray;
 use vortex_array::arrays::ExtensionArray;
 use vortex_array::arrays::FixedSizeListArray;
 use vortex_array::arrays::ListArray;
 use vortex_array::arrays::ListViewArray;
+use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::StructArray;
 use vortex_array::arrays::extension::ExtensionArrayExt;
 use vortex_array::arrays::fixed_size_list::FixedSizeListArrayExt;
@@ -311,7 +310,7 @@ impl CascadingCompressor {
         if array.is_empty() {
             return Ok(array);
         }
-        if array.all_invalid(&mut LEGACY_SESSION.create_execution_ctx())? {
+        if array.all_invalid(&mut self.execution_ctx())? {
             return Ok(
                 ConstantArray::new(Scalar::null(array.dtype().clone()), array.len()).into_array(),
             );
@@ -488,8 +487,11 @@ impl CascadingCompressor {
 
         // Record the root scheme with the offsets child index so root exclusion rules apply.
         let offset_ctx = ctx.descend_with_scheme(ROOT_SCHEME_ID, root_list_children::OFFSETS);
-        #[expect(deprecated)]
-        let list_offsets_primitive = list_array.offsets().to_primitive().narrow()?;
+        let list_offsets_primitive = list_array
+            .offsets()
+            .clone()
+            .execute::<PrimitiveArray>(&mut self.execution_ctx())?
+            .narrow()?;
         let compressed_offsets =
             self.compress_canonical(Canonical::Primitive(list_offsets_primitive), offset_ctx)?;
 
@@ -511,16 +513,22 @@ impl CascadingCompressor {
         let offset_ctx = ctx
             .clone()
             .descend_with_scheme(ROOT_SCHEME_ID, root_list_children::OFFSETS);
-        #[expect(deprecated)]
-        let list_view_offsets_primitive = list_view.offsets().to_primitive().narrow()?;
+        let list_view_offsets_primitive = list_view
+            .offsets()
+            .clone()
+            .execute::<PrimitiveArray>(&mut self.execution_ctx())?
+            .narrow()?;
         let compressed_offsets = self.compress_canonical(
             Canonical::Primitive(list_view_offsets_primitive),
             offset_ctx,
         )?;
 
         let sizes_ctx = ctx.descend_with_scheme(ROOT_SCHEME_ID, root_list_children::SIZES);
-        #[expect(deprecated)]
-        let list_view_sizes_primitive = list_view.sizes().to_primitive().narrow()?;
+        let list_view_sizes_primitive = list_view
+            .sizes()
+            .clone()
+            .execute::<PrimitiveArray>(&mut self.execution_ctx())?
+            .narrow()?;
         let compressed_sizes =
             self.compress_canonical(Canonical::Primitive(list_view_sizes_primitive), sizes_ctx)?;
 

--- a/vortex-compressor/src/stats/bool.rs
+++ b/vortex-compressor/src/stats/bool.rs
@@ -3,8 +3,7 @@
 
 //! Bool compression statistics.
 
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
+use vortex_array::ExecutionCtx;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::bool::BoolArrayExt;
 use vortex_error::VortexResult;
@@ -27,7 +26,7 @@ impl BoolStats {
     /// # Errors
     ///
     /// Returns an error if getting validity mask fails or values exceed `u32` bounds.
-    pub fn generate(input: &BoolArray) -> VortexResult<Self> {
+    pub fn generate(input: &BoolArray, ctx: &mut ExecutionCtx) -> VortexResult<Self> {
         if input.is_empty() {
             return Ok(Self {
                 null_count: 0,
@@ -36,8 +35,7 @@ impl BoolStats {
             });
         }
 
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
-        if input.all_invalid(&mut ctx)? {
+        if input.all_invalid(ctx)? {
             return Ok(Self {
                 null_count: u32::try_from(input.len())?,
                 value_count: 0,
@@ -48,7 +46,7 @@ impl BoolStats {
         let validity = input
             .as_ref()
             .validity()?
-            .to_mask(input.as_ref().len(), &mut ctx)?;
+            .to_mask(input.as_ref().len(), ctx)?;
         let null_count = validity.false_count();
         let value_count = validity.true_count();
 
@@ -94,6 +92,8 @@ impl BoolStats {
 
 #[cfg(test)]
 mod tests {
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::validity::Validity;
     use vortex_buffer::BitBuffer;
@@ -103,11 +103,12 @@ mod tests {
 
     #[test]
     fn test_all_true() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = BoolArray::new(
             BitBuffer::from(vec![true, true, true]),
             Validity::NonNullable,
         );
-        let stats = BoolStats::generate(&array)?;
+        let stats = BoolStats::generate(&array, &mut ctx)?;
         assert_eq!(stats.value_count, 3);
         assert_eq!(stats.null_count, 0);
         assert_eq!(stats.true_count, 3);
@@ -117,11 +118,12 @@ mod tests {
 
     #[test]
     fn test_all_false() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = BoolArray::new(
             BitBuffer::from(vec![false, false, false]),
             Validity::NonNullable,
         );
-        let stats = BoolStats::generate(&array)?;
+        let stats = BoolStats::generate(&array, &mut ctx)?;
         assert_eq!(stats.value_count, 3);
         assert_eq!(stats.null_count, 0);
         assert_eq!(stats.true_count, 0);
@@ -131,11 +133,12 @@ mod tests {
 
     #[test]
     fn test_mixed() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = BoolArray::new(
             BitBuffer::from(vec![true, false, true]),
             Validity::NonNullable,
         );
-        let stats = BoolStats::generate(&array)?;
+        let stats = BoolStats::generate(&array, &mut ctx)?;
         assert_eq!(stats.value_count, 3);
         assert_eq!(stats.null_count, 0);
         assert_eq!(stats.true_count, 2);
@@ -145,11 +148,12 @@ mod tests {
 
     #[test]
     fn test_with_nulls() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = BoolArray::new(
             BitBuffer::from(vec![true, false, true]),
             Validity::from_iter([true, false, true]),
         );
-        let stats = BoolStats::generate(&array)?;
+        let stats = BoolStats::generate(&array, &mut ctx)?;
         assert_eq!(stats.value_count, 2);
         assert_eq!(stats.null_count, 1);
         assert_eq!(stats.true_count, 2);

--- a/vortex-compressor/src/stats/cache.rs
+++ b/vortex-compressor/src/stats/cache.rs
@@ -8,8 +8,8 @@ use std::any::TypeId;
 
 use vortex_array::ArrayRef;
 use vortex_array::ArrayView;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
+use vortex_array::ExecutionCtx;
+use vortex_array::arrays::Bool;
 use vortex_array::arrays::Primitive;
 use vortex_array::arrays::VarBinView;
 use vortex_error::VortexExpect;
@@ -138,51 +138,59 @@ impl ArrayAndStats {
     }
 
     /// Returns bool stats, generating them lazily on first access.
-    pub fn bool_stats(&mut self) -> &BoolStats {
+    pub fn bool_stats(&mut self, ctx: &mut ExecutionCtx) -> &BoolStats {
         let array = self.array.clone();
 
         self.cache.get_or_insert_with::<BoolStats>(|| {
-            #[expect(deprecated)]
-            let bool_array = array.to_bool();
-            BoolStats::generate(&bool_array).vortex_expect("BoolStats shouldn't fail")
+            let bool_array = array
+                .as_opt::<Bool>()
+                .vortex_expect("the array is guaranteed to already be canonical by construction")
+                .into_owned();
+            BoolStats::generate(&bool_array, ctx).vortex_expect("BoolStats shouldn't fail")
         })
     }
 
     // TODO(connor): These should all have interior mutability instead!!!
 
     /// Returns integer stats, generating them lazily on first access.
-    pub fn integer_stats(&mut self) -> &IntegerStats {
+    pub fn integer_stats(&mut self, ctx: &mut ExecutionCtx) -> &IntegerStats {
         let array = self.array.clone();
         let opts = self.opts;
 
         self.cache.get_or_insert_with::<IntegerStats>(|| {
-            #[expect(deprecated)]
-            let primitive = array.to_primitive();
-            IntegerStats::generate_opts(&primitive, opts)
+            let primitive = array
+                .as_opt::<Primitive>()
+                .vortex_expect("the array is guaranteed to already be canonical by construction")
+                .into_owned();
+            IntegerStats::generate_opts(&primitive, opts, ctx)
         })
     }
 
     /// Returns float stats, generating them lazily on first access.
-    pub fn float_stats(&mut self) -> &FloatStats {
+    pub fn float_stats(&mut self, ctx: &mut ExecutionCtx) -> &FloatStats {
         let array = self.array.clone();
         let opts = self.opts;
 
         self.cache.get_or_insert_with::<FloatStats>(|| {
-            #[expect(deprecated)]
-            let primitive = array.to_primitive();
-            FloatStats::generate_opts(&primitive, opts)
+            let primitive = array
+                .as_opt::<Primitive>()
+                .vortex_expect("the array is guaranteed to already be canonical by construction")
+                .into_owned();
+            FloatStats::generate_opts(&primitive, opts, ctx)
         })
     }
 
     /// Returns string stats, generating them lazily on first access.
-    pub fn string_stats(&mut self) -> &StringStats {
+    pub fn string_stats(&mut self, ctx: &mut ExecutionCtx) -> &StringStats {
         let array = self.array.clone();
         let opts = self.opts;
 
         self.cache.get_or_insert_with::<StringStats>(|| {
-            #[expect(deprecated)]
-            let varbinview = array.to_varbinview();
-            StringStats::generate_opts(&varbinview, opts)
+            let varbinview = array
+                .as_opt::<VarBinView>()
+                .vortex_expect("the array is guaranteed to already be canonical by construction")
+                .into_owned();
+            StringStats::generate_opts(&varbinview, opts, ctx)
         })
     }
 

--- a/vortex-compressor/src/stats/float.rs
+++ b/vortex-compressor/src/stats/float.rs
@@ -8,8 +8,7 @@ use std::hash::Hash;
 use itertools::Itertools;
 use num_traits::Float;
 use rustc_hash::FxBuildHasher;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
+use vortex_array::ExecutionCtx;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::primitive::NativeValue;
 use vortex_array::dtype::NativePType;
@@ -109,11 +108,12 @@ impl FloatStats {
     fn generate_opts_fallible(
         input: &PrimitiveArray,
         opts: GenerateStatsOptions,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
         match input.ptype() {
-            PType::F16 => typed_float_stats::<f16>(input, opts.count_distinct_values),
-            PType::F32 => typed_float_stats::<f32>(input, opts.count_distinct_values),
-            PType::F64 => typed_float_stats::<f64>(input, opts.count_distinct_values),
+            PType::F16 => typed_float_stats::<f16>(input, opts.count_distinct_values, ctx),
+            PType::F32 => typed_float_stats::<f32>(input, opts.count_distinct_values, ctx),
+            PType::F64 => typed_float_stats::<f64>(input, opts.count_distinct_values, ctx),
             _ => vortex_panic!("cannot generate FloatStats from ptype {}", input.ptype()),
         }
     }
@@ -126,13 +126,17 @@ impl FloatStats {
 
 impl FloatStats {
     /// Generates stats with default options.
-    pub fn generate(input: &PrimitiveArray) -> Self {
-        Self::generate_opts(input, GenerateStatsOptions::default())
+    pub fn generate(input: &PrimitiveArray, ctx: &mut ExecutionCtx) -> Self {
+        Self::generate_opts(input, GenerateStatsOptions::default(), ctx)
     }
 
     /// Generates stats with provided options.
-    pub fn generate_opts(input: &PrimitiveArray, opts: GenerateStatsOptions) -> Self {
-        Self::generate_opts_fallible(input, opts)
+    pub fn generate_opts(
+        input: &PrimitiveArray,
+        opts: GenerateStatsOptions,
+        ctx: &mut ExecutionCtx,
+    ) -> Self {
+        Self::generate_opts_fallible(input, opts, ctx)
             .vortex_expect("FloatStats::generate_opts should not fail")
     }
 
@@ -161,6 +165,7 @@ impl FloatStats {
 fn typed_float_stats<T: NativePType + Float>(
     array: &PrimitiveArray,
     count_distinct_values: bool,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<FloatStats>
 where
     NativeValue<T>: Hash + Eq,
@@ -176,8 +181,7 @@ where
         });
     }
 
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    if array.all_invalid(&mut ctx)? {
+    if array.all_invalid(ctx)? {
         return Ok(FloatStats {
             null_count: u32::try_from(array.len())?,
             value_count: 0,
@@ -194,7 +198,7 @@ where
 
     let null_count = array
         .statistics()
-        .compute_null_count(&mut ctx)
+        .compute_null_count(ctx)
         .ok_or_else(|| vortex_err!("Failed to compute null_count"))?;
     let value_count = array.len() - null_count;
 
@@ -206,10 +210,10 @@ where
         HashSet::with_hasher(FxBuildHasher)
     };
 
-    let validity = array.as_ref().validity()?.to_mask(
-        array.as_ref().len(),
-        &mut LEGACY_SESSION.create_execution_ctx(),
-    )?;
+    let validity = array
+        .as_ref()
+        .validity()?
+        .to_mask(array.as_ref().len(), ctx)?;
 
     let mut runs = 1;
     let head_idx = validity
@@ -272,35 +276,39 @@ where
 #[cfg(test)]
 mod tests {
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::validity::Validity;
     use vortex_buffer::buffer;
+    use vortex_error::VortexResult;
 
     use super::FloatStats;
 
     #[test]
-    fn test_float_stats() {
+    fn test_float_stats() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let floats = buffer![0.0f32, 1.0f32, 2.0f32].into_array();
-        #[expect(deprecated)]
-        let floats = floats.to_primitive();
+        let floats = floats.execute::<PrimitiveArray>(&mut ctx)?;
 
         let stats = FloatStats::generate_opts(
             &floats,
             crate::stats::GenerateStatsOptions {
                 count_distinct_values: true,
             },
+            &mut ctx,
         );
 
         assert_eq!(stats.value_count, 3);
         assert_eq!(stats.null_count, 0);
         assert_eq!(stats.average_run_length, 1);
         assert_eq!(stats.distinct_count().unwrap(), 3);
+        Ok(())
     }
 
     #[test]
     fn test_float_stats_leading_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let floats = PrimitiveArray::new(
             buffer![0.0f32, 1.0f32, 2.0f32],
             Validity::from_iter([false, true, true]),
@@ -311,6 +319,7 @@ mod tests {
             crate::stats::GenerateStatsOptions {
                 count_distinct_values: true,
             },
+            &mut ctx,
         );
 
         assert_eq!(stats.value_count, 2);

--- a/vortex-compressor/src/stats/integer.rs
+++ b/vortex-compressor/src/stats/integer.rs
@@ -7,8 +7,7 @@ use std::hash::Hash;
 
 use num_traits::PrimInt;
 use rustc_hash::FxBuildHasher;
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
+use vortex_array::ExecutionCtx;
 use vortex_array::arrays::PrimitiveArray;
 use vortex_array::arrays::primitive::NativeValue;
 use vortex_array::dtype::IntegerPType;
@@ -257,9 +256,10 @@ impl IntegerStats {
     fn generate_opts_fallible(
         input: &PrimitiveArray,
         opts: GenerateStatsOptions,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
         match_each_integer_ptype!(input.ptype(), |T| {
-            typed_int_stats::<T>(input, opts.count_distinct_values)
+            typed_int_stats::<T>(input, opts.count_distinct_values, ctx)
         })
     }
 
@@ -276,13 +276,17 @@ impl IntegerStats {
 
 impl IntegerStats {
     /// Generates stats with default options.
-    pub fn generate(input: &PrimitiveArray) -> Self {
-        Self::generate_opts(input, GenerateStatsOptions::default())
+    pub fn generate(input: &PrimitiveArray, ctx: &mut ExecutionCtx) -> Self {
+        Self::generate_opts(input, GenerateStatsOptions::default(), ctx)
     }
 
     /// Generates stats with provided options.
-    pub fn generate_opts(input: &PrimitiveArray, opts: GenerateStatsOptions) -> Self {
-        Self::generate_opts_fallible(input, opts)
+    pub fn generate_opts(
+        input: &PrimitiveArray,
+        opts: GenerateStatsOptions,
+        ctx: &mut ExecutionCtx,
+    ) -> Self {
+        Self::generate_opts_fallible(input, opts, ctx)
             .vortex_expect("IntegerStats::generate_opts should not fail")
     }
 
@@ -311,6 +315,7 @@ impl IntegerStats {
 fn typed_int_stats<T>(
     array: &PrimitiveArray,
     count_distinct_values: bool,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<IntegerStats>
 where
     T: IntegerPType + PrimInt + for<'a> TryFrom<&'a Scalar, Error = VortexError>,
@@ -332,8 +337,7 @@ where
         });
     }
 
-    let mut ctx = LEGACY_SESSION.create_execution_ctx();
-    if array.all_invalid(&mut ctx)? {
+    if array.all_invalid(ctx)? {
         return Ok(IntegerStats {
             null_count: u32::try_from(array.len())?,
             value_count: 0,
@@ -352,10 +356,10 @@ where
         });
     }
 
-    let validity = array.as_ref().validity()?.to_mask(
-        array.as_ref().len(),
-        &mut LEGACY_SESSION.create_execution_ctx(),
-    )?;
+    let validity = array
+        .as_ref()
+        .validity()?
+        .to_mask(array.as_ref().len(), ctx)?;
     let null_count = validity.false_count();
     let value_count = validity.true_count();
 
@@ -437,12 +441,12 @@ where
     let array_ref = array.as_ref();
     let min = array_ref
         .statistics()
-        .compute_as::<T>(Stat::Min, &mut ctx)
+        .compute_as::<T>(Stat::Min, ctx)
         .vortex_expect("min should be computed");
 
     let max = array_ref
         .statistics()
-        .compute_as::<T>(Stat::Max, &mut ctx)
+        .compute_as::<T>(Stat::Max, ctx)
         .vortex_expect("max should be computed");
 
     let distinct = count_distinct_values.then(|| {
@@ -557,6 +561,8 @@ fn inner_loop_naive<T: IntegerPType>(
 mod tests {
     use std::iter;
 
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::validity::Validity;
     use vortex_buffer::BitBuffer;
@@ -569,46 +575,51 @@ mod tests {
 
     #[test]
     fn test_naive_count_distinct_values() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::new(buffer![217u8, 0], Validity::NonNullable);
-        let stats = typed_int_stats::<u8>(&array, true)?;
+        let stats = typed_int_stats::<u8>(&array, true, &mut ctx)?;
         assert_eq!(stats.distinct_count().unwrap(), 2);
         Ok(())
     }
 
     #[test]
     fn test_naive_count_distinct_values_nullable() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::new(
             buffer![217u8, 0],
             Validity::from(BitBuffer::from(vec![true, false])),
         );
-        let stats = typed_int_stats::<u8>(&array, true)?;
+        let stats = typed_int_stats::<u8>(&array, true, &mut ctx)?;
         assert_eq!(stats.distinct_count().unwrap(), 1);
         Ok(())
     }
 
     #[test]
     fn test_count_distinct_values() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::new((0..128u8).collect::<Buffer<u8>>(), Validity::NonNullable);
-        let stats = typed_int_stats::<u8>(&array, true)?;
+        let stats = typed_int_stats::<u8>(&array, true, &mut ctx)?;
         assert_eq!(stats.distinct_count().unwrap(), 128);
         Ok(())
     }
 
     #[test]
     fn test_count_distinct_values_nullable() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = PrimitiveArray::new(
             (0..128u8).collect::<Buffer<u8>>(),
             Validity::from(BitBuffer::from_iter(
                 iter::repeat_n(vec![true, false], 64).flatten(),
             )),
         );
-        let stats = typed_int_stats::<u8>(&array, true)?;
+        let stats = typed_int_stats::<u8>(&array, true, &mut ctx)?;
         assert_eq!(stats.distinct_count().unwrap(), 64);
         Ok(())
     }
 
     #[test]
     fn test_integer_stats_leading_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let ints = PrimitiveArray::new(buffer![0, 1, 2], Validity::from_iter([false, true, true]));
 
         let stats = IntegerStats::generate_opts(
@@ -616,6 +627,7 @@ mod tests {
             crate::stats::GenerateStatsOptions {
                 count_distinct_values: true,
             },
+            &mut ctx,
         );
 
         assert_eq!(stats.value_count, 2);

--- a/vortex-compressor/src/stats/string.rs
+++ b/vortex-compressor/src/stats/string.rs
@@ -3,8 +3,7 @@
 
 //! String compression statistics.
 
-use vortex_array::LEGACY_SESSION;
-use vortex_array::VortexSessionExecute;
+use vortex_array::ExecutionCtx;
 use vortex_array::arrays::VarBinViewArray;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
@@ -49,10 +48,11 @@ impl StringStats {
     fn generate_opts_fallible(
         input: &VarBinViewArray,
         opts: GenerateStatsOptions,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<Self> {
         let null_count = input
             .statistics()
-            .compute_null_count(&mut LEGACY_SESSION.create_execution_ctx())
+            .compute_null_count(ctx)
             .ok_or_else(|| vortex_err!("Failed to compute null_count"))?;
         let value_count = input.len() - null_count;
         let estimated_distinct_count = opts
@@ -70,13 +70,17 @@ impl StringStats {
 
 impl StringStats {
     /// Generates stats with default options.
-    pub fn generate(input: &VarBinViewArray) -> Self {
-        Self::generate_opts(input, GenerateStatsOptions::default())
+    pub fn generate(input: &VarBinViewArray, ctx: &mut ExecutionCtx) -> Self {
+        Self::generate_opts(input, GenerateStatsOptions::default(), ctx)
     }
 
     /// Generates stats with provided options.
-    pub fn generate_opts(input: &VarBinViewArray, opts: GenerateStatsOptions) -> Self {
-        Self::generate_opts_fallible(input, opts)
+    pub fn generate_opts(
+        input: &VarBinViewArray,
+        opts: GenerateStatsOptions,
+        ctx: &mut ExecutionCtx,
+    ) -> Self {
+        Self::generate_opts_fallible(input, opts, ctx)
             .vortex_expect("StringStats::generate_opts should not fail")
     }
 

--- a/vortex-cuda/benches/bitpacked_cuda.rs
+++ b/vortex-cuda/benches/bitpacked_cuda.rs
@@ -20,6 +20,8 @@ use criterion::Throughput;
 use cudarc::driver::DeviceRepr;
 use futures::executor::block_on;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::validity::Validity::NonNullable;
 use vortex::buffer::Buffer;
@@ -56,7 +58,8 @@ where
         .collect();
 
     let primitive_array = PrimitiveArray::new(Buffer::from(values), NonNullable);
-    BitPackedData::encode(&primitive_array.into_array(), bit_width)
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    BitPackedData::encode(&primitive_array.into_array(), bit_width, &mut ctx)
         .vortex_expect("failed to create BitPacked array")
 }
 
@@ -96,7 +99,8 @@ where
         .collect();
 
     let primitive_array = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
-    BitPackedData::encode(&primitive_array, bit_width)
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    BitPackedData::encode(&primitive_array, bit_width, &mut ctx)
         .vortex_expect("failed to create BitPacked array with patches")
 }
 

--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -187,7 +187,9 @@ fn bench_for_bitpacked(c: &mut Criterion) {
             .map(|i| (i as u64 % (max_val + 1)) as u32)
             .collect();
         let prim = PrimitiveArray::new(Buffer::from(residuals), NonNullable);
-        let bp = BitPackedData::encode(&prim.into_array(), bit_width).vortex_expect("bitpack");
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let bp =
+            BitPackedData::encode(&prim.into_array(), bit_width, &mut ctx).vortex_expect("bitpack");
         let array = FoR::try_new(bp.into_array(), Scalar::from(reference))
             .vortex_expect("for")
             .into_array();
@@ -230,7 +232,8 @@ fn bench_dict_bp_codes(c: &mut Criterion) {
 
         let codes: Vec<u32> = (0..*len).map(|i| (i % dict_size) as u32).collect();
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPackedData::encode(&codes_prim.into_array(), dict_bit_width)
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let codes_bp = BitPackedData::encode(&codes_prim.into_array(), dict_bit_width, &mut ctx)
             .vortex_expect("bitpack codes");
         let values_prim = PrimitiveArray::new(Buffer::from(dict_values.clone()), NonNullable);
         let dict = DictArray::new(codes_bp.into_array(), values_prim.into_array());
@@ -274,8 +277,7 @@ fn bench_runend(c: &mut Criterion) {
         let ends: Vec<u32> = (1..=num_runs).map(|i| (i * run_len) as u32).collect();
         let values: Vec<u32> = (0..num_runs).map(|i| (i * 7 + 42) as u32).collect();
 
-        let mut ctx =
-            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
         let re = RunEnd::new(ends_arr, values_arr, &mut ctx);
@@ -318,7 +320,8 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
     // Dict values: residuals 0..63 bitpacked, FoR adds 1_000_000
     let dict_residuals: Vec<u32> = (0..dict_size as u32).collect();
     let dict_prim = PrimitiveArray::new(Buffer::from(dict_residuals), NonNullable);
-    let dict_bp = BitPackedData::encode(&dict_prim.into_array(), dict_bit_width)
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
+    let dict_bp = BitPackedData::encode(&dict_prim.into_array(), dict_bit_width, &mut ctx)
         .vortex_expect("bitpack dict");
     let dict_for =
         FoR::try_new(dict_bp.into_array(), Scalar::from(dict_reference)).vortex_expect("for dict");
@@ -328,7 +331,7 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
 
         let codes: Vec<u32> = (0..*len).map(|i| (i % dict_size) as u32).collect();
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPackedData::encode(&codes_prim.into_array(), codes_bit_width)
+        let codes_bp = BitPackedData::encode(&codes_prim.into_array(), codes_bit_width, &mut ctx)
             .vortex_expect("bitpack codes");
 
         let dict = DictArray::new(codes_bp.into_array(), dict_for.clone().into_array());
@@ -377,8 +380,8 @@ fn bench_alp_for_bitpacked(c: &mut Criterion) {
         let float_prim = PrimitiveArray::new(Buffer::from(floats), NonNullable);
 
         // Encode: ALP → FoR → BitPacked
-        let alp = alp_encode(float_prim.as_view(), Some(exponents), &mut ctx)
-            .vortex_expect("alp_encode");
+        let alp =
+            alp_encode(float_prim.as_view(), Some(exponents), &mut ctx).vortex_expect("alp_encode");
         assert!(alp.patches().is_none());
         let for_arr = FoRData::encode(
             alp.encoded()
@@ -387,8 +390,8 @@ fn bench_alp_for_bitpacked(c: &mut Criterion) {
                 .vortex_expect("to primitive"),
         )
         .vortex_expect("for encode");
-        let bp =
-            BitPackedData::encode(for_arr.encoded(), bit_width).vortex_expect("bitpack encode");
+        let bp = BitPackedData::encode(for_arr.encoded(), bit_width, &mut ctx)
+            .vortex_expect("bitpack encode");
 
         let tree = ALP::new(
             FoR::try_new(bp.into_array(), for_arr.reference_scalar().clone())

--- a/vortex-cuda/benches/dynamic_dispatch_cuda.rs
+++ b/vortex-cuda/benches/dynamic_dispatch_cuda.rs
@@ -19,8 +19,6 @@ use cudarc::driver::PushKernelArg;
 use cudarc::driver::sys::CUevent_flags;
 use vortex::array::IntoArray;
 use vortex::array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
 use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::DictArray;
 use vortex::array::arrays::PrimitiveArray;
@@ -276,9 +274,11 @@ fn bench_runend(c: &mut Criterion) {
         let ends: Vec<u32> = (1..=num_runs).map(|i| (i * run_len) as u32).collect();
         let values: Vec<u32> = (0..num_runs).map(|i| (i * 7 + 42) as u32).collect();
 
+        let mut ctx =
+            CudaSession::create_execution_ctx(&VortexSession::empty()).vortex_expect("ctx");
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
-        let re = RunEnd::new(ends_arr, values_arr);
+        let re = RunEnd::new(ends_arr, values_arr, &mut ctx);
         let array = re.into_array();
 
         group.bench_with_input(
@@ -361,6 +361,7 @@ fn bench_dict_bp_codes_bp_for_values(c: &mut Criterion) {
 // Benchmark: ALP(FoR(BitPacked)) for f32
 // ---------------------------------------------------------------------------
 fn bench_alp_for_bitpacked(c: &mut Criterion) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let mut group = c.benchmark_group("alp_for_bp_6bw_f32");
 
     let exponents = Exponents { e: 2, f: 0 };
@@ -376,15 +377,16 @@ fn bench_alp_for_bitpacked(c: &mut Criterion) {
         let float_prim = PrimitiveArray::new(Buffer::from(floats), NonNullable);
 
         // Encode: ALP → FoR → BitPacked
-        let alp = alp_encode(
-            float_prim.as_view(),
-            Some(exponents),
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .vortex_expect("alp_encode");
+        let alp = alp_encode(float_prim.as_view(), Some(exponents), &mut ctx)
+            .vortex_expect("alp_encode");
         assert!(alp.patches().is_none());
-        #[expect(deprecated)]
-        let for_arr = FoRData::encode(alp.encoded().to_primitive()).vortex_expect("for encode");
+        let for_arr = FoRData::encode(
+            alp.encoded()
+                .clone()
+                .execute::<PrimitiveArray>(&mut ctx)
+                .vortex_expect("to primitive"),
+        )
+        .vortex_expect("for encode");
         let bp =
             BitPackedData::encode(for_arr.encoded(), bit_width).vortex_expect("bitpack encode");
 

--- a/vortex-cuda/benches/for_cuda.rs
+++ b/vortex-cuda/benches/for_cuda.rs
@@ -20,6 +20,8 @@ use criterion::Throughput;
 use cudarc::driver::DeviceRepr;
 use futures::executor::block_on;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::validity::Validity;
 use vortex::buffer::Buffer;
@@ -56,7 +58,9 @@ where
         PrimitiveArray::new(Buffer::from(data), Validity::NonNullable).into_array();
 
     if bp && T::PTYPE != PType::U8 {
-        let child = BitPackedData::encode(&primitive_array, 8).vortex_expect("failed to bitpack");
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let child =
+            BitPackedData::encode(&primitive_array, 8, &mut ctx).vortex_expect("failed to bitpack");
         FoR::try_new(child.into_array(), reference.into())
             .vortex_expect("failed to create FoR array")
     } else {

--- a/vortex-cuda/benches/runend_cuda.rs
+++ b/vortex-cuda/benches/runend_cuda.rs
@@ -73,8 +73,8 @@ where
         group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
 
         for run_len in [10, 1000, 100000] {
-            let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty()).unwrap();
-            let runend_array = make_runend_array_typed::<T>(len, run_len, &mut ctx);
+            let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty()).unwrap();
+            let runend_array = make_runend_array_typed::<T>(len, run_len, cuda_ctx.execution_ctx());
 
             group.bench_with_input(
                 BenchmarkId::new("runend", format!("{len_str}_{type_name}_runlen_{run_len}")),

--- a/vortex-cuda/benches/runend_cuda.rs
+++ b/vortex-cuda/benches/runend_cuda.rs
@@ -34,7 +34,11 @@ use vortex_cuda_macros::cuda_not_available;
 use crate::common::TimedLaunchStrategy;
 
 /// Creates a run-end encoded array with the specified output length and average run length.
-fn make_runend_array_typed<T>(output_len: usize, avg_run_len: usize) -> RunEndArray
+fn make_runend_array_typed<T>(
+    output_len: usize,
+    avg_run_len: usize,
+    ctx: &mut vortex::array::ExecutionCtx,
+) -> RunEndArray
 where
     T: NativePType + From<u8>,
 {
@@ -55,7 +59,7 @@ where
     let ends_array = PrimitiveArray::new(Buffer::from(ends), Validity::NonNullable).into_array();
     let values_array =
         PrimitiveArray::new(Buffer::from(values), Validity::NonNullable).into_array();
-    RunEnd::new(ends_array, values_array)
+    RunEnd::new(ends_array, values_array, ctx)
 }
 
 /// Benchmark run-end decoding for a specific type with varying run lengths
@@ -69,7 +73,8 @@ where
         group.throughput(Throughput::Bytes((len * size_of::<T>()) as u64));
 
         for run_len in [10, 1000, 100000] {
-            let runend_array = make_runend_array_typed::<T>(len, run_len);
+            let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty()).unwrap();
+            let runend_array = make_runend_array_typed::<T>(len, run_len, &mut ctx);
 
             group.bench_with_input(
                 BenchmarkId::new("runend", format!("{len_str}_{type_name}_runlen_{run_len}")),

--- a/vortex-cuda/benches/zstd_cuda.rs
+++ b/vortex-cuda/benches/zstd_cuda.rs
@@ -50,14 +50,22 @@ fn generate_string_data(count: usize) -> Vec<&'static str> {
 }
 
 /// Create a ZSTD-compressed array
-fn make_zstd_array(num_strings: usize) -> VortexResult<(ZstdArray, usize)> {
+fn make_zstd_array(
+    num_strings: usize,
+    cuda_ctx: &mut vortex_cuda::CudaExecutionCtx,
+) -> VortexResult<(ZstdArray, usize)> {
     let strings = generate_string_data(num_strings);
     let var_bin_view = VarBinViewArray::from_iter_str(strings.iter().copied());
     let uncompressed_size: usize = strings.iter().map(|s| s.len()).sum();
     let zstd_compression_level = -10; // Less compression but faster.
     let zstd_array =
         // Disable dictionary as nvCOMP doesn't support ZSTD dictionaries.
-        Zstd::from_var_bin_view_without_dict(&var_bin_view, zstd_compression_level, 2048)?;
+        Zstd::from_var_bin_view_without_dict(
+            &var_bin_view,
+            zstd_compression_level,
+            2048,
+            cuda_ctx.execution_ctx(),
+        )?;
 
     Ok((zstd_array, uncompressed_size))
 }
@@ -120,8 +128,10 @@ fn benchmark_zstd_cuda_decompress(c: &mut Criterion) {
     let mut group = c.benchmark_group("ZSTD_cuda");
 
     for (num_strings, label) in BENCH_ARGS {
-        let (zstd_array, uncompressed_size) =
-            make_zstd_array(*num_strings).vortex_expect("failed to create ZSTD array");
+        let mut setup_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
+            .vortex_expect("failed to create execution context");
+        let (zstd_array, uncompressed_size) = make_zstd_array(*num_strings, &mut setup_ctx)
+            .vortex_expect("failed to create ZSTD array");
 
         group.throughput(Throughput::Bytes(uncompressed_size as u64));
         group.bench_with_input(

--- a/vortex-cuda/gpu-scan-cli/src/main.rs
+++ b/vortex-cuda/gpu-scan-cli/src/main.rs
@@ -18,9 +18,9 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use vortex::VortexSessionDefault;
-#[expect(deprecated)]
-use vortex::array::ToCanonical as _;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::Dict;
+use vortex::array::arrays::StructArray;
 use vortex::array::arrays::struct_::StructArrayExt;
 use vortex::buffer::ByteBufferMut;
 use vortex::compressor::BtrBlocksCompressorBuilder;
@@ -179,8 +179,7 @@ async fn cmd_scan(path: PathBuf, gpu_file: bool, json_output: bool) -> VortexRes
 
     let mut chunk = 0;
     while let Some(next) = batches.next().await.transpose()? {
-        #[expect(deprecated)]
-        let record = next.to_struct();
+        let record = next.execute::<StructArray>(cuda_ctx.execution_ctx())?;
 
         for (field, field_name) in record
             .iter_unmasked_fields()

--- a/vortex-cuda/src/arrow/canonical.rs
+++ b/vortex-cuda/src/arrow/canonical.rs
@@ -5,8 +5,7 @@ use async_trait::async_trait;
 use futures::future::BoxFuture;
 use vortex::array::ArrayRef;
 use vortex::array::Canonical;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
+use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
 use vortex::array::arrays::bool::BoolDataParts;
 use vortex::array::arrays::decimal::DecimalDataParts;
@@ -117,8 +116,10 @@ fn export_canonical(
                     vortex_bail!("only support temporal extension types currently");
                 }
 
-                #[expect(deprecated)]
-                let values = extension.storage_array().to_primitive();
+                let values = extension
+                    .storage_array()
+                    .clone()
+                    .execute::<PrimitiveArray>(ctx.execution_ctx())?;
                 let len = extension.len();
 
                 let PrimitiveDataParts {

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -500,8 +500,6 @@ mod tests {
     use cudarc::driver::PushKernelArg;
     use rstest::rstest;
     use vortex::array::IntoArray;
-    #[expect(deprecated)]
-    use vortex::array::ToCanonical;
     use vortex::array::arrays::DictArray;
     use vortex::array::arrays::PrimitiveArray;
     use vortex::array::scalar::Scalar;
@@ -823,11 +821,11 @@ mod tests {
             expected.push(values[run]);
         }
 
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
-        let re = RunEnd::new(ends_arr, values_arr);
+        let re = RunEnd::new(ends_arr, values_arr, &mut cuda_ctx);
 
-        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let plan = dispatch_plan(&re.into_array(), &cuda_ctx)?;
 
         let actual =
@@ -872,6 +870,7 @@ mod tests {
 
     #[crate::test]
     fn test_alp_for_bitpacked() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // ALP(FoR(BitPacked)): encode each layer, then reassemble the tree
         // bottom-up because encode() methods produce flat outputs.
         let len = 3000;
@@ -881,14 +880,9 @@ mod tests {
             .collect();
         let float_prim = PrimitiveArray::new(Buffer::from(floats.clone()), NonNullable);
 
-        let alp = alp_encode(
-            float_prim.as_view(),
-            Some(exponents),
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )?;
+        let alp = alp_encode(float_prim.as_view(), Some(exponents), &mut ctx)?;
         assert!(alp.patches().is_none());
-        #[expect(deprecated)]
-        let for_arr = FoR::encode(alp.encoded().to_primitive())?;
+        let for_arr = FoR::encode(alp.encoded().clone().execute::<PrimitiveArray>(&mut ctx)?)?;
         let bp = BitPacked::encode(for_arr.encoded(), 6)?;
 
         let tree = ALP::new(
@@ -950,12 +944,12 @@ mod tests {
             expected.push(values[run] + reference);
         }
 
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
-        let re = RunEnd::new(ends_arr, values_arr);
+        let re = RunEnd::new(ends_arr, values_arr, &mut cuda_ctx);
         let for_arr = FoR::try_new(re.into_array(), Scalar::from(reference))?;
 
-        let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let plan = dispatch_plan(&for_arr.into_array(), &cuda_ctx)?;
 
         let actual =
@@ -1117,9 +1111,10 @@ mod tests {
         let values: Vec<u32> = vec![10, 20, 30];
         let len = 3000;
 
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
-        let re = RunEnd::new(ends_arr, values_arr);
+        let re = RunEnd::new(ends_arr, values_arr, &mut cuda_ctx);
         let array = re.into_array();
 
         // Ends (u64) are wider than values (u32), so the kernel would truncate
@@ -1131,7 +1126,6 @@ mod tests {
         );
 
         // Execute through the non-fused dispatch path.
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 
@@ -1683,9 +1677,10 @@ mod tests {
         let values: Vec<u16> = vec![100, 200, 300, 400];
         let len = 2000;
 
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
-        let re = RunEnd::new(ends_arr, values_arr);
+        let re = RunEnd::new(ends_arr, values_arr, &mut cuda_ctx);
         let array = re.into_array();
 
         // Ends (u32) are wider than values (u16), so the kernel would truncate
@@ -1696,7 +1691,6 @@ mod tests {
             "expected Unfused for RunEnd with wider ends"
         );
 
-        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let canonical = try_gpu_dispatch(&array, &mut cuda_ctx).await?;
         let result = CanonicalCudaExt::into_host(canonical).await?.into_array();
 

--- a/vortex-cuda/src/dynamic_dispatch/mod.rs
+++ b/vortex-cuda/src/dynamic_dispatch/mod.rs
@@ -540,8 +540,12 @@ mod tests {
             .map(|i| ((i as u64) % (max_val + 1)) as u32)
             .collect();
         let primitive = PrimitiveArray::new(Buffer::from(values), NonNullable);
-        BitPacked::encode(&primitive.into_array(), bit_width)
-            .vortex_expect("failed to create BitPacked array")
+        BitPacked::encode(
+            &primitive.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("failed to create BitPacked array")
     }
 
     fn dispatch_plan(
@@ -824,7 +828,7 @@ mod tests {
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
-        let re = RunEnd::new(ends_arr, values_arr, &mut cuda_ctx);
+        let re = RunEnd::new(ends_arr, values_arr, cuda_ctx.execution_ctx());
 
         let plan = dispatch_plan(&re.into_array(), &cuda_ctx)?;
 
@@ -849,12 +853,20 @@ mod tests {
 
         // BitPack+FoR the dict values
         let dict_prim = PrimitiveArray::new(Buffer::from(dict_residuals), NonNullable);
-        let dict_bp = BitPacked::encode(&dict_prim.into_array(), 6)?;
+        let dict_bp = BitPacked::encode(
+            &dict_prim.into_array(),
+            6,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         let dict_for = FoR::try_new(dict_bp.into_array(), Scalar::from(dict_reference))?;
 
         // BitPack the codes
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPacked::encode(&codes_prim.into_array(), 6)?;
+        let codes_bp = BitPacked::encode(
+            &codes_prim.into_array(),
+            6,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
 
         let dict = DictArray::try_new(codes_bp.into_array(), dict_for.into_array())?;
 
@@ -883,7 +895,11 @@ mod tests {
         let alp = alp_encode(float_prim.as_view(), Some(exponents), &mut ctx)?;
         assert!(alp.patches().is_none());
         let for_arr = FoR::encode(alp.encoded().clone().execute::<PrimitiveArray>(&mut ctx)?)?;
-        let bp = BitPacked::encode(for_arr.encoded(), 6)?;
+        let bp = BitPacked::encode(
+            for_arr.encoded(),
+            6,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
 
         let tree = ALP::new(
             FoR::try_new(bp.into_array(), for_arr.reference_scalar().clone())?.into_array(),
@@ -917,7 +933,11 @@ mod tests {
             .collect();
 
         let prim = PrimitiveArray::new(Buffer::from(raw), NonNullable);
-        let bp = BitPacked::encode(&prim.into_array(), bit_width)?;
+        let bp = BitPacked::encode(
+            &prim.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         let zz = ZigZag::try_new(bp.into_array())?;
 
         let cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
@@ -947,7 +967,7 @@ mod tests {
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
-        let re = RunEnd::new(ends_arr, values_arr, &mut cuda_ctx);
+        let re = RunEnd::new(ends_arr, values_arr, cuda_ctx.execution_ctx());
         let for_arr = FoR::try_new(re.into_array(), Scalar::from(reference))?;
 
         let plan = dispatch_plan(&for_arr.into_array(), &cuda_ctx)?;
@@ -1000,7 +1020,11 @@ mod tests {
         // BitPack codes, then wrap in FoR (reference=0 so values unchanged)
         let bit_width: u8 = 3;
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPacked::encode(&codes_prim.into_array(), bit_width)?;
+        let codes_bp = BitPacked::encode(
+            &codes_prim.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         let codes_for = FoR::try_new(codes_bp.into_array(), Scalar::from(0u32))?;
 
         let values_prim = PrimitiveArray::new(Buffer::from(dict_values), NonNullable);
@@ -1026,7 +1050,11 @@ mod tests {
 
         let bit_width: u8 = 2;
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPacked::encode(&codes_prim.into_array(), bit_width)?;
+        let codes_bp = BitPacked::encode(
+            &codes_prim.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         let values_prim = PrimitiveArray::new(Buffer::from(dict_values), NonNullable);
 
         let dict = DictArray::try_new(codes_bp.into_array(), values_prim.into_array())?;
@@ -1114,7 +1142,7 @@ mod tests {
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
-        let re = RunEnd::new(ends_arr, values_arr, &mut cuda_ctx);
+        let re = RunEnd::new(ends_arr, values_arr, cuda_ctx.execution_ctx());
         let array = re.into_array();
 
         // Ends (u64) are wider than values (u32), so the kernel would truncate
@@ -1220,7 +1248,11 @@ mod tests {
             .collect();
 
         let prim = PrimitiveArray::new(Buffer::from(raw), NonNullable);
-        let bp = BitPacked::encode(&prim.into_array(), bit_width)?;
+        let bp = BitPacked::encode(
+            &prim.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         let zz = ZigZag::try_new(bp.into_array())?;
 
         let sliced = zz.into_array().slice(slice_start..slice_end)?;
@@ -1316,7 +1348,11 @@ mod tests {
 
         let data: Vec<u32> = (0..len).map(|i| (i as u32) % max_val).collect();
         let prim = PrimitiveArray::new(Buffer::from(data.clone()), NonNullable);
-        let bp = BitPacked::encode(&prim.into_array(), bit_width)?;
+        let bp = BitPacked::encode(
+            &prim.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
 
         let sliced = bp.into_array().slice(slice_start..slice_end)?;
         let expected: Vec<u32> = data[slice_start..slice_end].to_vec();
@@ -1362,7 +1398,11 @@ mod tests {
 
         let encoded_data: Vec<u32> = (0..len).map(|i| (i as u32) % max_val).collect();
         let prim = PrimitiveArray::new(Buffer::from(encoded_data.clone()), NonNullable);
-        let bp = BitPacked::encode(&prim.into_array(), bit_width)?;
+        let bp = BitPacked::encode(
+            &prim.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         let for_arr = FoR::try_new(bp.into_array(), Scalar::from(reference))?;
 
         let all_decoded: Vec<u32> = encoded_data.iter().map(|&v| v + reference).collect();
@@ -1415,12 +1455,20 @@ mod tests {
 
         // BitPack+FoR the dict values
         let dict_prim = PrimitiveArray::new(Buffer::from(dict_residuals), NonNullable);
-        let dict_bp = BitPacked::encode(&dict_prim.into_array(), 6)?;
+        let dict_bp = BitPacked::encode(
+            &dict_prim.into_array(),
+            6,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         let dict_for = FoR::try_new(dict_bp.into_array(), Scalar::from(dict_reference))?;
 
         // BitPack the codes
         let codes_prim = PrimitiveArray::new(Buffer::from(codes), NonNullable);
-        let codes_bp = BitPacked::encode(&codes_prim.into_array(), 6)?;
+        let codes_bp = BitPacked::encode(
+            &codes_prim.into_array(),
+            6,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
 
         let dict = DictArray::try_new(codes_bp.into_array(), dict_for.into_array())?;
 
@@ -1520,7 +1568,12 @@ mod tests {
             .collect();
 
         let primitive = PrimitiveArray::new(Buffer::from(residuals), NonNullable);
-        let bp = BitPacked::encode(&primitive.into_array(), bit_width).vortex_expect("bitpack u8");
+        let bp = BitPacked::encode(
+            &primitive.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("bitpack u8");
         let for_arr = FoR::try_new(
             bp.into_array(),
             Scalar::primitive(reference, Nullability::NonNullable),
@@ -1551,7 +1604,12 @@ mod tests {
             .collect();
 
         let primitive = PrimitiveArray::new(Buffer::from(residuals), NonNullable);
-        let bp = BitPacked::encode(&primitive.into_array(), bit_width).vortex_expect("bitpack u16");
+        let bp = BitPacked::encode(
+            &primitive.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("bitpack u16");
         let for_arr = FoR::try_new(
             bp.into_array(),
             Scalar::primitive(reference, Nullability::NonNullable),
@@ -1580,7 +1638,12 @@ mod tests {
             .collect();
 
         let primitive = PrimitiveArray::new(Buffer::from(residuals), NonNullable);
-        let bp = BitPacked::encode(&primitive.into_array(), bit_width).vortex_expect("bitpack u64");
+        let bp = BitPacked::encode(
+            &primitive.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("bitpack u64");
         let for_arr = FoR::try_new(
             bp.into_array(),
             Scalar::primitive(reference, Nullability::NonNullable),
@@ -1611,7 +1674,12 @@ mod tests {
     async fn test_single_element() -> VortexResult<()> {
         let values: Vec<u32> = vec![42];
         let primitive = PrimitiveArray::new(Buffer::from(values.clone()), NonNullable);
-        let bp = BitPacked::encode(&primitive.into_array(), 6).vortex_expect("bitpack");
+        let bp = BitPacked::encode(
+            &primitive.into_array(),
+            6,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("bitpack");
         let for_arr = FoR::try_new(
             bp.into_array(),
             Scalar::primitive(0u32, Nullability::NonNullable),
@@ -1640,7 +1708,12 @@ mod tests {
         let expected: Vec<u32> = residuals.iter().map(|&r| r + reference).collect();
 
         let primitive = PrimitiveArray::new(Buffer::from(residuals), NonNullable);
-        let bp = BitPacked::encode(&primitive.into_array(), bit_width).vortex_expect("bitpack");
+        let bp = BitPacked::encode(
+            &primitive.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("bitpack");
         let for_arr = FoR::try_new(
             bp.into_array(),
             Scalar::primitive(reference, Nullability::NonNullable),
@@ -1680,7 +1753,7 @@ mod tests {
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())?;
         let ends_arr = PrimitiveArray::new(Buffer::from(ends), NonNullable).into_array();
         let values_arr = PrimitiveArray::new(Buffer::from(values), NonNullable).into_array();
-        let re = RunEnd::new(ends_arr, values_arr, &mut cuda_ctx);
+        let re = RunEnd::new(ends_arr, values_arr, cuda_ctx.execution_ctx());
         let array = re.into_array();
 
         // Ends (u32) are wider than values (u16), so the kernel would truncate
@@ -1723,8 +1796,12 @@ mod tests {
 
         let codes_prim = PrimitiveArray::new(Buffer::from(codes.clone()), NonNullable);
         // BitPack the u8 codes at 2 bits (4 values need 2 bits)
-        let codes_bp =
-            BitPacked::encode(&codes_prim.into_array(), 2).vortex_expect("bitpack codes");
+        let codes_bp = BitPacked::encode(
+            &codes_prim.into_array(),
+            2,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("bitpack codes");
         let values_prim = PrimitiveArray::new(Buffer::from(dict_values.clone()), NonNullable);
         let dict = DictArray::try_new(codes_bp.into_array(), values_prim.into_array())?;
         let array = dict.into_array();
@@ -1896,7 +1973,11 @@ mod tests {
             PrimitiveArray::from_option_iter(values.iter().map(|v| v.map(|x| x - reference)));
 
         // BitPacked::encode preserves nullable validity from the input.
-        let bp = BitPacked::encode(&residuals.into_array(), 6)?;
+        let bp = BitPacked::encode(
+            &residuals.into_array(),
+            6,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         let for_arr = FoR::try_new(bp.into_array(), reference.into())?;
 
         // Verify the plan actually fuses (not just a LOAD).

--- a/vortex-cuda/src/hybrid_dispatch/mod.rs
+++ b/vortex-cuda/src/hybrid_dispatch/mod.rs
@@ -124,6 +124,8 @@ mod tests {
     use vortex::error::VortexResult;
     use vortex::mask::Mask;
     use vortex::session::VortexSession;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
 
     use crate::CanonicalCudaExt;
     use crate::executor::CudaArrayExt;
@@ -138,6 +140,7 @@ mod tests {
         let bp = BitPacked::encode(
             &PrimitiveArray::new(Buffer::from(values), NonNullable).into_array(),
             7,
+            &mut LEGACY_SESSION.create_execution_ctx(),
         )
         .vortex_expect("bp");
         let arr = FoR::try_new(bp.into_array(), 1000u32.into()).vortex_expect("for");
@@ -167,6 +170,7 @@ mod tests {
         let bp = BitPacked::encode(
             &PrimitiveArray::new(Buffer::from(encoded), NonNullable).into_array(),
             9,
+            &mut LEGACY_SESSION.create_execution_ctx(),
         )
         .vortex_expect("bp");
         let alp = ALP::try_new(
@@ -253,7 +257,9 @@ mod tests {
         )
         .into_array();
         let vals = FoR::try_new(
-            BitPacked::encode(&vals, 6).vortex_expect("bp").into_array(),
+            BitPacked::encode(&vals, 6, &mut LEGACY_SESSION.create_execution_ctx())
+                .vortex_expect("bp")
+                .into_array(),
             0u32.into(),
         )
         .vortex_expect("for");
@@ -266,7 +272,7 @@ mod tests {
         )
         .into_array();
         let codes = FoR::try_new(
-            BitPacked::encode(&codes, 6)
+            BitPacked::encode(&codes, 6, &mut LEGACY_SESSION.create_execution_ctx())
                 .vortex_expect("bp")
                 .into_array(),
             0u32.into(),
@@ -302,6 +308,7 @@ mod tests {
         let bp = BitPacked::encode(
             &PrimitiveArray::new(Buffer::from(data.clone()), NonNullable).into_array(),
             7,
+            &mut LEGACY_SESSION.create_execution_ctx(),
         )
         .vortex_expect("bp");
         let for_arr = FoR::try_new(bp.into_array(), 100u32.into()).vortex_expect("for");

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -207,6 +207,8 @@ mod tests {
     use vortex::encodings::fastlanes::BitPackedArrayExt;
     use vortex::error::VortexExpect;
     use vortex::session::VortexSession;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
 
     use super::*;
     use crate::CanonicalCudaExt;
@@ -228,7 +230,11 @@ mod tests {
         let array = PrimitiveArray::new(iter.collect::<Buffer<_>>(), NonNullable);
 
         // Last two items should be patched
-        let bp_with_patches = BitPacked::encode(&array.into_array(), bw)?;
+        let bp_with_patches = BitPacked::encode(
+            &array.into_array(),
+            bw,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         assert!(bp_with_patches.patches().is_some());
 
         let cpu_result = crate::canonicalize_cpu(bp_with_patches.clone())?.into_array();
@@ -259,7 +265,11 @@ mod tests {
         );
 
         // Last two items should be patched
-        let bp_with_patches = BitPacked::encode(&array.into_array(), 9)?;
+        let bp_with_patches = BitPacked::encode(
+            &array.into_array(),
+            9,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         assert!(bp_with_patches.patches().is_some());
 
         let cpu_result = crate::canonicalize_cpu(bp_with_patches.clone())?.into_array();
@@ -301,8 +311,12 @@ mod tests {
             NonNullable,
         );
 
-        let bitpacked_array = BitPacked::encode(&primitive_array.into_array(), bit_width)
-            .vortex_expect("operation should succeed in test");
+        let bitpacked_array = BitPacked::encode(
+            &primitive_array.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("operation should succeed in test");
         let cpu_result = crate::canonicalize_cpu(bitpacked_array.clone())?;
 
         let gpu_result = block_on(async {
@@ -350,8 +364,12 @@ mod tests {
             NonNullable,
         );
 
-        let bitpacked_array = BitPacked::encode(&primitive_array.into_array(), bit_width)
-            .vortex_expect("operation should succeed in test");
+        let bitpacked_array = BitPacked::encode(
+            &primitive_array.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("operation should succeed in test");
         let cpu_result = crate::canonicalize_cpu(bitpacked_array.clone())?;
 
         let gpu_result = block_on(async {
@@ -415,8 +433,12 @@ mod tests {
             NonNullable,
         );
 
-        let bitpacked_array = BitPacked::encode(&primitive_array.into_array(), bit_width)
-            .vortex_expect("operation should succeed in test");
+        let bitpacked_array = BitPacked::encode(
+            &primitive_array.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("operation should succeed in test");
         let cpu_result = crate::canonicalize_cpu(bitpacked_array.clone())?;
 
         let gpu_result = block_on(async {
@@ -512,8 +534,12 @@ mod tests {
             NonNullable,
         );
 
-        let bitpacked_array = BitPacked::encode(&primitive_array.into_array(), bit_width)
-            .vortex_expect("operation should succeed in test");
+        let bitpacked_array = BitPacked::encode(
+            &primitive_array.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("operation should succeed in test");
         let cpu_result = crate::canonicalize_cpu(bitpacked_array.clone())?;
         let gpu_result = block_on(async {
             BitPackedExecutor
@@ -545,8 +571,12 @@ mod tests {
             NonNullable,
         );
 
-        let bitpacked_array = BitPacked::encode(&primitive_array.into_array(), bit_width)
-            .vortex_expect("operation should succeed in test");
+        let bitpacked_array = BitPacked::encode(
+            &primitive_array.into_array(),
+            bit_width,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .vortex_expect("operation should succeed in test");
         let sliced_array = bitpacked_array.into_array().slice(67..3969)?;
         assert!(sliced_array.is::<BitPacked>());
         let cpu_result = crate::canonicalize_cpu(sliced_array.clone())?;

--- a/vortex-cuda/src/kernel/encodings/bitpacked.rs
+++ b/vortex-cuda/src/kernel/encodings/bitpacked.rs
@@ -609,7 +609,11 @@ mod tests {
         let primitive_array = PrimitiveArray::new(buffer![100u8, 101, 102, 3, 4, 5], NonNullable);
 
         // Encode with bit width 4. First 3 elements patched, remainder will pack.
-        let bitpacked_array = BitPacked::encode(&primitive_array.into_array(), 4)?;
+        let bitpacked_array = BitPacked::encode(
+            &primitive_array.into_array(),
+            4,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         assert!(
             bitpacked_array.patches().is_some(),
             "Expected patches to be present"
@@ -655,7 +659,11 @@ mod tests {
         let primitive_array =
             PrimitiveArray::new(Buffer::from_iter(values.iter().copied()), NonNullable);
 
-        let bitpacked_array = BitPacked::encode(&primitive_array.into_array(), 9)?;
+        let bitpacked_array = BitPacked::encode(
+            &primitive_array.into_array(),
+            9,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         assert!(
             bitpacked_array.patches().is_some(),
             "Expected patches to be present"
@@ -708,7 +716,11 @@ mod tests {
         let primitive_array =
             PrimitiveArray::new(Buffer::from_iter(values.iter().copied()), NonNullable);
 
-        let bitpacked_array = BitPacked::encode(&primitive_array.into_array(), 9)?;
+        let bitpacked_array = BitPacked::encode(
+            &primitive_array.into_array(),
+            9,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )?;
         assert!(
             bitpacked_array.patches().is_some(),
             "Expected patches to be present"

--- a/vortex-cuda/src/kernel/encodings/for_.rs
+++ b/vortex-cuda/src/kernel/encodings/for_.rs
@@ -139,6 +139,8 @@ mod tests {
     use vortex::error::VortexExpect;
     use vortex::scalar::Scalar;
     use vortex::session::VortexSession;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
 
     use super::*;
     use crate::CanonicalCudaExt;
@@ -187,7 +189,9 @@ mod tests {
             .take(1024)
             .collect::<Buffer<_>>()
             .into_array();
-        let packed = BitPacked::encode(&values, 3).unwrap().into_array();
+        let packed = BitPacked::encode(&values, 3, &mut LEGACY_SESSION.create_execution_ctx())
+            .unwrap()
+            .into_array();
         let for_array = FoR::try_new(packed, (-8i8).into()).unwrap();
 
         let cpu_result = crate::canonicalize_cpu(for_array.clone()).unwrap();

--- a/vortex-cuda/src/kernel/encodings/runend.rs
+++ b/vortex-cuda/src/kernel/encodings/runend.rs
@@ -211,7 +211,7 @@ mod tests {
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
-        let runend_array = build(&mut cuda_ctx);
+        let runend_array = build(cuda_ctx.execution_ctx());
         let cpu_result = crate::canonicalize_cpu(runend_array.clone())?;
 
         let gpu_result = RunEndExecutor
@@ -239,7 +239,7 @@ mod tests {
         let ends: Vec<u64> = (1..=num_runs).map(|i| (i * run_length) as u64).collect();
         let values: Vec<i32> = (0..num_runs).map(|i| i32::try_from(i).unwrap()).collect();
 
-        let runend_array = make_runend_array(ends, values, &mut cuda_ctx);
+        let runend_array = make_runend_array(ends, values, cuda_ctx.execution_ctx());
         assert_eq!(runend_array.len(), total_len);
 
         let cpu_result = crate::canonicalize_cpu(runend_array.clone())?;
@@ -262,7 +262,7 @@ mod tests {
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
-        let runend_array = make_runend_array(vec![100u32], vec![42i32], &mut cuda_ctx);
+        let runend_array = make_runend_array(vec![100u32], vec![42i32], cuda_ctx.execution_ctx());
 
         let cpu_result = crate::canonicalize_cpu(runend_array.clone())?;
 
@@ -289,7 +289,7 @@ mod tests {
         let ends: Vec<u32> = (1..=num_elements).collect();
         let values: Vec<i32> = (0..num_elements as i32).collect();
 
-        let runend_array = make_runend_array(ends, values, &mut cuda_ctx);
+        let runend_array = make_runend_array(ends, values, cuda_ctx.execution_ctx());
 
         let cpu_result = crate::canonicalize_cpu(runend_array.clone())?;
 
@@ -319,7 +319,7 @@ mod tests {
             Validity::Array(BoolArray::from_iter([true, false, true].into_iter()).into_array());
         let values_array =
             PrimitiveArray::new(Buffer::from(vec![10i32, 0, 30]), validity).into_array();
-        let runend_array = RunEnd::new(ends_array, values_array, &mut cuda_ctx);
+        let runend_array = RunEnd::new(ends_array, values_array, cuda_ctx.execution_ctx());
 
         let cpu_result = crate::canonicalize_cpu(runend_array.clone())?.into_array();
 

--- a/vortex-cuda/src/kernel/encodings/runend.rs
+++ b/vortex-cuda/src/kernel/encodings/runend.rs
@@ -181,7 +181,11 @@ mod tests {
     use crate::executor::CudaArrayExt;
     use crate::session::CudaSession;
 
-    fn make_runend_array<V, E>(ends: Vec<E>, values: Vec<V>) -> RunEndArray
+    fn make_runend_array<V, E>(
+        ends: Vec<E>,
+        values: Vec<V>,
+        ctx: &mut vortex::array::ExecutionCtx,
+    ) -> RunEndArray
     where
         V: NativePType,
         E: NativePType,
@@ -190,21 +194,24 @@ mod tests {
             PrimitiveArray::new(Buffer::from(ends), Validity::NonNullable).into_array();
         let values_array =
             PrimitiveArray::new(Buffer::from(values), Validity::NonNullable).into_array();
-        RunEnd::new(ends_array, values_array)
+        RunEnd::new(ends_array, values_array, ctx)
     }
 
+    type RunEndBuilder = fn(&mut vortex::array::ExecutionCtx) -> RunEndArray;
+
     #[rstest]
-    #[case::u32_ends_u8_values(make_runend_array(vec![3u32, 6, 10], vec![10u8, 20, 30]))]
-    #[case::u32_ends_u32_values(make_runend_array(vec![2u32, 5, 10], vec![1u32, 2, 3]))]
-    #[case::u32_ends_f64_values(make_runend_array(vec![2u32, 5, 8], vec![1.5f64, 2.5, 3.5]))]
-    #[case::u8_ends_i32_values(make_runend_array(vec![2u8, 5, 10], vec![1i32, 2, 3]))]
-    #[case::u32_ends_i32_values(make_runend_array(vec![2u32, 5, 10], vec![1i32, 2, 3]))]
-    #[case::u64_ends_i32_values(make_runend_array(vec![2u64, 5, 10], vec![1i32, 2, 3]))]
+    #[case::u32_ends_u8_values(|ctx: &mut vortex::array::ExecutionCtx| make_runend_array(vec![3u32, 6, 10], vec![10u8, 20, 30], ctx))]
+    #[case::u32_ends_u32_values(|ctx: &mut vortex::array::ExecutionCtx| make_runend_array(vec![2u32, 5, 10], vec![1u32, 2, 3], ctx))]
+    #[case::u32_ends_f64_values(|ctx: &mut vortex::array::ExecutionCtx| make_runend_array(vec![2u32, 5, 8], vec![1.5f64, 2.5, 3.5], ctx))]
+    #[case::u8_ends_i32_values(|ctx: &mut vortex::array::ExecutionCtx| make_runend_array(vec![2u8, 5, 10], vec![1i32, 2, 3], ctx))]
+    #[case::u32_ends_i32_values(|ctx: &mut vortex::array::ExecutionCtx| make_runend_array(vec![2u32, 5, 10], vec![1i32, 2, 3], ctx))]
+    #[case::u64_ends_i32_values(|ctx: &mut vortex::array::ExecutionCtx| make_runend_array(vec![2u64, 5, 10], vec![1i32, 2, 3], ctx))]
     #[crate::test]
-    async fn test_cuda_runend_types(#[case] runend_array: RunEndArray) -> VortexResult<()> {
+    async fn test_cuda_runend_types(#[case] build: RunEndBuilder) -> VortexResult<()> {
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
+        let runend_array = build(&mut cuda_ctx);
         let cpu_result = crate::canonicalize_cpu(runend_array.clone())?;
 
         let gpu_result = RunEndExecutor
@@ -232,7 +239,7 @@ mod tests {
         let ends: Vec<u64> = (1..=num_runs).map(|i| (i * run_length) as u64).collect();
         let values: Vec<i32> = (0..num_runs).map(|i| i32::try_from(i).unwrap()).collect();
 
-        let runend_array = make_runend_array(ends, values);
+        let runend_array = make_runend_array(ends, values, &mut cuda_ctx);
         assert_eq!(runend_array.len(), total_len);
 
         let cpu_result = crate::canonicalize_cpu(runend_array.clone())?;
@@ -255,7 +262,7 @@ mod tests {
         let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty())
             .vortex_expect("failed to create execution context");
 
-        let runend_array = make_runend_array(vec![100u32], vec![42i32]);
+        let runend_array = make_runend_array(vec![100u32], vec![42i32], &mut cuda_ctx);
 
         let cpu_result = crate::canonicalize_cpu(runend_array.clone())?;
 
@@ -282,7 +289,7 @@ mod tests {
         let ends: Vec<u32> = (1..=num_elements).collect();
         let values: Vec<i32> = (0..num_elements as i32).collect();
 
-        let runend_array = make_runend_array(ends, values);
+        let runend_array = make_runend_array(ends, values, &mut cuda_ctx);
 
         let cpu_result = crate::canonicalize_cpu(runend_array.clone())?;
 
@@ -312,7 +319,7 @@ mod tests {
             Validity::Array(BoolArray::from_iter([true, false, true].into_iter()).into_array());
         let values_array =
             PrimitiveArray::new(Buffer::from(vec![10i32, 0, 30]), validity).into_array();
-        let runend_array = RunEnd::new(ends_array, values_array);
+        let runend_array = RunEnd::new(ends_array, values_array, &mut cuda_ctx);
 
         let cpu_result = crate::canonicalize_cpu(runend_array.clone())?.into_array();
 

--- a/vortex-cuda/src/kernel/encodings/zstd.rs
+++ b/vortex-cuda/src/kernel/encodings/zstd.rs
@@ -377,7 +377,7 @@ mod tests {
             "baz",
         ]);
 
-        let zstd_array = Zstd::from_var_bin_view(&strings, 3, 0)?;
+        let zstd_array = Zstd::from_var_bin_view(&strings, 3, 0, cuda_ctx.execution_ctx())?;
 
         let cpu_result = Zstd::decompress(&zstd_array, cuda_ctx.execution_ctx())?
             .execute::<Canonical>(cuda_ctx.execution_ctx())?;
@@ -413,7 +413,7 @@ mod tests {
 
         // Compress with ZSTD using values_per_frame=3 to create multiple frames.
         // 14 strings and 3 values per frame = ceil(14/3) = 5 frames.
-        let zstd_array = Zstd::from_var_bin_view(&strings, 3, 3)?;
+        let zstd_array = Zstd::from_var_bin_view(&strings, 3, 3, cuda_ctx.execution_ctx())?;
 
         let cpu_result = Zstd::decompress(&zstd_array, cuda_ctx.execution_ctx())?
             .execute::<Canonical>(cuda_ctx.execution_ctx())?;
@@ -443,7 +443,7 @@ mod tests {
             "final test string",
         ]);
 
-        let zstd_array = Zstd::from_var_bin_view(&strings, 3, 0)?;
+        let zstd_array = Zstd::from_var_bin_view(&strings, 3, 0, cuda_ctx.execution_ctx())?;
 
         // Slice the array to get a subset (indices 2..7)
         let sliced_zstd = zstd_array.slice(2..7)?;
@@ -474,7 +474,7 @@ mod tests {
             Some("another string"),
         ]);
 
-        let zstd_array = Zstd::from_var_bin_view(&strings, 3, 0)?;
+        let zstd_array = Zstd::from_var_bin_view(&strings, 3, 0, cuda_ctx.execution_ctx())?;
 
         let cpu_result = crate::canonicalize_cpu(zstd_array.clone())?.into_array();
 

--- a/vortex-cuda/src/kernel/patches/mod.rs
+++ b/vortex-cuda/src/kernel/patches/mod.rs
@@ -101,10 +101,9 @@ mod tests {
     use std::sync::Arc;
 
     use cudarc::driver::DeviceRepr;
+    use vortex::array::ExecutionCtx;
     use vortex::array::IntoArray;
     use vortex::array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex::array::ToCanonical;
     use vortex::array::VortexSessionExecute;
     use vortex::array::arrays::PrimitiveArray;
     use vortex::array::arrays::primitive::PrimitiveDataParts;
@@ -146,32 +145,30 @@ mod tests {
     }
 
     async fn full_test_case<Values: NativePType + DeviceRepr, Indices: NativePType + DeviceRepr>() {
-        let mut ctx = CudaSession::create_execution_ctx(&VortexSession::empty()).unwrap();
+        let mut cuda_ctx = CudaSession::create_execution_ctx(&VortexSession::empty()).unwrap();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
 
         let values = PrimitiveArray::from_iter(0..128);
-        let values = force_cast::<Values>(values);
+        let values = force_cast::<Values>(values, &mut ctx);
 
         let patch_idx = PrimitiveArray::new(buffer![0, 8, 16, 32], Validity::NonNullable);
-        let patch_idx = force_cast::<Indices>(patch_idx);
+        let patch_idx = force_cast::<Indices>(patch_idx, &mut ctx);
 
         let patch_val = PrimitiveArray::new(buffer![99, 99, 99, 99], Validity::NonNullable);
-        let patch_val = force_cast::<Values>(patch_val);
+        let patch_val = force_cast::<Values>(patch_val, &mut ctx);
 
         // Copy all to GPU
         let patches =
             Patches::new(128, 0, patch_idx.into_array(), patch_val.into_array(), None).unwrap();
 
-        let cpu_result = values
-            .clone()
-            .patch(&patches, &mut LEGACY_SESSION.create_execution_ctx())
-            .unwrap();
+        let cpu_result = values.clone().patch(&patches, &mut ctx).unwrap();
 
         let PrimitiveDataParts {
             buffer: cuda_buffer,
             ..
         } = values.into_data_parts();
 
-        let handle = ctx.ensure_on_device(cuda_buffer).await.unwrap();
+        let handle = cuda_ctx.ensure_on_device(cuda_buffer).await.unwrap();
         let device_buf = handle
             .as_device()
             .as_any()
@@ -179,7 +176,7 @@ mod tests {
             .unwrap()
             .clone();
 
-        let patched_buf = execute_patches::<Values, Indices>(patches, device_buf, &mut ctx)
+        let patched_buf = execute_patches::<Values, Indices>(patches, device_buf, &mut cuda_ctx)
             .await
             .unwrap();
 
@@ -189,7 +186,7 @@ mod tests {
             Validity::NonNullable,
         )
         .into_array()
-        .execute::<vortex::array::Canonical>(&mut LEGACY_SESSION.create_execution_ctx())
+        .execute::<vortex::array::Canonical>(&mut ctx)
         .unwrap()
         .into_host()
         .await
@@ -199,13 +196,12 @@ mod tests {
         assert_arrays_eq!(cpu_result, gpu_result);
     }
 
-    fn force_cast<T: NativePType>(array: PrimitiveArray) -> PrimitiveArray {
-        #[expect(deprecated)]
-        let result = array
+    fn force_cast<T: NativePType>(array: PrimitiveArray, ctx: &mut ExecutionCtx) -> PrimitiveArray {
+        array
             .into_array()
             .cast(DType::Primitive(T::PTYPE, Nullability::NonNullable))
             .unwrap()
-            .to_primitive();
-        result
+            .execute::<PrimitiveArray>(ctx)
+            .unwrap()
     }
 }

--- a/vortex-duckdb/src/convert/vector.rs
+++ b/vortex-duckdb/src/convert/vector.rs
@@ -376,8 +376,6 @@ mod tests {
     use std::ffi::CString;
 
     use vortex::array::LEGACY_SESSION;
-    #[expect(deprecated)]
-    use vortex::array::ToCanonical;
     use vortex::array::VortexSessionExecute;
     use vortex::array::arrays::BoolArray;
     use vortex::array::arrays::fixed_size_list::FixedSizeListArrayExt;
@@ -415,6 +413,7 @@ mod tests {
 
     #[test]
     fn test_timestamp_vector_conversion() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = vec![1_703_980_800_000_000_i64, 0i64, -86_400_000_000_i64]; // microseconds
         let len = values.len();
 
@@ -430,8 +429,11 @@ mod tests {
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
         let vortex_array = TemporalArray::try_from(result).unwrap();
-        #[expect(deprecated)]
-        let vortex_values = vortex_array.temporal_values().to_primitive();
+        let vortex_values = vortex_array
+            .temporal_values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let values_slice = vortex_values.as_slice::<i64>();
 
         assert_eq!(values_slice, values);
@@ -439,6 +441,7 @@ mod tests {
 
     #[test]
     fn test_timestamp_seconds_vector_conversion() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = vec![1_703_980_800_i64, 0i64, -86_400_i64]; // seconds
         let len = values.len();
 
@@ -454,8 +457,11 @@ mod tests {
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
         let vortex_array = TemporalArray::try_from(result).unwrap();
-        #[expect(deprecated)]
-        let vortex_values = vortex_array.temporal_values().to_primitive();
+        let vortex_values = vortex_array
+            .temporal_values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let values_slice = vortex_values.as_slice::<i64>();
 
         assert_eq!(values_slice, values);
@@ -463,6 +469,7 @@ mod tests {
 
     #[test]
     fn test_timestamp_milliseconds_vector_conversion() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = vec![1_703_980_800_000_i64, 0i64, -86_400_000_i64]; // milliseconds
         let len = values.len();
 
@@ -478,8 +485,11 @@ mod tests {
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
         let vortex_array = TemporalArray::try_from(result).unwrap();
-        #[expect(deprecated)]
-        let vortex_values = vortex_array.temporal_values().to_primitive();
+        let vortex_values = vortex_array
+            .temporal_values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let values_slice = vortex_values.as_slice::<i64>();
 
         assert_eq!(values_slice, values);
@@ -487,6 +497,7 @@ mod tests {
 
     #[test]
     fn test_timestamp_with_nulls_conversion() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = vec![1_703_980_800_000_000_i64, 0i64, -86_400_000_000_i64];
         let len = values.len();
 
@@ -507,8 +518,11 @@ mod tests {
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
         let vortex_array = TemporalArray::try_from(result).unwrap();
-        #[expect(deprecated)]
-        let vortex_values = vortex_array.temporal_values().to_primitive();
+        let vortex_values = vortex_array
+            .temporal_values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let values_slice = vortex_values.as_slice::<i64>();
 
         assert_eq!(values_slice, values);
@@ -517,10 +531,7 @@ mod tests {
                 .as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(
-                    vortex_values.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx()
-                )
+                .to_mask(vortex_values.as_ref().len(), &mut ctx)
                 .unwrap(),
             Mask::from_indices(3, vec![0, 2])
         );
@@ -550,8 +561,12 @@ mod tests {
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
         let vortex_array = TemporalArray::try_from(result).unwrap();
-        #[expect(deprecated)]
-        let vortex_values = vortex_array.temporal_values().to_primitive();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let vortex_values = vortex_array
+            .temporal_values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let values_slice = vortex_values.as_slice::<i64>();
 
         assert_eq!(values_slice, values);
@@ -559,6 +574,7 @@ mod tests {
 
     #[test]
     fn test_timestamp_single_value() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = vec![1_703_980_800_000_000_i64]; // Single microsecond timestamp
         let len = values.len();
 
@@ -574,8 +590,11 @@ mod tests {
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
         let vortex_array = TemporalArray::try_from(result).unwrap();
-        #[expect(deprecated)]
-        let vortex_values = vortex_array.temporal_values().to_primitive();
+        let vortex_values = vortex_array
+            .temporal_values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let values_slice = vortex_values.as_slice::<i64>();
 
         assert_eq!(values_slice, values);
@@ -583,6 +602,7 @@ mod tests {
 
     #[test]
     fn test_boolean_vector_conversion() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = vec![true, false, true, false];
         let len = values.len();
 
@@ -597,14 +617,14 @@ mod tests {
 
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
-        #[expect(deprecated)]
-        let vortex_array = result.to_bool();
+        let vortex_array = result.execute::<BoolArray>(&mut ctx).unwrap();
         let expected = BoolArray::new(BitBuffer::from(values), Validity::AllValid);
         assert_arrays_eq!(vortex_array, expected);
     }
 
     #[test]
     fn test_vector_with_nulls() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = vec![1i32, 2, 3];
         let len = values.len();
 
@@ -624,8 +644,7 @@ mod tests {
 
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
-        #[expect(deprecated)]
-        let vortex_array = result.to_primitive();
+        let vortex_array = result.execute::<PrimitiveArray>(&mut ctx).unwrap();
         let vortex_slice = vortex_array.as_slice::<i32>();
 
         assert_eq!(vortex_slice, values);
@@ -634,10 +653,7 @@ mod tests {
                 .as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(
-                    vortex_array.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx()
-                )
+                .to_mask(vortex_array.as_ref().len(), &mut ctx)
                 .unwrap(),
             Mask::from_indices(3, vec![0, 2])
         );
@@ -667,8 +683,8 @@ mod tests {
 
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
-        #[expect(deprecated)]
-        let vortex_array = result.to_listview();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let vortex_array = result.execute::<ListViewArray>(&mut ctx).unwrap();
 
         assert_eq!(vortex_array.len(), len);
         assert_arrays_eq!(
@@ -679,6 +695,7 @@ mod tests {
 
     #[test]
     fn test_fixed_sized_list() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values = vec![1i32, 2, 3, 4];
         let len = 1;
 
@@ -696,8 +713,7 @@ mod tests {
 
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
-        #[expect(deprecated)]
-        let vortex_array = result.to_fixed_size_list();
+        let vortex_array = result.execute::<FixedSizeListArray>(&mut ctx).unwrap();
 
         assert_eq!(vortex_array.len(), len);
         assert_arrays_eq!(
@@ -708,6 +724,7 @@ mod tests {
 
     #[test]
     fn test_empty_struct() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let len = 4;
         let logical_type = LogicalType::struct_type([], [])
             .vortex_expect("LogicalTypeRef creation should succeed for test data");
@@ -715,8 +732,7 @@ mod tests {
 
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
-        #[expect(deprecated)]
-        let vortex_array = result.to_struct();
+        let vortex_array = result.execute::<StructArray>(&mut ctx).unwrap();
 
         assert_eq!(vortex_array.len(), len);
         assert_eq!(vortex_array.struct_fields().nfields(), 0);
@@ -724,6 +740,7 @@ mod tests {
 
     #[test]
     fn test_struct() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let values1 = vec![1i32, 2, 3, 4];
         let values2 = vec![5i32, 6, 7, 8];
         let len = values1.len();
@@ -751,8 +768,7 @@ mod tests {
 
         // Test conversion
         let result = flat_vector_to_vortex(&vector, len).unwrap();
-        #[expect(deprecated)]
-        let vortex_array = result.to_struct();
+        let vortex_array = result.execute::<StructArray>(&mut ctx).unwrap();
 
         assert_eq!(vortex_array.len(), len);
         assert_eq!(vortex_array.struct_fields().nfields(), 2);
@@ -768,6 +784,7 @@ mod tests {
 
     #[test]
     fn test_list_with_trailing_null() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Regression test: when the last list entry is null, its offset/length may be 0/0,
         // so we can't use the last entry to compute child vector length.
         let child_values = vec![1i32, 2, 3, 4];
@@ -801,8 +818,7 @@ mod tests {
         // Test conversion - the old bug would compute child length as 0+0=0 instead of
         // max(4,0)=4.
         let result = flat_vector_to_vortex(&vector, len).unwrap();
-        #[expect(deprecated)]
-        let vortex_array = result.to_listview();
+        let vortex_array = result.execute::<ListViewArray>(&mut ctx).unwrap();
 
         assert_eq!(vortex_array.len(), len);
         assert_arrays_eq!(
@@ -814,10 +830,7 @@ mod tests {
                 .as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(
-                    vortex_array.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx()
-                )
+                .to_mask(vortex_array.as_ref().len(), &mut ctx)
                 .unwrap(),
             Mask::from_indices(2, vec![0])
         );
@@ -825,6 +838,7 @@ mod tests {
 
     #[test]
     fn test_list_out_of_order() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Regression test: list views can be out of order in DuckDB. The child vector length
         // must be computed as the maximum end offset, not just the last entry's end offset.
         let child_values = vec![1i32, 2, 3, 4];
@@ -855,8 +869,7 @@ mod tests {
         // Test conversion - the old bug would compute child length as 0+2=2 instead of
         // max(4,2)=4.
         let result = flat_vector_to_vortex(&vector, len).unwrap();
-        #[expect(deprecated)]
-        let vortex_array = result.to_listview();
+        let vortex_array = result.execute::<ListViewArray>(&mut ctx).unwrap();
 
         assert_eq!(vortex_array.len(), len);
         assert_arrays_eq!(
@@ -871,6 +884,7 @@ mod tests {
 
     #[test]
     fn test_list_null_garbage_data() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         // Test that null list entries with garbage offset/size values don't cause issues.
         // DuckDB doesn't guarantee valid offset/size for null list views, so we must check
         // validity before reading the offset/size values.
@@ -911,8 +925,7 @@ mod tests {
         // Test conversion. The old code would compute child_min_length as 9999+9999=19998, which
         // would panic when trying to read that much data from the child vector.
         let result = flat_vector_to_vortex(&vector, len).unwrap();
-        #[expect(deprecated)]
-        let vortex_array = result.to_listview();
+        let vortex_array = result.execute::<ListViewArray>(&mut ctx).unwrap();
 
         assert_eq!(vortex_array.len(), len);
 
@@ -927,10 +940,16 @@ mod tests {
         );
 
         // Verify the null entry has sanitized offset/size (offset=2, size=0) rather than garbage.
-        #[expect(deprecated)]
-        let offsets = vortex_array.offsets().to_primitive();
-        #[expect(deprecated)]
-        let sizes = vortex_array.sizes().to_primitive();
+        let offsets = vortex_array
+            .offsets()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
+        let sizes = vortex_array
+            .sizes()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         assert_eq!(offsets.as_slice::<i64>()[1], 2); // Previous end (0+2).
         assert_eq!(sizes.as_slice::<i64>()[1], 0);
 
@@ -939,10 +958,7 @@ mod tests {
                 .as_ref()
                 .validity()
                 .unwrap()
-                .to_mask(
-                    vortex_array.as_ref().len(),
-                    &mut LEGACY_SESSION.create_execution_ctx()
-                )
+                .to_mask(vortex_array.as_ref().len(), &mut ctx)
                 .unwrap(),
             Mask::from_indices(3, vec![0, 2])
         );

--- a/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
+++ b/vortex-duckdb/src/e2e_test/vortex_scan_test.rs
@@ -19,6 +19,8 @@ use jiff::tz::TimeZone;
 use num_traits::AsPrimitive;
 use tempfile::NamedTempFile;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::BoolArray;
 use vortex::array::arrays::ConstantArray;
 use vortex::array::arrays::DictArray;
@@ -823,7 +825,9 @@ async fn write_vortex_file_with_encodings() -> NamedTempFile {
     // 4. Run-End
     let run_ends = buffer![3u32, 5];
     let run_values = buffer![100i32, 200];
-    let rle_array = RunEnd::try_new(run_ends.into_array(), run_values.into_array()).unwrap();
+    let mut rle_ctx = LEGACY_SESSION.create_execution_ctx();
+    let rle_array =
+        RunEnd::try_new(run_ends.into_array(), run_values.into_array(), &mut rle_ctx).unwrap();
 
     // 5. Sequence array
     let sequence_array = Sequence::try_new(

--- a/vortex-duckdb/src/exporter/dict.rs
+++ b/vortex-duckdb/src/exporter/dict.rs
@@ -77,8 +77,7 @@ pub(crate) fn new_exporter_with_flatten(
         let canonical = match canonical {
             Some(c) => c,
             None => {
-                #[expect(deprecated)]
-                let canonical = values.to_canonical()?;
+                let canonical = values.clone().execute::<Canonical>(ctx)?;
                 cache
                     .canonical_cache
                     .insert(values_key, (values.clone(), canonical.clone()));

--- a/vortex-ffi/src/array.rs
+++ b/vortex-ffi/src/array.rs
@@ -11,11 +11,10 @@ use paste::paste;
 use vortex::array::ArrayRef;
 use vortex::array::IntoArray;
 use vortex::array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
 use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::NullArray;
 use vortex::array::arrays::PrimitiveArray;
+use vortex::array::arrays::StructArray;
 use vortex::array::arrays::struct_::StructArrayExt;
 use vortex::array::validity::Validity;
 use vortex::buffer::Buffer;
@@ -208,9 +207,10 @@ pub unsafe extern "C-unwind" fn vx_array_get_field(
     try_or_default(error_out, || {
         let array = vx_array::as_ref(array);
 
-        #[expect(deprecated)]
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let field_array = array
-            .to_struct()
+            .clone()
+            .execute::<StructArray>(&mut ctx)?
             .unmasked_fields()
             .get(index)
             .ok_or_else(|| vortex_err!("Field index out of bounds"))?
@@ -435,6 +435,8 @@ mod tests {
     use std::ptr;
 
     use vortex::array::IntoArray;
+    use vortex::array::LEGACY_SESSION;
+    use vortex::array::VortexSessionExecute;
     use vortex::array::arrays::BoolArray;
     use vortex::array::arrays::PrimitiveArray;
     use vortex::array::arrays::StructArray;
@@ -764,8 +766,8 @@ mod tests {
             assert!(!res.is_null());
             {
                 let res = vx_array::as_ref(res);
-                #[expect(deprecated)]
-                let bool_array = res.to_bool();
+                let mut ctx = LEGACY_SESSION.create_execution_ctx();
+                let bool_array = res.clone().execute::<BoolArray>(&mut ctx).unwrap();
                 let buffer = bool_array.to_bit_buffer();
                 let expected = BoolArray::from_iter(vec![false, false, true, true]);
                 assert_eq!(buffer, expected.to_bit_buffer());

--- a/vortex-ffi/src/expression.rs
+++ b/vortex-ffi/src/expression.rs
@@ -294,8 +294,8 @@ mod tests {
     use std::sync::Arc;
 
     use vortex::array::IntoArray;
-    #[expect(deprecated)]
-    use vortex::array::ToCanonical;
+    use vortex::array::LEGACY_SESSION;
+    use vortex::array::VortexSessionExecute;
     use vortex::array::arrays::BoolArray;
     use vortex::array::arrays::ListArray;
     use vortex::array::arrays::PrimitiveArray;
@@ -347,6 +347,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_get_item() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let (array, names_array, ages_array) = struct_array();
         unsafe {
             let root = vx_expression_root();
@@ -362,8 +363,10 @@ mod tests {
             {
                 let applied_array = vx_array::as_ref(applied_array);
                 let expected: Buffer<u8> = ages_array.to_buffer();
-                #[expect(deprecated)]
-                let prim = applied_array.to_primitive();
+                let prim = applied_array
+                    .clone()
+                    .execute::<PrimitiveArray>(&mut ctx)
+                    .unwrap();
                 assert_eq!(prim.to_buffer(), expected);
             }
             vx_array_free(applied_array);
@@ -433,6 +436,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_and_or() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let col1 = BoolArray::from_iter([true, false, true, true]);
         let col2 = BoolArray::from_iter([false, true, true, false]);
         let col3 = BoolArray::from_iter([false, true, true, true]);
@@ -468,8 +472,10 @@ mod tests {
             assert!(error.is_null());
             assert!(!applied_array.is_null());
             {
-                #[expect(deprecated)]
-                let array = vx_array::as_ref(applied_array).to_bool();
+                let array = vx_array::as_ref(applied_array)
+                    .clone()
+                    .execute::<BoolArray>(&mut ctx)
+                    .unwrap();
                 let expected = BoolArray::from_iter([false, false, true, false]);
                 assert_eq!(array.to_bit_buffer(), expected.to_bit_buffer());
             }
@@ -482,8 +488,10 @@ mod tests {
             assert!(error.is_null());
             assert!(!applied_array.is_null());
             {
-                #[expect(deprecated)]
-                let array = vx_array::as_ref(applied_array).to_bool();
+                let array = vx_array::as_ref(applied_array)
+                    .clone()
+                    .execute::<BoolArray>(&mut ctx)
+                    .unwrap();
                 let expected = BoolArray::from_iter([true, true, true, false]);
                 assert_eq!(array.to_bit_buffer(), expected.to_bit_buffer());
             }
@@ -520,6 +528,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_list_contains() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let elements = buffer![1i32, 2, 3, 4, 5].into_array();
         let offsets = buffer![0u32, 2, 5, 5].into_array();
         let array = ListArray::try_new(elements, offsets, Validity::NonNullable).unwrap();
@@ -537,8 +546,10 @@ mod tests {
             assert!(error.is_null());
             assert!(!applied.is_null());
             {
-                #[expect(deprecated)]
-                let applied = vx_array::as_ref(applied).to_bool();
+                let applied = vx_array::as_ref(applied)
+                    .clone()
+                    .execute::<BoolArray>(&mut ctx)
+                    .unwrap();
                 let expected = BoolArray::from_iter([true, false, false]);
                 assert_eq!(applied.to_bit_buffer(), expected.to_bit_buffer());
             }

--- a/vortex-ffi/src/struct_array.rs
+++ b/vortex-ffi/src/struct_array.rs
@@ -133,8 +133,8 @@ mod tests {
     use std::sync::Arc;
 
     use vortex::array::IntoArray;
-    #[expect(deprecated)]
-    use vortex::array::ToCanonical;
+    use vortex::array::LEGACY_SESSION;
+    use vortex::array::VortexSessionExecute;
     use vortex::array::arrays::PrimitiveArray;
     use vortex::array::arrays::StructArray;
     use vortex::array::arrays::VarBinViewArray;
@@ -171,6 +171,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_many() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let names = ["age", "name"];
         let age_field = PrimitiveArray::new(buffer![30u8, 25u8, 35u8], Validity::NonNullable);
         let name_field = VarBinViewArray::from_iter_str(["Alice", "Bob", "Charlie"]);
@@ -238,8 +239,10 @@ mod tests {
             assert!(!array.is_null());
 
             {
-                #[expect(deprecated)]
-                let array = vx_array::as_ref(array).to_struct();
+                let array = vx_array::as_ref(array)
+                    .clone()
+                    .execute::<StructArray>(&mut ctx)
+                    .unwrap();
                 assert_arrays_eq!(array, struct_array);
             }
 

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -1311,7 +1311,9 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
     .into_array();
 
     let mut ctx = SESSION.create_execution_ctx();
-    let result = round_trip(&array, Ok).await?.execute::<StructArray>(&mut ctx)?;
+    let result = round_trip(&array, Ok)
+        .await?
+        .execute::<StructArray>(&mut ctx)?;
 
     assert_eq!(result.len(), 3);
     assert_eq!(result.struct_fields().nfields(), 1);

--- a/vortex-file/src/tests.rs
+++ b/vortex-file/src/tests.rs
@@ -12,8 +12,6 @@ use futures::TryStreamExt;
 use futures::pin_mut;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::VortexSessionExecute;
 use vortex_array::accessor::ArrayAccessor;
 use vortex_array::arrays::ChunkedArray;
@@ -264,6 +262,7 @@ async fn test_read_simple_with_spawn() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_read_projection() {
+    let mut ctx = SESSION.create_execution_ctx();
     let strings_expected = ["ab", "foo", "bar", "baz", "ab", "foo", "bar", "baz"];
     let strings = ChunkedArray::from_iter([
         VarBinArray::from(strings_expected[..4].to_vec()).into_array(),
@@ -308,8 +307,11 @@ async fn test_read_projection() {
         )
     );
 
-    #[expect(deprecated)]
-    let actual = array.to_struct().unmasked_field(0).clone();
+    let actual = array
+        .execute::<StructArray>(&mut ctx)
+        .unwrap()
+        .unmasked_field(0)
+        .clone();
     let expected = VarBinArray::from(strings_expected.to_vec()).into_array();
     assert_arrays_eq!(actual, expected);
 
@@ -331,8 +333,11 @@ async fn test_read_projection() {
         )
     );
 
-    #[expect(deprecated)]
-    let actual = array.to_struct().unmasked_field(0).clone();
+    let actual = array
+        .execute::<StructArray>(&mut ctx)
+        .unwrap()
+        .unmasked_field(0)
+        .clone();
     let expected = Buffer::copy_from(numbers_expected).into_array();
     assert_arrays_eq!(actual, expected);
 }
@@ -340,6 +345,7 @@ async fn test_read_projection() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn unequal_batches() {
+    let mut ctx = SESSION.create_execution_ctx();
     let strings = ChunkedArray::from_iter([
         VarBinArray::from(vec!["ab", "foo", "bar", "bob"]).into_array(),
         VarBinArray::from(vec!["baz", "ab", "foo", "bar", "baz", "alice"]).into_array(),
@@ -376,12 +382,14 @@ async fn unequal_batches() {
         let array = array.unwrap();
         item_count += array.len();
 
-        #[expect(deprecated)]
         let numbers = array
-            .to_struct()
+            .execute::<StructArray>(&mut ctx)
+            .unwrap()
             .unmasked_field_by_name("numbers")
             .unwrap()
-            .to_primitive();
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         assert_eq!(numbers.ptype(), PType::U32);
     }
     assert_eq!(item_count, 10);
@@ -510,6 +518,7 @@ async fn issue_5385_filter_casted_column() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn filter_string() {
+    let mut ctx = SESSION.create_execution_ctx();
     let names_orig = VarBinArray::from_iter(
         vec![Some("Joseph"), None, Some("Angela"), Some("Mikhail"), None],
         DType::Utf8(Nullability::Nullable),
@@ -546,15 +555,23 @@ async fn filter_string() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    #[expect(deprecated)]
-    let names_actual = result[0].to_struct().unmasked_field(0).clone();
+    let names_actual = result[0]
+        .clone()
+        .execute::<StructArray>(&mut ctx)
+        .unwrap()
+        .unmasked_field(0)
+        .clone();
     let names_expected =
         VarBinArray::from_iter(vec![Some("Joseph")], DType::Utf8(Nullability::Nullable))
             .into_array();
     assert_arrays_eq!(names_actual, names_expected);
 
-    #[expect(deprecated)]
-    let ages_actual = result[0].to_struct().unmasked_field(1).clone();
+    let ages_actual = result[0]
+        .clone()
+        .execute::<StructArray>(&mut ctx)
+        .unwrap()
+        .unmasked_field(1)
+        .clone();
     let ages_expected = PrimitiveArray::from_option_iter([Some(25i32)]).into_array();
     assert_arrays_eq!(ages_actual, ages_expected);
 }
@@ -562,6 +579,7 @@ async fn filter_string() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn filter_or() {
+    let mut ctx = SESSION.create_execution_ctx();
     let names = VarBinArray::from_iter(
         vec![Some("Joseph"), None, Some("Angela"), Some("Mikhail"), None],
         DType::Utf8(Nullability::Nullable),
@@ -603,8 +621,12 @@ async fn filter_or() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    #[expect(deprecated)]
-    let names_actual = result[0].to_struct().unmasked_field(0).clone();
+    let names_actual = result[0]
+        .clone()
+        .execute::<StructArray>(&mut ctx)
+        .unwrap()
+        .unmasked_field(0)
+        .clone();
     let names_expected = VarBinArray::from_iter(
         vec![Some("Joseph"), Some("Angela")],
         DType::Utf8(Nullability::Nullable),
@@ -612,8 +634,12 @@ async fn filter_or() {
     .into_array();
     assert_arrays_eq!(names_actual, names_expected);
 
-    #[expect(deprecated)]
-    let ages_actual = result[0].to_struct().unmasked_field(1).clone();
+    let ages_actual = result[0]
+        .clone()
+        .execute::<StructArray>(&mut ctx)
+        .unwrap()
+        .unmasked_field(1)
+        .clone();
     let ages_expected = PrimitiveArray::from_option_iter([Some(25i32), None]).into_array();
     assert_arrays_eq!(ages_actual, ages_expected);
 }
@@ -621,6 +647,7 @@ async fn filter_or() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn filter_and() {
+    let mut ctx = SESSION.create_execution_ctx();
     let names = VarBinArray::from_iter(
         vec![Some("Joseph"), None, Some("Angela"), Some("Mikhail"), None],
         DType::Utf8(Nullability::Nullable),
@@ -659,8 +686,12 @@ async fn filter_and() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    #[expect(deprecated)]
-    let names_actual = result[0].to_struct().unmasked_field(0).clone();
+    let names_actual = result[0]
+        .clone()
+        .execute::<StructArray>(&mut ctx)
+        .unwrap()
+        .unmasked_field(0)
+        .clone();
     let names_expected = VarBinArray::from_iter(
         vec![Some("Joseph"), None],
         DType::Utf8(Nullability::Nullable),
@@ -668,8 +699,12 @@ async fn filter_and() {
     .into_array();
     assert_arrays_eq!(names_actual, names_expected);
 
-    #[expect(deprecated)]
-    let ages_actual = result[0].to_struct().unmasked_field(1).clone();
+    let ages_actual = result[0]
+        .clone()
+        .execute::<StructArray>(&mut ctx)
+        .unwrap()
+        .unmasked_field(1)
+        .clone();
     let ages_expected = PrimitiveArray::from_option_iter([Some(25i32), Some(31i32)]).into_array();
     assert_arrays_eq!(ages_actual, ages_expected);
 }
@@ -677,6 +712,7 @@ async fn filter_and() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_with_indices_simple() {
+    let mut ctx = SESSION.create_execution_ctx();
     let expected_numbers_split: Vec<Buffer<i16>> = (0..5).map(|_| (0_i16..100).collect()).collect();
     let expected_array = StructArray::from_fields(&[(
         "numbers",
@@ -701,7 +737,6 @@ async fn test_with_indices_simple() {
     let file = SESSION.open_options().open_buffer(buf).unwrap();
 
     // test no indices
-    #[expect(deprecated)]
     let actual_kept_array = file
         .scan()
         .unwrap()
@@ -711,14 +746,14 @@ async fn test_with_indices_simple() {
         .read_all()
         .await
         .unwrap()
-        .to_struct();
+        .execute::<StructArray>(&mut ctx)
+        .unwrap();
 
     assert_eq!(actual_kept_array.len(), 0);
 
     // test a few indices
     let kept_indices = [0_u64, 3, 99, 100, 101, 399, 400, 401, 499];
 
-    #[expect(deprecated)]
     let actual_kept_array = file
         .scan()
         .unwrap()
@@ -728,9 +763,13 @@ async fn test_with_indices_simple() {
         .read_all()
         .await
         .unwrap()
-        .to_struct();
-    #[expect(deprecated)]
-    let actual_kept_numbers_array = actual_kept_array.unmasked_field(0).to_primitive();
+        .execute::<StructArray>(&mut ctx)
+        .unwrap();
+    let actual_kept_numbers_array = actual_kept_array
+        .unmasked_field(0)
+        .clone()
+        .execute::<PrimitiveArray>(&mut ctx)
+        .unwrap();
 
     let expected_kept_numbers: Vec<i16> = kept_indices
         .iter()
@@ -740,7 +779,6 @@ async fn test_with_indices_simple() {
     assert_arrays_eq!(actual_kept_numbers_array, expected_array);
 
     // test all indices
-    #[expect(deprecated)]
     let actual_array = file
         .scan()
         .unwrap()
@@ -750,7 +788,8 @@ async fn test_with_indices_simple() {
         .read_all()
         .await
         .unwrap()
-        .to_struct();
+        .execute::<StructArray>(&mut ctx)
+        .unwrap();
     let actual_numbers_array = actual_array.unmasked_field(0).clone();
     let expected_array = Buffer::copy_from(&expected_numbers).into_array();
     assert_arrays_eq!(actual_numbers_array, expected_array);
@@ -759,6 +798,7 @@ async fn test_with_indices_simple() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_with_indices_on_two_columns() {
+    let mut ctx = SESSION.create_execution_ctx();
     let strings_expected = ["ab", "foo", "bar", "baz", "ab", "foo", "bar", "baz"];
     let strings = ChunkedArray::from_iter([
         VarBinArray::from(strings_expected[..4].to_vec()).into_array(),
@@ -784,7 +824,6 @@ async fn test_with_indices_on_two_columns() {
     let file = SESSION.open_options().open_buffer(buf).unwrap();
 
     let kept_indices = [0_u64, 3, 7];
-    #[expect(deprecated)]
     let array = file
         .scan()
         .unwrap()
@@ -794,7 +833,8 @@ async fn test_with_indices_on_two_columns() {
         .read_all()
         .await
         .unwrap()
-        .to_struct();
+        .execute::<StructArray>(&mut ctx)
+        .unwrap();
 
     let strings_actual = array.unmasked_field(0).clone();
     let strings_expected_vec: Vec<&str> = kept_indices
@@ -816,6 +856,7 @@ async fn test_with_indices_on_two_columns() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_with_indices_and_with_row_filter_simple() {
+    let mut ctx = SESSION.create_execution_ctx();
     let expected_numbers_split: Vec<Buffer<i16>> = (0..5).map(|_| (0_i16..100).collect()).collect();
     let expected_array = StructArray::from_fields(&[(
         "numbers",
@@ -839,7 +880,6 @@ async fn test_with_indices_and_with_row_filter_simple() {
 
     let file = SESSION.open_options().open_buffer(buf).unwrap();
 
-    #[expect(deprecated)]
     let actual_kept_array = file
         .scan()
         .unwrap()
@@ -850,14 +890,14 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .read_all()
         .await
         .unwrap()
-        .to_struct();
+        .execute::<StructArray>(&mut ctx)
+        .unwrap();
 
     assert_eq!(actual_kept_array.len(), 0);
 
     // test a few indices
     let kept_indices = [0u64, 3, 99, 100, 101, 399, 400, 401, 499];
 
-    #[expect(deprecated)]
     let actual_kept_array = file
         .scan()
         .unwrap()
@@ -868,10 +908,14 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .read_all()
         .await
         .unwrap()
-        .to_struct();
+        .execute::<StructArray>(&mut ctx)
+        .unwrap();
 
-    #[expect(deprecated)]
-    let actual_kept_numbers_array = actual_kept_array.unmasked_field(0).to_primitive();
+    let actual_kept_numbers_array = actual_kept_array
+        .unmasked_field(0)
+        .clone()
+        .execute::<PrimitiveArray>(&mut ctx)
+        .unwrap();
 
     let expected_kept_numbers: Buffer<i16> = kept_indices
         .iter()
@@ -882,7 +926,6 @@ async fn test_with_indices_and_with_row_filter_simple() {
     assert_arrays_eq!(actual_kept_numbers_array, expected_array);
 
     // test all indices
-    #[expect(deprecated)]
     let actual_array = file
         .scan()
         .unwrap()
@@ -893,7 +936,8 @@ async fn test_with_indices_and_with_row_filter_simple() {
         .read_all()
         .await
         .unwrap()
-        .to_struct();
+        .execute::<StructArray>(&mut ctx)
+        .unwrap();
 
     let actual_numbers_array = actual_array.unmasked_field(0).clone();
     let expected_filtered: Buffer<i16> = expected_numbers
@@ -908,6 +952,7 @@ async fn test_with_indices_and_with_row_filter_simple() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn filter_string_chunked() {
+    let mut ctx = SESSION.create_execution_ctx();
     let name_chunk1 =
         VarBinViewArray::from_iter_nullable_str([Some("Joseph"), Some("James"), Some("Angela")])
             .into_array();
@@ -943,7 +988,6 @@ async fn filter_string_chunked() {
 
     let file = SESSION.open_options().open_buffer(buf).unwrap();
 
-    #[expect(deprecated)]
     let actual_array = file
         .scan()
         .unwrap()
@@ -953,7 +997,8 @@ async fn filter_string_chunked() {
         .read_all()
         .await
         .unwrap()
-        .to_struct();
+        .execute::<StructArray>(&mut ctx)
+        .unwrap();
 
     assert_eq!(actual_array.len(), 1);
     let names_actual = actual_array.unmasked_field(0).clone();
@@ -970,6 +1015,7 @@ async fn filter_string_chunked() {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn test_pruning_with_or() {
+    let mut ctx = SESSION.create_execution_ctx();
     let letter_chunk1 = VarBinViewArray::from_iter_nullable_str([
         Some("A".to_owned()),
         Some("B".to_owned()),
@@ -1032,7 +1078,6 @@ async fn test_pruning_with_or() {
 
     let file = SESSION.open_options().open_buffer(buf).unwrap();
 
-    #[expect(deprecated)]
     let actual_array = file
         .scan()
         .unwrap()
@@ -1045,7 +1090,8 @@ async fn test_pruning_with_or() {
         .read_all()
         .await
         .unwrap()
-        .to_struct();
+        .execute::<StructArray>(&mut ctx)
+        .unwrap();
 
     assert_eq!(actual_array.len(), 10);
     let letters_actual = actual_array.unmasked_field(0).clone();
@@ -1083,6 +1129,7 @@ async fn test_pruning_with_or() {
 
 #[tokio::test]
 async fn test_repeated_projection() {
+    let mut ctx = SESSION.create_execution_ctx();
     let strings = ChunkedArray::from_iter([
         VarBinArray::from(vec!["ab", "foo", "bar", "baz"]).into_array(),
         VarBinArray::from(vec!["ab", "foo", "bar", "baz"]).into_array(),
@@ -1106,7 +1153,6 @@ async fn test_repeated_projection() {
 
     let file = SESSION.open_options().open_buffer(buf).unwrap();
 
-    #[expect(deprecated)]
     let actual = file
         .scan()
         .unwrap()
@@ -1116,7 +1162,8 @@ async fn test_repeated_projection() {
         .read_all()
         .await
         .unwrap()
-        .to_struct();
+        .execute::<StructArray>(&mut ctx)
+        .unwrap();
 
     assert_arrays_eq!(actual, expected);
 }
@@ -1263,16 +1310,17 @@ async fn write_nullable_nested_struct() -> VortexResult<()> {
     )?
     .into_array();
 
-    #[expect(deprecated)]
-    let result = round_trip(&array, Ok).await?.to_struct();
+    let mut ctx = SESSION.create_execution_ctx();
+    let result = round_trip(&array, Ok).await?.execute::<StructArray>(&mut ctx)?;
 
     assert_eq!(result.len(), 3);
     assert_eq!(result.struct_fields().nfields(), 1);
-    let mut ctx = SESSION.create_execution_ctx();
     assert!(result.all_valid(&mut ctx)?);
 
-    #[expect(deprecated)]
-    let nested_struct = result.unmasked_field_by_name("struct")?.to_struct();
+    let nested_struct = result
+        .unmasked_field_by_name("struct")?
+        .clone()
+        .execute::<StructArray>(&mut ctx)?;
     assert_eq!(nested_struct.dtype(), &nested_dtype);
     assert_eq!(nested_struct.len(), 3);
     assert!(nested_struct.all_invalid(&mut ctx)?);
@@ -1382,6 +1430,7 @@ async fn test_writer_basic_push() -> VortexResult<()> {
 
 #[tokio::test]
 async fn test_writer_multiple_pushes() -> VortexResult<()> {
+    let mut ctx = SESSION.create_execution_ctx();
     let chunk1 =
         StructArray::from_fields(&[("numbers", buffer![1u32, 2, 3].into_array())])?.into_array();
     let chunk2 =
@@ -1405,9 +1454,8 @@ async fn test_writer_multiple_pushes() -> VortexResult<()> {
     let result = file.scan()?.into_array_stream()?.read_all().await?;
 
     assert_eq!(result.len(), 9);
-    #[expect(deprecated)]
     let numbers = result
-        .to_struct()
+        .execute::<StructArray>(&mut ctx)?
         .unmasked_field_by_name("numbers")?
         .clone();
     let expected = buffer![1u32, 2, 3, 4, 5, 6, 7, 8, 9].into_array();
@@ -1418,6 +1466,7 @@ async fn test_writer_multiple_pushes() -> VortexResult<()> {
 
 #[tokio::test]
 async fn test_writer_push_stream() -> VortexResult<()> {
+    let mut ctx = SESSION.create_execution_ctx();
     let chunk1 =
         StructArray::from_fields(&[("numbers", buffer![1u32, 2, 3].into_array())])?.into_array();
     let chunk2 =
@@ -1440,9 +1489,8 @@ async fn test_writer_push_stream() -> VortexResult<()> {
     let result = file.scan()?.into_array_stream()?.read_all().await?;
 
     assert_eq!(result.len(), 6);
-    #[expect(deprecated)]
     let numbers = result
-        .to_struct()
+        .execute::<StructArray>(&mut ctx)?
         .unmasked_field_by_name("numbers")?
         .clone();
     let expected = buffer![1u32, 2, 3, 4, 5, 6].into_array();
@@ -1481,6 +1529,7 @@ async fn test_writer_bytes_written() -> VortexResult<()> {
 
 #[tokio::test]
 async fn test_writer_empty_chunks() -> VortexResult<()> {
+    let mut ctx = SESSION.create_execution_ctx();
     let empty = StructArray::from_fields(&[(
         "numbers",
         PrimitiveArray::new::<u32>(buffer![], Validity::NonNullable).into_array(),
@@ -1505,9 +1554,8 @@ async fn test_writer_empty_chunks() -> VortexResult<()> {
     let result = file.scan()?.into_array_stream()?.read_all().await?;
 
     assert_eq!(result.len(), 2);
-    #[expect(deprecated)]
     let numbers = result
-        .to_struct()
+        .execute::<StructArray>(&mut ctx)?
         .unmasked_field_by_name("numbers")?
         .clone();
     let expected = buffer![1u32, 2].into_array();
@@ -1518,6 +1566,7 @@ async fn test_writer_empty_chunks() -> VortexResult<()> {
 
 #[tokio::test]
 async fn test_writer_mixed_push_and_stream() -> VortexResult<()> {
+    let mut ctx = SESSION.create_execution_ctx();
     let chunk1 =
         StructArray::from_fields(&[("numbers", buffer![1u32, 2].into_array())])?.into_array();
     let chunk2 =
@@ -1544,9 +1593,8 @@ async fn test_writer_mixed_push_and_stream() -> VortexResult<()> {
     let result = file.scan()?.into_array_stream()?.read_all().await?;
 
     assert_eq!(result.len(), 6);
-    #[expect(deprecated)]
     let numbers = result
-        .to_struct()
+        .execute::<StructArray>(&mut ctx)?
         .unmasked_field_by_name("numbers")?
         .clone();
     let expected = buffer![1u32, 2, 3, 4, 5, 6].into_array();
@@ -1557,6 +1605,7 @@ async fn test_writer_mixed_push_and_stream() -> VortexResult<()> {
 
 #[tokio::test]
 async fn test_writer_with_complex_types() -> VortexResult<()> {
+    let mut ctx = SESSION.create_execution_ctx();
     let strings = VarBinArray::from(vec!["hello", "world", "test"]).into_array();
     let numbers = buffer![100i32, 200, 300].into_array();
     let lists = ListArray::from_iter_slow::<i16, _>(
@@ -1587,16 +1636,16 @@ async fn test_writer_with_complex_types() -> VortexResult<()> {
     assert_eq!(result.len(), 3);
     assert_eq!(result.dtype(), &dtype);
 
-    #[expect(deprecated)]
     let strings_field = result
-        .to_struct()
+        .execute::<StructArray>(&mut ctx)?
         .unmasked_field_by_name("strings")
         .cloned()?;
-    #[expect(deprecated)]
-    let strings = strings_field.to_varbinview().with_iterator(|iter| {
-        iter.map(|s| s.map(|st| unsafe { String::from_utf8_unchecked(st.to_vec()) }))
-            .collect::<Vec<_>>()
-    });
+    let strings = strings_field
+        .execute::<VarBinViewArray>(&mut ctx)?
+        .with_iterator(|iter| {
+            iter.map(|s| s.map(|st| unsafe { String::from_utf8_unchecked(st.to_vec()) }))
+                .collect::<Vec<_>>()
+        });
     assert_eq!(
         strings,
         vec![

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -165,6 +165,7 @@ impl VortexWriteOptions {
             stream,
             self.file_statistics.clone().into(),
             self.max_variable_length_statistics_size,
+            &self.session,
         );
 
         // First, write the magic bytes.

--- a/vortex-file/tests/test_write_table.rs
+++ b/vortex-file/tests/test_write_table.rs
@@ -9,8 +9,7 @@ use std::sync::LazyLock;
 use futures::StreamExt;
 use futures::pin_mut;
 use vortex_array::IntoArray;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::BoolArray;
 use vortex_array::arrays::DictArray;
 use vortex_array::arrays::ListViewArray;
@@ -47,6 +46,7 @@ static SESSION: LazyLock<VortexSession> = LazyLock::new(|| {
 
 #[tokio::test]
 async fn test_file_roundtrip() {
+    let mut ctx = SESSION.create_execution_ctx();
     // Create a simple roundtrip
     let nums = PrimitiveArray::from_iter((0..1024).cycle().take(16_384)).into_array();
 
@@ -103,10 +103,13 @@ async fn test_file_roundtrip() {
 
     while let Some(next) = stream.next().await {
         let next = next.expect("next");
-        #[expect(deprecated)]
-        let next = next.to_struct();
-        #[expect(deprecated)]
-        let a = next.unmasked_field_by_name("a").unwrap().to_struct();
+        let next = next.execute::<StructArray>(&mut ctx).unwrap();
+        let a = next
+            .unmasked_field_by_name("a")
+            .unwrap()
+            .clone()
+            .execute::<StructArray>(&mut ctx)
+            .unwrap();
         let b = next.unmasked_field_by_name("b").unwrap();
 
         let raw = a.unmasked_field_by_name("raw").unwrap();

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -236,10 +236,7 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getField(
 
     try_or_throw(&mut env, |_| {
         let mut ctx = SESSION.create_execution_ctx();
-        let struct_array = array_ref
-            .inner
-            .clone()
-            .execute::<StructArray>(&mut ctx)?;
+        let struct_array = array_ref.inner.clone().execute::<StructArray>(&mut ctx)?;
         let idx = index as usize;
         if idx >= struct_array.struct_fields().nfields() {
             return Err(vortex_err!("Field index out of bounds").into());
@@ -311,7 +308,8 @@ macro_rules! get_primitive {
                         .inner
                         .clone()
                         .execute::<ExtensionArray>(&mut ctx)?;
-                    ext.storage_array().execute_scalar(index as usize, &mut ctx)?
+                    ext.storage_array()
+                        .execute_scalar(index as usize, &mut ctx)?
                 } else {
                     array_ref.inner.execute_scalar(index as usize, &mut ctx)?
                 };
@@ -351,7 +349,8 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getBigDecimal(
                 .inner
                 .clone()
                 .execute::<ExtensionArray>(&mut ctx)?;
-            ext.storage_array().execute_scalar(index as usize, &mut ctx)?
+            ext.storage_array()
+                .execute_scalar(index as usize, &mut ctx)?
         } else {
             array_ref.inner.execute_scalar(index as usize, &mut ctx)?
         };

--- a/vortex-jni/src/array.rs
+++ b/vortex-jni/src/array.rs
@@ -28,10 +28,9 @@ use jni::sys::jshort;
 use jni::sys::jstring;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayView;
-use vortex::array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
 use vortex::array::VortexSessionExecute;
+use vortex::array::arrays::ExtensionArray;
+use vortex::array::arrays::StructArray;
 use vortex::array::arrays::VarBin;
 use vortex::array::arrays::VarBinView;
 use vortex::array::arrays::extension::ExtensionArrayExt;
@@ -45,6 +44,7 @@ use vortex::error::VortexExpect;
 use vortex::error::vortex_err;
 use vortex::scalar::DecimalValue;
 
+use crate::SESSION;
 use crate::errors::JNIError;
 use crate::errors::try_or_throw;
 
@@ -235,8 +235,11 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getField(
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
 
     try_or_throw(&mut env, |_| {
-        #[expect(deprecated)]
-        let struct_array = array_ref.inner.to_struct();
+        let mut ctx = SESSION.create_execution_ctx();
+        let struct_array = array_ref
+            .inner
+            .clone()
+            .execute::<StructArray>(&mut ctx)?;
         let idx = index as usize;
         if idx >= struct_array.struct_fields().nfields() {
             return Err(vortex_err!("Field index out of bounds").into());
@@ -271,9 +274,8 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getNull(
 ) -> jboolean {
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
     try_or_throw(&mut env, |_| {
-        let is_null = array_ref
-            .inner
-            .is_invalid(index as usize, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let mut ctx = SESSION.create_execution_ctx();
+        let is_null = array_ref.inner.is_invalid(index as usize, &mut ctx)?;
         if is_null { Ok(JNI_TRUE) } else { Ok(JNI_FALSE) }
     })
 }
@@ -286,9 +288,8 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getNullCount(
 ) -> jint {
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
     try_or_throw(&mut env, |_| {
-        let count = array_ref
-            .inner
-            .invalid_count(&mut LEGACY_SESSION.create_execution_ctx())?;
+        let mut ctx = SESSION.create_execution_ctx();
+        let count = array_ref.inner.invalid_count(&mut ctx)?;
         Ok(jint::try_from(count).unwrap_or(-1))
     })
 }
@@ -304,18 +305,15 @@ macro_rules! get_primitive {
         ) -> $jtype {
             let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
             try_or_throw(&mut env, |_| {
+                let mut ctx = SESSION.create_execution_ctx();
                 let scalar_value = if array_ref.is_extension {
-                    #[expect(deprecated)]
-                    let ext = array_ref.inner.to_extension();
-                    ext.storage_array().execute_scalar(
-                        index as usize,
-                        &mut LEGACY_SESSION.create_execution_ctx(),
-                    )?
+                    let ext = array_ref
+                        .inner
+                        .clone()
+                        .execute::<ExtensionArray>(&mut ctx)?;
+                    ext.storage_array().execute_scalar(index as usize, &mut ctx)?
                 } else {
-                    array_ref.inner.execute_scalar(
-                        index as usize,
-                        &mut LEGACY_SESSION.create_execution_ctx(),
-                    )?
+                    array_ref.inner.execute_scalar(index as usize, &mut ctx)?
                 };
 
                 Ok(scalar_value
@@ -347,15 +345,15 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getBigDecimal(
 ) -> jobject {
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
     try_or_throw(&mut env, |env| {
+        let mut ctx = SESSION.create_execution_ctx();
         let scalar_value = if array_ref.is_extension {
-            #[expect(deprecated)]
-            let ext = array_ref.inner.to_extension();
-            ext.storage_array()
-                .execute_scalar(index as usize, &mut LEGACY_SESSION.create_execution_ctx())?
-        } else {
-            array_ref
+            let ext = array_ref
                 .inner
-                .execute_scalar(index as usize, &mut LEGACY_SESSION.create_execution_ctx())?
+                .clone()
+                .execute::<ExtensionArray>(&mut ctx)?;
+            ext.storage_array().execute_scalar(index as usize, &mut ctx)?
+        } else {
+            array_ref.inner.execute_scalar(index as usize, &mut ctx)?
         };
 
         let decimal_scalar = scalar_value.as_decimal();
@@ -417,9 +415,8 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getBool(
 ) -> jboolean {
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
     try_or_throw(&mut env, |_| {
-        let value = array_ref
-            .inner
-            .execute_scalar(index as usize, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let mut ctx = SESSION.create_execution_ctx();
+        let value = array_ref.inner.execute_scalar(index as usize, &mut ctx)?;
         match value.as_bool().value() {
             None => Ok(JNI_FALSE),
             Some(b) => {
@@ -442,9 +439,8 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getUTF8<'local>(
 ) -> jstring {
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
     try_or_throw(&mut env, |env| {
-        let value = array_ref
-            .inner
-            .execute_scalar(index as usize, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let mut ctx = SESSION.create_execution_ctx();
+        let value = array_ref.inner.execute_scalar(index as usize, &mut ctx)?;
         match value.as_utf8().value() {
             None => Ok(JObject::null().into_raw()),
             Some(buf_str) => Ok(env.new_string(buf_str.as_str())?.into_raw()),
@@ -492,9 +488,8 @@ pub extern "system" fn Java_dev_vortex_jni_NativeArrayMethods_getBinary<'local>(
 ) -> jbyteArray {
     let array_ref = unsafe { NativeArray::from_ptr(array_ptr) };
     try_or_throw(&mut env, |env| {
-        let value = array_ref
-            .inner
-            .execute_scalar(index as usize, &mut LEGACY_SESSION.create_execution_ctx())?;
+        let mut ctx = SESSION.create_execution_ctx();
+        let value = array_ref.inner.execute_scalar(index as usize, &mut ctx)?;
         match value.as_binary().value() {
             None => Ok(JObject::null().into_raw()),
             Some(buf) => Ok(env.byte_array_from_slice(buf.as_slice())?.into_raw()),

--- a/vortex-layout/public-api.lock
+++ b/vortex-layout/public-api.lock
@@ -408,7 +408,7 @@ impl core::clone::Clone for vortex_layout::layouts::file_stats::FileStatsAccumul
 
 pub fn vortex_layout::layouts::file_stats::FileStatsAccumulator::clone(&self) -> vortex_layout::layouts::file_stats::FileStatsAccumulator
 
-pub fn vortex_layout::layouts::file_stats::accumulate_stats(stream: vortex_layout::sequence::SendableSequentialStream, stats: alloc::sync::Arc<[vortex_array::expr::stats::Stat]>, max_variable_length_statistics_size: usize) -> (vortex_layout::layouts::file_stats::FileStatsAccumulator, vortex_layout::sequence::SendableSequentialStream)
+pub fn vortex_layout::layouts::file_stats::accumulate_stats(stream: vortex_layout::sequence::SendableSequentialStream, stats: alloc::sync::Arc<[vortex_array::expr::stats::Stat]>, max_variable_length_statistics_size: usize, session: &vortex_session::VortexSession) -> (vortex_layout::layouts::file_stats::FileStatsAccumulator, vortex_layout::sequence::SendableSequentialStream)
 
 pub mod vortex_layout::layouts::flat
 

--- a/vortex-layout/public-api.lock
+++ b/vortex-layout/public-api.lock
@@ -800,7 +800,7 @@ pub fn vortex_layout::layouts::zoned::zone_map::StatsAccumulator::as_stats_table
 
 pub fn vortex_layout::layouts::zoned::zone_map::StatsAccumulator::new(dtype: &vortex_array::dtype::DType, stats: &[vortex_array::expr::stats::Stat], max_variable_length_statistics_size: usize) -> Self
 
-pub fn vortex_layout::layouts::zoned::zone_map::StatsAccumulator::push_chunk(&mut self, array: &vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<()>
+pub fn vortex_layout::layouts::zoned::zone_map::StatsAccumulator::push_chunk(&mut self, array: &vortex_array::array::erased::ArrayRef, ctx: &mut vortex_array::executor::ExecutionCtx) -> vortex_error::VortexResult<()>
 
 pub fn vortex_layout::layouts::zoned::zone_map::StatsAccumulator::push_chunk_without_compute(&mut self, array: &vortex_array::array::erased::ArrayRef) -> vortex_error::VortexResult<()>
 

--- a/vortex-layout/src/layouts/dict/reader.rs
+++ b/vortex-layout/src/layouts/dict/reader.rs
@@ -263,6 +263,7 @@ mod tests {
 
     use rstest::rstest;
     use vortex_array::ArrayContext;
+    use vortex_array::Canonical;
     use vortex_array::IntoArray as _;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::MaskFuture;
@@ -466,6 +467,7 @@ mod tests {
     #[test]
     fn reading_is_null_works() {
         block_on(|handle| async move {
+            let mut ctx_exec = LEGACY_SESSION.create_execution_ctx();
             let session = session_with_handle(handle);
             let strategy = DictStrategy::new(
                 FlatLayoutStrategy::default(),
@@ -525,12 +527,11 @@ mod tests {
             let expected = array
                 .validity()
                 .unwrap()
-                .to_mask(array.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                .to_mask(array.len(), &mut ctx_exec)
                 .unwrap()
                 .into_array();
-            #[expect(deprecated)]
             let actual_canonical = actual
-                .to_canonical()
+                .execute::<Canonical>(&mut ctx_exec)
                 .vortex_expect("to_canonical failed")
                 .into_array();
             assert_arrays_eq!(actual_canonical, expected);

--- a/vortex-layout/src/layouts/file_stats.rs
+++ b/vortex-layout/src/layouts/file_stats.rs
@@ -8,10 +8,9 @@ use futures::StreamExt;
 use itertools::Itertools;
 use parking_lot::Mutex;
 use vortex_array::ArrayRef;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical as _;
+use vortex_array::ExecutionCtx;
 use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::StructArray;
 use vortex_array::arrays::struct_::StructArrayExt;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
@@ -20,6 +19,7 @@ use vortex_array::stats::StatsSet;
 use vortex_error::VortexExpect;
 use vortex_error::VortexResult;
 use vortex_error::vortex_panic;
+use vortex_session::VortexSession;
 
 use crate::layouts::zoned::zone_map::StatsAccumulator;
 use crate::sequence::SendableSequentialStream;
@@ -31,9 +31,14 @@ pub fn accumulate_stats(
     stream: SendableSequentialStream,
     stats: Arc<[Stat]>,
     max_variable_length_statistics_size: usize,
+    session: &VortexSession,
 ) -> (FileStatsAccumulator, SendableSequentialStream) {
-    let accumulator =
-        FileStatsAccumulator::new(stream.dtype(), stats, max_variable_length_statistics_size);
+    let accumulator = FileStatsAccumulator::new(
+        stream.dtype(),
+        stats,
+        max_variable_length_statistics_size,
+        session,
+    );
     let stream = SequentialStreamAdapter::new(
         stream.dtype().clone(),
         stream.scan(accumulator.clone(), |acc, item| {
@@ -51,10 +56,16 @@ pub fn accumulate_stats(
 pub struct FileStatsAccumulator {
     stats: Arc<[Stat]>,
     accumulators: Arc<Mutex<Vec<StatsAccumulator>>>,
+    ctx: Arc<Mutex<ExecutionCtx>>,
 }
 
 impl FileStatsAccumulator {
-    fn new(dtype: &DType, stats: Arc<[Stat]>, max_variable_length_statistics_size: usize) -> Self {
+    fn new(
+        dtype: &DType,
+        stats: Arc<[Stat]>,
+        max_variable_length_statistics_size: usize,
+        session: &VortexSession,
+    ) -> Self {
         let accumulators = Arc::new(Mutex::new(match dtype.as_struct_fields_opt() {
             Some(struct_dtype) => {
                 if dtype.nullability() == Nullability::Nullable {
@@ -87,6 +98,7 @@ impl FileStatsAccumulator {
         Self {
             stats,
             accumulators,
+            ctx: Arc::new(Mutex::new(session.create_execution_ctx())),
         }
     }
 
@@ -95,25 +107,25 @@ impl FileStatsAccumulator {
         chunk: VortexResult<(SequenceId, ArrayRef)>,
     ) -> VortexResult<(SequenceId, ArrayRef)> {
         let (sequence_id, chunk) = chunk?;
+        let mut ctx = self.ctx.lock();
         if chunk.dtype().is_struct() {
-            #[expect(deprecated)]
-            let chunk = chunk.to_struct();
+            let struct_chunk = chunk.clone().execute::<StructArray>(&mut ctx)?;
             for (acc, field) in self
                 .accumulators
                 .lock()
                 .iter_mut()
-                .zip_eq(chunk.iter_unmasked_fields())
+                .zip_eq(struct_chunk.iter_unmasked_fields())
             {
-                acc.push_chunk(field)?;
+                acc.push_chunk(field, &mut ctx)?;
             }
         } else {
-            self.accumulators.lock()[0].push_chunk(&chunk)?;
+            self.accumulators.lock()[0].push_chunk(&chunk, &mut ctx)?;
         }
         Ok((sequence_id, chunk))
     }
 
     pub fn stats_sets(&self) -> Vec<StatsSet> {
-        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let mut ctx = self.ctx.lock();
         self.accumulators
             .lock()
             .iter_mut()

--- a/vortex-layout/src/layouts/flat/writer.rs
+++ b/vortex-layout/src/layouts/flat/writer.rs
@@ -201,8 +201,6 @@ mod tests {
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::MaskFuture;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::Dict;
@@ -344,6 +342,7 @@ mod tests {
     #[test]
     fn struct_array_round_trip() {
         block_on(|handle| async {
+            let mut ctx_exec = LEGACY_SESSION.create_execution_ctx();
             let session = SESSION.clone().with_handle(handle);
             let mut validity_builder = BitBufferMut::with_capacity(2);
             validity_builder.append(true);
@@ -400,26 +399,29 @@ mod tests {
                 result
                     .validity()
                     .unwrap()
-                    .to_mask(result.len(), &mut LEGACY_SESSION.create_execution_ctx())
+                    .to_mask(result.len(), &mut ctx_exec)
                     .unwrap()
                     .bit_buffer(),
                 AllOr::Some(&validity_boolean_buffer)
             );
-            #[expect(deprecated)]
-            let result_struct = result.to_struct();
-            #[expect(deprecated)]
+            let result_struct = result
+                .clone()
+                .execute::<StructArray>(&mut ctx_exec)
+                .unwrap();
             let field_a = result_struct
                 .unmasked_field_by_name("a")
                 .unwrap()
-                .to_primitive();
+                .clone()
+                .execute::<PrimitiveArray>(&mut ctx_exec)
+                .unwrap();
             assert_eq!(field_a.as_slice::<u64>(), &[1, 2]);
-            #[expect(deprecated)]
-            let result_struct_b = result.to_struct();
-            #[expect(deprecated)]
+            let result_struct_b = result.execute::<StructArray>(&mut ctx_exec).unwrap();
             let field_b = result_struct_b
                 .unmasked_field_by_name("b")
                 .unwrap()
-                .to_primitive();
+                .clone()
+                .execute::<PrimitiveArray>(&mut ctx_exec)
+                .unwrap();
             assert_eq!(field_b.as_slice::<u64>(), &[3, 4]);
         })
     }

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -10,7 +10,9 @@ use futures::StreamExt as _;
 use futures::pin_mut;
 use vortex_array::ArrayContext;
 use vortex_array::ArrayRef;
+use vortex_array::Canonical;
 use vortex_array::IntoArray;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::ChunkedArray;
 use vortex_array::dtype::DType;
 use vortex_error::VortexExpect;
@@ -103,12 +105,13 @@ impl LayoutStrategy for RepartitionStrategy {
         // canon_stream = stream.map(async {to_canonical}).map(spawn).buffered(parallelism)
         let dtype = stream.dtype().clone();
         let stream = if self.options.canonicalize {
+            let canonicalize_session = session.clone();
             SequentialStreamAdapter::new(
                 dtype.clone(),
-                stream.map(|chunk| {
+                stream.map(move |chunk| {
                     let (sequence_id, chunk) = chunk?;
-                    #[expect(deprecated)]
-                    let canonical = chunk.to_canonical()?.into_array();
+                    let mut ctx = canonicalize_session.create_execution_ctx();
+                    let canonical = chunk.execute::<Canonical>(&mut ctx)?.into_array();
                     VortexResult::Ok((sequence_id, canonical))
                 }),
             )
@@ -125,11 +128,13 @@ impl LayoutStrategy for RepartitionStrategy {
         // segments.
         let block_len = options.effective_block_len(&dtype);
         let block_size_minimum = options.block_size_minimum;
+        let repartition_session = session.clone();
 
         let repartitioned_stream = try_stream! {
             let canonical_stream = stream.peekable();
             pin_mut!(canonical_stream);
 
+            let mut ctx = repartition_session.create_execution_ctx();
             let mut chunks = ChunksBuffer::new(block_size_minimum, block_len);
             while let Some(chunk) = canonical_stream.as_mut().next().await {
                 let (sequence_id, chunk) = chunk?;
@@ -147,8 +152,7 @@ impl LayoutStrategy for RepartitionStrategy {
                         let chunked =
                             ChunkedArray::try_new(output_chunks, dtype_clone.clone())?;
                         if !chunked.is_empty() {
-                            #[expect(deprecated)]
-                            let canonical = chunked.into_array().to_canonical()?.into_array();
+                            let canonical = chunked.into_array().execute::<Canonical>(&mut ctx)?.into_array();
                             yield (
                                 sequence_pointer.advance(),
                                 canonical,
@@ -162,8 +166,7 @@ impl LayoutStrategy for RepartitionStrategy {
                         dtype_clone.clone(),
                     )?;
                     if !to_flush.is_empty() {
-                        #[expect(deprecated)]
-                        let canonical = to_flush.into_array().to_canonical()?.into_array();
+                        let canonical = to_flush.into_array().execute::<Canonical>(&mut ctx)?.into_array();
                         yield (
                             sequence_pointer.advance(),
                             canonical,
@@ -273,6 +276,7 @@ mod tests {
 
     use vortex_array::ArrayContext;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
     use vortex_array::arrays::ConstantArray;
     use vortex_array::arrays::FixedSizeListArray;
     use vortex_array::arrays::PrimitiveArray;
@@ -485,6 +489,7 @@ mod tests {
     /// `pop_front` subtracted the larger Cached-era values.
     #[test]
     fn chunks_buffer_pop_front_no_panic_after_shared_execution() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let n = 20_000usize;
         let block_len = 10_000usize;
 
@@ -504,8 +509,8 @@ mod tests {
 
         // Transition SharedState from Source to Cached for ALL slices sharing this Arc.
         use vortex_array::arrays::shared::SharedArrayExt;
-        #[expect(deprecated)]
-        let _canonical = shared_handle.get_or_compute(|source| source.to_canonical())?;
+        let _canonical = shared_handle
+            .get_or_compute(|source| source.clone().execute::<Canonical>(&mut ctx))?;
 
         // Before the fix this panicked with "attempt to subtract with overflow".
         let _s2 = buf.pop_front().unwrap();

--- a/vortex-layout/src/layouts/repartition.rs
+++ b/vortex-layout/src/layouts/repartition.rs
@@ -509,8 +509,8 @@ mod tests {
 
         // Transition SharedState from Source to Cached for ALL slices sharing this Arc.
         use vortex_array::arrays::shared::SharedArrayExt;
-        let _canonical = shared_handle
-            .get_or_compute(|source| source.clone().execute::<Canonical>(&mut ctx))?;
+        let _canonical =
+            shared_handle.get_or_compute(|source| source.clone().execute::<Canonical>(&mut ctx))?;
 
         // Before the fix this panicked with "attempt to subtract with overflow".
         let _s2 = buf.pop_front().unwrap();

--- a/vortex-layout/src/layouts/row_idx/mod.rs
+++ b/vortex-layout/src/layouts/row_idx/mod.rs
@@ -16,6 +16,7 @@ pub use expr::*;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use vortex_array::ArrayRef;
+use vortex_array::Canonical;
 use vortex_array::IntoArray;
 use vortex_array::MaskFuture;
 use vortex_array::VortexSessionExecute;
@@ -218,9 +219,13 @@ impl LayoutReader for RowIdxLayoutReader {
                     Partition::Child => self.child.filter_evaluation(row_range, expr, mask),
                 },
                 |annotation, expr, mask| match annotation {
-                    Partition::RowIdx => {
-                        Ok(row_idx_array_future(self.row_offset, row_range, expr, mask))
-                    }
+                    Partition::RowIdx => Ok(row_idx_array_future(
+                        self.row_offset,
+                        row_range,
+                        expr,
+                        mask,
+                        self.session.clone(),
+                    )),
                     Partition::Child => self.child.projection_evaluation(row_range, expr, mask),
                 },
                 self.session.clone(),
@@ -235,15 +240,23 @@ impl LayoutReader for RowIdxLayoutReader {
         mask: MaskFuture,
     ) -> VortexResult<BoxFuture<'static, VortexResult<ArrayRef>>> {
         match &self.partition_expr(expr) {
-            Partitioning::RowIdx(expr) => {
-                Ok(row_idx_array_future(self.row_offset, row_range, expr, mask))
-            }
+            Partitioning::RowIdx(expr) => Ok(row_idx_array_future(
+                self.row_offset,
+                row_range,
+                expr,
+                mask,
+                self.session.clone(),
+            )),
             Partitioning::Child(expr) => self.child.projection_evaluation(row_range, expr, mask),
             Partitioning::Partitioned(p) => {
                 Arc::clone(p).into_array_future(mask, |annotation, expr, mask| match annotation {
-                    Partition::RowIdx => {
-                        Ok(row_idx_array_future(self.row_offset, row_range, expr, mask))
-                    }
+                    Partition::RowIdx => Ok(row_idx_array_future(
+                        self.row_offset,
+                        row_range,
+                        expr,
+                        mask,
+                        self.session.clone(),
+                    )),
                     Partition::Child => self.child.projection_evaluation(row_range, expr, mask),
                 })
             }
@@ -292,14 +305,15 @@ fn row_idx_array_future(
     row_range: &Range<u64>,
     expr: &Expression,
     mask: MaskFuture,
+    session: VortexSession,
 ) -> ArrayFuture {
     let row_range = row_range.clone();
     let expr = expr.clone();
     async move {
         let array = idx_array(row_offset, &row_range).into_array();
         let filtered = array.filter(mask.await?)?;
-        #[expect(deprecated)]
-        let array = filtered.to_canonical()?.into_array();
+        let mut ctx = session.create_execution_ctx();
+        let array = filtered.execute::<Canonical>(&mut ctx)?.into_array();
         array.apply(&expr)
     }
     .boxed()

--- a/vortex-layout/src/layouts/struct_/reader.rs
+++ b/vortex-layout/src/layouts/struct_/reader.rs
@@ -11,8 +11,7 @@ use itertools::Itertools;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
 use vortex_array::MaskFuture;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
+use vortex_array::VortexSessionExecute;
 use vortex_array::arrays::StructArray;
 use vortex_array::arrays::struct_::StructArrayExt;
 use vortex_array::builtins::ArrayBuiltins;
@@ -354,14 +353,15 @@ impl LayoutReader for StructReader {
             ),
         };
 
+        let session = self.session.clone();
         Ok(Box::pin(async move {
             if let Some(validity_fut) = validity_fut {
                 let (array, validity) = try_join!(projected, validity_fut)?;
 
                 // If root expression was a pack, then we apply the validity to each child field
                 if is_pack_merge {
-                    #[expect(deprecated)]
-                    let struct_array = array.to_struct();
+                    let mut ctx = session.create_execution_ctx();
+                    let struct_array = array.execute::<StructArray>(&mut ctx)?;
                     let masked_fields: Vec<ArrayRef> = struct_array
                         .iter_unmasked_fields()
                         .map(|a| a.clone().mask(validity.clone()))
@@ -400,8 +400,6 @@ mod tests {
     use vortex_array::IntoArray;
     use vortex_array::LEGACY_SESSION;
     use vortex_array::MaskFuture;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
     use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
@@ -675,6 +673,7 @@ mod tests {
     fn test_struct_layout_select(
         #[from(struct_layout)] (segments, layout): (Arc<dyn SegmentSource>, LayoutRef),
     ) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let reader = layout.new_reader("".into(), segments, &SESSION).unwrap();
         let expr = pack(
             [("a", get_item("a", root())), ("b", get_item("b", root()))],
@@ -695,16 +694,14 @@ mod tests {
         assert_eq!(result.len(), 2);
 
         let expected_a = PrimitiveArray::from_iter([7i32, 2]);
-        #[expect(deprecated)]
-        let result_struct_a = result.to_struct();
+        let result_struct_a = result.clone().execute::<StructArray>(&mut ctx).unwrap();
         assert_arrays_eq!(
             result_struct_a.unmasked_field_by_name("a").unwrap(),
             expected_a
         );
 
         let expected_b = PrimitiveArray::from_iter([4i32, 5]);
-        #[expect(deprecated)]
-        let result_struct_b = result.to_struct();
+        let result_struct_b = result.execute::<StructArray>(&mut ctx).unwrap();
         assert_arrays_eq!(
             result_struct_b.unmasked_field_by_name("b").unwrap(),
             expected_b

--- a/vortex-layout/src/layouts/table.rs
+++ b/vortex-layout/src/layouts/table.rs
@@ -16,10 +16,8 @@ use itertools::Itertools;
 use vortex_array::ArrayContext;
 use vortex_array::ArrayRef;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
 use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::StructArray;
 use vortex_array::arrays::struct_::StructArrayExt;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Field;
@@ -234,18 +232,19 @@ impl LayoutStrategy for TableStrategy {
         }
 
         // stream<struct_chunk> -> stream<vec<column_chunk>>
+        let columns_session = session.clone();
         let columns_vec_stream = stream.map(move |chunk| {
             let (sequence_id, chunk) = chunk?;
             let mut sequence_pointer = sequence_id.descend();
-            #[expect(deprecated)]
-            let struct_chunk = chunk.to_struct();
+            let mut ctx = columns_session.create_execution_ctx();
+            let struct_chunk = chunk.clone().execute::<StructArray>(&mut ctx)?;
             let mut columns: Vec<(SequenceId, ArrayRef)> = Vec::new();
             if is_nullable {
                 columns.push((
                     sequence_pointer.advance(),
                     chunk
                         .validity()?
-                        .to_mask(chunk.len(), &mut LEGACY_SESSION.create_execution_ctx())?
+                        .to_mask(chunk.len(), &mut ctx)?
                         .into_array(),
                 ));
             }

--- a/vortex-layout/src/layouts/zoned/reader.rs
+++ b/vortex-layout/src/layouts/zoned/reader.rs
@@ -16,8 +16,8 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use vortex_array::ArrayRef;
 use vortex_array::MaskFuture;
-#[expect(deprecated)]
-use vortex_array::ToCanonical;
+use vortex_array::VortexSessionExecute;
+use vortex_array::arrays::StructArray;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::FieldMask;
 use vortex_array::dtype::FieldPath;
@@ -135,10 +135,11 @@ impl ZonedReader {
                         MaskFuture::new_true(nzones),
                     )
                     .vortex_expect("Failed construct zone map evaluation");
+                let session = self.session.clone();
 
                 async move {
-                    #[expect(deprecated)]
-                    let zones_array = zones_eval.await?.to_struct();
+                    let mut ctx = session.create_execution_ctx();
+                    let zones_array = zones_eval.await?.execute::<StructArray>(&mut ctx)?;
                     // SAFETY: This is only fine to call because we perform validation above
                     Ok(unsafe { ZoneMap::new_unchecked(zones_array, present_stats) })
                 }

--- a/vortex-layout/src/layouts/zoned/zone_map.rs
+++ b/vortex-layout/src/layouts/zoned/zone_map.rs
@@ -7,7 +7,6 @@ use itertools::Itertools;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
 use vortex_array::IntoArray;
-use vortex_array::LEGACY_SESSION;
 use vortex_array::VortexSessionExecute;
 use vortex_array::aggregate_fn::fns::sum::sum;
 use vortex_array::arrays::StructArray;
@@ -219,12 +218,9 @@ impl StatsAccumulator {
         Ok(())
     }
 
-    pub fn push_chunk(&mut self, array: &ArrayRef) -> VortexResult<()> {
+    pub fn push_chunk(&mut self, array: &ArrayRef, ctx: &mut ExecutionCtx) -> VortexResult<()> {
         for builder in self.builders.iter_mut() {
-            if let Some(v) = array
-                .statistics()
-                .compute_stat(builder.stat(), &mut LEGACY_SESSION.create_execution_ctx())?
-            {
+            if let Some(v) = array.statistics().compute_stat(builder.stat(), ctx)? {
                 builder.append_scalar(v.cast(&v.dtype().as_nullable())?)?;
             } else {
                 builder.append_null();
@@ -279,8 +275,8 @@ mod tests {
 
     use rstest::rstest;
     use vortex_array::IntoArray;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::LEGACY_SESSION;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::BoolArray;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::arrays::StructArray;
@@ -316,6 +312,7 @@ mod tests {
     #[case(DType::Utf8(Nullability::NonNullable))]
     #[case(DType::Binary(Nullability::NonNullable))]
     fn truncates_accumulated_stats(#[case] dtype: DType) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut builder = VarBinViewBuilder::with_capacity(dtype.clone(), 2);
         builder.append_value("Value to be truncated");
         builder.append_value("untruncated");
@@ -324,9 +321,9 @@ mod tests {
         builder2.append_value("wait a minute");
         let mut acc =
             StatsAccumulator::new(builder.dtype(), &[Stat::Max, Stat::Min, Stat::Sum], 12);
-        acc.push_chunk(&builder.finish())
+        acc.push_chunk(&builder.finish(), &mut ctx)
             .vortex_expect("push_chunk should succeed for test data");
-        acc.push_chunk(&builder2.finish())
+        acc.push_chunk(&builder2.finish(), &mut ctx)
             .vortex_expect("push_chunk should succeed for test data");
         let stats_table = acc
             .as_stats_table()
@@ -341,14 +338,22 @@ mod tests {
                 MIN_IS_TRUNCATED,
             ]
         );
-        #[expect(deprecated)]
-        let field1_bool = stats_table.array.unmasked_field(1).to_bool();
+        let field1_bool = stats_table
+            .array
+            .unmasked_field(1)
+            .clone()
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap();
         assert_eq!(
             field1_bool.to_bit_buffer(),
             BitBuffer::from(vec![false, true])
         );
-        #[expect(deprecated)]
-        let field3_bool = stats_table.array.unmasked_field(3).to_bool();
+        let field3_bool = stats_table
+            .array
+            .unmasked_field(3)
+            .clone()
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap();
         assert_eq!(
             field3_bool.to_bit_buffer(),
             BitBuffer::from(vec![true, false])
@@ -357,9 +362,10 @@ mod tests {
 
     #[test]
     fn always_adds_is_truncated_column() {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let array = buffer![0, 1, 2].into_array();
         let mut acc = StatsAccumulator::new(array.dtype(), &[Stat::Max, Stat::Min, Stat::Sum], 12);
-        acc.push_chunk(&array)
+        acc.push_chunk(&array, &mut ctx)
             .vortex_expect("push_chunk should succeed for test array");
         let stats_table = acc
             .as_stats_table()
@@ -375,11 +381,19 @@ mod tests {
                 Stat::Sum.name(),
             ]
         );
-        #[expect(deprecated)]
-        let field1_bool = stats_table.array.unmasked_field(1).to_bool();
+        let field1_bool = stats_table
+            .array
+            .unmasked_field(1)
+            .clone()
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap();
         assert_eq!(field1_bool.to_bit_buffer(), BitBuffer::from(vec![false]));
-        #[expect(deprecated)]
-        let field3_bool = stats_table.array.unmasked_field(3).to_bool();
+        let field3_bool = stats_table
+            .array
+            .unmasked_field(3)
+            .clone()
+            .execute::<BoolArray>(&mut ctx)
+            .unwrap();
         assert_eq!(field3_bool.to_bit_buffer(), BitBuffer::from(vec![false]));
     }
 

--- a/vortex-layout/src/scan/scan_builder.rs
+++ b/vortex-layout/src/scan/scan_builder.rs
@@ -465,9 +465,9 @@ mod test {
     use futures::task::noop_waker_ref;
     use parking_lot::Mutex;
     use vortex_array::IntoArray;
+    use vortex_array::LEGACY_SESSION;
     use vortex_array::MaskFuture;
-    #[expect(deprecated)]
-    use vortex_array::ToCanonical;
+    use vortex_array::VortexSessionExecute;
     use vortex_array::arrays::PrimitiveArray;
     use vortex_array::dtype::DType;
     use vortex_array::dtype::FieldMask;
@@ -662,6 +662,7 @@ mod test {
 
     #[test]
     fn into_stream_executes_after_prepare() -> VortexResult<()> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let calls = Arc::new(AtomicUsize::new(0));
         let reader = Arc::new(SplittingLayoutReader::new(Arc::clone(&calls)));
 
@@ -673,8 +674,7 @@ mod test {
 
         let mut values = Vec::new();
         for chunk in &mut iter {
-            #[expect(deprecated)]
-            let prim = chunk?.to_primitive();
+            let prim = chunk?.execute::<PrimitiveArray>(&mut ctx)?;
             values.push(prim.into_buffer::<i32>()[0]);
         }
 

--- a/vortex-python/src/arrays/compressed.rs
+++ b/vortex-python/src/arrays/compressed.rs
@@ -3,9 +3,10 @@
 
 use pyo3::prelude::*;
 use vortex::array::IntoArray;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::Dict;
+use vortex::array::arrays::PrimitiveArray;
 use vortex::encodings::alp::ALP;
 use vortex::encodings::alp::ALPRD;
 use vortex::encodings::datetime_parts::DateTimeParts;
@@ -90,8 +91,11 @@ impl EncodingSubclass for PyZigZagArray {
 impl PyZigZagArray {
     #[staticmethod]
     pub fn encode(array: PyArrayRef) -> PyVortexResult<PyArrayRef> {
-        #[expect(deprecated)]
-        let primitive = array.inner().clone().to_primitive();
+        // PyZigZagArray (and PyArrayRef) do not currently carry a VortexSession;
+        // threading one through would change the FromPyObject contract. Use
+        // LEGACY_SESSION until the wrappers are refactored.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let primitive = array.inner().clone().execute::<PrimitiveArray>(&mut ctx)?;
         Ok(PyVortex(zigzag_encode(primitive.as_view())?.into_array()))
     }
 }

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -23,11 +23,11 @@ use pyo3::types::PyRange;
 use pyo3::types::PyRangeMethods;
 use pyo3_bytes::PyBytes;
 use vortex::array::ArrayRef;
+use vortex::array::Canonical;
 use vortex::array::IntoArray;
 use vortex::array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
 use vortex::array::VortexSessionExecute;
+use vortex::array::arrays::BoolArray;
 use vortex::array::arrays::Chunked;
 use vortex::array::arrays::bool::BoolArrayExt;
 use vortex::array::arrays::chunked::ChunkedArrayExt;
@@ -527,12 +527,14 @@ impl PyArray {
     /// ]
     /// ```
     fn filter(slf: Bound<Self>, mask: PyArrayRef) -> PyVortexResult<PyArrayRef> {
+        // PyArray/PyArrayRef do not currently carry a VortexSession; threading one
+        // through would change the FromPyObject contract. Use LEGACY_SESSION until
+        // the wrappers are refactored.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let slf = PyArrayRef::extract(slf.as_any().as_borrowed())?.into_inner();
-        #[expect(deprecated)]
-        let mask_bool = (&*mask as &ArrayRef).to_bool();
-        let mask = mask_bool.to_mask_fill_null_false(&mut LEGACY_SESSION.create_execution_ctx());
-        #[expect(deprecated)]
-        let canonical = slf.filter(mask)?.to_canonical()?;
+        let mask_bool = (&*mask as &ArrayRef).clone().execute::<BoolArray>(&mut ctx)?;
+        let mask = mask_bool.to_mask_fill_null_false(&mut ctx);
+        let canonical = slf.filter(mask)?.execute::<Canonical>(&mut ctx)?;
         let inner = canonical.into_array();
         Ok(PyArrayRef::from(inner))
     }
@@ -608,6 +610,10 @@ impl PyArray {
     /// ```
     // TODO(ngates): return a vortex.Scalar
     fn scalar_at(slf: Bound<Self>, index: usize) -> PyVortexResult<Bound<PyScalar>> {
+        // PyArray/PyArrayRef do not currently carry a VortexSession; threading one
+        // through would change the FromPyObject contract. Use LEGACY_SESSION until
+        // the wrappers are refactored.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let py = slf.py();
         let slf = PyArrayRef::extract(slf.as_any().as_borrowed())?.into_inner();
         if index >= slf.len() {
@@ -617,10 +623,7 @@ impl PyArray {
             ))
             .into());
         }
-        Ok(PyScalar::init(
-            py,
-            slf.execute_scalar(index, &mut LEGACY_SESSION.create_execution_ctx())?,
-        )?)
+        Ok(PyScalar::init(py, slf.execute_scalar(index, &mut ctx)?)?)
     }
 
     /// Filter, permute, and/or repeat elements by their index.

--- a/vortex-python/src/arrays/mod.rs
+++ b/vortex-python/src/arrays/mod.rs
@@ -532,7 +532,9 @@ impl PyArray {
         // the wrappers are refactored.
         let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let slf = PyArrayRef::extract(slf.as_any().as_borrowed())?.into_inner();
-        let mask_bool = (&*mask as &ArrayRef).clone().execute::<BoolArray>(&mut ctx)?;
+        let mask_bool = (&*mask as &ArrayRef)
+            .clone()
+            .execute::<BoolArray>(&mut ctx)?;
         let mask = mask_bool.to_mask_fill_null_false(&mut ctx);
         let canonical = slf.filter(mask)?.execute::<Canonical>(&mut ctx)?;
         let inner = canonical.into_array();

--- a/vortex-python/src/dataset.rs
+++ b/vortex-python/src/dataset.rs
@@ -11,8 +11,9 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 use vortex::array::ArrayRef;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
+use vortex::array::ExecutionCtx;
+use vortex::array::VortexSessionExecute;
+use vortex::array::arrays::PrimitiveArray;
 use vortex::array::iter::ArrayIteratorExt;
 use vortex::dtype::FieldName;
 use vortex::dtype::FieldNames;
@@ -23,6 +24,7 @@ use vortex::expr::select;
 use vortex::file::OpenOptionsSessionExt;
 use vortex::file::VortexFile;
 use vortex::layout::scan::split_by::SplitBy;
+use vortex::session::VortexSession;
 
 use crate::RUNTIME;
 use crate::SESSION;
@@ -54,6 +56,7 @@ pub fn read_array_from_reader(
     filter: Option<Expression>,
     indices: Option<ArrayRef>,
     row_range: Option<(u64, u64)>,
+    ctx: &mut ExecutionCtx,
 ) -> VortexResult<ArrayRef> {
     let mut scan = vortex_file.scan()?.with_projection(projection);
 
@@ -62,8 +65,7 @@ pub fn read_array_from_reader(
     }
 
     if let Some(indices) = indices {
-        #[expect(deprecated)]
-        let primitive = indices.to_primitive();
+        let primitive = indices.execute::<PrimitiveArray>(ctx)?;
         let indices = primitive.into_buffer();
         scan = scan.with_row_indices(indices);
     }
@@ -106,12 +108,17 @@ fn filter_from_python(row_filter: Option<&Bound<PyExpr>>) -> Option<Expression> 
 pub struct PyVortexDataset {
     vxf: VortexFile,
     schema: SchemaRef,
+    session: VortexSession,
 }
 
 impl PyVortexDataset {
-    pub fn try_new(vxf: VortexFile) -> VortexResult<Self> {
+    pub fn try_new(vxf: VortexFile, session: VortexSession) -> VortexResult<Self> {
         let schema = Arc::new(vxf.dtype().to_arrow_schema()?);
-        Ok(Self { vxf, schema })
+        Ok(Self {
+            vxf,
+            schema,
+            session,
+        })
     }
 
     pub async fn from_url(
@@ -127,7 +134,7 @@ impl PyVortexDataset {
             }
             ResolvedStore::Path(path) => SESSION.open_options().open_path(path).await?,
         };
-        PyVortexDataset::try_new(vxf)
+        PyVortexDataset::try_new(vxf, SESSION.clone())
     }
 }
 
@@ -145,12 +152,14 @@ impl PyVortexDataset {
         indices: Option<PyArrayRef>,
         row_range: Option<(u64, u64)>,
     ) -> PyVortexResult<PyArrayRef> {
+        let mut ctx = self.session.create_execution_ctx();
         let array = read_array_from_reader(
             &self.vxf,
             projection_from_python(columns)?,
             filter_from_python(row_filter),
             indices.map(|i| i.into_inner()),
             row_range,
+            &mut ctx,
         )?;
         Ok(PyArrayRef::from(array))
     }

--- a/vortex-python/src/file.rs
+++ b/vortex-python/src/file.rs
@@ -9,8 +9,9 @@ use pyo3::prelude::*;
 use pyo3::types::PyList;
 use pyo3_object_store::PyObjectStore;
 use vortex::array::ArrayRef;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
+use vortex::array::ExecutionCtx;
+use vortex::array::VortexSessionExecute;
+use vortex::array::arrays::PrimitiveArray;
 use vortex::array::builtins::ArrayBuiltins;
 use vortex::dtype::DType;
 use vortex::dtype::FieldNames;
@@ -25,6 +26,7 @@ use vortex::file::VortexFile;
 use vortex::layout::scan::scan_builder::ScanBuilder;
 use vortex::layout::scan::split_by::SplitBy;
 use vortex::layout::segments::MokaSegmentCache;
+use vortex::session::VortexSession;
 
 use crate::RUNTIME;
 use crate::SESSION;
@@ -81,12 +83,16 @@ pub fn open(
         })
     })?;
 
-    Ok(PyVortexFile { vxf })
+    Ok(PyVortexFile {
+        vxf,
+        session: SESSION.clone(),
+    })
 }
 
 #[pyclass(name = "VortexFile", module = "vortex", frozen)]
 pub struct PyVortexFile {
     vxf: VortexFile,
+    session: VortexSession,
 }
 
 #[pymethods]
@@ -109,12 +115,14 @@ impl PyVortexFile {
         indices: Option<PyArrayRef>,
         batch_size: Option<usize>,
     ) -> PyVortexResult<PyArrayIterator> {
+        let mut ctx = slf.get().session.create_execution_ctx();
         let builder = slf.get().scan_builder(
             projection.map(|p| p.0),
             expr.map(|e| e.into_inner()),
             limit,
             indices.map(|i| i.into_inner()),
             batch_size,
+            &mut ctx,
         )?;
 
         Ok(PyArrayIterator::new(Box::new(
@@ -131,12 +139,14 @@ impl PyVortexFile {
         indices: Option<PyArrayRef>,
         batch_size: Option<usize>,
     ) -> PyVortexResult<PyRepeatedScan> {
+        let mut ctx = slf.get().session.create_execution_ctx();
         let builder = slf.get().scan_builder(
             projection.map(|p| p.0),
             expr.map(|e| e.into_inner()),
             limit,
             indices.map(|i| i.into_inner()),
             batch_size,
+            &mut ctx,
         )?;
 
         let scan = builder.prepare()?;
@@ -180,7 +190,10 @@ impl PyVortexFile {
     }
 
     fn to_dataset(slf: Bound<Self>) -> PyVortexResult<PyVortexDataset> {
-        Ok(PyVortexDataset::try_new(slf.get().vxf.clone())?)
+        Ok(PyVortexDataset::try_new(
+            slf.get().vxf.clone(),
+            slf.get().session.clone(),
+        )?)
     }
 
     #[pyo3(signature = (*))]
@@ -202,6 +215,7 @@ impl PyVortexFile {
         limit: Option<u64>,
         indices: Option<ArrayRef>,
         batch_size: Option<usize>,
+        ctx: &mut ExecutionCtx,
     ) -> VortexResult<ScanBuilder<ArrayRef>> {
         let mut builder = self
             .vxf
@@ -215,8 +229,7 @@ impl PyVortexFile {
 
         if let Some(indices) = indices {
             let casted = indices.cast(DType::Primitive(PType::U64, NonNullable))?;
-            #[expect(deprecated)]
-            let indices = casted.to_primitive().into_buffer::<u64>();
+            let indices = casted.execute::<PrimitiveArray>(ctx)?.into_buffer::<u64>();
             builder = builder.with_row_indices(indices);
         }
 

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/alprd.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/alprd.rs
@@ -5,6 +5,8 @@ use vortex::array::ArrayId;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
 use vortex::array::dtype::FieldNames;
@@ -46,6 +48,9 @@ impl FlatLayoutFixture for AlprdFixture {
     }
 
     fn build(&self) -> VortexResult<ArrayRef> {
+        // NOTE: `FlatLayoutFixture::build` has a fixed trait signature without `ExecutionCtx`, so
+        // we construct a legacy ctx locally at this trait boundary.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let sensor: PrimitiveArray = (0..N)
             .map(|i| {
                 let noise = ((i * 7 + 13) % 100) as f64 / 1000.0;
@@ -150,21 +155,31 @@ impl FlatLayoutFixture for AlprdFixture {
                 "nullable_specials",
             ]),
             vec![
-                sensor_enc.encode(sensor.as_view()).into_array(),
-                drift_enc.encode(drift.as_view()).into_array(),
-                constant_enc.encode(constant_series.as_view()).into_array(),
-                decreasing_enc.encode(decreasing.as_view()).into_array(),
-                oscillating_enc.encode(oscillating.as_view()).into_array(),
-                periodic_resets_enc
-                    .encode(periodic_resets.as_view())
+                sensor_enc.encode(sensor.as_view(), &mut ctx).into_array(),
+                drift_enc.encode(drift.as_view(), &mut ctx).into_array(),
+                constant_enc
+                    .encode(constant_series.as_view(), &mut ctx)
                     .into_array(),
-                nullable_enc.encode(sensor_nullable.as_view()).into_array(),
-                special_enc.encode(special_values.as_view()).into_array(),
+                decreasing_enc
+                    .encode(decreasing.as_view(), &mut ctx)
+                    .into_array(),
+                oscillating_enc
+                    .encode(oscillating.as_view(), &mut ctx)
+                    .into_array(),
+                periodic_resets_enc
+                    .encode(periodic_resets.as_view(), &mut ctx)
+                    .into_array(),
+                nullable_enc
+                    .encode(sensor_nullable.as_view(), &mut ctx)
+                    .into_array(),
+                special_enc
+                    .encode(special_values.as_view(), &mut ctx)
+                    .into_array(),
                 boundary_enc
-                    .encode(boundary_specials.as_view())
+                    .encode(boundary_specials.as_view(), &mut ctx)
                     .into_array(),
                 nullable_special_enc
-                    .encode(nullable_specials.as_view())
+                    .encode(nullable_specials.as_view(), &mut ctx)
                     .into_array(),
             ],
             N,

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/bitpacked.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/bitpacked.rs
@@ -5,6 +5,8 @@ use vortex::array::ArrayId;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
 use vortex::array::dtype::FieldNames;
@@ -32,6 +34,9 @@ impl FlatLayoutFixture for BitPackedFixture {
     }
 
     fn build(&self) -> VortexResult<ArrayRef> {
+        // NOTE: `FlatLayoutFixture::build` has a fixed `(&self)` trait signature, so we cannot
+        // plumb `ExecutionCtx` from a caller; construct one from `LEGACY_SESSION` here.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let u32_8bit: PrimitiveArray = (0..N as u32).map(|i| i % 256).collect();
         let u64_12bit: PrimitiveArray = (0..N as u64).map(|i| i % 4096).collect();
         let u16_4bit: PrimitiveArray = (0..N as u16).map(|i| i % 16).collect();
@@ -80,21 +85,21 @@ impl FlatLayoutFixture for BitPackedFixture {
                 "u16_head_tail_nulls",
             ]),
             vec![
-                bitpack_encode(&u32_8bit, 8, None)?.into_array(),
-                bitpack_encode(&u64_12bit, 12, None)?.into_array(),
-                bitpack_encode(&u16_4bit, 4, None)?.into_array(),
-                bitpack_encode(&u16_1bit, 1, None)?.into_array(),
-                bitpack_encode(&u32_nullable, 7, None)?.into_array(),
-                bitpack_encode(&u32_all_zero, 1, None)?.into_array(),
-                bitpack_encode(&u16_all_equal, 3, None)?.into_array(),
-                bitpack_encode(&u16_15bit, 15, None)?.into_array(),
-                bitpack_encode(&u32_31bit, 31, None)?.into_array(),
-                bitpack_encode(&u64_63bit, 63, None)?.into_array(),
-                bitpack_encode(&u8_3bit, 3, None)?.into_array(),
-                bitpack_encode(&u8_5bit, 5, None)?.into_array(),
-                bitpack_encode(&u16_9bit, 9, None)?.into_array(),
-                bitpack_encode(&u32_17bit, 17, None)?.into_array(),
-                bitpack_encode(&u16_head_tail_nulls, 5, None)?.into_array(),
+                bitpack_encode(&u32_8bit, 8, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u64_12bit, 12, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u16_4bit, 4, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u16_1bit, 1, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u32_nullable, 7, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u32_all_zero, 1, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u16_all_equal, 3, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u16_15bit, 15, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u32_31bit, 31, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u64_63bit, 63, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u8_3bit, 3, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u8_5bit, 5, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u16_9bit, 9, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u32_17bit, 17, None, &mut ctx)?.into_array(),
+                bitpack_encode(&u16_head_tail_nulls, 5, None, &mut ctx)?.into_array(),
             ],
             N,
             Validity::NonNullable,

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/datetimeparts.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/datetimeparts.rs
@@ -5,6 +5,8 @@ use vortex::array::ArrayId;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
 use vortex::array::arrays::TemporalArray;
@@ -22,7 +24,7 @@ pub struct DateTimePartsFixture;
 
 fn encode_temporal(temporal: TemporalArray) -> VortexResult<ArrayRef> {
     let dtype = temporal.dtype().clone();
-    let parts = split_temporal(temporal)?;
+    let parts = split_temporal(temporal, &mut LEGACY_SESSION.create_execution_ctx())?;
     Ok(DateTimeParts::try_new(dtype, parts.days, parts.seconds, parts.subseconds)?.into_array())
 }
 

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/fsst.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/fsst.rs
@@ -5,6 +5,8 @@ use vortex::array::ArrayId;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::StructArray;
 use vortex::array::arrays::VarBinArray;
 use vortex::array::dtype::FieldNames;
@@ -109,6 +111,7 @@ impl FlatLayoutFixture for FsstFixture {
         let high_entropy_comp = fsst_train_compressor(&high_entropy_col);
         let all_null_clustered_comp = fsst_train_compressor(&all_null_clustered);
 
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let arr = StructArray::try_new(
             FieldNames::from([
                 "urls",
@@ -121,22 +124,32 @@ impl FlatLayoutFixture for FsstFixture {
                 "all_null_clustered",
             ]),
             vec![
-                fsst_compress(&url_col, url_col.len(), url_col.dtype(), &url_comp).into_array(),
-                fsst_compress(&log_col, log_col.len(), log_col.dtype(), &log_comp).into_array(),
+                fsst_compress(&url_col, url_col.len(), url_col.dtype(), &url_comp, &mut ctx)
+                    .into_array(),
+                fsst_compress(&log_col, log_col.len(), log_col.dtype(), &log_comp, &mut ctx)
+                    .into_array(),
                 fsst_compress(
                     &nullable_col,
                     nullable_col.len(),
                     nullable_col.dtype(),
                     &nullable_comp,
+                    &mut ctx,
                 )
                 .into_array(),
-                fsst_compress(&short_col, short_col.len(), short_col.dtype(), &short_comp)
-                    .into_array(),
+                fsst_compress(
+                    &short_col,
+                    short_col.len(),
+                    short_col.dtype(),
+                    &short_comp,
+                    &mut ctx,
+                )
+                .into_array(),
                 fsst_compress(
                     &empty_and_unicode_col,
                     empty_and_unicode_col.len(),
                     empty_and_unicode_col.dtype(),
                     &empty_and_unicode_comp,
+                    &mut ctx,
                 )
                 .into_array(),
                 fsst_compress(
@@ -144,6 +157,7 @@ impl FlatLayoutFixture for FsstFixture {
                     suffix_shared_col.len(),
                     suffix_shared_col.dtype(),
                     &suffix_shared_comp,
+                    &mut ctx,
                 )
                 .into_array(),
                 fsst_compress(
@@ -151,6 +165,7 @@ impl FlatLayoutFixture for FsstFixture {
                     high_entropy_col.len(),
                     high_entropy_col.dtype(),
                     &high_entropy_comp,
+                    &mut ctx,
                 )
                 .into_array(),
                 fsst_compress(
@@ -158,6 +173,7 @@ impl FlatLayoutFixture for FsstFixture {
                     all_null_clustered.len(),
                     all_null_clustered.dtype(),
                     &all_null_clustered_comp,
+                    &mut ctx,
                 )
                 .into_array(),
             ],

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/fsst.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/fsst.rs
@@ -124,10 +124,22 @@ impl FlatLayoutFixture for FsstFixture {
                 "all_null_clustered",
             ]),
             vec![
-                fsst_compress(&url_col, url_col.len(), url_col.dtype(), &url_comp, &mut ctx)
-                    .into_array(),
-                fsst_compress(&log_col, log_col.len(), log_col.dtype(), &log_comp, &mut ctx)
-                    .into_array(),
+                fsst_compress(
+                    &url_col,
+                    url_col.len(),
+                    url_col.dtype(),
+                    &url_comp,
+                    &mut ctx,
+                )
+                .into_array(),
+                fsst_compress(
+                    &log_col,
+                    log_col.len(),
+                    log_col.dtype(),
+                    &log_comp,
+                    &mut ctx,
+                )
+                .into_array(),
                 fsst_compress(
                     &nullable_col,
                     nullable_col.len(),

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/pco.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/pco.rs
@@ -5,6 +5,8 @@ use vortex::array::ArrayId;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
 use vortex::array::dtype::FieldNames;
@@ -31,6 +33,9 @@ impl FlatLayoutFixture for PcoFixture {
     }
 
     fn build(&self) -> VortexResult<ArrayRef> {
+        // NOTE: `FlatLayoutFixture::build` has a fixed trait signature without `ExecutionCtx`, so
+        // we construct a legacy ctx locally at this trait boundary.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let irregular_i64: PrimitiveArray =
             (0..N as i64).map(|i| i * i + (i % 17) * 1000).collect();
         let smooth_f64: PrimitiveArray = (0..N)
@@ -70,14 +75,14 @@ impl FlatLayoutFixture for PcoFixture {
                 "narrow_i16",
             ]),
             vec![
-                Pco::from_primitive(irregular_i64.as_view(), 8, 0)?.into_array(),
-                Pco::from_primitive(smooth_f64.as_view(), 8, 0)?.into_array(),
-                Pco::from_primitive(pattern_u32.as_view(), 8, 0)?.into_array(),
-                Pco::from_primitive(nullable_f32.as_view(), 8, 0)?.into_array(),
-                Pco::from_primitive(negative_i32.as_view(), 8, 0)?.into_array(),
-                Pco::from_primitive(constant_u16.as_view(), 8, 0)?.into_array(),
-                Pco::from_primitive(spike_outliers.as_view(), 8, 0)?.into_array(),
-                Pco::from_primitive(narrow_i16.as_view(), 8, 0)?.into_array(),
+                Pco::from_primitive(irregular_i64.as_view(), 8, 0, &mut ctx)?.into_array(),
+                Pco::from_primitive(smooth_f64.as_view(), 8, 0, &mut ctx)?.into_array(),
+                Pco::from_primitive(pattern_u32.as_view(), 8, 0, &mut ctx)?.into_array(),
+                Pco::from_primitive(nullable_f32.as_view(), 8, 0, &mut ctx)?.into_array(),
+                Pco::from_primitive(negative_i32.as_view(), 8, 0, &mut ctx)?.into_array(),
+                Pco::from_primitive(constant_u16.as_view(), 8, 0, &mut ctx)?.into_array(),
+                Pco::from_primitive(spike_outliers.as_view(), 8, 0, &mut ctx)?.into_array(),
+                Pco::from_primitive(narrow_i16.as_view(), 8, 0, &mut ctx)?.into_array(),
             ],
             N,
             Validity::NonNullable,

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/rle.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/rle.rs
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+use vortex::VortexSessionDefault;
 use vortex::array::ArrayId;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
 use vortex::array::dtype::FieldNames;
 use vortex::array::validity::Validity;
 use vortex::encodings::fastlanes::RLE;
 use vortex::error::VortexResult;
+use vortex_session::VortexSession;
 
 use super::N;
 use crate::fixtures::FlatLayoutFixture;
@@ -31,6 +34,9 @@ impl FlatLayoutFixture for RleFixture {
     }
 
     fn build(&self) -> VortexResult<ArrayRef> {
+        let session = VortexSession::default();
+        let mut ctx = session.create_execution_ctx();
+
         let runs_i32: PrimitiveArray = (0..N as i32).map(|i| i / 64).collect();
         let single_run: PrimitiveArray = std::iter::repeat_n(42u64, N).collect();
         let nullable_runs = PrimitiveArray::from_option_iter(
@@ -69,14 +75,14 @@ impl FlatLayoutFixture for RleFixture {
                 "short_runs_u8",
             ]),
             vec![
-                RLE::encode(runs_i32.as_view())?.into_array(),
-                RLE::encode(single_run.as_view())?.into_array(),
-                RLE::encode(nullable_runs.as_view())?.into_array(),
-                RLE::encode(alternating_singletons.as_view())?.into_array(),
-                RLE::encode(exact_boundary_runs.as_view())?.into_array(),
-                RLE::encode(giant_final_run.as_view())?.into_array(),
-                RLE::encode(all_null_i32.as_view())?.into_array(),
-                RLE::encode(short_runs_u8.as_view())?.into_array(),
+                RLE::encode(runs_i32.as_view(), &mut ctx)?.into_array(),
+                RLE::encode(single_run.as_view(), &mut ctx)?.into_array(),
+                RLE::encode(nullable_runs.as_view(), &mut ctx)?.into_array(),
+                RLE::encode(alternating_singletons.as_view(), &mut ctx)?.into_array(),
+                RLE::encode(exact_boundary_runs.as_view(), &mut ctx)?.into_array(),
+                RLE::encode(giant_final_run.as_view(), &mut ctx)?.into_array(),
+                RLE::encode(all_null_i32.as_view(), &mut ctx)?.into_array(),
+                RLE::encode(short_runs_u8.as_view(), &mut ctx)?.into_array(),
             ],
             N,
             Validity::NonNullable,

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/runend.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/runend.rs
@@ -5,6 +5,7 @@ use vortex::array::ArrayId;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
 use vortex::array::arrays::BoolArray;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
@@ -34,6 +35,7 @@ impl FlatLayoutFixture for RunEndFixture {
     }
 
     fn build(&self) -> VortexResult<ArrayRef> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let run_lengths = [1usize, 5, 10, 50, 100];
         let mut values = Vec::with_capacity(N);
         let mut run_idx = 0i64;
@@ -47,8 +49,8 @@ impl FlatLayoutFixture for RunEndFixture {
             rl_idx += 1;
         }
         let run_prim: PrimitiveArray = values.into_iter().collect();
-        let (run_ends, run_values) = runend_encode(run_prim.as_view());
-        let run_col = RunEnd::try_new(run_ends.into_array(), run_values)?;
+        let (run_ends, run_values) = runend_encode(run_prim.as_view(), &mut ctx);
+        let run_col = RunEnd::try_new(run_ends.into_array(), run_values, &mut ctx)?;
 
         let statuses = ["open", "closed", "pending", "cancelled"];
         let mut status_values = Vec::new();
@@ -68,16 +70,17 @@ impl FlatLayoutFixture for RunEndFixture {
         let status_col = RunEnd::try_new(
             status_ends_prim.into_array(),
             VarBinArray::from_strs(status_values).into_array(),
+            &mut ctx,
         )?;
 
         let uniform_prim: PrimitiveArray = (0..N as i32).map(|i| i / 64).collect();
-        let (uniform_ends, uniform_values) = runend_encode(uniform_prim.as_view());
-        let uniform_col = RunEnd::try_new(uniform_ends.into_array(), uniform_values)?;
+        let (uniform_ends, uniform_values) = runend_encode(uniform_prim.as_view(), &mut ctx);
+        let uniform_col = RunEnd::try_new(uniform_ends.into_array(), uniform_values, &mut ctx)?;
 
         let bool_ends: PrimitiveArray = (1..=N / 32).map(|i| (i * 32) as u16).collect();
         let bool_values =
             BoolArray::from_iter((0..bool_ends.len()).map(|i| i % 2 == 0)).into_array();
-        let bool_runs = RunEnd::try_new(bool_ends.into_array(), bool_values)?;
+        let bool_runs = RunEnd::try_new(bool_ends.into_array(), bool_values, &mut ctx)?;
         let nullable_run_values = PrimitiveArray::from_option_iter([
             Some(10i32),
             None,
@@ -89,15 +92,20 @@ impl FlatLayoutFixture for RunEndFixture {
         let nullable_runs = RunEnd::try_new(
             PrimitiveArray::from_iter([16u16, 64, 128, 256, 512, N as u16]).into_array(),
             nullable_run_values.into_array(),
+            &mut ctx,
         )?;
         let single_run = RunEnd::try_new(
             PrimitiveArray::from_iter([N as u64]).into_array(),
             PrimitiveArray::from_iter([1234i64]).into_array(),
+            &mut ctx,
         )?;
         let singleton_values: PrimitiveArray = (0..N as i16).map(|i| i - 512).collect();
         let singleton_ends: PrimitiveArray = (1..=N as u16).collect();
-        let alternating_singletons =
-            RunEnd::try_new(singleton_ends.into_array(), singleton_values.into_array())?;
+        let alternating_singletons = RunEnd::try_new(
+            singleton_ends.into_array(),
+            singleton_values.into_array(),
+            &mut ctx,
+        )?;
 
         let arr = StructArray::try_new(
             FieldNames::from([

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/runend.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/runend.rs
@@ -6,6 +6,7 @@ use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
 use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::BoolArray;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/sparse.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/sparse.rs
@@ -5,6 +5,8 @@ use vortex::array::ArrayId;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::BoolArray;
 use vortex::array::arrays::ConstantArray;
 use vortex::array::arrays::PrimitiveArray;
@@ -36,6 +38,9 @@ impl FlatLayoutFixture for SparseFixture {
     }
 
     fn build(&self) -> VortexResult<ArrayRef> {
+        // `FlatLayoutFixture::build` has a fixed trait signature that can't accept a ctx,
+        // so we instantiate one here.
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let sparse_i64_col = PrimitiveArray::from_option_iter(
             (0..N as i64).map(|i| (i % 50 == 0).then_some(i * 1000)),
         );
@@ -89,22 +94,28 @@ impl FlatLayoutFixture for SparseFixture {
                 "mixed_null_and_values",
             ]),
             vec![
-                Sparse::encode(&sparse_i64_col.into_array(), None)?,
-                Sparse::encode(&sparse_str_col.into_array(), None)?,
-                Sparse::encode(&sparse_bool_col.into_array(), None)?,
-                Sparse::encode(&sparse_f64.into_array(), None)?,
-                Sparse::encode(&sparse_boundary.into_array(), None)?,
+                Sparse::encode(&sparse_i64_col.into_array(), None, &mut ctx)?,
+                Sparse::encode(&sparse_str_col.into_array(), None, &mut ctx)?,
+                Sparse::encode(&sparse_bool_col.into_array(), None, &mut ctx)?,
+                Sparse::encode(&sparse_f64.into_array(), None, &mut ctx)?,
+                Sparse::encode(&sparse_boundary.into_array(), None, &mut ctx)?,
                 Sparse::encode(
                     &explicit_fill_values.into_array(),
                     Some(Scalar::primitive(10i32, Nullability::Nullable)),
+                    &mut ctx,
                 )?,
-                Sparse::encode(&all_default, Some(Scalar::from(10i32)))?,
-                Sparse::encode(&clustered_edges.into_array(), None)?,
+                Sparse::encode(&all_default, Some(Scalar::from(10i32)), &mut ctx)?,
+                Sparse::encode(&clustered_edges.into_array(), None, &mut ctx)?,
                 Sparse::encode(
                     &almost_dense.into_array(),
                     Some(Scalar::primitive(0i32, Nullability::Nullable)),
+                    &mut ctx,
                 )?,
-                Sparse::encode(&mixed_null_and_values.into_array(), Some(mixed_null_fill))?,
+                Sparse::encode(
+                    &mixed_null_and_values.into_array(),
+                    Some(mixed_null_fill),
+                    &mut ctx,
+                )?,
             ],
             N,
             Validity::NonNullable,

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/zstd.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/zstd.rs
@@ -5,6 +5,7 @@ use vortex::array::ArrayId;
 use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
+use vortex::array::LEGACY_SESSION;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
 use vortex::array::arrays::VarBinViewArray;
@@ -32,6 +33,7 @@ impl FlatLayoutFixture for ZstdFixture {
     }
 
     fn build(&self) -> VortexResult<ArrayRef> {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let ints: PrimitiveArray = (0..N as i32).map(|i| i / 8).collect();
         let floats: PrimitiveArray = (0..N)
             .map(|i| {
@@ -87,14 +89,14 @@ impl FlatLayoutFixture for ZstdFixture {
                 "pseudo_random",
             ]),
             vec![
-                Zstd::from_primitive(&ints, 3, 128)?.into_array(),
-                Zstd::from_primitive(&floats, 3, 128)?.into_array(),
-                Zstd::from_primitive(&nullable_i64, 3, 128)?.into_array(),
-                Zstd::from_var_bin_view(&utf8, 3, 128)?.into_array(),
-                Zstd::from_var_bin_view(&nullable_utf8, 3, 128)?.into_array(),
-                Zstd::from_primitive(&all_zeros, 3, 128)?.into_array(),
-                Zstd::from_primitive(&all_null_i32, 3, 128)?.into_array(),
-                Zstd::from_primitive(&pseudo_random, 3, 128)?.into_array(),
+                Zstd::from_primitive(&ints, 3, 128, &mut ctx)?.into_array(),
+                Zstd::from_primitive(&floats, 3, 128, &mut ctx)?.into_array(),
+                Zstd::from_primitive(&nullable_i64, 3, 128, &mut ctx)?.into_array(),
+                Zstd::from_var_bin_view(&utf8, 3, 128, &mut ctx)?.into_array(),
+                Zstd::from_var_bin_view(&nullable_utf8, 3, 128, &mut ctx)?.into_array(),
+                Zstd::from_primitive(&all_zeros, 3, 128, &mut ctx)?.into_array(),
+                Zstd::from_primitive(&all_null_i32, 3, 128, &mut ctx)?.into_array(),
+                Zstd::from_primitive(&pseudo_random, 3, 128, &mut ctx)?.into_array(),
             ],
             N,
             Validity::NonNullable,

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/zstd.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/zstd.rs
@@ -6,6 +6,7 @@ use vortex::array::ArrayRef;
 use vortex::array::ArrayVTable;
 use vortex::array::IntoArray;
 use vortex::array::LEGACY_SESSION;
+use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::StructArray;
 use vortex::array::arrays::VarBinViewArray;

--- a/vortex-tui/src/browse/ui/layouts.rs
+++ b/vortex-tui/src/browse/ui/layouts.rs
@@ -27,10 +27,8 @@ use ratatui::widgets::Table;
 use ratatui::widgets::Widget;
 use ratatui::widgets::Wrap;
 use vortex::array::ArrayRef;
-use vortex::array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
 use vortex::array::VortexSessionExecute;
+use vortex::array::arrays::StructArray;
 use vortex::array::arrays::struct_::StructArrayExt;
 use vortex::error::VortexExpect;
 use vortex::layout::layouts::flat::Flat;
@@ -143,8 +141,11 @@ fn render_array(app: &AppState, area: Rect, buf: &mut Buffer, is_stats_table: bo
 
     if is_stats_table {
         // Render the stats table horizontally
-        #[expect(deprecated)]
-        let struct_array = array.to_struct();
+        let mut ctx = app.session.create_execution_ctx();
+        let struct_array = array
+            .clone()
+            .execute::<StructArray>(&mut ctx)
+            .vortex_expect("failed to canonicalize stats array to StructArray");
         // add 1 for the chunk column
         let field_count = struct_array.struct_fields().nfields() + 1;
         let header = std::iter::once("chunk")
@@ -163,17 +164,18 @@ fn render_array(app: &AppState, area: Rect, buf: &mut Buffer, is_stats_table: bo
         let field_arrays: Vec<ArrayRef> = struct_array.unmasked_fields().to_vec();
 
         // TODO: trim the number of displayed rows and allow paging through column stats.
-        let rows = (0..array.len()).map(|chunk_id| {
-            std::iter::once(Cell::from(Text::from(format!("{chunk_id}"))))
-                .chain(field_arrays.iter().map(|arr| {
-                    Cell::from(Text::from(
-                        arr.execute_scalar(chunk_id, &mut LEGACY_SESSION.create_execution_ctx())
-                            .vortex_expect("scalar_at failed")
-                            .to_string(),
-                    ))
-                }))
-                .collect::<Row>()
-        });
+        let mut rows = Vec::with_capacity(array.len());
+        for chunk_id in 0..array.len() {
+            let mut cells: Vec<Cell> = Vec::with_capacity(field_count);
+            cells.push(Cell::from(Text::from(format!("{chunk_id}"))));
+            for arr in &field_arrays {
+                let scalar = arr
+                    .execute_scalar(chunk_id, &mut ctx)
+                    .vortex_expect("scalar_at failed");
+                cells.push(Cell::from(Text::from(scalar.to_string())));
+            }
+            rows.push(cells.into_iter().collect::<Row>());
+        }
 
         Widget::render(
             Table::new(rows, (0..field_count).map(|_| Constraint::Min(6))).header(header),

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -95,10 +95,11 @@ mod setup {
 
     /// Create FoR <- BitPacked encoding tree for u64
     pub fn for_bp_u64() -> ArrayRef {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let (uint_array, ..) = setup_primitive_arrays();
         let compressed = FoR::encode(uint_array).unwrap();
         let inner = compressed.encoded();
-        let bp = BitPacked::encode(inner, 8).unwrap();
+        let bp = BitPacked::encode(inner, 8, &mut ctx).unwrap();
         FoR::try_new(bp.into_array(), compressed.reference_scalar().clone())
             .unwrap()
             .into_array()
@@ -118,7 +119,7 @@ mod setup {
             .unwrap();
         let for_array = FoR::encode(alp_encoded_prim).unwrap();
         let inner = for_array.encoded();
-        let bp = BitPacked::encode(inner, 8).unwrap();
+        let bp = BitPacked::encode(inner, 8, &mut ctx).unwrap();
         let for_with_bp =
             FoR::try_new(bp.into_array(), for_array.reference_scalar().clone()).unwrap();
 
@@ -153,7 +154,8 @@ mod setup {
         let codes_prim = PrimitiveArray::from_iter(codes);
 
         // Compress codes with BitPacked (6 bits should be enough for ~50 unique values)
-        let codes_bp = BitPacked::encode(&codes_prim.into_array(), 6)
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let codes_bp = BitPacked::encode(&codes_prim.into_array(), 6, &mut ctx)
             .unwrap()
             .into_array();
 
@@ -195,7 +197,7 @@ mod setup {
             .unwrap();
         let ends_for = FoR::encode(ends_prim).unwrap();
         let ends_inner = ends_for.encoded();
-        let ends_bp = BitPacked::encode(ends_inner, 8).unwrap();
+        let ends_bp = BitPacked::encode(ends_inner, 8, &mut ctx).unwrap();
         let compressed_ends =
             FoR::try_new(ends_bp.into_array(), ends_for.reference_scalar().clone())
                 .unwrap()
@@ -207,7 +209,7 @@ mod setup {
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)
             .unwrap();
-        let compressed_values = BitPacked::encode(&values_prim.into_array(), 8)
+        let compressed_values = BitPacked::encode(&values_prim.into_array(), 8, &mut ctx)
             .unwrap()
             .into_array();
 
@@ -289,7 +291,7 @@ mod setup {
             .clone()
             .execute::<PrimitiveArray>(&mut ctx)
             .unwrap();
-        let offsets_bp = BitPacked::encode(&offsets_prim.into_array(), 20).unwrap();
+        let offsets_bp = BitPacked::encode(&offsets_prim.into_array(), 20, &mut ctx).unwrap();
 
         // Rebuild VarBin with compressed offsets
         let compressed_codes = VarBinArray::try_new(
@@ -350,7 +352,7 @@ mod setup {
             .unwrap();
         let days_for = FoR::encode(days_prim).unwrap();
         let days_inner = days_for.encoded();
-        let days_bp = BitPacked::encode(days_inner, 16).unwrap();
+        let days_bp = BitPacked::encode(days_inner, 16, &mut ctx).unwrap();
         let compressed_days =
             FoR::try_new(days_bp.into_array(), days_for.reference_scalar().clone())
                 .unwrap()
@@ -364,7 +366,7 @@ mod setup {
             .unwrap();
         let seconds_for = FoR::encode(seconds_prim).unwrap();
         let seconds_inner = seconds_for.encoded();
-        let seconds_bp = BitPacked::encode(seconds_inner, 17).unwrap();
+        let seconds_bp = BitPacked::encode(seconds_inner, 17, &mut ctx).unwrap();
         let compressed_seconds = FoR::try_new(
             seconds_bp.into_array(),
             seconds_for.reference_scalar().clone(),
@@ -380,7 +382,7 @@ mod setup {
             .unwrap();
         let subseconds_for = FoR::encode(subseconds_prim).unwrap();
         let subseconds_inner = subseconds_for.encoded();
-        let subseconds_bp = BitPacked::encode(subseconds_inner, 20).unwrap();
+        let subseconds_bp = BitPacked::encode(subseconds_inner, 20, &mut ctx).unwrap();
         let compressed_subseconds = FoR::try_new(
             subseconds_bp.into_array(),
             subseconds_for.reference_scalar().clone(),

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -16,8 +16,6 @@ use vortex::array::ArrayRef;
 use vortex::array::Canonical;
 use vortex::array::IntoArray;
 use vortex::array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
 use vortex::array::VortexSessionExecute;
 use vortex::array::arrays::DictArray;
 use vortex::array::arrays::PrimitiveArray;
@@ -74,23 +72,24 @@ mod setup {
     use super::*;
 
     fn setup_primitive_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let mut rng = StdRng::seed_from_u64(0);
         let uint_array =
             PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
-        #[expect(deprecated)]
         let int_array = uint_array
             .clone()
             .into_array()
             .cast(PType::I32.into())
             .unwrap()
-            .to_primitive();
-        #[expect(deprecated)]
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let float_array = uint_array
             .clone()
             .into_array()
             .cast(PType::F64.into())
             .unwrap()
-            .to_primitive();
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         (uint_array, int_array, float_array)
     }
 
@@ -107,17 +106,16 @@ mod setup {
 
     /// Create ALP <- FoR <- BitPacked encoding tree for f64
     pub fn alp_for_bp_f64() -> ArrayRef {
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let (_, _, float_array) = setup_primitive_arrays();
-        let alp_compressed = alp_encode(
-            float_array.as_view(),
-            None,
-            &mut LEGACY_SESSION.create_execution_ctx(),
-        )
-        .unwrap();
+        let alp_compressed = alp_encode(float_array.as_view(), None, &mut ctx).unwrap();
 
         // Manually construct ALP <- FoR <- BitPacked tree
-        #[expect(deprecated)]
-        let alp_encoded_prim = alp_compressed.encoded().to_primitive();
+        let alp_encoded_prim = alp_compressed
+            .encoded()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let for_array = FoR::encode(alp_encoded_prim).unwrap();
         let inner = for_array.encoded();
         let bp = BitPacked::encode(inner, 8).unwrap();
@@ -185,12 +183,16 @@ mod setup {
             run_length -= 1;
         }
 
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let prim_array = PrimitiveArray::from_iter(values);
-        let runend = RunEnd::encode(prim_array.into_array()).unwrap();
+        let runend = RunEnd::encode(prim_array.into_array(), &mut ctx).unwrap();
 
         // Compress the ends with FoR <- BitPacked
-        #[expect(deprecated)]
-        let ends_prim = runend.ends().to_primitive();
+        let ends_prim = runend
+            .ends()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let ends_for = FoR::encode(ends_prim).unwrap();
         let ends_inner = ends_for.encoded();
         let ends_bp = BitPacked::encode(ends_inner, 8).unwrap();
@@ -200,13 +202,16 @@ mod setup {
                 .into_array();
 
         // Compress the values with BitPacked
-        #[expect(deprecated)]
-        let values_prim = runend.values().to_primitive();
+        let values_prim = runend
+            .values()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let compressed_values = BitPacked::encode(&values_prim.into_array(), 8)
             .unwrap()
             .into_array();
 
-        RunEnd::try_new(compressed_ends, compressed_values)
+        RunEnd::try_new(compressed_ends, compressed_values, &mut ctx)
             .unwrap()
             .into_array()
     }
@@ -227,6 +232,7 @@ mod setup {
             .collect();
 
         // Train and compress unique values with FSST
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let unique_varbinview = VarBinViewArray::from_iter_str(unique_strings);
         let fsst_compressor = fsst_train_compressor(&unique_varbinview);
         let fsst_values = fsst_compress(
@@ -234,6 +240,7 @@ mod setup {
             unique_varbinview.len(),
             unique_varbinview.dtype(),
             &fsst_compressor,
+            &mut ctx,
         );
 
         // Create codes array (random indices into unique values)
@@ -264,6 +271,7 @@ mod setup {
             .collect();
 
         // Train and compress unique values with FSST
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
         let unique_varbinview = VarBinViewArray::from_iter_str(unique_strings);
         let fsst_compressor = fsst_train_compressor(&unique_varbinview);
         let fsst = fsst_compress(
@@ -271,12 +279,16 @@ mod setup {
             unique_varbinview.len(),
             unique_varbinview.dtype(),
             &fsst_compressor,
+            &mut ctx,
         );
 
         // Compress the VarBin offsets with BitPacked
         let codes = fsst.codes();
-        #[expect(deprecated)]
-        let offsets_prim = codes.offsets().to_primitive();
+        let offsets_prim = codes
+            .offsets()
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let offsets_bp = BitPacked::encode(&offsets_prim.into_array(), 20).unwrap();
 
         // Rebuild VarBin with compressed offsets
@@ -297,6 +309,7 @@ mod setup {
             fsst.symbol_lengths().clone(),
             compressed_codes,
             fsst.uncompressed_lengths().clone(),
+            &mut ctx,
         )
         .unwrap();
 
@@ -326,11 +339,15 @@ mod setup {
         let temporal_array = TemporalArray::new_timestamp(ts_array, TimeUnit::Microseconds, None);
 
         // Split into days, seconds, subseconds
-        let parts = split_temporal(temporal_array.clone()).unwrap();
+        let mut ctx = LEGACY_SESSION.create_execution_ctx();
+        let parts = split_temporal(temporal_array.clone(), &mut ctx).unwrap();
 
         // Compress days with FoR <- BitPacked
-        #[expect(deprecated)]
-        let days_prim = parts.days.to_primitive();
+        let days_prim = parts
+            .days
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let days_for = FoR::encode(days_prim).unwrap();
         let days_inner = days_for.encoded();
         let days_bp = BitPacked::encode(days_inner, 16).unwrap();
@@ -340,8 +357,11 @@ mod setup {
                 .into_array();
 
         // Compress seconds with FoR <- BitPacked
-        #[expect(deprecated)]
-        let seconds_prim = parts.seconds.to_primitive();
+        let seconds_prim = parts
+            .seconds
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let seconds_for = FoR::encode(seconds_prim).unwrap();
         let seconds_inner = seconds_for.encoded();
         let seconds_bp = BitPacked::encode(seconds_inner, 17).unwrap();
@@ -353,8 +373,11 @@ mod setup {
         .into_array();
 
         // Compress subseconds with FoR <- BitPacked
-        #[expect(deprecated)]
-        let subseconds_prim = parts.subseconds.to_primitive();
+        let subseconds_prim = parts
+            .subseconds
+            .clone()
+            .execute::<PrimitiveArray>(&mut ctx)
+            .unwrap();
         let subseconds_for = FoR::encode(subseconds_prim).unwrap();
         let subseconds_inner = subseconds_for.encoded();
         let subseconds_bp = BitPacked::encode(subseconds_inner, 20).unwrap();

--- a/vortex/benches/common_encoding_tree_throughput.rs
+++ b/vortex/benches/common_encoding_tree_throughput.rs
@@ -377,7 +377,6 @@ mod setup {
         // Compress subseconds with FoR <- BitPacked
         let subseconds_prim = parts
             .subseconds
-            .clone()
             .execute::<PrimitiveArray>(&mut ctx)
             .unwrap();
         let subseconds_for = FoR::encode(subseconds_prim).unwrap();

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -336,9 +336,13 @@ fn bench_pcodec_compress_f64(bencher: Bencher) {
 #[divan::bench(name = "pcodec_decompress_f64")]
 fn bench_pcodec_decompress_f64(bencher: Bencher) {
     let (_, _, float_array) = setup_primitive_arrays();
-    let compressed =
-        Pco::from_primitive(float_array.as_view(), 3, 0, &mut SESSION.create_execution_ctx())
-            .unwrap();
+    let compressed = Pco::from_primitive(
+        float_array.as_view(),
+        3,
+        0,
+        &mut SESSION.create_execution_ctx(),
+    )
+    .unwrap();
 
     with_byte_counter(bencher, NUM_VALUES * 8)
         .with_inputs(|| (&compressed, SESSION.create_execution_ctx()))

--- a/vortex/benches/single_encoding_throughput.rs
+++ b/vortex/benches/single_encoding_throughput.rs
@@ -18,8 +18,6 @@ use vortex::array::Canonical;
 use vortex::array::ExecutionCtx;
 use vortex::array::IntoArray;
 use vortex::array::LEGACY_SESSION;
-#[expect(deprecated)]
-use vortex::array::ToCanonical;
 use vortex::array::arrays::PrimitiveArray;
 use vortex::array::arrays::VarBinViewArray;
 use vortex::array::builders::dict::dict_encode;
@@ -75,23 +73,24 @@ fn canonicalize(array: impl IntoArray, ctx: &mut ExecutionCtx) -> VortexResult<C
 
 // Setup functions
 fn setup_primitive_arrays() -> (PrimitiveArray, PrimitiveArray, PrimitiveArray) {
+    let mut ctx = LEGACY_SESSION.create_execution_ctx();
     let mut rng = StdRng::seed_from_u64(0);
     let uint_array =
         PrimitiveArray::from_iter((0..NUM_VALUES).map(|_| rng.random_range(42u32..256)));
-    #[expect(deprecated)]
     let int_array = uint_array
         .clone()
         .into_array()
         .cast(PType::I32.into())
         .unwrap()
-        .to_primitive();
-    #[expect(deprecated)]
+        .execute::<PrimitiveArray>(&mut ctx)
+        .unwrap();
     let float_array = uint_array
         .clone()
         .into_array()
         .cast(PType::F64.into())
         .unwrap()
-        .to_primitive();
+        .execute::<PrimitiveArray>(&mut ctx)
+        .unwrap();
     (uint_array, int_array, float_array)
 }
 
@@ -130,9 +129,14 @@ fn bench_bitpacked_decompress_u32(bencher: Bencher) {
 
     let (uint_array, ..) = setup_primitive_arrays();
     let bit_width = 8;
-    let compressed = bitpack_encode(&uint_array, bit_width, None)
-        .unwrap()
-        .into_array();
+    let compressed = bitpack_encode(
+        &uint_array,
+        bit_width,
+        None,
+        &mut SESSION.create_execution_ctx(),
+    )
+    .unwrap()
+    .into_array();
 
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| (&compressed, SESSION.create_execution_ctx()))
@@ -144,14 +148,18 @@ fn bench_runend_compress_u32(bencher: Bencher) {
     let (uint_array, ..) = setup_primitive_arrays();
 
     with_byte_counter(bencher, NUM_VALUES * 4)
-        .with_inputs(|| uint_array.clone())
-        .bench_values(|a| RunEnd::encode(a.into_array()).unwrap());
+        .with_inputs(|| (uint_array.clone(), LEGACY_SESSION.create_execution_ctx()))
+        .bench_values(|(a, mut ctx)| RunEnd::encode(a.into_array(), &mut ctx).unwrap());
 }
 
 #[divan::bench(name = "runend_decompress_u32")]
 fn bench_runend_decompress_u32(bencher: Bencher) {
     let (uint_array, ..) = setup_primitive_arrays();
-    let compressed = RunEnd::encode(uint_array.into_array()).unwrap();
+    let compressed = RunEnd::encode(
+        uint_array.into_array(),
+        &mut LEGACY_SESSION.create_execution_ctx(),
+    )
+    .unwrap();
 
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| (&compressed, SESSION.create_execution_ctx()))
@@ -246,8 +254,8 @@ fn bench_sequence_compress_u32(bencher: Bencher) {
     let seq_array = PrimitiveArray::from_iter(0..NUM_VALUES as u32);
 
     with_byte_counter(bencher, NUM_VALUES * 4)
-        .with_inputs(|| seq_array.clone())
-        .bench_values(|a| sequence_encode(a.as_view()).unwrap().unwrap());
+        .with_inputs(|| (seq_array.clone(), SESSION.create_execution_ctx()))
+        .bench_values(|(a, mut ctx)| sequence_encode(a.as_view(), &mut ctx).unwrap().unwrap());
 }
 
 #[expect(clippy::cast_possible_truncation)]
@@ -298,10 +306,10 @@ fn bench_alp_rd_compress_f64(bencher: Bencher) {
     let (_, _, float_array) = setup_primitive_arrays();
 
     with_byte_counter(bencher, NUM_VALUES * 8)
-        .with_inputs(|| &float_array)
-        .bench_refs(|a| {
+        .with_inputs(|| (&float_array, SESSION.create_execution_ctx()))
+        .bench_refs(|(a, ctx)| {
             let encoder = RDEncoder::new(a.as_slice::<f64>());
-            encoder.encode(a.as_view())
+            encoder.encode(a.as_view(), ctx)
         });
 }
 
@@ -309,7 +317,7 @@ fn bench_alp_rd_compress_f64(bencher: Bencher) {
 fn bench_alp_rd_decompress_f64(bencher: Bencher) {
     let (_, _, float_array) = setup_primitive_arrays();
     let encoder = RDEncoder::new(float_array.as_slice::<f64>());
-    let compressed = encoder.encode(float_array.as_view());
+    let compressed = encoder.encode(float_array.as_view(), &mut SESSION.create_execution_ctx());
 
     with_byte_counter(bencher, NUM_VALUES * 8)
         .with_inputs(|| (&compressed, SESSION.create_execution_ctx()))
@@ -321,14 +329,16 @@ fn bench_pcodec_compress_f64(bencher: Bencher) {
     let (_, _, float_array) = setup_primitive_arrays();
 
     with_byte_counter(bencher, NUM_VALUES * 8)
-        .with_inputs(|| &float_array)
-        .bench_refs(|a| Pco::from_primitive(a.as_view(), 3, 0).unwrap());
+        .with_inputs(|| (&float_array, SESSION.create_execution_ctx()))
+        .bench_refs(|(a, ctx)| Pco::from_primitive(a.as_view(), 3, 0, ctx).unwrap());
 }
 
 #[divan::bench(name = "pcodec_decompress_f64")]
 fn bench_pcodec_decompress_f64(bencher: Bencher) {
     let (_, _, float_array) = setup_primitive_arrays();
-    let compressed = Pco::from_primitive(float_array.as_view(), 3, 0).unwrap();
+    let compressed =
+        Pco::from_primitive(float_array.as_view(), 3, 0, &mut SESSION.create_execution_ctx())
+            .unwrap();
 
     with_byte_counter(bencher, NUM_VALUES * 8)
         .with_inputs(|| (&compressed, SESSION.create_execution_ctx()))
@@ -343,7 +353,9 @@ fn bench_zstd_compress_u32(bencher: Bencher) {
 
     with_byte_counter(bencher, NUM_VALUES * 4)
         .with_inputs(|| array.clone())
-        .bench_values(|a| ZstdData::from_array(a, 3, 8192).unwrap());
+        .bench_values(|a| {
+            ZstdData::from_array(a, 3, 8192, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
+        });
 }
 
 #[cfg(feature = "zstd")]
@@ -354,7 +366,13 @@ fn bench_zstd_decompress_u32(bencher: Bencher) {
     let validity = uint_array.validity().unwrap();
     let compressed = Zstd::try_new(
         dtype,
-        ZstdData::from_array(uint_array.into_array(), 3, 8192).unwrap(),
+        ZstdData::from_array(
+            uint_array.into_array(),
+            3,
+            8192,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap(),
         validity,
     )
     .unwrap()
@@ -397,8 +415,8 @@ fn bench_fsst_compress_string(bencher: Bencher) {
     let nbytes = varbinview_arr.nbytes() as u64;
 
     with_byte_counter(bencher, nbytes)
-        .with_inputs(|| &varbinview_arr)
-        .bench_refs(|a| fsst_compress(*a, a.len(), a.dtype(), &fsst_compressor));
+        .with_inputs(|| (&varbinview_arr, LEGACY_SESSION.create_execution_ctx()))
+        .bench_refs(|(a, ctx)| fsst_compress(*a, a.len(), a.dtype(), &fsst_compressor, ctx));
 }
 
 #[divan::bench(name = "fsst_decompress_string")]
@@ -411,6 +429,7 @@ fn bench_fsst_decompress_string(bencher: Bencher) {
         varbinview_arr.len(),
         varbinview_arr.dtype(),
         &fsst_compressor,
+        &mut LEGACY_SESSION.create_execution_ctx(),
     );
     let nbytes = varbinview_arr.into_array().nbytes() as u64;
 
@@ -429,7 +448,9 @@ fn bench_zstd_compress_string(bencher: Bencher) {
 
     with_byte_counter(bencher, nbytes)
         .with_inputs(|| array.clone())
-        .bench_values(|a| ZstdData::from_array(a, 3, 8192).unwrap());
+        .bench_values(|a| {
+            ZstdData::from_array(a, 3, 8192, &mut LEGACY_SESSION.create_execution_ctx()).unwrap()
+        });
 }
 
 #[cfg(feature = "zstd")]
@@ -441,7 +462,13 @@ fn bench_zstd_decompress_string(bencher: Bencher) {
     let validity = varbinview_arr.validity().unwrap();
     let compressed = Zstd::try_new(
         dtype,
-        ZstdData::from_array(varbinview_arr.clone().into_array(), 3, 8192).unwrap(),
+        ZstdData::from_array(
+            varbinview_arr.clone().into_array(),
+            3,
+            8192,
+            &mut LEGACY_SESSION.create_execution_ctx(),
+        )
+        .unwrap(),
         validity,
     )
     .unwrap()


### PR DESCRIPTION
## Summary

Remove deprecated compute methods that lack an `ExecutionCtx` parameter (e.g., `to_canonical`) and plumb `ExecutionCtx` through remaining callsites.

Key changes:
- Remove deprecated non-ctx methods across encodings
- Add `&mut ExecutionCtx` parameter to `BitPacked::encode`, `RunEnd::new`, and other encoding methods
- Fix all callsites in benchmarks, tests, CUDA code, compat-gen, and production code
- Fix clippy warnings (redundant clones, too-many-arguments, auto-deref)
- Regenerate public-api.lock files

## API Changes

Breaking change: encoding methods like `BitPacked::encode` now require an `&mut ExecutionCtx` parameter.
