### PR TITLE
Add `unstable_encodings` feature to `vortex-tui`

### DIFF
--- a/vortex-tui/Cargo.toml
+++ b/vortex-tui/Cargo.toml
@@ -30,6 +30,7 @@ native = [
     "vortex/tokio",
     "vortex/zstd",
 ]
+unstable_encodings = ["vortex/unstable_encodings"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## Summary

Without this, we cannot view unstable encodings (like the tensor encodings).

## Testing

N/A