### PR TITLE
avoid including experimental encoding in footer

### DIFF
--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -349,6 +349,7 @@ fn apply_patches_primitive<V: NativePType>(
 
 #[cfg(test)]
 mod tests {
+    use crate::session::ArraySessionExt;
     use rstest::rstest;
     use vortex_buffer::ByteBufferMut;
     use vortex_buffer::buffer;
@@ -588,7 +589,9 @@ mod tests {
         let dtype = array.dtype().clone();
         let len = array.len();
 
-        let ctx = ArrayContext::empty();
+        LEGACY_SESSION.arrays().register(Patched);
+
+        let ctx = ArrayContext::empty().with_registry(LEGACY_SESSION.arrays().registry().clone());
         let serialized = array
             .serialize(&ctx, &LEGACY_SESSION, &SerializeOptions::default())
             .unwrap();

--- a/vortex-array/src/arrays/patched/vtable/mod.rs
+++ b/vortex-array/src/arrays/patched/vtable/mod.rs
@@ -349,7 +349,6 @@ fn apply_patches_primitive<V: NativePType>(
 
 #[cfg(test)]
 mod tests {
-    use crate::session::ArraySessionExt;
     use rstest::rstest;
     use vortex_buffer::ByteBufferMut;
     use vortex_buffer::buffer;
@@ -374,6 +373,7 @@ mod tests {
     use crate::patches::Patches;
     use crate::serde::SerializeOptions;
     use crate::serde::SerializedArray;
+    use crate::session::ArraySessionExt;
     use crate::validity::Validity;
 
     #[test]

--- a/vortex-array/src/session/mod.rs
+++ b/vortex-array/src/session/mod.rs
@@ -23,7 +23,6 @@ use crate::arrays::List;
 use crate::arrays::ListView;
 use crate::arrays::Masked;
 use crate::arrays::Null;
-use crate::arrays::Patched;
 use crate::arrays::Primitive;
 use crate::arrays::Struct;
 use crate::arrays::VarBin;
@@ -80,7 +79,6 @@ impl Default for ArraySession {
         this.register(Dict);
         this.register(List);
         this.register(Masked);
-        this.register(Patched);
         this.register(VarBin);
 
         this

--- a/vortex-file/src/lib.rs
+++ b/vortex-file/src/lib.rs
@@ -110,6 +110,8 @@ pub use forever_constant::*;
 pub use open::*;
 pub use strategy::*;
 use vortex_array::arrays::Dict;
+use vortex_array::arrays::Patched;
+use vortex_array::arrays::patched::use_experimental_patches;
 use vortex_array::session::ArraySessionExt;
 use vortex_bytebool::ByteBool;
 use vortex_fsst::FSST;
@@ -168,6 +170,9 @@ pub fn register_default_encodings(session: &VortexSession) {
         arrays.register(vortex_zstd::Zstd);
         #[cfg(all(feature = "zstd", feature = "unstable_encodings"))]
         arrays.register(vortex_zstd::ZstdBuffers);
+        if use_experimental_patches() {
+            arrays.register(Patched);
+        }
     }
 
     // Eventually all encodings crates should expose an initialize function. For now it's only

--- a/vortex-file/src/strategy.rs
+++ b/vortex-file/src/strategy.rs
@@ -90,10 +90,6 @@ pub static ALLOWED_ENCODINGS: LazyLock<HashSet<ArrayId>> = LazyLock::new(|| {
     allowed.insert(Masked.id());
     allowed.insert(Dict.id());
 
-    if use_experimental_patches() {
-        allowed.insert(Patched.id());
-    }
-
     // Compressed encodings from encoding crates
     allowed.insert(ALP.id());
     allowed.insert(ALPRD.id());
@@ -110,6 +106,12 @@ pub static ALLOWED_ENCODINGS: LazyLock<HashSet<ArrayId>> = LazyLock::new(|| {
     allowed.insert(Sequence.id());
     allowed.insert(Sparse.id());
     allowed.insert(ZigZag.id());
+
+    // Experimental encodings
+
+    if use_experimental_patches() {
+        allowed.insert(Patched.id());
+    }
 
     #[cfg(feature = "zstd")]
     allowed.insert(Zstd.id());

--- a/vortex-file/src/writer.rs
+++ b/vortex-file/src/writer.rs
@@ -47,6 +47,7 @@ use vortex_session::SessionExt;
 use vortex_session::VortexSession;
 use vortex_session::registry::ReadContext;
 
+use crate::ALLOWED_ENCODINGS;
 use crate::Footer;
 use crate::MAGIC_BYTES;
 use crate::WriteStrategyBuilder;
@@ -147,7 +148,7 @@ impl VortexWriteOptions {
         // serialised array order is deterministic. The serialisation of arrays are done
         // parallel and with an empty context they can register their encodings to the context
         // in different order, changing the written bytes from run to run.
-        let ctx = ArrayContext::new(self.session.arrays().registry().ids().sorted().collect())
+        let ctx = ArrayContext::new(ALLOWED_ENCODINGS.iter().cloned().sorted().collect())
             // Configure a registry just to ensure only known encodings are interned.
             .with_registry(self.session.arrays().registry().clone());
         let dtype = stream.dtype().clone();

--- a/vortex-python/src/io.rs
+++ b/vortex-python/src/io.rs
@@ -280,7 +280,7 @@ impl PyVortexWriteOptions {
     /// >>> vx.io.VortexWriteOptions.default().write(sprl, "chonky.vortex")
     /// >>> import os
     /// >>> os.path.getsize('chonky.vortex')
-    /// 216036
+    /// 215972
     /// ```
     ///
     /// Wow, Vortex manages to use about two bytes per integer! So advanced. So tiny.
@@ -292,7 +292,7 @@ impl PyVortexWriteOptions {
     /// ```python
     /// >>> vx.io.VortexWriteOptions.compact().write(sprl, "tiny.vortex")
     /// >>> os.path.getsize('tiny.vortex')
-    /// 55152
+    /// 55088
     /// ```
     ///
     /// Random numbers are not (usually) composed of random bytes!

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/mod.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/mod.rs
@@ -43,7 +43,8 @@ pub fn fixtures() -> Vec<Box<dyn FlatLayoutFixture>> {
         Box::new(dict::DictFixture),
         Box::new(fsst::FsstFixture),
         Box::new(for_::FoRFixture),
-        Box::new(patched::PatchedFixture),
+        // TODO(aduffy): add back once we stabilized Patched array
+        // Box::new(patched::PatchedFixture),
         Box::new(pco::PcoFixture),
         Box::new(rle::RleFixture),
         Box::new(runend::RunEndFixture),

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/patched.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/patched.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
-#![allow(dead_code)]
-
 use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;
@@ -16,6 +14,10 @@ use vortex_session::VortexSession;
 
 use crate::fixtures::FlatLayoutFixture;
 
+#[expect(
+    dead_code,
+    reason = "This will be unused until we stabilize Patched array"
+)]
 pub struct PatchedFixture;
 
 impl FlatLayoutFixture for PatchedFixture {

--- a/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/patched.rs
+++ b/vortex-test/compat-gen/src/fixtures/arrays/synthetic/encodings/patched.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright the Vortex contributors
 
+#![allow(dead_code)]
+
 use vortex_array::ArrayId;
 use vortex_array::ArrayRef;
 use vortex_array::ExecutionCtx;


### PR DESCRIPTION
## Summary

We have been publishing a footer reference to `vortex.patched` experimental encoding in the last few releases.

The issue is that we should not be including the Patched encoding in the default array context

This removes Patched from the default array context, instead registering it conditionally where we register the other unstable encodings.

I've verified that after this change writing a file with default settings no longer includes Patched encoding

<img width="1356" height="185" alt="image" src="https://github.com/user-attachments/assets/56a89186-68ff-4588-8058-3ee6dc7bb767" />
