### PR TITLE
Hack to support forcing normalization

### DIFF
--- a/vortex-compressor/src/compressor.rs
+++ b/vortex-compressor/src/compressor.rs
@@ -28,6 +28,7 @@ use vortex_array::arrays::list::ListArrayExt;
 use vortex_array::arrays::listview::ListViewArrayExt;
 use vortex_array::arrays::listview::list_from_list_view;
 use vortex_array::arrays::primitive::PrimitiveArrayExt;
+use vortex_array::arrays::scalar_fn::AnyScalarFn;
 use vortex_array::arrays::struct_::StructArrayExt;
 use vortex_array::dtype::DType;
 use vortex_array::dtype::Nullability;
@@ -254,6 +255,11 @@ impl CascadingCompressor {
                     return Ok(result);
                 }
 
+                // TODO(connor): HACK TO SUPPORT L2 DENORMALIZATION!!!
+                if result.is::<AnyScalarFn>() {
+                    return Ok(result);
+                }
+
                 // Otherwise, fall back to compressing the underlying storage array.
                 let compressed_storage = self.compress(ext_array.storage_array())?;
 
@@ -335,6 +341,11 @@ impl CascadingCompressor {
             // Only choose the compressed array if it is smaller than the canonical one.
             if compressed.nbytes() < before_nbytes {
                 // TODO(connor): Add a tracing warning here too.
+                return Ok(compressed);
+            }
+
+            // TODO(connor): HACK TO SUPPORT L2 DENORMALIZATION!!!
+            if compressed.is::<AnyScalarFn>() {
                 return Ok(compressed);
             }
         }


### PR DESCRIPTION
## Summary

We need to support normalization of vector arrays to perform faster compute. However, this will essentially always create larger arrays on disk. This is a hack specifically for `L2Denorm` that will allow us write normalized vector arrays to disk.

Given that writing scalar fn arrays to disk is already gated by an environment variable and the unstable encodings feature flag, I think this hack is fine for now.

## Testing

This just allows some arrays that are larger than canonical.
