### PR TITLE
Implement validity for Between scalar function

### DIFF
--- a/vortex-array/public-api.lock
+++ b/vortex-array/public-api.lock
@@ -15504,7 +15504,7 @@ pub fn vortex_array::scalar_fn::fns::between::Between::stat_expression(&self, op
 
 pub fn vortex_array::scalar_fn::fns::between::Between::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
-pub fn vortex_array::scalar_fn::fns::between::Between::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+pub fn vortex_array::scalar_fn::fns::between::Between::validity(&self, _options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 pub struct vortex_array::scalar_fn::fns::between::BetweenExecuteAdaptor<V>(pub V)
 
@@ -17738,7 +17738,7 @@ pub fn vortex_array::scalar_fn::fns::between::Between::stat_expression(&self, op
 
 pub fn vortex_array::scalar_fn::fns::between::Between::stat_falsification(&self, options: &Self::Options, expr: &vortex_array::expr::Expression, catalog: &dyn vortex_array::expr::pruning::StatsCatalog) -> core::option::Option<vortex_array::expr::Expression>
 
-pub fn vortex_array::scalar_fn::fns::between::Between::validity(&self, options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
+pub fn vortex_array::scalar_fn::fns::between::Between::validity(&self, _options: &Self::Options, expression: &vortex_array::expr::Expression) -> vortex_error::VortexResult<core::option::Option<vortex_array::expr::Expression>>
 
 impl vortex_array::scalar_fn::ScalarFnVTable for vortex_array::scalar_fn::fns::binary::Binary
 

--- a/vortex-array/src/scalar_fn/fns/between/mod.rs
+++ b/vortex-array/src/scalar_fn/fns/between/mod.rs
@@ -8,6 +8,7 @@ use std::fmt::Formatter;
 
 pub use kernel::*;
 use prost::Message;
+use vortex_array::expr::and;
 use vortex_error::VortexResult;
 use vortex_error::vortex_bail;
 use vortex_proto::expr as pb;
@@ -308,9 +309,18 @@ impl ScalarFnVTable for Between {
         let lhs = Binary.new_expr(options.lower_strict.to_operator(), [lower, arr.clone()]);
         let rhs = Binary.new_expr(options.upper_strict.to_operator(), [arr, upper]);
 
-        Binary
-            .new_expr(Operator::And, [lhs, rhs])
-            .stat_falsification(catalog)
+        and(lhs, rhs).stat_falsification(catalog)
+    }
+
+    fn validity(
+        &self,
+        _options: &Self::Options,
+        expression: &Expression,
+    ) -> VortexResult<Option<Expression>> {
+        let arr = expression.child(0).validity()?;
+        let lower = expression.child(1).validity()?;
+        let upper = expression.child(2).validity()?;
+        Ok(Some(and(and(arr, lower), upper)))
     }
 
     fn is_null_sensitive(&self, _instance: &Self::Options) -> bool {


### PR DESCRIPTION
Avoid using IsNotNull(expr) fallback which can lead to infinite recursion. As a followup we should make validity required thing for scalar functions

Signed-off-by: Robert Kruszewski <github@robertk.io>

